### PR TITLE
Feature  pdf ticket attachments + resend email functionality

### DIFF
--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -21,7 +21,7 @@ definitions:
     enabled: true
   myeventlane_rsvp__my_rsvps:
     weight: -50
-    parent: myeventlane_dashboard.my_events
+    parent: user.page
     menu_name: account
     expanded: false
     enabled: true
@@ -33,14 +33,14 @@ definitions:
     enabled: true
   myeventlane_core__my_categories:
     weight: -49
-    parent: myeventlane_dashboard.my_events
+    parent: user.page
     menu_name: account
     expanded: false
     enabled: true
   myeventlane_dashboard__my_events:
     parent: user.page
     menu_name: account
-    enabled: true
+    enabled: false
     expanded: false
     weight: -50
   myeventlane_rsvp__ics_bundle_link:

--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -150,7 +150,6 @@ function myeventlane_account_theme_suggestions_page_alter(array &$suggestions, a
  * Adds account sidebar variables for customer account pages.
  */
 function myeventlane_account_preprocess_page__account(array &$variables): void {
-  $route = \Drupal::routeMatch()->getRouteName();
   $account = \Drupal::currentUser();
 
   if ($account->isAnonymous()) {
@@ -158,15 +157,9 @@ function myeventlane_account_preprocess_page__account(array &$variables): void {
   }
 
   $account_links_service = \Drupal::service('myeventlane_account.account_links');
-  $active_map = [
-    'myeventlane_checkout_flow.my_tickets' => 'my_tickets',
-    'myeventlane_checkout_flow.order_detail' => 'my_tickets',
-    'myeventlane_dashboard.customer' => 'my_events',
-  ];
-  $active = $active_map[$route] ?? 'dashboard';
 
   $variables['account_show_sidebar'] = TRUE;
-  $variables['account_links'] = $account_links_service->buildLinks($active);
+  $variables['account_links'] = $account_links_service->buildLinks('dashboard');
   $variables['display_name'] = $account->getDisplayName();
 
   _myeventlane_account_add_header_vars($variables);

--- a/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
+++ b/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
@@ -144,7 +144,7 @@ final class MyAccountController extends ControllerBase {
 
     [, , $pastEvents] = $this->buildEventData($userId, $account->getEmail(), $now);
 
-    $accountLinks = $this->accountLinksService->buildLinks('past_events');
+    $accountLinks = $this->accountLinksService->buildLinks('dashboard');
 
     $cache = (new CacheableMetadata())
       ->addCacheContexts(['user', 'route'])

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -7,7 +7,6 @@ namespace Drupal\myeventlane_account\Service;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Builds account navigation links for the customer sidebar.
@@ -24,20 +23,11 @@ final class AccountLinksService {
   ) {}
 
   /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('module_handler')
-    );
-  }
-
-  /**
    * Builds account navigation links.
    *
    * @param string $active
-   *   Route key for the active link: 'dashboard', 'my_tickets', 'my_events',
-   *   'past_events'.
+   *   Active section: only "dashboard" is used (My Tickets / My Events / Past
+   *   Events are not shown in the sidebar; deep routes still mark Dashboard).
    *
    * @return array<int, array{title: \Drupal\Core\StringTranslation\TranslatableMarkup, url: string, active: bool}>
    *   Array of nav links with title, url, and active flag.
@@ -63,21 +53,6 @@ final class AccountLinksService {
         'title' => $this->t('Dashboard'),
         'url' => Url::fromRoute('myeventlane_account.dashboard')->toString(),
         'active' => $active === 'dashboard',
-      ],
-      [
-        'title' => $this->t('My Tickets'),
-        'url' => Url::fromRoute('myeventlane_checkout_flow.my_tickets')->toString(),
-        'active' => $active === 'my_tickets',
-      ],
-      [
-        'title' => $this->t('My Events'),
-        'url' => Url::fromRoute('myeventlane_dashboard.customer')->toString(),
-        'active' => $active === 'my_events',
-      ],
-      [
-        'title' => $this->t('Past Events'),
-        'url' => Url::fromRoute('myeventlane_account.past_events')->toString(),
-        'active' => $active === 'past_events',
       ],
       [
         'title' => $this->t('Profile & Settings'),

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
@@ -89,10 +89,10 @@
                     {% if event.ics_url %}
                       <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
                     {% endif %}
-                    {% if event.order_item_id %}
-                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
-                    {% elseif event.ticket_code %}
+                    {% if event.ticket_code %}
                       <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
                     {% endif %}
                     <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Tickets'|t }}</a>
                   </div>
@@ -141,10 +141,10 @@
                     {% if event.ics_url %}
                       <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
                     {% endif %}
-                    {% if event.order_item_id %}
-                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
-                    {% elseif event.ticket_code %}
+                    {% if event.ticket_code %}
                       <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
                     {% endif %}
                     <a href="{{ path('myeventlane_dashboard.customer') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Events'|t }}</a>
                   </div>
@@ -218,10 +218,10 @@
                   </div>
                   <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
                     <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
-                    {% if event.order_item_id %}
-                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
-                    {% elseif event.ticket_code %}
+                    {% if event.ticket_code %}
                       <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
                     {% endif %}
                     {% if show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
                       <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'Leave a review'|t }}</a>

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
@@ -84,12 +84,21 @@
                       <span class="mel-my-account__event-location">{{ event.location }}</span>
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions">
+                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
                     <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
                     {% if event.ics_url %}
                       <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
                     {% endif %}
+                    {% if event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.ticket_code %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% endif %}
+                    <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Tickets'|t }}</a>
                   </div>
+                  {% if event.ticket_code %}
+                    <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
+                  {% endif %}
                 </div>
               </article>
             {% endfor %}
@@ -127,12 +136,21 @@
                       <span class="mel-my-account__event-location">{{ event.location }}</span>
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions">
+                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
                     <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
                     {% if event.ics_url %}
                       <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
                     {% endif %}
+                    {% if event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.ticket_code %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                    {% endif %}
+                    <a href="{{ path('myeventlane_dashboard.customer') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Events'|t }}</a>
                   </div>
+                  {% if event.ticket_code %}
+                    <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
+                  {% endif %}
                 </div>
               </article>
             {% endfor %}
@@ -198,12 +216,21 @@
                       <span class="mel-my-account__event-location">{{ event.location }}</span>
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions">
+                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
                     <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
+                    {% if event.order_item_id %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
+                    {% elseif event.ticket_code %}
+                      <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
+                    {% endif %}
                     {% if show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
                       <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'Leave a review'|t }}</a>
                     {% endif %}
+                    <a href="{{ path('myeventlane_account.past_events') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'Past Events'|t }}</a>
                   </div>
+                  {% if event.ticket_code %}
+                    <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
+                  {% endif %}
                 </div>
               </article>
             {% endfor %}

--- a/web/modules/custom/myeventlane_dashboard/myeventlane_dashboard.links.menu.yml
+++ b/web/modules/custom/myeventlane_dashboard/myeventlane_dashboard.links.menu.yml
@@ -1,8 +1,0 @@
-# User account menu link for "My Events".
-myeventlane_dashboard.my_events:
-  title: 'Your Events'
-  description: 'View your RSVPs and purchased tickets'
-  route_name: myeventlane_dashboard.customer
-  menu_name: account
-  weight: 10
-

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
@@ -308,6 +308,20 @@
   align-items: center;
 }
 
+// Primary actions grouped on each card (calendar, PDF, account destinations).
+.mel-my-account__card-actions--onestop {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.mel-my-account__ticket-code {
+  font-size: typography.mel-font-size(xs);
+  font-family: ui-monospace, monospace;
+  color: colors.$mel-color-text-muted;
+  margin: spacing.mel-space(2) 0 0;
+  word-break: break-all;
+}
+
 // ---------------------------------------------------------------------------
 // Quick Actions
 // ---------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -60,19 +60,24 @@
   <header class="mel-confirmation__hero">
     <div class="mel-confirmation__hero-icon" aria-hidden="true">✓</div>
     <div class="mel-confirmation__hero-content">
-      {% if mel_confirmation_has_tickets %}
+      {# Donation before tickets: mixed orders use donation-led hero copy only (same as original). #}
+      {% if mel_donation_total_formatted %}
+        <h1 class="mel-confirmation__title">{{ 'Thank you'|t }}</h1>
+      {% elseif mel_confirmation_has_tickets %}
         {% if mel_confirm_paid %}
           <h1 class="mel-confirmation__title">{{ "You're booked"|t }}</h1>
         {% else %}
           <h1 class="mel-confirmation__title">{{ "You're registered"|t }}</h1>
         {% endif %}
-      {% elseif mel_donation_total_formatted %}
-        <h1 class="mel-confirmation__title">{{ 'Thank you'|t }}</h1>
       {% else %}
         <h1 class="mel-confirmation__title">{{ 'Order confirmed'|t }}</h1>
       {% endif %}
 
-      {% if mel_confirmation_has_tickets %}
+      {% if mel_donation_total_formatted %}
+        <p class="mel-confirmation__subtitle">
+          {{ 'We\'ve emailed your receipt to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
+        </p>
+      {% elseif mel_confirmation_has_tickets %}
         {% if mel_confirm_paid %}
           <p class="mel-confirmation__subtitle">
             {{ 'Your booking is confirmed. We\'ve emailed your confirmation and tickets to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
@@ -82,10 +87,6 @@
             {{ 'Your registration is confirmed. We\'ve emailed your confirmation to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
           </p>
         {% endif %}
-      {% elseif mel_donation_total_formatted %}
-        <p class="mel-confirmation__subtitle">
-          {{ 'We\'ve emailed your receipt to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
-        </p>
       {% else %}
         <p class="mel-confirmation__subtitle">
           {{ 'We\'ve emailed your confirmation to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
@@ -269,15 +270,16 @@
       </div>
 
       <div class="mel-confirmation-access">
-        {% if mel_confirmation_has_tickets %}
+        {# Donation before tickets: one access line for mixed orders (donation copy). #}
+        {% if mel_donation_total_formatted %}
+          <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
+        {% elseif mel_confirmation_has_tickets %}
           {% if mel_logged_in and order_entity.getCustomerId() %}
             <p>{{ 'Your tickets are saved in your account.'|t }}</p>
             <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-link">{{ 'View my tickets'|t }}</a>
           {% else %}
             <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
           {% endif %}
-        {% elseif mel_donation_total_formatted %}
-          <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
         {% endif %}
       </div>
 
@@ -324,10 +326,11 @@
       <section class="mel-confirmation-next">
         <h2 class="mel-confirmation-next__title">{{ 'What happens next'|t }}</h2>
         <ul class="mel-confirmation-next__list">
-          {% if mel_confirmation_has_tickets %}
-            <li class="mel-confirmation-next__item">{{ 'Your tickets are ready now.'|t }}</li>
-          {% elseif mel_donation_total_formatted %}
+          {# Donation before tickets: mixed orders show only the donation line here (original behaviour). #}
+          {% if mel_donation_total_formatted %}
             <li class="mel-confirmation-next__item">{{ 'Your donation is confirmed.'|t }}</li>
+          {% elseif mel_confirmation_has_tickets %}
+            <li class="mel-confirmation-next__item">{{ 'Your tickets are ready now.'|t }}</li>
           {% else %}
             <li class="mel-confirmation-next__item">{{ 'Your order is complete.'|t }}</li>
           {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/navigation changes: adjusts account menu links and sidebar contents, plus adds new dashboard CTAs for ticket PDF downloads. Main risk is broken routes/permissions for the new PDF links or unexpected menu visibility changes.
> 
> **Overview**
> Simplifies the My Account sidebar/navigation by disabling the separate `Your Events` account menu link, re-parenting account menu items under `user.page`, and making all account sidebar pages treat `Dashboard` as the active section (removing `My Tickets`/`My Events`/`Past Events` entries from the sidebar).
> 
> Enhances the My Account dashboard cards with one-stop actions, adding `View ticket PDF` (by `ticket_code` or `order_item_id`), contextual deep links back to `My Tickets`/`My Events`/`Past Events`, and displaying the ticket code; includes small SCSS additions for the new action layout.
> 
> Tweaks checkout completion copy so donation-led messaging takes precedence over ticket messaging for mixed donation+ticket orders (hero/subtitle/access/next sections).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090628e2de2c932855a99971da6cb3d149f567e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->