### PR TITLE
feat(event_studio): implement AI content rewrite functionality

### DIFF
--- a/web/modules/custom/myeventlane_ai/src/Service/AiManager.php
+++ b/web/modules/custom/myeventlane_ai/src/Service/AiManager.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_ai\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\myeventlane_ai\Provider\AiProviderInterface;
 use Drupal\myeventlane_ai\Value\AiResult;
 use Drupal\myeventlane_ai\Value\PromptDefinition;
@@ -166,23 +167,933 @@ final class AiManager {
    *   When the AI call fails or the response is not usable JSON.
    */
   public function generateEventCopy(array $context, ?int $requested_by_uid = NULL, ?int $vendor_id = NULL): array {
-    $category = (string) ($context['category'] ?? '');
-    $title = (string) ($context['title'] ?? '');
-    $summary = (string) ($context['summary'] ?? '');
-    $tags = (string) ($context['tags'] ?? '');
-    $toneKey = (string) ($context['tone'] ?? 'community');
-    $audienceKey = (string) ($context['audience'] ?? 'general');
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $timeoutSeconds = (int) ($config->get('openai.timeout_seconds') ?? 20);
+    return $this->performEventCopyGeneration($context, $requested_by_uid, $vendor_id, $timeoutSeconds, 1);
+  }
 
-    $toneDesc = $this->mapToneForEventCopy($toneKey);
-    $audienceDesc = $this->mapAudienceForEventCopy($audienceKey);
-    $categoryLine = $category !== '' ? $category : 'general';
-    $tagsLine = $tags !== '' ? $tags : '(none)';
+  /**
+   * Same generation as generateEventCopy with retries, timeout, and mock fallback.
+   *
+   * Returns ranked variants with scores; title/summary reflect the best-ranked variant.
+   *
+   * @param array<string, mixed> $payload
+   *   Keys: title, summary, category, tags, tone, audience.
+   * @param int|null $requested_by_uid
+   *   User ID for rate limiting and usage accounting.
+   * @param int|null $vendor_id
+   *   Optional vendor ID for opt-in and quota.
+   *
+   * @return array{ok: bool, title: string, summary: string, error: string, variants?: array<int, array<string, mixed>>}
+   *   Always a safe structure for JSON responses.
+   */
+  public function generateEventCopyReliable(array $payload, ?int $requested_by_uid = NULL, ?int $vendor_id = NULL): array {
+    return $this->generateEventCopyVariantsReliable($payload, $requested_by_uid, $vendor_id);
+  }
 
-    $system = 'You are an event marketing assistant for MyEventLane. Respond with ONLY valid JSON (no markdown fences): {"title":"...","summary":"..."}. Title: max ~12 words, clear and engaging. Summary: 1–2 sentences on value and vibe, max ~300 characters. Match the requested tone and audience; avoid generic filler. Make it feel local, real, and specific.';
-    $user = "Write a compelling event title and short summary.\n\nContext:\n- Category: {$categoryLine}\n- Tags / keywords: {$tagsLine}\n- Audience: {$audienceDesc}\n- Tone: {$toneDesc}\n\nExisting draft (may be empty):\n- Title: {$title}\n- Summary notes: {$summary}\n\nInstructions:\n- Reflect tone and audience in word choice.\n- Avoid generic phrases.\n";
+  /**
+   * Generates multiple variants with deterministic scoring and a marked best option.
+   *
+   * @param array<string, mixed> $payload
+   *   Keys: title, summary, category, tags, tone, audience.
+   * @param int|null $requested_by_uid
+   *   User ID for rate limiting and usage accounting.
+   * @param int|null $vendor_id
+   *   Optional vendor ID for opt-in and quota.
+   *
+   * @return array{ok: bool, title: string, summary: string, error: string, variants?: array<int, array<string, mixed>>}
+   */
+  public function generateEventCopyVariantsReliable(array $payload, ?int $requested_by_uid = NULL, ?int $vendor_id = NULL): array {
+    $attempt = 0;
+    $lastError = NULL;
+
+    while ($attempt <= $this->maxRetries()) {
+      try {
+        return $this->buildVariantsForProvider($this->primaryProvider(), $payload, $requested_by_uid, $vendor_id);
+      }
+      catch (\Throwable $e) {
+        $lastError = $e->getMessage();
+        if (!$this->isRetryable($e)) {
+          break;
+        }
+        $this->logger->notice('AI event copy retry: attempt=@attempt error=@msg', [
+          '@attempt' => (string) $attempt,
+          '@msg' => $lastError,
+        ]);
+        $this->sleepBackoff($attempt);
+        $attempt++;
+      }
+    }
+
+    try {
+      return $this->buildVariantsForProvider($this->fallbackProvider(), $payload, $requested_by_uid, $vendor_id);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('AI event copy fallback failed: @msg', ['@msg' => $e->getMessage()]);
+      return [
+        'ok' => FALSE,
+        'error' => 'AI unavailable',
+        'title' => '',
+        'summary' => '',
+        'variants' => [],
+      ];
+    }
+  }
+
+  /**
+   * Rewrites About + What to expect with retries and mock fallback (unchanged text).
+   *
+   * @param array<string, mixed> $payload
+   *   Keys: about, what_to_expect, category, tone, audience.
+   *
+   * @return array{ok: bool, about: string, what_to_expect: string, error: string}
+   */
+  public function rewriteEventContentReliable(array $payload, ?int $requested_by_uid = NULL, ?int $vendor_id = NULL): array {
+    $aboutIn = trim((string) ($payload['about'] ?? ''));
+    $expectIn = trim((string) ($payload['what_to_expect'] ?? ''));
+
+    if ($aboutIn === '' && $expectIn === '') {
+      return [
+        'ok' => FALSE,
+        'error' => 'No content to rewrite',
+        'about' => '',
+        'what_to_expect' => '',
+      ];
+    }
+
+    $attempt = 0;
+    $lastError = NULL;
+
+    while ($attempt <= $this->maxRetries()) {
+      try {
+        return $this->rewriteEventContentForProvider($this->primaryProvider(), $payload, $requested_by_uid, $vendor_id);
+      }
+      catch (\Throwable $e) {
+        $lastError = $e->getMessage();
+        if (!$this->isRetryable($e)) {
+          break;
+        }
+        $this->logger->notice('AI content rewrite retry: attempt=@attempt error=@msg', [
+          '@attempt' => (string) $attempt,
+          '@msg' => $lastError,
+        ]);
+        $this->sleepBackoff($attempt);
+        $attempt++;
+      }
+    }
+
+    try {
+      return $this->rewriteEventContentForProvider($this->fallbackProvider(), $payload, $requested_by_uid, $vendor_id);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('AI content rewrite fallback failed: @msg', ['@msg' => $e->getMessage()]);
+      return [
+        'ok' => FALSE,
+        'error' => 'AI unavailable',
+        'about' => $aboutIn,
+        'what_to_expect' => $expectIn,
+      ];
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return array{ok: bool, about: string, what_to_expect: string, error: string}
+   */
+  private function rewriteEventContentForProvider(string $provider, array $payload, ?int $requested_by_uid, ?int $vendor_id): array {
+    if ($provider === 'openai') {
+      if ($this->apiKey() === '') {
+        throw new \RuntimeException('missing api key');
+      }
+      return $this->rewriteEventContent($payload, $requested_by_uid, $vendor_id);
+    }
+
+    if ($provider === 'mock') {
+      $aboutIn = trim((string) ($payload['about'] ?? ''));
+      $expectIn = trim((string) ($payload['what_to_expect'] ?? ''));
+      return [
+        'ok' => TRUE,
+        'about' => $aboutIn,
+        'what_to_expect' => $expectIn,
+        'error' => '',
+      ];
+    }
+
+    throw new \RuntimeException('Unknown provider');
+  }
+
+  /**
+   * Single-provider rewrite using the shared analyze() pipeline.
+   *
+   * @param array<string, mixed> $payload
+   *   Keys: about, what_to_expect, category, tone, audience.
+   *
+   * @return array{ok: bool, about: string, what_to_expect: string, error: string}
+   */
+  private function rewriteEventContent(array $payload, ?int $requested_by_uid = NULL, ?int $vendor_id = NULL): array {
+    $category = (string) ($payload['category'] ?? 'Community');
+    $tone = $this->mapToneForEventCopy($payload['tone'] ?? 'community');
+    $audience = $this->mapAudienceForEventCopy($payload['audience'] ?? 'general');
+
+    $about = trim((string) ($payload['about'] ?? ''));
+    $expect = trim((string) ($payload['what_to_expect'] ?? ''));
+
+    $system = <<<SYS
+You improve event descriptions.
+
+Rules:
+- Do NOT change meaning
+- Do NOT invent details
+- Keep factual accuracy
+- Improve clarity and readability
+- Improve flow and structure
+- Optimise for attendance and engagement
+- No emojis or hashtags
+
+Output JSON:
+{
+  "about": "...",
+  "what_to_expect": "..."
+}
+SYS;
+
+    $user = <<<USR
+Rewrite the following event content.
+
+Category: {$category}
+Tone: {$tone}
+Audience: {$audience}
+
+About:
+{$about}
+
+What to expect:
+{$expect}
+
+Return improved versions only.
+USR;
 
     $hash = hash('sha256', $system . "\n" . $user);
-    $definition = new PromptDefinition('event_studio.generate_event_copy', 'v2', $system, $user, $hash);
+    $definition = new PromptDefinition('event_studio.rewrite_content', 'v1', $system, $user, $hash);
+
+    $scopeId = 'event_studio:rewrite:' . substr($hash, 0, 20);
+
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $timeoutSeconds = (int) max(1, (int) round($this->reliableTimeoutMs() / 1000));
+    $maxTokens = (int) ($config->get('openai.max_tokens') ?? 600);
+    $maxTokens = max(400, min($maxTokens, 1200));
+
+    $result = $this->analyze(
+      $definition,
+      [
+        'model' => (string) ($config->get('openai.model') ?: 'gpt-4o-mini'),
+        'temperature' => (float) ($config->get('openai.temperature') ?? 0.35),
+        'max_tokens' => $maxTokens,
+        'timeout_seconds' => $timeoutSeconds,
+      ],
+      $requested_by_uid,
+      $scopeId,
+      $vendor_id,
+    );
+
+    if (!$result->ok) {
+      throw new \RuntimeException($result->error ?? 'AI request failed');
+    }
+
+    $decoded = $result->json;
+    if (!is_array($decoded)) {
+      $trimmed = trim($result->raw);
+      if ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '[')) {
+        $try = json_decode($trimmed, TRUE);
+        $decoded = is_array($try) ? $try : NULL;
+      }
+    }
+
+    if (!is_array($decoded)) {
+      $this->logger->notice('Event Studio AI rewrite: response was not valid JSON.');
+      throw new \RuntimeException('AI response was not valid JSON');
+    }
+
+    $aboutOut = trim((string) ($decoded['about'] ?? ''));
+    $expectOut = trim((string) ($decoded['what_to_expect'] ?? ''));
+
+    if ($aboutOut === '') {
+      $aboutOut = $about;
+    }
+
+    if ($expectOut === '') {
+      $expectOut = $expect;
+    }
+
+    return [
+      'ok' => TRUE,
+      'about' => $aboutOut,
+      'what_to_expect' => $expectOut,
+      'error' => '',
+    ];
+  }
+
+  /**
+   * OpenAI API key (same resolution as OpenAiProvider).
+   */
+  private function apiKey(): string {
+    $api_key = (string) (getenv('MEL_OPENAI_API_KEY') ?: '');
+    if ($api_key === '') {
+      $from_settings = Settings::get('myeventlane_ai');
+      if (is_array($from_settings)) {
+        $api_key = (string) ($from_settings['api_key'] ?? '');
+      }
+    }
+    return $api_key;
+  }
+
+  /**
+   * Reliable-layer primary provider (config or default openai).
+   */
+  private function primaryProvider(): string {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $p = $config->get('event_copy_reliable.primary');
+    if (is_string($p) && $p !== '') {
+      return $p;
+    }
+    $mel = Settings::get('myeventlane_ai');
+    if (is_array($mel) && isset($mel['event_copy_reliable_primary']) && is_string($mel['event_copy_reliable_primary']) && $mel['event_copy_reliable_primary'] !== '') {
+      return $mel['event_copy_reliable_primary'];
+    }
+    return 'openai';
+  }
+
+  /**
+   * Reliable-layer fallback provider (config or default mock).
+   */
+  private function fallbackProvider(): string {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $p = $config->get('event_copy_reliable.fallback');
+    if (is_string($p) && $p !== '') {
+      return $p;
+    }
+    $mel = Settings::get('myeventlane_ai');
+    if (is_array($mel) && isset($mel['event_copy_reliable_fallback']) && is_string($mel['event_copy_reliable_fallback']) && $mel['event_copy_reliable_fallback'] !== '') {
+      return $mel['event_copy_reliable_fallback'];
+    }
+    return 'mock';
+  }
+
+  /**
+   * Timeout for reliable OpenAI attempts (ms), from config or defaults.
+   */
+  private function reliableTimeoutMs(): int {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $ms = $config->get('event_copy_reliable.timeout_ms');
+    if ($ms !== NULL && $ms !== '') {
+      return max(500, (int) $ms);
+    }
+    $mel = Settings::get('myeventlane_ai');
+    if (is_array($mel) && isset($mel['event_copy_reliable_timeout_ms'])) {
+      return max(500, (int) $mel['event_copy_reliable_timeout_ms']);
+    }
+    return 8000;
+  }
+
+  private function maxRetries(): int {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $v = $config->get('event_copy_reliable.max_retries');
+    if ($v !== NULL && $v !== '') {
+      return max(0, (int) $v);
+    }
+    $mel = Settings::get('myeventlane_ai');
+    if (is_array($mel) && isset($mel['event_copy_reliable_max_retries'])) {
+      return max(0, (int) $mel['event_copy_reliable_max_retries']);
+    }
+    return 2;
+  }
+
+  private function baseDelayMs(): int {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $v = $config->get('event_copy_reliable.base_delay_ms');
+    if ($v !== NULL && $v !== '') {
+      return max(50, (int) $v);
+    }
+    $mel = Settings::get('myeventlane_ai');
+    if (is_array($mel) && isset($mel['event_copy_reliable_base_delay_ms'])) {
+      return max(50, (int) $mel['event_copy_reliable_base_delay_ms']);
+    }
+    return 300;
+  }
+
+  private function isRetryable(\Throwable $e): bool {
+    $msg = strtolower($e->getMessage());
+
+    // Drupal Flood quota (per user / per scope): retrying immediately never helps.
+    if (str_contains($msg, 'rate limit exceeded (user)') || str_contains($msg, 'rate limit exceeded (scope)')) {
+      return FALSE;
+    }
+
+    return str_contains($msg, 'timeout')
+      || str_contains($msg, '429')
+      || str_contains($msg, 'rate limit')
+      || str_contains($msg, 'temporarily')
+      || str_contains($msg, 'connection');
+  }
+
+  private function sleepBackoff(int $attempt): void {
+    $base = $this->baseDelayMs();
+    $delay = (int) ($base * (2 ** $attempt));
+    usleep($delay * 1000);
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return array{ok: bool, title: string, summary: string, error: string, variants: array<int, array<string, mixed>>}
+   */
+  private function buildVariantsForProvider(string $provider, array $payload, ?int $requested_by_uid, ?int $vendor_id): array {
+    $timeout = (int) max(1, (int) round($this->reliableTimeoutMs() / 1000));
+
+    if ($provider === 'openai') {
+      if ($this->apiKey() === '') {
+        throw new \RuntimeException('missing api key');
+      }
+
+      $context = $this->normalizeEventCopyPayload($payload);
+      if (array_key_exists('tags', $payload)) {
+        $context['tags'] = $payload['tags'];
+      }
+
+      // One OpenAI request returns all variants so we only consume one per-user rate limit slot.
+      $pairs = $this->performEventCopyTripleVariantGeneration($context, $requested_by_uid, $vendor_id, $timeout);
+
+      if ($pairs === []) {
+        throw new \RuntimeException('all variants failed');
+      }
+
+      return $this->finalizeScoredVariants($pairs, $payload);
+    }
+
+    if ($provider === 'mock') {
+      $mock = $this->mockResponse($payload);
+      if (empty($mock['ok'])) {
+        throw new \RuntimeException('mock unavailable');
+      }
+      $pairs = [
+        [
+          'title' => $mock['title'],
+          'summary' => $mock['summary'],
+        ],
+      ];
+      return $this->finalizeScoredVariants($pairs, $payload);
+    }
+
+    throw new \RuntimeException('Unknown provider');
+  }
+
+  /**
+   * Dedupe, score, sort (stable on ties), renumber ids, set best, log.
+   *
+   * @param array<int, array{title: string, summary: string}> $pairs
+   * @param array<string, mixed> $payload
+   *
+   * @return array{ok: true, title: string, summary: string, error: string, variants: array<int, array<string, mixed>>}
+   */
+  private function finalizeScoredVariants(array $pairs, array $payload): array {
+    $seen = [];
+    $deduped = [];
+    foreach ($pairs as $p) {
+      $key = strtolower(trim($p['title'])) . '|' . strtolower(trim($p['summary']));
+      if (isset($seen[$key])) {
+        continue;
+      }
+      $seen[$key] = TRUE;
+      $deduped[] = $p;
+    }
+
+    $variants = [];
+    foreach ($deduped as $idx => $p) {
+      $variants[] = [
+        'id' => 'v' . ($idx + 1),
+        'title' => $p['title'],
+        'summary' => $p['summary'],
+      ];
+    }
+
+    foreach ($variants as &$variant) {
+      $variant['score'] = $this->scoreVariant($variant, (string) ($payload['category'] ?? ''));
+    }
+    unset($variant);
+
+    foreach ($variants as $i => &$variant) {
+      $variant['_ord'] = $i;
+    }
+    unset($variant);
+
+    usort($variants, function (array $a, array $b): int {
+      $c = ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
+      if ($c !== 0) {
+        return $c;
+      }
+      return ($a['_ord'] ?? 0) <=> ($b['_ord'] ?? 0);
+    });
+
+    foreach ($variants as &$v) {
+      unset($v['_ord']);
+    }
+    unset($v);
+
+    foreach ($variants as $idx => &$v) {
+      $v['id'] = 'v' . ($idx + 1);
+      $v['best'] = ($idx === 0);
+    }
+    unset($v);
+
+    \Drupal::logger('myeventlane_ai')->notice('AI variant scores: @scores', [
+      '@scores' => json_encode(array_map(static fn(array $v): int => (int) ($v['score'] ?? 0), $variants)),
+    ]);
+
+    return [
+      'ok' => TRUE,
+      'title' => $variants[0]['title'],
+      'summary' => $variants[0]['summary'],
+      'error' => '',
+      'variants' => $variants,
+    ];
+  }
+
+  private function optimiseTitleForConversion(string $title, string $category): string {
+    $title = trim($title);
+
+    // Ensure strong structure
+    if (!preg_match('/\b(workshop|party|meetup|class|session|event)\b/i', $title)) {
+      $title .= ' ' . $category . ' Event';
+    }
+
+    // Remove weak words
+    $title = (string) preg_replace('/\b(amazing|great|nice|fun)\b/i', '', $title);
+
+    // Collapse whitespace
+    $title = (string) preg_replace('/\s+/', ' ', $title);
+
+    return trim($title);
+  }
+
+  /**
+   * Splits "Title: subtitle" style strings for short titles + what-to-expect merge.
+   *
+   * @return array{title: string, extra: string}
+   */
+  private function splitTitleForConversion(string $title): array {
+    $parts = explode(':', $title, 2);
+
+    if (count($parts) < 2) {
+      return [
+        'title' => trim($title),
+        'extra' => '',
+      ];
+    }
+
+    return [
+      'title' => trim($parts[0]),
+      'extra' => trim($parts[1]),
+    ];
+  }
+
+  /**
+   * Enforces a single leading action verb for conversion-style headlines.
+   */
+  private function enforceHeadlinePattern(string $title, string $category): string {
+    $title = trim($title);
+
+    if (preg_match('/^(join|discover|experience|learn|celebrate|explore)\b/i', $title)) {
+      $title = (string) preg_replace('/\s+/', ' ', $title);
+      $title = trim($title);
+
+      return mb_substr($title, 0, 60);
+    }
+
+    $verbMap = [
+      'Music' => 'Experience',
+      'Workshop' => 'Learn',
+      'Community' => 'Join',
+      'LGBT' => 'Celebrate',
+      'Food' => 'Discover',
+    ];
+
+    $verb = 'Join';
+    $catTrim = trim($category);
+    foreach ($verbMap as $key => $v) {
+      if ($catTrim !== '' && stripos($catTrim, $key) !== FALSE) {
+        $verb = $v;
+        break;
+      }
+    }
+
+    $title = (string) preg_replace('/^(the|a|an)\s+/i', '', $title);
+    $title = (string) preg_replace('/^(join|discover|experience|learn|celebrate|explore)\s+/i', '', $title);
+    $title = trim($title);
+
+    if ($title === '') {
+      $fallback = $catTrim !== '' ? $catTrim : 'Event';
+      $title = $verb . ' ' . $fallback;
+    }
+    else {
+      $title = $verb . ' ' . ucfirst($title);
+    }
+
+    $title = (string) preg_replace('/\s+/', ' ', $title);
+    $title = trim($title);
+
+    return mb_substr($title, 0, 60);
+  }
+
+  /**
+   * @param array<string, mixed> $variant
+   */
+  private function scoreVariant(array $variant, string $category): int {
+    $score = 0;
+
+    $title = strtolower($variant['title'] ?? '');
+    $summary = strtolower($variant['summary'] ?? '');
+
+    // Length sweet spot
+    $len = strlen($title);
+    if ($len >= 20 && $len <= 65) {
+      $score += 20;
+    }
+
+    // Keyword relevance
+    if (str_contains($title, strtolower($category))) {
+      $score += 15;
+    }
+
+    // Actionability
+    if (preg_match('/\b(join|learn|discover|experience|build)\b/', $title)) {
+      $score += 20;
+    }
+
+    // Specificity (numbers, time, or detail)
+    if (preg_match('/\d/', $title)) {
+      $score += 10;
+    }
+
+    // Summary completeness
+    if (strlen($summary) > 80) {
+      $score += 15;
+    }
+
+    // Penalty for vague words
+    if (preg_match('/\b(amazing|great|fun|nice)\b/', $title)) {
+      $score -= 10;
+    }
+
+    return $score;
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return array<string, string>
+   */
+  private function normalizeEventCopyPayload(array $payload): array {
+    return [
+      'title' => (string) ($payload['title'] ?? ''),
+      'summary' => (string) ($payload['summary'] ?? ''),
+      'category' => (string) ($payload['category'] ?? ''),
+      'tags' => (string) ($payload['tags'] ?? ''),
+      'tone' => (string) ($payload['tone'] ?? 'community'),
+      'audience' => (string) ($payload['audience'] ?? 'general'),
+    ];
+  }
+
+  /**
+   * Normalises one title/summary pair from the model (fallbacks, length, cleanup, conversion optimiser).
+   *
+   * @return array{title: string, summary: string}
+   */
+  private function finalizeEventCopyPair(string $category, string $audienceDesc, string $title, string $summary): array {
+    $title = trim($title);
+    $summary = trim($summary);
+
+    if ($title === '' || strlen($title) < 5) {
+      $title = ucfirst($category) . ' Event';
+    }
+
+    if ($summary === '' || strlen($summary) < 20) {
+      $summary = 'Join us for an engaging ' . strtolower($category) . ' event designed for ' . strtolower($audienceDesc) . '.';
+    }
+
+    $title = mb_substr($title, 0, 80);
+    $summary = mb_substr($summary, 0, 200);
+
+    $title = (string) preg_replace('/[#@]/', '', $title);
+    $summary = (string) preg_replace('/[#@]/', '', $summary);
+
+    $title = $this->optimiseTitleForConversion($title, $category);
+    $title = mb_substr($title, 0, 80);
+
+    $split = $this->splitTitleForConversion($title);
+
+    $title = $split['title'];
+    $title = $this->enforceHeadlinePattern($title, $category);
+    $titleExtra = $split['extra'];
+
+    if ($titleExtra !== '') {
+      $summary = $titleExtra . '. ' . $summary;
+    }
+
+    $summary = (string) preg_replace('/\.\s*\./', '.', $summary);
+    $summary = trim($summary);
+
+    $summary = (string) preg_replace('/\b(food & drink,?\s*)+/i', '', $summary);
+    $summary = trim($summary);
+
+    $summary = mb_substr($summary, 0, 200);
+
+    return [
+      'title' => $title,
+      'summary' => $summary,
+    ];
+  }
+
+  /**
+   * One HTTP request: three distinct title/summary variants (single rate-limit + usage slot).
+   *
+   * @param array<string, mixed> $context
+   *
+   * @return array<int, array{title: string, summary: string}>
+   */
+  private function performEventCopyTripleVariantGeneration(array $context, ?int $requested_by_uid, ?int $vendor_id, int $timeoutSeconds): array {
+    $payload = $context;
+
+    $category = $payload['category'] ?? 'Community';
+    $category = (string) $category;
+
+    $rawTags = $payload['tags'] ?? '';
+    if (is_array($rawTags)) {
+      $tags = implode(', ', array_filter(array_map('trim', $rawTags)));
+    }
+    else {
+      $tags = trim((string) $rawTags);
+    }
+
+    $tone = $this->mapToneForEventCopy($payload['tone'] ?? 'community');
+    $audience = $this->mapAudienceForEventCopy($payload['audience'] ?? 'general');
+
+    $contextParts = array_filter([
+      trim((string) ($payload['title'] ?? '')),
+      trim((string) ($payload['summary'] ?? '')),
+    ]);
+    $contextText = implode('. ', $contextParts);
+
+    $variantSeed = substr(md5($contextText), 0, 6);
+
+    $system = <<<SYS
+You generate high-quality event listings for a community event platform.
+
+Rules:
+- Output must be concise, clear, and engaging
+- No emojis
+- No hashtags
+- No fluff or repetition
+- Match tone and audience exactly
+- Always return structured JSON
+
+Produce exactly 3 distinct title/summary pairs (different angles or emphasis). Each pair must follow:
+- title: max 80 characters
+- summary: 1–2 sentences, max 200 characters
+- Optimise titles for click-through and attendance
+- Prefer clear, specific, benefit-driven language
+- Avoid vague wording like "amazing" or "great"
+- Use concrete hooks (who, what, when, why)
+- Keep titles under 80 characters
+
+Output JSON only:
+{
+  "variants": [
+    {"title":"...","summary":"..."},
+    {"title":"...","summary":"..."},
+    {"title":"...","summary":"..."}
+  ]
+}
+SYS;
+
+    $user = <<<USR
+Create three distinct event listing options using:
+
+Category: {$category}
+Tags: {$tags}
+Tone: {$tone}
+Audience: {$audience}
+
+Context:
+{$contextText}
+
+Variant seed: {$variantSeed}
+
+Return JSON only with the variants array as specified.
+USR;
+
+    \Drupal::logger('myeventlane_ai')->notice('AI input category=@c tone=@t audience=@a', [
+      '@c' => $category,
+      '@t' => $tone,
+      '@a' => $audience,
+    ]);
+
+    $hash = hash('sha256', $system . "\n" . $user);
+    $definition = new PromptDefinition('event_studio.generate_event_copy', 'v4-batch', $system, $user, $hash);
+
+    $scopeId = 'event_studio:generate_copy_batch:' . substr($hash, 0, 20);
+
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $baseMax = (int) ($config->get('openai.max_tokens') ?? 600);
+    $baseMax = max(200, min($baseMax, 600));
+    $maxTokens = max(800, min(2000, 3 * $baseMax));
+
+    $batchTimeout = (int) max($timeoutSeconds, 20);
+
+    $result = $this->analyze(
+      $definition,
+      [
+        'model' => (string) ($config->get('openai.model') ?: 'gpt-4o-mini'),
+        'temperature' => (float) ($config->get('openai.temperature') ?? 0.35),
+        'max_tokens' => $maxTokens,
+        'timeout_seconds' => $batchTimeout,
+      ],
+      $requested_by_uid,
+      $scopeId,
+      $vendor_id,
+    );
+
+    if (!$result->ok) {
+      throw new \RuntimeException($result->error ?? 'AI request failed');
+    }
+
+    $decoded = $result->json;
+    if (!is_array($decoded)) {
+      $trimmed = trim($result->raw);
+      if ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '[')) {
+        $try = json_decode($trimmed, TRUE);
+        $decoded = is_array($try) ? $try : NULL;
+      }
+    }
+
+    if (!is_array($decoded)) {
+      $this->logger->notice('Event Studio AI: batch response was not valid JSON.');
+      throw new \RuntimeException('AI response was not valid JSON');
+    }
+
+    $variantsRaw = [];
+    if (isset($decoded['variants']) && is_array($decoded['variants'])) {
+      foreach ($decoded['variants'] as $item) {
+        if (!is_array($item)) {
+          continue;
+        }
+        $variantsRaw[] = [
+          'title' => trim((string) ($item['title'] ?? '')),
+          'summary' => trim((string) ($item['summary'] ?? '')),
+        ];
+      }
+    }
+    elseif (isset($decoded['title']) || isset($decoded['summary'])) {
+      $variantsRaw[] = [
+        'title' => trim((string) ($decoded['title'] ?? '')),
+        'summary' => trim((string) ($decoded['summary'] ?? '')),
+      ];
+    }
+
+    $variantsRaw = array_slice($variantsRaw, 0, 3);
+
+    $pairs = [];
+    foreach ($variantsRaw as $item) {
+      $pairs[] = $this->finalizeEventCopyPair($category, $audience, $item['title'], $item['summary']);
+    }
+
+    if ($pairs === []) {
+      throw new \RuntimeException('AI response contained no variants');
+    }
+
+    return $pairs;
+  }
+
+  /**
+   * @param array<string, mixed> $context
+   *   Event copy payload (title, summary, category, tags, tone, audience). Tags may be string or list of strings.
+   *
+   * @return array{title: string, summary: string}
+   */
+  private function performEventCopyGeneration(array $context, ?int $requested_by_uid, ?int $vendor_id, int $timeoutSeconds, int $variantOrdinal = 1): array {
+    $payload = $context;
+
+    $category = $payload['category'] ?? 'Community';
+
+    $rawTags = $payload['tags'] ?? '';
+    if (is_array($rawTags)) {
+      $tags = implode(', ', array_filter(array_map('trim', $rawTags)));
+    }
+    else {
+      $tags = trim((string) $rawTags);
+    }
+
+    $tone = $this->mapToneForEventCopy($payload['tone'] ?? 'community');
+    $audience = $this->mapAudienceForEventCopy($payload['audience'] ?? 'general');
+
+    $contextParts = array_filter([
+      trim((string) ($payload['title'] ?? '')),
+      trim((string) ($payload['summary'] ?? '')),
+    ]);
+    $contextText = implode('. ', $contextParts);
+
+    $variantSeed = substr(md5($contextText), 0, 6);
+
+    $system = <<<SYS
+You generate high-quality event listings for a community event platform.
+
+Rules:
+- Output must be concise, clear, and engaging
+- No emojis
+- No hashtags
+- No fluff or repetition
+- Match tone and audience exactly
+- Always return structured JSON
+
+Fields:
+- title: max 80 characters
+- summary: 1–2 sentences, max 200 characters
+- Optimise titles for click-through and attendance
+- Prefer clear, specific, benefit-driven language
+- Avoid vague wording like "amazing" or "great"
+- Use concrete hooks (who, what, when, why)
+- Keep titles under 80 characters
+SYS;
+
+    $user = <<<USR
+Create an event listing using:
+
+Category: {$category}
+Tags: {$tags}
+Tone: {$tone}
+Audience: {$audience}
+
+Context:
+{$contextText}
+
+Return JSON:
+{
+  "title": "...",
+  "summary": "..."
+}
+USR;
+
+    $user .= "\nVariant seed: {$variantSeed}";
+    $user .= "\nDistinct variant number: {$variantOrdinal}";
+
+    \Drupal::logger('myeventlane_ai')->notice('AI input category=@c tone=@t audience=@a', [
+      '@c' => (string) $category,
+      '@t' => $tone,
+      '@a' => $audience,
+    ]);
+
+    $hash = hash('sha256', $system . "\n" . $user);
+    $definition = new PromptDefinition('event_studio.generate_event_copy', 'v3', $system, $user, $hash);
 
     $scopeId = 'event_studio:generate_copy:' . substr($hash, 0, 20);
 
@@ -196,7 +1107,7 @@ final class AiManager {
         'model' => (string) ($config->get('openai.model') ?: 'gpt-4o-mini'),
         'temperature' => (float) ($config->get('openai.temperature') ?? 0.35),
         'max_tokens' => $maxTokens,
-        'timeout_seconds' => (int) ($config->get('openai.timeout_seconds') ?? 20),
+        'timeout_seconds' => $timeoutSeconds,
       ],
       $requested_by_uid,
       $scopeId,
@@ -221,9 +1132,53 @@ final class AiManager {
       throw new \RuntimeException('AI response was not valid JSON');
     }
 
+    $data = $decoded;
+    $category = (string) $category;
+
+    return $this->finalizeEventCopyPair(
+      $category,
+      $audience,
+      trim((string) ($data['title'] ?? '')),
+      trim((string) ($data['summary'] ?? ''))
+    );
+  }
+
+  /**
+   * Deterministic fallback so UX never breaks.
+   *
+   * @param array<string, mixed> $payload
+   *
+   * @return array{ok: bool, title: string, summary: string, error: string}
+   */
+  private function mockResponse(array $payload): array {
+    $category = (string) ($payload['category'] ?? 'Event');
+    if ($category === '') {
+      $category = 'Event';
+    }
+
+    // When OpenAI is unavailable, do not overwrite vendor drafts with canned text.
+    $draftTitle = trim((string) ($payload['title'] ?? ''));
+    $draftSummary = trim((string) ($payload['summary'] ?? ''));
+
+    if ($draftTitle !== '') {
+      $title = mb_substr($draftTitle, 0, 80);
+    }
+    else {
+      $title = $category . ' Event — Join Us';
+    }
+
+    if ($draftSummary !== '') {
+      $summary = mb_substr($draftSummary, 0, 200);
+    }
+    else {
+      $summary = 'An engaging event designed for your audience. Stay tuned for more details.';
+    }
+
     return [
-      'title' => trim((string) ($decoded['title'] ?? '')),
-      'summary' => trim((string) ($decoded['summary'] ?? '')),
+      'ok' => TRUE,
+      'title' => $title,
+      'summary' => $summary,
+      'error' => '',
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -145,6 +145,188 @@
     return el && el.value ? el.value : 'general';
   }
 
+  /**
+   * Word-level highlight of tokens present in new but not in old (naive).
+   *
+   * @param {string} oldText
+   * @param {string} newText
+   * @return {string}
+   */
+  function melSimpleDiff(oldText, newText) {
+    var oldWords = oldText.split(/\s+/);
+    var newWords = newText.split(/\s+/);
+    var result = '';
+    newWords.forEach(function (word) {
+      if (oldWords.indexOf(word) === -1) {
+        result += '<span class="mel-diff-added">' + word + '</span> ';
+      } else {
+        result += word + ' ';
+      }
+    });
+    return result.trim();
+  }
+
+  /**
+   * Side-by-side preview before applying AI rewrite.
+   *
+   * @param {string} oldText
+   * @param {string} newText
+   * @param {function(): void} onApply
+   */
+  function melShowDiffModal(oldText, newText, onApply) {
+    var modal = document.getElementById('mel-ai-diff-modal');
+    var currentEl = document.getElementById('mel-ai-diff-current');
+    var newEl = document.getElementById('mel-ai-diff-new');
+
+    if (!modal || !currentEl || !newEl) {
+      return;
+    }
+
+    var previousActive = document.activeElement;
+
+    currentEl.textContent = oldText;
+    newEl.innerHTML = melSimpleDiff(oldText, newText);
+
+    modal.removeAttribute('hidden');
+
+    var applyBtn = document.getElementById('mel-ai-diff-apply');
+    var cancelBtn = document.getElementById('mel-ai-diff-cancel');
+    var overlay = modal.querySelector('.mel-ai-diff-modal__overlay');
+
+    if (!applyBtn || !cancelBtn) {
+      return;
+    }
+
+    function cleanup() {
+      modal.setAttribute('hidden', 'hidden');
+      applyBtn.removeEventListener('click', applyHandler);
+      cancelBtn.removeEventListener('click', cancelHandler);
+      document.removeEventListener('keydown', keyHandler);
+      if (overlay) {
+        overlay.removeEventListener('click', cancelHandler);
+      }
+      if (previousActive && typeof previousActive.focus === 'function') {
+        try {
+          previousActive.focus();
+        } catch (e) {}
+      }
+    }
+
+    function applyHandler() {
+      onApply();
+      cleanup();
+    }
+
+    function cancelHandler() {
+      cleanup();
+    }
+
+    function keyHandler(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelHandler();
+      }
+    }
+
+    applyBtn.addEventListener('click', applyHandler);
+    cancelBtn.addEventListener('click', cancelHandler);
+    document.addEventListener('keydown', keyHandler);
+    if (overlay) {
+      overlay.addEventListener('click', cancelHandler);
+    }
+
+    window.setTimeout(function () {
+      applyBtn.focus();
+    }, 0);
+  }
+
+  /**
+   * AI rewrite for About (body) and What to expect (field_event_intro).
+   *
+   * @param {HTMLFormElement} form
+   * @param {'about'|'expect'} field
+   */
+  function melRewriteField(form, field) {
+    syncAiControlsToForm(form);
+    var aboutEl = form.querySelector('[name="mel[body]"]');
+    var expectEl = form.querySelector('[name="mel[field_event_intro]"]');
+    var about = aboutEl ? String(aboutEl.value || '') : '';
+    var expect = expectEl ? String(expectEl.value || '') : '';
+
+    setFormState(form, 'mel-studio--saving', Drupal.t('Improving your text…'));
+
+    var rewriteUrl = Drupal.url('vendor/events/ai/rewrite');
+
+    melGetCsrfToken()
+      .then(function (token) {
+        if (!token) {
+          return Promise.reject(new Error('empty_csrf_token'));
+        }
+        return fetch(rewriteUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': token,
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            about: about,
+            what_to_expect: expect,
+            category: categoryForAiPayload(form),
+            tone: aiToneFromPanel(form),
+            audience: aiAudienceFromPanel(form),
+          }),
+        });
+      })
+      .then(function (response) {
+        return response.text().then(function (text) {
+          var data = {};
+          if (text) {
+            try {
+              data = JSON.parse(text);
+            } catch (parseErr) {
+              data = { ok: false };
+            }
+          }
+          return { ok: response.ok, data: data };
+        });
+      })
+      .then(function (result) {
+        if (!result.ok || !result.data || !result.data.ok) {
+          setFormState(form, 'mel-studio--error', Drupal.t('Rewrite could not be applied.'));
+          return;
+        }
+
+        var original = field === 'about' ? about : expect;
+        var updated =
+          field === 'about' ? result.data.about : result.data.what_to_expect;
+        if (updated === undefined || updated === null) {
+          updated = '';
+        }
+
+        setFormState(form, '', '');
+
+        melShowDiffModal(original, updated, function () {
+          if (field === 'about' && aboutEl) {
+            aboutEl.value = updated;
+            aboutEl.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+
+          if (field === 'expect' && expectEl) {
+            expectEl.value = updated;
+            expectEl.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+
+          refreshIntelligence(form);
+          setFormState(form, 'mel-studio--dirty', Drupal.t('AI changes applied'));
+        });
+      })
+      .catch(function () {
+        setFormState(form, 'mel-studio--error', Drupal.t('Rewrite request failed.'));
+      });
+  }
+
   function valRadio(form, name) {
     var el = form.querySelector('[name="' + name + '"]:checked');
     return el ? el.value : '';
@@ -1719,6 +1901,18 @@
         });
 
         form.addEventListener('click', function (e) {
+          var rewriteAboutBtn = e.target.closest('#mel-ai-rewrite-about');
+          if (rewriteAboutBtn && form.contains(rewriteAboutBtn)) {
+            e.preventDefault();
+            melRewriteField(form, 'about');
+            return;
+          }
+          var rewriteExpectBtn = e.target.closest('#mel-ai-rewrite-expect');
+          if (rewriteExpectBtn && form.contains(rewriteExpectBtn)) {
+            e.preventDefault();
+            melRewriteField(form, 'expect');
+            return;
+          }
           var genBtn = e.target.closest('#mel-ai-generate');
           if (genBtn && form.contains(genBtn)) {
             e.preventDefault();

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -37,3 +37,12 @@ myeventlane_event_studio.ai_generate:
   requirements:
     _permission: 'access content'
     _csrf_request_header_token: 'TRUE'
+
+myeventlane_event_studio.ai_rewrite:
+  path: '/vendor/events/ai/rewrite'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioAiController::rewrite'
+  methods: [POST]
+  requirements:
+    _permission: 'access content'
+    _csrf_request_header_token: 'TRUE'

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAiController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAiController.php
@@ -49,36 +49,97 @@ final class EventStudioAiController implements ContainerInjectionInterface {
       }
     }
 
-    $context = [
-      'title' => (string) ($data['title'] ?? ''),
-      'summary' => (string) ($data['summary'] ?? ''),
+    $title = (string) ($data['title'] ?? '');
+    $summary = (string) ($data['summary'] ?? '');
+    $category = (string) ($data['category'] ?? '');
+    $tags = (string) ($data['tags'] ?? '');
+    $tone = (string) ($data['tone'] ?? 'community');
+    $audience = (string) ($data['audience'] ?? 'general');
+
+    $uid = $this->currentUser->isAuthenticated() ? (int) $this->currentUser->id() : NULL;
+
+    $response = $this->aiGenerator->generateEventCopyReliable([
+      'title' => $title,
+      'summary' => $summary,
+      'category' => $category,
+      'tags' => $tags,
+      'tone' => $tone,
+      'audience' => $audience,
+    ], $uid, NULL);
+
+    \Drupal::logger('myeventlane_ai')->notice('AI result ok=@ok', [
+      '@ok' => !empty($response['ok']) ? '1' : '0',
+    ]);
+
+    if (empty($response['ok'])) {
+      return new JsonResponse([
+        'ok' => FALSE,
+        'error' => $response['error'] ?? 'AI failed',
+        'title' => '',
+        'summary' => '',
+      ], 200);
+    }
+
+    return new JsonResponse([
+      'ok' => TRUE,
+      'title' => $response['title'] ?? '',
+      'summary' => $response['summary'] ?? '',
+      'error' => '',
+    ], 200);
+  }
+
+  /**
+   * POST JSON: AI rewrite for About (body) and What to expect (field_event_intro).
+   */
+  public function rewrite(Request $request): JsonResponse {
+    if (!$request->isMethod('POST')) {
+      return new JsonResponse(['ok' => FALSE, 'error' => 'Method not allowed'], 405);
+    }
+
+    $raw = $request->getContent();
+    $data = [];
+    if ($raw !== '') {
+      try {
+        $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+        $data = is_array($decoded) ? $decoded : [];
+      }
+      catch (\JsonException $e) {
+        $this->logger->notice('Event Studio AI rewrite: invalid JSON body: @msg', ['@msg' => $e->getMessage()]);
+        return new JsonResponse(['ok' => FALSE, 'error' => 'Invalid JSON'], 400);
+      }
+    }
+
+    $payload = [
+      'about' => (string) ($data['about'] ?? ''),
+      'what_to_expect' => (string) ($data['what_to_expect'] ?? ''),
       'category' => (string) ($data['category'] ?? ''),
-      'tags' => (string) ($data['tags'] ?? ''),
       'tone' => (string) ($data['tone'] ?? 'community'),
       'audience' => (string) ($data['audience'] ?? 'general'),
     ];
 
     $uid = $this->currentUser->isAuthenticated() ? (int) $this->currentUser->id() : NULL;
 
-    try {
-      $result = $this->aiGenerator->generateEventCopy($context, $uid, NULL);
+    $response = $this->aiGenerator->rewriteEventContentReliable($payload, $uid, NULL);
 
-      return new JsonResponse([
-        'ok' => TRUE,
-        'title' => $result['title'],
-        'summary' => $result['summary'],
-      ]);
-    }
-    catch (\Throwable $e) {
-      $this->logger->error('Event Studio AI generation failed: @msg', [
-        '@msg' => $e->getMessage(),
-      ]);
+    \Drupal::logger('myeventlane_ai')->notice('AI rewrite ok=@ok', [
+      '@ok' => !empty($response['ok']) ? '1' : '0',
+    ]);
 
+    if (empty($response['ok'])) {
       return new JsonResponse([
         'ok' => FALSE,
-        'error' => 'AI generation failed',
-      ], 500);
+        'error' => $response['error'] ?? 'AI failed',
+        'about' => $response['about'] ?? '',
+        'what_to_expect' => $response['what_to_expect'] ?? '',
+      ], 200);
     }
+
+    return new JsonResponse([
+      'ok' => TRUE,
+      'about' => $response['about'] ?? '',
+      'what_to_expect' => $response['what_to_expect'] ?? '',
+      'error' => '',
+    ], 200);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -148,7 +148,13 @@
               </div>
               {{ element.mel.summary }}
               {{ element.mel.field_event_intro }}
+              <div class="mel-ai-rewrite-actions">
+                <button type="button" id="mel-ai-rewrite-expect" class="mel-btn mel-btn--secondary">{{ 'Rewrite What to Expect'|t }}</button>
+              </div>
               {{ element.mel.body }}
+              <div class="mel-ai-rewrite-actions">
+                <button type="button" id="mel-ai-rewrite-about" class="mel-btn mel-btn--secondary">{{ 'Rewrite About'|t }}</button>
+              </div>
             </div>
 
             <div class="mel-identity-media">
@@ -345,6 +351,36 @@
 
       <div class="mel-actions">
         {{ element.actions }}
+      </div>
+    </div>
+  </div>
+
+  <div id="mel-ai-diff-modal" class="mel-ai-diff-modal" hidden>
+    <div class="mel-ai-diff-modal__overlay"></div>
+
+    <div
+      class="mel-ai-diff-modal__panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mel-ai-diff-modal-title"
+    >
+      <h3 id="mel-ai-diff-modal-title">{{ 'Review AI changes'|t }}</h3>
+
+      <div class="mel-ai-diff">
+        <div class="mel-ai-diff__col">
+          <h4>{{ 'Current'|t }}</h4>
+          <div id="mel-ai-diff-current" class="mel-ai-diff__body"></div>
+        </div>
+
+        <div class="mel-ai-diff__col">
+          <h4>{{ 'AI suggestion'|t }}</h4>
+          <div id="mel-ai-diff-new" class="mel-ai-diff__body"></div>
+        </div>
+      </div>
+
+      <div class="mel-ai-diff-modal__actions">
+        <button type="button" id="mel-ai-diff-cancel" class="mel-btn">{{ 'Cancel'|t }}</button>
+        <button type="button" id="mel-ai-diff-apply" class="mel-btn mel-btn--primary">{{ 'Apply changes'|t }}</button>
       </div>
     </div>
   </div>

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
@@ -482,3 +482,86 @@ form.mel-event-studio-form .mel-event-studio,
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+// AI rewrite diff preview modal
+.mel-ai-diff-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.mel-ai-diff-modal[hidden] {
+  display: none !important;
+}
+
+.mel-ai-diff-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.mel-ai-diff-modal__panel {
+  position: relative;
+  z-index: 1;
+  max-width: 900px;
+  margin: 80px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.15);
+}
+
+.mel-ai-diff-modal__panel h3 {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+}
+
+.mel-ai-diff-modal__panel h4 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.mel-ai-diff {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin: 20px 0;
+}
+
+.mel-ai-diff__body {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 50vh;
+  overflow: auto;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  padding: 12px;
+  background: var(--mel-studio-surface-muted, #f8fafc);
+  border-radius: 8px;
+  border: 1px solid var(--mel-studio-border, #e2e8f0);
+}
+
+.mel-diff-added {
+  background: #d4f8d4;
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+.mel-ai-diff-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .mel-ai-diff {
+    grid-template-columns: 1fr;
+  }
+
+  .mel-ai-diff-modal__panel {
+    margin: 24px 12px;
+  }
+}


### PR DESCRIPTION
- Added a new route and controller method for AI content rewriting, allowing users to improve event descriptions and expectations.
- Enhanced the JavaScript to handle AI rewrite requests, including a modal for previewing changes before application.
- Updated the template to include buttons for triggering AI rewrites for specific fields, improving user interaction.
- Introduced new SCSS styles for the AI diff modal, ensuring a clear and responsive layout for content comparison.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new vendor-facing AI rewrite endpoint and significantly expands AI generation logic (retries, provider fallback, multi-variant scoring), which can affect UX and rate/usage behavior if misconfigured.
> 
> **Overview**
> Adds an Event Studio **AI rewrite** capability for `About` and `What to expect`, exposed via new `POST /vendor/events/ai/rewrite` endpoint and UI buttons that show a side-by-side diff modal before applying changes.
> 
> Refactors AI title/summary generation to use a new *reliable* layer (`generateEventCopyReliable` / `generateEventCopyVariantsReliable`) with retry/backoff, configurable primary/fallback providers (`openai` → `mock`), deterministic mock responses, and single-request **3-variant** generation with scoring/deduping to pick a best result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d65c76c7d693bc5941cec7ae4c0912bea572607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->