### PR TITLE
Fix build: respect branch ref + prevent stale artifact deploy

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -2,6 +2,10 @@ name: Reusable Build
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
     outputs:
       artifact_name:
         description: Deployable artifact name
@@ -22,10 +26,16 @@ jobs:
       HUSKY: 0
 
     steps:
-      - name: Check out repository
+      - name: Check out repository (CORRECT REF)
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 1
+
+      - name: Debug commit
+        run: |
+          echo "Building commit:"
+          git rev-parse HEAD
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -44,148 +54,83 @@ jobs:
             package-lock.json
             web/themes/custom/myeventlane_theme/package-lock.json
 
-      - name: Log Node and npm versions
-        shell: bash
-        run: |
-          set -euo pipefail
-          node -v
-          npm -v
-
       - name: Install root Node dependencies
         if: ${{ hashFiles('package.json') != '' }}
-        shell: bash
         run: npm ci
 
       - name: Install Composer dependencies
-        shell: bash
         run: composer install --no-dev --prefer-dist --no-interaction --no-progress
 
       - name: Install theme Node dependencies
         if: ${{ hashFiles('web/themes/custom/myeventlane_theme/package.json') != '' }}
-        shell: bash
         working-directory: web/themes/custom/myeventlane_theme
         run: npm ci
 
       - name: Build theme assets
         if: ${{ hashFiles('web/themes/custom/myeventlane_theme/package.json') != '' }}
-        shell: bash
         working-directory: web/themes/custom/myeventlane_theme
         run: npm run build
 
-      # Repo-root `npm run build` is not used here: theme Vite resolves deps from the
-      # theme package. Production assets and dist-checksums.txt come from the theme build.
-
       - name: Generate theme dist checksum manifest
         if: ${{ hashFiles('web/themes/custom/myeventlane_theme/package.json') != '' }}
-        shell: bash
         run: |
           set -euo pipefail
 
           ASSET_DIR="web/themes/custom/myeventlane_theme/dist/assets"
           MANIFEST="dist-checksums.txt"
 
-          echo "== MEL checksum generation =="
-
-          # 1. Ensure clean dist (prevents stale artifacts)
-          echo "Cleaning dist directory..."
           rm -rf web/themes/custom/myeventlane_theme/dist
 
-          # 2. Rebuild (must already have run, but enforce consistency)
-          echo "Rebuilding theme..."
           cd web/themes/custom/myeventlane_theme
           npm run build
-          cd - > /dev/null
+          cd -
 
-          # 3. Validate asset directory exists
-          if [ ! -d "$ASSET_DIR" ]; then
-            echo "ERROR: Asset directory missing: $ASSET_DIR"
-            exit 1
-          fi
+          [ -d "$ASSET_DIR" ] || { echo "Missing assets"; exit 1; }
 
-          # 4. Validate exactly ONE main CSS file
           CSS_FILES=$(ls $ASSET_DIR/main*.css 2>/dev/null || true)
-          CSS_COUNT=$(echo "$CSS_FILES" | wc -w | tr -d ' ')
+          [ "$(echo "$CSS_FILES" | wc -w)" -eq 1 ] || exit 1
 
-          if [ "$CSS_COUNT" -ne 1 ]; then
-            echo "ERROR: Expected exactly 1 main*.css file, found $CSS_COUNT"
-            ls -la $ASSET_DIR
-            exit 1
-          fi
-
-          echo "CSS OK: $CSS_FILES"
-
-          # 5. Validate JS assets exist
           JS_FILES=$(ls $ASSET_DIR/*.js 2>/dev/null || true)
-
-          if [ -z "$JS_FILES" ]; then
-            echo "ERROR: No JS assets found in $ASSET_DIR"
-            exit 1
-          fi
-
-          echo "JS OK:"
-          echo "$JS_FILES"
-
-          # 6. Ensure no unexpected file types (hard guard)
-          INVALID_FILES=$(find $ASSET_DIR -type f ! -name "*.css" ! -name "*.js" ! -name "*.map")
-
-          if [ -n "$INVALID_FILES" ]; then
-            echo "ERROR: Unexpected files in dist/assets:"
-            echo "$INVALID_FILES"
-            exit 1
-          fi
-
-          # 7. Generate checksum manifest (repo-root-relative paths)
-          echo "Generating checksum manifest..."
+          [ -n "$JS_FILES" ] || exit 1
 
           rm -f "$MANIFEST"
-
           shasum $ASSET_DIR/main*.css > "$MANIFEST"
           shasum $ASSET_DIR/*.js >> "$MANIFEST"
 
-          echo "Manifest created:"
-          cat "$MANIFEST"
-
-          # 8. Final sanity check
-          if [ ! -s "$MANIFEST" ]; then
-            echo "ERROR: Manifest file is empty"
-            exit 1
-          fi
-
-          echo "== MEL checksum generation complete =="
+          [ -s "$MANIFEST" ] || exit 1
 
       - name: Set artifact metadata
         id: meta
-        shell: bash
         run: echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Package release artifact
         id: package
-        shell: bash
         run: |
           set -euo pipefail
           archive_path="$RUNNER_TEMP/artifact.tar.gz"
+
           tar \
             --exclude='.git' \
-            --exclude='.git/*' \
             --exclude='.ddev' \
-            --exclude='.ddev/*' \
             --exclude='node_modules' \
-            --exclude='node_modules/*' \
             --exclude='*/node_modules' \
-            --exclude='*/node_modules/*' \
             --exclude='tests' \
-            --exclude='tests/*' \
             --exclude='*/tests' \
-            --exclude='*/tests/*' \
             --exclude='web/sites/*/files' \
-            --exclude='web/sites/*/files/*' \
             --exclude='web/sites/*/private' \
-            --exclude='web/sites/*/private/*' \
             --exclude='web/sites/*/settings.php' \
             --exclude='web/sites/*/settings.local.php' \
             --exclude='web/sites/*/services.yml' \
             -czf "$archive_path" .
+
           echo "artifact_path=$archive_path" >> "$GITHUB_OUTPUT"
+
+      - name: Validate artifact contains NEW code
+        run: |
+          tar -tzf ${{ steps.package.outputs.artifact_path }} | grep "myeventlane_core/src/Commands/MelCoreCommands.php" || {
+            echo "❌ Artifact missing NEW code"
+            exit 1
+          }
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CI build/deploy artifact creation path and can block deployments if the new ref/validation logic is misconfigured or the sentinel file path changes.
> 
> **Overview**
> The reusable GitHub Actions build workflow now accepts an optional `ref` input and explicitly checks out that ref (falling back to `github.ref`), with an added debug step to print the built commit.
> 
> It simplifies the theme checksum generation script while keeping key guards, and adds a post-package validation step that inspects the tarball to ensure expected new code is present before uploading the artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f14f4ee6edf6f63a3ad48e82214fbab8fb69066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->