### PR TITLE
Feature  pdf ticket attachments + resend email functionality

### DIFF
--- a/config/sync/core.entity_form_display.node.faq.default.yml
+++ b/config/sync/core.entity_form_display.node.faq.default.yml
@@ -39,16 +39,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_help_audience:
-    type: entity_reference_autocomplete_tags
-    weight: 6
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_help_category:
     type: entity_reference_autocomplete
     weight: 5
@@ -104,5 +94,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_help_audience: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.help_article.default.yml
+++ b/config/sync/core.entity_form_display.node.help_article.default.yml
@@ -27,6 +27,7 @@ dependencies:
   module:
     - commerce
     - content_moderation
+    - options
     - path
     - text
 id: node.help_article.default
@@ -43,6 +44,12 @@ content:
       summary_rows: 3
       placeholder: ''
       show_summary: false
+    third_party_settings: {  }
+  field_audience:
+    type: options_buttons
+    weight: 0
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_help_article_type:
     type: entity_reference_autocomplete
@@ -123,7 +130,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 0
+    weight: -1
     region: content
     settings:
       size: 60
@@ -131,7 +138,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_audience: true
   field_content_owner: true
   field_featured_help: true
   field_help_ai_allowed: true

--- a/config/sync/core.entity_view_display.node.faq.default.yml
+++ b/config/sync/core.entity_view_display.node.faq.default.yml
@@ -31,14 +31,6 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
-  field_help_audience:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
   field_help_category:
     type: entity_reference_label
     label: above
@@ -53,5 +45,6 @@ content:
     weight: 100
     region: content
 hidden:
+  field_help_audience: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/search_api.index.mel_content.yml
+++ b/config/sync/search_api.index.mel_content.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.storage.node.field_event_start
     - field.storage.node.field_audience
     - field.storage.node.field_help_article_type
-    - field.storage.node.field_help_audience
     - field.storage.node.field_help_keywords
     - field.storage.node.field_help_summary
     - field.storage.node.field_help_topic
@@ -75,14 +74,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_help_article_type
-  field_help_audience:
-    label: 'Help audience'
-    datasource_id: 'entity:node'
-    property_path: field_help_audience
-    type: string
-    dependencies:
-      config:
-        - field.storage.node.field_help_audience
   field_help_keywords:
     label: 'Help keywords'
     datasource_id: 'entity:node'

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
@@ -62,44 +62,47 @@
       </header>
 
       {# Your Tickets (upcoming 1-3) #}
-      <section class="mel-my-account__section" aria-labelledby="your-tickets-title">
+      <section class="mel-my-account__section mel-dashboard__section" aria-labelledby="your-tickets-title">
         <h2 id="your-tickets-title" class="mel-my-account__section-title">{{ 'Your Tickets'|t }}</h2>
         {% if upcoming_tickets is not empty %}
           <div class="mel-my-account__cards">
             {% for event in upcoming_tickets %}
               <article class="mel-card mel-my-account__card">
-                <a href="{{ event.url }}" class="mel-card__link">
-                  <div class="mel-card__media{% if not event.image_url %} mel-card__media--placeholder{% endif %}" aria-hidden="true">
-                    {% if event.image_url %}
-                      <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__media--placeholder');" />
-                    {% endif %}
-                  </div>
-                </a>
+                <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
+                  {% if event.image_url %}
+                    <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
+                  {% endif %}
+                </div>
                 <div class="mel-card__body">
-                  <h3 class="mel-card__title">
-                    <a href="{{ event.url }}">{{ event.title }}</a>
-                  </h3>
-                  <div class="mel-my-account__event-meta">
+                  <h3 class="mel-card__title">{{ event.title }}</h3>
+                  <div class="mel-card__meta">
                     {% if event.start_date %}
-                      <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} {{ event.start_time }}{% endif %}</time>
+                      <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} {{ event.start_time }}{% endif %}</time><br>
                     {% endif %}
                     {% if event.location %}
-                      <span class="mel-my-account__event-location">{{ event.location }}</span>
+                      {{ event.location }}
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
-                    <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
-                    {% if event.ics_url %}
-                      <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
-                    {% endif %}
+                  <div class="mel-card__actions">
                     {% if event.pdf_available %}
                       {% if event.has_ticket_code %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% else %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% endif %}
+                    {% else %}
+                      <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View Event'|t }}</a>
                     {% endif %}
-                    <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Tickets'|t }}</a>
+                    {% if event.pdf_available or event.ics_url %}
+                      <div class="mel-card__links">
+                        {% if event.pdf_available %}
+                          <a href="{{ event.url }}">{{ 'View Event'|t }}</a>
+                        {% endif %}
+                        {% if event.ics_url %}
+                          <a href="{{ event.ics_url }}" download>{{ 'Add to Calendar'|t }}</a>
+                        {% endif %}
+                      </div>
+                    {% endif %}
                   </div>
                   {% if event.has_ticket_code %}
                     <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
@@ -116,44 +119,47 @@
       </section>
 
       {# Your RSVPs (upcoming 1-3) #}
-      <section class="mel-my-account__section" aria-labelledby="your-rsvps-title">
+      <section class="mel-my-account__section mel-dashboard__section" aria-labelledby="your-rsvps-title">
         <h2 id="your-rsvps-title" class="mel-my-account__section-title">{{ 'Your RSVPs'|t }}</h2>
         {% if upcoming_rsvps is not empty %}
           <div class="mel-my-account__cards">
             {% for event in upcoming_rsvps %}
               <article class="mel-card mel-my-account__card">
-                <a href="{{ event.url }}" class="mel-card__link">
-                  <div class="mel-card__media{% if not event.image_url %} mel-card__media--placeholder{% endif %}" aria-hidden="true">
-                    {% if event.image_url %}
-                      <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__media--placeholder');" />
-                    {% endif %}
-                  </div>
-                </a>
+                <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
+                  {% if event.image_url %}
+                    <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
+                  {% endif %}
+                </div>
                 <div class="mel-card__body">
-                  <h3 class="mel-card__title">
-                    <a href="{{ event.url }}">{{ event.title }}</a>
-                  </h3>
-                  <div class="mel-my-account__event-meta">
+                  <h3 class="mel-card__title">{{ event.title }}</h3>
+                  <div class="mel-card__meta">
                     {% if event.start_date %}
-                      <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} {{ event.start_time }}{% endif %}</time>
+                      <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} {{ event.start_time }}{% endif %}</time><br>
                     {% endif %}
                     {% if event.location %}
-                      <span class="mel-my-account__event-location">{{ event.location }}</span>
+                      {{ event.location }}
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
-                    <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
-                    {% if event.ics_url %}
-                      <a href="{{ event.ics_url }}" class="mel-btn mel-btn--sm mel-btn--link" download>{{ 'Add to Calendar'|t }}</a>
-                    {% endif %}
+                  <div class="mel-card__actions">
                     {% if event.pdf_available %}
                       {% if event.has_ticket_code %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% else %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% endif %}
+                    {% else %}
+                      <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View Event'|t }}</a>
                     {% endif %}
-                    <a href="{{ path('myeventlane_dashboard.customer') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'My Events'|t }}</a>
+                    {% if event.pdf_available or event.ics_url %}
+                      <div class="mel-card__links">
+                        {% if event.pdf_available %}
+                          <a href="{{ event.url }}">{{ 'View Event'|t }}</a>
+                        {% endif %}
+                        {% if event.ics_url %}
+                          <a href="{{ event.ics_url }}" download>{{ 'Add to Calendar'|t }}</a>
+                        {% endif %}
+                      </div>
+                    {% endif %}
                   </div>
                   {% if event.has_ticket_code %}
                     <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
@@ -198,44 +204,50 @@
       </section>
 
       {# Past events preview (last 3) #}
-      <section class="mel-my-account__section" aria-labelledby="past-events-title">
+      <section class="mel-my-account__section mel-dashboard__section" aria-labelledby="past-events-title">
         <h2 id="past-events-title" class="mel-my-account__section-title">{{ 'Past events'|t }}</h2>
         {% if past_events is not empty %}
           <div class="mel-my-account__cards">
             {% for event in past_events %}
+              {% set primary_review = show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
               <article class="mel-card mel-my-account__card mel-my-account__card--past">
-                <a href="{{ event.url }}" class="mel-card__link">
-                  <div class="mel-card__media{% if not event.image_url %} mel-card__media--placeholder{% endif %}" aria-hidden="true">
-                    {% if event.image_url %}
-                      <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__media--placeholder');" />
-                    {% endif %}
-                  </div>
-                </a>
+                <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
+                  {% if event.image_url %}
+                    <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
+                  {% endif %}
+                </div>
                 <div class="mel-card__body">
-                  <h3 class="mel-card__title">
-                    <a href="{{ event.url }}">{{ event.title }}</a>
-                  </h3>
-                  <div class="mel-my-account__event-meta">
+                  <h3 class="mel-card__title">{{ event.title }}</h3>
+                  <div class="mel-card__meta">
                     {% if event.start_date %}
-                      <time datetime="{{ event.start_date }}">{{ event.start_date }}</time>
+                      <time datetime="{{ event.start_date }}">{{ event.start_date }}</time><br>
                     {% endif %}
                     {% if event.location %}
-                      <span class="mel-my-account__event-location">{{ event.location }}</span>
+                      {{ event.location }}
                     {% endif %}
                   </div>
-                  <div class="mel-my-account__card-actions mel-my-account__card-actions--onestop">
-                    <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
-                    {% if event.pdf_available %}
+                  <div class="mel-card__actions">
+                    {% if primary_review %}
+                      <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-button mel-button--primary">{{ 'Leave a review'|t }}</a>
+                    {% elseif event.pdf_available %}
                       {% if event.has_ticket_code %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% else %}
-                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View ticket PDF'|t }}</a>
+                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
                       {% endif %}
+                    {% else %}
+                      <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View Event'|t }}</a>
                     {% endif %}
-                    {% if show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
-                      <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'Leave a review'|t }}</a>
+                    {% if primary_review or event.pdf_available or event.ics_url %}
+                      <div class="mel-card__links">
+                        {% if primary_review or event.pdf_available %}
+                          <a href="{{ event.url }}">{{ 'View Event'|t }}</a>
+                        {% endif %}
+                        {% if event.ics_url %}
+                          <a href="{{ event.ics_url }}" download>{{ 'Add to Calendar'|t }}</a>
+                        {% endif %}
+                      </div>
                     {% endif %}
-                    <a href="{{ path('myeventlane_account.past_events') }}" class="mel-btn mel-btn--sm mel-btn--link">{{ 'Past Events'|t }}</a>
                   </div>
                   {% if event.has_ticket_code %}
                     <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-past-events.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-past-events.html.twig
@@ -46,38 +46,57 @@
       </header>
 
       {% if past_events is not empty %}
-        <div class="mel-my-account__cards">
-          {% for event in past_events %}
-            <article class="mel-card mel-my-account__card mel-my-account__card--past">
-              <a href="{{ event.url }}" class="mel-card__link">
-                <div class="mel-card__media{% if not event.image_url %} mel-card__media--placeholder{% endif %}" aria-hidden="true">
+        <section class="mel-dashboard__section" aria-label="{{ 'Past events list'|t }}">
+          <div class="mel-my-account__cards">
+            {% for event in past_events %}
+              {% set primary_review = show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
+              <article class="mel-card mel-my-account__card mel-my-account__card--past">
+                <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
                   {% if event.image_url %}
-                    <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__media--placeholder');" />
+                    <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
                   {% endif %}
                 </div>
-              </a>
-              <div class="mel-card__body">
-                <h2 class="mel-card__title">
-                  <a href="{{ event.url }}">{{ event.title }}</a>
-                </h2>
-                <div class="mel-my-account__event-meta">
-                  {% if event.start_date %}
-                    <time datetime="{{ event.start_date }}">{{ event.start_date }}</time>
-                  {% endif %}
-                  {% if event.location %}
-                    <span class="mel-my-account__event-location">{{ event.location }}</span>
+                <div class="mel-card__body">
+                  <h2 class="mel-card__title">{{ event.title }}</h2>
+                  <div class="mel-card__meta">
+                    {% if event.start_date %}
+                      <time datetime="{{ event.start_date }}">{{ event.start_date }}</time><br>
+                    {% endif %}
+                    {% if event.location %}
+                      {{ event.location }}
+                    {% endif %}
+                  </div>
+                  <div class="mel-card__actions">
+                    {% if primary_review %}
+                      <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-button mel-button--primary">{{ 'Leave a review'|t }}</a>
+                    {% elseif event.pdf_available %}
+                      {% if event.has_ticket_code %}
+                        <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
+                      {% else %}
+                        <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
+                      {% endif %}
+                    {% else %}
+                      <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View Event'|t }}</a>
+                    {% endif %}
+                    {% if primary_review or event.pdf_available or event.ics_url %}
+                      <div class="mel-card__links">
+                        {% if primary_review or event.pdf_available %}
+                          <a href="{{ event.url }}">{{ 'View Event'|t }}</a>
+                        {% endif %}
+                        {% if event.ics_url %}
+                          <a href="{{ event.ics_url }}" download>{{ 'Add to Calendar'|t }}</a>
+                        {% endif %}
+                      </div>
+                    {% endif %}
+                  </div>
+                  {% if event.has_ticket_code %}
+                    <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
                   {% endif %}
                 </div>
-                <div class="mel-my-account__card-actions">
-                  <a href="{{ event.url }}" class="mel-btn mel-btn--sm mel-btn--secondary">{{ 'View Event'|t }}</a>
-                  {% if show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
-                    <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-btn mel-btn--sm mel-btn--primary">{{ 'Leave a review'|t }}</a>
-                  {% endif %}
-                </div>
-              </div>
-            </article>
-          {% endfor %}
-        </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
       {% else %}
         <p class="mel-my-account__empty">{{ "No past events yet — once you've attended something, it'll show up here."|t }}</p>
         <a href="{{ path('<front>') }}" class="mel-btn mel-btn--primary">{{ 'Browse events'|t }}</a>

--- a/web/modules/custom/myeventlane_help_assistant/tests/src/Kernel/HelpRetrieverKernelTest.php
+++ b/web/modules/custom/myeventlane_help_assistant/tests/src/Kernel/HelpRetrieverKernelTest.php
@@ -28,6 +28,7 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
     'field',
     'text',
     'node',
+    'options',
     'taxonomy',
     'path_alias',
     'myeventlane_help_assistant',
@@ -47,7 +48,7 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
     $this->installConfig(['myeventlane_help_assistant']);
 
     $this->createBundles();
-    $this->createTaxonomyFields();
+    $this->createFields();
     $this->seedHelpContent();
   }
 
@@ -82,16 +83,12 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
       'vid' => 'help_categories',
       'name' => 'Help Categories',
     ])->save();
-    Vocabulary::create([
-      'vid' => 'help_audience',
-      'name' => 'Help Audience',
-    ])->save();
   }
 
   /**
-   * Creates taxonomy reference fields used by retrieval scoring.
+   * Creates field_help_category and canonical field_audience for test bundles.
    */
-  private function createTaxonomyFields(): void {
+  private function createFields(): void {
     FieldStorageConfig::create([
       'field_name' => 'field_help_category',
       'entity_type' => 'node',
@@ -103,11 +100,15 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
     ])->save();
 
     FieldStorageConfig::create([
-      'field_name' => 'field_help_audience',
+      'field_name' => 'field_audience',
       'entity_type' => 'node',
-      'type' => 'entity_reference',
+      'type' => 'list_string',
       'settings' => [
-        'target_type' => 'taxonomy_term',
+        'allowed_values' => [
+          'public' => 'Public',
+          'vendor' => 'Vendor',
+          'staff' => 'Staff',
+        ],
       ],
       'cardinality' => -1,
     ])->save();
@@ -125,14 +126,11 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
       ])->save();
 
       FieldConfig::create([
-        'field_name' => 'field_help_audience',
+        'field_name' => 'field_audience',
         'entity_type' => 'node',
         'bundle' => $bundle,
-        'label' => 'Help audience',
-        'settings' => [
-          'handler' => 'default:taxonomy_term',
-          'handler_settings' => ['target_bundles' => ['help_audience' => 'help_audience']],
-        ],
+        'label' => 'Audience',
+        'required' => FALSE,
       ])->save();
     }
   }
@@ -147,12 +145,6 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
     ]);
     $refundCategory->save();
 
-    $publicAudience = Term::create([
-      'vid' => 'help_audience',
-      'name' => 'Public',
-    ]);
-    $publicAudience->save();
-
     Node::create([
       'type' => 'faq',
       'title' => 'How refund requests work',
@@ -162,7 +154,9 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
         'format' => 'plain_text',
       ],
       'field_help_category' => [$refundCategory->id()],
-      'field_help_audience' => [$publicAudience->id()],
+      'field_audience' => [
+        ['value' => 'public'],
+      ],
     ])->save();
 
     Node::create([
@@ -174,7 +168,9 @@ final class HelpRetrieverKernelTest extends KernelTestBase {
         'format' => 'plain_text',
       ],
       'field_help_category' => [$refundCategory->id()],
-      'field_help_audience' => [$publicAudience->id()],
+      'field_audience' => [
+        ['value' => 'public'],
+      ],
     ])->save();
   }
 

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
@@ -343,41 +343,27 @@ final class HelpContentSeeder {
       return;
     }
 
-    // Deprecated: taxonomy field_help_audience — kept in sync for backward
-    // compatibility; canonical audience is field_audience (list: public,
-    // vendor, staff).
-    if ($node->hasField('field_help_audience')) {
-      $values = [];
-      foreach ($names as $name) {
-        $term = $this->loadTermByName('help_audience', $name);
-        if ($term instanceof TermInterface) {
-          $values[] = ['target_id' => (int) $term->id()];
-        }
-      }
-      if ($values !== []) {
-        $node->set('field_help_audience', $values);
-      }
+    if (!$node->hasField('field_audience')) {
+      return;
     }
 
-    if ($node->hasField('field_audience')) {
-      $canonical = [];
-      foreach ($names as $name) {
-        $mapped = $this->mapSeedAudienceNameToCanonical($name);
-        if ($mapped !== NULL) {
-          $canonical[$mapped] = $mapped;
-        }
+    $canonical = [];
+    foreach ($names as $name) {
+      $mapped = $this->mapSeedAudienceNameToCanonical($name);
+      if ($mapped !== NULL) {
+        $canonical[$mapped] = $mapped;
       }
-      if ($canonical !== []) {
-        $node->set('field_audience', array_map(
-          static fn(string $v): array => ['value' => $v],
-          array_values($canonical),
-        ));
-      }
+    }
+    if ($canonical !== []) {
+      $node->set('field_audience', array_map(
+        static fn(string $v): array => ['value' => $v],
+        array_values($canonical),
+      ));
     }
   }
 
   /**
-   * Maps seeded taxonomy audience labels to field_audience values.
+   * Maps seeded audience labels to field_audience list values.
    */
   private function mapSeedAudienceNameToCanonical(string $name): ?string {
     $key = mb_strtolower(trim($name));

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_cards.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_cards.scss
@@ -196,3 +196,166 @@
   background: colors.$mel-color-surface;
   box-shadow: shadows.$mel-shadow-2;
 }
+
+// ---------------------------------------------------------------------------
+// My Account dashboard — stacked event cards (Tickets / RSVPs / Past)
+// ---------------------------------------------------------------------------
+// Unified hierarchy: hero image, title, meta, full-width primary CTA, link row.
+
+.mel-dashboard__section {
+  margin-bottom: spacing.mel-space(8);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  // Wins over .mel-my-account__section when both are on the same <section>.
+  &.mel-my-account__section {
+    margin-bottom: spacing.mel-space(8);
+  }
+
+  h2.mel-my-account__section-title {
+    font-size: typography.mel-font-size(2xl);
+    font-weight: typography.$mel-font-extrabold;
+    margin-bottom: spacing.mel-space(4);
+  }
+
+  .mel-my-account__cards {
+    display: grid;
+    gap: spacing.mel-space(5);
+    grid-template-columns: 1fr;
+
+    @include breakpoints.mel-break(md) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include breakpoints.mel-break(lg) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .mel-card__image {
+    position: relative;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: colors.$mel-color-surface-alt;
+  }
+
+  .mel-card__image img {
+    display: block;
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+  }
+
+  .mel-card__image--placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 160px;
+    color: colors.$mel-color-text-muted;
+    background: linear-gradient(135deg, var(--mel-peach) 0%, var(--mel-lilac) 100%);
+
+    &::before {
+      content: '🎫';
+      font-size: 2.5rem;
+      opacity: 0.6;
+    }
+  }
+
+  .mel-card__meta {
+    font-size: typography.mel-font-size(sm);
+    color: colors.$mel-color-text-muted;
+    line-height: typography.$mel-leading-relaxed;
+    margin-bottom: spacing.mel-space(4);
+  }
+
+  .mel-card__actions {
+    display: flex;
+    flex-direction: column;
+    gap: spacing.mel-space(3);
+    margin-top: auto;
+  }
+
+  .mel-card__links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: spacing.mel-space(2) spacing.mel-space(3);
+    margin-top: spacing.mel-space(2);
+
+    a {
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-medium;
+      color: colors.$mel-color-accent;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      &:focus-visible {
+        @include colors.mel-focus-ring;
+      }
+    }
+  }
+
+  .mel-card {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    background: colors.$mel-color-surface;
+    border: none;
+    border-radius: radii.$mel-radius-md;
+    box-shadow: 0 4px 16px rgba(36, 48, 58, 0.1);
+  }
+
+  .mel-card__body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+    padding: spacing.mel-space(5);
+  }
+
+  .mel-card__title {
+    margin: 0 0 spacing.mel-space(2) 0;
+    font-size: typography.mel-font-size(xl);
+    font-weight: typography.$mel-font-bold;
+    line-height: typography.$mel-leading-tight;
+    color: colors.$mel-color-text;
+  }
+
+  .mel-button {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    min-height: 44px;
+    padding: spacing.mel-space(4) spacing.mel-space(5);
+    border-radius: radii.$mel-radius-pill;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-bold;
+    text-align: center;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .mel-button--primary {
+    background: colors.$mel-color-primary;
+    color: colors.$mel-color-text-inverse;
+
+    &:hover {
+      background: colors.$mel-color-primary-hover;
+      color: colors.$mel-color-text-inverse;
+    }
+
+    &:focus-visible {
+      @include colors.mel-focus-ring;
+    }
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
@@ -230,88 +230,20 @@
   margin: 0 0 spacing.mel-space(4) 0;
 }
 
-// ---------------------------------------------------------------------------
-// Cards Grid — reuses mel-card
-// ---------------------------------------------------------------------------
-// Image on top (cropped), title, date + location, CTA right bottom.
-
-.mel-my-account__cards {
-  display: grid;
-  gap: spacing.mel-space(4);
-  grid-template-columns: 1fr;
-
-  @include breakpoints.mel-break(sm) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @include breakpoints.mel-break(md) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
+// Card grid + dashboard section titles: components/_cards.scss (.mel-dashboard__section).
 
 .mel-my-account__card {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-
-  .mel-card__link {
-    flex-shrink: 0;
-  }
-
-  .mel-card__body {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
   .mel-card__title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
     line-clamp: 3;
-  }
-
-  .mel-card__media--placeholder {
-    &::before {
-      content: "🎫";
-      font-size: 2.5rem;
-      opacity: 0.6;
-    }
+    overflow: hidden;
   }
 }
 
 .mel-my-account__card--past {
   opacity: 0.9;
-}
-
-.mel-my-account__event-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  font-size: typography.mel-font-size(sm);
-  color: colors.$mel-color-text-muted;
-  margin: 0 0 spacing.mel-space(3) 0;
-}
-
-.mel-my-account__event-location {
-  &::before {
-    content: '';
-    display: none;
-  }
-}
-
-.mel-my-account__card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: spacing.mel-space(2);
-  margin-top: spacing.mel-space(3);
-  justify-content: flex-end;
-  align-items: center;
-}
-
-// Primary actions grouped on each card (calendar, PDF, account destinations).
-.mel-my-account__card-actions--onestop {
-  justify-content: flex-start;
-  width: 100%;
 }
 
 .mel-my-account__ticket-code {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Drupal config for help content audience fields and Search API indexing, which can affect editorial workflows and search/retrieval behavior. Frontend changes are mostly template/CSS refactors but could impact ticket/review CTA visibility.
> 
> **Overview**
> Standardizes Help Centre audience handling on canonical `field_audience`: hides/removes `field_help_audience` from FAQ displays, adds `field_audience` to the help article form, and drops `field_help_audience` from the `mel_content` Search API index.
> 
> Updates help seeding and kernel tests to use `field_audience` as a `list_string` (and includes the `options` module) rather than taxonomy-based audience.
> 
> Refreshes My Account dashboard and past-events templates to a new stacked card layout with a full-width primary CTA (prefer `View Ticket` when PDFs are available, otherwise `View Event`), secondary links (calendar/event), and clearer review-CTA precedence, with corresponding SCSS moved into `components/_cards.scss` and removed from `_my-account.scss`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4998be3e26569e45b5867cc624119339df9fad6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->