### PR TITLE
Add MEL health endpoint

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
@@ -101,3 +101,12 @@ myeventlane_core.error_404:
     _title: 'Page not found'
   requirements:
     _access: 'TRUE'
+
+myeventlane_core.health:
+  path: '/health'
+  defaults:
+    _controller: '\Drupal\myeventlane_core\Controller\HealthController::check'
+  requirements:
+    _access: 'TRUE'
+  options:
+    _maintenance_access: TRUE

--- a/web/modules/custom/myeventlane_core/src/Controller/HealthController.php
+++ b/web/modules/custom/myeventlane_core/src/Controller/HealthController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+use Drupal\Core\Database\Database;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
+
+final class HealthController extends ControllerBase {
+
+  public function __construct(
+    private readonly CacheBackendInterface $cache,
+    private readonly ThemeHandlerInterface $themeHandler,
+  ) {}
+
+  public static function create($container): self {
+    return new self(
+      $container->get('cache.default'),
+      $container->get('theme_handler'),
+    );
+  }
+
+  public function check(): Response {
+    try {
+      // 1. Database check
+      Database::getConnection()->query('SELECT 1')->fetchField();
+
+      // 2. Cache write/read check
+      $this->cache->set('mel_health_check', 'ok', time() + 60);
+      $cache = $this->cache->get('mel_health_check');
+
+      if (!$cache || $cache->data !== 'ok') {
+        return new Response('cache failed', 503);
+      }
+
+      // 3. Theme asset check
+      $default_theme = \Drupal::config('system.theme')->get('default');
+      $theme_path = $this->themeHandler->getTheme($default_theme)?->getPath();
+
+      if (!$theme_path) {
+        return new Response('theme missing', 503);
+      }
+
+      $asset_path = DRUPAL_ROOT . '/' . $theme_path . '/dist/assets';
+
+      if (!is_dir($asset_path)) {
+        return new Response('assets missing', 503);
+      }
+
+      $css_files = glob($asset_path . '/main*.css');
+
+      if (count($css_files) !== 1) {
+        return new Response('css invalid', 503);
+      }
+
+      return new Response('ok', 200);
+
+    } catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_core')->error($e->getMessage());
+      return new Response('error', 503);
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a publicly accessible health endpoint that touches database, cache writes, and filesystem theme assets, which could introduce availability/perf issues or leak minimal status info if misused.
> 
> **Overview**
> Adds a new public `GET /health` route (allowed during maintenance) backed by `HealthController::check`.
> 
> The endpoint performs basic runtime checks (DB query, cache write/read, and presence/shape of built theme assets under `dist/assets`) and returns `200 ok` or `503` with a short failure reason, logging unexpected exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b862d73b412185a1f158bf04e9a3cb532b3e38f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->