### PR TITLE
Feature/hybrid identity onboarding

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2701,16 +2701,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "11.3.5",
+            "version": "11.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "6de8a6ff360ad1c2719af077259c3ef77ba3d23f"
+                "reference": "bb36d7d09b0132185bd33be730ec2e6d35c2d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/6de8a6ff360ad1c2719af077259c3ef77ba3d23f",
-                "reference": "6de8a6ff360ad1c2719af077259c3ef77ba3d23f",
+                "url": "https://api.github.com/repos/drupal/core/zipball/bb36d7d09b0132185bd33be730ec2e6d35c2d627",
+                "reference": "bb36d7d09b0132185bd33be730ec2e6d35c2d627",
                 "shasum": ""
             },
             "require": {
@@ -2868,13 +2868,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/11.3.5"
+                "source": "https://github.com/drupal/core/tree/11.3.7"
             },
-            "time": "2026-03-06T09:54:42+00:00"
+            "time": "2026-04-15T15:47:32+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "11.3.5",
+            "version": "11.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2918,13 +2918,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.5"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.7"
             },
             "time": "2026-02-10T11:39:53+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "11.3.5",
+            "version": "11.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -2959,13 +2959,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-project-message/tree/11.3.5"
+                "source": "https://github.com/drupal/core-project-message/tree/11.3.7"
             },
             "time": "2025-02-03T10:59:29+00:00"
         },
         {
             "name": "drupal/core-recipe-unpack",
-            "version": "11.3.5",
+            "version": "11.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recipe-unpack.git",
@@ -3003,29 +3003,29 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.3.5"
+                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.3.7"
             },
             "time": "2025-10-28T11:20:22+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "11.3.5",
+            "version": "11.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "957d0a4e92e90fcf8375a64d63bdff47f7c88b52"
+                "reference": "fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/957d0a4e92e90fcf8375a64d63bdff47f7c88b52",
-                "reference": "957d0a4e92e90fcf8375a64d63bdff47f7c88b52",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94",
+                "reference": "fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94",
                 "shasum": ""
             },
             "require": {
                 "asm89/stack-cors": "~v2.3.0",
                 "composer/semver": "~3.4.4",
                 "doctrine/lexer": "~3.0.1",
-                "drupal/core": "11.3.5",
+                "drupal/core": "11.3.7",
                 "egulias/email-validator": "~4.0.4",
                 "guzzlehttp/guzzle": "~7.10.0",
                 "guzzlehttp/promises": "~2.3.0",
@@ -3087,9 +3087,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/11.3.5"
+                "source": "https://github.com/drupal/core-recommended/tree/11.3.7"
             },
-            "time": "2026-03-06T09:54:42+00:00"
+            "time": "2026-04-15T15:47:32+00:00"
         },
         {
             "name": "drupal/crop",
@@ -4131,17 +4131,17 @@
         },
         {
             "name": "drupal/klaro",
-            "version": "3.0.8",
+            "version": "3.0.10",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/klaro.git",
-                "reference": "3.0.8"
+                "reference": "3.0.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/klaro-3.0.8.zip",
-                "reference": "3.0.8",
-                "shasum": "b2cb6d85a75177a6707fa053ec8c7741b41b5355"
+                "url": "https://ftp.drupal.org/files/projects/klaro-3.0.10.zip",
+                "reference": "3.0.10",
+                "shasum": "cd4bda917970711f1a0f8a99707b4ac5773d7485"
             },
             "require": {
                 "drupal/core": "^10.2 || ^11",
@@ -4150,8 +4150,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.8",
-                    "datestamp": "1765384478",
+                    "version": "3.0.10",
+                    "datestamp": "1775891436",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10388,7 +10388,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -10444,7 +10444,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10468,16 +10468,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
                 "shasum": ""
             },
             "require": {
@@ -10524,7 +10524,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10544,7 +10544,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -12343,16 +12343,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.5",
+            "version": "2.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6"
+                "reference": "82a2fbd1372a98d7915cfb092acf05207d9b4113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
+                "url": "https://api.github.com/repos/composer/composer/zipball/82a2fbd1372a98d7915cfb092acf05207d9b4113",
+                "reference": "82a2fbd1372a98d7915cfb092acf05207d9b4113",
                 "shasum": ""
             },
             "require": {
@@ -12440,7 +12440,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.5"
+                "source": "https://github.com/composer/composer/tree/2.9.7"
             },
             "funding": [
                 {
@@ -12452,7 +12452,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-29T10:40:53+00:00"
+            "time": "2026-04-14T11:31:52+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -12525,24 +12525,24 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.9",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f"
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/edf364cefe8c43501e21e88110aac10b284c3c9f",
-                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/5ecd0cb4177696f9fd48f1605dda81db3dee7889",
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
+                "symfony/phpunit-bridge": "^6.4.25 || ^7.3.3 || ^8.0"
             },
             "type": "library",
             "extra": {
@@ -12585,7 +12585,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.9"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.6.0"
             },
             "funding": [
                 {
@@ -12595,13 +12595,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-05-12T21:07:07+00:00"
+            "time": "2026-04-08T20:18:39+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -14372,16 +14368,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.26.0",
+            "version": "v1.26.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "0da07c10d5fe64cd0c748f0523b47599400f2ed1"
+                "reference": "09c2e5949d676286358a62af818f8407167a9dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/0da07c10d5fe64cd0c748f0523b47599400f2ed1",
-                "reference": "0da07c10d5fe64cd0c748f0523b47599400f2ed1",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/09c2e5949d676286358a62af818f8407167a9dd6",
+                "reference": "09c2e5949d676286358a62af818f8407167a9dd6",
                 "shasum": ""
             },
             "require": {
@@ -14437,9 +14433,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.26.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.26.1"
             },
-            "time": "2026-02-24T15:40:48+00:00"
+            "time": "2026-04-13T14:35:16+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -16970,7 +16966,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -17026,7 +17022,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -17050,16 +17046,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -17110,7 +17106,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -17130,20 +17126,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php82",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php82.git",
-                "reference": "5d2ed36f7734637dacc025f179698031951b1692"
+                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/5d2ed36f7734637dacc025f179698031951b1692",
-                "reference": "5d2ed36f7734637dacc025f179698031951b1692",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/34808efe3e68f69685796f7c253a2f1d8ea9df59",
+                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59",
                 "shasum": ""
             },
             "require": {
@@ -17190,7 +17186,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php82/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -17210,7 +17206,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "tbachert/spi",
@@ -17316,16 +17312,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.6",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
                 "shasum": ""
             },
             "require": {
@@ -17372,9 +17368,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
-            "time": "2026-02-27T10:28:38+00:00"
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],

--- a/web/modules/custom/myeventlane_auth/css/login-create-event-intent.css
+++ b/web/modules/custom/myeventlane_auth/css/login-create-event-intent.css
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Login form: create-event intent callout (Gin Login + default theme).
+ */
+
+.mel-login-intent {
+  background: #fef5ec;
+  border: 1px solid #f26d5b;
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.mel-login-intent strong {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.mel-login-intent p {
+  margin: 0;
+  line-height: 1.45;
+  opacity: 0.92;
+}

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.libraries.yml
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.libraries.yml
@@ -1,0 +1,5 @@
+# Create-event intent callout on user.login (works with Gin Login / any active theme).
+login_create_event_intent:
+  css:
+    theme:
+      css/login-create-event-intent.css: {}

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -8,10 +8,12 @@ declare(strict_types=1);
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\user\UserInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\myeventlane_auth\EventSubscriber\MelPostLoginSessionRedirectSubscriber;
+use Drupal\myeventlane_auth\Service\IdentityIntentResolver;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -33,10 +35,209 @@ function myeventlane_auth_cron(): void {
 }
 
 /**
+ * Resolves raw MEL intent for the login request (GET or POST).
+ *
+ * Priority: mel_intent (query/POST), intent (query/POST), then destination
+ * (query/POST): internal path starting with /create-event maps to create_event;
+ * also inspects query strings inside destination (e.g. /mel/auth/continue?...).
+ *
+ * Used by the login form hidden field and hook_user_login() so behavior stays
+ * in one place.
+ */
+function myeventlane_auth_resolve_mel_intent_for_login_request(Request $request): string {
+  foreach ([
+    [$request->query, 'mel_intent'],
+    [$request->request, 'mel_intent'],
+    [$request->query, 'intent'],
+    [$request->request, 'intent'],
+  ] as $pair) {
+    [$bag, $key] = $pair;
+    $raw = $bag->get($key);
+    if (is_string($raw) && $raw !== '') {
+      return $raw;
+    }
+  }
+
+  foreach ([$request->query->get('destination'), $request->request->get('destination')] as $dest) {
+    if (!is_string($dest) || $dest === '') {
+      continue;
+    }
+    $from_dest = myeventlane_auth_resolve_intent_from_destination_value($dest, $request);
+    if ($from_dest !== '') {
+      return $from_dest;
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Derives intent from a destination parameter value, including nested URLs.
+ *
+ * Handles e.g. destination=/mel/auth/continue?destination=/create-event&mel_intent=create_event
+ * (Create Event → auth continue handoff) where intent lives in the inner query string.
+ */
+function myeventlane_auth_resolve_intent_from_destination_value(string $dest, Request $request, int $depth = 0): string {
+  if ($depth > 5) {
+    return '';
+  }
+
+  $dest = trim(urldecode($dest));
+  if ($dest === '') {
+    return '';
+  }
+
+  $path_part = $dest;
+  $query_string = '';
+  if (preg_match('#^https?://#i', $dest)) {
+    $parsed = parse_url($dest);
+    if ($parsed === FALSE) {
+      return '';
+    }
+    $path_part = $parsed['path'] ?? '';
+    $query_string = $parsed['query'] ?? '';
+  }
+  elseif (str_contains($dest, '?')) {
+    $parts = explode('?', $dest, 2);
+    $path_part = $parts[0];
+    $query_string = $parts[1] ?? '';
+  }
+
+  $path_only = $path_part;
+  $base = $request->getBasePath();
+  if ($base !== '' && str_starts_with($path_only, $base)) {
+    $path_only = substr($path_only, strlen($base)) ?: '/';
+  }
+  if ($path_only !== '' && !str_starts_with($path_only, '/')) {
+    $path_only = '/' . $path_only;
+  }
+  if ($path_only !== '' && str_starts_with($path_only, '/create-event')) {
+    return 'create_event';
+  }
+
+  if ($query_string !== '') {
+    parse_str($query_string, $q);
+    foreach (['mel_intent', 'intent'] as $key) {
+      if (!empty($q[$key]) && is_string($q[$key]) && trim($q[$key]) !== '') {
+        return trim($q[$key]);
+      }
+    }
+    if (!empty($q['destination']) && is_string($q['destination'])) {
+      return myeventlane_auth_resolve_intent_from_destination_value($q['destination'], $request, $depth + 1);
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Whether the registration page should show create-event–specific messaging.
+ *
+ * Uses myeventlane_auth_resolve_mel_intent_for_login_request() and
+ * IdentityIntentResolver (no PostLoginRouter duplication).
+ */
+function myeventlane_auth_register_page_is_create_event_flow(Request $request): bool {
+  $raw = myeventlane_auth_resolve_mel_intent_for_login_request($request);
+  /** @var \Drupal\myeventlane_auth\Service\IdentityIntentResolver $resolver */
+  $resolver = \Drupal::service('myeventlane_auth.identity_intent_resolver');
+  return $resolver->normalizeIntent($raw) === IdentityIntentResolver::INTENT_CREATE_EVENT;
+}
+
+/**
+ * Implements hook_form_user_register_form_alter().
+ *
+ * Minimal signup UI: hide optional components (presentation only). Runs for any
+ * theme, including Gin Login on /user/register.
+ */
+function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  foreach ([
+    'user_picture',
+    'contact',
+    'timezone',
+    'path',
+    'language',
+    'vendor_profiles',
+  ] as $key) {
+    if (isset($form[$key])) {
+      $form[$key]['#access'] = FALSE;
+    }
+  }
+  foreach (['field_marketing', 'field_vendor'] as $key) {
+    if (isset($form[$key])) {
+      $form[$key]['#access'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Implements hook_form_user_login_form_alter().
+ *
+ * - Carries mel_intent through POST /user/login (hub + PostLoginRouter).
+ * - When normalized intent is create_event, adds in-form messaging + CSS.
+ *   Implemented here (not only in the front theme) so Gin Login (Gin/Claro)
+ *   still shows the callout: https://www.drupal.org/project/gin_login
+ */
+function myeventlane_auth_form_user_login_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $request = \Drupal::request();
+  $raw_intent = myeventlane_auth_resolve_mel_intent_for_login_request($request);
+
+  if ($raw_intent !== '') {
+    $form['mel_intent'] = [
+      '#type' => 'hidden',
+      '#value' => $raw_intent,
+      '#weight' => -50,
+    ];
+  }
+
+  /** @var \Drupal\myeventlane_auth\Service\IdentityIntentResolver $resolver */
+  $resolver = \Drupal::service('myeventlane_auth.identity_intent_resolver');
+  if ($resolver->normalizeIntent($raw_intent) !== IdentityIntentResolver::INTENT_CREATE_EVENT) {
+    return;
+  }
+
+  // Use Form API elements (container + html_tag), not inline_template — the latter
+  // is not a form element and can fail to render inside $form.
+  $intent_cache_contexts = [
+    'url.query_args:destination',
+    'url.query_args:mel_intent',
+    'url.query_args:intent',
+  ];
+
+  $form['mel_login_create_event_info'] = [
+    '#type' => 'container',
+    '#attributes' => [
+      'class' => ['mel-login-intent'],
+      'role' => 'region',
+      'aria-labelledby' => 'mel-login-intent-title',
+    ],
+    '#weight' => -60,
+    '#attached' => [
+      'library' => ['myeventlane_auth/login_create_event_intent'],
+    ],
+    '#cache' => [
+      'contexts' => $intent_cache_contexts,
+    ],
+    'title' => [
+      '#type' => 'html_tag',
+      '#tag' => 'strong',
+      '#attributes' => ['id' => 'mel-login-intent-title'],
+      '#value' => t('✨ Create your event'),
+    ],
+    'body' => [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => t('Log in or sign up to start your event — we’ll guide you through the rest.'),
+    ],
+  ];
+
+  $existing = $form['#cache']['contexts'] ?? [];
+  $form['#cache']['contexts'] = array_values(array_unique(array_merge($existing, $intent_cache_contexts)));
+}
+
+/**
  * Implements hook_user_login().
  *
  * Stages destination + intent for post-login hub redirect (session commit safe).
- * Does not alter the login form or POST handling.
  */
 function myeventlane_auth_user_login(UserInterface $account): void {
   \Drupal::logger('myeventlane_auth')->notice('Audit: login success uid=@uid.', [
@@ -60,18 +261,7 @@ function myeventlane_auth_user_login(UserInterface $account): void {
     $raw_dest = '/user/' . $account->id();
   }
 
-  $intent = '';
-  foreach ([
-    $request->query->get('mel_intent'),
-    $request->request->get('mel_intent'),
-    $request->query->get('intent'),
-    $request->request->get('intent'),
-  ] as $candidate) {
-    if (is_string($candidate) && $candidate !== '') {
-      $intent = $candidate;
-      break;
-    }
-  }
+  $intent = myeventlane_auth_resolve_mel_intent_for_login_request($request);
 
   $internal = myeventlane_auth_destination_to_internal_path($request, $raw_dest);
   if ($internal === NULL || myeventlane_auth_should_skip_mel_hub_wrap($internal)) {

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -38,8 +38,8 @@ function myeventlane_auth_cron(): void {
  * Resolves raw MEL intent for the login request (GET or POST).
  *
  * Priority: mel_intent (query/POST), intent (query/POST), then destination
- * (query/POST): internal path starting with /create-event maps to create_event;
- * also inspects query strings inside destination (e.g. /mel/auth/continue?...).
+ * (query/POST): path /create-event or /create-event/… maps to create_event (not
+ * /create-event-copy, etc.); also inspects query strings inside destination.
  *
  * Used by the login form hidden field and hook_user_login() so behavior stays
  * in one place.
@@ -69,6 +69,16 @@ function myeventlane_auth_resolve_mel_intent_for_login_request(Request $request)
   }
 
   return '';
+}
+
+/**
+ * Whether an internal path is the create-event route or a subpath (not a false prefix).
+ *
+ * Matches /create-event and /create-event/…; does not match /create-event-copy,
+ * /create-eventuality, etc.
+ */
+function myeventlane_auth_path_implies_create_event_route(string $path_only): bool {
+  return $path_only === '/create-event' || str_starts_with($path_only, '/create-event/');
 }
 
 /**
@@ -111,7 +121,7 @@ function myeventlane_auth_resolve_intent_from_destination_value(string $dest, Re
   if ($path_only !== '' && !str_starts_with($path_only, '/')) {
     $path_only = '/' . $path_only;
   }
-  if ($path_only !== '' && str_starts_with($path_only, '/create-event')) {
+  if ($path_only !== '' && myeventlane_auth_path_implies_create_event_route($path_only)) {
     return 'create_event';
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
@@ -94,7 +94,7 @@ class CreateEventGatewayController extends ControllerBase {
     $current_user = $this->currentUser();
 
     // Anonymous users: intent-aware auth handoff, then return to this gateway.
-    // Encouraging copy for create-event lives on user.login (see myeventlane_theme page--user-login).
+    // Encouraging copy for create-event is added on user.login by myeventlane_auth (Gin Login–safe).
     if ($current_user->isAnonymous()) {
       $login_url = $this->buildAnonymousAuthEntryLoginUrl();
       return new RedirectResponse($login_url->toString());

--- a/web/themes/custom/myeventlane_theme/components/hero/hero.twig
+++ b/web/themes/custom/myeventlane_theme/components/hero/hero.twig
@@ -40,7 +40,7 @@
           {{ 'Explore events'|t }}
         </a>
         <a class="mel-link hero__cta hero__cta--secondary" href="{{ path('myeventlane_vendor.create_event_gateway') }}">
-          {{ 'Create event'|t }}
+          {{ 'Create Event'|t }}
         </a>
       </div>
 

--- a/web/themes/custom/myeventlane_theme/components/mobile-drawer/mobile-drawer.twig
+++ b/web/themes/custom/myeventlane_theme/components/mobile-drawer/mobile-drawer.twig
@@ -1,12 +1,12 @@
 {#
 /**
- * @component Mobile Drawer (design mirror — runtime uses templates/components/…)
+ * @component Mobile Drawer
  *
  * Variables:
  * - drawer_menu (primary links)
  * - drawer_organiser (organiser links/context)
- * - create_event_url (optional; gateway URL)
- * - mel_cart_url, mel_cart_item_count, mel_cart_count_text, mel_checkout_url
+ * - create_event_url
+ * - mel_cart_url, mel_cart_item_count, mel_cart_count_text, mel_checkout_url (cart continuity)
  */
 #}
 <details class="mobile-drawer">
@@ -51,7 +51,7 @@
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>
         </svg>
-        {{ 'Create event'|t }}
+        {{ 'Create Event'|t }}
       </a>
     </div>
   </div>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -868,6 +868,9 @@ function myeventlane_theme_theme_suggestions_page_alter(array &$suggestions, arr
   if ($route === 'user.login') {
     $suggestions[] = 'page__user_login';
   }
+  if ($route === 'user.register') {
+    $suggestions[] = 'page__user_register';
+  }
   if ($route === 'view.events_calendar.page_calendar') {
     $suggestions[] = 'page__calendar';
   }
@@ -885,33 +888,6 @@ function myeventlane_theme_theme_suggestions_page_alter(array &$suggestions, arr
 }
 
 /**
- * Whether the login page request is for the create-event organiser flow.
- *
- * Deterministic checks only (query + POST body): intent keys and destination
- * path prefix. Does not mirror PostLoginRouter or gateway routing.
- */
-function _myeventlane_theme_login_page_is_create_event_context(\Symfony\Component\HttpFoundation\Request $request): bool {
-  foreach ([$request->query, $request->request] as $bag) {
-    foreach (['mel_intent', 'intent'] as $key) {
-      $v = $bag->get($key);
-      if (is_string($v) && strtolower(trim($v)) === 'create_event') {
-        return TRUE;
-      }
-    }
-    $dest = $bag->get('destination');
-    if (!is_string($dest) || $dest === '') {
-      continue;
-    }
-    $decoded = urldecode(trim($dest));
-    $path_only = strtok($decoded, '?') ?: $decoded;
-    if (str_starts_with($path_only, '/create-event')) {
-      return TRUE;
-    }
-  }
-  return FALSE;
-}
-
-/**
  * Implements hook_preprocess_page().
  *
  * Adds cart block to header if not already placed.
@@ -924,14 +900,6 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
   // Ensure directory variable is available for all templates (especially homepage hero).
   if (!isset($variables['directory'])) {
     $variables['directory'] = base_path() . $theme_path;
-  }
-
-  // user.login: encouraging create-event panel (replaces legacy gateway messenger warning).
-  if (\Drupal::routeMatch()->getRouteName() === 'user.login') {
-    $variables['mel_login_create_event_info'] = _myeventlane_theme_login_page_is_create_event_context(\Drupal::request());
-    $variables['#cache']['contexts'][] = 'url.query_args:destination';
-    $variables['#cache']['contexts'][] = 'url.query_args:mel_intent';
-    $variables['#cache']['contexts'][] = 'url.query_args:intent';
   }
 
   // Footer: dynamic categories (only if > 3 published events) + organiser detection.
@@ -2523,6 +2491,19 @@ function myeventlane_theme_preprocess_user(array &$variables): void {
   $user = $variables['user'];
   $view_mode = $variables['view_mode'] ?? 'full';
 
+  if ($view_mode === 'register') {
+    $variables['mel_register_create_event_context'] = FALSE;
+    if (\Drupal::moduleHandler()->moduleExists('myeventlane_auth')) {
+      $variables['mel_register_create_event_context'] = myeventlane_auth_register_page_is_create_event_flow(\Drupal::request());
+    }
+    $variables['#cache']['contexts'][] = 'url.query_args:destination';
+    $variables['#cache']['contexts'][] = 'url.query_args:mel_intent';
+    $variables['#cache']['contexts'][] = 'url.query_args:intent';
+    $variables['attributes']['class'][] = 'mel-user-form';
+    $variables['attributes']['class'][] = 'mel-user-form--register';
+    return;
+  }
+
   // Only process form view modes.
   if ($view_mode !== 'form' && $view_mode !== 'default') {
     return;
@@ -2679,6 +2660,17 @@ function myeventlane_theme_form_alter(array &$form, \Drupal\Core\Form\FormStateI
     $form['#attributes']['class'][] = 'mel-form--register';
     $form['#attributes']['class'][] = 'user-register-form';
     $form['#attached']['library'][] = 'myeventlane_theme/auth_pages';
+    if (isset($form['actions']['submit'])) {
+      if (!isset($form['actions']['submit']['#attributes']['class'])) {
+        $form['actions']['submit']['#attributes']['class'] = [];
+      }
+      elseif (!is_array($form['actions']['submit']['#attributes']['class'])) {
+        $form['actions']['submit']['#attributes']['class'] = [$form['actions']['submit']['#attributes']['class']];
+      }
+      foreach (['mel-btn', 'mel-btn-primary', 'mel-auth-submit'] as $class) {
+        $form['actions']['submit']['#attributes']['class'][] = $class;
+      }
+    }
   }
 
   // User password reset form.

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
@@ -124,35 +124,43 @@
   }
 }
 
-// ---------------------------------------------------------------------------
-// Login: create-event intro (neutral / positive — not status-warning)
-// ---------------------------------------------------------------------------
+// Login form create-event callout: see myeventlane_auth/css/login-create-event-intent.css
+// (must load under Gin Login / Claro as well as the default theme).
 
-.mel-login-create-event-banner {
-  padding-top: spacing.mel-space(4);
-  padding-bottom: spacing.mel-space(2);
+// Registration: create-event intent strip (preprocess: mel_register_create_event_context).
+.mel-register-intent {
+  background: #fef5ec;
+  border: 1px solid #f26d5b;
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin-bottom: spacing.mel-space(5);
+  text-align: center;
 }
 
-.mel-auth-info {
-  background: color.mix(colors.$mel-color-accent, #ffffff, 8%);
-  border: 1px solid colors.$mel-color-border;
-  border-radius: radii.$mel-radius-lg;
-  padding: spacing.mel-space(4) spacing.mel-space(5);
-  box-shadow: shadows.$mel-shadow-sm;
+.mel-register-intent__text {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text;
+}
 
-  &__title {
-    display: block;
-    font-size: typography.mel-font-size(lg);
-    font-weight: typography.$mel-font-bold;
-    color: colors.$mel-color-text;
-    margin: 0 0 spacing.mel-space(2) 0;
+// Minimal register: hide default field descriptions (errors still show).
+.mel-auth-form-wrapper--register {
+  .form-item .description:not(.form-item--error-message) {
+    display: none;
   }
 
-  &__body {
-    margin: 0;
-    font-size: typography.mel-font-size(base);
-    line-height: 1.55;
-    color: colors.$mel-color-text-muted;
+  .form-actions {
+    margin-top: spacing.mel-space(6);
+
+    .form-submit,
+    .button--primary {
+      width: 100%;
+      min-height: 52px;
+      font-weight: typography.$mel-font-bold;
+      border-radius: radii.$mel-radius-pill;
+    }
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/components/mobile-drawer/mobile-drawer.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mobile-drawer/mobile-drawer.html.twig
@@ -51,7 +51,7 @@
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>
         </svg>
-        {{ 'Create event'|t }}
+        {{ 'Create Event'|t }}
       </a>
     </div>
   </div>

--- a/web/themes/custom/myeventlane_theme/templates/components/site-header/site-header.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/site-header/site-header.html.twig
@@ -43,7 +43,7 @@
               <line x1="12" y1="5" x2="12" y2="19"></line>
               <line x1="5" y1="12" x2="19" y2="12"></line>
             </svg>
-            {{ 'Create event'|t }}
+            {{ 'Create Event'|t }}
           </a>
         </div>
         <div class="site-header__organiser">

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -120,7 +120,7 @@
             </p>
           </div>
           <div class="mel-host-cta__actions">
-            <a class="mel-btn mel-btn--cta" href="{{ path('myeventlane_vendor.create_event_gateway') }}">{{ 'Create event'|t }}</a>
+            <a class="mel-btn mel-btn--cta" href="{{ path('myeventlane_vendor.create_event_gateway') }}">{{ 'Create Event'|t }}</a>
             <a class="mel-btn mel-btn-secondary" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Host help'|t }}</a>
           </div>
         </div>

--- a/web/themes/custom/myeventlane_theme/templates/page--user-login.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--user-login.html.twig
@@ -1,24 +1,10 @@
 {#
 /**
  * @file
- * Login page — extends default page; adds create-event encouraging panel when relevant.
- * Template name matches suggestion page__user_login (page--user-login.html.twig).
+ * Login page — extends default page.
  *
- * Visibility is driven by mel_login_create_event_info (see myeventlane_theme_preprocess_page).
+ * Create-event messaging is added by myeventlane_auth (user login form alter),
+ * including when Gin Login uses the Gin/Claro theme for /user/login.
  */
 #}
 {% extends '@myeventlane_theme/page.html.twig' %}
-
-{% block mel_pre_highlighted %}
-  {% if mel_login_create_event_info %}
-    <div class="mel-container mel-login-create-event-banner">
-      <div class="mel-auth-info" role="region" aria-label="{{ 'Create an event'|t }}">
-        <strong class="mel-auth-info__title">{{ '✨ Create your own event'|t }}</strong>
-        <p class="mel-auth-info__body">
-          {{ 'Want to create your own event?'|t }}<br>
-          {{ "Log in or create an account to get started — we'll guide you through setting up your organiser profile in just a few steps."|t }}
-        </p>
-      </div>
-    </div>
-  {% endif %}
-{% endblock %}

--- a/web/themes/custom/myeventlane_theme/templates/page--user-register.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--user-register.html.twig
@@ -1,0 +1,7 @@
+{#
+/**
+ * @file
+ * Registration page — same shell as login (header + main content).
+ */
+#}
+{% extends '@myeventlane_theme/page.html.twig' %}

--- a/web/themes/custom/myeventlane_theme/templates/user/user--register.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/user/user--register.html.twig
@@ -1,11 +1,10 @@
 {#
 /**
  * @file
- * Theme override for user registration form.
+ * User registration — MEL auth card (aligned with login UX).
  *
- * Provides a centered, branded authentication card layout.
- * All fields sit inside .mel-auth-form-wrapper so validation errors (legal, etc.)
- * receive the same visible styling as account fields.
+ * Optional fields are hidden via myeventlane_auth_form_user_register_form_alter().
+ * Create-event messaging uses mel_register_create_event_context (preprocess_user).
  */
 #}
 
@@ -22,52 +21,29 @@
             <line x1="48" y1="28" x2="58" y2="28" stroke="#ffd46f" stroke-width="4" stroke-linecap="round"/>
           </svg>
         </a>
-        <h1 class="mel-auth-title">{{ 'Create your MyEventLane account'|t }}</h1>
-        <p class="mel-auth-subtitle">{{ 'Join our community of event creators and attendees.'|t }}</p>
+        <h1 class="mel-auth-title">{{ '✨ Create your account'|t }}</h1>
+        <p class="mel-auth-subtitle">{{ 'Start discovering events — or host your own in minutes.'|t }}</p>
       </div>
 
-      <div class="mel-auth-form-wrapper">
-        {{ form|without('account', 'actions', 'form_build_id', 'form_token', 'form_id') }}
-
-        <div class="mel-auth-form">
-          <div class="form-item">
-            {{ form.account.name }}
-            <div class="description">{{ 'Choose a unique username for your account.'|t }}</div>
-          </div>
-
-          <div class="form-item">
-            {{ form.account.mail }}
-            <div class="description">{{ "We'll never share your email with anyone else."|t }}</div>
-          </div>
-
-          {% if form.account.pass %}
-            <div class="form-item">
-              {{ form.account.pass }}
-              <div class="description">{{ 'Use at least 8 characters with a mix of letters and numbers.'|t }}</div>
-            </div>
-          {% endif %}
-
-          {% if form.timezone %}
-            <div class="form-item">
-              {{ form.timezone }}
-            </div>
-          {% endif %}
-
-          <div class="mel-auth-actions">
-            {{ form.actions }}
-          </div>
+      {% if mel_register_create_event_context %}
+        <div class="mel-register-intent" role="status">
+          <p class="mel-register-intent__text">{{ 'You’re just one step away from creating your event.'|t }}</p>
         </div>
+      {% endif %}
+
+      <div class="mel-auth-form-wrapper mel-auth-form-wrapper--register">
+        {{ form|without('form_build_id', 'form_token', 'form_id') }}
       </div>
+
+      {{ form.form_build_id }}
+      {{ form.form_token }}
+      {{ form.form_id }}
 
       <div class="mel-auth-footer">
         <p class="mel-auth-link">
           {{ 'Already have an account?'|t }} <a href="{{ path('user.login') }}">{{ 'Log in'|t }}</a>
         </p>
       </div>
-
-      {{ form.form_build_id }}
-      {{ form.form_token }}
-      {{ form.form_id }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies authentication form alters and intent parsing for post-login redirect handling; mistakes could impact login UX/redirect behavior. Also includes multiple dependency updates (Drupal core and Composer ecosystem) that may introduce broader compatibility/regression risk.
> 
> **Overview**
> Moves *create-event* onboarding messaging into `myeventlane_auth` so it renders on `/user/login` even under Gin Login (Gin/Claro), while also preserving `mel_intent` across the login POST and centralizing intent extraction (including nested `destination` URLs).
> 
> Adds a minimal registration flow by hiding optional fields on `/user/register`, introducing a dedicated `page--user-register` suggestion/template, and showing create-event-specific messaging when the request intent indicates `create_event`.
> 
> Separately standardizes CTA copy to **“Create Event”** across theme templates and bumps dependencies in `composer.lock` (Drupal core `11.3.5`→`11.3.7`, `drupal/klaro` `3.0.8`→`3.0.10`, plus several Symfony/Composer library updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1a3bec119bf5db9b3a6f3c9300b8750e3214d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->