### PR TITLE
Refactor help audience to canonical field audience

### DIFF
--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -518,19 +518,24 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
 
   $step_id = $variables['form']['#step_id'] ?? NULL;
   $route_name = \Drupal::routeMatch()->getRouteName();
-  $engine = \Drupal::service('myeventlane_help.recommendation_engine');
-  $recommendation = $engine->getRecommendations($route_name, 'checkout');
 
-  $builder = \Drupal::service('myeventlane_help_centre.support_panel_builder');
-  if (!empty($recommendation['panel_key'])) {
-    $panel = $builder->build((string) $recommendation['panel_key'], 'checkout', $route_name);
-  }
-  else {
-    $panel = $builder->buildForRoute($route_name, 'checkout') ?? [];
-  }
-  if ($panel !== []) {
-    _myeventlane_help_centre_attach_support_panel_articles($panel, $recommendation, 'checkout');
-    $variables['mel_support_panel'] = $panel;
+  // Omit the sidebar support panel on the order completion step — pre-purchase
+  // copy (e.g. "Need help buying tickets?") is wrong after a successful purchase.
+  if ($step_id !== 'complete') {
+    $engine = \Drupal::service('myeventlane_help.recommendation_engine');
+    $recommendation = $engine->getRecommendations($route_name, 'checkout');
+
+    $builder = \Drupal::service('myeventlane_help_centre.support_panel_builder');
+    if (!empty($recommendation['panel_key'])) {
+      $panel = $builder->build((string) $recommendation['panel_key'], 'checkout', $route_name);
+    }
+    else {
+      $panel = $builder->buildForRoute($route_name, 'checkout') ?? [];
+    }
+    if ($panel !== []) {
+      _myeventlane_help_centre_attach_support_panel_articles($panel, $recommendation, 'checkout');
+      $variables['mel_support_panel'] = $panel;
+    }
   }
 
   $resolver = _myeventlane_help_centre_resolver();

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -107,6 +107,7 @@ services:
       - '@cache.default'
       - '@datetime.time'
       - '@logger.channel.myeventlane_help_centre'
+      - '@myeventlane_help.analytics'
 
   myeventlane_help.intelligence:
     class: Drupal\myeventlane_help_centre\Service\HelpPanelIntelligence

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpAnalyticsSummary.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpAnalyticsSummary.php
@@ -21,6 +21,7 @@ final class HelpAnalyticsSummary {
     private readonly CacheBackendInterface $cache,
     private readonly TimeInterface $time,
     private readonly LoggerChannelInterface $logger,
+    private readonly HelpPanelAnalytics $panelAnalytics,
   ) {}
 
   /**
@@ -49,7 +50,7 @@ final class HelpAnalyticsSummary {
     }
 
     $summary = $this->loadPanelSummary($keys);
-    $this->cache->set($cid, $summary, $this->time->getRequestTime() + self::CACHE_TTL, ['myeventlane_help_panel_analytics']);
+    $this->cache->set($cid, $summary, $this->time->getRequestTime() + self::CACHE_TTL, [$this->panelAnalytics->getCacheTag()]);
 
     return $summary;
   }

--- a/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
+++ b/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
@@ -5,14 +5,44 @@
  */
 #}
 {% set articles = mel_help_articles is defined ? mel_help_articles : (elements['#mel_help_articles'] is defined ? elements['#mel_help_articles'] : []) %}
-<div class="mel-support-panel">
+{% set is_checkout = 'checkout' in attributes.class|join(' ') or analytics_key|default('') == 'buy_tickets' %}
+{% set is_vendor = 'vendor' in attributes.class|join(' ') or analytics_key|default('') == 'vendor_dashboard' %}
+<div{{ attributes.addClass('mel-support-panel') }}>
   <div class="mel-support-panel__content">
-    {% if title %}
-      <h3 class="mel-support-panel__title">{{ title }}</h3>
+    {% if is_checkout %}
+      <h3 class="mel-support-panel__title">
+        {{ 'Secure checkout — you\'re protected'|t }}
+      </h3>
+
+      <ul class="mel-support-panel__list">
+        <li>✔ {{ 'Instant confirmation emailed'|t }}</li>
+        <li>✔ {{ 'Easy refunds if needed'|t }}</li>
+      </ul>
+
+    {% elseif is_vendor %}
+      <h3 class="mel-support-panel__title">
+        {{ 'Boost your event performance'|t }}
+      </h3>
+
+      <p class="mel-support-panel__summary">
+        {{ 'You\'re not getting ticket sales yet. Try:'|t }}
+      </p>
+
+      <ul class="mel-support-panel__list">
+        <li>• {{ 'Add an event image'|t }}</li>
+        <li>• {{ 'Share your event'|t }}</li>
+        <li>• {{ 'Adjust pricing'|t }}</li>
+      </ul>
+
+    {% else %}
+      {% if title %}
+        <h3 class="mel-support-panel__title">{{ title }}</h3>
+      {% endif %}
+      {% if summary %}
+        <p class="mel-support-panel__summary">{{ summary }}</p>
+      {% endif %}
     {% endif %}
-    {% if summary %}
-      <p class="mel-support-panel__summary">{{ summary }}</p>
-    {% endif %}
+
     {% if url %}
       <a
         href="{{ url }}"
@@ -21,7 +51,7 @@
           data-analytics-key="{{ analytics_key }}"
           onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"
         {% endif %}
-      >{{ 'View full guide'|t }}</a>
+      >{{ 'Get help'|t }}</a>
     {% endif %}
   </div>
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_support-panel.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_support-panel.scss
@@ -39,6 +39,17 @@
   line-height: 1.45;
 }
 
+.mel-support-panel__list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 12px;
+}
+
+.mel-support-panel__list li {
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
 .mel-support-panel__suggestions {
   margin-top: spacing.mel-space(3);
   padding-top: spacing.mel-space(2);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to help-panel rendering and caching, plus skipping the sidebar panel on the checkout completion step; no payment or order state logic is modified.
> 
> **Overview**
> Updates the checkout help integration to **not render the sidebar `mel_support_panel` on the `complete` step**, avoiding pre-purchase CTAs after a successful order.
> 
> Adjusts `mel-support-panel.html.twig` to render **context-specific copy** for checkout and vendor dashboard panels (including new list styling), and renames the primary CTA from *“View full guide”* to *“Get help”*.
> 
> Refactors `HelpAnalyticsSummary` to inject `HelpPanelAnalytics` and use its `getCacheTag()` when caching aggregated panel metrics, instead of hard-coding the cache tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29776038fde5589c85d857439fbf01291e6932a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->