### PR TITLE
Refactor help audience to canonical field audience

### DIFF
--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -93,6 +93,8 @@ function myeventlane_help_centre_theme(): array {
     ],
     'mel_support_panel' => [
       'variables' => [
+        'attributes' => [],
+        'checkout_step_id' => NULL,
         'title' => '',
         'summary' => '',
         'url' => '',
@@ -103,6 +105,34 @@ function myeventlane_help_centre_theme(): array {
       'path' => $module_path . '/templates',
     ],
   ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for mel_support_panel.
+ *
+ * Normalizes `attributes` as an array before ThemeManager builds the Attribute
+ * object so `#attributes` from the render array (and the base BEM class) apply.
+ */
+function myeventlane_help_centre_preprocess_mel_support_panel(array &$variables): void {
+  $attrs = $variables['attributes'] ?? [];
+  if ($attrs instanceof \Drupal\Core\Template\Attribute) {
+    return;
+  }
+  if (!is_array($attrs)) {
+    $attrs = [];
+  }
+  $classes = [];
+  if (isset($attrs['class'])) {
+    $class_value = $attrs['class'];
+    $classes = is_array($class_value)
+      ? $class_value
+      : preg_split('/\s+/', (string) $class_value, -1, PREG_SPLIT_NO_EMPTY);
+  }
+  if (!in_array('mel-support-panel', $classes, TRUE)) {
+    array_unshift($classes, 'mel-support-panel');
+  }
+  $attrs['class'] = $classes;
+  $variables['attributes'] = $attrs;
 }
 
 /**
@@ -519,23 +549,20 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
   $step_id = $variables['form']['#step_id'] ?? NULL;
   $route_name = \Drupal::routeMatch()->getRouteName();
 
-  // Omit the sidebar support panel on the order completion step — pre-purchase
-  // copy (e.g. "Need help buying tickets?") is wrong after a successful purchase.
-  if ($step_id !== 'complete') {
-    $engine = \Drupal::service('myeventlane_help.recommendation_engine');
-    $recommendation = $engine->getRecommendations($route_name, 'checkout');
+  $engine = \Drupal::service('myeventlane_help.recommendation_engine');
+  $recommendation = $engine->getRecommendations($route_name, 'checkout');
 
-    $builder = \Drupal::service('myeventlane_help_centre.support_panel_builder');
-    if (!empty($recommendation['panel_key'])) {
-      $panel = $builder->build((string) $recommendation['panel_key'], 'checkout', $route_name);
-    }
-    else {
-      $panel = $builder->buildForRoute($route_name, 'checkout') ?? [];
-    }
-    if ($panel !== []) {
-      _myeventlane_help_centre_attach_support_panel_articles($panel, $recommendation, 'checkout');
-      $variables['mel_support_panel'] = $panel;
-    }
+  $builder = \Drupal::service('myeventlane_help_centre.support_panel_builder');
+  if (!empty($recommendation['panel_key'])) {
+    $panel = $builder->build((string) $recommendation['panel_key'], 'checkout', $route_name);
+  }
+  else {
+    $panel = $builder->buildForRoute($route_name, 'checkout') ?? [];
+  }
+  if ($panel !== []) {
+    $panel['#checkout_step_id'] = $step_id;
+    _myeventlane_help_centre_attach_support_panel_articles($panel, $recommendation, 'checkout');
+    $variables['mel_support_panel'] = $panel;
   }
 
   $resolver = _myeventlane_help_centre_resolver();

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -95,6 +95,7 @@ function myeventlane_help_centre_theme(): array {
       'variables' => [
         'attributes' => [],
         'checkout_step_id' => NULL,
+        'mel_help_state' => NULL,
         'title' => '',
         'summary' => '',
         'url' => '',
@@ -110,12 +111,15 @@ function myeventlane_help_centre_theme(): array {
 /**
  * Implements hook_preprocess_HOOK() for mel_support_panel.
  *
- * Normalizes `attributes` as an array before ThemeManager builds the Attribute
- * object so `#attributes` from the render array (and the base BEM class) apply.
+ * Normalizes `attributes` (array or Attribute) so the base `mel-support-panel`
+ * class is always present for `#attributes` from the render array.
  */
 function myeventlane_help_centre_preprocess_mel_support_panel(array &$variables): void {
   $attrs = $variables['attributes'] ?? [];
   if ($attrs instanceof \Drupal\Core\Template\Attribute) {
+    if (!$attrs->hasClass('mel-support-panel')) {
+      $attrs->addClass('mel-support-panel');
+    }
     return;
   }
   if (!is_array($attrs)) {
@@ -708,6 +712,34 @@ function myeventlane_help_centre_preprocess_myeventlane_vendor_dashboard(array &
   }
   if ($panel !== []) {
     _myeventlane_help_centre_attach_support_panel_articles($panel, $recommendation, 'vendor_dashboard');
+
+    $events = $variables['events'] ?? [];
+    $total_tickets = 0;
+    $total_revenue = 0.0;
+    $total_views = 0;
+    foreach ($events as $event) {
+      $total_tickets += (int) ($event['tickets_sold'] ?? 0);
+      $rev = $event['revenue'] ?? 0;
+      $total_revenue += is_numeric($rev) ? (float) $rev : 0.0;
+      $total_views += (int) ($event['views'] ?? 0);
+    }
+    $conversion = $total_views > 0
+      ? ($total_tickets / $total_views)
+      : 0.0;
+    $panel['#mel_help_state'] = [
+      'tickets_sold' => $total_tickets,
+      'has_events' => !empty($events),
+      'revenue' => $total_revenue,
+      'views' => $total_views,
+      'conversion' => $conversion,
+    ];
+    if (!isset($panel['#cache']['contexts'])) {
+      $panel['#cache']['contexts'] = [];
+    }
+    if (!in_array('user', $panel['#cache']['contexts'], TRUE)) {
+      $panel['#cache']['contexts'][] = 'user';
+    }
+
     $variables['mel_support_panel'] = $panel;
   }
 }

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -121,8 +121,19 @@ final class SupportPanelBuilder {
 
     $this->helpPanelAnalytics->logImpression($key);
 
+    $classes = ['mel-support-panel'];
+    if ($surface === 'checkout') {
+      $classes[] = 'mel-support-panel--checkout';
+    }
+    elseif ($surface === 'vendor_dashboard') {
+      $classes[] = 'mel-support-panel--vendor';
+    }
+
     return [
       '#theme' => 'mel_support_panel',
+      '#attributes' => [
+        'class' => $classes,
+      ],
       '#title' => $title,
       '#summary' => trim((string) ($panel['summary'] ?? '')),
       '#url' => $url->setAbsolute(FALSE)->toString(),

--- a/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
+++ b/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
@@ -5,53 +5,122 @@
  */
 #}
 {% set articles = mel_help_articles is defined ? mel_help_articles : (elements['#mel_help_articles'] is defined ? elements['#mel_help_articles'] : []) %}
-{% set is_checkout = 'checkout' in attributes.class|join(' ') or analytics_key|default('') == 'buy_tickets' %}
-{% set is_vendor = 'vendor' in attributes.class|join(' ') or analytics_key|default('') == 'vendor_dashboard' %}
-<div{{ attributes.addClass('mel-support-panel') }}>
+{% set step_id = checkout_step_id|default('') %}
+{% set key = analytics_key|default('') %}
+{% set state = mel_help_state|default({}) %}
+{% set is_order_complete = step_id == 'complete' %}
+{% set is_checkout = key == 'buy_tickets' and not is_order_complete %}
+{% set is_vendor = key == 'vendor_dashboard' %}
+{% set tickets_sold = state.tickets_sold|default(0) %}
+{% set state_views = state.views|default(0) %}
+{% set state_conversion = state.conversion|default(0) %}
+<div{{ attributes }}>
   <div class="mel-support-panel__content">
-    {% if is_checkout %}
+    {% if is_order_complete %}
       <h3 class="mel-support-panel__title">
-        {{ 'Secure checkout — you\'re protected'|t }}
+        {{ 'Your booking is confirmed'|t }}
+      </h3>
+
+      <p class="mel-support-panel__summary">
+        {{ 'Confirmation and ticket details are emailed. Contact support if anything looks wrong.'|t }}
+      </p>
+
+    {% elseif is_checkout %}
+      <h3 class="mel-support-panel__title">
+        {{ 'Almost there — your booking is secure'|t }}
       </h3>
 
       <ul class="mel-support-panel__list">
         <li>✔ {{ 'Instant confirmation emailed'|t }}</li>
-        <li>✔ {{ 'Easy refunds if needed'|t }}</li>
+        <li>✔ {{ 'Secure payment processing'|t }}</li>
       </ul>
 
     {% elseif is_vendor %}
-      <h3 class="mel-support-panel__title">
-        {{ 'Boost your event performance'|t }}
-      </h3>
+      {% if state_views > 0 and state_conversion < 0.02 %}
+        <h3 class="mel-support-panel__title">
+          {{ '📉 Your event isn’t converting'|t }}
+        </h3>
 
-      <p class="mel-support-panel__summary">
-        {{ 'You\'re not getting ticket sales yet. Try:'|t }}
-      </p>
+        <ul class="mel-support-panel__list">
+          <li>• {{ 'Adjust ticket pricing'|t }}</li>
+          <li>• {{ 'Improve description'|t }}</li>
+          <li>• {{ 'Add urgency'|t }}</li>
+        </ul>
 
-      <ul class="mel-support-panel__list">
-        <li>• {{ 'Add an event image'|t }}</li>
-        <li>• {{ 'Share your event'|t }}</li>
-        <li>• {{ 'Adjust pricing'|t }}</li>
-      </ul>
+      {% elseif tickets_sold > 20 %}
+        <h3 class="mel-support-panel__title">
+          {{ '🔥 Your event is performing well'|t }}
+        </h3>
+
+        <ul class="mel-support-panel__list">
+          <li>• {{ 'Boost your event'|t }}</li>
+          <li>• {{ 'Add another session'|t }}</li>
+        </ul>
+
+      {% else %}
+        {% if tickets_sold == 0 %}
+          <h3 class="mel-support-panel__title">
+            {{ '⚡ Your event isn’t selling yet'|t }}
+          </h3>
+
+          <ul class="mel-support-panel__list">
+            <li>• {{ 'Add a cover image'|t }}</li>
+            <li>• {{ 'Share your event'|t }}</li>
+            <li>• {{ 'Boost visibility'|t }}</li>
+          </ul>
+
+        {% elseif tickets_sold < 10 %}
+          <h3 class="mel-support-panel__title">
+            {{ '📈 Your event is gaining traction'|t }}
+          </h3>
+
+          <ul class="mel-support-panel__list">
+            <li>• {{ 'Share on social'|t }}</li>
+            <li>• {{ 'Add ticket options'|t }}</li>
+          </ul>
+
+        {% else %}
+          <h3 class="mel-support-panel__title">
+            {{ '🔥 Your event is performing well'|t }}
+          </h3>
+
+          <ul class="mel-support-panel__list">
+            <li>• {{ 'Boost your event'|t }}</li>
+            <li>• {{ 'Add another session'|t }}</li>
+          </ul>
+        {% endif %}
+      {% endif %}
 
     {% else %}
       {% if title %}
-        <h3 class="mel-support-panel__title">{{ title }}</h3>
+        <h3>{{ title }}</h3>
       {% endif %}
       {% if summary %}
-        <p class="mel-support-panel__summary">{{ summary }}</p>
+        <p>{{ summary }}</p>
       {% endif %}
     {% endif %}
 
     {% if url %}
-      <a
-        href="{{ url }}"
-        class="mel-button mel-button--primary"
-        {% if analytics_key is defined and analytics_key %}
-          data-analytics-key="{{ analytics_key }}"
-          onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"
-        {% endif %}
-      >{{ 'Get help'|t }}</a>
+      <div class="mel-support-panel__cta">
+        <a
+          href="{{ url }}"
+          class="mel-button mel-button--primary"
+          {% if analytics_key is defined and analytics_key %}
+            data-analytics-key="{{ analytics_key }}"
+            onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"
+          {% endif %}
+        >
+          {% if is_order_complete %}
+            {{ 'Get help'|t }}
+          {% elseif is_checkout %}
+            {{ 'Get help with checkout'|t }}
+          {% elseif is_vendor %}
+            {{ 'Improve my event'|t }}
+          {% else %}
+            {{ 'Get help'|t }}
+          {% endif %}
+        </a>
+      </div>
     {% endif %}
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how `mel_support_panel` is built and rendered, including new per-user state and cache-context updates that could affect caching behavior and sidebar content across checkout/vendor surfaces.
> 
> **Overview**
> Updates the `mel_support_panel` component to support richer surface-specific rendering via new template variables (`#attributes`, `#checkout_step_id`, `#mel_help_state`) and a new preprocess hook that guarantees the base `mel-support-panel` class is always applied.
> 
> Checkout now always builds the support panel and passes the current checkout step so the template can swap copy/CTA on the order completion step. Vendor dashboard support panels now receive aggregated event performance state (tickets, views, revenue, conversion) to drive conditional messaging, and the panel cache is explicitly varied by `user`.
> 
> `SupportPanelBuilder` now attaches surface-specific CSS classes (`--checkout`/`--vendor`) via `#attributes`, and the Twig template is refactored to use these inputs and adjust the CTA label and content accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7170ae2bf7ad83638e7041bbbde1807b9eec0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->