### PR TITLE
Deploy: platform fee fix, domain enforcement, healthcheck, and deploy…

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -119,6 +119,7 @@ jobs:
             'cd "$temp_dir"' \
             '' \
             'APP_PATH="$HOME/staging" \' \
+            'APP_ENV=staging \' \
             'SITE_URI="https://staging.myeventlane.com.au" \' \
             'ARTIFACT_PATH="$temp_dir" \' \
             'bash scripts/deploy/remote-deploy.sh' \

--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify config/sync has no DDEV hostnames
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -rE 'ddev\.site' config/sync --include='*.yml' --include='*.yaml' 2>/dev/null | grep -q .; then
+            echo "::error::config/sync must not contain ddev.site (use staging/production hosts or relative URLs)."
+            grep -rE 'ddev\.site' config/sync --include='*.yml' --include='*.yaml' || true
+            exit 1
+          fi
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/config/sync/klaro.texts.yml
+++ b/config/sync/klaro.texts.yml
@@ -7,7 +7,7 @@ consentModal:
   privacyPolicy:
     name: 'Privacy Policy'
     text: "To learn more, please read our {privacyPolicy}.\r\n"
-    url: 'https://myeventlane.ddev.site/privacy'
+    url: '/privacy'
 consentNotice:
   title: 'Use of personal data and cookies'
   changeDescription: 'There were changes since your last visit, please update your consent.'

--- a/config/sync/myeventlane_core.domain_settings.yml
+++ b/config/sync/myeventlane_core.domain_settings.yml
@@ -1,5 +1,5 @@
-public_domain: 'https://myeventlane.ddev.site'
-vendor_domain: 'https://vendor.myeventlane.ddev.site'
-admin_domain: 'https://admin.myeventlane.ddev.site'
+public_domain: 'https://staging.myeventlane.com.au'
+vendor_domain: 'https://vendor.staging.myeventlane.com.au'
+admin_domain: 'https://admin.staging.myeventlane.com.au'
 force_redirects: true
 allow_admin_override: true

--- a/config/sync/myeventlane_core.settings.yml
+++ b/config/sync/myeventlane_core.settings.yml
@@ -1,4 +1,4 @@
-platform_fee_percent: 5.0
+platform_fee_percent: 1.5
 stripe_fee_percent: 3.0
 stripe_fee_fixed_cents: 30
 fee_payer: buyer

--- a/config/sync/myeventlane_dashboard.settings.yml
+++ b/config/sync/myeventlane_dashboard.settings.yml
@@ -1,1 +1,1 @@
-platform_fee_percent: 5.0
+platform_fee_percent: 1.5

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Optional: APP_ENV=production|prod|staging|stage — drives post-deploy domain cset.
+# Falls back to SITE_URI containing "staging" vs production *.myeventlane.com.au (no staging).
+
 APP_PATH="${APP_PATH:-$HOME/staging}"
 SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
 ARTIFACT_PATH="${ARTIFACT_PATH:-}"
@@ -145,6 +148,18 @@ ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
 
 cd "$CURRENT_PATH"
 
+# ---- CONFIG SYNC SANITY (before cim) ----
+CONFIG_SYNC_DIR="$CURRENT_PATH/config/sync"
+if [ -d "$CONFIG_SYNC_DIR" ]; then
+  if grep -rE 'ddev\.site' "$CONFIG_SYNC_DIR" --include='*.yml' --include='*.yaml' 2>/dev/null | grep -q .; then
+    echo "ERROR: DDEV hostname found in config/sync — fix export before deploy." >&2
+    grep -rE 'ddev\.site' "$CONFIG_SYNC_DIR" --include='*.yml' --include='*.yaml' >&2 || true
+    exit 1
+  fi
+else
+  echo "WARNING: config/sync missing at $CONFIG_SYNC_DIR (skipping ddev grep)." >&2
+fi
+
 # ---- OPTIONAL UPDATES ----
 if [ "$RUN_UPDB" = "1" ]; then
   vendor/bin/drush updb -y --uri="$SITE_URI"
@@ -152,6 +167,46 @@ fi
 
 if [ "$RUN_CIM" = "1" ]; then
   vendor/bin/drush cim -y --uri="$SITE_URI"
+fi
+
+# ---- DOMAIN ENFORCEMENT (after cim; runs every deploy) ----
+# Prevents production from keeping staging hosts from sync; idempotent on staging.
+mel_resolve_deploy_mode() {
+  local app_raw="${APP_ENV:-}"
+  local app_lc
+  app_lc=$(printf '%s' "$app_raw" | tr '[:upper:]' '[:lower:]')
+  case "$app_lc" in
+    production|prod) echo production; return ;;
+    staging|stage) echo staging; return ;;
+  esac
+  case "${SITE_URI:-}" in
+    *staging*) echo staging; return ;;
+  esac
+  case "${SITE_URI:-}" in
+    *myeventlane.com.au*)
+      case "${SITE_URI:-}" in
+        *staging*) echo staging; return ;;
+        *) echo production; return ;;
+      esac
+      ;;
+  esac
+  echo ""
+}
+
+MEL_DEPLOY_MODE="$(mel_resolve_deploy_mode)"
+
+if [ "$MEL_DEPLOY_MODE" = "production" ]; then
+  echo "Applying production domain settings (APP_ENV/SITE_URI → production)..."
+  vendor/bin/drush cset myeventlane_core.domain_settings public_domain 'https://myeventlane.com.au' -y --uri="$SITE_URI"
+  vendor/bin/drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.myeventlane.com.au' -y --uri="$SITE_URI"
+  vendor/bin/drush cset myeventlane_core.domain_settings admin_domain 'https://admin.myeventlane.com.au' -y --uri="$SITE_URI"
+elif [ "$MEL_DEPLOY_MODE" = "staging" ]; then
+  echo "Applying staging domain settings (APP_ENV/SITE_URI → staging)..."
+  vendor/bin/drush cset myeventlane_core.domain_settings public_domain 'https://staging.myeventlane.com.au' -y --uri="$SITE_URI"
+  vendor/bin/drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.staging.myeventlane.com.au' -y --uri="$SITE_URI"
+  vendor/bin/drush cset myeventlane_core.domain_settings admin_domain 'https://admin.staging.myeventlane.com.au' -y --uri="$SITE_URI"
+else
+  echo "NOTICE: Skipping automatic domain cset (set APP_ENV=production|staging, or SITE_URI with staging vs myeventlane.com.au)." >&2
 fi
 
 # ---- FINALISE ----

--- a/web/modules/custom/myeventlane_ai/src/Provider/OpenAiProvider.php
+++ b/web/modules/custom/myeventlane_ai/src/Provider/OpenAiProvider.php
@@ -13,8 +13,9 @@ use Psr\Log\LoggerInterface;
 /**
  * Minimal OpenAI-compatible Chat Completions provider.
  *
- * NOTE: Secrets are read from settings.php ONLY:
- * $settings['myeventlane_ai']['api_key'] = '...';
+ * API key resolution order:
+ * 1. MEL_OPENAI_API_KEY environment variable (preferred for all environments).
+ * 2. $settings['myeventlane_ai']['api_key'] from settings.php (optional fallback).
  */
 final class OpenAiProvider implements AiProviderInterface {
 
@@ -53,9 +54,15 @@ final class OpenAiProvider implements AiProviderInterface {
     $max_tokens = (int) ($options['max_tokens'] ?? $config->get('openai.max_tokens') ?? 600);
     $temperature = (float) ($options['temperature'] ?? $config->get('openai.temperature') ?? 0.2);
 
-    $api_key = (string) (Settings::get('myeventlane_ai')['api_key'] ?? '');
+    $api_key = (string) (getenv('MEL_OPENAI_API_KEY') ?: '');
     if ($api_key === '') {
-      return AiResult::error('Missing myeventlane_ai.api_key in settings.php', '', $this->getName(), $model);
+      $from_settings = Settings::get('myeventlane_ai');
+      if (is_array($from_settings)) {
+        $api_key = (string) ($from_settings['api_key'] ?? '');
+      }
+    }
+    if ($api_key === '') {
+      return AiResult::error('Missing OpenAI API key: set MEL_OPENAI_API_KEY or $settings[\'myeventlane_ai\'][\'api_key\']', '', $this->getName(), $model);
     }
 
     $messages = $options['_messages'] ?? NULL;

--- a/web/modules/custom/myeventlane_commerce/src/OrderProcessor/PlatformFeeOrderProcessor.php
+++ b/web/modules/custom/myeventlane_commerce/src/OrderProcessor/PlatformFeeOrderProcessor.php
@@ -11,6 +11,7 @@ use Drupal\commerce_price\Price;
 use Drupal\commerce_price\RounderInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 
 /**
  * Applies a configurable platform fee (% of ticket subtotal) to orders.
@@ -70,7 +71,7 @@ final class PlatformFeeOrderProcessor implements OrderProcessorInterface {
       return;
     }
 
-    $percent = (float) ($settings->get('platform_fee_percent') ?? 5);
+    $percent = PlatformFeeDefaults::normalizePercent($settings->get('platform_fee_percent'));
 
     if ($percent <= 0) {
       return;

--- a/web/modules/custom/myeventlane_core/config/install/myeventlane_core.settings.yml
+++ b/web/modules/custom/myeventlane_core/config/install/myeventlane_core.settings.yml
@@ -1,4 +1,4 @@
-platform_fee_percent: 5
+platform_fee_percent: 1.5
 stripe_fee_percent: 3
 stripe_fee_fixed_cents: 30
 fee_payer: buyer

--- a/web/modules/custom/myeventlane_core/config/schema/myeventlane_core.schema.yml
+++ b/web/modules/custom/myeventlane_core/config/schema/myeventlane_core.schema.yml
@@ -4,7 +4,7 @@ myeventlane_core.settings:
   mapping:
     platform_fee_percent:
       type: float
-      label: 'Platform fee percentage (0-100, e.g. 5 for 5%)'
+      label: 'Platform fee percentage (0-100, e.g. 1.5 for 1.5%)'
     stripe_fee_percent:
       type: float
       label: 'Stripe application fee percentage (e.g. 3 for 3%)'

--- a/web/modules/custom/myeventlane_core/drush.services.yml
+++ b/web/modules/custom/myeventlane_core/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  myeventlane_core.commands:
+    class: Drupal\myeventlane_core\Commands\MelCoreCommands
+    arguments:
+      - '@config.factory'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
+++ b/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Commands;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Core MyEventLane Drush commands (environment sanity).
+ */
+final class MelCoreCommands extends DrushCommands {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Validates active config for DDEV leakage, platform fee range, and domain/env alignment.
+   *
+   * @command mel:healthcheck
+   * @usage drush mel:healthcheck
+   *   Run MyEventLane environment sanity checks (read-only except exit code).
+   *
+   * @return int
+   *   0 if OK, 1 if failures.
+   */
+  public function healthcheck(): int {
+    $failures = 0;
+    $isDdev = getenv('IS_DDEV_PROJECT') === 'true';
+
+    $domainCfg = $this->configFactory->get('myeventlane_core.domain_settings');
+    foreach (['public_domain', 'vendor_domain', 'admin_domain'] as $key) {
+      $val = (string) $domainCfg->get($key);
+      if ($val !== '' && str_contains(strtolower($val), 'ddev.site') && !$isDdev) {
+        $this->io()->error("Active config {$key} references ddev.site outside DDEV: {$val}");
+        $failures++;
+      }
+    }
+
+    $feeRaw = $this->configFactory->get('myeventlane_core.settings')->get('platform_fee_percent');
+    $fee = PlatformFeeDefaults::normalizePercent($feeRaw);
+    $this->io()->writeln(sprintf('platform_fee_percent (normalized): %s', $fee));
+
+    $appEnv = strtolower((string) (getenv('APP_ENV') ?: ''));
+
+    if (in_array($appEnv, ['production', 'prod'], TRUE)) {
+      $expect = [
+        'public_domain' => 'https://myeventlane.com.au',
+        'vendor_domain' => 'https://vendor.myeventlane.com.au',
+        'admin_domain' => 'https://admin.myeventlane.com.au',
+      ];
+      foreach ($expect as $k => $expected) {
+        $actual = (string) $domainCfg->get($k);
+        if ($actual !== $expected) {
+          $this->io()->error("APP_ENV=production expects {$k}={$expected}, got {$actual}.");
+          $failures++;
+        }
+      }
+    }
+    elseif (in_array($appEnv, ['staging', 'stage'], TRUE)) {
+      $expect = [
+        'public_domain' => 'https://staging.myeventlane.com.au',
+        'vendor_domain' => 'https://vendor.staging.myeventlane.com.au',
+        'admin_domain' => 'https://admin.staging.myeventlane.com.au',
+      ];
+      foreach ($expect as $k => $expected) {
+        $actual = (string) $domainCfg->get($k);
+        if ($actual !== $expected) {
+          $this->io()->error("APP_ENV=staging expects {$k}={$expected}, got {$actual}.");
+          $failures++;
+        }
+      }
+    }
+    else {
+      $this->io()->note('APP_ENV not set to production|staging — skipping strict domain trio assertion.');
+    }
+
+    if ($failures > 0) {
+      $this->io()->error("mel:healthcheck failed with {$failures} error(s).");
+      return 1;
+    }
+
+    $this->io()->success('mel:healthcheck passed.');
+    return 0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
@@ -34,6 +34,8 @@ final class VendorDomainSubscriber implements EventSubscriberInterface {
       return;
     }
 
+    $this->assertDomainSettingsNotLeakingDdev();
+
     $request = $event->getRequest();
     $path = $request->getPathInfo();
     $host = $request->getHost();
@@ -169,6 +171,27 @@ final class VendorDomainSubscriber implements EventSubscriberInterface {
         ]);
 
         $event->setResponse(new TrustedRedirectResponse($public_url, 302));
+      }
+    }
+  }
+
+  /**
+   * Fails loudly if active domain config still references DDEV outside DDEV.
+   */
+  private function assertDomainSettingsNotLeakingDdev(): void {
+    if (getenv('IS_DDEV_PROJECT') === 'true') {
+      return;
+    }
+
+    $cfg = $this->configFactory->get('myeventlane_core.domain_settings');
+    foreach (['public_domain', 'vendor_domain', 'admin_domain'] as $key) {
+      $val = (string) $cfg->get($key);
+      if ($val !== '' && str_contains(strtolower($val), 'ddev.site')) {
+        throw new \RuntimeException(sprintf(
+          'myeventlane_core.domain_settings.%s must not reference ddev.site outside DDEV (effective value: %s).',
+          $key,
+          $val
+        ));
       }
     }
   }

--- a/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_core\Form;
 use Drupal\Core\Datetime\TimeZoneFormHelper;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 
 /**
  * General settings form for MyEventLane platform.
@@ -86,8 +87,8 @@ final class GeneralSettingsForm extends ConfigFormBase {
     $form['payments']['platform_fee_percent'] = [
       '#type' => 'number',
       '#title' => $this->t('Platform fee percentage'),
-      '#description' => $this->t('Percentage applied to ticket subtotals (excludes donations and Boost). For example, 5 applies a 5% platform fee. Set to 0 to disable.'),
-      '#default_value' => (string) ($config->get('platform_fee_percent') ?? 5),
+      '#description' => $this->t('Percentage applied to ticket subtotals (excludes donations and Boost). For example, 1.5 applies a 1.5% platform fee. Set to 0 to disable.'),
+      '#default_value' => (string) PlatformFeeDefaults::normalizePercent($config->get('platform_fee_percent')),
       '#min' => 0,
       '#max' => 100,
       '#step' => 0.5,
@@ -134,8 +135,12 @@ final class GeneralSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $v = $form_state->getValue(['payments', 'platform_fee_percent']);
-    $platform_fee_percent = is_numeric($v) ? (float) $v : 5;
-    $platform_fee_percent = max(0, min(100, $platform_fee_percent));
+    $existing_fee = PlatformFeeDefaults::normalizePercent(
+      $this->config('myeventlane_core.settings')->get('platform_fee_percent')
+    );
+    $platform_fee_percent = is_numeric($v)
+      ? PlatformFeeDefaults::normalizePercent($v)
+      : $existing_fee;
 
     $v = $form_state->getValue(['payments', 'stripe_fee_percent']);
     $stripe_fee_percent = is_numeric($v) ? (float) $v : 3;

--- a/web/modules/custom/myeventlane_core/src/PlatformFeeDefaults.php
+++ b/web/modules/custom/myeventlane_core/src/PlatformFeeDefaults.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core;
+
+/**
+ * Single source of truth for platform fee fallbacks when config is missing.
+ *
+ * Canonical values live in config (myeventlane_core.settings). Use this only
+ * for ?? fallbacks in PHP so defaults cannot drift across modules.
+ */
+final class PlatformFeeDefaults {
+
+  /**
+   * Default platform fee as a percentage (e.g. 1.5 means 1.5%).
+   */
+  public const DEFAULT_PLATFORM_FEE_PERCENT = 1.5;
+
+  /**
+   * Resolves raw config (or default) to a clamped, rounded percentage (0–100).
+   */
+  public static function normalizePercent(mixed $raw): float {
+    $v = is_numeric($raw) ? (float) $raw : self::DEFAULT_PLATFORM_FEE_PERCENT;
+    return round(max(0.0, min(100.0, $v)), 2);
+  }
+
+}

--- a/web/modules/custom/myeventlane_summary/src/Service/PlatformSummaryAggregator.php
+++ b/web/modules/custom/myeventlane_summary/src/Service/PlatformSummaryAggregator.php
@@ -9,6 +9,7 @@ use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\myeventlane_analytics\Service\OrderItemClassifier;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,8 +34,6 @@ final class PlatformSummaryAggregator {
   private const WINDOW_DAYS = 90;
 
   private const DEFAULT_CURRENCY = 'AUD';
-
-  private const DEFAULT_FEE_PERCENT = 5.0;
 
   private const RESOLVED_STATUSES = ['resolved', 'closed'];
 
@@ -65,7 +64,9 @@ final class PlatformSummaryAggregator {
     }
 
     $currency = $this->getDefaultCurrency();
-    $feePercent = (float) ($this->configFactory->get('myeventlane_core.settings')->get('platform_fee_percent') ?? self::DEFAULT_FEE_PERCENT);
+    $feePercent = PlatformFeeDefaults::normalizePercent(
+      $this->configFactory->get('myeventlane_core.settings')->get('platform_fee_percent')
+    );
     $feeRate = $feePercent / 100;
 
     $end_day = (int) strtotime('today midnight');

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -72,6 +72,7 @@ services:
       - '@database'
       - '@logger.factory'
       - '@myeventlane_vendor.subscription'
+      - '@config.factory'
 
   myeventlane_vendor.subscription:
     class: Drupal\myeventlane_vendor\Service\VendorSubscriptionService

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
 use Drupal\myeventlane_vendor\Entity\Vendor;
@@ -356,8 +357,11 @@ final class VendorDetailController extends ControllerBase implements ContainerIn
       // Attendee module may not be available.
     }
 
-    // Calculate platform fees and net revenue.
-    $platform_fee_rate = 0.05;
+    // Calculate platform fees and net revenue (aligned with myeventlane_core.settings).
+    $fee_percent = PlatformFeeDefaults::normalizePercent(
+      $this->config('myeventlane_core.settings')->get('platform_fee_percent')
+    );
+    $platform_fee_rate = $fee_percent / 100;
     $platform_fees = $total_revenue * $platform_fee_rate;
     $net_revenue = $total_revenue - $platform_fees;
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
@@ -6,10 +6,12 @@ namespace Drupal\myeventlane_vendor\Service;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_price\Price;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\myeventlane_analytics\Service\OrderItemClassifier;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 
@@ -30,6 +32,7 @@ final class TicketSalesService {
     private readonly Connection $database,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly VendorSubscriptionService $subscriptionService,
+    private readonly ConfigFactoryInterface $configFactory,
   ) {}
 
   /**
@@ -675,7 +678,10 @@ final class TicketSalesService {
       // Commerce may not be available.
     }
 
-    $feeRate = 0.05;
+    $feePercent = PlatformFeeDefaults::normalizePercent(
+      $this->configFactory->get('myeventlane_core.settings')->get('platform_fee_percent')
+    );
+    $feeRate = $feePercent / 100;
     $fees = $totalGross * $feeRate;
     $net = $totalGross - $fees;
 

--- a/web/modules/custom/myeventlane_vendor/tests/src/Kernel/EventOverviewSalesSummaryTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Kernel/EventOverviewSalesSummaryTest.php
@@ -10,11 +10,14 @@ use Drupal\commerce_order\Entity\OrderItemType;
 use Drupal\commerce_order\Entity\OrderType;
 use Drupal\commerce_price\Entity\Currency;
 use Drupal\commerce_price\Price;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Database\SchemaObjectExistsException;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_analytics\Service\OrderItemClassifier;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
 use Drupal\myeventlane_vendor\Service\TicketSalesService;
 use Drupal\myeventlane_vendor\Service\VendorSubscriptionService;
 use Drupal\node\Entity\Node;
@@ -76,12 +79,24 @@ final class EventOverviewSalesSummaryTest extends KernelTestBase {
     $this->ensureOrderItemTargetEventField();
     $this->ensureRefundLogTable();
 
+    $coreSettings = $this->createMock(ImmutableConfig::class);
+    $coreSettings->method('get')
+      ->willReturnCallback(static function (string $key, $default = NULL) {
+        return $key === 'platform_fee_percent' ? PlatformFeeDefaults::DEFAULT_PLATFORM_FEE_PERCENT : $default;
+      });
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')
+      ->with('myeventlane_core.settings')
+      ->willReturn($coreSettings);
+
     $this->service = new TicketSalesService(
       $this->container->get('entity_type.manager'),
       new OrderItemClassifier(),
       $this->container->get('database'),
       $this->container->get('logger.factory'),
       $this->createMock(VendorSubscriptionService::class),
+      $configFactory,
     );
   }
 


### PR DESCRIPTION
… hardening

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes deploy-time behavior (domain `cset` enforcement and config sanity checks) and adjusts platform fee defaults/calculation, which impacts checkout totals and reporting.
> 
> **Overview**
> **Hardens deploy and config hygiene** by passing `APP_ENV=staging` in the staging workflow, adding CI/deploy-time guards to fail if `config/sync` leaks `ddev.site`, and enforcing correct staging vs production domain trio via post-deploy `drush cset` in `remote-deploy.sh`.
> 
> **Adjusts platform fee behavior** by changing the default/exported `platform_fee_percent` to **1.5%** and introducing `PlatformFeeDefaults::normalizePercent()` as a single source of truth used across commerce fee processing, admin settings form, vendor analytics, and platform summary aggregation.
> 
> **Adds runtime sanity checks**: a new `drush mel:healthcheck` command for domain/fee/env validation, and `VendorDomainSubscriber` now throws outside DDEV if active domain settings still reference `ddev.site`. Also updates `OpenAiProvider` to prefer `MEL_OPENAI_API_KEY` with a settings.php fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355460f5bc7d40723879014b5f3d6ba542918961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->