### PR TITLE
feat(admin_dashboard): improve route handling for local tasks and men…

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.module
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Template\Attribute;
 use Drupal\node\NodeInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Returns TRUE when the route should show Platform Control Centre chrome.
@@ -234,6 +235,62 @@ function myeventlane_admin_dashboard_theme(): array {
       'template' => 'platform-control-centre--pro-kpis',
     ],
   ];
+}
+
+/**
+ * Implements hook_local_tasks_alter().
+ *
+ * Drops PCC tabs whose routes are missing from the route collection (stale
+ * deploy or cache) so LocalTaskManager::getTasksBuild() does not fatal when
+ * building the admin toolbar / secondary tabs.
+ */
+function myeventlane_admin_dashboard_local_tasks_alter(array &$local_tasks): void {
+  $route_tasks = [
+    'myeventlane_admin_dashboard.orders_tab' => 'myeventlane_admin_dashboard.orders',
+  ];
+  $route_provider = \Drupal::service('router.route_provider');
+  foreach ($route_tasks as $task_id => $route_name) {
+    if (!isset($local_tasks[$task_id])) {
+      continue;
+    }
+    try {
+      $route_provider->getRouteByName($route_name);
+    }
+    catch (RouteNotFoundException $e) {
+      unset($local_tasks[$task_id]);
+      \Drupal::logger('myeventlane_admin_dashboard')->warning(
+        'Local task @task references missing route @route; tab removed. Rebuild caches (drush cr) after deploy.',
+        ['@task' => $task_id, '@route' => $route_name]
+      );
+    }
+  }
+}
+
+/**
+ * Implements hook_menu_links_discovered_alter().
+ *
+ * Same guard as hook_local_tasks_alter() for static menu links under PCC.
+ */
+function myeventlane_admin_dashboard_menu_links_discovered_alter(array &$links): void {
+  $route_links = [
+    'myeventlane_admin_dashboard.orders_menu' => 'myeventlane_admin_dashboard.orders',
+  ];
+  $route_provider = \Drupal::service('router.route_provider');
+  foreach ($route_links as $link_id => $route_name) {
+    if (!isset($links[$link_id])) {
+      continue;
+    }
+    try {
+      $route_provider->getRouteByName($route_name);
+    }
+    catch (RouteNotFoundException $e) {
+      unset($links[$link_id]);
+      \Drupal::logger('myeventlane_admin_dashboard')->warning(
+        'Menu link @link references missing route @route; link removed. Rebuild caches (drush cr) after deploy.',
+        ['@link' => $link_id, '@route' => $route_name]
+      );
+    }
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Routing/RouteSubscriber.php
@@ -21,6 +21,7 @@ final class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
+    $events = [];
     $events[RoutingEvents::ALTER] = ['onAlterRoutes', -20];
     return $events;
   }

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -196,7 +196,7 @@ services:
       - '@entity_type.manager'
       - '@date.formatter'
       - '@myeventlane_vendor.service.event_tabs'
-      - '@router.route_provider'
+      - '@myeventlane_core.route_helper'
       - '@logger.channel.myeventlane_vendor'
       - '@?myeventlane_refunds.processor'
     tags:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
@@ -7,17 +7,16 @@ namespace Drupal\myeventlane_vendor\Controller;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_core\Service\RouteHelper;
 use Drupal\myeventlane_refunds\Service\RefundProcessor;
 use Drupal\myeventlane_vendor\Service\VendorEventTabsService;
 use Drupal\node\NodeInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Event orders controller for vendor console.
@@ -64,8 +63,8 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
    *   The entity type manager.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter
    *   The date formatter.
-   * @param \Drupal\Core\Routing\RouteProviderInterface $routeProvider
-   *   The route provider.
+   * @param \Drupal\myeventlane_core\Service\RouteHelper $routeHelper
+   *   Route helper for existence checks.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
    */
@@ -76,7 +75,7 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly DateFormatterInterface $dateFormatter,
     private readonly VendorEventTabsService $eventTabsService,
-    private readonly RouteProviderInterface $routeProvider,
+    private readonly RouteHelper $routeHelper,
     private readonly LoggerInterface $logger,
     private readonly ?RefundProcessor $refundProcessor = NULL,
   ) {
@@ -589,17 +588,14 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
     if ($this->resendOrderRouteRegistered !== NULL) {
       return $this->resendOrderRouteRegistered;
     }
-    try {
-      $this->routeProvider->getRouteByName(self::ROUTE_RESEND_ORDER_CONFIRMATION);
-      $this->resendOrderRouteRegistered = TRUE;
-    }
-    catch (RouteNotFoundException $e) {
+    $exists = $this->routeHelper->routeExists(self::ROUTE_RESEND_ORDER_CONFIRMATION);
+    $this->resendOrderRouteRegistered = $exists;
+    if (!$exists) {
       $this->logger->warning('Route @route is not registered; resend confirmation links are omitted. Clear caches and ensure myeventlane_messaging is installed and up to date.', [
         '@route' => self::ROUTE_RESEND_ORDER_CONFIRMATION,
       ]);
-      $this->resendOrderRouteRegistered = FALSE;
     }
-    return $this->resendOrderRouteRegistered;
+    return $exists;
   }
 
   /**


### PR DESCRIPTION
…u links

- Added functionality to drop stale local tasks and menu links referencing missing routes, preventing fatal errors in the admin toolbar.
- Implemented logging to warn about removed tasks and links, guiding users to rebuild caches after deployment.
- Enhanced the RouteSubscriber to ensure proper route alterations for better management of admin dashboard navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Drupal routing and admin navigation (local tasks/menu links), so misconfiguration could hide tabs/links or alter admin paths. Changes are defensive but should be validated across deployments/cached router rebuild scenarios.
> 
> **Overview**
> Prevents admin UI fatals from stale deploys/caches by **removing local tasks and discovered menu links** that reference missing PCC routes, with warning logs prompting a cache rebuild.
> 
> Tightens PCC routing behavior by **removing the `view.vendor_orders.admin_orders` route**, and ensuring `myeventlane_admin_dashboard.orders` exists by registering a fallback route when absent; also minor cleanup in `RouteSubscriber::getSubscribedEvents()`.
> 
> Refactors vendor orders to use `myeventlane_core`’s `RouteHelper::routeExists()` (instead of direct route provider try/catch) when deciding whether to show resend-confirmation links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13f4d861f434c0efa6985c06ec7296197d1e31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->