### PR TITLE
refactor(boost): streamline BoostPerformanceService and update URL ro…

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -100,7 +100,6 @@ services:
       - '@url_generator'
       - '@string_translation'
       - '@state'
-      - '@current_user'
 
   # Boost impression tracker.
   myeventlane_boost.impression_tracker:

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPerformanceService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPerformanceService.php
@@ -6,7 +6,6 @@ namespace Drupal\myeventlane_boost\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
@@ -49,7 +48,6 @@ final class BoostPerformanceService {
     private readonly UrlGeneratorInterface $urlGenerator,
     TranslationInterface $stringTranslation,
     private readonly StateInterface $state,
-    private readonly AccountProxyInterface $currentUser,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -430,14 +428,16 @@ final class BoostPerformanceService {
         'variant' => 'boost_worked',
         'emoji' => '🔥',
         'title' => (string) $this->t('Your boost worked'),
-        'intro' => (string) $this->t('Bookings increased by @pct%. Keep momentum going while your event is active.', ['@pct' => $pct]),
+        'intro' => $pct > 0
+          ? (string) $this->t('Bookings increased by @pct%. Keep momentum going while your event is active.', ['@pct' => $pct])
+          : (string) $this->t('Keep momentum going while your event is active.'),
         'tips' => [],
         'cta' => [
           'url' => $urls['boost'],
           'label' => (string) $this->t('Boost again'),
           'classes' => 'mel-btn mel-btn--sm mel-btn--cta',
         ],
-        'headline_percent' => (string) $pct,
+        'headline_percent' => $pct > 0 ? (string) $pct : NULL,
       ];
     }
 
@@ -474,14 +474,25 @@ final class BoostPerformanceService {
    */
   private function formatWorkedPercent(?float $upliftPct, array $metrics): int {
     if ($upliftPct !== NULL) {
-      return (int) max(1, (int) round(abs($upliftPct)));
+      $rounded = (int) round($upliftPct);
+      if ($rounded > 0) {
+        return $rounded;
+      }
     }
+
     $tb = (int) ($metrics['tickets_before'] ?? 0);
     $ta = (int) ($metrics['tickets_after'] ?? 0);
+    $delta = $ta - $tb;
+
     if ($tb <= 0 && $ta > 0) {
       return 100;
     }
-    return (int) max(1, $ta - $tb);
+
+    if ($delta > 0) {
+      return $delta;
+    }
+
+    return 0;
   }
 
   /**
@@ -717,7 +728,7 @@ final class BoostPerformanceService {
       return $out;
     }
     try {
-      $out['boost'] = $this->urlGenerator->generateFromRoute('myeventlane_boost.boost_page', ['node' => $eventId]);
+      $out['boost'] = $this->urlGenerator->generateFromRoute('myeventlane_boost.vendor_event_boost', ['event' => $eventId]);
       $out['analytics'] = $this->urlGenerator->generateFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $eventId]);
       $out['overview'] = $this->urlGenerator->generateFromRoute('myeventlane_vendor.console.event_overview', ['event' => $eventId]);
       $out['edit'] = $this->urlGenerator->generateFromRoute('myeventlane_event_studio.edit', ['node' => $eventId]);
@@ -732,15 +743,10 @@ final class BoostPerformanceService {
   }
 
   /**
-   * Whether dev/staging UI fallback is enabled (production unchanged when off).
-   *
-   * Uses state key mel.dev_mode, or user 1, so staging can enable for all users.
+   * Whether dev/staging UI fallback is enabled.
    */
   private function isDevUiFallbackEnabled(): bool {
-    if ($this->state->get('mel.dev_mode', FALSE)) {
-      return TRUE;
-    }
-    return (int) $this->currentUser->id() === 1;
+    return (bool) $this->state->get('mel.dev_mode', FALSE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
+++ b/web/modules/custom/myeventlane_help_centre/templates/mel-support-panel.html.twig
@@ -63,7 +63,7 @@
 
         <div class="mel-support-panel__cta">
           <a
-            href="{{ event_id ? path('myeventlane_boost.boost_page', {'node': event_id}) : '#' }}"
+            href="{{ event_id ? path('myeventlane_boost.vendor_event_boost', {'event': event_id}) : '#' }}"
             class="mel-button mel-button--primary mel-button--highlight"
             data-analytics-key="boost_event"
             onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"

--- a/web/themes/custom/myeventlane_theme/templates/mel-support-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/mel-support-panel.html.twig
@@ -67,7 +67,7 @@
 
         <div class="mel-support-panel__cta">
           <a
-            href="{{ event_id ? path('myeventlane_boost.boost_page', {'node': event_id}) : '#' }}"
+            href="{{ event_id ? path('myeventlane_boost.vendor_event_boost', {'event': event_id}) : '#' }}"
             class="mel-button mel-button--primary mel-button--highlight"
             data-analytics-key="boost_event"
             onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-support-panel.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-support-panel.html.twig
@@ -67,7 +67,7 @@
 
         <div class="mel-support-panel__cta">
           <a
-            href="{{ event_id ? path('myeventlane_boost.boost_page', {'node': event_id}) : '#' }}"
+            href="{{ event_id ? path('myeventlane_boost.vendor_event_boost', {'event': event_id}) : '#' }}"
             class="mel-button mel-button--primary mel-button--highlight"
             data-analytics-key="boost_event"
             onclick="if (typeof melHelpTrackClick === 'function') { melHelpTrackClick(this); }"


### PR DESCRIPTION
…uting

- Removed the dependency on AccountProxyInterface from BoostPerformanceService, simplifying the service structure.
- Enhanced the buildBoostWindowUi method to conditionally display messages based on performance metrics, improving user feedback.
- Updated URL generation in safeUrls method to reflect the new route for vendor event boosts, ensuring accurate navigation.
- Adjusted support panel templates across multiple themes to use the updated vendor event boost route, maintaining consistency in user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to routing/URL generation changes (switching to `myeventlane_boost.vendor_event_boost`) that could break navigation if any callers still expect the legacy `{node}` route, plus small but user-visible changes to boost performance messaging/percent calculations.
> 
> **Overview**
> Updates Boost-related navigation to consistently target the vendor workspace route `myeventlane_boost.vendor_event_boost` (including `BoostPerformanceService::safeUrls()` and the support panel CTAs in help centre and both themes).
> 
> Simplifies `BoostPerformanceService` by removing the injected `current_user` dependency and tightening the dev UI fallback toggle to only respect the `mel.dev_mode` state flag.
> 
> Refines the “boost worked” UI copy/metrics: only shows the bookings-increased message and `headline_percent` when the computed uplift is positive, and adjusts `formatWorkedPercent()` to return `0` instead of forcing a minimum of `1`/`100` based on absolute uplift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784410c0c14e632d991f15a5e2421b4aad111e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->