### PR TITLE
Release/staging 2026 q1 build

### DIFF
--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -1,5 +1,13 @@
 ## Release hardening (MyEventLane)
 
+### Config sync directory (CRITICAL)
+
+The **config sync directory** is the single source of truth for Drupal configuration. On artifact-based hosts it must be **overwritten on every deploy** using `rsync -av --delete` from the extracted release’s `config/sync` into the server’s shared sync path (for example `/home/mel/staging/config/sync`). Failure to do so causes config drift, misleading `drush cim` results, partial sync states, and production instability.
+
+**Operational rule:** do not hand-edit YAML under the shared sync directory on the server. Change configuration in local development, run `drush cex`, commit to Git, and deploy a new artifact. Treat staging and production sync directories as **read-only** except for the deploy pipeline.
+
+Staging/production deploys implement this via `scripts/deploy/remote-deploy.sh` (shared sync + `drush cim` + `drush cst` verification when `RUN_CIM=1`).
+
 ### When to run
 
 - **Before tagging a release** (local/DDEV): ensure code + config are consistent and diagnostics are clean.
@@ -65,4 +73,3 @@ Exit codes:
   - Queue backend is not readable for that queue (schema/runtime issue).
 - **Messaging templates = FAIL**
   - An enabled messaging template has invalid Twig syntax and will not render correctly.
-

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Falls back to SITE_URI containing "staging" vs production *.myeventlane.com.au (no staging).
 
 APP_PATH="${APP_PATH:-$HOME/staging}"
+# Shared config sync directory on the server (must match $settings['config_sync_directory'] in
+# shared settings.php). Default: /home/mel/staging/config/sync when APP_PATH is ~/staging.
+SHARED_CONFIG_SYNC="${SHARED_CONFIG_SYNC:-$APP_PATH/config/sync}"
 SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
 ARTIFACT_PATH="${ARTIFACT_PATH:-}"
 RUN_UPDB="${RUN_UPDB:-0}"
@@ -159,8 +162,24 @@ ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
 
 cd "$CURRENT_PATH"
 
-# ---- CONFIG SYNC SANITY (before cim) ----
-CONFIG_SYNC_DIR="$CURRENT_PATH/config/sync"
+# ---- CONFIG SYNC: mirror artifact → shared sync directory (single source of truth per release) ----
+# Staging uses a shared path (e.g. /home/mel/staging/config/sync) referenced by settings.php.
+# Without this step, an incomplete or stale sync dir causes cim to report "no changes" while
+# active config drifts; missing files can delete config on import.
+RELEASE_CONFIG_SYNC="$RELEASE_PATH/config/sync"
+if [ ! -d "$RELEASE_CONFIG_SYNC" ]; then
+  echo "ERROR: Missing $RELEASE_CONFIG_SYNC in artifact — cannot deploy config."
+  exit 1
+fi
+
+mkdir -p "$SHARED_CONFIG_SYNC"
+echo "Syncing config from release to shared directory (rsync --delete)..."
+echo "  Source: $RELEASE_CONFIG_SYNC/"
+echo "  Dest:   $SHARED_CONFIG_SYNC/"
+rsync -av --delete "$RELEASE_CONFIG_SYNC/" "$SHARED_CONFIG_SYNC/"
+
+# ---- CONFIG SYNC SANITY (before cim): validate what Drupal will import ----
+CONFIG_SYNC_DIR="$SHARED_CONFIG_SYNC"
 if [ -d "$CONFIG_SYNC_DIR" ]; then
   if grep -rE 'ddev\.site' "$CONFIG_SYNC_DIR" --include='*.yml' --include='*.yaml' 2>/dev/null | grep -q .; then
     echo "ERROR: DDEV hostname found in config/sync — fix export before deploy." >&2
@@ -178,6 +197,20 @@ fi
 
 if [ "$RUN_CIM" = "1" ]; then
   vendor/bin/drush cim -y --uri="$SITE_URI"
+
+  # Deploy safety: active storage must match sync after import (see Drush docs: grep "No differences").
+  echo "Verifying config:status after import..."
+  CST_OUT="$(vendor/bin/drush cst --uri="$SITE_URI" 2>&1)" || true
+  if echo "$CST_OUT" | grep -qi 'configuration differences'; then
+    echo "ERROR: config:status reports configuration differences — deployment aborted." >&2
+    echo "$CST_OUT" >&2
+    exit 1
+  fi
+  if ! echo "$CST_OUT" | grep -q 'No differences'; then
+    echo "ERROR: config:status must report no differences between DB and sync after cim." >&2
+    echo "$CST_OUT" >&2
+    exit 1
+  fi
 fi
 
 # ---- DOMAIN ENFORCEMENT (after cim; runs every deploy) ----

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -112,5 +112,4 @@ services:
   myeventlane_help.intelligence:
     class: Drupal\myeventlane_help_centre\Service\HelpPanelIntelligence
     arguments:
-      - '@database'
-      - '@logger.channel.myeventlane_help_centre'
+      - '@myeventlane_help.analytics_summary'

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpInsightsController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpInsightsController.php
@@ -187,7 +187,7 @@ final class HelpInsightsController extends ControllerBase {
       ];
     }
 
-    $orderedKeys = $this->panelIntelligence->getTopPanels($panels);
+    $orderedKeys = $this->panelIntelligence->getOrderedPanelKeys($panels);
     if ($orderedKeys === []) {
       $orderedKeys = array_keys($panels);
     }

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelIntelligence.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpPanelIntelligence.php
@@ -4,62 +4,101 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_help_centre\Service;
 
-use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelInterface;
-
 /**
- * Provides basic performance scoring for support panels.
+ * Determines ordering and selection of help panels.
+ *
+ * MyEventLane v2 rules:
+ * - Deterministic fallback (config order)
+ * - Analytics enhances, never controls
+ * - Safe with zero data
  */
 final class HelpPanelIntelligence {
 
   public function __construct(
-    private readonly Connection $database,
-    private readonly LoggerChannelInterface $logger,
+    private readonly HelpAnalyticsSummary $analyticsSummary,
   ) {}
 
   /**
-   * Orders panel keys by click-through rate, falling back to config order.
+   * Returns ordered panel keys.
    *
    * @param array<string, array<string, mixed>> $panels
-   *   Support panel definitions keyed by panel ID.
+   *   Panel definitions keyed by panel_key.
    *
    * @return array<int, string>
-   *   Ordered panel keys (all keys are returned).
+   *   Ordered list of panel keys.
    */
-  public function getTopPanels(array $panels): array {
-    $panelKeys = array_values(array_map('strval', array_keys($panels)));
-    if ($panelKeys === []) {
+  public function getOrderedPanelKeys(array $panels): array {
+    if ($panels === []) {
       return [];
     }
 
-    $orderIndex = array_flip($panelKeys);
-    $stats = $this->loadStats($panelKeys);
+    // Base deterministic order (config order).
+    $panel_keys = array_keys($panels);
 
-    $scores = [];
-    foreach ($panelKeys as $key) {
-      $stat = $stats[$key] ?? [
-        'impressions' => 0,
-        'clicks' => 0,
-      ];
-      $impressions = (int) $stat['impressions'];
-      $clicks = (int) $stat['clicks'];
-      $ctr = $impressions > 0 ? $clicks / $impressions : 0;
-      $scores[$key] = $ctr;
+    // Fetch analytics summary (cached layer). API requires explicit keys.
+    $analytics = $this->analyticsSummary->getPanelSummary($panel_keys);
+
+    // CRITICAL: Handle empty analytics safely.
+    if ($analytics === []) {
+      return $panel_keys;
     }
 
-    usort($panelKeys, function (string $a, string $b) use ($scores, $orderIndex): int {
-      $scoreDiff = $scores[$b] <=> $scores[$a];
-      if ($scoreDiff !== 0) {
-        return $scoreDiff;
+    // Build scores.
+    $scores = [];
+    $has_any_data = FALSE;
+
+    foreach ($panel_keys as $key) {
+      $panel_data = $analytics[$key] ?? NULL;
+
+      if (!is_array($panel_data)) {
+        $scores[$key] = 0.0;
+        continue;
       }
-      return ($orderIndex[$a] ?? 0) <=> ($orderIndex[$b] ?? 0);
+
+      $views = (int) ($panel_data['impressions'] ?? 0);
+      $clicks = (int) ($panel_data['clicks'] ?? 0);
+
+      // Avoid division by zero.
+      $ctr = $views > 0 ? ($clicks / $views) : 0.0;
+
+      // Composite score:
+      // - CTR weighted higher
+      // - Views provide confidence signal
+      $score = ($ctr * 0.7) + (min($views, 100) / 100 * 0.3);
+
+      if ($views > 0 || $clicks > 0) {
+        $has_any_data = TRUE;
+      }
+
+      $scores[$key] = $score;
+    }
+
+    // SECOND SAFETY: No meaningful data → fallback
+    if (!$has_any_data) {
+      return $panel_keys;
+    }
+
+    // Stable sort:
+    // - Highest score first
+    // - Preserve original order on ties
+    $indexed = array_values($panel_keys);
+
+    usort($indexed, function (string $a, string $b) use ($scores, $panel_keys): int {
+      $score_a = $scores[$a] ?? 0.0;
+      $score_b = $scores[$b] ?? 0.0;
+
+      if ($score_a === $score_b) {
+        return array_search($a, $panel_keys, TRUE) <=> array_search($b, $panel_keys, TRUE);
+      }
+
+      return $score_b <=> $score_a;
     });
 
-    return $panelKeys;
+    return $indexed;
   }
 
   /**
-   * Returns aggregate metrics for known panels.
+   * Returns aggregate metrics for known panels (admin insights table).
    *
    * @param array<string, array<string, mixed>> $panels
    *   Support panel definitions keyed by panel ID.
@@ -68,82 +107,43 @@ final class HelpPanelIntelligence {
    *   Metrics keyed by panel ID.
    */
   public function getPanelMetrics(array $panels): array {
-    $panelKeys = array_values(array_map('strval', array_keys($panels)));
-    if ($panelKeys === []) {
+    $panel_keys = array_values(array_map('strval', array_keys($panels)));
+    if ($panel_keys === []) {
       return [];
     }
 
-    $stats = $this->loadStats($panelKeys);
+    $summary = $this->analyticsSummary->getPanelSummary($panel_keys);
     $metrics = [];
 
-    foreach ($panelKeys as $key) {
-      $stat = $stats[$key] ?? [
-        'impressions' => 0,
-        'clicks' => 0,
-        'feedback_total' => 0,
-        'helpful' => 0,
-      ];
-      $impressions = (int) $stat['impressions'];
-      $clicks = (int) $stat['clicks'];
-      $feedbackTotal = (int) $stat['feedback_total'];
-      $helpful = (int) $stat['helpful'];
-      $ctr = $impressions > 0 ? $clicks / $impressions : 0;
-      $helpfulRate = $feedbackTotal > 0 ? $helpful / $feedbackTotal : 0;
+    foreach ($panel_keys as $key) {
+      $row = $summary[$key] ?? NULL;
+      if (!is_array($row)) {
+        $metrics[$key] = [
+          'impressions' => 0,
+          'clicks' => 0,
+          'ctr' => 0.0,
+          'feedback_total' => 0,
+          'helpful' => 0,
+          'helpful_rate' => 0.0,
+        ];
+        continue;
+      }
+
+      $helpful = (int) ($row['helpful_count'] ?? 0);
+      $unhelpful = (int) ($row['unhelpful_count'] ?? 0);
+      $feedback_total = $helpful + $unhelpful;
 
       $metrics[$key] = [
-        'impressions' => $impressions,
-        'clicks' => $clicks,
-        'ctr' => $ctr,
-        'feedback_total' => $feedbackTotal,
+        'impressions' => (int) ($row['impressions'] ?? 0),
+        'clicks' => (int) ($row['clicks'] ?? 0),
+        'ctr' => (float) ($row['ctr'] ?? 0.0),
+        'feedback_total' => $feedback_total,
         'helpful' => $helpful,
-        'helpful_rate' => $helpfulRate,
+        'helpful_rate' => (float) ($row['helpful_ratio'] ?? 0.0),
       ];
     }
 
     return $metrics;
-  }
-
-  /**
-   * Loads aggregated stats for the requested panels.
-   *
-   * @param array<int, string> $panelKeys
-   *
-   * @return array<string, array<string, int>>
-   */
-  private function loadStats(array $panelKeys): array {
-    $stats = [];
-    if ($panelKeys === []) {
-      return $stats;
-    }
-
-    try {
-      $query = $this->database->select('mel_help_panel_analytics', 'a');
-      $query->addField('a', 'panel_key');
-      $query->addExpression("SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END)", 'clicks');
-      $query->addExpression("SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END)", 'impressions');
-      $query->addExpression("SUM(CASE WHEN event_type = 'feedback' THEN 1 ELSE 0 END)", 'feedback_total');
-      $query->addExpression("SUM(CASE WHEN event_type = 'feedback' AND is_helpful = 1 THEN 1 ELSE 0 END)", 'helpful');
-      $query->condition('panel_key', $panelKeys, 'IN');
-      $query->groupBy('panel_key');
-
-      $results = $query->execute();
-      foreach ($results as $row) {
-        $key = (string) $row->panel_key;
-        $stats[$key] = [
-          'clicks' => (int) $row->clicks,
-          'impressions' => (int) $row->impressions,
-          'feedback_total' => (int) $row->feedback_total,
-          'helpful' => (int) $row->helpful,
-        ];
-      }
-    }
-    catch (\Throwable $throwable) {
-      $this->logger->error('Failed to load support panel analytics: @message', [
-        '@message' => $throwable->getMessage(),
-      ]);
-    }
-
-    return $stats;
   }
 
 }

--- a/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/SupportPanelBuilder.php
@@ -40,7 +40,7 @@ final class SupportPanelBuilder {
       return NULL;
     }
 
-    $orderedKeys = $this->helpPanelIntelligence->getTopPanels($panels);
+    $orderedKeys = $this->helpPanelIntelligence->getOrderedPanelKeys($panels);
     if ($orderedKeys === []) {
       $orderedKeys = array_keys($panels);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the remote deploy pipeline’s config import behavior (rsync --delete + post-import drift gating) and alters production ordering/scoring of help panels based on analytics, which could affect deploy success and UI ordering.
> 
> **Overview**
> **Deploy hardening:** `remote-deploy.sh` now mirrors each release’s `config/sync` into a shared server sync directory via `rsync -av --delete`, uses that shared directory for pre-`cim` sanity checks, and (when `RUN_CIM=1`) aborts the deploy if `drush cst` shows any remaining config drift.
> 
> **Help Centre analytics refactor:** `HelpPanelIntelligence` no longer queries the DB directly; it consumes `HelpAnalyticsSummary`, renames `getTopPanels` → `getOrderedPanelKeys`, adds deterministic fallbacks when analytics is empty/zero, and updates both the admin insights table and route-based panel selection to use the new ordering and summary-derived metrics. Documentation is updated to call out the config-sync single-source-of-truth rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7fab77ea69aa19f8ae191e68926ce66cee33234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->