### PR TITLE
fix: implement scroll-only navigation and continue behaviour in event…

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -3,6 +3,20 @@
  * MEL Event Studio — product workflow styling (aligned with vendor console tone).
  */
 
+/**
+ * Scroll-only Studio: all wizard steps stay in the document flow (no display toggling).
+ */
+.mel-studio--scroll-all .mel-step {
+  display: block !important;
+}
+
+.mel-event-studio-nav__track a.mel-nav-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
 .mel-event-studio {
   --mel-studio-radius: 12px;
   --mel-studio-radius-sm: 8px;

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -7,22 +7,6 @@
 
   var HIGHLIGHT_MAX = 6;
 
-  /**
-   * Guided wizard step model (order is fixed).
-   *
-   * @type {{id: string, label: string}[]}
-   */
-  var MEL_STEPS = [
-    { id: 'basic', label: 'Basic Info' },
-    { id: 'schedule', label: 'Date & Time' },
-    { id: 'location', label: 'Location' },
-    { id: 'tickets', label: 'Tickets' },
-    { id: 'advanced', label: 'Advanced' },
-  ];
-
-  /** Keys for #mel-event-studio-nav — one per wizard step index (matches showStep). */
-  var MEL_OVERVIEW_BY_STEP = ['basic', 'date_location', 'date_location', 'tickets', 'publish'];
-
   function melPrefersReducedMotion() {
     return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
@@ -36,39 +20,6 @@
       behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
       block: 'start',
     });
-  }
-
-  function scrollMelOverviewActiveIntoView(form) {
-    var nav = form.querySelector('#mel-event-studio-nav');
-    if (!nav) {
-      return;
-    }
-    var active = nav.querySelector('.mel-event-studio-nav__item.is-active, .mel-event-studio-nav__item.active');
-    if (!active) {
-      return;
-    }
-    active.scrollIntoView({
-      behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-      inline: 'center',
-      block: 'nearest',
-    });
-  }
-
-  function setMelOverviewActive(form, overviewKey) {
-    var nav = form.querySelector('#mel-event-studio-nav');
-    if (!nav) {
-      return;
-    }
-    nav.querySelectorAll('[data-mel-overview]').forEach(function (btn) {
-      var key = btn.getAttribute('data-mel-overview') || '';
-      var on = key === overviewKey;
-      btn.classList.toggle('is-active', on);
-      btn.classList.toggle('active', on);
-      btn.setAttribute('aria-selected', on ? 'true' : 'false');
-    });
-    window.setTimeout(function () {
-      scrollMelOverviewActiveIntoView(form);
-    }, 60);
   }
 
   function getSettings() {
@@ -1717,16 +1668,6 @@
     );
   }
 
-  function getWizardStepIndex(form) {
-    var v = form.getAttribute('data-mel-wizard-step');
-    var n = v ? parseInt(v, 10) : 0;
-    return isNaN(n) ? 0 : n;
-  }
-
-  function setWizardStepIndex(form, index) {
-    form.setAttribute('data-mel-wizard-step', String(index));
-  }
-
   function calculateScore(form) {
     var score = 0;
     var total = 10;
@@ -1985,222 +1926,119 @@
     }
   }
 
-  function isStepComplete(step, form) {
-    switch (step) {
-      case 'basic':
-        return !!(val(form, 'mel[title]') && categoryFieldHasValue(form));
-      case 'schedule': {
-        var sd = form.querySelector('[name="mel[start_date][date]"]');
-        return !!(sd && sd.value);
-      }
-      case 'location': {
-        var vm = valRadio(form, 'mel[venue_mode]');
-        if (vm === 'saved') {
-          return val(form, 'mel[venue_saved]') !== '';
-        }
-        if (vm === 'create') {
-          return val(form, 'mel[venue_create_name]') !== '' && parseHiddenLocation(form) !== '';
-        }
-        return parseHiddenLocation(form) !== '';
-      }
-      case 'tickets': {
-        var tt = valRadio(form, 'mel[field_event_type]');
-        if (tt === 'external') return !!val(form, 'mel[external_url]');
-        if (tt === 'paid') return !!val(form, 'mel[field_product_target]');
-        return true;
-      }
-      default:
-        return true;
-    }
-  }
-
-  function showStep(form, index) {
-    form._melOverviewScrollLock = true;
-    window.clearTimeout(form._melOverviewScrollLockTimer);
-    form._melOverviewScrollLockTimer = window.setTimeout(function () {
-      form._melOverviewScrollLock = false;
-    }, 450);
-
-    var steps = form.querySelectorAll('.mel-wizard .mel-step');
-    var max = steps.length - 1;
-    if (index < 0) index = 0;
-    if (index > max) index = max;
-
-    steps.forEach(function (el, i) {
-      var on = i === index;
-      el.style.display = on ? 'block' : 'none';
-      if (on) {
-        var prevBtn = el.querySelector('.mel-prev');
-        var nextBtn = el.querySelector('.mel-next');
-        if (prevBtn) prevBtn.disabled = index === 0;
-        if (nextBtn) nextBtn.hidden = index >= MEL_STEPS.length - 1;
-      }
-    });
-
-    var overviewKey = MEL_OVERVIEW_BY_STEP[index];
-    if (overviewKey) {
-      setMelOverviewActive(form, overviewKey);
-    }
-
-    setWizardStepIndex(form, index);
-  }
-
   /**
-   * While on Basic Info step, refine overview highlight (basic vs description vs preview) from scroll.
+   * Scroll-only overview: all steps visible; nav and Continue move the viewport.
    *
    * @param {HTMLFormElement} form
    */
-  function initOverviewScrollSpy(form) {
-    if (!form.querySelector('#mel-event-studio-nav')) {
-      return;
-    }
-
-    var previewEl = document.getElementById('mel-preview-card');
-    var descEl = document.getElementById('mel-studio-section-description');
-
-    function tick() {
-      form._melOverviewScrollSpyRaf = null;
-      if (form._melOverviewScrollLock) {
-        return;
-      }
-      if (getWizardStepIndex(form) !== 0) {
-        return;
-      }
-      if (!form._melOverviewUserScrolledOnce) {
-        return;
-      }
-
-      var vh = window.innerHeight || 800;
-      function visibleRatio(el) {
-        if (!el) {
-          return 0;
-        }
-        var r = el.getBoundingClientRect();
-        var h = Math.max(0, Math.min(r.bottom, vh) - Math.max(0, r.top));
-        var eh = r.height || el.offsetHeight || 1;
-        return Math.min(1, h / Math.min(eh, vh));
-      }
-
-      var pRatio = visibleRatio(previewEl);
-      var dRatio = visibleRatio(descEl);
-      var key = 'basic';
-      if (dRatio > 0.18 && dRatio + 0.05 >= pRatio) {
-        key = 'description';
-      } else if (pRatio > 0.1) {
-        key = 'preview';
-      }
-      setMelOverviewActive(form, key);
-    }
-
-    function scheduleTick() {
-      if (form._melOverviewScrollSpyRaf !== null && form._melOverviewScrollSpyRaf !== undefined) {
-        return;
-      }
-      form._melOverviewScrollSpyRaf = window.requestAnimationFrame(tick);
-    }
-
-    if (window.IntersectionObserver) {
-      var io = new IntersectionObserver(
-        function () {
-          scheduleTick();
-        },
-        { root: null, threshold: [0, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1] },
-      );
-      if (previewEl) {
-        io.observe(previewEl);
-      }
-      if (descEl) {
-        io.observe(descEl);
-      }
-    }
-
-    window.addEventListener(
-      'scroll',
-      function () {
-        form._melOverviewUserScrolledOnce = true;
-        scheduleTick();
-      },
-      { passive: true },
-    );
-  }
-
   function initMelWizard(form) {
-    if (!form.querySelector('.mel-wizard') || !form.querySelector('#mel-event-studio-nav')) {
+    var wizard = form.querySelector('.mel-wizard');
+    var nav = form.querySelector('#mel-wizard-nav');
+    if (!wizard || !nav) {
       return;
     }
 
-    showStep(form, 0);
     updateProgress(form);
 
-    var nav = form.querySelector('#mel-event-studio-nav');
-    nav.querySelectorAll('[data-mel-overview]').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        var o = btn.getAttribute('data-mel-overview') || '';
-        if (o === 'description') {
-          showStep(form, 0);
-          window.setTimeout(function () {
-            setMelOverviewActive(form, 'description');
-            melScrollToSelector('#mel-studio-section-description');
-          }, 100);
-          return;
+    function scrollOverviewActiveIntoView() {
+      var active = nav.querySelector('.mel-nav-link.is-active, .mel-nav-link.active');
+      if (!active) {
+        return;
+      }
+      active.scrollIntoView({
+        behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+        inline: 'center',
+        block: 'nearest',
+      });
+    }
+
+    function setNavActive(link) {
+      nav.querySelectorAll('.mel-nav-link').forEach(function (l) {
+        l.classList.remove('is-active');
+        l.classList.remove('active');
+        l.setAttribute('aria-selected', 'false');
+      });
+      link.classList.add('is-active');
+      link.classList.add('active');
+      link.setAttribute('aria-selected', 'true');
+      window.setTimeout(scrollOverviewActiveIntoView, 60);
+    }
+
+    nav.querySelectorAll('.mel-nav-link').forEach(function (link) {
+      link.addEventListener('click', function (e) {
+        e.preventDefault();
+        var targetId = link.getAttribute('href');
+        var target = targetId ? document.querySelector(targetId) : null;
+        if (typeof console !== 'undefined' && console.log) {
+          console.log('NAV CLICK', targetId);
         }
-        if (o === 'preview') {
-          setMelOverviewActive(form, 'preview');
-          melScrollToSelector('#mel-preview-card');
-          return;
+        if (target) {
+          target.scrollIntoView({
+            behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+            block: 'start',
+          });
+        } else if (typeof console !== 'undefined' && console.warn) {
+          console.warn('Target not found:', targetId);
         }
-        var si = btn.getAttribute('data-mel-step-index');
-        if (si === null || si === '') {
-          return;
-        }
-        var idx = parseInt(si, 10);
-        if (isNaN(idx)) {
-          return;
-        }
-        showStep(form, idx);
-        if (o === 'publish') {
-          window.setTimeout(function () {
-            melScrollToSelector('#mel-studio-section-publish');
-          }, 100);
-        }
+        setNavActive(link);
       });
     });
 
-    initOverviewScrollSpy(form);
-
-    form.addEventListener(
-      'click',
-      function (e) {
-        var nextBtn = e.target.closest('.mel-next');
-        if (!nextBtn || !form.contains(nextBtn)) return;
-
-        var stepIdx = getWizardStepIndex(form);
-        var stepId = MEL_STEPS[stepIdx].id;
-
-        if (!isStepComplete(stepId, form)) {
-          alert(Drupal.t('Complete required fields before continuing.'));
+    form.querySelectorAll('.mel-continue-button').forEach(function (button) {
+      button.addEventListener('click', function () {
+        if (typeof console !== 'undefined' && console.log) {
+          console.log('CONTINUE CLICKED');
+        }
+        var currentSection = button.closest('.mel-studio-scroll-step');
+        if (!currentSection) {
+          if (typeof console !== 'undefined' && console.warn) {
+            console.warn('No parent section found');
+          }
           return;
         }
-
-        if (stepIdx >= MEL_STEPS.length - 1) {
+        var next = currentSection.nextElementSibling;
+        while (next && !next.classList.contains('mel-studio-scroll-step')) {
+          next = next.nextElementSibling;
+        }
+        if (!next) {
+          if (typeof console !== 'undefined' && console.warn) {
+            console.warn('No next section found');
+          }
           return;
         }
+        next.scrollIntoView({
+          behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+          block: 'start',
+        });
+      });
+    });
 
-        showStep(form, stepIdx + 1);
-      },
-      false,
-    );
+    form.querySelectorAll('.mel-prev').forEach(function (button) {
+      button.addEventListener('click', function () {
+        var currentSection = button.closest('.mel-studio-scroll-step');
+        if (!currentSection) {
+          return;
+        }
+        var prev = currentSection.previousElementSibling;
+        while (prev && !prev.classList.contains('mel-studio-scroll-step')) {
+          prev = prev.previousElementSibling;
+        }
+        if (!prev) {
+          return;
+        }
+        prev.scrollIntoView({
+          behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+          block: 'start',
+        });
+      });
+    });
 
-    form.addEventListener(
-      'click',
-      function (e) {
-        var prevBtn = e.target.closest('.mel-prev');
-        if (!prevBtn || !form.contains(prevBtn)) return;
-        var stepIdx = getWizardStepIndex(form);
-        showStep(form, stepIdx - 1);
-      },
-      false,
-    );
+    var jumpPreview = form.querySelector('#mel-jump-to-preview-card');
+    if (jumpPreview) {
+      jumpPreview.addEventListener('click', function () {
+        melScrollToSelector('#mel-preview-card');
+      });
+    }
   }
 
   function publishReadiness(form, init, str) {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -116,15 +116,27 @@
       </div>
     </div>
 
-    {# Overview navigation (scroll targets + step switching — see mel-event-studio.js) #}
-    {% include '@myeventlane_event_studio/mel-event-studio-nav.html.twig' %}
+    {# Overview navigation — anchor scroll targets (see mel-event-studio.js initMelWizard). #}
+    <nav class="mel-event-studio-nav" id="mel-wizard-nav" aria-label="{{ 'Event overview'|t }}">
+      <p class="mel-event-studio-nav__label">{{ 'Overview'|t }}</p>
+      <div class="mel-event-studio-nav__scroll">
+        <div class="mel-event-studio-nav__track" role="tablist">
+          <a href="#mel-step-basic" class="mel-nav-link mel-event-studio-nav__item is-active active" role="tab" aria-selected="true">{{ 'Basic info'|t }}</a>
+          <a href="#mel-step-datetime" class="mel-nav-link mel-event-studio-nav__item" role="tab" aria-selected="false">{{ 'Date & Location'|t }}</a>
+          <a href="#mel-step-tickets" class="mel-nav-link mel-event-studio-nav__item" role="tab" aria-selected="false">{{ 'Tickets / RSVP'|t }}</a>
+          <a href="#mel-step-description" class="mel-nav-link mel-event-studio-nav__item" role="tab" aria-selected="false">{{ 'Description'|t }}</a>
+          <a href="#mel-step-preview" class="mel-nav-link mel-event-studio-nav__item" role="tab" aria-selected="false">{{ 'Preview'|t }}</a>
+          <a href="#mel-step-publish" class="mel-nav-link mel-event-studio-nav__item mel-event-studio-nav__item--publish" role="tab" aria-selected="false">{{ 'Publish'|t }}</a>
+        </div>
+      </div>
+    </nav>
 
     {# FORM ZONE — wizard + actions (single root <form> above; not a nested form). #}
     <div class="mel-studio-form-wrapper mel-event-studio__form-full mel-studio-main-full">
-      <div class="mel-wizard">
+      <div class="mel-wizard mel-studio--scroll-all">
         {# —— Basic —— #}
-        <div id="mel-studio-step-basic" class="mel-step" data-step="basic" role="tabpanel">
-          <section class="mel-section mel-section--card mel-section--builder mel-section--basic" aria-labelledby="mel-basic-heading">
+        <section id="mel-step-basic" class="mel-step mel-studio-scroll-step" data-step="basic" role="tabpanel">
+          <div class="mel-section mel-section--card mel-section--builder mel-section--basic" aria-labelledby="mel-basic-heading">
             <header class="mel-section__header">
               <h2 class="mel-section__title" id="mel-basic-heading">{{ 'Basic info'|t }}</h2>
               <p class="mel-section__hint">{{ 'Name your event, how it shows in listings, and your cover image.'|t }}</p>
@@ -165,38 +177,17 @@
                   {{ element.mel.field_event_image_alt }}
                 </div>
               </div>
-
-              <div id="mel-studio-section-description" class="mel-section">
-                <h3>{{ 'About the event'|t }}</h3>
-                {{ element.mel.body }}
-                <div class="mel-ai-rewrite-actions">
-                  <button type="button" id="mel-ai-rewrite-about" class="mel-btn mel-btn--secondary">{{ 'Rewrite About'|t }}</button>
-                </div>
-              </div>
-
-              <div class="mel-section">
-                <h3>{{ 'Highlights'|t }}</h3>
-                {{ element.mel.event_highlights }}
-              </div>
-
-              <div class="mel-section">
-                <h3>{{ 'What to expect'|t }}</h3>
-                {{ element.mel.field_event_intro }}
-                <div class="mel-ai-rewrite-actions">
-                  <button type="button" id="mel-ai-rewrite-expect" class="mel-btn mel-btn--secondary">{{ 'Rewrite What to Expect'|t }}</button>
-                </div>
-              </div>
             </div>
 
             <div class="mel-step-actions">
               <button type="button" class="mel-btn mel-prev" disabled>{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-next">{{ 'Continue'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button">{{ 'Continue'|t }}</button>
             </div>
-          </section>
-        </div>
+          </div>
+        </section>
 
-        {# —— Schedule —— #}
-        <div id="mel-studio-step-schedule" class="mel-step" data-step="schedule" role="tabpanel">
+        {# —— Date & location —— #}
+        <section id="mel-step-datetime" class="mel-step mel-studio-scroll-step" data-step="datetime" role="tabpanel">
           <section class="mel-section mel-section--card mel-section--builder mel-section--details" aria-labelledby="mel-details-heading">
             <header class="mel-section__header">
               <h2 class="mel-section__title" id="mel-details-heading">{{ 'Date & time'|t }}</h2>
@@ -207,16 +198,8 @@
               {{ element.mel.start_date }}
               {{ element.mel.end_date }}
             </div>
-
-            <div class="mel-step-actions">
-              <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-next">{{ 'Continue'|t }}</button>
-            </div>
           </section>
-        </div>
 
-        {# —— Location —— #}
-        <div id="mel-studio-step-location" class="mel-step" data-step="location" role="tabpanel">
           <section class="mel-section mel-section--card mel-section--builder mel-section--location" aria-labelledby="mel-location-heading">
             <header class="mel-section__header">
               <h2 class="mel-section__title" id="mel-location-heading">{{ 'Location'|t }}</h2>
@@ -243,16 +226,16 @@
               {{ element.mel.field_location_latitude }}
               {{ element.mel.field_location_longitude }}
             </div>
-
-            <div class="mel-step-actions">
-              <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-next">{{ 'Continue'|t }}</button>
-            </div>
           </section>
-        </div>
+
+          <div class="mel-step-actions">
+            <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+            <button type="button" class="mel-btn mel-continue-button">{{ 'Continue'|t }}</button>
+          </div>
+        </section>
 
         {# —— Tickets —— #}
-        <div id="mel-studio-step-tickets" class="mel-step" data-step="tickets" role="tabpanel">
+        <section id="mel-step-tickets" class="mel-step mel-studio-scroll-step" data-step="tickets" role="tabpanel">
           <section class="mel-section mel-section--card mel-section--builder mel-section--tickets" aria-labelledby="mel-tickets-heading">
             <header class="mel-section__header">
               <h2 class="mel-section__title" id="mel-tickets-heading">{{ 'Tickets'|t }}</h2>
@@ -285,16 +268,37 @@
               {{ element.mel.field_sales_start }}
               {{ element.mel.field_sales_end }}
             </div>
-
-            <div class="mel-step-actions">
-              <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-next">{{ 'Continue'|t }}</button>
-            </div>
           </section>
-        </div>
 
-        {# —— Advanced —— #}
-        <div id="mel-studio-step-advanced" class="mel-step" data-step="advanced" role="tabpanel">
+          <div class="mel-step-actions">
+            <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+            <button type="button" class="mel-btn mel-continue-button">{{ 'Continue'|t }}</button>
+          </div>
+        </section>
+
+        {# —— Description & advanced —— #}
+        <section id="mel-step-description" class="mel-step mel-studio-scroll-step" data-step="description" role="tabpanel">
+          <div id="mel-studio-section-description" class="mel-section">
+            <h3>{{ 'About the event'|t }}</h3>
+            {{ element.mel.body }}
+            <div class="mel-ai-rewrite-actions">
+              <button type="button" id="mel-ai-rewrite-about" class="mel-btn mel-btn--secondary">{{ 'Rewrite About'|t }}</button>
+            </div>
+          </div>
+
+          <div class="mel-section">
+            <h3>{{ 'Highlights'|t }}</h3>
+            {{ element.mel.event_highlights }}
+          </div>
+
+          <div class="mel-section">
+            <h3>{{ 'What to expect'|t }}</h3>
+            {{ element.mel.field_event_intro }}
+            <div class="mel-ai-rewrite-actions">
+              <button type="button" id="mel-ai-rewrite-expect" class="mel-btn mel-btn--secondary">{{ 'Rewrite What to Expect'|t }}</button>
+            </div>
+          </div>
+
           <details class="mel-advanced">
             <summary>{{ 'Advanced options'|t }}</summary>
 
@@ -341,6 +345,31 @@
             </section>
           </details>
 
+          <div class="mel-step-actions">
+            <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+            <button type="button" class="mel-btn mel-continue-button">{{ 'Continue'|t }}</button>
+          </div>
+        </section>
+
+        {# —— Preview (jump to card above) —— #}
+        <section id="mel-step-preview" class="mel-step mel-studio-scroll-step" data-step="preview" role="tabpanel">
+          <section class="mel-section mel-section--card mel-section--builder" aria-labelledby="mel-studio-preview-heading">
+            <header class="mel-section__header">
+              <h2 class="mel-section__title" id="mel-studio-preview-heading">{{ 'Preview'|t }}</h2>
+              <p class="mel-section__hint">{{ 'See how your event appears in listings — the live card stays at the top of this page.'|t }}</p>
+            </header>
+            <p class="mel-section__hint">{{ 'Jump to the preview card to review title, schedule, location, and ticket summary.'|t }}</p>
+            <button type="button" class="mel-btn mel-btn--secondary" id="mel-jump-to-preview-card">{{ 'Show live preview'|t }}</button>
+          </section>
+
+          <div class="mel-step-actions">
+            <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+            <button type="button" class="mel-btn mel-continue-button">{{ 'Continue'|t }}</button>
+          </div>
+        </section>
+
+        {# —— Publish —— #}
+        <section id="mel-step-publish" class="mel-step mel-studio-scroll-step" data-step="publish" role="tabpanel">
           <section id="mel-studio-section-publish" class="mel-section mel-section--card mel-section--builder mel-section--publish" aria-labelledby="mel-publish-heading">
             <header class="mel-section__header">
               <h2 class="mel-section__title" id="mel-publish-heading">{{ 'Publishing'|t }}</h2>
@@ -350,9 +379,8 @@
 
           <div class="mel-step-actions">
             <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-            <button type="button" class="mel-btn mel-next">{{ 'Continue'|t }}</button>
           </div>
-        </div>
+        </section>
       </div>
 
       {{ element.nid }}


### PR DESCRIPTION
… studio

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Event Studio navigation from step-hiding to scroll-based anchors, which can affect user progression and accessibility/UX across all event edits. Also removes prior step-completion gating and adds new click handlers, so regressions in navigation state are possible.
> 
> **Overview**
> Updates Event Studio from a *hide/show step wizard* to a **scroll-only flow** where all sections remain in the DOM and navigation/Continue/Back simply scroll the viewport.
> 
> Replaces the previous button-driven overview include with an inline anchor-based `#mel-wizard-nav` and restructures the Twig layout into explicit scroll targets (including new dedicated **Description**, **Preview**, and **Publish** sections) with `mel-continue-button` actions.
> 
> Simplifies `initMelWizard()` by removing step-index state, step completion checks/alerts, and the overview scroll-spy; adds anchor click handling, continue/prev scrolling logic, and a “jump to live preview” button. CSS is updated to force all `.mel-step` blocks visible and normalize nav link styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c118d93b9c4cf4677a1f9ec50f8b5997bec07864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->