### PR TITLE
feat(event_studio): replace category autocomplete with multi-select t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "vite preview",
     "prepare": "husky",
     "mel:hero-check": "cd web/themes/custom/myeventlane_theme && npm run check:hero",
-    "mel:build": "cd web/themes/custom/myeventlane_theme && npm run build",
+    "mel:build": "cd web/themes/custom/myeventlane_theme && npm run build && cd ../myeventlane_vendor_theme && npm run build",
     "mel:lint": "cd web/themes/custom/myeventlane_theme && npm run check:hero && npm run lint:css"
   },
   "devDependencies": {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -39,6 +39,15 @@
     return (el.value || '').trim();
   }
 
+  /** Category: multi-select uses mel[field_category][]; autocomplete uses mel[field_category]. */
+  function categoryFieldHasValue(form) {
+    var multi = form.querySelector('select[name="mel[field_category][]"]');
+    if (multi && multi.selectedOptions && multi.selectedOptions.length > 0) {
+      return true;
+    }
+    return !!val(form, 'mel[field_category]');
+  }
+
   function valRadio(form, name) {
     var el = form.querySelector('[name="' + name + '"]:checked');
     return el ? el.value : '';
@@ -871,6 +880,19 @@
     if (!host) {
       return;
     }
+    var sel = form.querySelector('select[name="mel[field_category][]"]');
+    if (sel) {
+      var chips = [];
+      for (var i = 0; i < sel.selectedOptions.length; i++) {
+        chips.push(
+          '<span class="mel-chip">' +
+            Drupal.checkPlain(sel.selectedOptions[i].text) +
+            '</span>',
+        );
+      }
+      host.innerHTML = chips.join('');
+      return;
+    }
     var raw = val(form, 'mel[field_category]');
     if (!raw) {
       host.innerHTML = '';
@@ -1227,7 +1249,7 @@
     if (val(form, 'mel[title]').length >= 3) score++;
     if (val(form, 'mel[summary]').length >= 10) score++;
     if (val(form, 'mel[body]').length >= 40) score++;
-    if (val(form, 'mel[field_category]')) score++;
+    if (categoryFieldHasValue(form)) score++;
     if (hasCoverFile(form)) score++;
 
     var sd = form.querySelector('[name="mel[start_date][date]"]');
@@ -1259,7 +1281,7 @@
   function isStepComplete(step, form) {
     switch (step) {
       case 'basic':
-        return !!(val(form, 'mel[title]') && val(form, 'mel[field_category]'));
+        return !!(val(form, 'mel[title]') && categoryFieldHasValue(form));
       case 'schedule': {
         var sd = form.querySelector('[name="mel[start_date][date]"]');
         return !!(sd && sd.value);
@@ -1367,7 +1389,7 @@
       out.push(Drupal.t('Add a cover image to increase visibility in discovery and social previews.'));
     }
 
-    if (!val(form, 'mel[field_category]')) {
+    if (!categoryFieldHasValue(form)) {
       out.push(Drupal.t('Select a category so the right audience can find your event.'));
     }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -31,33 +31,35 @@
     </div>
 
     <div class="mel-studio-top">
-      <div class="mel-studio-preview">
-        <article class="mel-preview-card" id="mel-preview-card">
-          <div class="mel-preview-card__media" id="mel-preview-card-media">
-            <img class="mel-preview-card__img" id="mel-preview-card-img" src="" alt="" width="640" height="336" loading="lazy" hidden />
-            <div class="mel-preview-card__media-placeholder" id="mel-preview-card-placeholder">
-              <span aria-hidden="true"></span>
+      <div class="mel-studio-top__preview">
+        <div id="mel-preview-card">
+          <article class="mel-preview-card">
+            <div class="mel-preview-card__media" id="mel-preview-card-media">
+              <img class="mel-preview-card__img" id="mel-preview-card-img" src="" alt="" width="640" height="336" loading="lazy" hidden />
+              <div class="mel-preview-card__media-placeholder" id="mel-preview-card-placeholder">
+                <span aria-hidden="true"></span>
+              </div>
             </div>
-          </div>
-          <div class="mel-preview-card__body">
-            <h3 class="mel-preview-card__title" id="mel-preview-title">—</h3>
-            <p class="mel-preview-card__meta">
-              <time class="mel-preview-card__time" id="mel-preview-schedule" datetime="">—</time>
-            </p>
-            <p class="mel-preview-card__location" id="mel-preview-location">—</p>
-            <p class="mel-preview-card__badge" id="mel-preview-tickets">—</p>
-            <p class="mel-preview-card__status" id="mel-preview-status">—</p>
-          </div>
-        </article>
+            <div class="mel-preview-card__body">
+              <h3 class="mel-preview-card__title" id="mel-preview-title">—</h3>
+              <p class="mel-preview-card__meta">
+                <time class="mel-preview-card__time" id="mel-preview-schedule" datetime="">—</time>
+              </p>
+              <p class="mel-preview-card__location" id="mel-preview-location">—</p>
+              <p class="mel-preview-card__badge" id="mel-preview-tickets">—</p>
+              <p class="mel-preview-card__status" id="mel-preview-status">—</p>
+            </div>
+          </article>
+        </div>
       </div>
 
-      <div class="mel-studio-insights">
-        <div class="mel-aside-card mel-aside-card--insights">
+      <div class="mel-studio-top__insights">
+        <div class="mel-insights-card">
           <h3 class="mel-aside-card__title">{{ 'Suggestions'|t }}</h3>
           <ul class="mel-insights-list" id="mel-insights-list" aria-live="polite"></ul>
         </div>
 
-        <div class="mel-aside-card mel-aside-card--publish mel-aside-card--muted">
+        <div class="mel-publish-card">
           <h3 class="mel-aside-card__title">{{ 'Publish readiness'|t }}</h3>
           <p class="mel-publish-readiness" id="mel-publish-readiness"></p>
         </div>
@@ -74,7 +76,7 @@
       <button type="button" data-step="advanced" role="tab" aria-selected="false">{{ 'Advanced'|t }}</button>
     </div>
 
-    <div class="mel-studio-main-full mel-event-studio-main">
+    <div class="mel-event-studio__form-full mel-studio-main-full">
       <div class="mel-wizard">
         {# —— Basic —— #}
         <div class="mel-step" data-step="basic" role="tabpanel">

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
@@ -3,27 +3,135 @@
 // Complements module css/mel-event-studio.css (library mel_event_studio).
 // ==========================================================================
 
+// Override module mel-event-studio.css (max-width: 1200px on .mel-event-studio).
 .mel-event-studio {
+  max-width: 100% !important;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+// Full-width region below step nav (wizard + primary actions). Single root <form> wraps
+// .mel-event-studio; there is no nested form inside this div.
+.mel-event-studio__form-full {
+  width: 100%;
   max-width: 100%;
+  flex: 1 1 100%;
+  min-width: 0;
+  display: block;
+  box-sizing: border-box;
+}
+
+.mel-event-studio__form-full .form-wrapper,
+.mel-event-studio__form-full .form-item,
+.mel-event-studio__form-full .js-form-wrapper {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-event-studio__form-full input,
+.mel-event-studio__form-full textarea,
+.mel-event-studio__form-full select {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+// Vendor page: utility rail + main column grid — span full main column width.
+.mel-vendor-shell__content .mel-shell-layout__main .mel-event-studio__form-full,
+.mel-vendor-shell__content .mel-event-studio .mel-event-studio__form-full {
+  grid-column: 1 / -1;
+  width: 100%;
+  max-width: 100%;
+}
+
+.mel-shell-layout__main {
+  min-width: 0;
+}
+
+// Module CSS defines .mel-studio-layout (2-col at 960px); neutralize if present anywhere.
+.mel-event-studio .mel-studio-layout {
+  display: block !important;
+  width: 100%;
+  max-width: 100%;
+}
+
+// Vendor workspace.css targets .mel-studio-main inside shell; Event Studio must not pick up that grid.
+.mel-vendor-shell__content .mel-event-studio .mel-event-studio__form-full {
+  display: block !important;
+  grid-template-columns: none !important;
 }
 
 .mel-studio-top {
   display: grid;
-  grid-template-columns: 1.2fr 1fr;
+  grid-template-columns: 2fr 1fr;
   gap: 16px;
+  align-items: start;
+  width: 100%;
   margin-bottom: 16px;
 }
 
-.mel-studio-preview {
-  background: #fff;
-  border-radius: 12px;
-  overflow: hidden;
+.mel-studio-top__preview {
+  width: 100%;
+  min-width: 0;
 }
 
-.mel-studio-insights {
+.mel-studio-top__insights {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
+}
+
+/* Mobile fallback */
+@media (max-width: 768px) {
+  .mel-studio-top {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mel-insights-card,
+.mel-publish-card {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.mel-layout-grid {
+  grid-template-columns: 1fr !important;
+}
+
+/* Kill ALL width constraints */
+.mel-event-studio form,
+.mel-wizard,
+.mel-studio-main-full,
+.mel-event-studio__form-full {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+/* Ensure steps expand (wizard visibility still toggled inline by JS) */
+.mel-wizard .mel-step {
+  width: 100%;
+  min-width: 0;
+}
+
+.mel-step input,
+.mel-step textarea,
+.mel-step select {
+  width: 100%;
+}
+
+/* Remove card-style narrowing */
+.mel-step > div {
+  max-width: none !important;
+}
+
+/* Prevent flex/grid shrink */
+.mel-event-studio,
+.mel-event-studio * {
+  min-width: 0;
 }
 
 /* Horizontal tabs (v2 uses .mel-tabs-horizontal; alias .mel-tabs + .mel-tabs__btn if templates differ) */
@@ -65,7 +173,7 @@
   outline-offset: 2px;
 }
 
-/* Full width form */
+/* Full width form (alias kept on same node as .mel-event-studio__form-full) */
 .mel-studio-main-full {
   width: 100%;
   max-width: 100%;
@@ -88,10 +196,6 @@
 }
 
 @media (max-width: 768px) {
-  .mel-studio-top {
-    grid-template-columns: 1fr;
-  }
-
   .mel-form-grid {
     grid-template-columns: 1fr;
   }

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -477,6 +477,11 @@ function myeventlane_vendor_theme_preprocess_html(array &$variables): void {
  * Implements hook_form_alter().
  */
 function myeventlane_vendor_theme_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  // Event Studio: taxonomy select list instead of entity autocomplete (presentation).
+  if ($form_id === 'mel_event_studio_form') {
+    _myeventlane_vendor_theme_mel_event_studio_category_select($form);
+  }
+
   // Style node event forms.
   if (str_starts_with($form_id, 'node_event_')) {
     $form['#attributes']['class'][] = 'mel-event-form';
@@ -505,6 +510,68 @@ function myeventlane_vendor_theme_form_alter(array &$form, FormStateInterface $f
     $form['#attached']['library'][] = 'core/drupal.states';
     $form['#attached']['library'][] = 'core/drupal.ajax';
   }
+}
+
+/**
+ * Replaces Event Studio category autocomplete with a multi-select (taxonomy terms).
+ *
+ * Submits mel[field_category] as an array of term IDs, which matches
+ * EventStudioForm::extractMultipleEntityIds() for array input.
+ */
+function _myeventlane_vendor_theme_mel_event_studio_category_select(array &$form): void {
+  if (!isset($form['mel']['field_category']) || !is_array($form['mel']['field_category'])) {
+    return;
+  }
+  $original = $form['mel']['field_category'];
+  if (($original['#type'] ?? '') !== 'entity_autocomplete') {
+    return;
+  }
+
+  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  $tids = $term_storage->getQuery()
+    ->accessCheck(TRUE)
+    ->condition('vid', 'categories')
+    ->sort('name')
+    ->execute();
+
+  if ($tids === []) {
+    return;
+  }
+
+  $terms = $term_storage->loadMultiple($tids);
+  $options = [];
+  foreach ($terms as $term) {
+    $options[$term->id()] = $term->label();
+  }
+
+  $default_tids = [];
+  $dv = $original['#default_value'] ?? [];
+  if (is_array($dv)) {
+    foreach ($dv as $entity) {
+      if (is_object($entity) && method_exists($entity, 'id')) {
+        $default_tids[] = $entity->id();
+      }
+    }
+  }
+
+  $classes = ['mel-input', 'mel-select--category'];
+  if (!empty($original['#attributes']['class']) && is_array($original['#attributes']['class'])) {
+    $classes = array_merge($classes, $original['#attributes']['class']);
+  }
+
+  $form['mel']['field_category'] = [
+    '#type' => 'select',
+    '#title' => $original['#title'] ?? t('Categories'),
+    '#options' => $options,
+    '#multiple' => TRUE,
+    '#default_value' => $default_tids,
+    '#description' => $original['#description'] ?? NULL,
+    '#attributes' => [
+      'class' => array_values(array_unique($classes)),
+      'size' => (string) min(12, max(4, count($options))),
+    ],
+    '#weight' => $original['#weight'] ?? 0,
+  ];
 }
 
 /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_event-form.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_event-form.scss
@@ -286,8 +286,10 @@
 // ============================================================================
 // WIZARD LAYOUT (LEFT SIDEBAR + RIGHT CONTENT)
 // ============================================================================
+// Event Studio also uses .mel-wizard (step panels only; no .mel-wizard__layout).
+// Do not apply this 2-column grid there — scope to layouts that include the sidebar rail.
 
-.mel-wizard,
+.mel-wizard:has(.mel-wizard__layout),
 .mel-wizard--event,
 .mel-vendor-wizard {
   display: grid;

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -87,6 +87,8 @@
   @include meta.load-css('../../../myeventlane_theme/src/scss/components/vendor-studio-editor');
   @include meta.load-css('../../../myeventlane_theme/src/scss/components/studio-inspector');
   @include meta.load-css('../../../myeventlane_theme/src/scss/components/help-centre');
+  // Event Studio layout (preview + insights grid, full-width form) — shared with public theme.
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/event-studio');
 
   @include meta.load-css('pages/dashboard');
   @include meta.load-css('pages/dashboard-mel-support');


### PR DESCRIPTION
…axonomy field

- Updated the Event Studio form to use a multi-select taxonomy field for categories instead of an entity autocomplete, enhancing user experience and allowing multiple selections.
- Adjusted JavaScript validation to accommodate the new multi-select field, ensuring proper scoring and feedback during form completion.
- Enhanced layout and styling for the Event Studio to support full-width forms and improved responsiveness across devices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Event Studio category input from autocomplete text to a multi-select `select`, altering the submitted shape of `mel[field_category]` and related JS/UI behavior. Also introduces broad CSS overrides to force full-width layout, which could cause regressions in vendor/public theme pages if selectors are too global.
> 
> **Overview**
> Event Studio now presents `field_category` as a taxonomy term **multi-select** (via vendor theme `hook_form_alter`) instead of an entity autocomplete, supporting multiple category selections while keeping autosave compatible with array term IDs.
> 
> The Event Studio frontend logic is updated to treat category completion/insights/progress as satisfied by either the new `mel[field_category][]` select or the legacy `mel[field_category]` value, and category “chips” rendering now supports multi-select labels.
> 
> The Event Studio template/CSS are adjusted for a **full-width, responsive** top layout (preview + suggestions) and to avoid vendor wizard grid styles leaking onto Event Studio; build tooling is updated to build both the public and vendor themes in `mel:build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94e98cef58cf31766c23b82c250dbf4b2df0f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->