### PR TITLE
fix(event_studio): [describe change]

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -307,8 +307,12 @@ final class EventStudioForm extends FormBase {
       '#description' => $this->t('Hero image (PNG, JPG, WebP; max 5 MB). Recommended 1200×630.'),
       '#upload_location' => 'public://events',
       '#upload_validators' => [
-        'file_validate_extensions' => ['png gif jpg jpeg webp'],
-        'file_validate_size' => [5 * 1024 * 1024],
+        'FileExtension' => [
+          'extensions' => 'png gif jpg jpeg webp',
+        ],
+        'FileSizeLimit' => [
+          'fileLimit' => 5 * 1024 * 1024,
+        ],
       ],
       '#default_value' => $image_fids,
       '#attributes' => ['class' => ['mel-input-file']],


### PR DESCRIPTION
Reset main to PR-based history (ONLY if safe):

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `managed_file` upload validator configuration; if the validator keys/options don’t match the running Drupal/core version, image uploads could start failing or allow unexpected files.
> 
> **Overview**
> Updates Event Studio’s cover image upload field to use the newer `#upload_validators` plugin-style configuration (`FileExtension`/`FileSizeLimit`) instead of the legacy `file_validate_*` callbacks, while keeping the same allowed extensions and 5MB limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7532782bcbd3c5fd4c6a00e2792c779bf61768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->