### PR TITLE
Event studio alignment v01

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -670,15 +670,16 @@ final class EventStudioSaveService {
       $v = trim((string) $payload['field_age_policy']);
       $allowed = $this->listStringValueKeys($node->getFieldDefinition('field_age_policy'));
       if ($allowed === []) {
-        $this->logger->warning('Studio save: field_age_policy allowed values missing; coercing to all_ages (nid @nid).', [
+        $this->logger->warning('Studio save: field_age_policy allowed values missing; skipping field_age_policy set (nid @nid).', [
           '@nid' => (string) ($node->id() ?? 'new'),
         ]);
-        $v = 'all_ages';
       }
-      elseif ($v === '' || !in_array($v, $allowed, TRUE)) {
-        $v = 'all_ages';
+      else {
+        if ($v === '' || !in_array($v, $allowed, TRUE)) {
+          $v = in_array('all_ages', $allowed, TRUE) ? 'all_ages' : (string) reset($allowed);
+        }
+        $node->set('field_age_policy', $v);
       }
-      $node->set('field_age_policy', $v);
     }
 
     if ($node->hasField('field_age_policy_note') && array_key_exists('field_age_policy_note', $payload)) {

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -13,6 +13,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Drupal\myeventlane_help_centre\Service\ContextualHelpResolver;
 use Drupal\node\NodeInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
@@ -142,13 +143,13 @@ function _myeventlane_help_centre_vendor_event_boost_url(mixed $event_id): ?stri
   if ($event_id === NULL || $event_id === '') {
     return NULL;
   }
-  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_boost')) {
-    return NULL;
-  }
   try {
     return Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => (int) $event_id])
       ->setAbsolute(FALSE)
       ->toString();
+  }
+  catch (RouteNotFoundException) {
+    return NULL;
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_help_centre')->warning('Could not build vendor_event_boost URL: @message', [

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -128,7 +128,7 @@ services:
       - '@myeventlane_core.domain_detector'
       - '@current_user'
       - '@messenger'
-      - '@module_handler'
+      - '@router.route_provider'
       - '@myeventlane_vendor.service.rsvp_stats'
       - '@entity_type.manager'
       - '@myeventlane_core.entity_id_normalizer'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -8,8 +8,8 @@ use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\myeventlane_ai\Service\AiUsageTracker;
@@ -36,6 +36,7 @@ use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -139,9 +140,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   protected LoggerInterface $melDebugLogger;
 
   /**
-   * Module handler (for optional myeventlane_boost routes).
+   * Route provider (detect optional myeventlane_boost routes; module may be on without routes).
    */
-  protected ModuleHandlerInterface $moduleHandler;
+  protected RouteProviderInterface $routeProvider;
 
   /**
    * Boost lifecycle metrics façade (optional, myeventlane_boost.performance).
@@ -157,7 +158,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     DomainDetector $domain_detector,
     AccountProxyInterface $current_user,
     MessengerInterface $messenger,
-    ModuleHandlerInterface $module_handler,
+    RouteProviderInterface $route_provider,
     RsvpStatsService $rsvp_stats,
     EntityTypeManagerInterface $entity_type_manager,
     EntityIdNormalizer $entity_id_normalizer,
@@ -181,7 +182,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     mixed $boost_performance = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
-    $this->moduleHandler = $module_handler;
+    $this->routeProvider = $route_provider;
     $this->rsvpStats = $rsvp_stats;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityIdNormalizer = $entity_id_normalizer;
@@ -213,7 +214,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $container->get('myeventlane_core.domain_detector'),
       $container->get('current_user'),
       $container->get('messenger'),
-      $container->get('module_handler'),
+      $container->get('router.route_provider'),
       $container->get('myeventlane_vendor.service.rsvp_stats'),
       $container->get('entity_type.manager'),
       $container->get('myeventlane_core.entity_id_normalizer'),
@@ -1027,6 +1028,19 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   }
 
   /**
+   * Whether a named route is registered (handles module on but router stale/partial).
+   */
+  private function routeExists(string $name): bool {
+    try {
+      $this->routeProvider->getRouteByName($name);
+      return TRUE;
+    }
+    catch (RouteNotFoundException) {
+      return FALSE;
+    }
+  }
+
+  /**
    * Get events table data with full details.
    *
    * Loads event nodes and builds table data including revenue, tickets, RSVPs.
@@ -1069,6 +1083,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     }
 
     $events = [];
+
+    $vendorBoostRouteOk = $this->routeExists('myeventlane_boost.vendor_event_boost');
+    $boostWizardStep1Ok = $this->routeExists('myeventlane_boost.wizard.step1');
 
     foreach ($melEvents as $dto) {
       if (!$dto instanceof MelEventData) {
@@ -1194,12 +1211,10 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $isEligible = !empty($boostData['eligible']);
 
       // Build boost button data with proper state handling.
-      $boostModuleOn = $this->moduleHandler->moduleExists('myeventlane_boost');
-
       $boost = [
         'allowed' => $isPublished && $isEligible,
         'label' => $isBoosted ? 'Boost active' : ($isPublished ? 'Boost event' : 'Publish to boost'),
-        'url' => ($isPublished && $isEligible && $boostModuleOn)
+        'url' => ($isPublished && $isEligible && $vendorBoostRouteOk)
           ? Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $eventId])->toString()
           : NULL,
         'is_boosted' => $isBoosted,
@@ -1209,7 +1224,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       // Boost wizard entrypoint (Step 1), per event. Only if user has boost
       // permission, event is published, and event meets eligibility.
       $boostWizardUrl = NULL;
-      if ($boostModuleOn && $isPublished && $isEligible && $this->currentUser->hasPermission('purchase boost for events')) {
+      if ($boostWizardStep1Ok && $isPublished && $isEligible && $this->currentUser->hasPermission('purchase boost for events')) {
         $boostWizardUrl = Url::fromRoute('myeventlane_boost.wizard.step1', ['event' => $eventId])->toString();
       }
 
@@ -2319,6 +2334,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       return [];
     }
 
+    $vendorBoostRouteOk = $this->routeExists('myeventlane_boost.vendor_event_boost');
+
     try {
       $now = time();
       $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
@@ -2349,7 +2366,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
           'event_id' => $event_id,
           'event_title' => $event ? $event->label() : $this->t('Unknown event'),
           'ends_at' => $ends > 0 ? date('M j, Y g:ia', $ends) : $this->t('Unknown'),
-          'manage_url' => ($event_id > 0 && $this->moduleHandler->moduleExists('myeventlane_boost'))
+          'manage_url' => ($event_id > 0 && $vendorBoostRouteOk)
             ? Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $event_id])->toString()
             : NULL,
         ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `field_age_policy` is persisted and how boost URLs are generated, which can affect event data and vendor dashboard navigation in edge cases (missing allowed values or missing routes).
> 
> **Overview**
> **Improves resilience around Event Studio saves and optional Boost integration.** `EventStudioSaveService` now avoids writing `field_age_policy` when allowed values are unavailable, and coerces invalid/empty values to a safe default from the field’s configured options (preferring `all_ages`).
> 
> Help Centre and Vendor Dashboard no longer rely on `moduleExists('myeventlane_boost')` to build boost links; instead they detect route availability (catching `RouteNotFoundException`) and only emit boost/manage URLs when the relevant routes are actually registered, with `VendorDashboardController` updated to inject `router.route_provider` and centralize this check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28114e4f0d23b623aae5dc2ef32c934c41417335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->