### PR TITLE
Feature  pdf ticket attachments + resend email functionality

### DIFF
--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -97,13 +97,26 @@ body_html: |
         </div>
       </div>
 
-      <div style="text-align: center; margin: 24px 0 12px;">
-        {% if order_url %}
-          <a href="{{ order_url }}" style="display: inline-block; background-color: #ff6b9d; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; font-size: 16px; margin: 4px;">
-            View your tickets
-          </a>
+      <div style="margin: 28px 0; padding: 22px; background-color: #eef7ff; border-radius: 8px; border: 1px solid #cce5ff;">
+        <p style="color: #1a3a52; font-size: 15px; line-height: 1.55; margin: 0 0 10px 0; text-align: center;">
+          Your tickets are attached when available.
+        </p>
+        <p style="color: #34495e; font-size: 14px; line-height: 1.5; margin: 0 0 18px 0; text-align: center;">
+          You can always access your tickets from your order page.
+        </p>
+        <div style="text-align: center;">
+          {% set download_href = tickets_url|default(order_url) %}
+          {% if download_href %}
+            <a href="{{ download_href }}" style="display: inline-block; background-color: #2563eb; color: #ffffff; text-decoration: none; padding: 14px 28px; border-radius: 6px; font-weight: 700; font-size: 17px; margin: 4px;">
+              Download your tickets
+            </a>
+          {% endif %}
+        </div>
+        {% if order_url and download_href and download_href != order_url %}
+          <p style="text-align: center; margin: 14px 0 0;"><a href="{{ order_url }}" style="color: #34495e; font-size: 14px;">View order details</a></p>
         {% endif %}
       </div>
+
       <div style="text-align: center; margin: 12px 0 30px;">
         <p style="color: #34495e; font-size: 14px; margin: 0 0 8px 0;"><strong>Add to calendar:</strong> open the attached .ics file, or save it and import into your calendar app.</p>
       </div>

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -98,8 +98,11 @@ body_html: |
       </div>
 
       <div style="margin: 28px 0; padding: 22px; background-color: #eef7ff; border-radius: 8px; border: 1px solid #cce5ff;">
-        <p style="color: #1a3a52; font-size: 16px; line-height: 1.55; margin: 0 0 16px 0; text-align: center;">
-          <strong>Your tickets</strong> — PDFs may be attached when they are ready. You can always open your order online and download tickets; no attachment is required.
+        <p style="color: #1a3a52; font-size: 15px; line-height: 1.55; margin: 0 0 10px 0; text-align: center;">
+          Your tickets are attached when available.
+        </p>
+        <p style="color: #34495e; font-size: 14px; line-height: 1.5; margin: 0 0 18px 0; text-align: center;">
+          You can always access your tickets from your order page.
         </p>
         <div style="text-align: center;">
           {% set download_href = tickets_url|default(order_url) %}

--- a/web/modules/custom/myeventlane_messaging/src/Controller/ResendOrderEmailController.php
+++ b/web/modules/custom/myeventlane_messaging/src/Controller/ResendOrderEmailController.php
@@ -53,10 +53,10 @@ final class ResendOrderEmailController extends ControllerBase {
 
     $messageId = $this->orderConfirmationQueue->queue($commerce_order, trim($mail), TRUE);
     if ($messageId) {
-      $this->messenger()->addStatus($this->t('Confirmation email resent.'));
+      $this->messenger()->addStatus($this->t('Confirmation email resent successfully.'));
     }
     else {
-      $this->messenger()->addError($this->t('The confirmation email could not be queued. Please try again or contact support if the problem continues.'));
+      $this->messenger()->addError($this->t('The confirmation email could not be queued. Please try again in a moment, or contact support if this keeps happening.'));
     }
 
     return $this->redirectAfterResend($commerce_order);

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrdersController.php
@@ -450,8 +450,8 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
    *
    * @return array
    *   Row with order_id, order_number, placed_date, purchaser_name,
-   *   purchaser_email, ticket_count, net_sales, fees, total, status, view_link,
-   *   resend_link.
+   *   purchaser_email, ticket_count, net_sales, fees, total, status, view_link
+   *   (render array), resend_link (render array or NULL).
    */
   private function buildOrderRow(
     OrderInterface $order,
@@ -508,11 +508,15 @@ final class VendorEventOrdersController extends VendorConsoleBaseController {
     $orderNumber = $order->getOrderNumber() ?: '#' . $order->id();
 
     $viewLink = [
-      'url' => Url::fromRoute('myeventlane_vendor.console.event_order_view', [
+      '#type' => 'link',
+      '#title' => $this->t('View'),
+      '#url' => Url::fromRoute('myeventlane_vendor.console.event_order_view', [
         'event' => $eventId,
         'order' => $order->id(),
-      ])->toString(),
-      'label' => $this->t('View'),
+      ]),
+      '#attributes' => [
+        'class' => ['mel-link', 'mel-link--action'],
+      ],
     ];
 
     $resendLink = NULL;

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -248,7 +248,7 @@
             <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
                class="mel-confirmation-button mel-confirmation-button--primary">
               {% if mel_confirm_paid %}
-                {{ 'View / download tickets'|t }}
+                {{ 'Download tickets'|t }}
               {% else %}
                 {{ 'View your RSVP'|t }}
               {% endif %}
@@ -272,21 +272,27 @@
         {% endif %}
       </div>
 
-      <div class="mel-confirmation-access">
-        {% if mel_confirmation_has_tickets %}
-          {% if mel_logged_in and order_entity.getCustomerId() %}
-            <p>{{ 'Your tickets are saved in your account.'|t }}</p>
-          {% else %}
-            <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
+      {% if (mel_confirmation_has_tickets and mel_logged_in and order_entity.getCustomerId()) or mel_donation_total_formatted %}
+        <div class="mel-confirmation-access">
+          {% if mel_confirmation_has_tickets and mel_logged_in and order_entity.getCustomerId() %}
+            <p>{{ 'Your tickets stay in your account — use the button above anytime to download.'|t }}</p>
+          {% elseif mel_donation_total_formatted %}
+            <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
           {% endif %}
-        {% elseif mel_donation_total_formatted %}
-          <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
-        {% endif %}
-      </div>
+        </div>
+      {% endif %}
+
+      {% if mel_event_url and events|length > 0 %}
+        <div class="mel-confirmation-actions__secondary">
+          <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
+            {{ 'View event'|t }}
+          </a>
+        </div>
+      {% endif %}
 
       {% if mel_calendar_links|length > 0 %}
         <div class="mel-confirmation-calendar">
-          <h3 class="mel-confirmation-calendar__title">{{ 'Add to your calendar'|t }}</h3>
+          <h3 class="mel-confirmation-calendar__title">{{ 'Add to calendar'|t }}</h3>
           <div class="mel-calendar-actions">
             {% if mel_calendar_links.apple is defined and mel_calendar_links.apple %}
               <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Apple Calendar'|t }}</a>
@@ -301,17 +307,9 @@
         </div>
       {% endif %}
 
-      {% if mel_event_url and events|length > 0 %}
-        <div class="mel-confirmation-actions__secondary">
-          <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
-            {{ 'View event page'|t }}
-          </a>
-        </div>
-      {% endif %}
-
       {% if mel_event_url %}
         <section class="mel-confirmation-share">
-          <h3 class="mel-confirmation-share__title">{{ 'Share this event'|t }}</h3>
+          <h3 class="mel-confirmation-share__title">{{ 'Share'|t }}</h3>
           <div class="mel-share-actions">
             <button type="button" class="mel-share-copy" data-url="{{ mel_event_url }}">{{ 'Copy event link'|t }}</button>
           </div>
@@ -326,16 +324,14 @@
       <section class="mel-confirmation-next">
         <h2 class="mel-confirmation-next__title">{{ 'What happens next'|t }}</h2>
         <ul class="mel-confirmation-next__list">
-          {% if mel_confirmation_has_tickets %}
-            <li class="mel-confirmation-next__item">{{ 'Your tickets are ready now.'|t }}</li>
-          {% elseif mel_donation_total_formatted %}
+          {% if mel_donation_total_formatted %}
             <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
-          {% else %}
+          {% elseif not mel_confirmation_has_tickets %}
             <li class="mel-confirmation-next__item">{{ 'Your order is complete.'|t }}</li>
           {% endif %}
           <li class="mel-confirmation-next__item">{{ 'Save the date — add to your calendar above if you have not already.'|t }}</li>
-          {% if order_entity.getCustomerId() %}
-            <li class="mel-confirmation-next__item">{{ 'You can come back to your tickets anytime from My Account.'|t }}</li>
+          {% if order_entity.getCustomerId() and mel_confirmation_has_tickets %}
+            <li class="mel-confirmation-next__item">{{ 'You can return to this order anytime from My Account.'|t }}</li>
           {% endif %}
         </ul>
       </section>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -272,11 +272,16 @@
         {% endif %}
       </div>
 
-      {% if (mel_confirmation_has_tickets and mel_logged_in and order_entity.getCustomerId()) or mel_donation_total_formatted %}
+      {% if mel_confirmation_has_tickets or mel_donation_total_formatted %}
         <div class="mel-confirmation-access">
-          {% if mel_confirmation_has_tickets and mel_logged_in and order_entity.getCustomerId() %}
-            <p>{{ 'Your tickets stay in your account — use the button above anytime to download.'|t }}</p>
-          {% elseif mel_donation_total_formatted %}
+          {% if mel_confirmation_has_tickets %}
+            {% if mel_logged_in and order_entity.getCustomerId() %}
+              <p>{{ 'Your tickets stay in your account — use the button above anytime to download.'|t }}</p>
+            {% else %}
+              <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
+            {% endif %}
+          {% endif %}
+          {% if mel_donation_total_formatted %}
             <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
           {% endif %}
         </div>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -326,7 +326,13 @@
         <ul class="mel-confirmation-next__list">
           {% if mel_donation_total_formatted %}
             <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
-          {% elseif not mel_confirmation_has_tickets %}
+          {% elseif mel_confirmation_has_tickets %}
+            {% if mel_logged_in and order_entity.getCustomerId() %}
+              <li class="mel-confirmation-next__item">{{ 'Your tickets are confirmed for this order.'|t }}</li>
+            {% else %}
+              <li class="mel-confirmation-next__item">{{ 'Your tickets are in the email we sent. Keep your order number (#@number) handy.'|t({'@number': order_entity.getOrderNumber()}) }}</li>
+            {% endif %}
+          {% else %}
             <li class="mel-confirmation-next__item">{{ 'Your order is complete.'|t }}</li>
           {% endif %}
           <li class="mel-confirmation-next__item">{{ 'Save the date — add to your calendar above if you have not already.'|t }}</li>

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_inline-actions.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_inline-actions.scss
@@ -18,7 +18,8 @@
 .mel-inline-actions {
   display: flex;
   align-items: center;
-  gap: $spacing-1;
+  flex-wrap: wrap;
+  gap: $spacing-2;
 }
 
 .mel-inline-actions__btn {

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/orders.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/orders.html.twig
@@ -66,7 +66,7 @@
               {% endif %}
             </div>
             <div data-label="{{ 'Actions'|t }}" class="mel-inline-actions">
-              <a href="{{ row.view_link.url }}" class="mel-link">{{ row.view_link.label }}</a>
+              {{ row.view_link }}
               {{ row.resend_link }}
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to email/checkout/vendor UI copy and link rendering, with no changes to payment/auth/data models. Main risk is minor regressions in template rendering or link styling/availability.
> 
> **Overview**
> Improves the order confirmation email template CTA by prioritizing a `Download your tickets` button (preferring `tickets_url` over `order_url`) and optionally showing a secondary `View order details` link.
> 
> Refines copy and conditional messaging on the checkout completion page (tickets vs donation vs guest), adds a `View event` secondary action, and updates headings/buttons for clarity.
> 
> Updates vendor order list actions to render `view_link` as a styled link render array (matching `resend_link`), adjusts inline action layout to wrap with larger spacing, and tweaks resend confirmation success/error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f18763882a0459f80bd3c9c9212ffa32f813741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->