### PR TITLE
feat(help_centre): implement feedback mechanism for support panels

### DIFF
--- a/web/modules/custom/myeventlane_help_centre/js/help-analytics.js
+++ b/web/modules/custom/myeventlane_help_centre/js/help-analytics.js
@@ -1,5 +1,74 @@
 /**
  * @file
+ * Tracks support panel analytics events.
+ */
+(function (drupalSettings) {
+  'use strict';
+
+  const base = drupalSettings?.path?.baseUrl ?? '/';
+  const prefix = drupalSettings?.path?.pathPrefix ?? '';
+  const buildEndpoint = (suffix) => (base.endsWith('/') ? base : `${base}/`) + prefix + suffix;
+
+  const sendJson = (endpoint, payload, extraHeaders = {}) => fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+    credentials: 'same-origin',
+    body: JSON.stringify(payload),
+  });
+
+  /**
+   * Sends a click event for a support panel.
+   *
+   * @param {HTMLElement} el
+   *   The link element that was clicked.
+   */
+  window.melHelpTrackClick = function (el) {
+    if (!el || !el.dataset) {
+      return;
+    }
+    const key = el.dataset.analyticsKey || '';
+    if (!key) {
+      return;
+    }
+
+    const endpoint = buildEndpoint('mel-help/click');
+
+    sendJson(endpoint, { key }).catch((error) => {
+      console.error('melHelpTrackClick failed', error);
+    });
+  };
+
+  /**
+   * Sends "Was this helpful?" feedback for a support panel.
+   *
+   * @param {string} key
+   *   Analytics key for the support panel.
+   * @param {boolean} helpful
+   *   Whether the panel was helpful.
+   */
+  window.melHelpFeedback = function (key, helpful) {
+    if (!key) {
+      console.error('melHelpFeedback missing analytics key');
+      return;
+    }
+    const csrfToken = drupalSettings?.ajaxPageState?.csrfToken;
+    if (!csrfToken) {
+      console.error('melHelpFeedback missing CSRF token');
+      return;
+    }
+
+    const endpoint = buildEndpoint('mel-help/feedback');
+    sendJson(endpoint, { key, helpful: !!helpful }, { 'X-CSRF-Token': csrfToken })
+      .catch((error) => {
+        console.error('melHelpFeedback failed', error);
+      });
+  };
+})(drupalSettings);
+/**
+ * @file
  * Tracks support panel click events.
  */
 (function (drupalSettings) {

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
@@ -129,6 +129,11 @@ function myeventlane_help_centre_schema(): array {
         'length' => 32,
         'not null' => TRUE,
       ],
+      'is_helpful' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => FALSE,
+      ],
       'path' => [
         'type' => 'varchar',
         'length' => 255,
@@ -1812,6 +1817,27 @@ function myeventlane_help_centre_update_10033(): string {
 
   $schema->createTable('mel_help_panel_analytics', $definitions['mel_help_panel_analytics']);
   return 'Created mel_help_panel_analytics table for support panel analytics.';
+}
+
+/**
+ * Add is_helpful column to support panel analytics.
+ */
+function myeventlane_help_centre_update_10034(): string {
+  $schema = Database::getConnection()->schema();
+  if (!$schema->tableExists('mel_help_panel_analytics')) {
+    return 'mel_help_panel_analytics is missing; no changes applied.';
+  }
+  if ($schema->fieldExists('mel_help_panel_analytics', 'is_helpful')) {
+    return 'is_helpful already present on mel_help_panel_analytics.';
+  }
+
+  $schema->addField('mel_help_panel_analytics', 'is_helpful', [
+    'type' => 'int',
+    'size' => 'tiny',
+    'not null' => FALSE,
+  ]);
+
+  return 'Added is_helpful column to mel_help_panel_analytics.';
 }
 
 /**

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
@@ -143,3 +143,11 @@ myeventlane_help.analytics_click:
   requirements:
     _access: 'TRUE'
   methods: [POST]
+
+myeventlane_help.feedback_panel:
+  path: '/mel-help/feedback'
+  defaults:
+    _controller: '\Drupal\myeventlane_help_centre\Controller\HelpFeedbackController::submitPanelFeedback'
+  requirements:
+    _csrf_token: 'TRUE'
+  methods: [POST]

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -15,6 +15,7 @@ services:
       - '@myeventlane_help_centre.help_content_repository'
       - '@path.validator'
       - '@myeventlane_help.analytics'
+      - '@myeventlane_help.intelligence'
 
   myeventlane_help_centre.seeder:
     class: Drupal\myeventlane_help_centre\Service\HelpContentSeeder
@@ -90,4 +91,10 @@ services:
       - '@database'
       - '@request_stack'
       - '@datetime.time'
+      - '@logger.channel.myeventlane_help_centre'
+
+  myeventlane_help.intelligence:
+    class: Drupal\myeventlane_help_centre\Service\HelpPanelIntelligence
+    arguments:
+      - '@database'
       - '@logger.channel.myeventlane_help_centre'

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpFeedbackController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpFeedbackController.php
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\node\NodeInterface;
 use Drupal\myeventlane_help_centre\Service\HelpAnalyticsService;
+use Drupal\myeventlane_help_centre\Service\HelpPanelAnalytics;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,7 @@ final class HelpFeedbackController extends ControllerBase {
     private readonly AccountProxyInterface $accountProxy,
     private readonly CsrfTokenGenerator $csrfToken,
     private readonly HelpAnalyticsService $analyticsService,
+    private readonly HelpPanelAnalytics $panelAnalytics,
     private readonly TimeInterface $time,
   ) {}
 
@@ -46,6 +48,7 @@ final class HelpFeedbackController extends ControllerBase {
       $container->get('current_user'),
       $container->get('csrf_token'),
       $container->get('myeventlane_help_centre.analytics'),
+      $container->get('myeventlane_help.analytics'),
       $container->get('datetime.time'),
     );
   }
@@ -100,6 +103,43 @@ final class HelpFeedbackController extends ControllerBase {
       'helpful' => $helpful ? 1 : 0,
       'message' => $this->t('Thanks for your feedback.'),
     ]);
+  }
+
+  /**
+   * Stores "Was this helpful?" feedback for support panels.
+   */
+  public function submitPanelFeedback(Request $request): JsonResponse {
+    $token = (string) ($request->headers->get('X-CSRF-Token') ?? '');
+    if ($token === '' || !$this->csrfToken->validate($token, 'rest')) {
+      return new JsonResponse(['status' => 'error', 'message' => $this->t('Invalid CSRF token.')], 403);
+    }
+
+    $payload = json_decode($request->getContent() ?: '', TRUE);
+    if (!is_array($payload)) {
+      return new JsonResponse(['status' => 'error', 'message' => $this->t('Invalid payload.')], 400);
+    }
+
+    $key = trim((string) ($payload['key'] ?? ''));
+    if ($key === '' || !array_key_exists('helpful', $payload)) {
+      return new JsonResponse(['status' => 'error', 'message' => $this->t('Missing required fields.')], 400);
+    }
+
+    $helpfulRaw = $payload['helpful'];
+    $helpful = match (TRUE) {
+      is_bool($helpfulRaw) => $helpfulRaw,
+      $helpfulRaw === 1 => TRUE,
+      $helpfulRaw === 0 => FALSE,
+      $helpfulRaw === '1' => TRUE,
+      $helpfulRaw === '0' => FALSE,
+      default => NULL,
+    };
+    if (!is_bool($helpful)) {
+      return new JsonResponse(['status' => 'error', 'message' => $this->t('Invalid helpful value.')], 422);
+    }
+
+    $this->panelAnalytics->logFeedback($key, $helpful);
+
+    return new JsonResponse(['status' => 'ok']);
   }
 
 }

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpInsightsController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpInsightsController.php
@@ -8,6 +8,8 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\MelAdminShellBuilder;
+use Drupal\myeventlane_help_centre\Service\HelpContentRepository;
+use Drupal\myeventlane_help_centre\Service\HelpPanelIntelligence;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -17,6 +19,8 @@ final class HelpInsightsController extends ControllerBase {
 
   public function __construct(
     private readonly MelAdminShellBuilder $adminShellBuilder,
+    private readonly HelpPanelIntelligence $panelIntelligence,
+    private readonly HelpContentRepository $helpContentRepository,
   ) {}
 
   /**
@@ -25,6 +29,8 @@ final class HelpInsightsController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_core.mel_admin_shell_builder'),
+      $container->get('myeventlane_help.intelligence'),
+      $container->get('myeventlane_help_centre.help_content_repository'),
     );
   }
 
@@ -63,6 +69,12 @@ final class HelpInsightsController extends ControllerBase {
     ];
     $build['least_helpful'] = views_embed_view('mel_help_least_helpful', 'block_1');
     $build['most_helpful'] = views_embed_view('mel_help_most_helpful', 'block_1');
+    $build['support_panels_heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $this->t('Support panel performance'),
+    ];
+    $build['support_panels'] = $this->buildSupportPanelTable();
     $build['#cache'] = [
       'contexts' => ['user.permissions'],
     ];
@@ -109,6 +121,12 @@ final class HelpInsightsController extends ControllerBase {
       '#value' => $this->t('Least helpful articles'),
     ];
     $build['least_helpful'] = views_embed_view('mel_help_least_helpful', 'block_1');
+    $build['support_panels_heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $this->t('Support panel performance'),
+    ];
+    $build['support_panels'] = $this->buildSupportPanelTable();
     $build['#cache'] = [
       'contexts' => ['user.permissions'],
       'max-age' => 300,
@@ -116,6 +134,7 @@ final class HelpInsightsController extends ControllerBase {
         'config:views.view.mel_help_top_articles',
         'config:views.view.mel_help_zero_results',
         'config:views.view.mel_help_least_helpful',
+        'config:myeventlane_help_centre.help_content',
       ],
     ];
 
@@ -152,6 +171,70 @@ final class HelpInsightsController extends ControllerBase {
       '#attributes' => ['class' => ['mel-help-improvement-nav']],
       '#cache' => [
         'contexts' => ['user.permissions'],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   Table render array for panel analytics.
+   */
+  private function buildSupportPanelTable(): array {
+    $panels = $this->helpContentRepository->getSupportPanels();
+    if (!is_array($panels) || $panels === []) {
+      return [
+        '#markup' => $this->t('No support panels configured.'),
+      ];
+    }
+
+    $orderedKeys = $this->panelIntelligence->getTopPanels($panels);
+    if ($orderedKeys === []) {
+      $orderedKeys = array_keys($panels);
+    }
+    $metrics = $this->panelIntelligence->getPanelMetrics($panels);
+
+    $rows = [];
+    foreach ($orderedKeys as $key) {
+      $panel = $panels[$key] ?? [];
+      $panelTitle = trim((string) ($panel['title'] ?? '')) ?: $key;
+      $stat = $metrics[$key] ?? [
+        'impressions' => 0,
+        'clicks' => 0,
+        'ctr' => 0,
+        'feedback_total' => 0,
+        'helpful' => 0,
+        'helpful_rate' => 0,
+      ];
+      $rows[] = [
+        $panelTitle,
+        $key,
+        (int) $stat['impressions'],
+        (int) $stat['clicks'],
+        sprintf('%.1f%%', ((float) $stat['ctr']) * 100),
+        (int) $stat['feedback_total'],
+        (int) $stat['helpful'],
+        sprintf('%.1f%%', ((float) $stat['helpful_rate']) * 100),
+      ];
+    }
+
+    return [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Panel'),
+        $this->t('Key'),
+        $this->t('Impressions'),
+        $this->t('Clicks'),
+        $this->t('CTR'),
+        $this->t('Feedback'),
+        $this->t('Helpful'),
+        $this->t('Helpful rate'),
+      ],
+      '#rows' => $rows,
+      '#empty' => $this->t('No support panel activity recorded yet.'),
+      '#cache' => [
+        'contexts' => ['user.permissions'],
+        'tags' => ['config:myeventlane_help_centre.help_content'],
+        'max-age' => 300,
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelAnalytics.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelAnalytics.php
@@ -10,6 +10,144 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
+ * Records support panel impressions, clicks, and feedback.
+ */
+final class HelpPanelAnalytics {
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly RequestStack $requestStack,
+    private readonly TimeInterface $time,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  public function logImpression(string $key): void {
+    $this->logEvent($key, 'impression');
+  }
+
+  public function logClick(string $key): void {
+    $this->logEvent($key, 'click');
+  }
+
+  public function logFeedback(string $key, bool $helpful): void {
+    $this->logEvent($key, 'feedback', $helpful);
+  }
+
+  private function logEvent(string $key, string $eventType, ?bool $isHelpful = NULL): void {
+    $panelKey = trim($key);
+    if ($panelKey === '') {
+      return;
+    }
+
+    $path = $this->requestStack->getCurrentRequest()?->getPathInfo() ?? '';
+    $created = (int) $this->time->getRequestTime();
+
+    try {
+      $fields = [
+        'panel_key' => mb_substr($panelKey, 0, 128),
+        'event_type' => $eventType,
+        'path' => mb_substr($path, 0, 255),
+        'created' => $created,
+      ];
+      if ($isHelpful !== NULL) {
+        $fields['is_helpful'] = $isHelpful ? 1 : 0;
+      }
+
+      $this->database->insert('mel_help_panel_analytics')
+        ->fields($fields)
+        ->execute();
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Failed to record @type for help panel @key: @message', [
+        '@type' => $eventType,
+        '@key' => $panelKey,
+        '@message' => $exception->getMessage(),
+      ]);
+    }
+  }
+
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Records support panel impressions, clicks, and feedback.
+ */
+final class HelpPanelAnalytics {
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly RequestStack $requestStack,
+    private readonly TimeInterface $time,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  public function logImpression(string $key): void {
+    $this->logEvent($key, 'impression');
+  }
+
+  public function logClick(string $key): void {
+    $this->logEvent($key, 'click');
+  }
+
+  public function logFeedback(string $key, bool $helpful): void {
+    $this->logEvent($key, 'feedback', $helpful);
+  }
+
+  private function logEvent(string $key, string $eventType, ?bool $isHelpful = NULL): void {
+    $panelKey = trim($key);
+    if ($panelKey === '') {
+      return;
+    }
+
+    $path = $this->requestStack->getCurrentRequest()?->getPathInfo() ?? '';
+    $created = (int) $this->time->getRequestTime();
+
+    try {
+      $fields = [
+        'panel_key' => mb_substr($panelKey, 0, 128),
+        'event_type' => $eventType,
+        'path' => mb_substr($path, 0, 255),
+        'created' => $created,
+      ];
+      if ($isHelpful !== NULL) {
+        $fields['is_helpful'] = $isHelpful ? 1 : 0;
+      }
+
+      $this->database->insert('mel_help_panel_analytics')
+        ->fields($fields)
+        ->execute();
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Failed to record @type for help panel @key: @message', [
+        '@type' => $eventType,
+        '@key' => $panelKey,
+        '@message' => $exception->getMessage(),
+      ]);
+    }
+  }
+
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
  * Records support panel impressions and clicks.
  */
 final class HelpPanelAnalytics {

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelIntelligence.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelIntelligence.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelInterface;
+
+/**
+ * Provides basic performance scoring for support panels.
+ */
+final class HelpPanelIntelligence {
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Orders panel keys by click-through rate, falling back to config order.
+   *
+   * @param array<string, array<string, mixed>> $panels
+   *   Support panel definitions keyed by panel ID.
+   *
+   * @return array<int, string>
+   *   Ordered panel keys (all keys are returned).
+   */
+  public function getTopPanels(array $panels): array {
+    $panelKeys = array_values(array_map('strval', array_keys($panels)));
+    if ($panelKeys === []) {
+      return [];
+    }
+
+    $orderIndex = array_flip($panelKeys);
+    $stats = $this->loadStats($panelKeys);
+
+    $scores = [];
+    foreach ($panelKeys as $key) {
+      $stat = $stats[$key] ?? [
+        'impressions' => 0,
+        'clicks' => 0,
+      ];
+      $impressions = (int) $stat['impressions'];
+      $clicks = (int) $stat['clicks'];
+      $ctr = $impressions > 0 ? $clicks / $impressions : 0;
+      $scores[$key] = $ctr;
+    }
+
+    usort($panelKeys, function (string $a, string $b) use ($scores, $orderIndex): int {
+      $scoreDiff = $scores[$b] <=> $scores[$a];
+      if ($scoreDiff !== 0) {
+        return $scoreDiff;
+      }
+      return ($orderIndex[$a] ?? 0) <=> ($orderIndex[$b] ?? 0);
+    });
+
+    return $panelKeys;
+  }
+
+  /**
+   * Returns aggregate metrics for known panels.
+   *
+   * @param array<string, array<string, mixed>> $panels
+   *   Support panel definitions keyed by panel ID.
+   *
+   * @return array<string, array<string, float|int>>
+   *   Metrics keyed by panel ID.
+   */
+  public function getPanelMetrics(array $panels): array {
+    $panelKeys = array_values(array_map('strval', array_keys($panels)));
+    if ($panelKeys === []) {
+      return [];
+    }
+
+    $stats = $this->loadStats($panelKeys);
+    $metrics = [];
+
+    foreach ($panelKeys as $key) {
+      $stat = $stats[$key] ?? [
+        'impressions' => 0,
+        'clicks' => 0,
+        'feedback_total' => 0,
+        'helpful' => 0,
+      ];
+      $impressions = (int) $stat['impressions'];
+      $clicks = (int) $stat['clicks'];
+      $feedbackTotal = (int) $stat['feedback_total'];
+      $helpful = (int) $stat['helpful'];
+      $ctr = $impressions > 0 ? $clicks / $impressions : 0;
+      $helpfulRate = $feedbackTotal > 0 ? $helpful / $feedbackTotal : 0;
+
+      $metrics[$key] = [
+        'impressions' => $impressions,
+        'clicks' => $clicks,
+        'ctr' => $ctr,
+        'feedback_total' => $feedbackTotal,
+        'helpful' => $helpful,
+        'helpful_rate' => $helpfulRate,
+      ];
+    }
+
+    return $metrics;
+  }
+
+  /**
+   * Loads aggregated stats for the requested panels.
+   *
+   * @param array<int, string> $panelKeys
+   *
+   * @return array<string, array<string, int>>
+   */
+  private function loadStats(array $panelKeys): array {
+    $stats = [];
+    if ($panelKeys === []) {
+      return $stats;
+    }
+
+    try {
+      $query = $this->database->select('mel_help_panel_analytics', 'a');
+      $query->addField('a', 'panel_key');
+      $query->addExpression("SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END)", 'clicks');
+      $query->addExpression("SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END)", 'impressions');
+      $query->addExpression("SUM(CASE WHEN event_type = 'feedback' THEN 1 ELSE 0 END)", 'feedback_total');
+      $query->addExpression("SUM(CASE WHEN event_type = 'feedback' AND is_helpful = 1 THEN 1 ELSE 0 END)", 'helpful');
+      $query->condition('panel_key', $panelKeys, 'IN');
+      $query->groupBy('panel_key');
+
+      $results = $query->execute();
+      foreach ($results as $row) {
+        $key = (string) $row->panel_key;
+        $stats[$key] = [
+          'clicks' => (int) $row->clicks,
+          'impressions' => (int) $row->impressions,
+          'feedback_total' => (int) $row->feedback_total,
+          'helpful' => (int) $row->helpful,
+        ];
+      }
+    }
+    catch (\Throwable $throwable) {
+      $this->logger->error('Failed to load support panel analytics: @message', [
+        '@message' => $throwable->getMessage(),
+      ]);
+    }
+
+    return $stats;
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -16,6 +16,280 @@ final class SupportPanelBuilder {
     private readonly HelpContentRepository $helpContentRepository,
     private readonly PathValidatorInterface $pathValidator,
     private readonly HelpPanelAnalytics $helpPanelAnalytics,
+    private readonly HelpPanelIntelligence $helpPanelIntelligence,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   *   Render array, or empty if the key is missing or invalid.
+   */
+  public function build(string $key, ?string $surface = NULL, ?string $routeName = NULL): array {
+    $panel = $this->helpContentRepository->getSupportPanel($key);
+    return $panel === NULL ? [] : $this->buildPanel($key, $panel, $surface, $routeName);
+  }
+
+  /**
+   * Builds the first matching panel for a given route.
+   *
+   * @return array<string, mixed>|null
+   *   Render array when a match is found, NULL otherwise.
+   */
+  public function buildForRoute(string $routeName, ?string $surface = NULL): ?array {
+    $panels = $this->helpContentRepository->getSupportPanels();
+    if (!is_array($panels) || $panels === []) {
+      return NULL;
+    }
+
+    $orderedKeys = $this->helpPanelIntelligence->getTopPanels($panels);
+    if ($orderedKeys === []) {
+      $orderedKeys = array_keys($panels);
+    }
+
+    foreach ($orderedKeys as $key) {
+      $panel = $panels[$key] ?? NULL;
+      if (!is_array($panel)) {
+        continue;
+      }
+      $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+      if ($routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+        continue;
+      }
+      $built = $this->buildPanel((string) $key, $panel, $surface, $routeName);
+      if ($built !== []) {
+        return $built;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @param array<int|string, string>|string $values
+   *
+   * @return array<int, string>
+   */
+  private function normalizeStringList(array|string $values): array {
+    if (!is_array($values)) {
+      $values = $values === '' ? [] : [$values];
+    }
+    $out = [];
+    foreach ($values as $value) {
+      $value = trim((string) $value);
+      if ($value !== '') {
+        $out[] = $value;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $panel
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPanel(string $key, array $panel, ?string $surface, ?string $routeName): array {
+    $surfaces = $this->normalizeStringList($panel['surfaces'] ?? []);
+    if ($surface !== NULL && $surfaces !== [] && !in_array($surface, $surfaces, TRUE)) {
+      return [];
+    }
+    $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+    if ($routeName !== NULL && $routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+      return [];
+    }
+    $title = trim((string) ($panel['title'] ?? ''));
+    $linkPath = trim((string) ($panel['link_path'] ?? ''));
+    if ($title === '' || $linkPath === '' || !str_starts_with($linkPath, '/')) {
+      return [];
+    }
+
+    $url = $this->pathValidator->getUrlIfValidWithoutAccessCheck($linkPath);
+    if (!$url instanceof Url || $url->isExternal()) {
+      return [];
+    }
+
+    $cacheContexts = [];
+    if ($routeNames !== []) {
+      $cacheContexts[] = 'route';
+    }
+
+    $cache = [
+      'tags' => ['config:myeventlane_help_centre.help_content'],
+      'max-age' => 0,
+    ];
+    if ($cacheContexts !== []) {
+      $cache['contexts'] = $cacheContexts;
+    }
+
+    $this->helpPanelAnalytics->logImpression($key);
+
+    return [
+      '#theme' => 'mel_support_panel',
+      '#title' => $title,
+      '#summary' => trim((string) ($panel['summary'] ?? '')),
+      '#url' => $url->setAbsolute(FALSE)->toString(),
+      '#analytics_key' => $key,
+      '#cache' => $cache,
+      '#attached' => [
+        'library' => ['myeventlane_help_centre/support_panel_analytics'],
+      ],
+    ];
+  }
+
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\Url;
+
+/**
+ * Builds a themed support panel render array from YAML config.
+ */
+final class SupportPanelBuilder {
+
+  public function __construct(
+    private readonly HelpContentRepository $helpContentRepository,
+    private readonly PathValidatorInterface $pathValidator,
+    private readonly HelpPanelAnalytics $helpPanelAnalytics,
+    private readonly HelpPanelIntelligence $helpPanelIntelligence,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   *   Render array, or empty if the key is missing or invalid.
+   */
+  public function build(string $key, ?string $surface = NULL, ?string $routeName = NULL): array {
+    $panel = $this->helpContentRepository->getSupportPanel($key);
+    return $panel === NULL ? [] : $this->buildPanel($key, $panel, $surface, $routeName);
+  }
+
+  /**
+   * Builds the first matching panel for a given route.
+   *
+   * @return array<string, mixed>|null
+   *   Render array when a match is found, NULL otherwise.
+   */
+  public function buildForRoute(string $routeName, ?string $surface = NULL): ?array {
+    $panels = $this->helpContentRepository->getSupportPanels();
+    if (!is_array($panels) || $panels === []) {
+      return NULL;
+    }
+
+    $orderedKeys = $this->helpPanelIntelligence->getTopPanels($panels);
+    if ($orderedKeys === []) {
+      $orderedKeys = array_keys($panels);
+    }
+
+    foreach ($orderedKeys as $key) {
+      $panel = $panels[$key] ?? NULL;
+      if (!is_array($panel)) {
+        continue;
+      }
+      $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+      if ($routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+        continue;
+      }
+      $built = $this->buildPanel((string) $key, $panel, $surface, $routeName);
+      if ($built !== []) {
+        return $built;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @param array<int|string, string>|string $values
+   *
+   * @return array<int, string>
+   */
+  private function normalizeStringList(array|string $values): array {
+    if (!is_array($values)) {
+      $values = $values === '' ? [] : [$values];
+    }
+    $out = [];
+    foreach ($values as $value) {
+      $value = trim((string) $value);
+      if ($value !== '') {
+        $out[] = $value;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $panel
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPanel(string $key, array $panel, ?string $surface, ?string $routeName): array {
+    $surfaces = $this->normalizeStringList($panel['surfaces'] ?? []);
+    if ($surface !== NULL && $surfaces !== [] && !in_array($surface, $surfaces, TRUE)) {
+      return [];
+    }
+    $routeNames = $this->normalizeStringList($panel['route_names'] ?? []);
+    if ($routeName !== NULL && $routeNames !== [] && !in_array($routeName, $routeNames, TRUE)) {
+      return [];
+    }
+    $title = trim((string) ($panel['title'] ?? ''));
+    $linkPath = trim((string) ($panel['link_path'] ?? ''));
+    if ($title === '' || $linkPath === '' || !str_starts_with($linkPath, '/')) {
+      return [];
+    }
+
+    $url = $this->pathValidator->getUrlIfValidWithoutAccessCheck($linkPath);
+    if (!$url instanceof Url || $url->isExternal()) {
+      return [];
+    }
+
+    $cacheContexts = [];
+    if ($routeNames !== []) {
+      $cacheContexts[] = 'route';
+    }
+
+    $cache = [
+      'tags' => ['config:myeventlane_help_centre.help_content'],
+      'max-age' => 0,
+    ];
+    if ($cacheContexts !== []) {
+      $cache['contexts'] = $cacheContexts;
+    }
+
+    $this->helpPanelAnalytics->logImpression($key);
+
+    return [
+      '#theme' => 'mel_support_panel',
+      '#title' => $title,
+      '#summary' => trim((string) ($panel['summary'] ?? '')),
+      '#url' => $url->setAbsolute(FALSE)->toString(),
+      '#analytics_key' => $key,
+      '#cache' => $cache,
+      '#attached' => [
+        'library' => ['myeventlane_help_centre/support_panel_analytics'],
+      ],
+    ];
+  }
+
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\Url;
+
+/**
+ * Builds a themed support panel render array from YAML config.
+ */
+final class SupportPanelBuilder {
+
+  public function __construct(
+    private readonly HelpContentRepository $helpContentRepository,
+    private readonly PathValidatorInterface $pathValidator,
+    private readonly HelpPanelAnalytics $helpPanelAnalytics,
   ) {}
 
   /**

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-support-panel.html.twig
@@ -17,4 +17,21 @@
   >
     {{ 'View help'|t }}
   </a>
+  {% if analytics_key is defined and analytics_key %}
+    <div class="mel-support-panel__feedback">
+      <span>{{ 'Was this helpful?'|t }}</span>
+      <button
+        type="button"
+        class="mel-support-panel__feedback-button"
+        data-analytics-key="{{ analytics_key }}"
+        onclick="if (typeof melHelpFeedback === 'function') { melHelpFeedback(this.dataset.analyticsKey, true); }"
+      >👍</button>
+      <button
+        type="button"
+        class="mel-support-panel__feedback-button"
+        data-analytics-key="{{ analytics_key }}"
+        onclick="if (typeof melHelpFeedback === 'function') { melHelpFeedback(this.dataset.analyticsKey, false); }"
+      >👎</button>
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
- Added functionality to track user feedback on support panels with "Was this helpful?" buttons, enhancing user engagement and insights.
- Created a new route and controller for handling feedback submissions, ensuring secure processing with CSRF token validation.
- Updated the support panel template to include feedback buttons, allowing users to provide immediate responses.
- Enhanced the HelpPanelAnalytics service to log feedback data, contributing to improved analytics on support panel performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new POST feedback endpoint with CSRF validation and expands analytics storage/querying for support panels, touching routing, database schema, and admin dashboards. The PR also appears to introduce duplicated PHP/JS blocks in `HelpPanelAnalytics.php`, `SupportPanelBuilder.php`, and `help-analytics.js`, which is high-risk for runtime syntax/definition errors if not cleaned up.
> 
> **Overview**
> Adds support-panel *helpfulness feedback* end-to-end: the support panel template now renders 👍/👎 buttons, frontend JS posts feedback to a new `POST /mel-help/feedback` route (CSRF-protected), and `HelpFeedbackController::submitPanelFeedback()` records it via `HelpPanelAnalytics::logFeedback()`.
> 
> Extends the `mel_help_panel_analytics` schema with an optional `is_helpful` column (plus update hook `10034`), introduces `HelpPanelIntelligence` to aggregate CTR/helpful-rate metrics, updates `SupportPanelBuilder` to order panels by performance, and adds a support panel performance table to the Help Insights dashboards.
> 
> Note: the diff shows duplicated/concatenated class and script definitions in `HelpPanelAnalytics.php`, `SupportPanelBuilder.php`, and `help-analytics.js`, which should be resolved before merge to avoid fatal errors and double-binding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316ba6b43a77984716d9870741bf3f128bd83ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->