### PR TITLE
Fix deploy pipeline: ensure script in artifact + YAML + validation

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,8 +46,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Listing artifact files:"
-          tar -tzf ./artifact/artifact.tar.gz | grep remote-deploy.sh || true
+          echo "Checking for deploy script in artifact..."
+          tar -tzf ./artifact/artifact.tar.gz | grep scripts/deploy/remote-deploy.sh || {
+            echo "ERROR: deploy script missing from artifact"
+            exit 1
+          }
 
       - name: Write SSH key
         shell: bash
@@ -91,29 +94,35 @@ jobs:
           scp -i ~/.ssh/id_ed25519 ./artifact/artifact.tar.gz \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/tmp/artifact.tar.gz"
 
+      # Heredoc body cannot start at column 0 inside YAML `run: |` (invalid YAML).
+      # This block is equivalent to the requested ssh … <<'EOF' … EOF remote script.
       - name: Run remote deploy script
         shell: bash
         run: |
           set -euo pipefail
-
-          ssh -i ~/.ssh/id_ed25519 "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" << 'EOF'
-set -euo pipefail
-
-temp_dir="$(mktemp -d)"
-trap 'rm -rf "$temp_dir"; rm -f /tmp/artifact.tar.gz' EXIT
-
-echo "Extracting artifact..."
-tar -xzf /tmp/artifact.tar.gz -C "$temp_dir"
-
-echo "Running deploy..."
-cd "$temp_dir"
-
-APP_PATH="$HOME/staging" \
-SITE_URI="https://staging.myeventlane.com.au" \
-ARTIFACT_PATH="$temp_dir" \
-bash scripts/deploy/remote-deploy.sh
-
-EOF
+          printf '%s\n' \
+            'set -euo pipefail' \
+            '' \
+            'temp_dir="$(mktemp -d)"' \
+            'trap '\''rm -rf "$temp_dir"; rm -f /tmp/artifact.tar.gz'\'' EXIT' \
+            '' \
+            'echo "TEMP DIR:"' \
+            'echo "$temp_dir"' \
+            '' \
+            'echo "Extracting artifact..."' \
+            'tar -xzf /tmp/artifact.tar.gz -C "$temp_dir"' \
+            '' \
+            'echo "TEMP DIR CONTENTS:"' \
+            'ls -lah "$temp_dir"' \
+            '' \
+            'echo "Running deploy..."' \
+            'cd "$temp_dir"' \
+            '' \
+            'APP_PATH="$HOME/staging" \' \
+            'SITE_URI="https://staging.myeventlane.com.au" \' \
+            'ARTIFACT_PATH="$temp_dir" \' \
+            'bash scripts/deploy/remote-deploy.sh' \
+            | ssh -i ~/.ssh/id_ed25519 "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" bash -s
 
       - name: Verify release
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,7 @@
 ############################################
 /node_modules/
 /web/themes/custom/*/node_modules/
-<<<<<<< HEAD
 /web/themes/custom/**/dist/
-=======
-/web/themes/custom/*/dist/
->>>>>>> 312d2744 (fix: correct gitignore for CI/CD safe deploy)
 /build/
 /.npm-cache/
 

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -20,7 +20,7 @@ mkdir -p "$SHARED_PATH/files"
 
 # ---- CRITICAL FIX: validate directory, not file ----
 if [ -z "$ARTIFACT_PATH" ] || [ ! -d "$ARTIFACT_PATH" ]; then
-  echo "Artifact directory not found or empty: $ARTIFACT_PATH"
+  echo "Artifact directory not found"
   exit 1
 fi
 
@@ -30,10 +30,10 @@ echo "Copying artifact contents..."
 cp -a "$ARTIFACT_PATH"/. "$RELEASE_PATH"/
 
 # ---- SAFETY CHECK (prevents bad deploys) ----
-if [ ! -f "$RELEASE_PATH/web/index.php" ]; then
-  echo "Invalid artifact: missing web/index.php"
+[ -f "$RELEASE_PATH/web/index.php" ] || {
+  echo "Invalid artifact structure"
   exit 1
-fi
+}
 
 echo "== MEL deploy asset validation =="
 


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the staging GitHub Actions deployment flow and remote deploy validation, which can directly block or alter staging releases if assumptions about artifact layout/SSH scripting differ.
> 
> **Overview**
> Staging deployment workflow is hardened to **fail fast** if `scripts/deploy/remote-deploy.sh` is missing from the build artifact, and the remote execution step is rewritten to avoid invalid YAML heredoc usage by piping a generated script into `ssh` (with additional temp-dir debug output).
> 
> The remote deploy script tightens/standardizes artifact validation (directory existence + required `web/index.php`) with clearer error messages, and `.gitignore` is cleaned up by removing leftover merge-conflict markers around theme `dist/` ignores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b25d0c28b13eadef2f3b94c0d07881c8c36096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->