### PR TITLE
Refactor help audience to canonical field audience

### DIFF
--- a/config/sync/core.entity_form_display.node.help_article.default.yml
+++ b/config/sync/core.entity_form_display.node.help_article.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.help_article.field_help_category
     - field.field.node.help_article.field_help_cta_label
     - field.field.node.help_article.field_help_cta_link
+    - field.field.node.help_article.field_help_seed_key
     - field.field.node.help_article.field_help_keywords
     - field.field.node.help_article.field_help_status
     - field.field.node.help_article.field_help_summary
@@ -144,6 +145,7 @@ hidden:
   field_help_audience: true
   field_help_cta_label: true
   field_help_cta_link: true
+  field_help_seed_key: true
   field_help_keywords: true
   field_help_status: true
   field_last_reviewed: true

--- a/config/sync/core.entity_view_display.node.help_article.default.yml
+++ b/config/sync/core.entity_view_display.node.help_article.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.help_article.field_help_category
     - field.field.node.help_article.field_help_cta_label
     - field.field.node.help_article.field_help_cta_link
+    - field.field.node.help_article.field_help_seed_key
     - field.field.node.help_article.field_help_keywords
     - field.field.node.help_article.field_help_status
     - field.field.node.help_article.field_help_summary
@@ -49,6 +50,7 @@ hidden:
   field_help_category: true
   field_help_cta_label: true
   field_help_cta_link: true
+  field_help_seed_key: true
   field_help_keywords: true
   field_help_status: true
   field_help_summary: true

--- a/config/sync/field.field.node.help_article.field_help_seed_key.yml
+++ b/config/sync/field.field.node.help_article.field_help_seed_key.yml
@@ -1,0 +1,22 @@
+uuid: 10d88b1c-98dd-4b99-a5a0-8d49854174b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_help_seed_key
+    - node.type.help_article
+id: node.help_article.field_help_seed_key
+field_name: field_help_seed_key
+entity_type: node
+bundle: help_article
+label: 'Seed key'
+description: 'Stable machine key for YAML-seeded help articles.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  max_length: 128
+  is_ascii: true
+  case_sensitive: false
+field_type: string

--- a/config/sync/field.storage.node.field_help_seed_key.yml
+++ b/config/sync/field.storage.node.field_help_seed_key.yml
@@ -1,0 +1,21 @@
+uuid: e09e7e7f-fb18-4ea3-8e3f-4644a61e58c3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_help_seed_key
+field_name: field_help_seed_key
+entity_type: node
+type: string
+settings:
+  max_length: 128
+  is_ascii: true
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/myeventlane_help_centre.help_content.yml
+++ b/config/sync/myeventlane_help_centre.help_content.yml
@@ -5,6 +5,7 @@ dependencies:
     - myeventlane_help_centre
 help_articles:
   how_to_buy_tickets:
+    seed_key: how_to_buy_tickets
     title: 'How to buy tickets'
     summary: 'Buy tickets in a few quick steps from event page to confirmation.'
     body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
@@ -18,6 +19,7 @@ help_articles:
     alias: '/help/attendees/how-to-buy-tickets'
     featured: true
   how_to_rsvp:
+    seed_key: how_to_rsvp
     title: 'How to RSVP to a free event'
     summary: 'Reserve your place at a free event and keep your confirmation handy.'
     body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
@@ -31,6 +33,7 @@ help_articles:
     alias: '/help/attendees/how-to-rsvp-to-a-free-event'
     featured: true
   how_to_access_tickets:
+    seed_key: how_to_access_tickets
     title: 'How to access your tickets'
     summary: 'Where to find your ticket email and QR code before event day.'
     body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
@@ -44,6 +47,7 @@ help_articles:
     alias: '/help/attendees/how-to-access-your-tickets'
     featured: false
   how_to_request_refund:
+    seed_key: how_to_request_refund
     title: 'How to request a refund'
     summary: 'Check eligibility and send a refund request through the right channel.'
     body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
@@ -57,6 +61,7 @@ help_articles:
     alias: '/help/attendees/how-to-request-a-refund'
     featured: true
   how_to_create_event:
+    seed_key: how_to_create_event
     title: 'How to create an event'
     summary: 'Set up your event details, timing, and tickets before publishing.'
     body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
@@ -70,6 +75,7 @@ help_articles:
     alias: '/help/organisers/how-to-create-an-event'
     featured: true
   choosing_rsvp_or_paid:
+    seed_key: choosing_rsvp_or_paid
     title: 'Choosing RSVP or paid tickets'
     summary: 'Pick the right ticket setup based on your event goals.'
     body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
@@ -83,6 +89,7 @@ help_articles:
     alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
     featured: false
   managing_dashboard:
+    seed_key: managing_dashboard
     title: 'Managing your event dashboard'
     summary: 'Track bookings, attendee activity, and quick event edits.'
     body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
@@ -96,6 +103,7 @@ help_articles:
     alias: '/help/organisers/managing-your-event-dashboard'
     featured: true
   vendor_dashboard_overview:
+    seed_key: vendor_dashboard_overview
     title: 'Vendor dashboard overview'
     summary: 'Navigate your vendor workspace, events, and stall tools.'
     body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
@@ -109,6 +117,7 @@ help_articles:
     alias: '/help/vendors/vendor-dashboard-overview'
     featured: false
   refund_policy:
+    seed_key: refund_policy
     title: 'Refund policy'
     summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
     body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
@@ -122,6 +131,7 @@ help_articles:
     alias: '/help/policies/refund-policy'
     featured: true
   community_guidelines:
+    seed_key: community_guidelines
     title: 'Community guidelines'
     summary: 'Our expectations for respectful behaviour across the platform.'
     body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
@@ -139,7 +149,21 @@ support_panels:
     title: 'How to buy tickets'
     summary: 'Learn how to purchase tickets and complete checkout securely.'
     link_path: '/help/attendees/how-to-buy-tickets'
+    surfaces:
+      - checkout
+    route_names:
+      - commerce_checkout.form
   create_event:
     title: 'How to create an event'
     summary: 'Step-by-step guide to publishing your event.'
     link_path: '/help/organisers/how-to-create-an-event'
+    surfaces:
+      - event_creation_wizard
+  vendor_dashboard:
+    title: 'Vendor dashboard overview'
+    summary: 'Know where to manage your vendor workspace, events, and payouts.'
+    link_path: '/help/vendors/vendor-dashboard-overview'
+    surfaces:
+      - vendor_dashboard
+    route_names:
+      - myeventlane_vendor.console.dashboard

--- a/web/modules/custom/myeventlane_help_centre/config/install/myeventlane_help_centre.help_content.yml
+++ b/web/modules/custom/myeventlane_help_centre/config/install/myeventlane_help_centre.help_content.yml
@@ -4,6 +4,7 @@ dependencies:
     - myeventlane_help_centre
 help_articles:
   how_to_buy_tickets:
+    seed_key: how_to_buy_tickets
     title: 'How to buy tickets'
     summary: 'Buy tickets in a few quick steps from event page to confirmation.'
     body: '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>'
@@ -17,6 +18,7 @@ help_articles:
     alias: '/help/attendees/how-to-buy-tickets'
     featured: true
   how_to_rsvp:
+    seed_key: how_to_rsvp
     title: 'How to RSVP to a free event'
     summary: 'Reserve your place at a free event and keep your confirmation handy.'
     body: '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>'
@@ -30,6 +32,7 @@ help_articles:
     alias: '/help/attendees/how-to-rsvp-to-a-free-event'
     featured: true
   how_to_access_tickets:
+    seed_key: how_to_access_tickets
     title: 'How to access your tickets'
     summary: 'Where to find your ticket email and QR code before event day.'
     body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
@@ -43,6 +46,7 @@ help_articles:
     alias: '/help/attendees/how-to-access-your-tickets'
     featured: false
   how_to_request_refund:
+    seed_key: how_to_request_refund
     title: 'How to request a refund'
     summary: 'Check eligibility and send a refund request through the right channel.'
     body: '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>'
@@ -56,6 +60,7 @@ help_articles:
     alias: '/help/attendees/how-to-request-a-refund'
     featured: true
   how_to_create_event:
+    seed_key: how_to_create_event
     title: 'How to create an event'
     summary: 'Set up your event details, timing, and tickets before publishing.'
     body: '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>'
@@ -69,6 +74,7 @@ help_articles:
     alias: '/help/organisers/how-to-create-an-event'
     featured: true
   choosing_rsvp_or_paid:
+    seed_key: choosing_rsvp_or_paid
     title: 'Choosing RSVP or paid tickets'
     summary: 'Pick the right ticket setup based on your event goals.'
     body: '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>'
@@ -82,6 +88,7 @@ help_articles:
     alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
     featured: false
   managing_dashboard:
+    seed_key: managing_dashboard
     title: 'Managing your event dashboard'
     summary: 'Track bookings, attendee activity, and quick event edits.'
     body: '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>'
@@ -95,6 +102,7 @@ help_articles:
     alias: '/help/organisers/managing-your-event-dashboard'
     featured: true
   vendor_dashboard_overview:
+    seed_key: vendor_dashboard_overview
     title: 'Vendor dashboard overview'
     summary: 'Navigate your vendor workspace, events, and stall tools.'
     body: '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>'
@@ -108,6 +116,7 @@ help_articles:
     alias: '/help/vendors/vendor-dashboard-overview'
     featured: false
   refund_policy:
+    seed_key: refund_policy
     title: 'Refund policy'
     summary: 'How refunds are handled, assessed, and paid back on MyEventLane.'
     body: '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>'
@@ -121,6 +130,7 @@ help_articles:
     alias: '/help/policies/refund-policy'
     featured: true
   community_guidelines:
+    seed_key: community_guidelines
     title: 'Community guidelines'
     summary: 'Our expectations for respectful behaviour across the platform.'
     body: '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>'
@@ -138,7 +148,21 @@ support_panels:
     title: 'How to buy tickets'
     summary: 'Learn how to purchase tickets and complete checkout securely.'
     link_path: '/help/attendees/how-to-buy-tickets'
+    surfaces:
+      - checkout
+    route_names:
+      - commerce_checkout.form
   create_event:
     title: 'How to create an event'
     summary: 'Step-by-step guide to publishing your event.'
     link_path: '/help/organisers/how-to-create-an-event'
+    surfaces:
+      - event_creation_wizard
+  vendor_dashboard:
+    title: 'Vendor dashboard overview'
+    summary: 'Know where to manage your vendor workspace, events, and payouts.'
+    link_path: '/help/vendors/vendor-dashboard-overview'
+    surfaces:
+      - vendor_dashboard
+    route_names:
+      - myeventlane_vendor.console.dashboard

--- a/web/modules/custom/myeventlane_help_centre/config/schema/myeventlane_help_centre.schema.yml
+++ b/web/modules/custom/myeventlane_help_centre/config/schema/myeventlane_help_centre.schema.yml
@@ -20,11 +20,86 @@ myeventlane_help_centre.contextual_help:
         '*':
           type: myeventlane_help_centre.contextual_help.link
 
+myeventlane_help_centre.help_content.article:
+  type: mapping
+  label: 'Help article seed'
+  mapping:
+    seed_key:
+      type: string
+      label: 'Seed key'
+    title:
+      type: label
+      label: 'Title'
+    summary:
+      type: text
+      label: 'Summary'
+    body:
+      type: text
+      label: 'Body'
+    audience:
+      type: sequence
+      label: 'Audience labels'
+      sequence:
+        type: string
+    topic:
+      type: string
+      label: 'Topic'
+    article_type:
+      type: string
+      label: 'Article type'
+    keywords:
+      type: string
+      label: 'Keywords'
+    cta_label:
+      type: label
+      label: 'CTA label'
+    cta_link:
+      type: string
+      label: 'CTA link'
+    alias:
+      type: string
+      label: 'URL alias'
+    featured:
+      type: boolean
+      label: 'Featured'
+
+myeventlane_help_centre.help_content.panel:
+  type: mapping
+  label: 'Support panel definition'
+  mapping:
+    title:
+      type: label
+      label: 'Title'
+    summary:
+      type: text
+      label: 'Summary'
+    link_path:
+      type: string
+      label: 'Internal link path'
+    surfaces:
+      type: sequence
+      label: 'Surfaces'
+      sequence:
+        type: string
+    route_names:
+      type: sequence
+      label: 'Route names'
+      sequence:
+        type: string
+
 myeventlane_help_centre.help_content:
   type: config_object
   label: 'MEL help content (YAML seeds and support panels)'
   mapping:
     help_articles:
-      type: ignore
+      type: mapping
+      label: 'Help articles'
+      mapping:
+        '*':
+          type: myeventlane_help_centre.help_content.article
     support_panels:
-      type: ignore
+      type: mapping
+      label: 'Support panels'
+      mapping:
+        '*':
+          type: myeventlane_help_centre.help_content.panel

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -475,7 +475,8 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
     }
   }
 
-  $has_inline_card = !empty($variables['mel_contextual_help_checkout'] ?? []);
+  $has_inline_card = !empty($variables['mel_contextual_help_checkout'] ?? [])
+    || !empty($variables['mel_help_yaml_support_panel'] ?? []);
   if (!$has_inline_card) {
     $item = myeventlane_help_centre_get_link('refunds_checkout');
     if ($item) {

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -453,10 +453,11 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
   }
 
   $step_id = $variables['form']['#step_id'] ?? NULL;
+  $route_name = \Drupal::routeMatch()->getRouteName();
   if ($step_id !== 'complete') {
-    $panel = \Drupal::service('myeventlane_help_centre.support_panel_builder')->build('buy_tickets');
+    $panel = \Drupal::service('myeventlane_help_centre.support_panel_builder')->build('buy_tickets', 'checkout', $route_name);
     if ($panel !== []) {
-      $variables['mel_help_yaml_support_panel'] = $panel;
+      $variables['mel_support_panel'] = $panel;
     }
   }
 
@@ -476,7 +477,7 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
   }
 
   $has_inline_card = !empty($variables['mel_contextual_help_checkout'] ?? [])
-    || !empty($variables['mel_help_yaml_support_panel'] ?? []);
+    || !empty($variables['mel_support_panel'] ?? []);
   if (!$has_inline_card) {
     $item = myeventlane_help_centre_get_link('refunds_checkout');
     if ($item) {
@@ -583,12 +584,16 @@ function myeventlane_help_centre_preprocess_myeventlane_vendor_dashboard(array &
   ]);
   if ($card !== []) {
     $variables['mel_vendor_contextual_help'] = $card;
-    return;
   }
 
   $item = myeventlane_help_centre_get_link('vendor_dashboard');
   if ($item) {
     $variables['mel_help_vendor_dashboard'] = myeventlane_help_link($item['text'], $item['url']);
+  }
+
+  $panel = \Drupal::service('myeventlane_help_centre.support_panel_builder')->build('vendor_dashboard', 'vendor_dashboard', \Drupal::routeMatch()->getRouteName());
+  if ($panel !== []) {
+    $variables['mel_support_panel'] = $panel;
   }
 }
 

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -13,6 +13,7 @@ services:
     class: Drupal\myeventlane_help_centre\Service\SupportPanelBuilder
     arguments:
       - '@myeventlane_help_centre.help_content_repository'
+      - '@path.validator'
 
   myeventlane_help_centre.seeder:
     class: Drupal\myeventlane_help_centre\Service\HelpContentSeeder

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
@@ -78,154 +78,18 @@ final class HelpContentSeeder {
 
   public function seedHelpArticles(): int {
     $yaml = $this->helpContentRepository->getHelpArticleSeeds();
-    if ($yaml !== []) {
-      $rows = $this->normalizeYamlSeedsToArticleRows($yaml);
-      if ($rows !== []) {
-        return $this->seedArticleNodes($rows);
-      }
+    if ($yaml === []) {
+      $this->logger->warning('No YAML help article seeds found; nothing to seed.');
+      return 0;
     }
 
-    return $this->seedHelpArticlesLegacy();
-  }
+    $rows = $this->normalizeYamlSeedsToArticleRows($yaml);
+    if ($rows === []) {
+      $this->logger->warning('YAML help article seeds were invalid; nothing to seed.');
+      return 0;
+    }
 
-  /**
-   * Legacy baseline articles — used when YAML config is empty or invalid.
-   */
-  private function seedHelpArticlesLegacy(): int {
-    $articles = [
-      [
-        'title' => 'How to buy tickets',
-        'summary' => 'Buy tickets in a few quick steps from event page to confirmation.',
-        'body' => '<p>Open the event page, choose your ticket type, and continue to checkout. After payment, your ticket and receipt are sent by email straight away.</p>',
-        'audience' => ['Attendees'],
-        'topic' => 'Tickets',
-        'article_type' => 'Guide',
-        'keywords' => 'buy ticket, checkout, purchase, order',
-        'cta_label' => 'Browse events',
-        'cta_link' => '/events',
-        'alias' => '/help/attendees/how-to-buy-tickets',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'How to RSVP to a free event',
-        'summary' => 'Reserve your place at a free event and keep your confirmation handy.',
-        'body' => '<p>Select RSVP on the event page and complete your details. Keep the confirmation email so you can check in faster on the day.</p>',
-        'audience' => ['Attendees'],
-        'topic' => 'RSVP',
-        'article_type' => 'Guide',
-        'keywords' => 'free event, rsvp, register',
-        'cta_label' => 'Find free events',
-        'cta_link' => '/events',
-        'alias' => '/help/attendees/how-to-rsvp-to-a-free-event',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'How to access your tickets',
-        'summary' => 'Where to find your ticket email and QR code before event day.',
-        'body' => '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>',
-        'audience' => ['Attendees'],
-        'topic' => 'Check-in',
-        'article_type' => 'FAQ',
-        'keywords' => 'ticket email, qr code, check in',
-        'cta_label' => 'Open your account',
-        'cta_link' => '/user',
-        'alias' => '/help/attendees/how-to-access-your-tickets',
-        'featured' => FALSE,
-      ],
-      [
-        'title' => 'How to request a refund',
-        'summary' => 'Check eligibility and send a refund request through the right channel.',
-        'body' => '<p>Open your booking, review the organiser refund policy, then submit a refund request. If approved, the refund returns to the original payment method.</p>',
-        'audience' => ['Attendees'],
-        'topic' => 'Refunds',
-        'article_type' => 'Troubleshooting',
-        'keywords' => 'refund request, cancellation, ticket refund',
-        'cta_label' => 'Read refund policy',
-        'cta_link' => '/help/policies/refund-policy',
-        'alias' => '/help/attendees/how-to-request-a-refund',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'How to create an event',
-        'summary' => 'Set up your event details, timing, and tickets before publishing.',
-        'body' => '<p>From your organiser dashboard, create a new event, complete the required details, and preview before publishing. Keep the event summary simple and clear.</p>',
-        'audience' => ['Organisers'],
-        'topic' => 'Event creation',
-        'article_type' => 'Guide',
-        'keywords' => 'create event, publish event, organiser',
-        'cta_label' => 'Open organiser dashboard',
-        'cta_link' => '/dashboard',
-        'alias' => '/help/organisers/how-to-create-an-event',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'Choosing RSVP or paid tickets',
-        'summary' => 'Pick the right ticket setup based on your event goals.',
-        'body' => '<p>Use RSVP when attendance is free and you mainly need numbers. Use paid tickets when you need checkout, receipts, and clearer revenue tracking.</p>',
-        'audience' => ['Organisers'],
-        'topic' => 'Ticket setup',
-        'article_type' => 'Overview',
-        'keywords' => 'rsvp vs paid, ticket setup, pricing',
-        'cta_label' => 'Configure ticket types',
-        'cta_link' => '/dashboard',
-        'alias' => '/help/organisers/choosing-rsvp-or-paid-tickets',
-        'featured' => FALSE,
-      ],
-      [
-        'title' => 'Managing your event dashboard',
-        'summary' => 'Track bookings, attendee activity, and quick event edits.',
-        'body' => '<p>Your dashboard gives a live view of bookings, capacity, and messages. Use it to make quick updates and keep attendees informed.</p>',
-        'audience' => ['Organisers'],
-        'topic' => 'Analytics',
-        'article_type' => 'Guide',
-        'keywords' => 'event dashboard, analytics, organiser tools',
-        'cta_label' => 'Go to dashboard',
-        'cta_link' => '/dashboard',
-        'alias' => '/help/organisers/managing-your-event-dashboard',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'Vendor dashboard overview',
-        'summary' => 'Navigate your vendor workspace, events, and stall tools.',
-        'body' => '<p>Use the vendor dashboard to review applications, manage your profile, and access event-day workflows. Links from your dashboard open the right tools for each task.</p>',
-        'audience' => ['Vendors'],
-        'topic' => 'Getting started',
-        'article_type' => 'Guide',
-        'keywords' => 'vendor dashboard, vendor workspace, stall',
-        'cta_label' => 'Vendor help',
-        'cta_link' => '/help/vendors',
-        'alias' => '/help/vendors/vendor-dashboard-overview',
-        'featured' => FALSE,
-      ],
-      [
-        'title' => 'Refund policy',
-        'summary' => 'How refunds are handled, assessed, and paid back on MyEventLane.',
-        'body' => '<p>Refunds depend on the organiser policy and event circumstances. Approved refunds are returned to the original payment method and timing may vary by bank.</p>',
-        'audience' => ['General'],
-        'topic' => 'Privacy',
-        'article_type' => 'Policy',
-        'keywords' => 'refund rules, policy, cancelled event',
-        'cta_label' => 'Contact support',
-        'cta_link' => '/help',
-        'alias' => '/help/policies/refund-policy',
-        'featured' => TRUE,
-      ],
-      [
-        'title' => 'Community guidelines',
-        'summary' => 'Our expectations for respectful behaviour across the platform.',
-        'body' => '<p>MyEventLane is community-first. We expect respectful conduct, clear communication, and safe participation from attendees, organisers, and vendors.</p>',
-        'audience' => ['General'],
-        'topic' => 'Community guidelines',
-        'article_type' => 'Policy',
-        'keywords' => 'community rules, safety, respectful behaviour',
-        'cta_label' => 'Read policies',
-        'cta_link' => '/help/policies',
-        'alias' => '/help/policies/community-guidelines',
-        'featured' => TRUE,
-      ],
-    ];
-
-    return $this->seedArticleNodes($articles);
+    return $this->seedArticleNodes($rows);
   }
 
   /**
@@ -235,8 +99,12 @@ final class HelpContentSeeder {
    */
   private function normalizeYamlSeedsToArticleRows(array $helpArticles): array {
     $out = [];
-    foreach ($helpArticles as $row) {
+    foreach ($helpArticles as $key => $row) {
       if (!is_array($row)) {
+        continue;
+      }
+      $seedKey = trim((string) ($row['seed_key'] ?? $key ?? ''));
+      if ($seedKey === '') {
         continue;
       }
       $title = trim((string) ($row['title'] ?? ''));
@@ -252,6 +120,7 @@ final class HelpContentSeeder {
         $audience = $audience !== '' && $audience !== NULL ? [(string) $audience] : [];
       }
       $out[] = [
+        'seed_key' => $seedKey,
         'title' => $title,
         'summary' => (string) ($row['summary'] ?? ''),
         'body' => (string) ($row['body'] ?? ''),
@@ -302,21 +171,33 @@ final class HelpContentSeeder {
   private function seedArticleNodes(array $definitions): int {
     $storage = $this->entityTypeManager->getStorage('node');
     $created = 0;
+    $updated = 0;
 
     foreach ($definitions as $item) {
-      $existing = $storage->loadByProperties([
-        'type' => 'help_article',
-        'title' => $item['title'],
-      ]);
-      if ($existing !== []) {
+      $seedKey = (string) ($item['seed_key'] ?? '');
+      if ($seedKey === '') {
         continue;
       }
-
-      $node = Node::create([
+      $existing = $storage->loadByProperties([
+        'type' => 'help_article',
+        'field_help_seed_key' => $seedKey,
+      ]);
+      if ($existing === []) {
+        $existing = $storage->loadByProperties([
+          'type' => 'help_article',
+          'title' => $item['title'],
+        ]);
+      }
+      $node = $existing !== [] ? reset($existing) : Node::create([
         'type' => 'help_article',
         'title' => $item['title'],
         'status' => 1,
       ]);
+      $node->setTitle($item['title']);
+      if ($node->isNew()) {
+        $node->set('status', 1);
+      }
+      $this->setTextField($node, 'field_help_seed_key', $seedKey);
       $this->setTextField($node, 'field_help_summary', (string) $item['summary']);
       $this->setBodyField($node, (string) $item['body']);
       $this->setAudienceField($node, (array) $item['audience']);
@@ -326,14 +207,21 @@ final class HelpContentSeeder {
       $this->setBoolField($node, 'field_featured_help', (bool) ($item['featured'] ?? FALSE));
       $this->setTextField($node, 'field_help_cta_label', (string) $item['cta_label']);
       $this->setLinkField($node, 'field_help_cta_link', (string) $item['cta_link']);
-      $this->setDateField($node, 'field_last_reviewed', date('Y-m-d'));
+      if ($node->isNew() || ($node->hasField('field_last_reviewed') && $node->get('field_last_reviewed')->isEmpty())) {
+        $this->setDateField($node, 'field_last_reviewed', date('Y-m-d'));
+      }
       $this->setAlias($node, (string) $item['alias']);
-      $node->save();
-      $created++;
+      if ($node->isNew() || $node->hasChanges()) {
+        $node->save();
+        $node->isNew() ? $created++ : $updated++;
+      }
     }
 
-    $this->logger->notice('Help Centre articles seeded. Created @count articles.', ['@count' => (string) $created]);
-    return $created;
+    $this->logger->notice('Help Centre articles seeded. Created @created, updated @updated.', [
+      '@created' => (string) $created,
+      '@updated' => (string) $updated,
+    ]);
+    return $created + $updated;
   }
 
   private function setBodyField(NodeInterface $node, string $html): void {

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_help_centre\Service;
 
+use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Core\Url;
 
 /**
@@ -13,39 +14,75 @@ final class SupportPanelBuilder {
 
   public function __construct(
     private readonly HelpContentRepository $helpContentRepository,
+    private readonly PathValidatorInterface $pathValidator,
   ) {}
 
   /**
    * @return array<string, mixed>
    *   Render array, or empty if the key is missing or invalid.
    */
-  public function build(string $key): array {
+  public function build(string $key, ?string $surface = NULL, ?string $routeName = NULL): array {
     $panel = $this->helpContentRepository->getSupportPanel($key);
     if ($panel === NULL) {
       return [];
     }
+    $surfaces = $this->normalizeStringList($panel['surfaces'] ?? []);
+    if ($surface !== NULL && $surfaces !== [] && !in_array($surface, $surfaces, TRUE)) {
+      return [];
+    }
+    $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+    if ($routeName !== NULL && $routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+      return [];
+    }
     $title = trim((string) ($panel['title'] ?? ''));
     $linkPath = trim((string) ($panel['link_path'] ?? ''));
-    if ($title === '' || $linkPath === '') {
+    if ($title === '' || $linkPath === '' || !str_starts_with($linkPath, '/')) {
       return [];
     }
 
-    try {
-      $url = Url::fromUserInput($linkPath)->setAbsolute(FALSE)->toString();
-    }
-    catch (\Throwable) {
+    $url = $this->pathValidator->getUrlIfValidWithoutAccessCheck($linkPath);
+    if (!$url instanceof Url || $url->isExternal()) {
       return [];
+    }
+
+    $cacheContexts = [];
+    if ($routeNames !== []) {
+      $cacheContexts[] = 'route';
+    }
+
+    $cache = [
+      'tags' => ['config:myeventlane_help_centre.help_content'],
+    ];
+    if ($cacheContexts !== []) {
+      $cache['contexts'] = $cacheContexts;
     }
 
     return [
       '#theme' => 'mel_support_panel',
       '#title' => $title,
       '#summary' => trim((string) ($panel['summary'] ?? '')),
-      '#url' => $url,
-      '#cache' => [
-        'tags' => ['config:myeventlane_help_centre.help_content'],
-      ],
+      '#url' => $url->setAbsolute(FALSE)->toString(),
+      '#cache' => $cache,
     ];
+  }
+
+  /**
+   * @param array<int|string, string>|string $values
+   *
+   * @return array<int, string>
+   */
+  private function normalizeStringList(array|string $values): array {
+    if (!is_array($values)) {
+      $values = $values === '' ? [] : [$values];
+    }
+    $out = [];
+    foreach ($values as $value) {
+      $value = trim((string) $value);
+      if ($value !== '') {
+        $out[] = $value;
+      }
+    }
+    return $out;
   }
 
 }

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -54,9 +54,9 @@
       <div class="mel-checkout__main">
         <p class="mel-checkout-helper">{{ "Just a few details and you're done."|t }}</p>
 
-        {% if mel_help_yaml_support_panel is defined and mel_help_yaml_support_panel %}
+        {% if mel_support_panel is defined and mel_support_panel %}
           <div class="mel-checkout-yaml-support" role="region" aria-label="{{ 'Help'|t }}">
-            {{ mel_help_yaml_support_panel }}
+            {{ mel_support_panel }}
           </div>
         {% endif %}
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -60,9 +60,9 @@
       <div class="mel-checkout__main">
         <p class="mel-checkout-helper">{{ "Just a few details and you're done."|t }}</p>
 
-        {% if mel_help_yaml_support_panel is defined and mel_help_yaml_support_panel %}
+        {% if mel_support_panel is defined and mel_support_panel %}
           <div class="mel-checkout-yaml-support" role="region" aria-label="{{ 'Help'|t }}">
-            {{ mel_help_yaml_support_panel }}
+            {{ mel_support_panel }}
           </div>
         {% endif %}
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -248,6 +248,12 @@
     </div>
 
     <aside class="mel-dashboard-layout__rail">
+      {% if mel_support_panel is defined and mel_support_panel %}
+        <section class="mel-panel-card mel-dashboard-rail-widget" aria-label="{{ 'Help and support'|t }}">
+          {{ mel_support_panel }}
+        </section>
+      {% endif %}
+
       <section class="mel-panel-card mel-dashboard-rail-widget">
         {% include '@myeventlane_vendor_theme/components/section-heading.html.twig' with {
           title: 'Alerts and next steps'|t


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: updates the help-article seeding logic to create/update existing nodes based on a new `field_help_seed_key`, and changes how support panels are selected/rendered on checkout and vendor dashboards (route/surface filtering and template variable rename).
> 
> **Overview**
> Adds a new `field_help_seed_key` to `help_article` nodes and extends the YAML help-article seeds to include `seed_key`, enabling stable identification of seeded content across environments.
> 
> Updates `HelpContentSeeder` to *only* seed from YAML (removing legacy fallback), normalize/require `seed_key`, and create **or update** existing help articles by `seed_key` (fallbacking to title), including smarter `field_last_reviewed` initialization and updated logging.
> 
> Enhances YAML-driven support panels by adding config schema, `surfaces`/`route_names` targeting, and safer link handling via `path.validator`; wires this into checkout and vendor dashboard preprocessors, renames the Twig variable to `mel_support_panel`, and renders the panel in the vendor dashboard sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7a72753a18dd03d222ef9f83a5601b10612747f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->