### PR TITLE
Event studio alignment v01

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -867,3 +867,124 @@ textarea.mel-input--body {
   }
 }
 
+/* Event highlights (Event Studio editor) */
+.mel-event-highlights-editor.mel-section--card {
+  border-radius: 16px;
+  background: var(--mel-studio-bg);
+}
+
+.mel-event-highlights-editor {
+  margin-bottom: 1.25rem;
+}
+
+.mel-highlights-editor__errors {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.mel-highlights-editor__errors[hidden] {
+  display: none !important;
+}
+
+.mel-highlights-editor__errors:focus {
+  outline: none;
+}
+
+.mel-highlights-editor__errors:focus-visible {
+  outline: 2px solid var(--mel-studio-focus);
+  outline-offset: 2px;
+}
+
+.mel-highlights-editor__errors-text {
+  margin: 0;
+}
+
+.mel-highlights-builder {
+  margin: 0.75rem 0 0;
+  padding: 1rem 1rem 1.15rem;
+  border-radius: 16px;
+  border: 1px solid var(--mel-studio-border);
+  background: var(--mel-studio-card);
+}
+
+.mel-highlights-builder-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.mel-highlights-builder-table th,
+.mel-highlights-builder-table td {
+  padding: 0.45rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--mel-studio-border);
+}
+
+.mel-highlights-builder-table th {
+  font-size: 0.6875rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mel-studio-muted);
+}
+
+.mel-highlights-builder-table .mel-input {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-highlights-builder-table textarea.mel-highlight-text {
+  min-height: 3.25rem;
+  resize: vertical;
+}
+
+.mel-highlight-order {
+  white-space: nowrap;
+}
+
+.mel-highlight-order .mel-btn {
+  margin-right: 0.35rem;
+  margin-bottom: 0.25rem;
+}
+
+.mel-highlights-builder-table td:last-child {
+  width: 5.5rem;
+  white-space: nowrap;
+}
+
+.mel-highlights-builder .mel-highlight-remove {
+  font-size: 0.8125rem;
+}
+
+.mel-btn--touch {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
+}
+
+.mel-highlight-move:focus-visible,
+.mel-highlight-remove:focus-visible {
+  outline: 2px solid var(--mel-studio-focus);
+  outline-offset: 2px;
+}
+
+.mel-highlight-move:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .mel-highlights-builder-table {
+    display: block;
+    overflow-x: auto;
+  }
+}
+

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -8,7 +8,7 @@
   var HIGHLIGHT_MAX = 6;
 
   function getSettings() {
-    return (drupalSettings && drupalSettings.melEventStudio) || {};
+    return (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudio) || {};
   }
 
   function formRoot(form) {
@@ -255,12 +255,12 @@
     var up = document.createElement('button');
     up.type = 'button';
     up.className = 'mel-btn mel-btn--secondary mel-btn--touch mel-highlight-move mel-highlight-move--up';
-    up.setAttribute('aria-label', Drupal.t('Move highlight up'));
+    up.setAttribute('aria-label', Drupal.t('Move highlight @n up', { '@n': String(index + 1) }));
     up.textContent = Drupal.t('Up');
     var down = document.createElement('button');
     down.type = 'button';
     down.className = 'mel-btn mel-btn--secondary mel-btn--touch mel-highlight-move mel-highlight-move--down';
-    down.setAttribute('aria-label', Drupal.t('Move highlight down'));
+    down.setAttribute('aria-label', Drupal.t('Move highlight @n down', { '@n': String(index + 1) }));
     down.textContent = Drupal.t('Down');
     var isFirst = index === 0;
     var isLast = index >= totalCount - 1;
@@ -341,9 +341,7 @@
   function forceSyncHighlightsBeforeSubmit(form) {
     try {
       syncHighlightsFromDomToHidden(form);
-    } catch (e) {
-      console.warn('Highlights sync failed before submit', e);
-    }
+    } catch (e) {}
   }
 
   function initHighlightsBuilder(form) {
@@ -362,6 +360,8 @@
     if (parsed.parseError) {
       var jsonErr = getHighlightErrorStrings();
       setHighlightsError(form, jsonErr.json);
+      form.setAttribute('data-mel-highlights-json-error', '1');
+      return;
     }
 
     form.addEventListener(
@@ -373,6 +373,13 @@
           if (cur.length >= HIGHLIGHT_MAX) {
             var maxErr = getHighlightErrorStrings();
             setHighlightsError(form, maxErr.max);
+            var box = getHighlightsErrorEl();
+            if (box) {
+              if (!box.hasAttribute('tabindex')) {
+                box.setAttribute('tabindex', '-1');
+              }
+              box.focus();
+            }
             return;
           }
           setHighlightsError(form, '');
@@ -704,9 +711,7 @@
   function forceSyncTicketTiersBeforeSubmit(form) {
     try {
       syncTicketTiersFromDomToHidden(form);
-    } catch (e) {
-      console.warn('Ticket sync failed before submit', e);
-    }
+    } catch (e) {}
   }
 
   function syncTicketBuilderEventType(form) {
@@ -1323,7 +1328,9 @@
     syncTicketBuilderEventType(form);
     syncTicketTiersFromDomToHidden(form);
     syncHighlightsFromDomToHidden(form);
-    updateHighlightErrors(form);
+    if (form.getAttribute('data-mel-highlights-json-error') !== '1') {
+      updateHighlightErrors(form);
+    }
 
     var title = val(form, 'mel[title]') || '—';
     var titleEl = document.getElementById('mel-preview-title');

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -5,6 +5,8 @@
 (function (Drupal, once) {
   'use strict';
 
+  var HIGHLIGHT_MAX = 6;
+
   function getSettings() {
     return (drupalSettings && drupalSettings.melEventStudio) || {};
   }
@@ -117,6 +119,352 @@
 
   function getBuilderTable(form) {
     return form.querySelector('table[data-mel-ticket-builder-table]');
+  }
+
+  function getHighlightsTable(form) {
+    return form.querySelector('table[data-mel-highlights-table]');
+  }
+
+  function getHighlightIconOptions() {
+    var s = getSettings();
+    return (s && s.highlightIconOptions) || {};
+  }
+
+  function getHighlightErrorStrings() {
+    var s = getSettings().highlightErrors || {};
+    return {
+      max: s.max || 'You can add at most 6 highlights.',
+      iconNoText: s.iconNoText || 'Add text for each highlight that has an icon.',
+      json: s.json || 'Highlights data could not be read. Reset the list or reload the page.',
+    };
+  }
+
+  function getHighlightsErrorEl() {
+    return document.getElementById('mel-highlights-editor-errors');
+  }
+
+  function setHighlightsError(form, message) {
+    var box = getHighlightsErrorEl();
+    var textEl = box ? box.querySelector('.mel-highlights-editor__errors-text') : null;
+    if (!box || !textEl) {
+      return;
+    }
+    var msg = (message || '').trim();
+    if (msg === '') {
+      textEl.textContent = '';
+      box.setAttribute('hidden', 'hidden');
+      return;
+    }
+    textEl.textContent = msg;
+    box.removeAttribute('hidden');
+  }
+
+  function validateHighlightRows(rows) {
+    var err = getHighlightErrorStrings();
+    if (rows.length > HIGHLIGHT_MAX) {
+      return { ok: false, message: err.max };
+    }
+    var i;
+    for (i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      var icon = r && r.icon != null ? String(r.icon).trim() : '';
+      var text = r && r.text != null ? String(r.text).trim() : '';
+      if (icon !== '' && text === '') {
+        return { ok: false, message: err.iconNoText };
+      }
+    }
+    return { ok: true };
+  }
+
+  function parseHighlightsHiddenWithStatus(raw) {
+    if (!raw || !String(raw).trim()) {
+      return { rows: [], parseError: false };
+    }
+    try {
+      var d = JSON.parse(raw);
+      if (!Array.isArray(d)) {
+        return { rows: [], parseError: true };
+      }
+      return {
+        rows: d.filter(function (x) {
+          return x && typeof x === 'object';
+        }),
+        parseError: false,
+      };
+    } catch (e) {
+      return { rows: [], parseError: true };
+    }
+  }
+
+  function parseHighlightsHidden(raw) {
+    return parseHighlightsHiddenWithStatus(raw).rows;
+  }
+
+  function collectHighlightsFromDom(form) {
+    var table = getHighlightsTable(form);
+    if (!table) {
+      return [];
+    }
+    var rows = table.querySelectorAll('tbody .mel-highlight-row');
+    var out = [];
+    rows.forEach(function (tr) {
+      var sel = tr.querySelector('.mel-highlight-icon');
+      var ta = tr.querySelector('.mel-highlight-text');
+      var icon = sel ? String(sel.value || '').trim() : '';
+      var text = ta ? String(ta.value || '').trim() : '';
+      out.push({ icon: icon, text: text });
+    });
+    return out;
+  }
+
+  function createHighlightRow(row, index, totalCount) {
+    var tr = document.createElement('tr');
+    tr.className = 'mel-highlight-row';
+    tr.setAttribute('data-highlight-index', String(index));
+    var icons = getHighlightIconOptions();
+    var tdIcon = document.createElement('td');
+    var sel = document.createElement('select');
+    sel.className = 'mel-input mel-highlight-icon';
+    sel.setAttribute('aria-label', Drupal.t('Highlight icon'));
+    var optEmpty = document.createElement('option');
+    optEmpty.value = '';
+    optEmpty.textContent = Drupal.t('None');
+    sel.appendChild(optEmpty);
+    Object.keys(icons).forEach(function (k) {
+      var o = document.createElement('option');
+      o.value = k;
+      o.textContent = icons[k];
+      sel.appendChild(o);
+    });
+    if (row && row.icon) {
+      sel.value = row.icon;
+    }
+    tdIcon.appendChild(sel);
+
+    var tdText = document.createElement('td');
+    var ta = document.createElement('textarea');
+    ta.className = 'mel-input mel-highlight-text';
+    ta.rows = 2;
+    ta.setAttribute('aria-label', Drupal.t('Highlight text'));
+    ta.value = row && row.text != null ? String(row.text) : '';
+
+    tdText.appendChild(ta);
+
+    var tdOrder = document.createElement('td');
+    tdOrder.className = 'mel-highlight-order';
+    var up = document.createElement('button');
+    up.type = 'button';
+    up.className = 'mel-btn mel-btn--secondary mel-btn--touch mel-highlight-move mel-highlight-move--up';
+    up.setAttribute('aria-label', Drupal.t('Move highlight up'));
+    up.textContent = Drupal.t('Up');
+    var down = document.createElement('button');
+    down.type = 'button';
+    down.className = 'mel-btn mel-btn--secondary mel-btn--touch mel-highlight-move mel-highlight-move--down';
+    down.setAttribute('aria-label', Drupal.t('Move highlight down'));
+    down.textContent = Drupal.t('Down');
+    var isFirst = index === 0;
+    var isLast = index >= totalCount - 1;
+    up.disabled = isFirst;
+    down.disabled = isLast;
+    tdOrder.appendChild(up);
+    tdOrder.appendChild(down);
+
+    var tdAct = document.createElement('td');
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mel-btn mel-btn--secondary mel-btn--touch mel-highlight-remove';
+    btn.setAttribute(
+      'aria-label',
+      Drupal.t('Remove highlight @n', { '@n': String(index + 1) }),
+    );
+    btn.textContent = Drupal.t('Remove');
+    tdAct.appendChild(btn);
+
+    tr.appendChild(tdIcon);
+    tr.appendChild(tdText);
+    tr.appendChild(tdOrder);
+    tr.appendChild(tdAct);
+    return tr;
+  }
+
+  function updateHighlightAddButton(form, rowCount) {
+    var addBtn = document.getElementById('mel-add-event-highlight');
+    if (!addBtn) {
+      return;
+    }
+    if (rowCount >= HIGHLIGHT_MAX) {
+      addBtn.setAttribute('disabled', 'disabled');
+    } else {
+      addBtn.removeAttribute('disabled');
+    }
+  }
+
+  function updateHighlightErrors(form) {
+    var rows = collectHighlightsFromDom(form);
+    var v = validateHighlightRows(rows);
+    if (v.ok) {
+      setHighlightsError(form, '');
+    } else {
+      setHighlightsError(form, v.message);
+    }
+  }
+
+  function renderHighlightRows(form, table, rows) {
+    if (!table) {
+      return;
+    }
+    var tbody = table.querySelector('tbody');
+    if (!tbody) {
+      tbody = document.createElement('tbody');
+      table.appendChild(tbody);
+    }
+    tbody.innerHTML = '';
+    var n = rows.length;
+    rows.forEach(function (row, index) {
+      tbody.appendChild(createHighlightRow(row, index, n));
+    });
+    updateHighlightAddButton(form, rows.length);
+    syncHighlightsFromDomToHidden(form);
+    updateHighlightErrors(form);
+  }
+
+  function syncHighlightsFromDomToHidden(form) {
+    var hidden = form.querySelector('input[data-mel-highlights-state]');
+    var table = getHighlightsTable(form);
+    if (!hidden || !table) {
+      return;
+    }
+    var rows = collectHighlightsFromDom(form);
+    hidden.value = JSON.stringify(rows);
+  }
+
+  function forceSyncHighlightsBeforeSubmit(form) {
+    try {
+      syncHighlightsFromDomToHidden(form);
+    } catch (e) {
+      console.warn('Highlights sync failed before submit', e);
+    }
+  }
+
+  function initHighlightsBuilder(form) {
+    var hidden = form.querySelector('input[data-mel-highlights-state]');
+    var table = getHighlightsTable(form);
+    if (!hidden || !table) {
+      return;
+    }
+    var parsed = parseHighlightsHiddenWithStatus(hidden.value);
+    var rows = parsed.rows;
+    if (parsed.parseError) {
+      hidden.value = '[]';
+      rows = [];
+    }
+    renderHighlightRows(form, table, rows);
+    if (parsed.parseError) {
+      var jsonErr = getHighlightErrorStrings();
+      setHighlightsError(form, jsonErr.json);
+    }
+
+    form.addEventListener(
+      'click',
+      function (e) {
+        if (e.target.closest('#mel-add-event-highlight')) {
+          e.preventDefault();
+          var cur = collectHighlightsFromDom(form);
+          if (cur.length >= HIGHLIGHT_MAX) {
+            var maxErr = getHighlightErrorStrings();
+            setHighlightsError(form, maxErr.max);
+            return;
+          }
+          setHighlightsError(form, '');
+          cur.push({ icon: '', text: '' });
+          renderHighlightRows(form, table, cur);
+          setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
+          refreshIntelligence(form);
+          return;
+        }
+        var rm = e.target.closest('.mel-highlight-remove');
+        if (rm && table.contains(rm)) {
+          e.preventDefault();
+          var tr = rm.closest('tr');
+          if (!tr) {
+            return;
+          }
+          var arr = collectHighlightsFromDom(form);
+          var rowList = table.querySelectorAll('tbody .mel-highlight-row');
+          var found = -1;
+          rowList.forEach(function (r, i) {
+            if (r === tr) {
+              found = i;
+            }
+          });
+          if (found >= 0 && found < arr.length) {
+            arr.splice(found, 1);
+          }
+          renderHighlightRows(form, table, arr);
+          setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
+          refreshIntelligence(form);
+          return;
+        }
+        var up = e.target.closest('.mel-highlight-move--up');
+        var down = e.target.closest('.mel-highlight-move--down');
+        if (!up && !down) {
+          return;
+        }
+        var trMove = (up || down).closest('tr');
+        if (!trMove || !table.contains(trMove)) {
+          return;
+        }
+        e.preventDefault();
+        var arr = collectHighlightsFromDom(form);
+        var rowList = table.querySelectorAll('tbody .mel-highlight-row');
+        var idx = -1;
+        rowList.forEach(function (r, i) {
+          if (r === trMove) {
+            idx = i;
+          }
+        });
+        if (idx < 0) {
+          return;
+        }
+        if (up && idx > 0) {
+          var t = arr[idx - 1];
+          arr[idx - 1] = arr[idx];
+          arr[idx] = t;
+        }
+        if (down && idx < arr.length - 1) {
+          var t2 = arr[idx + 1];
+          arr[idx + 1] = arr[idx];
+          arr[idx] = t2;
+        }
+        renderHighlightRows(form, table, arr);
+        setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
+        refreshIntelligence(form);
+      },
+      true,
+    );
+
+    form.addEventListener(
+      'input',
+      function (e) {
+        if (!e.target.closest('.mel-highlight-row')) {
+          return;
+        }
+        syncHighlightsFromDomToHidden(form);
+        updateHighlightErrors(form);
+      },
+      true,
+    );
+    form.addEventListener(
+      'change',
+      function (e) {
+        if (!e.target.closest('.mel-highlight-row')) {
+          return;
+        }
+        syncHighlightsFromDomToHidden(form);
+        updateHighlightErrors(form);
+      },
+      true,
+    );
   }
 
   function parseTiersHidden(raw) {
@@ -316,7 +664,6 @@
     if (!table) {
       return;
     }
-    console.log('MEL TIERS STATE:', tiers);
     var kind = valRadio(form, 'mel[field_event_type]') || 'rsvp';
     updateTicketBuilderTableClass(table, kind);
     var tbody = table.querySelector('tbody');
@@ -975,6 +1322,8 @@
 
     syncTicketBuilderEventType(form);
     syncTicketTiersFromDomToHidden(form);
+    syncHighlightsFromDomToHidden(form);
+    updateHighlightErrors(form);
 
     var title = val(form, 'mel[title]') || '—';
     var titleEl = document.getElementById('mel-preview-title');
@@ -1057,6 +1406,7 @@
         var str = getSettings().strings || {};
 
         initTicketBuilder(form);
+        initHighlightsBuilder(form);
         refreshIntelligence(form);
         bindCoverFilePreview(form);
 
@@ -1098,8 +1448,7 @@
               timeoutId = null;
               setFormState(form, 'mel-studio--saving', Drupal.t('Saving draft…'));
               forceSyncTicketTiersBeforeSubmit(form);
-              var tierHidden = form.querySelector('input[name="mel[studio_ticket_tiers]"]');
-              console.log('AUTOSAVE PAYLOAD TIERS:', tierHidden ? tierHidden.value : '');
+              forceSyncHighlightsBeforeSubmit(form);
               var body = new FormData(form);
               fetch(url, {
                 method: 'POST',
@@ -1195,6 +1544,17 @@
         return;
       }
       forceSyncTicketTiersBeforeSubmit(form);
+      forceSyncHighlightsBeforeSubmit(form);
+      var rows = collectHighlightsFromDom(form);
+      var hv = validateHighlightRows(rows);
+      if (!hv.ok) {
+        e.preventDefault();
+        setHighlightsError(form, hv.message);
+        var errBox = getHighlightsErrorEl();
+        if (errBox && typeof errBox.focus === 'function') {
+          errBox.focus();
+        }
+      }
     },
     true,
   );

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\node\NodeInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -107,7 +108,7 @@ final class EventStudioAutosaveController {
       $image_fid = (int) reset($image_fids);
     }
 
-    return [
+    $payload = [
       'title' => $mel['title'] ?? $params['basics']['title'] ?? $params['title'] ?? '',
       'summary' => $mel['summary'] ?? $params['basics']['summary'] ?? $params['summary'] ?? '',
       'body' => $mel['body'] ?? $params['basics']['body'] ?? $params['body'] ?? '',
@@ -139,6 +140,79 @@ final class EventStudioAutosaveController {
       'field_location_longitude' => $mel['field_location_longitude'] ?? $params['field_location_longitude'] ?? NULL,
       'studio_ticket_tiers' => $this->decodeStudioTicketTiers($mel['studio_ticket_tiers'] ?? NULL),
     ];
+    if (array_key_exists('event_highlights', $mel)) {
+      $payload['event_highlights'] = $this->decodeEventHighlightsFromMel($mel['event_highlights']);
+      $payload['event_highlights_items_state'] = trim(
+        (string) (($mel['event_highlights']['items_state'] ?? '')),
+      );
+    }
+    return $payload;
+  }
+
+  /**
+   * @return list<array{icon: string, text: string, weight: int}>
+   */
+  private function decodeEventHighlightsFromMel(mixed $raw): array {
+    if (!is_array($raw) || !isset($raw['items_state'])) {
+      return [];
+    }
+    $json = trim((string) $raw['items_state']);
+    if ($json === '') {
+      return [];
+    }
+    try {
+      $decoded = json_decode($json, TRUE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException) {
+      return [];
+    }
+    if (!is_array($decoded)) {
+      return [];
+    }
+    $allowed = $this->loadHighlightIconKeysFromStorage();
+    $out = [];
+    $weight = 0;
+    foreach ($decoded as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $text = trim((string) ($item['text'] ?? ''));
+      if ($text === '') {
+        continue;
+      }
+      $icon = trim((string) ($item['icon'] ?? ''));
+      if ($icon !== '' && !in_array($icon, $allowed, TRUE)) {
+        $icon = '';
+      }
+      $out[] = [
+        'icon' => $icon,
+        'text' => $text,
+        'weight' => $weight,
+      ];
+      $weight++;
+    }
+    return $out;
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function loadHighlightIconKeysFromStorage(): array {
+    $storage = FieldStorageConfig::load('paragraph.field_highlight_icon');
+    if ($storage === NULL) {
+      return [];
+    }
+    $raw = $storage->getSetting('allowed_values');
+    if (!is_array($raw)) {
+      return [];
+    }
+    $keys = [];
+    foreach ($raw as $item) {
+      if (is_array($item) && isset($item['value'])) {
+        $keys[] = (string) $item['value'];
+      }
+    }
+    return $keys;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Url;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
@@ -299,6 +300,79 @@ final class EventStudioForm extends FormBase {
       '#default_value' => $body_default,
       '#description' => $this->t('Longer description for your event page (plain text).'),
       '#attributes' => ['class' => ['mel-input', 'mel-input--body']],
+    ];
+
+    $highlights_json = $this->encodeEventHighlightsJsonForEvent($event);
+    $form['mel']['event_highlights'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-section--card', 'mel-event-highlights-editor']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('What makes your event special?'),
+        '#attributes' => ['class' => ['mel-section__title']],
+      ],
+      'hint' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Add up to 6 highlights that help people decide to attend.'),
+        '#attributes' => ['class' => ['mel-section__hint']],
+      ],
+      'errors' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'id' => 'mel-highlights-editor-errors',
+          'class' => ['mel-highlights-editor__errors', 'messages', 'messages--error'],
+          'role' => 'alert',
+          'aria-live' => 'polite',
+          'hidden' => 'hidden',
+          'data-mel-highlights-errors' => '1',
+          'tabindex' => '-1',
+        ],
+        'text' => [
+          '#markup' => '<p class="mel-highlights-editor__errors-text"></p>',
+        ],
+      ],
+      'items_state' => [
+        '#type' => 'hidden',
+        '#default_value' => $highlights_json,
+        '#attributes' => [
+          'id' => 'mel-event-highlights-json',
+          'data-mel-highlights-state' => '1',
+        ],
+      ],
+      'builder' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-highlights-builder'],
+          'data-mel-highlights-builder' => '1',
+        ],
+        'table' => [
+          '#type' => 'table',
+          '#header' => [
+            $this->t('Icon'),
+            $this->t('Highlight'),
+            $this->t('Order'),
+            $this->t('Actions'),
+          ],
+          '#rows' => [],
+          '#empty' => $this->t('No highlights yet.'),
+          '#attributes' => [
+            'class' => ['mel-highlights-builder-table'],
+            'data-mel-highlights-table' => '1',
+          ],
+        ],
+        'add' => [
+          '#type' => 'button',
+          '#value' => $this->t('Add highlight'),
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--secondary', 'mel-btn--touch', 'button'],
+            'type' => 'button',
+            'id' => 'mel-add-event-highlight',
+            'aria-label' => (string) $this->t('Add highlight row'),
+          ],
+        ],
+      ],
     ];
 
     $form['mel']['field_event_image'] = [
@@ -690,6 +764,12 @@ final class EventStudioForm extends FormBase {
         'ticketType' => $type_default,
         'venueMode' => $venue_mode_default,
       ],
+      'highlightIconOptions' => $this->getHighlightIconOptionsForJs(),
+      'highlightErrors' => [
+        'max' => (string) $this->t('You can add at most 6 highlights.'),
+        'iconNoText' => (string) $this->t('Add text for each highlight that has an icon.'),
+        'json' => (string) $this->t('Highlights data could not be read. Reset the list or reload the page.'),
+      ],
       'strings' => [
         'draft' => (string) $this->t('Draft'),
         'live' => (string) $this->t('Live'),
@@ -714,6 +794,55 @@ final class EventStudioForm extends FormBase {
     ];
 
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    parent::validateForm($form, $form_state);
+    $mel = $form_state->getValue('mel');
+    if (!is_array($mel) || !isset($mel['event_highlights']) || !is_array($mel['event_highlights'])) {
+      return;
+    }
+    $raw = '';
+    if (isset($mel['event_highlights']['items_state'])) {
+      $raw = (string) $mel['event_highlights']['items_state'];
+    }
+    $decoded = [];
+    if ($raw !== '') {
+      try {
+        $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+      }
+      catch (\JsonException) {
+        $form_state->setErrorByName('mel][event_highlights][items_state', $this->t('Highlights data could not be read. Please refresh and try again.'));
+        return;
+      }
+    }
+    if (!is_array($decoded)) {
+      $decoded = [];
+    }
+
+    $non_empty = 0;
+    foreach ($decoded as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $text = trim((string) ($item['text'] ?? ''));
+      $icon = trim((string) ($item['icon'] ?? ''));
+      if ($text === '' && $icon === '') {
+        continue;
+      }
+      if ($text === '' && $icon !== '') {
+        $form_state->setErrorByName('mel][event_highlights][items_state', $this->t('Each highlight with an icon needs highlight text.'));
+        return;
+      }
+      $non_empty++;
+    }
+
+    if ($non_empty > 6) {
+      $form_state->setErrorByName('mel][event_highlights][items_state', $this->t('You can add at most 6 highlights.'));
+    }
   }
 
   /**
@@ -755,8 +884,106 @@ final class EventStudioForm extends FormBase {
   }
 
   /**
-   * Encodes attached mel_ticket_type rows for the inline builder (JSON in hidden field).
+   * Encodes paragraph highlights for the Event Studio JS builder (JSON in hidden field).
    */
+  private function encodeEventHighlightsJsonForEvent(NodeInterface $event): string {
+    if (!$event->hasField('field_event_highlights') || $event->get('field_event_highlights')->isEmpty()) {
+      return '[]';
+    }
+    $rows = [];
+    foreach ($event->get('field_event_highlights')->referencedEntities() as $p) {
+      if ($p->bundle() !== 'event_highlight') {
+        continue;
+      }
+      $text = '';
+      if ($p->hasField('field_highlight_text') && !$p->get('field_highlight_text')->isEmpty()) {
+        $text = trim((string) $p->get('field_highlight_text')->value);
+      }
+      $icon = '';
+      if ($p->hasField('field_highlight_icon') && !$p->get('field_highlight_icon')->isEmpty()) {
+        $icon = trim((string) $p->get('field_highlight_icon')->value);
+      }
+      $rows[] = [
+        'text' => $text,
+        'icon' => $icon,
+      ];
+    }
+    try {
+      return json_encode($rows, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException) {
+      return '[]';
+    }
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  private function getHighlightIconOptionsForJs(): array {
+    $storage = FieldStorageConfig::load('paragraph.field_highlight_icon');
+    if ($storage === NULL) {
+      return [];
+    }
+    $raw = $storage->getSetting('allowed_values');
+    if (!is_array($raw)) {
+      return [];
+    }
+    $out = [];
+    foreach ($raw as $item) {
+      if (is_array($item) && isset($item['value'], $item['label'])) {
+        $out[(string) $item['value']] = (string) $item['label'];
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $mel
+   *
+   * @return list<array{icon: string, text: string, weight: int}>
+   */
+  private function normalizeEventHighlightsPayload(array $mel): array {
+    if (!isset($mel['event_highlights']['items_state'])) {
+      return [];
+    }
+    $raw = trim((string) $mel['event_highlights']['items_state']);
+    if ($raw === '') {
+      return [];
+    }
+    try {
+      $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException) {
+      return [];
+    }
+    if (!is_array($decoded)) {
+      return [];
+    }
+    $allowed = array_keys($this->getHighlightIconOptionsForJs());
+    $out = [];
+    $weight = 0;
+    foreach ($decoded as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $text = trim((string) ($item['text'] ?? ''));
+      if ($text === '') {
+        continue;
+      }
+      $icon = trim((string) ($item['icon'] ?? ''));
+      if ($icon !== '' && !in_array($icon, $allowed, TRUE)) {
+        $icon = '';
+      }
+      $out[] = [
+        'icon' => $icon,
+        'text' => $text,
+        'weight' => $weight,
+      ];
+      $weight++;
+    }
+    return array_slice($out, 0, 6);
+  }
+
   private function encodeStudioTiersJsonForEvent(NodeInterface $event): string {
     if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
       return '[]';
@@ -965,6 +1192,8 @@ final class EventStudioForm extends FormBase {
       'status' => !empty($mel['status']),
       'field_location_latitude' => $mel['field_location_latitude'] ?? NULL,
       'field_location_longitude' => $mel['field_location_longitude'] ?? NULL,
+      'event_highlights' => $this->normalizeEventHighlightsPayload($mel),
+      'event_highlights_items_state' => trim((string) (($mel['event_highlights'] ?? [])['items_state'] ?? '')),
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -6,11 +6,13 @@ namespace Drupal\myeventlane_event_studio\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\file\FileInterface;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_venue\Entity\Venue;
 use Drupal\myeventlane_venue\Service\VenueManager;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -210,9 +212,24 @@ final class EventStudioSaveService {
       return ['node' => NULL, 'errors' => $image_errors];
     }
 
+    if (array_key_exists('event_highlights_items_state', $payload)) {
+      $highlight_errors = $this->validateHighlightItemsStateJson((string) ($payload['event_highlights_items_state'] ?? ''));
+      if ($highlight_errors !== []) {
+        return ['node' => NULL, 'errors' => $highlight_errors];
+      }
+    }
+
     $studio_tier_errors = $this->melTicketTypeManager->validateStudioTicketDefinitions($node, $account, $payload, $draft);
     if ($studio_tier_errors !== []) {
       return ['node' => NULL, 'errors' => $studio_tier_errors];
+    }
+
+    try {
+      $this->syncEventHighlights($node, $payload);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Studio event highlights sync failed: @m', ['@m' => $e->getMessage()]);
+      return ['node' => NULL, 'errors' => ['Could not save event highlights.']];
     }
 
     EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio draft.' : 'Event Studio save.');
@@ -615,6 +632,174 @@ final class EventStudioSaveService {
     }
     if ($node->hasField('field_location_longitude') && $lng !== NULL && $lng !== '') {
       $node->set('field_location_longitude', (string) $lng);
+    }
+  }
+
+  /**
+   * Replaces `field_event_highlights` with paragraph entities in submitted order.
+   *
+   * Reuses existing paragraph entities by delta when possible; removes extras;
+   * creates new paragraphs when the list grows. Paragraphs dropped from the
+   * field are deleted to avoid orphans (same pattern as other MEL inline
+   * paragraph writers).
+   *
+   * @param array<string, mixed> $payload
+   */
+  private function syncEventHighlights(NodeInterface $node, array $payload): void {
+    if (!$node->hasField('field_event_highlights')) {
+      return;
+    }
+    if (!array_key_exists('event_highlights', $payload) || !is_array($payload['event_highlights'])) {
+      return;
+    }
+
+    $allowed_icons = $this->loadHighlightIconAllowedKeys();
+    $normalized = [];
+    foreach ($payload['event_highlights'] as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $text = trim((string) ($row['text'] ?? ''));
+      if ($text === '') {
+        continue;
+      }
+      $icon = trim((string) ($row['icon'] ?? ''));
+      if ($icon !== '' && !in_array($icon, $allowed_icons, TRUE)) {
+        $icon = '';
+      }
+      $normalized[] = ['text' => $text, 'icon' => $icon];
+    }
+    $normalized = array_slice($normalized, 0, 6);
+
+    $paragraph_storage = $this->entityTypeManager->getStorage('paragraph');
+    $old_entities = array_values($node->get('field_event_highlights')->referencedEntities());
+    $refs = [];
+
+    if ($normalized === []) {
+      $node->set('field_event_highlights', []);
+      foreach ($old_entities as $entity) {
+        if ($entity instanceof Paragraph && $entity->bundle() === 'event_highlight') {
+          $entity->delete();
+        }
+      }
+      return;
+    }
+
+    foreach ($normalized as $i => $item) {
+      if (isset($old_entities[$i]) && $old_entities[$i] instanceof Paragraph && $old_entities[$i]->bundle() === 'event_highlight') {
+        $paragraph = $old_entities[$i];
+      }
+      else {
+        $paragraph = $paragraph_storage->create(['type' => 'event_highlight']);
+      }
+      $this->applyHighlightParagraphValues($paragraph, $item['text'], $item['icon']);
+      $paragraph->save();
+      $refs[] = [
+        'target_id' => (int) $paragraph->id(),
+        'target_revision_id' => (int) $paragraph->getRevisionId(),
+      ];
+    }
+
+    for ($j = count($normalized); $j < count($old_entities); $j++) {
+      $drop = $old_entities[$j];
+      if ($drop instanceof Paragraph && $drop->bundle() === 'event_highlight') {
+        $drop->delete();
+      }
+    }
+
+    $node->set('field_event_highlights', $refs);
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function loadHighlightIconAllowedKeys(): array {
+    $storage = FieldStorageConfig::load('paragraph.field_highlight_icon');
+    if ($storage === NULL) {
+      return [];
+    }
+    $raw = $storage->getSetting('allowed_values');
+    if (!is_array($raw)) {
+      return [];
+    }
+    $keys = [];
+    foreach ($raw as $item) {
+      if (is_array($item) && isset($item['value'])) {
+        $keys[] = (string) $item['value'];
+      }
+    }
+    return $keys;
+  }
+
+  /**
+   * Validates the hidden JSON for Event Studio highlights (aligns with EventStudioForm).
+   *
+   * Empty string means “no editor state sent”; validation is skipped.
+   *
+   * @return list<string>
+   */
+  private function validateHighlightItemsStateJson(string $raw): array {
+    if ($raw === '') {
+      return [];
+    }
+    try {
+      $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException) {
+      return ['Highlights data could not be read.'];
+    }
+    if (!is_array($decoded)) {
+      return ['Highlights data could not be read.'];
+    }
+    $non_empty = 0;
+    foreach ($decoded as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $text = trim((string) ($item['text'] ?? ''));
+      $icon = trim((string) ($item['icon'] ?? ''));
+      if ($text === '' && $icon === '') {
+        continue;
+      }
+      if ($text === '' && $icon !== '') {
+        return ['Each highlight with an icon needs highlight text.'];
+      }
+      $non_empty++;
+    }
+    if ($non_empty > 6) {
+      return ['You can add at most 6 highlights.'];
+    }
+    return [];
+  }
+
+  /**
+   * Sets highlight text/icon respecting the configured field types on the bundle.
+   */
+  private function applyHighlightParagraphValues(Paragraph $paragraph, string $text, string $icon): void {
+    $text_def = $paragraph->getFieldDefinition('field_highlight_text');
+    if ($text_def->getType() === 'text') {
+      $format = 'plain_text';
+      $allowed = $text_def->getSetting('allowed_formats');
+      if (is_array($allowed) && $allowed !== []) {
+        $format = (string) reset($allowed);
+      }
+      $paragraph->set('field_highlight_text', [
+        'value' => $text,
+        'format' => $format,
+      ]);
+    }
+    elseif ($text_def->getType() === 'string_long') {
+      $paragraph->set('field_highlight_text', ['value' => $text]);
+    }
+    else {
+      $paragraph->set('field_highlight_text', $text);
+    }
+
+    if ($icon === '') {
+      $paragraph->set('field_highlight_icon', NULL);
+    }
+    else {
+      $paragraph->set('field_highlight_icon', $icon);
     }
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -1189,7 +1189,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'allowed' => $isPublished && $isEligible,
         'label' => $isBoosted ? 'Boost active' : ($isPublished ? 'Boost event' : 'Publish to boost'),
         'url' => ($isPublished && $isEligible)
-          ? Url::fromRoute('myeventlane_boost.boost_page', ['node' => $eventId])->toString()
+          ? Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $eventId])->toString()
           : NULL,
         'is_boosted' => $isBoosted,
         'message' => !$isPublished ? 'Publish this event to enable boosting.' : ($boostData['reason'] ?? NULL),
@@ -1352,13 +1352,10 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   }
 
   /**
-   * Dev/staging: align with BoostPerformanceService visibility (state mel.dev_mode or uid 1).
+   * Dev/staging: align with BoostPerformanceService visibility (state mel.dev_mode only).
    */
   private function isMelDevUiFallbackEnabled(): bool {
-    if ($this->state->get('mel.dev_mode', FALSE)) {
-      return TRUE;
-    }
-    return (int) $this->currentUser->id() === 1;
+    return (bool) $this->state->get('mel.dev_mode', FALSE);
   }
 
   /**
@@ -2341,7 +2338,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
           'event_id' => $event_id,
           'event_title' => $event ? $event->label() : $this->t('Unknown event'),
           'ends_at' => $ends > 0 ? date('M j, Y g:ia', $ends) : $this->t('Unknown'),
-          'manage_url' => $event_id > 0 ? Url::fromRoute('myeventlane_boost.boost_page', ['node' => $event_id])->toString() : NULL,
+          'manage_url' => $event_id > 0 ? Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $event_id])->toString() : NULL,
         ];
       }
 

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -230,20 +230,19 @@
                 {% for item in highlights %}
                   {% set icon_key = item.icon|default('') %}
                   {% set icon_char = '' %}
+                  {# Keys match paragraph.field_highlight_icon allowed_values (config/sync). #}
                   {% if icon_key == 'star' %}
                     {% set icon_char = '★' %}
                   {% elseif icon_key == 'music' %}
                     {% set icon_char = '♪' %}
                   {% elseif icon_key == 'food' %}
                     {% set icon_char = '☕' %}
-                  {% elseif icon_key == 'community' %}
-                    {% set icon_char = '◎' %}
-                  {% elseif icon_key == 'workshop' %}
-                    {% set icon_char = '✦' %}
-                  {% elseif icon_key == 'accessibility' %}
+                  {% elseif icon_key == 'clock' %}
+                    {% set icon_char = '🕐' %}
+                  {% elseif icon_key == 'info' %}
+                    {% set icon_char = 'ℹ' %}
+                  {% elseif icon_key == 'access' %}
                     {% set icon_char = '♿' %}
-                  {% elseif icon_key == 'warning' %}
-                    {% set icon_char = '⚠' %}
                   {% endif %}
 
                   <li class="mel-event-highlights__item">
@@ -252,7 +251,7 @@
                         {{ icon_char }}
                       {% endif %}
                     </span>
-                    <span class="mel-event-highlights__text">{{ item.text }}</span>
+                    <span class="mel-event-highlights__text">{{ item.text|e }}</span>
                   </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Event Studio editor that creates/updates/deletes paragraph entities on save/autosave, which could impact event content if the JSON/state sync or validation is wrong. Also changes boost routing and icon rendering/escaping, so regressions would be user-visible but scoped.
> 
> **Overview**
> Adds an **Event Studio “Event highlights” editor** (UI + JS builder) that lets vendors add/reorder/remove up to 6 highlight rows with optional icons, syncs state to a hidden JSON field, and validates on input, autosave, and submit.
> 
> Extends backend autosave and full-save payloads to include highlights, validates the submitted JSON, and persists it by syncing `field_event_highlights` to `event_highlight` paragraph entities (creating/reusing by delta and deleting removed paragraphs). Updates the event full-page template to align icon keys and **escape highlight text**, and adjusts vendor boost links to use the `myeventlane_boost.vendor_event_boost` route (plus tightens dev UI fallback to `mel.dev_mode` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e885ad78d466abe7f2d648b8bbd0629ff0c098dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->