### PR TITLE
feat(ci,deploy): deterministic theme build and deploy asset gate

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,6 +44,18 @@ jobs:
             package-lock.json
             web/themes/custom/myeventlane_theme/package-lock.json
 
+      - name: Log Node and npm versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -v
+          npm -v
+
+      - name: Install root Node dependencies
+        if: ${{ hashFiles('package.json') != '' }}
+        shell: bash
+        run: npm ci
+
       - name: Install Composer dependencies
         shell: bash
         run: composer install --no-dev --prefer-dist --no-interaction --no-progress
@@ -60,14 +72,86 @@ jobs:
         working-directory: web/themes/custom/myeventlane_theme
         run: npm run build
 
-      - name: Install root Node dependencies
-        if: ${{ hashFiles('package.json') != '' }}
-        shell: bash
-        run: npm ci
+      # Repo-root `npm run build` is not used here: theme Vite resolves deps from the
+      # theme package. Production assets and dist-checksums.txt come from the theme build.
 
-      # Repo-root `npm run build` uses ./vite.config.js with the same theme entry but
-      # resolves packages from the repo root, so deps like swiper (installed only under
-      # the theme) fail. Production assets are built in the theme steps above.
+      - name: Generate theme dist checksum manifest
+        if: ${{ hashFiles('web/themes/custom/myeventlane_theme/package.json') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ASSET_DIR="web/themes/custom/myeventlane_theme/dist/assets"
+          MANIFEST="dist-checksums.txt"
+
+          echo "== MEL checksum generation =="
+
+          # 1. Ensure clean dist (prevents stale artifacts)
+          echo "Cleaning dist directory..."
+          rm -rf web/themes/custom/myeventlane_theme/dist
+
+          # 2. Rebuild (must already have run, but enforce consistency)
+          echo "Rebuilding theme..."
+          cd web/themes/custom/myeventlane_theme
+          npm run build
+          cd - > /dev/null
+
+          # 3. Validate asset directory exists
+          if [ ! -d "$ASSET_DIR" ]; then
+            echo "ERROR: Asset directory missing: $ASSET_DIR"
+            exit 1
+          fi
+
+          # 4. Validate exactly ONE main CSS file
+          CSS_FILES=$(ls $ASSET_DIR/main*.css 2>/dev/null || true)
+          CSS_COUNT=$(echo "$CSS_FILES" | wc -w | tr -d ' ')
+
+          if [ "$CSS_COUNT" -ne 1 ]; then
+            echo "ERROR: Expected exactly 1 main*.css file, found $CSS_COUNT"
+            ls -la $ASSET_DIR
+            exit 1
+          fi
+
+          echo "CSS OK: $CSS_FILES"
+
+          # 5. Validate JS assets exist
+          JS_FILES=$(ls $ASSET_DIR/*.js 2>/dev/null || true)
+
+          if [ -z "$JS_FILES" ]; then
+            echo "ERROR: No JS assets found in $ASSET_DIR"
+            exit 1
+          fi
+
+          echo "JS OK:"
+          echo "$JS_FILES"
+
+          # 6. Ensure no unexpected file types (hard guard)
+          INVALID_FILES=$(find $ASSET_DIR -type f ! -name "*.css" ! -name "*.js" ! -name "*.map")
+
+          if [ -n "$INVALID_FILES" ]; then
+            echo "ERROR: Unexpected files in dist/assets:"
+            echo "$INVALID_FILES"
+            exit 1
+          fi
+
+          # 7. Generate checksum manifest (repo-root-relative paths)
+          echo "Generating checksum manifest..."
+
+          rm -f "$MANIFEST"
+
+          shasum $ASSET_DIR/main*.css > "$MANIFEST"
+          shasum $ASSET_DIR/*.js >> "$MANIFEST"
+
+          echo "Manifest created:"
+          cat "$MANIFEST"
+
+          # 8. Final sanity check
+          if [ ! -s "$MANIFEST" ]; then
+            echo "ERROR: Manifest file is empty"
+            exit 1
+          fi
+
+          echo "== MEL checksum generation complete =="
 
       - name: Set artifact metadata
         id: meta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myeventlane",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "dev": "vite",
     "build": "npm run mel:build",

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -6,7 +6,6 @@ SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
 ARTIFACT_PATH="${ARTIFACT_PATH:-/tmp/artifact.tar.gz}"
 RUN_UPDB="${RUN_UPDB:-0}"
 RUN_CIM="${RUN_CIM:-0}"
-THEME_PATH_RELATIVE="web/themes/custom/myeventlane_theme"
 
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 RELEASE_PATH="$APP_PATH/releases/$TIMESTAMP"
@@ -31,6 +30,69 @@ if [ ! -d "$RELEASE_PATH/web" ]; then
   echo "Invalid artifact: web/ not found"
   exit 1
 fi
+
+set -euo pipefail
+
+echo "== MEL deploy asset validation =="
+
+ASSET_DIR="$RELEASE_PATH/web/themes/custom/myeventlane_theme/dist/assets"
+MANIFEST="$RELEASE_PATH/dist-checksums.txt"
+
+# 1. Validate manifest exists
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: Missing checksum manifest at $MANIFEST"
+  exit 1
+fi
+
+echo "Manifest found"
+
+# 2. Validate asset directory exists
+if [ ! -d "$ASSET_DIR" ]; then
+  echo "ERROR: Asset directory missing: $ASSET_DIR"
+  exit 1
+fi
+
+# 3. Validate exactly ONE main CSS file
+CSS_FILES=$(ls $ASSET_DIR/main*.css 2>/dev/null || true)
+CSS_COUNT=$(echo "$CSS_FILES" | wc -w | tr -d ' ')
+
+if [ "$CSS_COUNT" -ne 1 ]; then
+  echo "ERROR: Expected exactly 1 main*.css file, found $CSS_COUNT"
+  ls -la "$ASSET_DIR"
+  exit 1
+fi
+
+echo "CSS OK: $CSS_FILES"
+
+# 4. Validate JS assets exist
+JS_FILES=$(ls $ASSET_DIR/*.js 2>/dev/null || true)
+
+if [ -z "$JS_FILES" ]; then
+  echo "ERROR: No JS assets found"
+  exit 1
+fi
+
+echo "JS OK:"
+echo "$JS_FILES"
+
+# 5. Ensure no unexpected file types
+INVALID_FILES=$(find "$ASSET_DIR" -type f ! -name "*.css" ! -name "*.js" ! -name "*.map")
+
+if [ -n "$INVALID_FILES" ]; then
+  echo "ERROR: Unexpected files in dist/assets:"
+  echo "$INVALID_FILES"
+  exit 1
+fi
+
+# 6. Run checksum verification (repo-root-relative paths)
+cd "$RELEASE_PATH"
+
+echo "Running checksum verification..."
+shasum -c dist-checksums.txt
+
+echo "Checksum verification passed"
+
+echo "== MEL deploy asset validation complete =="
 
 # Files (shared)
 rm -rf "$DEFAULT_PATH/files"
@@ -69,30 +131,7 @@ ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
 
 cd "$CURRENT_PATH"
 
-# Theme build
-THEME_PATH="$CURRENT_PATH/$THEME_PATH_RELATIVE"
-
-if [ ! -d "$THEME_PATH" ]; then
-  echo "Theme directory not found: $THEME_PATH"
-  exit 1
-fi
-
-if [ ! -f "$THEME_PATH/package.json" ]; then
-  echo "Theme package.json not found: $THEME_PATH/package.json"
-  exit 1
-fi
-
-if [ ! -f "$THEME_PATH/package-lock.json" ]; then
-  echo "Theme package-lock.json not found: $THEME_PATH/package-lock.json"
-  exit 1
-fi
-
-echo "Building theme assets in: $THEME_PATH"
-cd "$THEME_PATH"
-rm -rf dist
-npm ci
-npm run build
-cd "$CURRENT_PATH"
+# Theme assets are built in CI and verified above; do not rebuild on the server.
 
 # Optional updates (disabled by default)
 if [ "$RUN_UPDB" = "1" ]; then


### PR DESCRIPTION
- Reusable build: log Node/npm versions; root npm ci before Composer and theme install; harden dist-checksums.txt (clean dist, rebuild, exactly one main*.css, JS present, file-type guard, shasum manifest).
- remote-deploy: full MEL asset validation and shasum -c before any shared symlinks, Drush, or switching current; no npm on server.
- Set package.json version to 2.0.0.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI build ordering and adds strict asset/manifest gates that can fail builds or block deployments if theme output shape changes.
> 
> **Overview**
> Makes CI builds and deploys deterministic by treating theme assets as **CI-built artifacts** and adding strict validation gates.
> 
> The reusable build workflow now logs Node/npm versions, runs root `npm ci` before Composer/theme installs, and generates a `dist-checksums.txt` by cleaning/rebuilding the theme and asserting expected outputs (exactly one `main*.css`, at least one `.js`, and no unexpected file types).
> 
> The remote deploy script no longer runs `npm`/rebuilds the theme on the server; instead it validates the shipped `dist-checksums.txt` and `dist/assets` contents and runs `shasum -c` *before* proceeding with symlinks, Drush, or switching the current release. Also bumps root `package.json` version to `2.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb56003c0242cf216c36c028129e4435e215acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->