### PR TITLE
Fix deploy script: settings handling + DB safe deploy

### DIFF
--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
@@ -177,9 +177,15 @@ final class VendorDomainSubscriber implements EventSubscriberInterface {
 
   /**
    * Fails loudly if active domain config still references DDEV outside DDEV.
+   *
+   * Skipped for CLI so Drush can repair misconfiguration (HTTP remains blocked).
    */
   private function assertDomainSettingsNotLeakingDdev(): void {
     if (getenv('IS_DDEV_PROJECT') === 'true') {
+      return;
+    }
+
+    if (\PHP_SAPI === 'cli') {
       return;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: narrows a safety assertion to HTTP requests only, reducing false failures during Drush/CLI maintenance without altering redirect behavior for web traffic.
> 
> **Overview**
> Adjusts `VendorDomainSubscriber::assertDomainSettingsNotLeakingDdev()` to **skip the DDEV domain-leak runtime assertion when running under `cli`**, so Drush/CLI tasks can execute even if domain settings are misconfigured.
> 
> HTTP requests outside DDEV remain blocked by the existing assertion, but CLI workflows can now proceed to repair configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70611c2d1fabd5ca48d45c12524f4468f962d374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->