### PR TITLE
Fix artifact download to use dynamic build output

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Download release artifact
         uses: actions/download-artifact@v4
         with:
-          name: artifact
-          path: artifact.tar.gz
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ./artifact
 
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; staging deploy now pulls the artifact by the dynamically generated name/output, reducing chances of missing or mismatched artifacts.
> 
> **Overview**
> Updates the staging GitHub Actions deploy workflow to download the build artifact using `needs.build.outputs.artifact_name` instead of a hardcoded `artifact` name, and downloads into `./artifact` for subsequent `scp` of `artifact.tar.gz`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa29e4c0a48f6e6ebd09a5f2465658db784632b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->