### PR TITLE
Feature/mel v2 event wizard rebuild

### DIFF
--- a/web/modules/custom/myeventlane_event/css/event-wizard.css
+++ b/web/modules/custom/myeventlane_event/css/event-wizard.css
@@ -228,15 +228,122 @@ form .mel-simple-tabs {
   content: 'Event image';
 }
 
-/* Phase IV — Content layout (stepper moved to sidebar; single column) */
+/* Overview nav + main: two columns on wide screens; horizontal scroll on small. */
 .mel-event-wizard .mel-event-wizard__layout {
-  display: block;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
   width: 100%;
+  align-items: start;
+}
+
+@media (min-width: 900px) {
+  .mel-event-wizard .mel-event-wizard__layout {
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+.mel-event-wizard .mel-event-wizard-nav {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 2;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  padding: 0.75rem 0.5rem 0.75rem 0.75rem;
+}
+
+.mel-event-wizard .mel-event-wizard-nav__title {
+  margin: 0 0 0.5rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.mel-event-wizard .mel-event-wizard-nav__scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.25rem;
+}
+
+@media (max-width: 899px) {
+  .mel-event-wizard .mel-event-wizard-nav__scroll .mel-wizard-steps {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    min-height: 44px;
+    align-items: stretch;
+  }
+
+  .mel-event-wizard .mel-event-wizard-nav__scroll .mel-wizard-steps__item {
+    flex: 0 0 auto;
+  }
+
+  .mel-event-wizard .mel-event-wizard-nav__scroll .mel-wizard-steps__link {
+    min-height: 44px;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+  }
+}
+
+.mel-event-wizard .mel-wizard-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.mel-event-wizard .mel-wizard-steps__item.is-current .mel-wizard-steps__link {
+  border-color: rgba(232, 121, 98, 0.55);
+  background: rgba(255, 245, 242, 0.95);
+  font-weight: 600;
+}
+
+.mel-event-wizard .mel-wizard-steps__item.is-disabled .mel-wizard-steps__link {
+  opacity: 0.55;
+}
+
+.mel-event-wizard .mel-wizard-steps__link {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  padding: 0.45rem 0.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.02);
+  text-decoration: none;
+  color: inherit;
+  min-height: 44px;
+  box-sizing: border-box;
+}
+
+.mel-event-wizard .mel-wizard-steps__link.is-active {
+  outline: 2px solid transparent;
+}
+
+.mel-event-wizard .mel-wizard-steps__number {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .mel-event-wizard .mel-wizard-steps__label {
   font-size: 13px;
   font-weight: 500;
+  line-height: 1.25;
 }
 
 /* Phase V — Mobile density */

--- a/web/modules/custom/myeventlane_event/js/event-wizard.js
+++ b/web/modules/custom/myeventlane_event/js/event-wizard.js
@@ -15,6 +15,9 @@
 (function (Drupal, once) {
   'use strict';
 
+  // TEMP: verify library loads on every wizard step (remove after QA).
+  console.log('MEL event wizard library loaded');
+
   /**
    * Wizard state helpers
    */

--- a/web/modules/custom/myeventlane_event/js/event-wizard.js
+++ b/web/modules/custom/myeventlane_event/js/event-wizard.js
@@ -333,6 +333,11 @@
       setTimeout(() => {
         updateStepButtonAccessibility(context);
       }, 100);
+
+      // Mobile overview nav: keep the current step in view inside the horizontal scroller.
+      once('mel-wizard-nav-current', '.mel-event-wizard-nav .mel-wizard-steps__item.is-current', context).forEach((li) => {
+        li.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+      });
     },
   };
 

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -70,6 +70,7 @@ services:
       - '@logger.factory'
       - '@messenger'
       - '@lock'
+      - '@myeventlane_event.ticket_type_manager'
 
   myeventlane_event.event_mode_manager:
     class: Drupal\myeventlane_event\Service\EventModeManager

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardBaseForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardBaseForm.php
@@ -116,6 +116,33 @@ abstract class EventWizardBaseForm extends FormBase {
   }
 
   /**
+   * {@inheritdoc}
+   *
+   * Attaches the shared event wizard asset library (CSS/JS) for every step.
+   * Concrete wizard forms should call parent::buildForm() first so
+   * \#attached is merged before fields are added.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $this->attachEventWizardLibrary($form);
+    return $form;
+  }
+
+  /**
+   * Ensures myeventlane_event/event_wizard is attached exactly once.
+   *
+   * @param array<string, mixed> $form
+   *   The form or render array root (modified by reference).
+   */
+  protected function attachEventWizardLibrary(array &$form): void {
+    if (!isset($form['#attached']['library'])) {
+      $form['#attached']['library'] = [];
+    }
+    if (!in_array('myeventlane_event/event_wizard', $form['#attached']['library'], TRUE)) {
+      $form['#attached']['library'][] = 'myeventlane_event/event_wizard';
+    }
+  }
+
+  /**
    * Builds prefix markup for wizard step forms (stepper + card header).
    *
    * @param array $steps

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardBaseForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardBaseForm.php
@@ -36,12 +36,36 @@ abstract class EventWizardBaseForm extends FormBase {
    * Wizard step order.
    */
   protected const STEPS = [
-    'basics' => ['label' => 'Basics', 'route' => 'myeventlane_event.wizard.basics'],
-    'when_where' => ['label' => 'When & Where', 'route' => 'myeventlane_event.wizard.when_where'],
-    'tickets' => ['label' => 'Tickets', 'route' => 'myeventlane_event.wizard.tickets'],
-    'details' => ['label' => 'Details', 'route' => 'myeventlane_event.wizard.details'],
-    'review' => ['label' => 'Review', 'route' => 'myeventlane_event.wizard.review'],
-    'publish' => ['label' => 'Publish', 'route' => 'myeventlane_event.wizard.publish'],
+    'basics' => [
+      'label' => 'Basics',
+      'overview_label' => 'Basic Info',
+      'route' => 'myeventlane_event.wizard.basics',
+    ],
+    'when_where' => [
+      'label' => 'When & Where',
+      'overview_label' => 'Date & Location',
+      'route' => 'myeventlane_event.wizard.when_where',
+    ],
+    'tickets' => [
+      'label' => 'Tickets',
+      'overview_label' => 'Tickets / RSVP',
+      'route' => 'myeventlane_event.wizard.tickets',
+    ],
+    'details' => [
+      'label' => 'Details',
+      'overview_label' => 'Description',
+      'route' => 'myeventlane_event.wizard.details',
+    ],
+    'review' => [
+      'label' => 'Review',
+      'overview_label' => 'Preview',
+      'route' => 'myeventlane_event.wizard.review',
+    ],
+    'publish' => [
+      'label' => 'Publish',
+      'overview_label' => 'Publish',
+      'route' => 'myeventlane_event.wizard.publish',
+    ],
   ];
 
   /**
@@ -519,6 +543,7 @@ abstract class EventWizardBaseForm extends FormBase {
       $navigation[] = [
         'id' => $step_id,
         'label' => $step['label'],
+        'overview_label' => $step['overview_label'] ?? $step['label'],
         'url' => $url,
         'is_current' => $is_current,
         'is_complete' => $is_complete,

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardBasicsForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardBasicsForm.php
@@ -63,6 +63,7 @@ final class EventWizardBasicsForm extends EventWizardBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
     $form_state->disableCache();
 
     $event = $this->getEvent();

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardDetailsForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardDetailsForm.php
@@ -60,6 +60,7 @@ final class EventWizardDetailsForm extends EventWizardBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
     $event = $this->getEvent();
 
     $form_display = EntityFormDisplay::collectRenderDisplay($event, 'wizard_step_details');

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardPublishForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardPublishForm.php
@@ -68,6 +68,7 @@ final class EventWizardPublishForm extends EventWizardBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
     $event = $this->getEvent();
 
     $form['#title'] = $this->t('Publish event');

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardPublishForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardPublishForm.php
@@ -7,9 +7,11 @@ namespace Drupal\myeventlane_event\Form;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
+use Drupal\myeventlane_event\Service\EventProductManager;
+use Drupal\myeventlane_event\Service\EventWizardPublishValidator;
 use Drupal\myeventlane_event\Service\MelPlatformSupportWizardFormHelper;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
+use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -32,6 +34,8 @@ final class EventWizardPublishForm extends EventWizardBaseForm {
     RendererInterface $renderer,
     LoggerInterface $logger,
     private readonly MelPlatformSupportWizardFormHelper $melPlatformSupportWizardForm,
+    private readonly EventProductManager $eventProductManager,
+    private readonly EventWizardPublishValidator $eventWizardPublishValidator,
   ) {
     parent::__construct($entity_type_manager, $domain_detector, $current_user, $renderer);
     $this->logger = $logger;
@@ -48,6 +52,8 @@ final class EventWizardPublishForm extends EventWizardBaseForm {
       $container->get('renderer'),
       $container->get('logger.factory')->get('myeventlane_event'),
       $container->get('myeventlane_event.mel_platform_support_wizard_form'),
+      $container->get('myeventlane_event.event_product_manager'),
+      $container->get('myeventlane_event.wizard_publish_validator'),
     );
   }
 
@@ -124,6 +130,14 @@ final class EventWizardPublishForm extends EventWizardBaseForm {
     $event = $this->getEvent();
     $event_type = (string) ($event->get('field_event_type')->value ?? 'rsvp');
     $this->melPlatformSupportWizardForm->validate($form_state, $event, $event_type);
+
+    $publish_errors = $this->eventWizardPublishValidator->validate($event, $form_state);
+    if ($publish_errors !== []) {
+      $form_state->setErrorByName('submit', (string) reset($publish_errors));
+      foreach (array_slice($publish_errors, 1) as $additional) {
+        $this->messenger()->addError((string) $additional);
+      }
+    }
   }
 
   /**
@@ -143,14 +157,21 @@ final class EventWizardPublishForm extends EventWizardBaseForm {
       '@uid' => $this->currentUser->id(),
     ]);
 
-    $this->messenger()->addStatus($this->t('Event "@title" has been published!', [
-      '@title' => $event->label(),
-    ]));
-
     $fresh = $this->entityTypeManager->getStorage('node')->load($event->id());
     if ($fresh instanceof NodeInterface) {
       $event = $fresh;
     }
+
+    if (!$this->eventProductManager->syncProducts($event, 'publish')) {
+      $this->logger->warning('Commerce product sync did not complete for event @nid after publish.', [
+        '@nid' => $event->id(),
+      ]);
+      $this->messenger()->addWarning($this->t('Your event was published, but ticket products may still be syncing. Refresh in a moment if checkout does not show tiers yet.'));
+    }
+
+    $this->messenger()->addStatus($this->t('Event "@title" has been published!', [
+      '@title' => $event->label(),
+    ]));
 
     $vendor_uid = (int) $event->getOwnerId();
     $checkout_url = $this->melPlatformSupportWizardForm->getPostPublishCheckoutUrl($event, $vendor_uid);

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardReviewForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardReviewForm.php
@@ -93,7 +93,7 @@ final class EventWizardReviewForm extends EventWizardBaseForm {
     $view_builder = $this->entityTypeManager->getViewBuilder('node');
     $card_preview = $view_builder->view($event, 'teaser');
 
-    return [
+    $build = [
       '#theme' => 'myeventlane_event_wizard_review',
       '#title' => $title,
       // Also expose entity on the form root for shared wizard helpers (e.g. suggestions).
@@ -106,10 +106,10 @@ final class EventWizardReviewForm extends EventWizardBaseForm {
       '#publish_url' => $publish_url,
       '#card_preview' => $card_preview,
       '#step_id' => 'review',
-      '#attached' => [
-        'library' => ['myeventlane_event/event_wizard'],
-      ],
     ];
+    $this->attachEventWizardLibrary($build);
+
+    return $build;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardTicketsForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardTicketsForm.php
@@ -74,6 +74,7 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
     $event = $this->getEvent();
 
     $form_state->set('event', $event);

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardTicketsForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardTicketsForm.php
@@ -28,11 +28,7 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
 
   protected EventTicketsBuilder $ticketBuilder;
 
-  /**
-   * @var \Drupal\myeventlane_event\Service\MelPlatformSupportWizardFormHelper|null
-   *   Null when form was unserialized from cache; lazy-loaded on first access.
-   */
-  protected ?MelPlatformSupportWizardFormHelper $melPlatformSupportWizardForm = null;
+  protected MelPlatformSupportWizardFormHelper $melPlatformSupportWizardForm;
 
   public function __construct(
     $entity_type_manager,
@@ -49,21 +45,6 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
     $this->ticketTypeManager = $ticket_type_manager;
     $this->ticketBuilder = $ticket_builder;
     $this->melPlatformSupportWizardForm = $mel_platform_support_wizard_form;
-  }
-
-  /**
-   * Returns the MEL platform support wizard form helper.
-   *
-   * Lazy-loaded when form was unserialized from cache (AJAX rebuilds). The
-   * form object is serialized for form cache; constructor-injected services
-   * are not restored, so we re-fetch from container on first access.
-   */
-  protected function getMelPlatformSupportWizardForm(): MelPlatformSupportWizardFormHelper {
-    if ($this->melPlatformSupportWizardForm === null) {
-      $this->melPlatformSupportWizardForm = \Drupal::getContainer()
-        ->get('myeventlane_event.mel_platform_support_wizard_form');
-    }
-    return $this->melPlatformSupportWizardForm;
   }
 
   /**
@@ -112,7 +93,7 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
 
     $this->applyTicketTypeStates($form);
     $this->addCapacityWarning($form, $event);
-    $this->getMelPlatformSupportWizardForm()->buildSection($form, $form_state, $event);
+    $this->melPlatformSupportWizardForm->buildSection($form, $form_state, $event);
 
     $form['#title'] = $this->t('Create event: Tickets');
     $form['#event'] = $event;
@@ -206,7 +187,7 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
         }
       }
 
-      $this->getMelPlatformSupportWizardForm()->validate($form_state, $event, (string) $value);
+      $this->melPlatformSupportWizardForm->validate($form_state, $event, (string) $value);
     }
   }
 
@@ -227,7 +208,7 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
 
     $this->copyFormValuesToEvent($event, $form, $form_state, 'wizard_step_4');
 
-    $this->getMelPlatformSupportWizardForm()->apply($event, $form_state);
+    $this->melPlatformSupportWizardForm->apply($event, $form_state);
 
     $event->set('field_ticket_types', $saved_ticket_types);
     EventNodeRevisionSave::prepare($event, 'Event wizard: tickets step (field_ticket_types).');
@@ -237,6 +218,22 @@ final class EventWizardTicketsForm extends EventWizardBaseForm {
       '@id' => $event->id(),
       '@fields' => implode(', ', $field_names),
     ]);
+
+    $reloaded = $this->entityTypeManager->getStorage('node')->load($event->id());
+    if ($reloaded instanceof NodeInterface) {
+      if (!$this->ticketTypeManager->syncTicketTypesToVariations($reloaded)) {
+        $this->logger->notice('Ticket variation sync returned FALSE after tickets step for event @nid.', [
+          '@nid' => $event->id(),
+        ]);
+      }
+    }
+
+    $event_type = $event->get('field_event_type')->value ?? '';
+    if (in_array($event_type, ['paid', 'both'], TRUE)) {
+      if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+        $this->messenger()->addWarning($this->t('Add at least one ticket tier (for example a paid tier or RSVP) before you publish. Use the buttons above to create tickets.'));
+      }
+    }
 
     $this->redirectToNextStep($form_state, 'tickets');
   }

--- a/web/modules/custom/myeventlane_event/src/Form/EventWizardWhenWhereForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventWizardWhenWhereForm.php
@@ -58,6 +58,7 @@ final class EventWizardWhenWhereForm extends EventWizardBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
     $event = $this->getEvent();
 
     $form_display = EntityFormDisplay::collectRenderDisplay($event, 'wizard_step_2');

--- a/web/modules/custom/myeventlane_event/src/Service/EventProductManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventProductManager.php
@@ -36,6 +36,7 @@ final class EventProductManager {
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly MessengerInterface $messenger,
     private readonly LockBackendInterface $lock,
+    private readonly TicketTypeManager $ticketTypeManager,
   ) {}
 
   /**
@@ -129,14 +130,27 @@ final class EventProductManager {
       return $this->syncRsvpProduct($event);
     }
 
-    // Paid and Both events: validate product link exists.
+    // Paid and hybrid events: mel_ticket_type is source of truth; mirror to Commerce.
     if (in_array($eventType, ['paid', 'both'], TRUE)) {
-      $hasTicketTypes = $event->hasField('field_ticket_types')
+      $variation_sync = $this->ticketTypeManager->syncTicketTypesToVariations($event);
+      if (!$variation_sync) {
+        $this->loggerFactory->get('myeventlane_event')->notice(
+          'Ticket variation sync returned FALSE for event @eid (verify field_event_type is paid/both and Commerce store exists).',
+          ['@eid' => (string) $event->id()]
+        );
+      }
+
+      $fresh = $this->entityTypeManager->getStorage('node')->load($event->id());
+      if ($fresh instanceof NodeInterface) {
+        $event = $fresh;
+      }
+
+      $has_ticket_types = $event->hasField('field_ticket_types')
         && !$event->get('field_ticket_types')->isEmpty();
 
-      if ($event->get('field_product_target')->isEmpty() && !$hasTicketTypes) {
+      if ($event->get('field_product_target')->isEmpty() && !$has_ticket_types) {
         $this->messenger->addWarning(
-          $this->t('Please link a ticket product for this @type event, or define ticket types below.', [
+          $this->t('Please add at least one ticket tier for this @type event, or link a ticket product.', [
             '@type' => $eventType === 'paid' ? 'paid' : 'hybrid',
           ])
         );

--- a/web/modules/custom/myeventlane_event/src/Service/EventWizardPublishValidator.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventWizardPublishValidator.php
@@ -89,9 +89,8 @@ final class EventWizardPublishValidator {
       }
     }
     elseif (in_array($joinType, ['paid', 'both'], TRUE)) {
-      $productTarget = $this->resolveProductTarget($event, $form_state);
-      if (empty($productTarget)) {
-        $errors[] = (string) t('Paid events need at least one ticket or product linked.');
+      if (!$this->hasPaidTicketingCoverage($event, $form_state)) {
+        $errors[] = (string) t('Paid events need at least one ticket tier on the event, or a linked Commerce ticket product.');
       }
     }
     elseif ($joinType === 'rsvp') {
@@ -192,17 +191,20 @@ final class EventWizardPublishValidator {
   }
 
   /**
-   * Resolves product target (paid/both) from form or entity.
+   * Whether paid/hybrid events have ticketing data (ticket types and/or product).
    */
-  private function resolveProductTarget(NodeInterface $event, FormStateInterface $form_state): mixed {
+  private function hasPaidTicketingCoverage(NodeInterface $event, FormStateInterface $form_state): bool {
+    if ($event->hasField('field_ticket_types') && !$event->get('field_ticket_types')->isEmpty()) {
+      return TRUE;
+    }
     $v = $form_state->getValue(['field_product_target', 0, 'target_id']);
     if ($v !== NULL && $v !== '') {
-      return $v;
+      return TRUE;
     }
     if ($event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
-      return $event->get('field_product_target')->target_id;
+      return TRUE;
     }
-    return NULL;
+    return FALSE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/templates/event-wizard-review.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/event-wizard-review.html.twig
@@ -17,7 +17,7 @@
 #}
 <div class="mel-event-wizard">
   <div class="mel-event-wizard__layout">
-    {# Wizard stepper moved to left sidebar (myeventlane_vendor_theme) #}
+    {% include '@myeventlane_event/mel-event-wizard-nav.html.twig' %}
     <div class="mel-event-wizard__main">
       <div class="mel-wizard-step-card mel-wizard-step-card--review">
         <div class="mel-wizard-step-card__header">

--- a/web/modules/custom/myeventlane_event/templates/event-wizard-step-prefix.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/event-wizard-step-prefix.html.twig
@@ -3,17 +3,17 @@
  * @file
  * Prefix markup for wizard step forms (card header + content wrapper).
  *
- * Wizard step navigation is rendered in the left sidebar (myeventlane_vendor_theme)
- * when on vendor event wizard routes. Inline stepper removed in favor of sidebar.
+ * Overview navigation is rendered here (mel-event-wizard-nav) for all wizard routes.
  *
  * Variables:
- * - steps: Step navigation array (kept for compatibility; no longer rendered here)
+ * - steps: Step navigation array from EventWizardBaseForm::buildStepper()
  * - step: Current step (id, label)
  * - title: Page title (fallback)
  */
 #}
 <div class="mel-event-wizard">
   <div class="mel-event-wizard__layout">
+    {% include '@myeventlane_event/mel-event-wizard-nav.html.twig' %}
     <div class="mel-event-wizard__main">
       <div class="mel-wizard-frame">
         <div class="mel-wizard-frame__header">

--- a/web/modules/custom/myeventlane_event/templates/mel-event-wizard-nav.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-wizard-nav.html.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file
+ * Persistent overview navigation for the multi-route event wizard.
+ *
+ * Variables:
+ * - steps: Navigation items from EventWizardBaseForm::buildStepper() (id, overview_label, url, …).
+ */
+#}
+<nav class="mel-event-wizard__nav mel-event-wizard-nav" aria-label="{{ 'Event wizard overview'|t }}">
+  <p class="mel-event-wizard-nav__title">{{ 'Overview'|t }}</p>
+  <div class="mel-event-wizard-nav__scroll">
+    <ol class="mel-wizard-steps">
+      {% for nav_step in steps %}
+        <li class="mel-wizard-steps__item{% if nav_step.is_current %} is-current{% endif %}{% if nav_step.is_complete %} is-complete{% endif %}{% if not nav_step.is_accessible and not nav_step.is_current %} is-disabled{% endif %}">
+          {% if nav_step.url and (nav_step.is_accessible or nav_step.is_current) %}
+            <a href="{{ nav_step.url }}"
+               class="mel-wizard-steps__link js-mel-stepper-button{% if nav_step.is_current %} is-active{% endif %}"
+               data-step-target="{{ nav_step.id }}"
+               {% if nav_step.is_current %}aria-current="step"{% endif %}>
+              <span class="mel-wizard-steps__number">{{ nav_step.step_number }}</span>
+              <span class="mel-wizard-steps__label">{{ nav_step.overview_label }}</span>
+            </a>
+          {% else %}
+            <span class="mel-wizard-steps__link" aria-disabled="true">
+              <span class="mel-wizard-steps__number">{{ nav_step.step_number }}</span>
+              <span class="mel-wizard-steps__label">{{ nav_step.overview_label }}</span>
+            </span>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ol>
+  </div>
+</nav>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies the event wizard publish/tickets flows to trigger Commerce product/variation syncing and adds stricter publish-time validation, which could impact checkout availability and publishing behavior if edge cases are missed.
> 
> **Overview**
> Adds a persistent **Overview** navigation to the multi-route event wizard (new `mel-event-wizard-nav.html.twig`), updates templates to render it on step pages and review, and introduces responsive CSS/JS so the nav is sticky on desktop and horizontally scrolls/focuses the current step on mobile.
> 
> Ensures the shared `myeventlane_event/event_wizard` library is attached consistently by centralizing attachment in `EventWizardBaseForm` and updating step forms to call `parent::buildForm()`.
> 
> Tightens publish and ticketing behavior: publish now runs `EventWizardPublishValidator`, triggers `EventProductManager::syncProducts()` after publishing (with a warning if sync doesn’t complete), and paid/hybrid flows now sync `mel_ticket_type` tiers to Commerce variations after the Tickets step and during product sync, with improved validation/messaging when no ticket tiers/product are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbfe770975f0acc4b5274076c6a540e8cba73d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->