### PR TITLE
refactor(admin_dashboard): update permissions and routing for Orders …

### DIFF
--- a/config/sync/views.view.vendor_orders.yml
+++ b/config/sync/views.view.vendor_orders.yml
@@ -548,7 +548,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer myeventlane messaging'
+          perm: 'access myeventlane platform control centre'
       cache:
         type: tag
         options: {  }

--- a/web/modules/custom/myeventlane_admin_dashboard/config/install/views.view.vendor_orders.yml
+++ b/web/modules/custom/myeventlane_admin_dashboard/config/install/views.view.vendor_orders.yml
@@ -548,7 +548,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer myeventlane messaging'
+          perm: 'access myeventlane platform control centre'
       cache:
         type: tag
         options: {  }

--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.module
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.module
@@ -259,7 +259,7 @@ function myeventlane_admin_dashboard_menu_local_tasks_alter(array &$data, string
   $tab_permissions = [
     'myeventlane_admin_dashboard.financials_tab' => 'view myeventlane financials',
     'myeventlane_admin_dashboard.vendors_tab' => 'view myeventlane vendors',
-    'myeventlane_admin_dashboard.orders_tab' => 'administer myeventlane messaging',
+    'myeventlane_admin_dashboard.orders_tab' => 'access myeventlane platform control centre',
     'myeventlane_admin_dashboard.escalations_tab' => 'view myeventlane escalations',
     'myeventlane_admin_dashboard.payouts_tab' => 'view myeventlane payouts',
     'myeventlane_admin_dashboard.reports_tab' => 'view myeventlane reports',

--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.routing.yml
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.routing.yml
@@ -66,7 +66,7 @@ myeventlane_admin_dashboard.orders:
     _controller: '\Drupal\myeventlane_admin_dashboard\Controller\OrdersController::build'
     _title: 'Orders'
   requirements:
-    _permission: 'administer myeventlane messaging'
+    _permission: 'access myeventlane platform control centre'
   options:
     _admin_route: TRUE
     _menu_base_route: myeventlane_admin_dashboard.platform_control

--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml
@@ -160,4 +160,4 @@ services:
   myeventlane_admin_dashboard.route_subscriber:
     class: Drupal\myeventlane_admin_dashboard\Routing\RouteSubscriber
     tags:
-      - { name: event_subscriber, priority: -20 }
+      - { name: event_subscriber }

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/OrdersController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/OrdersController.php
@@ -74,7 +74,7 @@ final class OrdersController extends ControllerBase {
       );
     }
 
-    $build = $executable->executeDisplay();
+    $build = $executable->executeDisplay('admin_orders');
     return $this->adminShellBuilder->wrapStandard(
       $build,
       $this->t('Orders'),

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Routing/RouteSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_admin_dashboard\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -15,6 +16,14 @@ use Symfony\Component\Routing\RouteCollection;
  * so myeventlane_admin_dashboard.reports can use /admin/myeventlane/reports.
  */
 final class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -20];
+    return $events;
+  }
 
   /**
    * Reporting routes that should allow PCC users (not only "view admin reports").
@@ -80,7 +89,7 @@ final class RouteSubscriber extends RouteSubscriberBase {
           '_title' => 'Orders',
         ],
         [
-          '_permission' => 'administer myeventlane messaging',
+          '_permission' => 'access myeventlane platform control centre',
         ]
       );
       $ordersRoute->setOption('_admin_route', TRUE);

--- a/web/modules/custom/myeventlane_messaging/src/Controller/ResendOrderEmailController.php
+++ b/web/modules/custom/myeventlane_messaging/src/Controller/ResendOrderEmailController.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_messaging\Controller;
 
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\myeventlane_messaging\Service\OrderConfirmationQueueBuilder;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Queues a duplicate order_confirmation (resend) for staff or event vendors.
@@ -18,6 +22,8 @@ final class ResendOrderEmailController extends ControllerBase {
 
   public function __construct(
     private readonly OrderConfirmationQueueBuilder $orderConfirmationQueue,
+    private readonly RequestStack $requestStack,
+    private readonly AccessManagerInterface $accessManager,
   ) {}
 
   /**
@@ -26,6 +32,8 @@ final class ResendOrderEmailController extends ControllerBase {
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('myeventlane_messaging.order_confirmation_queue'),
+      $container->get('request_stack'),
+      $container->get('access_manager'),
     );
   }
 
@@ -40,7 +48,7 @@ final class ResendOrderEmailController extends ControllerBase {
     }
     if (!$mail || trim($mail) === '') {
       $this->messenger()->addError($this->t('This order has no recipient email address.'));
-      return $this->redirectToOrder($commerce_order);
+      return $this->redirectAfterResend($commerce_order);
     }
 
     $messageId = $this->orderConfirmationQueue->queue($commerce_order, trim($mail), TRUE);
@@ -51,14 +59,70 @@ final class ResendOrderEmailController extends ControllerBase {
       $this->messenger()->addError($this->t('The confirmation email could not be queued. Please try again or contact support if the problem continues.'));
     }
 
-    return $this->redirectToOrder($commerce_order);
+    return $this->redirectAfterResend($commerce_order);
   }
 
-  private function redirectToOrder(OrderInterface $order): RedirectResponse {
-    $url = Url::fromRoute('entity.commerce_order.canonical', [
-      'commerce_order' => $order->id(),
+  private function redirectAfterResend(OrderInterface $order): RedirectResponse {
+    $request = $this->requestStack->getCurrentRequest();
+    $destination = $request?->query->get('destination');
+    if (is_string($destination) && $destination !== '' && !UrlHelper::isExternal($destination)) {
+      try {
+        $url = Url::fromUserInput($destination);
+        return new RedirectResponse($url->setAbsolute()->toString());
+      }
+      catch (\InvalidArgumentException $e) {
+        $this->getLogger('myeventlane_messaging')->warning('Invalid destination query on resend confirmation: @msg', [
+          '@msg' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    if ($this->accessManager->checkNamedRoute('entity.commerce_order.canonical', ['commerce_order' => $order->id()], $this->currentUser())) {
+      $url = Url::fromRoute('entity.commerce_order.canonical', [
+        'commerce_order' => $order->id(),
+      ]);
+      return new RedirectResponse($url->setAbsolute()->toString());
+    }
+
+    $eventId = $this->getFirstEventIdFromOrder($order);
+    if ($eventId !== NULL) {
+      $url = Url::fromRoute('myeventlane_vendor.console.event_orders', [
+        'event' => $eventId,
+      ]);
+      return new RedirectResponse($url->setAbsolute()->toString());
+    }
+
+    if ($this->currentUser()->hasPermission('access myeventlane platform control centre')) {
+      $url = Url::fromRoute('myeventlane_admin_dashboard.orders');
+      return new RedirectResponse($url->setAbsolute()->toString());
+    }
+
+    $this->getLogger('myeventlane_messaging')->warning('Resend confirmation: no safe redirect target for order @id.', [
+      '@id' => (string) $order->id(),
     ]);
-    return new RedirectResponse($url->setAbsolute()->toString());
+
+    return new RedirectResponse(Url::fromRoute('<front>')->setAbsolute()->toString());
+  }
+
+  /**
+   * @return int|null
+   *   First event node ID from ticket lines, or NULL if none.
+   */
+  private function getFirstEventIdFromOrder(OrderInterface $order): ?int {
+    foreach ($order->getItems() as $item) {
+      $bundle = $item->bundle();
+      if (in_array($bundle, ['checkout_donation', 'platform_donation', 'rsvp_donation', 'boost'], TRUE)) {
+        continue;
+      }
+      if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+        $event = $item->get('field_target_event')->entity;
+        if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+          return (int) $event->id();
+        }
+      }
+    }
+
+    return NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
@@ -502,7 +502,14 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
       '#title' => $this->t('Resend email'),
       '#url' => Url::fromRoute(
         'myeventlane_messaging.resend_order_confirmation',
-        ['commerce_order' => $order->id()]
+        ['commerce_order' => $order->id()],
+        [
+          'query' => [
+            'destination' => Url::fromRoute('myeventlane_vendor.console.event_orders', [
+              'event' => $eventId,
+            ])->toString(),
+          ],
+        ]
       ),
       '#attributes' => [
         'class' => ['mel-link', 'mel-link--action'],


### PR DESCRIPTION
…functionality

- Replaced the 'administer myeventlane messaging' permission with 'access myeventlane platform control centre' across various configurations and routes.
- Adjusted the OrdersController to ensure proper display execution and redirection after email resends.
- Enhanced the RouteSubscriber to manage route alterations effectively, ensuring consistent access control for the Orders tab in the admin dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route/view access permissions and route subscriber behavior for the Orders tab, which can impact who can view orders and which route wins at `/admin/myeventlane/orders`. Adds more complex post-action redirect logic for resend-confirmation, which could misroute users if destinations or access checks are wrong.
> 
> **Overview**
> **Orders access control is re-aligned to PCC:** the `vendor_orders` view and the `myeventlane_admin_dashboard.orders` route/tab now require `access myeventlane platform control centre` instead of `administer myeventlane messaging`.
> 
> **Orders routing is hardened:** `OrdersController` explicitly executes the `admin_orders` display, and `RouteSubscriber` now subscribes with a fixed `ALTER` priority and ensures the module-owned `/admin/myeventlane/orders` route wins (removing `view.vendor_orders.admin_orders` and re-adding the module route if missing).
> 
> **Resend confirmation UX is improved:** `ResendOrderEmailController` now redirects to a safe `destination` when provided, otherwise falls back based on access (order canonical, vendor event orders, PCC orders, then front), and vendor “Resend email” links now include a destination back to the vendor event orders page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8440924658dece1756a893f66ec2237897779e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->