### PR TITLE
refactor(support_panel): improve cache management in SupportPanelBuilder

### DIFF
--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -106,12 +106,18 @@ final class SupportPanelBuilder {
       return [];
     }
 
-    $cacheContexts = ['route'];
+    $cacheContexts = [];
+    if ($routeNames !== []) {
+      $cacheContexts[] = 'route';
+    }
+
     $cache = [
       'tags' => ['config:myeventlane_help_centre.help_content'],
       'max-age' => 0,
-      'contexts' => $cacheContexts,
     ];
+    if ($cacheContexts !== []) {
+      $cache['contexts'] = $cacheContexts;
+    }
 
     $this->helpPanelAnalytics->logImpression($key);
 


### PR DESCRIPTION
- Updated cache context handling in the SupportPanelBuilder to conditionally include 'route' only when route names are present, enhancing performance and reducing unnecessary cache context entries.
- Streamlined cache array construction for better clarity and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to render cache metadata: it only omits the `route` cache context (and the `contexts` key) when panels are not route-filtered, which should reduce unnecessary cache variations.
> 
> **Overview**
> Updates `SupportPanelBuilder::buildPanel()` to only vary cache by **route** when a panel is configured with `route_names`. The render array now omits the `#cache.contexts` entry entirely when no cache contexts are needed, keeping cache metadata minimal while preserving existing tags and max-age behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54eb5e54debd98f0b2845a8a32a7ff7e3154b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->