### PR TITLE
Refactor help audience to canonical field audience

### DIFF
--- a/config/sync/mel_help_content.settings.yml
+++ b/config/sync/mel_help_content.settings.yml
@@ -1,0 +1,142 @@
+uuid: 8f3c2a91-4d0e-4b1f-9c7a-2e6d5b4c3a10
+langcode: en
+help_articles:
+  how_to_buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Buy tickets in a few quick steps from event page to confirmation.'
+    body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
+    audience:
+      - Attendees
+    topic: Tickets
+    article_type: Guide
+    keywords: 'buy ticket, checkout, purchase, order'
+    cta_label: 'Browse events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-buy-tickets'
+    featured: true
+  how_to_rsvp:
+    title: 'How to RSVP to a free event'
+    summary: 'Reserve your place at a free event and keep your confirmation handy.'
+    body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
+    audience:
+      - Attendees
+    topic: RSVP
+    article_type: Guide
+    keywords: 'free event, rsvp, register'
+    cta_label: 'Find free events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-rsvp-to-a-free-event'
+    featured: true
+  how_to_access_tickets:
+    title: 'How to access your tickets'
+    summary: 'Where to find your ticket email and QR code before event day.'
+    body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
+    audience:
+      - Attendees
+    topic: 'Check-in'
+    article_type: FAQ
+    keywords: 'ticket email, qr code, check in'
+    cta_label: 'Open your account'
+    cta_link: '/user'
+    alias: '/help/attendees/how-to-access-your-tickets'
+    featured: false
+  how_to_request_refund:
+    title: 'How to request a refund'
+    summary: 'Check eligibility and send a refund request through the right channel.'
+    body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
+    audience:
+      - Attendees
+    topic: Refunds
+    article_type: Troubleshooting
+    keywords: 'refund request, cancellation, ticket refund'
+    cta_label: 'Read refund policy'
+    cta_link: '/help/policies/refund-policy'
+    alias: '/help/attendees/how-to-request-a-refund'
+    featured: true
+  how_to_create_event:
+    title: 'How to create an event'
+    summary: 'Set up your event details, timing, and tickets before publishing.'
+    body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
+    audience:
+      - Organisers
+    topic: 'Event creation'
+    article_type: Guide
+    keywords: 'create event, publish event, organiser'
+    cta_label: 'Open organiser dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/how-to-create-an-event'
+    featured: true
+  choosing_rsvp_or_paid:
+    title: 'Choosing RSVP or paid tickets'
+    summary: 'Pick the right ticket setup based on your event goals.'
+    body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
+    audience:
+      - Organisers
+    topic: 'Ticket setup'
+    article_type: Overview
+    keywords: 'rsvp vs paid, ticket setup, pricing'
+    cta_label: 'Configure ticket types'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
+    featured: false
+  managing_dashboard:
+    title: 'Managing your event dashboard'
+    summary: 'Track bookings, attendee activity, and quick event edits.'
+    body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
+    audience:
+      - Organisers
+    topic: Analytics
+    article_type: Guide
+    keywords: 'event dashboard, analytics, organiser tools'
+    cta_label: 'Go to dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/managing-your-event-dashboard'
+    featured: true
+  vendor_dashboard_overview:
+    title: 'Vendor dashboard overview'
+    summary: 'Navigate your vendor workspace, events, and stall tools.'
+    body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
+    audience:
+      - Vendors
+    topic: 'Getting started'
+    article_type: Guide
+    keywords: 'vendor dashboard, vendor workspace, stall'
+    cta_label: 'Vendor help'
+    cta_link: '/help/vendors'
+    alias: '/help/vendors/vendor-dashboard-overview'
+    featured: false
+  refund_policy:
+    title: 'Refund policy'
+    summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
+    body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
+    audience:
+      - General
+    topic: Privacy
+    article_type: Policy
+    keywords: 'refund rules, policy, cancelled event'
+    cta_label: 'Contact support'
+    cta_link: '/help'
+    alias: '/help/policies/refund-policy'
+    featured: true
+  community_guidelines:
+    title: 'Community guidelines'
+    summary: 'Our expectations for respectful behaviour across the platform.'
+    body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
+    audience:
+      - General
+    topic: 'Community guidelines'
+    article_type: Policy
+    keywords: 'community rules, safety, respectful behaviour'
+    cta_label: 'Read policies'
+    cta_link: '/help/policies'
+    alias: '/help/policies/community-guidelines'
+    featured: true
+support_panels:
+  buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Learn how to purchase tickets and complete checkout securely.'
+    link_path: '/help/attendees/how-to-buy-tickets'
+  create_event:
+    title: 'How to create an event'
+    summary: 'Step-by-step guide to publishing your event.'
+    link_path: '/help/organisers/how-to-create-an-event'

--- a/config/sync/myeventlane_help_centre.help_content.yml
+++ b/config/sync/myeventlane_help_centre.help_content.yml
@@ -1,0 +1,145 @@
+uuid: 8f3c2a91-4d0e-4b1f-9c7a-2e6d5b4c3a10
+langcode: en
+dependencies:
+  module:
+    - myeventlane_help_centre
+help_articles:
+  how_to_buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Buy tickets in a few quick steps from event page to confirmation.'
+    body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
+    audience:
+      - Attendees
+    topic: Tickets
+    article_type: Guide
+    keywords: 'buy ticket, checkout, purchase, order'
+    cta_label: 'Browse events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-buy-tickets'
+    featured: true
+  how_to_rsvp:
+    title: 'How to RSVP to a free event'
+    summary: 'Reserve your place at a free event and keep your confirmation handy.'
+    body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
+    audience:
+      - Attendees
+    topic: RSVP
+    article_type: Guide
+    keywords: 'free event, rsvp, register'
+    cta_label: 'Find free events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-rsvp-to-a-free-event'
+    featured: true
+  how_to_access_tickets:
+    title: 'How to access your tickets'
+    summary: 'Where to find your ticket email and QR code before event day.'
+    body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
+    audience:
+      - Attendees
+    topic: 'Check-in'
+    article_type: FAQ
+    keywords: 'ticket email, qr code, check in'
+    cta_label: 'Open your account'
+    cta_link: '/user'
+    alias: '/help/attendees/how-to-access-your-tickets'
+    featured: false
+  how_to_request_refund:
+    title: 'How to request a refund'
+    summary: 'Check eligibility and send a refund request through the right channel.'
+    body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
+    audience:
+      - Attendees
+    topic: Refunds
+    article_type: Troubleshooting
+    keywords: 'refund request, cancellation, ticket refund'
+    cta_label: 'Read refund policy'
+    cta_link: '/help/policies/refund-policy'
+    alias: '/help/attendees/how-to-request-a-refund'
+    featured: true
+  how_to_create_event:
+    title: 'How to create an event'
+    summary: 'Set up your event details, timing, and tickets before publishing.'
+    body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
+    audience:
+      - Organisers
+    topic: 'Event creation'
+    article_type: Guide
+    keywords: 'create event, publish event, organiser'
+    cta_label: 'Open organiser dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/how-to-create-an-event'
+    featured: true
+  choosing_rsvp_or_paid:
+    title: 'Choosing RSVP or paid tickets'
+    summary: 'Pick the right ticket setup based on your event goals.'
+    body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
+    audience:
+      - Organisers
+    topic: 'Ticket setup'
+    article_type: Overview
+    keywords: 'rsvp vs paid, ticket setup, pricing'
+    cta_label: 'Configure ticket types'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
+    featured: false
+  managing_dashboard:
+    title: 'Managing your event dashboard'
+    summary: 'Track bookings, attendee activity, and quick event edits.'
+    body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
+    audience:
+      - Organisers
+    topic: Analytics
+    article_type: Guide
+    keywords: 'event dashboard, analytics, organiser tools'
+    cta_label: 'Go to dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/managing-your-event-dashboard'
+    featured: true
+  vendor_dashboard_overview:
+    title: 'Vendor dashboard overview'
+    summary: 'Navigate your vendor workspace, events, and stall tools.'
+    body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
+    audience:
+      - Vendors
+    topic: 'Getting started'
+    article_type: Guide
+    keywords: 'vendor dashboard, vendor workspace, stall'
+    cta_label: 'Vendor help'
+    cta_link: '/help/vendors'
+    alias: '/help/vendors/vendor-dashboard-overview'
+    featured: false
+  refund_policy:
+    title: 'Refund policy'
+    summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
+    body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
+    audience:
+      - General
+    topic: Privacy
+    article_type: Policy
+    keywords: 'refund rules, policy, cancelled event'
+    cta_label: 'Contact support'
+    cta_link: '/help'
+    alias: '/help/policies/refund-policy'
+    featured: true
+  community_guidelines:
+    title: 'Community guidelines'
+    summary: 'Our expectations for respectful behaviour across the platform.'
+    body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
+    audience:
+      - General
+    topic: 'Community guidelines'
+    article_type: Policy
+    keywords: 'community rules, safety, respectful behaviour'
+    cta_label: 'Read policies'
+    cta_link: '/help/policies'
+    alias: '/help/policies/community-guidelines'
+    featured: true
+support_panels:
+  buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Learn how to purchase tickets and complete checkout securely.'
+    link_path: '/help/attendees/how-to-buy-tickets'
+  create_event:
+    title: 'How to create an event'
+    summary: 'Step-by-step guide to publishing your event.'
+    link_path: '/help/organisers/how-to-create-an-event'

--- a/web/modules/custom/myeventlane_help_centre/config/install/mel_help_content.settings.yml
+++ b/web/modules/custom/myeventlane_help_centre/config/install/mel_help_content.settings.yml
@@ -1,0 +1,141 @@
+langcode: en
+help_articles:
+  how_to_buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Buy tickets in a few quick steps from event page to confirmation.'
+    body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
+    audience:
+      - Attendees
+    topic: Tickets
+    article_type: Guide
+    keywords: 'buy ticket, checkout, purchase, order'
+    cta_label: 'Browse events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-buy-tickets'
+    featured: true
+  how_to_rsvp:
+    title: 'How to RSVP to a free event'
+    summary: 'Reserve your place at a free event and keep your confirmation handy.'
+    body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
+    audience:
+      - Attendees
+    topic: RSVP
+    article_type: Guide
+    keywords: 'free event, rsvp, register'
+    cta_label: 'Find free events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-rsvp-to-a-free-event'
+    featured: true
+  how_to_access_tickets:
+    title: 'How to access your tickets'
+    summary: 'Where to find your ticket email and QR code before event day.'
+    body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
+    audience:
+      - Attendees
+    topic: 'Check-in'
+    article_type: FAQ
+    keywords: 'ticket email, qr code, check in'
+    cta_label: 'Open your account'
+    cta_link: '/user'
+    alias: '/help/attendees/how-to-access-your-tickets'
+    featured: false
+  how_to_request_refund:
+    title: 'How to request a refund'
+    summary: 'Check eligibility and send a refund request through the right channel.'
+    body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
+    audience:
+      - Attendees
+    topic: Refunds
+    article_type: Troubleshooting
+    keywords: 'refund request, cancellation, ticket refund'
+    cta_label: 'Read refund policy'
+    cta_link: '/help/policies/refund-policy'
+    alias: '/help/attendees/how-to-request-a-refund'
+    featured: true
+  how_to_create_event:
+    title: 'How to create an event'
+    summary: 'Set up your event details, timing, and tickets before publishing.'
+    body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
+    audience:
+      - Organisers
+    topic: 'Event creation'
+    article_type: Guide
+    keywords: 'create event, publish event, organiser'
+    cta_label: 'Open organiser dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/how-to-create-an-event'
+    featured: true
+  choosing_rsvp_or_paid:
+    title: 'Choosing RSVP or paid tickets'
+    summary: 'Pick the right ticket setup based on your event goals.'
+    body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
+    audience:
+      - Organisers
+    topic: 'Ticket setup'
+    article_type: Overview
+    keywords: 'rsvp vs paid, ticket setup, pricing'
+    cta_label: 'Configure ticket types'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
+    featured: false
+  managing_dashboard:
+    title: 'Managing your event dashboard'
+    summary: 'Track bookings, attendee activity, and quick event edits.'
+    body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
+    audience:
+      - Organisers
+    topic: Analytics
+    article_type: Guide
+    keywords: 'event dashboard, analytics, organiser tools'
+    cta_label: 'Go to dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/managing-your-event-dashboard'
+    featured: true
+  vendor_dashboard_overview:
+    title: 'Vendor dashboard overview'
+    summary: 'Navigate your vendor workspace, events, and stall tools.'
+    body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
+    audience:
+      - Vendors
+    topic: 'Getting started'
+    article_type: Guide
+    keywords: 'vendor dashboard, vendor workspace, stall'
+    cta_label: 'Vendor help'
+    cta_link: '/help/vendors'
+    alias: '/help/vendors/vendor-dashboard-overview'
+    featured: false
+  refund_policy:
+    title: 'Refund policy'
+    summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
+    body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
+    audience:
+      - General
+    topic: Privacy
+    article_type: Policy
+    keywords: 'refund rules, policy, cancelled event'
+    cta_label: 'Contact support'
+    cta_link: '/help'
+    alias: '/help/policies/refund-policy'
+    featured: true
+  community_guidelines:
+    title: 'Community guidelines'
+    summary: 'Our expectations for respectful behaviour across the platform.'
+    body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
+    audience:
+      - General
+    topic: 'Community guidelines'
+    article_type: Policy
+    keywords: 'community rules, safety, respectful behaviour'
+    cta_label: 'Read policies'
+    cta_link: '/help/policies'
+    alias: '/help/policies/community-guidelines'
+    featured: true
+support_panels:
+  buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Learn how to purchase tickets and complete checkout securely.'
+    link_path: '/help/attendees/how-to-buy-tickets'
+  create_event:
+    title: 'How to create an event'
+    summary: 'Step-by-step guide to publishing your event.'
+    link_path: '/help/organisers/how-to-create-an-event'

--- a/web/modules/custom/myeventlane_help_centre/config/install/myeventlane_help_centre.help_content.yml
+++ b/web/modules/custom/myeventlane_help_centre/config/install/myeventlane_help_centre.help_content.yml
@@ -1,0 +1,144 @@
+langcode: en
+dependencies:
+  module:
+    - myeventlane_help_centre
+help_articles:
+  how_to_buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Buy tickets in a few quick steps from event page to confirmation.'
+    body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
+    audience:
+      - Attendees
+    topic: Tickets
+    article_type: Guide
+    keywords: 'buy ticket, checkout, purchase, order'
+    cta_label: 'Browse events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-buy-tickets'
+    featured: true
+  how_to_rsvp:
+    title: 'How to RSVP to a free event'
+    summary: 'Reserve your place at a free event and keep your confirmation handy.'
+    body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
+    audience:
+      - Attendees
+    topic: RSVP
+    article_type: Guide
+    keywords: 'free event, rsvp, register'
+    cta_label: 'Find free events'
+    cta_link: '/events'
+    alias: '/help/attendees/how-to-rsvp-to-a-free-event'
+    featured: true
+  how_to_access_tickets:
+    title: 'How to access your tickets'
+    summary: 'Where to find your ticket email and QR code before event day.'
+    body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
+    audience:
+      - Attendees
+    topic: 'Check-in'
+    article_type: FAQ
+    keywords: 'ticket email, qr code, check in'
+    cta_label: 'Open your account'
+    cta_link: '/user'
+    alias: '/help/attendees/how-to-access-your-tickets'
+    featured: false
+  how_to_request_refund:
+    title: 'How to request a refund'
+    summary: 'Check eligibility and send a refund request through the right channel.'
+    body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
+    audience:
+      - Attendees
+    topic: Refunds
+    article_type: Troubleshooting
+    keywords: 'refund request, cancellation, ticket refund'
+    cta_label: 'Read refund policy'
+    cta_link: '/help/policies/refund-policy'
+    alias: '/help/attendees/how-to-request-a-refund'
+    featured: true
+  how_to_create_event:
+    title: 'How to create an event'
+    summary: 'Set up your event details, timing, and tickets before publishing.'
+    body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
+    audience:
+      - Organisers
+    topic: 'Event creation'
+    article_type: Guide
+    keywords: 'create event, publish event, organiser'
+    cta_label: 'Open organiser dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/how-to-create-an-event'
+    featured: true
+  choosing_rsvp_or_paid:
+    title: 'Choosing RSVP or paid tickets'
+    summary: 'Pick the right ticket setup based on your event goals.'
+    body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
+    audience:
+      - Organisers
+    topic: 'Ticket setup'
+    article_type: Overview
+    keywords: 'rsvp vs paid, ticket setup, pricing'
+    cta_label: 'Configure ticket types'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
+    featured: false
+  managing_dashboard:
+    title: 'Managing your event dashboard'
+    summary: 'Track bookings, attendee activity, and quick event edits.'
+    body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
+    audience:
+      - Organisers
+    topic: Analytics
+    article_type: Guide
+    keywords: 'event dashboard, analytics, organiser tools'
+    cta_label: 'Go to dashboard'
+    cta_link: '/dashboard'
+    alias: '/help/organisers/managing-your-event-dashboard'
+    featured: true
+  vendor_dashboard_overview:
+    title: 'Vendor dashboard overview'
+    summary: 'Navigate your vendor workspace, events, and stall tools.'
+    body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
+    audience:
+      - Vendors
+    topic: 'Getting started'
+    article_type: Guide
+    keywords: 'vendor dashboard, vendor workspace, stall'
+    cta_label: 'Vendor help'
+    cta_link: '/help/vendors'
+    alias: '/help/vendors/vendor-dashboard-overview'
+    featured: false
+  refund_policy:
+    title: 'Refund policy'
+    summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
+    body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
+    audience:
+      - General
+    topic: Privacy
+    article_type: Policy
+    keywords: 'refund rules, policy, cancelled event'
+    cta_label: 'Contact support'
+    cta_link: '/help'
+    alias: '/help/policies/refund-policy'
+    featured: true
+  community_guidelines:
+    title: 'Community guidelines'
+    summary: 'Our expectations for respectful behaviour across the platform.'
+    body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
+    audience:
+      - General
+    topic: 'Community guidelines'
+    article_type: Policy
+    keywords: 'community rules, safety, respectful behaviour'
+    cta_label: 'Read policies'
+    cta_link: '/help/policies'
+    alias: '/help/policies/community-guidelines'
+    featured: true
+support_panels:
+  buy_tickets:
+    title: 'How to buy tickets'
+    summary: 'Learn how to purchase tickets and complete checkout securely.'
+    link_path: '/help/attendees/how-to-buy-tickets'
+  create_event:
+    title: 'How to create an event'
+    summary: 'Step-by-step guide to publishing your event.'
+    link_path: '/help/organisers/how-to-create-an-event'

--- a/web/modules/custom/myeventlane_help_centre/config/schema/myeventlane_help_centre.schema.yml
+++ b/web/modules/custom/myeventlane_help_centre/config/schema/myeventlane_help_centre.schema.yml
@@ -19,3 +19,12 @@ myeventlane_help_centre.contextual_help:
       mapping:
         '*':
           type: myeventlane_help_centre.contextual_help.link
+
+myeventlane_help_centre.help_content:
+  type: config_object
+  label: 'MEL help content (YAML seeds and support panels)'
+  mapping:
+    help_articles:
+      type: ignore
+    support_panels:
+      type: ignore

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -90,6 +90,15 @@ function myeventlane_help_centre_theme(): array {
       'template' => 'components/mel-support-layer',
       'path' => $theme_path . '/templates',
     ],
+    'mel_support_panel' => [
+      'variables' => [
+        'title' => '',
+        'summary' => '',
+        'url' => '',
+      ],
+      'template' => 'components/mel-support-panel',
+      'path' => $theme_path . '/templates',
+    ],
   ];
 }
 
@@ -444,6 +453,13 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
   }
 
   $step_id = $variables['form']['#step_id'] ?? NULL;
+  if ($step_id !== 'complete') {
+    $panel = \Drupal::service('myeventlane_help_centre.support_panel_builder')->build('buy_tickets');
+    if ($panel !== []) {
+      $variables['mel_help_yaml_support_panel'] = $panel;
+    }
+  }
+
   $resolver = _myeventlane_help_centre_resolver();
 
   if ($step_id === 'complete') {

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -4,11 +4,22 @@ services:
     factory: ['@logger.factory', 'get']
     arguments: ['myeventlane_help_centre']
 
+  myeventlane_help_centre.help_content_repository:
+    class: Drupal\myeventlane_help_centre\Service\HelpContentRepository
+    arguments:
+      - '@config.factory'
+
+  myeventlane_help_centre.support_panel_builder:
+    class: Drupal\myeventlane_help_centre\Service\SupportPanelBuilder
+    arguments:
+      - '@myeventlane_help_centre.help_content_repository'
+
   myeventlane_help_centre.seeder:
     class: Drupal\myeventlane_help_centre\Service\HelpContentSeeder
     public: true
     arguments:
       - '@entity_type.manager'
+      - '@myeventlane_help_centre.help_content_repository'
       - '@logger.factory'
 
   myeventlane_help_centre.analytics:

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentRepository.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Loads YAML-backed help seeds and support panel definitions from config.
+ */
+final class HelpContentRepository {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * @return array<string, array<string, mixed>>
+   *   Keyed help article seed definitions (see myeventlane_help_centre.help_content).
+   */
+  public function getHelpArticleSeeds(): array {
+    $raw = $this->configFactory->get('myeventlane_help_centre.help_content')->get('help_articles');
+    return is_array($raw) ? $raw : [];
+  }
+
+  /**
+   * @return array<string, array<string, mixed>>
+   */
+  public function getSupportPanels(): array {
+    $raw = $this->configFactory->get('myeventlane_help_centre.help_content')->get('support_panels');
+    return is_array($raw) ? $raw : [];
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  public function getSupportPanel(string $key): ?array {
+    $panels = $this->getSupportPanels();
+    $item = $panels[$key] ?? NULL;
+    return is_array($item) ? $item : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
@@ -12,18 +12,12 @@ use Drupal\taxonomy\TermInterface;
 
 /**
  * Seeds Help Centre landing pages and baseline help articles.
- *
- * TODO: Replace hardcoded baseline article bodies with config-driven import
- * (e.g. default_content or install YAML) so editorial copy is not tied to
- * PHP releases.
  */
 final class HelpContentSeeder {
 
-  /**
-   * Constructs a help content seeder service.
-   */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly HelpContentRepository $helpContentRepository,
     LoggerChannelFactoryInterface $loggerFactory,
   ) {
     $this->logger = $loggerFactory->get('myeventlane_help_centre');
@@ -83,6 +77,21 @@ final class HelpContentSeeder {
   }
 
   public function seedHelpArticles(): int {
+    $yaml = $this->helpContentRepository->getHelpArticleSeeds();
+    if ($yaml !== []) {
+      $rows = $this->normalizeYamlSeedsToArticleRows($yaml);
+      if ($rows !== []) {
+        return $this->seedArticleNodes($rows);
+      }
+    }
+
+    return $this->seedHelpArticlesLegacy();
+  }
+
+  /**
+   * Legacy baseline articles — used when YAML config is empty or invalid.
+   */
+  private function seedHelpArticlesLegacy(): int {
     $articles = [
       [
         'title' => 'How to buy tickets',
@@ -217,6 +226,46 @@ final class HelpContentSeeder {
     ];
 
     return $this->seedArticleNodes($articles);
+  }
+
+  /**
+   * @param array<string, array<string, mixed>> $helpArticles
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function normalizeYamlSeedsToArticleRows(array $helpArticles): array {
+    $out = [];
+    foreach ($helpArticles as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $title = trim((string) ($row['title'] ?? ''));
+      if ($title === '') {
+        continue;
+      }
+      $kw = $row['keywords'] ?? '';
+      if (is_array($kw)) {
+        $kw = implode(', ', $kw);
+      }
+      $audience = $row['audience'] ?? [];
+      if (!is_array($audience)) {
+        $audience = $audience !== '' && $audience !== NULL ? [(string) $audience] : [];
+      }
+      $out[] = [
+        'title' => $title,
+        'summary' => (string) ($row['summary'] ?? ''),
+        'body' => (string) ($row['body'] ?? ''),
+        'audience' => $audience,
+        'topic' => (string) ($row['topic'] ?? ''),
+        'article_type' => (string) ($row['article_type'] ?? ''),
+        'keywords' => (string) $kw,
+        'cta_label' => (string) ($row['cta_label'] ?? ''),
+        'cta_link' => (string) ($row['cta_link'] ?? ''),
+        'alias' => (string) ($row['alias'] ?? ''),
+        'featured' => (bool) ($row['featured'] ?? FALSE),
+      ];
+    }
+    return $out;
   }
 
   private function seedLandingPageNodes(array $definitions): int {
@@ -398,4 +447,5 @@ final class HelpContentSeeder {
     $term = reset($terms);
     return $term instanceof TermInterface ? $term : NULL;
   }
+
 }

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Url;
+
+/**
+ * Builds a themed support panel render array from YAML config.
+ */
+final class SupportPanelBuilder {
+
+  public function __construct(
+    private readonly HelpContentRepository $helpContentRepository,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   *   Render array, or empty if the key is missing or invalid.
+   */
+  public function build(string $key): array {
+    $panel = $this->helpContentRepository->getSupportPanel($key);
+    if ($panel === NULL) {
+      return [];
+    }
+    $title = trim((string) ($panel['title'] ?? ''));
+    $linkPath = trim((string) ($panel['link_path'] ?? ''));
+    if ($title === '' || $linkPath === '') {
+      return [];
+    }
+
+    try {
+      $url = Url::fromUserInput($linkPath)->setAbsolute(FALSE)->toString();
+    }
+    catch (\Throwable) {
+      return [];
+    }
+
+    return [
+      '#theme' => 'mel_support_panel',
+      '#title' => $title,
+      '#summary' => trim((string) ($panel['summary'] ?? '')),
+      '#url' => $url,
+      '#cache' => [
+        'tags' => ['config:myeventlane_help_centre.help_content'],
+      ],
+    ];
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -1271,6 +1271,10 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   line-height: 1.4;
 }
 
+.mel-checkout-yaml-support {
+  margin-bottom: spacing.mel-space(3);
+}
+
 /* Trust list — above primary CTA (Phase 4) */
 .mel-checkout-trust {
   margin: spacing.mel-space(3) 0 spacing.mel-space(2);

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
@@ -25,15 +25,15 @@
 .mel-my-account__layout {
   display: flex;
   flex-direction: column;
-  gap: spacing.mel-space(6);
+  gap: spacing.mel-space(5);
   max-width: 1320px;
   margin: 0 auto;
-  padding: spacing.mel-space(4);
+  padding: spacing.mel-space(2) spacing.mel-space(3);
 
   @include breakpoints.mel-break(md) {
     flex-direction: row;
-    gap: spacing.mel-space(8);
-    padding: spacing.mel-space(6);
+    gap: spacing.mel-space(6);
+    padding: spacing.mel-space(3) spacing.mel-space(5);
   }
 }
 
@@ -137,10 +137,10 @@
   grid-template-columns: 1fr auto;
   align-items: center;
   gap: spacing.mel-space(4);
-  margin-bottom: spacing.mel-space(6);
+  margin-bottom: spacing.mel-space(4);
 
   @include breakpoints.mel-break(md) {
-    margin-bottom: spacing.mel-space(8);
+    margin-bottom: spacing.mel-space(5);
   }
 }
 
@@ -216,7 +216,7 @@
 // ---------------------------------------------------------------------------
 
 .mel-my-account__section {
-  margin-bottom: spacing.mel-space(6);
+  margin-bottom: spacing.mel-space(5);
 
   &:last-child {
     margin-bottom: 0;

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -53,6 +53,13 @@
     <div class="mel-checkout__layout mel-checkout__grid mel-checkout__grid--sidebar-flow">
       <div class="mel-checkout__main">
         <p class="mel-checkout-helper">{{ "Just a few details and you're done."|t }}</p>
+
+        {% if mel_help_yaml_support_panel is defined and mel_help_yaml_support_panel %}
+          <div class="mel-checkout-yaml-support" role="region" aria-label="{{ 'Help'|t }}">
+            {{ mel_help_yaml_support_panel }}
+          </div>
+        {% endif %}
+
         {{ form|without('progress', 'sidebar', 'actions', 'payment_information', 'mel_buyer_details', 'mel_donation', 'mel_legal_consent', 'ticket_holder_paragraph', 'mel_checkout_confidence') }}
 
         {% if mel_contextual_help_checkout is not defined or not mel_contextual_help_checkout %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -60,6 +60,12 @@
       <div class="mel-checkout__main">
         <p class="mel-checkout-helper">{{ "Just a few details and you're done."|t }}</p>
 
+        {% if mel_help_yaml_support_panel is defined and mel_help_yaml_support_panel %}
+          <div class="mel-checkout-yaml-support" role="region" aria-label="{{ 'Help'|t }}">
+            {{ mel_help_yaml_support_panel }}
+          </div>
+        {% endif %}
+
         {% if mel_contextual_help_checkout is defined and mel_contextual_help_checkout and form.sidebar is not defined %}
           <div class="mel-contextual-help mel-contextual-help--checkout mel-contextual-help--checkout-card">
             {{ mel_contextual_help_checkout }}

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Compact support CTA from myeventlane_help_centre.help_content (support_panels).
+ */
+#}
+<div class="mel-support-panel">
+  <h3 class="mel-support-panel__title">{{ title }}</h3>
+  {% if summary %}
+    <p class="mel-support-panel__summary">{{ summary }}</p>
+  {% endif %}
+  <a href="{{ url }}" class="mel-button mel-button--primary">{{ 'View help'|t }}</a>
+</div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates help-article seeding to be driven by YAML config and adds a new checkout support panel render path, which could affect initial content provisioning and checkout page rendering if config is missing or malformed.
> 
> **Overview**
> **Help Centre content is now config-driven.** Adds new `myeventlane_help_centre.help_content` config (with sync + install YAML) to define `help_articles` seeds and `support_panels`.
> 
> **Seeding and checkout UI now consume this config.** Introduces `HelpContentRepository` and updates `HelpContentSeeder` to import YAML seeds with a legacy fallback, and adds `SupportPanelBuilder` + new `mel_support_panel` theme/Twig to render a configurable help CTA on non-complete Commerce checkout steps (with minor SCSS spacing tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9820b2e5f2a036d88bc0cb42d44ad8dbb4d5bfe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->