### PR TITLE
Fix deploy script: settings handling + DB safe deploy

### DIFF
--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -109,9 +109,10 @@ if [ -f "$SHARED_PATH/settings.php" ]; then
   fi
 fi
 
+# Do not symlink settings.local.php: it is DDEV-only in this project and must
+# never override staging/production trusted hosts or domains from shared/.
 if [ -f "$SHARED_PATH/settings.local.php" ]; then
-  rm -f "$DEFAULT_PATH/settings.local.php"
-  ln -sfn "$SHARED_PATH/settings.local.php" "$DEFAULT_PATH/settings.local.php"
+  echo "WARNING: $SHARED_PATH/settings.local.php exists but is never symlinked (DDEV-only). Remove it from shared to avoid operator confusion." >&2
 fi
 
 if [ -f "$SHARED_PATH/services.yml" ]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: deploy script change only affects staging/prod config linking by skipping `settings.local.php` and emitting a warning if it exists.
> 
> **Overview**
> Prevents `settings.local.php` from being symlinked during remote deploys so DDEV-only local settings cannot override staging/production configuration.
> 
> If `shared/settings.local.php` is present, the deploy now logs a warning to stderr instead of linking it into the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8329afe17bd4e89b91ca497396962d9c9d5410d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->