### PR TITLE
Fix deploy script: settings handling + DB safe deploy

### DIFF
--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -119,6 +119,14 @@ if [ -f "$SHARED_PATH/services.yml" ]; then
   ln -sfn "$SHARED_PATH/services.yml" "$DEFAULT_PATH/services.yml"
 fi
 
+# CI packages exclude web/sites/*/settings.php; Drush steps need $databases['default'].
+# Staging must provide ~/staging/shared/settings.php (symlinked above). Skip only for custom flows.
+if [ "${SKIP_DB_SETTINGS_CHECK:-0}" != "1" ] && [ ! -f "$DEFAULT_PATH/settings.php" ]; then
+  echo "ERROR: $DEFAULT_PATH/settings.php is missing. The build artifact does not include settings.php."
+  echo "Create $SHARED_PATH/settings.php defining \$databases['default']['default'], then redeploy."
+  exit 1
+fi
+
 cd "$RELEASE_PATH"
 
 # ---- DRUSH CHECK ----


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deployment behavior to hard-fail if `web/sites/default/settings.php` is absent, which can block releases if staging/shared settings are misconfigured. Limited to the deploy script but impacts production deploy flow.
> 
> **Overview**
> Adds a deploy-time guard in `scripts/deploy/remote-deploy.sh` to ensure `web/sites/default/settings.php` exists (typically via the `shared/settings.php` symlink) before running any Drush steps.
> 
> The check can be bypassed with `SKIP_DB_SETTINGS_CHECK=1`, and provides clearer error output instructing how to supply a settings file with `\$databases['default']` configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523faaf2eb5fad4dc527957b3bf85d1e36962b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->