### PR TITLE
Add SSH debug step

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,13 +29,22 @@ jobs:
       - name: Download release artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build.outputs.artifact_name }}
-          path: ./artifact
+          name: artifact
+          path: artifact.tar.gz
 
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Test SSH connection
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Testing SSH connection..."
+          ssh -o StrictHostKeyChecking=no \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "echo 'SSH OK from $(hostname)'"   
 
       - name: Add staging host to known_hosts
         shell: bash
@@ -58,12 +67,20 @@ jobs:
           set -euo pipefail
           ssh "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" <<'EOF'
           set -euo pipefail
+
           temp_dir="$(mktemp -d)"
-          trap 'rm -rf "$temp_dir"; rm -f /tmp/artifact.tar.gz' EXIT
+          trap 'rm -rf "$temp_dir"' EXIT
+
+          echo "Extracting artifact..."
           tar -xzf /tmp/artifact.tar.gz -C "$temp_dir"
+
+          echo "Running deploy..."
           cd "$temp_dir"
+
           APP_PATH="$HOME/staging" \
           SITE_URI="https://staging.myeventlane.com.au" \
-          ARTIFACT_PATH="/tmp/artifact.tar.gz" \
+          ARTIFACT_PATH="$temp_dir" \
           bash scripts/deploy/remote-deploy.sh
+
+          rm -f /tmp/artifact.tar.gz
           EOF


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the staging GitHub Actions deploy workflow (artifact download/extraction and remote `ARTIFACT_PATH`), which could break automated deployments if the remote deploy script expects the previous tarball layout. Added SSH preflight is low risk but can fail the job earlier on connectivity/host key issues.
> 
> **Overview**
> Updates the staging deploy workflow to **add an explicit SSH preflight check** before uploading and deploying.
> 
> The workflow also changes how the build artifact is downloaded/handled and updates the remote deploy step to extract `/tmp/artifact.tar.gz` into a temporary directory, adjust cleanup/trapping, and pass a different `ARTIFACT_PATH` into `scripts/deploy/remote-deploy.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257c8d48d8df58e849012f20f900aa8e4a581ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->