### PR TITLE
Refactor help audience to canonical field audience

### DIFF
--- a/config/sync/core.entity_form_display.node.help_article.default.yml
+++ b/config/sync/core.entity_form_display.node.help_article.default.yml
@@ -145,8 +145,8 @@ hidden:
   field_help_audience: true
   field_help_cta_label: true
   field_help_cta_link: true
-  field_help_seed_key: true
   field_help_keywords: true
+  field_help_seed_key: true
   field_help_status: true
   field_last_reviewed: true
   field_last_updated: true

--- a/config/sync/core.entity_view_display.node.help_article.default.yml
+++ b/config/sync/core.entity_view_display.node.help_article.default.yml
@@ -50,8 +50,8 @@ hidden:
   field_help_category: true
   field_help_cta_label: true
   field_help_cta_link: true
-  field_help_seed_key: true
   field_help_keywords: true
+  field_help_seed_key: true
   field_help_status: true
   field_help_summary: true
   field_help_topic: true

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -2,9 +2,9 @@ _core:
   default_config_hash: CXhei_vpaZk-3f_Mj2cH0YmpK-ZpKHoSzVA3yZrDq0g
 definitions:
   contact__site_page:
-    weight: -49
     menu_name: footer
     parent: ''
+    weight: -49
     expanded: false
     enabled: true
   standard__front_page:
@@ -14,44 +14,44 @@ definitions:
     expanded: false
     enabled: false
   user__page:
-    weight: -50
     menu_name: account
     parent: ''
+    weight: -50
     expanded: false
     enabled: true
   user__logout:
-    weight: -46
     menu_name: account
     parent: ''
+    weight: -46
     expanded: false
     enabled: true
   myeventlane_core__my_categories:
-    weight: -49
-    parent: user.page
     menu_name: account
+    parent: user.page
+    weight: -49
     expanded: false
     enabled: true
   myeventlane_dashboard__my_events:
+    menu_name: account
     parent: user.page
-    menu_name: account
-    enabled: false
+    weight: -50
     expanded: false
-    weight: -50
+    enabled: false
   myeventlane_rsvp__ics_bundle_link:
-    weight: -50
-    parent: user.logout
     menu_name: account
+    parent: user.logout
+    weight: -50
     expanded: false
     enabled: false
   myeventlane_help_centre__public_help:
-    weight: -50
-    parent: 'menu_link_content:f7cb2911-b1a1-46a4-908a-9286e792b6bf'
     menu_name: footer
+    parent: 'menu_link_content:f7cb2911-b1a1-46a4-908a-9286e792b6bf'
+    weight: -50
     expanded: false
     enabled: true
   myeventlane_public_trust__footer:
-    weight: -48
     menu_name: footer
     parent: ''
+    weight: -48
     expanded: false
     enabled: true

--- a/config/sync/field.field.node.help_article.field_help_seed_key.yml
+++ b/config/sync/field.field.node.help_article.field_help_seed_key.yml
@@ -15,8 +15,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  max_length: 128
-  is_ascii: true
-  case_sensitive: false
+settings: {  }
 field_type: string

--- a/config/sync/field.storage.node.field_help_seed_key.yml
+++ b/config/sync/field.storage.node.field_help_seed_key.yml
@@ -10,8 +10,8 @@ entity_type: node
 type: string
 settings:
   max_length: 128
-  is_ascii: true
   case_sensitive: false
+  is_ascii: true
 module: core
 locked: false
 cardinality: 1

--- a/config/sync/myeventlane_help_centre.help_content.yml
+++ b/config/sync/myeventlane_help_centre.help_content.yml
@@ -1,8 +1,4 @@
-uuid: 8f3c2a91-4d0e-4b1f-9c7a-2e6d5b4c3a10
 langcode: en
-dependencies:
-  module:
-    - myeventlane_help_centre
 help_articles:
   how_to_buy_tickets:
     seed_key: how_to_buy_tickets
@@ -15,8 +11,8 @@ help_articles:
     article_type: Guide
     keywords: 'buy ticket, checkout, purchase, order'
     cta_label: 'Browse events'
-    cta_link: '/events'
-    alias: '/help/attendees/how-to-buy-tickets'
+    cta_link: /events
+    alias: /help/attendees/how-to-buy-tickets
     featured: true
   how_to_rsvp:
     seed_key: how_to_rsvp
@@ -29,8 +25,8 @@ help_articles:
     article_type: Guide
     keywords: 'free event, rsvp, register'
     cta_label: 'Find free events'
-    cta_link: '/events'
-    alias: '/help/attendees/how-to-rsvp-to-a-free-event'
+    cta_link: /events
+    alias: /help/attendees/how-to-rsvp-to-a-free-event
     featured: true
   how_to_access_tickets:
     seed_key: how_to_access_tickets
@@ -39,12 +35,12 @@ help_articles:
     body: '<p>Your tickets are sent to your account email and can also be found in your MyEventLane account. Open the QR code at the gate for quick entry.</p>'
     audience:
       - Attendees
-    topic: 'Check-in'
+    topic: Check-in
     article_type: FAQ
     keywords: 'ticket email, qr code, check in'
     cta_label: 'Open your account'
-    cta_link: '/user'
-    alias: '/help/attendees/how-to-access-your-tickets'
+    cta_link: /user
+    alias: /help/attendees/how-to-access-your-tickets
     featured: false
   how_to_request_refund:
     seed_key: how_to_request_refund
@@ -57,8 +53,8 @@ help_articles:
     article_type: Troubleshooting
     keywords: 'refund request, cancellation, ticket refund'
     cta_label: 'Read refund policy'
-    cta_link: '/help/policies/refund-policy'
-    alias: '/help/attendees/how-to-request-a-refund'
+    cta_link: /help/policies/refund-policy
+    alias: /help/attendees/how-to-request-a-refund
     featured: true
   how_to_create_event:
     seed_key: how_to_create_event
@@ -71,8 +67,8 @@ help_articles:
     article_type: Guide
     keywords: 'create event, publish event, organiser'
     cta_label: 'Open organiser dashboard'
-    cta_link: '/dashboard'
-    alias: '/help/organisers/how-to-create-an-event'
+    cta_link: /dashboard
+    alias: /help/organisers/how-to-create-an-event
     featured: true
   choosing_rsvp_or_paid:
     seed_key: choosing_rsvp_or_paid
@@ -85,8 +81,8 @@ help_articles:
     article_type: Overview
     keywords: 'rsvp vs paid, ticket setup, pricing'
     cta_label: 'Configure ticket types'
-    cta_link: '/dashboard'
-    alias: '/help/organisers/choosing-rsvp-or-paid-tickets'
+    cta_link: /dashboard
+    alias: /help/organisers/choosing-rsvp-or-paid-tickets
     featured: false
   managing_dashboard:
     seed_key: managing_dashboard
@@ -99,8 +95,8 @@ help_articles:
     article_type: Guide
     keywords: 'event dashboard, analytics, organiser tools'
     cta_label: 'Go to dashboard'
-    cta_link: '/dashboard'
-    alias: '/help/organisers/managing-your-event-dashboard'
+    cta_link: /dashboard
+    alias: /help/organisers/managing-your-event-dashboard
     featured: true
   vendor_dashboard_overview:
     seed_key: vendor_dashboard_overview
@@ -113,8 +109,8 @@ help_articles:
     article_type: Guide
     keywords: 'vendor dashboard, vendor workspace, stall'
     cta_label: 'Vendor help'
-    cta_link: '/help/vendors'
-    alias: '/help/vendors/vendor-dashboard-overview'
+    cta_link: /help/vendors
+    alias: /help/vendors/vendor-dashboard-overview
     featured: false
   refund_policy:
     seed_key: refund_policy
@@ -127,8 +123,8 @@ help_articles:
     article_type: Policy
     keywords: 'refund rules, policy, cancelled event'
     cta_label: 'Contact support'
-    cta_link: '/help'
-    alias: '/help/policies/refund-policy'
+    cta_link: /help
+    alias: /help/policies/refund-policy
     featured: true
   community_guidelines:
     seed_key: community_guidelines
@@ -141,29 +137,37 @@ help_articles:
     article_type: Policy
     keywords: 'community rules, safety, respectful behaviour'
     cta_label: 'Read policies'
-    cta_link: '/help/policies'
-    alias: '/help/policies/community-guidelines'
+    cta_link: /help/policies
+    alias: /help/policies/community-guidelines
     featured: true
 support_panels:
   buy_tickets:
-    title: 'How to buy tickets'
-    summary: 'Learn how to purchase tickets and complete checkout securely.'
-    link_path: '/help/attendees/how-to-buy-tickets'
+    title: 'Need help buying tickets?'
+    summary: 'Get help with checkout and payments'
+    link_path: /help/how-to-buy-tickets
     surfaces:
       - checkout
     route_names:
       - commerce_checkout.form
+    analytics_key: buy_tickets
   create_event:
     title: 'How to create an event'
     summary: 'Step-by-step guide to publishing your event.'
-    link_path: '/help/organisers/how-to-create-an-event'
+    link_path: /help/organisers/how-to-create-an-event
     surfaces:
       - event_creation_wizard
   vendor_dashboard:
-    title: 'Vendor dashboard overview'
-    summary: 'Know where to manage your vendor workspace, events, and payouts.'
-    link_path: '/help/vendors/vendor-dashboard-overview'
+    title: 'Managing your events'
+    summary: 'Learn how to manage and track your events'
+    link_path: /help/vendor-dashboard
     surfaces:
+      - vendor
       - vendor_dashboard
     route_names:
+      - myeventlane_vendor.dashboard
       - myeventlane_vendor.console.dashboard
+    analytics_key: vendor_dashboard
+uuid: 8f3c2a91-4d0e-4b1f-9c7a-2e6d5b4c3a10
+dependencies:
+  module:
+    - myeventlane_help_centre

--- a/config/sync/myeventlane_help_centre.help_content.yml
+++ b/config/sync/myeventlane_help_centre.help_content.yml
@@ -144,7 +144,7 @@ support_panels:
   buy_tickets:
     title: 'Need help buying tickets?'
     summary: 'Get help with checkout and payments'
-    link_path: /help/how-to-buy-tickets
+    link_path: /help/attendees/how-to-buy-tickets
     surfaces:
       - checkout
     route_names:

--- a/config/sync/myeventlane_help_centre.help_content.yml
+++ b/config/sync/myeventlane_help_centre.help_content.yml
@@ -159,7 +159,7 @@ support_panels:
   vendor_dashboard:
     title: 'Managing your events'
     summary: 'Learn how to manage and track your events'
-    link_path: /help/vendor-dashboard
+    link_path: /help/vendors/vendor-dashboard-overview
     surfaces:
       - vendor
       - vendor_dashboard

--- a/web/modules/custom/myeventlane_help_centre/js/help-analytics.js
+++ b/web/modules/custom/myeventlane_help_centre/js/help-analytics.js
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Tracks support panel click events.
+ */
+(function (drupalSettings) {
+  'use strict';
+
+  /**
+   * Sends a click event for a support panel.
+   *
+   * @param {HTMLElement} el
+   *   The link element that was clicked.
+   */
+  window.melHelpTrackClick = function (el) {
+    if (!el || !el.dataset) {
+      return;
+    }
+    const key = el.dataset.analyticsKey || '';
+    if (!key) {
+      return;
+    }
+    const base = drupalSettings?.path?.baseUrl ?? '/';
+    const prefix = drupalSettings?.path?.pathPrefix ?? '';
+    const endpoint = (base.endsWith('/') ? base : base + '/') + prefix + 'mel-help/click';
+
+    fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ key }),
+    }).catch((error) => {
+      console.error('melHelpTrackClick failed', error);
+    });
+  };
+})(drupalSettings);

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
@@ -112,6 +112,42 @@ function myeventlane_help_centre_schema(): array {
     ],
   ];
 
+  $schema['mel_help_panel_analytics'] = [
+    'description' => 'Tracks support panel impressions and clicks.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'panel_key' => [
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+      ],
+      'event_type' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'path' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+      'created' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'panel_key' => ['panel_key'],
+      'event_type' => ['event_type'],
+      'created' => ['created'],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -1758,6 +1794,24 @@ function myeventlane_help_centre_update_10032(): string {
 
   $logger->notice('update_10032: applied entity definition update for node.field_help_status.');
   return 'Applied entity definition update for node.field_help_status (synced installed field schema).';
+}
+
+/**
+ * Create analytics table for support panel impressions and clicks.
+ */
+function myeventlane_help_centre_update_10033(): string {
+  $schema = Database::getConnection()->schema();
+  $definitions = myeventlane_help_centre_schema();
+
+  if ($schema->tableExists('mel_help_panel_analytics')) {
+    return 'mel_help_panel_analytics already exists.';
+  }
+  if (!isset($definitions['mel_help_panel_analytics'])) {
+    return 'mel_help_panel_analytics definition missing; no changes applied.';
+  }
+
+  $schema->createTable('mel_help_panel_analytics', $definitions['mel_help_panel_analytics']);
+  return 'Created mel_help_panel_analytics table for support panel analytics.';
 }
 
 /**

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.libraries.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.libraries.yml
@@ -9,6 +9,12 @@ support_components:
     - core/drupalSettings
     - core/once
 
+support_panel_analytics:
+  js:
+    js/help-analytics.js: {}
+  dependencies:
+    - core/drupalSettings
+
 help_feedback:
   js:
     js/help-feedback.js: {}

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
@@ -135,3 +135,11 @@ myeventlane_help_centre.docs_health:
     _permission: 'view mel help insights'
   options:
     _admin_route: TRUE
+
+myeventlane_help.analytics_click:
+  path: '/mel-help/click'
+  defaults:
+    _controller: '\Drupal\myeventlane_help_centre\Controller\HelpAnalyticsController::track'
+  requirements:
+    _access: 'TRUE'
+  methods: [POST]

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -14,6 +14,7 @@ services:
     arguments:
       - '@myeventlane_help_centre.help_content_repository'
       - '@path.validator'
+      - '@myeventlane_help.analytics'
 
   myeventlane_help_centre.seeder:
     class: Drupal\myeventlane_help_centre\Service\HelpContentSeeder
@@ -82,3 +83,11 @@ services:
       - '@current_route_match'
       - '@request_stack'
       - '@myeventlane_help_centre.mel_support_settings_builder'
+
+  myeventlane_help.analytics:
+    class: Drupal\myeventlane_help_centre\Service\HelpPanelAnalytics
+    arguments:
+      - '@database'
+      - '@request_stack'
+      - '@datetime.time'
+      - '@logger.channel.myeventlane_help_centre'

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpAnalyticsController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpAnalyticsController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\myeventlane_help_centre\Service\HelpPanelAnalytics;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Handles Help panel analytics events.
+ */
+final class HelpAnalyticsController implements ContainerInjectionInterface {
+
+  public function __construct(
+    private readonly HelpPanelAnalytics $analytics,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_help.analytics'),
+    );
+  }
+
+  public function track(Request $request): JsonResponse {
+    $data = json_decode($request->getContent() ?: '', TRUE);
+    if (!is_array($data)) {
+      return new JsonResponse(['status' => 'error', 'message' => 'Invalid payload'], 400);
+    }
+    $key = trim((string) ($data['key'] ?? ''));
+    if ($key === '') {
+      return new JsonResponse(['status' => 'error', 'message' => 'Missing key'], 400);
+    }
+
+    $this->analytics->logClick($key);
+
+    return new JsonResponse(['status' => 'ok']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelAnalytics.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelAnalytics.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Records support panel impressions and clicks.
+ */
+final class HelpPanelAnalytics {
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly RequestStack $requestStack,
+    private readonly TimeInterface $time,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  public function logImpression(string $key): void {
+    $this->logEvent($key, 'impression');
+  }
+
+  public function logClick(string $key): void {
+    $this->logEvent($key, 'click');
+  }
+
+  private function logEvent(string $key, string $eventType): void {
+    $panelKey = trim($key);
+    if ($panelKey === '') {
+      return;
+    }
+
+    $path = $this->requestStack->getCurrentRequest()?->getPathInfo() ?? '';
+    $created = (int) $this->time->getRequestTime();
+
+    try {
+      $this->database->insert('mel_help_panel_analytics')
+        ->fields([
+          'panel_key' => mb_substr($panelKey, 0, 128),
+          'event_type' => $eventType,
+          'path' => mb_substr($path, 0, 255),
+          'created' => $created,
+        ])
+        ->execute();
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Failed to record @type for help panel @key: @message', [
+        '@type' => $eventType,
+        '@key' => $panelKey,
+        '@message' => $exception->getMessage(),
+      ]);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -15,6 +15,7 @@ final class SupportPanelBuilder {
   public function __construct(
     private readonly HelpContentRepository $helpContentRepository,
     private readonly PathValidatorInterface $pathValidator,
+    private readonly HelpPanelAnalytics $helpPanelAnalytics,
   ) {}
 
   /**
@@ -23,9 +24,58 @@ final class SupportPanelBuilder {
    */
   public function build(string $key, ?string $surface = NULL, ?string $routeName = NULL): array {
     $panel = $this->helpContentRepository->getSupportPanel($key);
-    if ($panel === NULL) {
-      return [];
+    return $panel === NULL ? [] : $this->buildPanel($key, $panel, $surface, $routeName);
+  }
+
+  /**
+   * Builds the first matching panel for a given route.
+   *
+   * @return array<string, mixed>|null
+   *   Render array when a match is found, NULL otherwise.
+   */
+  public function buildForRoute(string $routeName, ?string $surface = NULL): ?array {
+    $panels = $this->helpContentRepository->getSupportPanels();
+    foreach ($panels as $key => $panel) {
+      if (!is_array($panel)) {
+        continue;
+      }
+      $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+      if ($routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+        continue;
+      }
+      $built = $this->buildPanel((string) $key, $panel, $surface, $routeName);
+      if ($built !== []) {
+        return $built;
+      }
     }
+    return NULL;
+  }
+
+  /**
+   * @param array<int|string, string>|string $values
+   *
+   * @return array<int, string>
+   */
+  private function normalizeStringList(array|string $values): array {
+    if (!is_array($values)) {
+      $values = $values === '' ? [] : [$values];
+    }
+    $out = [];
+    foreach ($values as $value) {
+      $value = trim((string) $value);
+      if ($value !== '') {
+        $out[] = $value;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $panel
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPanel(string $key, array $panel, ?string $surface, ?string $routeName): array {
     $surfaces = $this->normalizeStringList($panel['surfaces'] ?? []);
     if ($surface !== NULL && $surfaces !== [] && !in_array($surface, $surfaces, TRUE)) {
       return [];
@@ -52,37 +102,25 @@ final class SupportPanelBuilder {
 
     $cache = [
       'tags' => ['config:myeventlane_help_centre.help_content'],
+      'max-age' => 0,
     ];
     if ($cacheContexts !== []) {
       $cache['contexts'] = $cacheContexts;
     }
+
+    $this->helpPanelAnalytics->logImpression($key);
 
     return [
       '#theme' => 'mel_support_panel',
       '#title' => $title,
       '#summary' => trim((string) ($panel['summary'] ?? '')),
       '#url' => $url->setAbsolute(FALSE)->toString(),
+      '#analytics_key' => $key,
       '#cache' => $cache,
+      '#attached' => [
+        'library' => ['myeventlane_help_centre/support_panel_analytics'],
+      ],
     ];
-  }
-
-  /**
-   * @param array<int|string, string>|string $values
-   *
-   * @return array<int, string>
-   */
-  private function normalizeStringList(array|string $values): array {
-    if (!is_array($values)) {
-      $values = $values === '' ? [] : [$values];
-    }
-    $out = [];
-    foreach ($values as $value) {
-      $value = trim((string) $value);
-      if ($value !== '') {
-        $out[] = $value;
-      }
-    }
-    return $out;
   }
 
 }

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
@@ -9,5 +9,12 @@
   {% if summary %}
     <p class="mel-support-panel__summary">{{ summary }}</p>
   {% endif %}
-  <a href="{{ url }}" class="mel-button mel-button--primary">{{ 'View help'|t }}</a>
+  <a
+    href="{{ url }}"
+    class="mel-button mel-button--primary"
+    data-analytics-key="{{ analytics_key|default('') }}"
+    onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"
+  >
+    {{ 'View help'|t }}
+  </a>
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated POST endpoint and database writes for analytics events, which introduces some security/abuse and performance considerations if not rate-limited or protected by CSRF/session controls.
> 
> **Overview**
> Adds support-panel analytics tracking: support panels now log **impressions server-side** and **clicks via a new JS library** that POSTs to `POST /mel-help/click`.
> 
> Introduces the `mel_help_panel_analytics` table (schema + update hook), a new `HelpPanelAnalytics` service, and `HelpAnalyticsController::track()` to record click events. Support panel rendering is updated to attach the analytics library, disable caching (`max-age: 0`), and emit a `data-analytics-key` used by the theme template.
> 
> Also updates `myeventlane_help_centre.help_content` support panel copy/surfaces/route targeting and includes minor config normalization changes in exported YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75101aa4a2c1863585746b31f4659a2e1a603d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->