### PR TITLE
Feature  pdf ticket attachments + resend email functionality

### DIFF
--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
@@ -5,6 +5,7 @@
  *
  * Variables:
  * - display_name: User display name for greeting.
+ * - logo_url: URL to MEL logo for header.
  * - avatar_url: URL to user picture (empty if none).
  * - avatar_initials: Fallback initials for avatar.
  * - upcoming_tickets: Array of upcoming ticket event data (max 3).
@@ -36,8 +37,15 @@
 
     {# Main content #}
     <main class="mel-my-account__main">
-      {# Welcome + avatar (global site_header already provides branding). #}
+      {# Header row: logo, welcome, avatar #}
       <header class="mel-my-account__header">
+        <a href="{{ path('<front>') }}" class="mel-my-account__logo" aria-label="{{ 'Home'|t }}">
+          {% if logo_url %}
+            <img src="{{ logo_url }}" alt="" width="32" height="32" />
+          {% else %}
+            <span class="mel-my-account__logo-text">MyEventLane</span>
+          {% endif %}
+        </a>
         <h1 class="mel-my-account__welcome">
           {{ 'Welcome, @name!'|t({'@name': display_name}) }}
         </h1>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -329,15 +329,17 @@
       <section class="mel-confirmation-next">
         <h2 class="mel-confirmation-next__title">{{ 'What happens next'|t }}</h2>
         <ul class="mel-confirmation-next__list">
-          {% if mel_donation_total_formatted %}
-            <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
-          {% elseif mel_confirmation_has_tickets %}
+          {% if mel_confirmation_has_tickets %}
             {% if mel_logged_in and order_entity.getCustomerId() %}
               <li class="mel-confirmation-next__item">{{ 'Your tickets are confirmed for this order.'|t }}</li>
             {% else %}
               <li class="mel-confirmation-next__item">{{ 'Your tickets are in the email we sent. Keep your order number (#@number) handy.'|t({'@number': order_entity.getOrderNumber()}) }}</li>
             {% endif %}
-          {% else %}
+          {% endif %}
+          {% if mel_donation_total_formatted %}
+            <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
+          {% endif %}
+          {% if not mel_confirmation_has_tickets and not mel_donation_total_formatted %}
             <li class="mel-confirmation-next__item">{{ 'Your order is complete.'|t }}</li>
           {% endif %}
           <li class="mel-confirmation-next__item">{{ 'Save the date — add to your calendar above if you have not already.'|t }}</li>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -247,11 +247,7 @@
           {% if order_entity.getCustomerId() %}
             <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
                class="mel-confirmation-button mel-confirmation-button--primary">
-              {% if mel_confirm_paid %}
-                {{ 'Download tickets'|t }}
-              {% else %}
-                {{ 'View your RSVP'|t }}
-              {% endif %}
+              {{ 'View / download tickets'|t }}
             </a>
           {% else %}
             <div class="mel-confirmation-actions__guest-note">
@@ -272,32 +268,22 @@
         {% endif %}
       </div>
 
-      {% if mel_confirmation_has_tickets or mel_donation_total_formatted %}
-        <div class="mel-confirmation-access">
-          {% if mel_confirmation_has_tickets %}
-            {% if mel_logged_in and order_entity.getCustomerId() %}
-              <p>{{ 'Your tickets stay in your account — use the button above anytime to download.'|t }}</p>
-            {% else %}
-              <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
-            {% endif %}
+      <div class="mel-confirmation-access">
+        {% if mel_confirmation_has_tickets %}
+          {% if mel_logged_in and order_entity.getCustomerId() %}
+            <p>{{ 'Your tickets are saved in your account.'|t }}</p>
+            <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-link">{{ 'View my tickets'|t }}</a>
+          {% else %}
+            <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
           {% endif %}
-          {% if mel_donation_total_formatted %}
-            <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
-          {% endif %}
-        </div>
-      {% endif %}
-
-      {% if mel_event_url and events|length > 0 %}
-        <div class="mel-confirmation-actions__secondary">
-          <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
-            {{ 'View event'|t }}
-          </a>
-        </div>
-      {% endif %}
+        {% elseif mel_donation_total_formatted %}
+          <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
+        {% endif %}
+      </div>
 
       {% if mel_calendar_links|length > 0 %}
         <div class="mel-confirmation-calendar">
-          <h3 class="mel-confirmation-calendar__title">{{ 'Add to calendar'|t }}</h3>
+          <h3 class="mel-confirmation-calendar__title">{{ 'Add to your calendar'|t }}</h3>
           <div class="mel-calendar-actions">
             {% if mel_calendar_links.apple is defined and mel_calendar_links.apple %}
               <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Apple Calendar'|t }}</a>
@@ -312,11 +298,20 @@
         </div>
       {% endif %}
 
+      {% if mel_event_url and events|length > 0 %}
+        <div class="mel-confirmation-actions__secondary">
+          <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
+            {{ 'View event page'|t }}
+          </a>
+        </div>
+      {% endif %}
+
       {% if mel_event_url %}
         <section class="mel-confirmation-share">
-          <h3 class="mel-confirmation-share__title">{{ 'Share'|t }}</h3>
+          <h3 class="mel-confirmation-share__title">{{ 'Share this event'|t }}</h3>
           <div class="mel-share-actions">
             <button type="button" class="mel-share-copy" data-url="{{ mel_event_url }}">{{ 'Copy event link'|t }}</button>
+            <a href="{{ mel_event_url }}" class="mel-share-view">{{ 'View event page'|t }}</a>
           </div>
         </section>
       {% endif %}
@@ -330,21 +325,16 @@
         <h2 class="mel-confirmation-next__title">{{ 'What happens next'|t }}</h2>
         <ul class="mel-confirmation-next__list">
           {% if mel_confirmation_has_tickets %}
-            {% if mel_logged_in and order_entity.getCustomerId() %}
-              <li class="mel-confirmation-next__item">{{ 'Your tickets are confirmed for this order.'|t }}</li>
-            {% else %}
-              <li class="mel-confirmation-next__item">{{ 'Your tickets are in the email we sent. Keep your order number (#@number) handy.'|t({'@number': order_entity.getOrderNumber()}) }}</li>
-            {% endif %}
-          {% endif %}
-          {% if mel_donation_total_formatted %}
+            <li class="mel-confirmation-next__item">{{ 'Your tickets are ready now.'|t }}</li>
+          {% elseif mel_donation_total_formatted %}
             <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
-          {% endif %}
-          {% if not mel_confirmation_has_tickets and not mel_donation_total_formatted %}
+          {% else %}
             <li class="mel-confirmation-next__item">{{ 'Your order is complete.'|t }}</li>
           {% endif %}
+          <li class="mel-confirmation-next__item">{{ 'We\'ve sent your confirmation details to your email.'|t }}</li>
           <li class="mel-confirmation-next__item">{{ 'Save the date — add to your calendar above if you have not already.'|t }}</li>
-          {% if order_entity.getCustomerId() and mel_confirmation_has_tickets %}
-            <li class="mel-confirmation-next__item">{{ 'You can return to this order anytime from My Account.'|t }}</li>
+          {% if order_entity.getCustomerId() %}
+            <li class="mel-confirmation-next__item">{{ 'You can come back to your tickets anytime from My Account.'|t }}</li>
           {% endif %}
         </ul>
       </section>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Template-only changes that adjust UI copy and links on the My Account dashboard and checkout completion page, with minimal logic impact. Main risk is missing/incorrect variables or routes causing broken links or rendering issues.
> 
> **Overview**
> **Improves post-checkout and account navigation UX via template updates.**
> 
> The My Account dashboard header now includes a home-linked MEL logo (new `logo_url` variable with text fallback) alongside the welcome message and avatar.
> 
> The checkout completion page copy and CTAs are simplified and clarified: the primary ticket action becomes `View / download tickets`, logged-in users get an explicit `View my tickets` link, headings/text are updated (calendar/share/event-page wording), and the “What happens next” section is reordered to emphasize ticket readiness and email confirmation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e74b48e29355367dcd2108628d010aa95328a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->