### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -86,6 +86,7 @@ module:
   myeventlane_analytics: 0
   myeventlane_api: 0
   myeventlane_attendee: 0
+  myeventlane_auth: 0
   myeventlane_automation: 0
   myeventlane_blocks: 0
   myeventlane_boost: 0

--- a/config/sync/gin.settings.yml
+++ b/config/sync/gin.settings.yml
@@ -15,12 +15,12 @@ third_party_settings:
 preset_accent_color: purple
 preset_focus_color: custom
 enable_darkmode: auto
-classic_toolbar: new
+classic_toolbar: vertical
 secondary_toolbar_frontend: true
 high_contrast_mode: false
 accent_color: ''
 focus_color: '#f4a4c0'
-layout_density: small
+layout_density: default
 show_description_toggle: true
 show_user_theme_settings: true
 sticky_action_buttons: false

--- a/config/sync/gin_login.settings.yml
+++ b/config/sync/gin_login.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: OhypfKr4_Eo8XwXg3Sios05lN-LjxOhSdSOSkEN9Ndo
 logo:
   use_default: false
-  path: 'public://myeventlane_Logo.png'
+  path: 'public://myeventlane_logo_0.png'
 brand_image:
   use_default: false
-  path: 'public://MyEventLane Login Image_0.png'
+  path: 'public://myeventlane-login-image_0.png'

--- a/config/sync/klaro.klaro_app.posthog.yml
+++ b/config/sync/klaro.klaro_app.posthog.yml
@@ -18,7 +18,7 @@ privacy_policy_url: 'https://posthog.com/privacy'
 purposes:
   - analytics
 cookies: {  }
-callback_code: "window.posthog.set_config({ cookieless_mode: 'on_reject' })\r\nif (consent === true) {\r\n  window.posthog.opt_in_capturing()\r\n}\r\nif (consent === false) {\r\n  window.posthog.opt_out_capturing()\r\n}\r\n"
+callback_code: "// NOTE: \r\n// - On initial call window.posthog and its functions may not be initialized yet:\r\n// - The posthog module detects Klaro and initializes with cookieless_mode: 'on_reject'\r\nif (window.posthog) {\r\n  if (consent === true && window.posthog.opt_in_capturing) {\r\n    window.posthog.opt_in_capturing();\r\n  }\r\n  else if (consent === false && window.posthog.opt_out_capturing) {\r\n    window.posthog.opt_out_capturing();\r\n  }\r\n}"
 javascripts: {  }
 wrapper_identifier: {  }
 attachments: {  }

--- a/config/sync/myeventlane_auth.settings.yml
+++ b/config/sync/myeventlane_auth.settings.yml
@@ -1,0 +1,19 @@
+_core:
+  default_config_hash: WK2swfKFYouUC2Azyhd92_s0gs9BamOZWck04_P03Bs
+auth_base_url: ''
+jwt_issuer: ''
+jwt_audience: ''
+access_token_ttl: 900
+refresh_token_ttl: 2592000
+authorization_code_ttl: 600
+refresh_cookie_name: mel_auth_rt
+refresh_cookie_path: /auth
+refresh_cookie_domain: ''
+vendor_sso_redirect_enabled: false
+vendor_sso_client_id: vendor
+vendor_sso_callback_path: /vendor/sso/callback
+vendor_sso_success_path: /vendor/dashboard
+vendor_sso_redirect_hosts: {  }
+allowed_redirect_hosts: {  }
+allowed_cors_origins: {  }
+oauth_clients: {  }

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -14,8 +14,8 @@ dependencies:
     - media
     - myeventlane_checkin
     - myeventlane_escalations_portal
-    - myeventlane_help_assistant
     - myeventlane_event_state
+    - myeventlane_help_assistant
     - paragraphs
     - profile
     - search

--- a/config/sync/user.role.mel_pro.yml
+++ b/config/sync/user.role.mel_pro.yml
@@ -2,21 +2,22 @@ uuid: a1b2c3d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d
 langcode: en
 status: true
 dependencies:
+  config:
+    - workflows.workflow.editorial
   module:
-    - mel_ticket
-    - myeventlane_vendor
     - commerce_order
     - commerce_product
     - commerce_stripe
     - content_moderation
+    - mel_ticket
     - myeventlane_boost
     - myeventlane_escalations_refunds
     - myeventlane_event_state
     - myeventlane_refunds
+    - myeventlane_vendor
     - myeventlane_vendor_ai
     - paragraphs
     - paragraphs_type_permissions
-    - workflows
 id: mel_pro
 label: 'MEL Pro'
 weight: -6

--- a/config/sync/user.role.vendor.yml
+++ b/config/sync/user.role.vendor.yml
@@ -6,9 +6,9 @@ dependencies:
     - filter.format.basic_html
     - node.type.event
     - taxonomy.vocabulary.tags
+    - workflows.workflow.editorial
   module:
     - comment
-    - mel_ticket
     - commerce_checkout
     - commerce_order
     - commerce_payment
@@ -18,6 +18,7 @@ dependencies:
     - contextual
     - file
     - filter
+    - mel_ticket
     - myeventlane_analytics
     - myeventlane_attendee
     - myeventlane_automation
@@ -44,7 +45,6 @@ dependencies:
     - social_auth
     - taxonomy
     - toolbar
-    - workflows
 id: vendor
 label: Vendor
 weight: -7

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-nav.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-nav.css
@@ -1,81 +1,15 @@
 /**
  * @file
- * Event Studio overview navigation — horizontal scroll on small screens, MEL tokens.
+ * Event Studio nav — thin baseline; primary layout in theme _event-studio.scss.
  */
 
-.mel-event-studio-nav {
-  margin: 0 0 1rem;
-  padding: 0.75rem 0 0;
-  border-bottom: 1px solid var(--mel-studio-border, #e2e8f0);
-}
-
-.mel-event-studio-nav__label {
-  margin: 0 0 0.5rem 0.25rem;
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--mel-studio-muted, #64748b);
-}
-
-.mel-event-studio-nav__scroll {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  padding-bottom: 0.25rem;
-  margin: 0 -0.25rem;
-  scrollbar-width: thin;
-}
-
-.mel-event-studio-nav__track {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 0.5rem;
-  align-items: stretch;
-  min-height: 44px;
-  padding: 0 0.25rem 0.25rem;
-}
-
-.mel-event-studio-nav__item {
-  flex: 0 0 auto;
-  min-height: 44px;
-  min-width: 44px;
-  padding: 0.5rem 0.85rem;
+.mel-sidebar-nav {
   margin: 0;
-  border-radius: 10px;
-  border: 1px solid var(--mel-studio-border, #e2e8f0);
-  background: var(--mel-studio-bg, #f8fafc);
-  color: var(--mel-studio-text, #0f172a);
-  font: inherit;
-  font-weight: 600;
-  font-size: 0.8125rem;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  padding: 0;
 }
 
-.mel-event-studio-nav__item:hover {
-  border-color: rgba(242, 109, 91, 0.45);
-  background: var(--mel-studio-card, #fff);
-}
-
-.mel-event-studio-nav__item.is-active,
-.mel-event-studio-nav__item.active {
-  background: #f26d5b;
-  border-color: #f26d5b;
-  color: #fff;
-}
-
-.mel-event-studio-nav__item--publish:not(.is-active):not(.active) {
-  border-color: rgba(242, 109, 91, 0.35);
-}
-
-.mel-event-studio-nav__item:focus-visible {
-  outline: 2px solid var(--mel-studio-focus, #2563eb);
-  outline-offset: 2px;
-}
-
-@media (min-width: 960px) {
-  .mel-event-studio-nav__track {
-    flex-wrap: wrap;
-  }
+.mel-sidebar-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -1,0 +1,293 @@
+/**
+ * @file
+ * Event Studio shell: sidebar layout + ticket region (module-owned).
+ *
+ * Loaded with mel_event_studio so styles apply on vendor console (myeventlane_vendor_theme),
+ * where myeventlane_theme/dist/main.css (Vite) is not used — theme SCSS alone is not enough.
+ *
+ * vendor-workspace.css (global on vendor theme) sets
+ * `.mel-vendor-shell__content .mel-studio-layout { display: grid }` for legacy Studio.
+ * Event Studio reuses `.mel-studio-layout`; include `.mel-event-studio` in the selector so
+ * we win the cascade (see myeventlane_vendor_theme/css/vendor-workspace.css ~827).
+ */
+
+/* --- Two-column layout --- */
+.mel-vendor-shell__content .mel-event-studio .mel-studio-layout,
+.mel-event-studio .mel-studio-layout {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 24px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-event-studio__layout {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
+
+.mel-event-studio .mel-studio-sidebar {
+  /* vendor-workspace.css sets .mel-studio-sidebar { display: grid } — override for Event Studio nav column */
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 220px;
+  width: 220px;
+  max-width: 100%;
+  position: sticky;
+  top: 100px;
+  align-self: flex-start;
+  height: fit-content;
+  z-index: 2;
+}
+
+.mel-event-studio .mel-studio-content {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.mel-vendor-shell__content .mel-event-studio .mel-event-studio__form-full,
+.mel-vendor-shell__content .mel-event-studio .mel-studio-form-wrapper {
+  display: block !important;
+  grid-template-columns: none !important;
+}
+
+.vendor-workspace--studio .mel-event-studio .mel-studio-sidebar .mel-studio-nav.mel-wizard-nav {
+  overflow: visible;
+  height: auto;
+  padding: 0;
+  background: transparent;
+}
+
+/* --- Sidebar step list (#mel-wizard-nav) --- */
+.mel-event-studio .mel-sidebar-nav {
+  background: #fff;
+  border-radius: 16px;
+  padding: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  border: 1px solid #e2e8f0;
+}
+
+.mel-event-studio .mel-sidebar-nav .mel-event-studio-nav__label {
+  margin: 0 0 8px 4px;
+}
+
+.mel-event-studio .mel-sidebar-nav__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mel-event-studio .mel-sidebar-nav__list li {
+  margin-bottom: 6px;
+}
+
+.mel-event-studio .mel-sidebar-nav__list li:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: #333;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  border: 1px solid transparent;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item:hover {
+  background: #f5f7ff;
+  color: #0f172a;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item.is-active,
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item.active {
+  background: #f26d5b;
+  color: #fff;
+  border-color: #f26d5b;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .mel-vendor-shell__content .mel-event-studio .mel-studio-layout,
+  .mel-event-studio .mel-studio-layout {
+    flex-direction: column;
+  }
+
+  .mel-event-studio .mel-studio-sidebar {
+    position: static;
+    width: 100%;
+    flex: none;
+  }
+}
+
+/* --- Tickets region --- */
+.mel-event-studio .mel-ticket-section {
+  margin-top: 0.5rem;
+  padding: 1rem 1.1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.mel-event-studio .mel-ticket-section .mel-tickets-intro {
+  margin-top: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-builder,
+.mel-event-studio .mel-ticket-section .mel-ticket-wizard-embed {
+  background: #fff;
+  border-color: #eee;
+  box-shadow: none;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-controls {
+  margin-bottom: 12px;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-controls--primary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mel-event-studio .mel-ticket-section .btn-primary,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__paid,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls [name='ticket_save_sync'] {
+  background: #f26d5b !important;
+  color: #fff !important;
+  border-radius: 10px !important;
+  padding: 12px 14px !important;
+  font-weight: 600 !important;
+  border: none !important;
+}
+
+.mel-event-studio .mel-ticket-section .btn-secondary,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__rsvp {
+  background: #eef2ff !important;
+  color: #4f46e5 !important;
+  border-radius: 10px !important;
+  padding: 10px 12px !important;
+  font-weight: 600 !important;
+  border: none !important;
+}
+
+.mel-event-studio .mel-ticket-section .btn-ghost,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__external {
+  background: transparent !important;
+  border: 1px dashed #ddd !important;
+  color: #666 !important;
+  border-radius: 10px !important;
+  padding: 10px 12px !important;
+  font-weight: 500 !important;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card {
+  border-radius: 16px;
+  border: 1px solid #eee;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: #fff;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__title {
+  font-weight: 600;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__price {
+  color: #6e7ef2;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+  color: #666;
+  margin-top: 8px;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__meta li {
+  margin: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__actions {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+  align-self: flex-start;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  min-width: 2.5rem;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] {
+  padding: 8px;
+  min-width: 11rem;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger {
+  list-style: none;
+  cursor: pointer;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  margin: 0;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: #0f172a;
+  font-size: 1.25rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] .mel-ticket-card__overflow-trigger {
+  margin-bottom: 6px;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn {
+  width: 100%;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button:first-of-type,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn:first-of-type,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn:first-of-type {
+  margin-top: 0;
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -4,10 +4,14 @@
  */
 
 /**
- * Scroll-only Studio: all wizard steps stay in the document flow (no display toggling).
+ * Wizard steps stay visible in normal document flow (no nested scroll region).
  */
-.mel-studio--scroll-all .mel-step {
+.mel-wizard .mel-step {
   display: block !important;
+}
+
+.mel-studio-scroll-step {
+  scroll-margin-top: 120px;
 }
 
 .mel-event-studio-nav__track a.mel-nav-link {
@@ -35,11 +39,14 @@
   margin: 0;
   padding: 1rem 1.25rem 2.5rem;
   color: var(--mel-studio-text);
+  height: auto;
+  overflow: visible;
 }
 
 .mel-studio-form-wrapper {
   width: 100%;
   max-width: 100%;
+  overflow: visible;
 }
 
 .mel-event-studio__page-title {

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -14,10 +14,9 @@
   scroll-margin-top: 120px;
 }
 
+.mel-sidebar-nav a.mel-nav-link,
 .mel-event-studio-nav__track a.mel-nav-link {
   text-decoration: none;
-  display: inline-flex;
-  align-items: center;
   box-sizing: border-box;
 }
 
@@ -1018,43 +1017,7 @@ textarea.mel-input--body {
   }
 }
 
-/* Section overview nav — horizontal scroll, scroll-margin for in-page jumps */
-.mel-event-studio #mel-wizard-nav {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 0.35rem;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  padding-bottom: 0.35rem;
-  margin-bottom: 1rem;
-  scrollbar-width: thin;
-}
-
-.mel-event-studio #mel-wizard-nav a.mel-nav-link {
-  flex: 0 0 auto;
-  min-height: 44px;
-  padding: 0.45rem 0.85rem;
-  border-radius: var(--mel-studio-radius-sm);
-  border: 1px solid var(--mel-studio-border);
-  background: var(--mel-studio-card);
-  color: var(--mel-studio-text);
-  font-size: 0.875rem;
-  font-weight: 600;
-  white-space: nowrap;
-  cursor: pointer;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
-}
-
-.mel-event-studio #mel-wizard-nav a.mel-nav-link.is-active {
-  border-color: var(--mel-studio-accent);
-  background: var(--mel-studio-accent-soft);
-  color: var(--mel-studio-accent);
-}
-
+/* Step nav lives in theme (left sidebar); keep scroll-margin for in-page jumps. */
 .mel-event-studio .mel-studio-section {
   scroll-margin-top: 5.5rem;
 }

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -1992,7 +1992,7 @@
       window.setTimeout(function () {
         activeLink.scrollIntoView({
           block: 'nearest',
-          inline: 'center',
+          inline: 'nearest',
           behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
         });
       }, 60);
@@ -2536,6 +2536,39 @@
           refreshIntelligence(form);
         });
       });
+    },
+  };
+
+  /**
+   * Collapse Duplicate / Archive / Remove into a compact details menu (Event Studio ticket cards).
+   */
+  Drupal.behaviors.melEventStudioTicketOverflow = {
+    attach: function (context) {
+      once('mel-ticket-overflow', '.mel-event-studio .js-mel-ticket-card.is-view .mel-ticket-card__actions', context).forEach(
+        function (actions) {
+          if (actions.querySelector('details.mel-ticket-card__overflow')) {
+            return;
+          }
+          var dup = actions.querySelector('[name^="ticket_duplicate_"]');
+          var arch = actions.querySelector('[name^="ticket_archive_"]');
+          var rem = actions.querySelector('[name^="ticket_remove_"]');
+          var toMove = [dup, arch, rem].filter(Boolean);
+          if (toMove.length === 0) {
+            return;
+          }
+          var details = document.createElement('details');
+          details.className = 'mel-ticket-card__overflow';
+          var summary = document.createElement('summary');
+          summary.className = 'mel-ticket-card__overflow-trigger';
+          summary.setAttribute('aria-label', Drupal.t('More ticket actions'));
+          summary.appendChild(document.createTextNode('\u22EF'));
+          details.appendChild(summary);
+          toMove.forEach(function (btn) {
+            details.appendChild(btn);
+          });
+          actions.appendChild(details);
+        },
+      );
     },
   };
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -28,9 +28,6 @@
       top: Math.max(0, y),
       behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
     });
-    if (typeof console !== 'undefined' && console.log) {
-      console.log('SCROLL TO', target.id || target);
-    }
   }
 
   /**
@@ -1999,6 +1996,42 @@
     }
   }
 
+  function isStepComplete(step, form) {
+    switch (step) {
+      case 'basic':
+        return !!(val(form, 'mel[title]') && categoryFieldHasValue(form));
+      case 'datetime': {
+        var sd = form.querySelector('[name="mel[start_date][date]"]');
+        if (!sd || !sd.value) {
+          return false;
+        }
+        var vm = valRadio(form, 'mel[venue_mode]');
+        if (vm === 'saved') {
+          return val(form, 'mel[venue_saved]') !== '';
+        }
+        if (vm === 'create') {
+          return val(form, 'mel[venue_create_name]') !== '' && parseHiddenLocation(form) !== '';
+        }
+        return parseHiddenLocation(form) !== '';
+      }
+      case 'tickets': {
+        var tt = valRadio(form, 'mel[field_event_type]');
+        if (tt === 'external') {
+          return !!val(form, 'mel[external_url]');
+        }
+        if (tt === 'paid') {
+          return !!val(form, 'mel[field_product_target]');
+        }
+        return true;
+      }
+      case 'description':
+      case 'preview':
+      case 'publish':
+      default:
+        return true;
+    }
+  }
+
   function scrollToStudioSection(form, index) {
     if (index < 0 || index >= MEL_STEPS.length) {
       return;
@@ -2008,6 +2041,39 @@
     scrollToTarget(el);
     setWizardNavActive(form, index);
     setWizardStepIndex(form, index);
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {HTMLElement} cont Continue control (.mel-continue-button).
+   */
+  function melContinueToNextSection(form, cont) {
+    var section = cont && cont.closest ? cont.closest('section.mel-step[data-step]') : null;
+    var stepIdx = -1;
+    if (section) {
+      var sid = section.getAttribute('data-step');
+      for (var s = 0; s < MEL_STEPS.length; s++) {
+        if (MEL_STEPS[s].id === sid) {
+          stepIdx = s;
+          break;
+        }
+      }
+    }
+    if (stepIdx < 0) {
+      stepIdx = getWizardStepIndex(form);
+    }
+    if (stepIdx < 0 || stepIdx >= MEL_STEPS.length) {
+      return;
+    }
+    var validateId = MEL_STEPS[stepIdx].id;
+    if (!isStepComplete(validateId, form)) {
+      alert(Drupal.t('Complete required fields before continuing.'));
+      return;
+    }
+    if (stepIdx >= MEL_STEPS.length - 1) {
+      return;
+    }
+    scrollToStudioSection(form, stepIdx + 1);
   }
 
   function initMelWizard(form) {
@@ -2055,18 +2121,19 @@
       false,
     );
 
-    form.querySelectorAll('.mel-continue-button').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        if (typeof console !== 'undefined' && console.log) {
-          console.log('CONTINUE CLICKED');
+    form.addEventListener(
+      'click',
+      function (e) {
+        var cont = e.target.closest('.mel-continue-button');
+        if (!cont || !form.contains(cont)) {
+          return;
         }
-        var current = btn.closest('.mel-studio-scroll-step');
-        var next = current ? current.nextElementSibling : null;
-        if (next) {
-          scrollToTarget(next);
-        }
-      });
-    });
+        e.preventDefault();
+        e.stopPropagation();
+        melContinueToNextSection(form, cont);
+      },
+      true,
+    );
 
     form.addEventListener(
       'click',

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -11,15 +11,37 @@
     return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 
-  function melScrollToSelector(sel) {
-    var el = typeof sel === 'string' ? document.querySelector(sel) : sel;
-    if (!el || !el.scrollIntoView) {
+  /** Sticky header buffer for window scroll (matches .mel-studio-scroll-step scroll-margin). */
+  var MEL_SCROLL_OFFSET = 120;
+
+  /**
+   * Window scroll only — no nested scroll containers.
+   *
+   * @param {HTMLElement|null} target
+   */
+  function scrollToTarget(target) {
+    if (!target) {
       return;
     }
-    el.scrollIntoView({
+    var y = target.getBoundingClientRect().top + window.scrollY - MEL_SCROLL_OFFSET;
+    window.scrollTo({
+      top: Math.max(0, y),
       behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-      block: 'start',
     });
+    if (typeof console !== 'undefined' && console.log) {
+      console.log('SCROLL TO', target.id || target);
+    }
+  }
+
+  /**
+   * @param {string|HTMLElement} sel
+   */
+  function melScrollToSelector(sel) {
+    var el = typeof sel === 'string' ? document.querySelector(sel) : sel;
+    if (!el) {
+      return;
+    }
+    scrollToTarget(el);
   }
 
   /**
@@ -70,12 +92,7 @@
       return;
     }
     var scrollTarget = el.closest('.js-form-item, .form-item, .fieldset, .mel-step') || el;
-    if (scrollTarget.scrollIntoView) {
-      scrollTarget.scrollIntoView({
-        behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-        block: 'center',
-      });
-    }
+    scrollToTarget(scrollTarget);
     window.setTimeout(function () {
       try {
         if (el && typeof el.focus === 'function' && !el.disabled) {
@@ -1953,38 +1970,6 @@
     }
   }
 
-  function isStepComplete(step, form) {
-    switch (step) {
-      case 'basic':
-        return !!(val(form, 'mel[title]') && categoryFieldHasValue(form));
-      case 'datetime': {
-        var sd = form.querySelector('[name="mel[start_date][date]"]');
-        if (!sd || !sd.value) {
-          return false;
-        }
-        var vm = valRadio(form, 'mel[venue_mode]');
-        if (vm === 'saved') {
-          return val(form, 'mel[venue_saved]') !== '';
-        }
-        if (vm === 'create') {
-          return val(form, 'mel[venue_create_name]') !== '' && parseHiddenLocation(form) !== '';
-        }
-        return parseHiddenLocation(form) !== '';
-      }
-      case 'tickets': {
-        var tt = valRadio(form, 'mel[field_event_type]');
-        if (tt === 'external') return !!val(form, 'mel[external_url]');
-        if (tt === 'paid') return !!val(form, 'mel[field_product_target]');
-        return true;
-      }
-      case 'description':
-      case 'preview':
-      case 'publish':
-      default:
-        return true;
-    }
-  }
-
   function setWizardNavActive(form, activeIndex) {
     var nav = form.querySelector('#mel-wizard-nav');
     if (!nav) {
@@ -2020,30 +2005,9 @@
     }
     var step = MEL_STEPS[index];
     var el = document.getElementById('mel-step-' + step.id);
-    if (el && el.scrollIntoView) {
-      el.scrollIntoView({
-        behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-        block: 'start',
-      });
-    }
+    scrollToTarget(el);
     setWizardNavActive(form, index);
     setWizardStepIndex(form, index);
-  }
-
-  function melContinueToNextSection(form) {
-    var stepIdx = getWizardStepIndex(form);
-    var stepId = MEL_STEPS[stepIdx].id;
-
-    if (!isStepComplete(stepId, form)) {
-      alert(Drupal.t('Complete required fields before continuing.'));
-      return;
-    }
-
-    if (stepIdx >= MEL_STEPS.length - 1) {
-      return;
-    }
-
-    scrollToStudioSection(form, stepIdx + 1);
   }
 
   function initMelWizard(form) {
@@ -2056,18 +2020,13 @@
     setWizardNavActive(form, 0);
     updateProgress(form);
 
-    var nav = form.querySelector('#mel-wizard-nav');
-    nav.querySelectorAll('a.mel-nav-link').forEach(function (link) {
+    form.querySelectorAll('a.mel-nav-link').forEach(function (link) {
       link.addEventListener('click', function (e) {
         e.preventDefault();
-        var targetId = link.getAttribute('href');
-        var target = targetId ? document.querySelector(targetId) : null;
-        if (target && target.scrollIntoView) {
-          target.scrollIntoView({
-            behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-            block: 'start',
-          });
-        }
+        var href = link.getAttribute('href') || '';
+        var id = href.replace(/^#/, '');
+        var target = id ? document.getElementById(id) : null;
+        scrollToTarget(target);
         var stepAttr = link.getAttribute('data-step');
         var idx = -1;
         for (var s = 0; s < MEL_STEPS.length; s++) {
@@ -2096,19 +2055,18 @@
       false,
     );
 
-    form.addEventListener(
-      'click',
-      function (e) {
-        var cont = e.target.closest('.mel-continue-button');
-        if (!cont || !form.contains(cont)) {
-          return;
+    form.querySelectorAll('.mel-continue-button').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        if (typeof console !== 'undefined' && console.log) {
+          console.log('CONTINUE CLICKED');
         }
-        e.preventDefault();
-        e.stopPropagation();
-        melContinueToNextSection(form);
-      },
-      true,
-    );
+        var current = btn.closest('.mel-studio-scroll-step');
+        var next = current ? current.nextElementSibling : null;
+        if (next) {
+          scrollToTarget(next);
+        }
+      });
+    });
 
     form.addEventListener(
       'click',
@@ -2146,7 +2104,7 @@
             }
           });
         },
-        { root: null, rootMargin: '-40% 0px -50% 0px', threshold: 0.1 },
+        { rootMargin: '-40% 0px -50% 0px', threshold: 0.1 },
       );
       steps.forEach(function (s) {
         io.observe(s);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -3,6 +3,8 @@ mel_event_studio:
     theme:
       css/mel-event-studio.css: {}
       css/mel-event-studio-nav.css: {}
+      # After vendor theme global CSS so sidebar/ticket shell wins in cascade.
+      css/mel-event-studio-shell.css: { weight: 200 }
   js:
     js/mel-event-studio.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -23,6 +23,19 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       'render element' => 'element',
       'template' => 'mel-event-studio',
     ],
+    'mel_event_studio_wizard_nav' => [
+      'variables' => [
+        'node' => NULL,
+        'current_step' => '',
+      ],
+      'template' => 'mel-event-studio-wizard-nav',
+    ],
+    'mel_event_studio_wizard_preview' => [
+      'variables' => [
+        'node' => NULL,
+      ],
+      'template' => 'mel-event-studio-wizard-preview',
+    ],
   ];
 }
 
@@ -37,6 +50,12 @@ function myeventlane_event_studio_preprocess_html(array &$variables): void {
   $studio_routes = [
     'myeventlane_event_studio.create',
     'myeventlane_event_studio.edit',
+    'myeventlane_event_studio.edit_basic',
+    'myeventlane_event_studio.edit_datetime',
+    'myeventlane_event_studio.edit_tickets',
+    'myeventlane_event_studio.edit_description',
+    'myeventlane_event_studio.edit_preview',
+    'myeventlane_event_studio.edit_publish',
   ];
   if (!in_array($route_name, $studio_routes, TRUE)) {
     return;

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -19,6 +19,78 @@ myeventlane_event_studio.edit:
       node:
         type: entity:node
 
+myeventlane_event_studio.edit_basic:
+  path: '/vendor/events/{node}/edit/basic'
+  defaults:
+    _form: '\Drupal\myeventlane_event_studio\Form\EventStudioBasicForm'
+    _title: 'Basic info'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.edit_datetime:
+  path: '/vendor/events/{node}/edit/datetime'
+  defaults:
+    _form: '\Drupal\myeventlane_event_studio\Form\EventStudioDateForm'
+    _title: 'Date & location'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.edit_tickets:
+  path: '/vendor/events/{node}/edit/tickets'
+  defaults:
+    _form: '\Drupal\myeventlane_event_studio\Form\EventStudioTicketsForm'
+    _title: 'Tickets'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.edit_description:
+  path: '/vendor/events/{node}/edit/description'
+  defaults:
+    _form: '\Drupal\myeventlane_event_studio\Form\EventStudioDescriptionForm'
+    _title: 'Description'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.edit_preview:
+  path: '/vendor/events/{node}/edit/preview'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioPreviewController::build'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioPreviewController::title'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.edit_publish:
+  path: '/vendor/events/{node}/edit/publish'
+  defaults:
+    _form: '\Drupal\myeventlane_event_studio\Form\EventStudioPublishForm'
+    _title: 'Publish'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
 myeventlane_event_studio.autosave:
   path: '/vendor/events/autosave'
   defaults:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -25,6 +25,16 @@ services:
     arguments:
       - '@entity_type.manager'
 
+  myeventlane_event_studio.mel_payload:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService
+    arguments:
+      - '@myeventlane_event_studio.highlight_helper'
+
+  myeventlane_event_studio.wizard_mel_baseline:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline
+    arguments:
+      - '@form_builder'
+
   myeventlane_event_studio.ticket_link_suggestion:
     class: Drupal\myeventlane_event_studio\Service\EventStudioTicketLinkSuggestionService
     arguments:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -30,10 +30,17 @@ services:
     arguments:
       - '@myeventlane_event_studio.highlight_helper'
 
+  myeventlane_event_studio.entity_autocomplete_mel_normalizer:
+    class: Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer
+    arguments:
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_event_studio'
+
   myeventlane_event_studio.wizard_mel_baseline:
     class: Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline
     arguments:
       - '@form_builder'
+      - '@myeventlane_event_studio.entity_autocomplete_mel_normalizer'
 
   myeventlane_event_studio.ticket_link_suggestion:
     class: Drupal\myeventlane_event_studio\Service\EventStudioTicketLinkSuggestionService

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Form\EventStudioForm;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -28,21 +30,16 @@ final class EventStudioController extends ControllerBase {
     return $form;
   }
 
-  public function buildEdit(NodeInterface $node): array {
+  public function buildEdit(NodeInterface $node): RedirectResponse {
     if ($node->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
-    $this->getLogger('myeventlane_event_studio')->notice('Vendor Event Studio entry: route=myeventlane_event_studio.edit studio_selected=1 event_id=@eid uid=@uid', [
+    $this->getLogger('myeventlane_event_studio')->notice('Vendor Event Studio entry: route=myeventlane_event_studio.edit redirect=edit_basic event_id=@eid uid=@uid', [
       '@eid' => (string) $node->id(),
       '@uid' => (string) $this->currentUser()->id(),
     ]);
-    $form = $this->formBuilder()->getForm(EventStudioForm::class, $node);
-    $form['#theme_wrappers'] = [];
-    $form['#theme'] = 'mel_event_studio';
-    $form['#mel_studio_mode'] = 'edit';
-    $form['#attached']['library'] ??= [];
-    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio';
-    return $form;
+    $url = Url::fromRoute('myeventlane_event_studio.edit_basic', ['node' => $node->id()])->setAbsolute();
+    return new RedirectResponse($url->toString());
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPreviewController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPreviewController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Read-only preview step between description and publish.
+ */
+final class EventStudioPreviewController extends ControllerBase {
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function build(NodeInterface $node): array {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    if ((int) $node->getOwnerId() !== (int) $this->currentUser()->id() && !$this->currentUser()->hasPermission('administer nodes')) {
+      throw new NotFoundHttpException();
+    }
+
+    $build = [
+      '#theme' => 'mel_event_studio_wizard_preview',
+      '#node' => $node,
+      '#attached' => [
+        'library' => ['myeventlane_event_studio/mel_event_studio'],
+      ],
+      '#cache' => [
+        'tags' => $node->getCacheTags(),
+        'contexts' => ['user', 'user.permissions'],
+      ],
+    ];
+    return $build;
+  }
+
+  /**
+   * Title callback for preview route.
+   */
+  public function title(NodeInterface $node): string {
+    return (string) $this->t('Preview');
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Shared route-based Event Studio wizard (save + redirect per step).
+ */
+abstract class EventStudioBaseForm extends FormBase {
+
+  public function __construct(
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountProxyInterface $currentUser,
+    protected EventStudioSaveService $saveService,
+    protected EventStudioMelPayloadService $melPayloadService,
+    protected EventStudioWizardMelBaseline $wizardMelBaseline,
+    protected LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('myeventlane_event_studio.save'),
+      $container->get('myeventlane_event_studio.mel_payload'),
+      $container->get('myeventlane_event_studio.wizard_mel_baseline'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+    );
+  }
+
+  /**
+   * Route name for the next step (Continue).
+   */
+  abstract protected function getNextRouteName(): string;
+
+  /**
+   * Route name for the previous step, or NULL on first step.
+   */
+  abstract protected function getPreviousRouteName(): ?string;
+
+  /**
+   * Build step-specific fields under $form['mel'].
+   *
+   * @param array<string, mixed> $melDefaults
+   *   Baseline mel from {@see EventStudioWizardMelBaseline::getBaselineMel()}.
+   */
+  abstract protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void;
+
+  protected function getRouteNode(?NodeInterface $parameter_node = NULL): NodeInterface {
+    if ($parameter_node instanceof NodeInterface) {
+      return $parameter_node;
+    }
+    $node = $this->getRouteMatch()->getParameter('node');
+    return $node instanceof NodeInterface ? $node : throw new NotFoundHttpException();
+  }
+
+  protected function assertVendorEvent(NodeInterface $node): void {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    if ((int) $node->getOwnerId() !== (int) $this->currentUser->id() && !$this->currentUser->hasPermission('administer nodes')) {
+      throw new AccessDeniedHttpException();
+    }
+  }
+
+  /**
+   * Deep-merge wizard mel: submitted keys override baseline (associative only).
+   *
+   * @param array<string, mixed> $base
+   * @param array<string, mixed> $override
+   *
+   * @return array<string, mixed>
+   */
+  protected function mergeMel(array $base, array $override): array {
+    foreach ($override as $k => $v) {
+      if (is_array($v) && isset($base[$k]) && is_array($base[$k]) && $this->isAssociativeArray($v) && $this->isAssociativeArray($base[$k])) {
+        $base[$k] = $this->mergeMel($base[$k], $v);
+      }
+      else {
+        $base[$k] = $v;
+      }
+    }
+    return $base;
+  }
+
+  /**
+   * @param array<mixed> $a
+   */
+  private function isAssociativeArray(array $a): bool {
+    return array_keys($a) !== range(0, count($a) - 1);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    $node = $this->getRouteNode($node);
+    $this->assertVendorEvent($node);
+
+    $form['#attributes']['class'][] = 'mel-event-studio-wizard-form';
+    $form['#attributes']['data-mel-event-studio-wizard'] = '1';
+    $form['#attributes']['data-mel-event-studio-form'] = '1';
+    $form['#tree'] = TRUE;
+
+    $form['nid'] = [
+      '#type' => 'hidden',
+      '#default_value' => (string) (int) $node->id(),
+    ];
+
+    $form['wizard_nav'] = [
+      '#theme' => 'mel_event_studio_wizard_nav',
+      '#node' => $node,
+      '#current_step' => $this->getCurrentStepId(),
+    ];
+
+    $melDefaults = $this->wizardMelBaseline->getBaselineMel($node);
+
+    $form['mel'] = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+      '#attributes' => ['class' => ['mel-event-studio', 'mel-wizard-step-content']],
+    ];
+
+    $this->buildWizardStepContent($form, $form_state, $node, $melDefaults);
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#weight' => 100,
+    ];
+
+    $prev = $this->getPreviousRouteName();
+    if ($prev !== NULL) {
+      $form['actions']['back'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Back'),
+        '#url' => Url::fromRoute($prev, ['node' => $node->id()]),
+        '#attributes' => ['class' => ['button', 'mel-btn']],
+      ];
+    }
+
+    $form['actions']['continue'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Continue'),
+      '#button_type' => 'primary',
+      '#submit' => ['::submitContinue'],
+    ];
+
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio';
+
+    return $form;
+  }
+
+  /**
+   * Machine id for nav highlighting (basic, datetime, tickets, …).
+   */
+  abstract protected function getCurrentStepId(): string;
+
+  /**
+   * Options for a list_string field on the event bundle (empty if unavailable).
+   *
+   * @return array<string, string>
+   */
+  protected function listStringFieldOptions(string $field_name): array {
+    try {
+      $definitions = $this->entityFieldManager->getFieldDefinitions('node', 'event');
+    }
+    catch (\Throwable) {
+      return [];
+    }
+    $def = $definitions[$field_name] ?? NULL;
+    if ($def === NULL || $def->getType() !== 'list_string') {
+      return [];
+    }
+    $allowed = $def->getSetting('allowed_values');
+    if (!is_array($allowed)) {
+      return [];
+    }
+    $out = [];
+    foreach ($allowed as $key => $item) {
+      if (is_array($item) && isset($item['value'])) {
+        $out[(string) $item['value']] = (string) ($item['label'] ?? $item['value']);
+      }
+      elseif (!is_array($item) && !is_int($key)) {
+        $out[(string) $key] = (string) $item;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Primary submit path is {@see submitContinue()} on the Continue button.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {}
+
+  /**
+   * Saves merged mel via EventStudioSaveService and redirects to the next route.
+   */
+  public function submitContinue(array &$form, FormStateInterface $form_state): void {
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid < 1) {
+      return;
+    }
+    $storage = $this->entityTypeManager->getStorage('node');
+    $loaded = $storage->load($nid);
+    if (!$loaded instanceof NodeInterface) {
+      return;
+    }
+    $this->assertVendorEvent($loaded);
+
+    $baseline = $this->wizardMelBaseline->getBaselineMel($loaded);
+    $submitted = $form_state->getValue('mel') ?? [];
+    if (!is_array($submitted)) {
+      $submitted = [];
+    }
+    $merged = $this->mergeMel($baseline, $submitted);
+    $form_state->setValue('mel', $merged);
+
+    $payload = $this->melPayloadService->buildFromFormState($form_state, $this->entityTypeManager);
+    $result = $this->saveService->save($payload, $loaded, $this->currentUser(), TRUE);
+
+    if ($result['errors'] !== []) {
+      foreach ($result['errors'] as $msg) {
+        $this->messenger()->addError($msg);
+      }
+      return;
+    }
+
+    $saved = $result['node'];
+    if (!$saved instanceof NodeInterface) {
+      $this->messenger()->addError($this->t('Could not save the event.'));
+      return;
+    }
+
+    $this->messenger()->addStatus($this->t('Saved.'));
+    $form_state->setRedirect($this->getNextRouteName(), ['node' => $saved->id()]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBasicForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBasicForm.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Wizard step: basic info (title, summary, category, cover).
+ */
+final class EventStudioBasicForm extends EventStudioBaseForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'mel_event_studio_wizard_basic';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.edit_datetime';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'basic';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['mel']['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Event title'),
+      '#default_value' => $melDefaults['title'] ?? $node->label(),
+      '#required' => TRUE,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['summary'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Summary'),
+      '#default_value' => $melDefaults['summary'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_category'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Categories'),
+      '#target_type' => 'taxonomy_term',
+      '#tags' => TRUE,
+      '#selection_handler' => 'default',
+      '#selection_settings' => [
+        'target_bundles' => ['categories' => 'categories'],
+      ],
+      '#default_value' => $melDefaults['field_category'] ?? [],
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_event_image'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('Cover image'),
+      '#upload_location' => 'public://events',
+      '#upload_validators' => [
+        'FileExtension' => ['extensions' => 'png gif jpg jpeg webp'],
+        'FileSizeLimit' => ['fileLimit' => 5 * 1024 * 1024],
+      ],
+      '#default_value' => $melDefaults['field_event_image'] ?? [],
+      '#attributes' => ['class' => ['mel-input-file']],
+    ];
+
+    $form['mel']['field_event_image_alt'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Image alt text'),
+      '#default_value' => $melDefaults['field_event_image_alt'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_location\Service\LocationProviderManager;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Wizard step: date/time + location.
+ */
+final class EventStudioDateForm extends EventStudioBaseForm {
+
+  protected ?LocationProviderManager $locationProvider = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    if ($container->has('myeventlane_location.provider_manager')) {
+      $instance->locationProvider = $container->get('myeventlane_location.provider_manager');
+    }
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'mel_event_studio_wizard_datetime';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.edit_tickets';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPreviousRouteName(): ?string {
+    return 'myeventlane_event_studio.edit_basic';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'datetime';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    if ($this->locationProvider instanceof LocationProviderManager) {
+      $form['#attached']['drupalSettings']['myeventlaneLocation'] = $this->locationProvider->getFrontendSettings();
+    }
+
+    $venue_mode_default = 'one_off';
+    if ($node->hasField('field_venue') && !$node->get('field_venue')->isEmpty()) {
+      $venue_mode_default = 'saved';
+    }
+    $venue_default = $node->hasField('field_venue') && !$node->get('field_venue')->isEmpty()
+      ? $node->get('field_venue')->entity
+      : NULL;
+
+    $location_json_default = $melDefaults['field_location'] ?? '';
+    $lat_default = $melDefaults['field_location_latitude'] ?? '';
+    $lng_default = $melDefaults['field_location_longitude'] ?? '';
+
+    $form['mel']['start_date'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('Start'),
+      '#default_value' => $melDefaults['start_date'] ?? (
+        $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()
+          ? new DrupalDateTime($node->get('field_event_start')->value)
+          : NULL
+      ),
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['end_date'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('End'),
+      '#default_value' => $melDefaults['end_date'] ?? (
+        $node->hasField('field_event_end') && !$node->get('field_event_end')->isEmpty()
+          ? new DrupalDateTime($node->get('field_event_end')->value)
+          : NULL
+      ),
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['venue_mode'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Location'),
+      '#options' => [
+        'saved' => $this->t('Use saved venue'),
+        'create' => $this->t('Create new venue'),
+        'one_off' => $this->t('One-off address'),
+      ],
+      '#default_value' => $form_state->getValue(['mel', 'venue_mode'], $melDefaults['venue_mode'] ?? $venue_mode_default),
+      '#attributes' => ['class' => ['mel-radios']],
+    ];
+
+    $form['mel']['venue_saved'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Search your venues'),
+      '#target_type' => 'myeventlane_venue',
+      '#default_value' => $melDefaults['venue_saved'] ?? $venue_default,
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'saved'],
+        ],
+      ],
+    ];
+
+    $form['mel']['venue_create_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Venue name'),
+      '#default_value' => $melDefaults['venue_create_name'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'create'],
+        ],
+      ],
+    ];
+
+    $form['mel']['location_search'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search address'),
+      '#attributes' => [
+        'class' => ['mel-location-search', 'mel-input'],
+        'data-mel-location' => 'true',
+      ],
+      '#states' => [
+        'visible' => [
+          'or' => [
+            [':input[name="mel[venue_mode]"]' => ['value' => 'one_off']],
+            [':input[name="mel[venue_mode]"]' => ['value' => 'create']],
+          ],
+        ],
+      ],
+    ];
+
+    $form['mel']['field_location'] = [
+      '#type' => 'hidden',
+      '#default_value' => $location_json_default,
+    ];
+
+    $form['mel']['field_location_latitude'] = [
+      '#type' => 'hidden',
+      '#default_value' => $lat_default,
+    ];
+
+    $form['mel']['field_location_longitude'] = [
+      '#type' => 'hidden',
+      '#default_value' => $lng_default,
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Wizard step: description, discovery, and policies.
+ */
+final class EventStudioDescriptionForm extends EventStudioBaseForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'mel_event_studio_wizard_description';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.edit_preview';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPreviousRouteName(): ?string {
+    return 'myeventlane_event_studio.edit_tickets';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'description';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $items_state = '[]';
+    if (isset($melDefaults['event_highlights']) && is_array($melDefaults['event_highlights'])) {
+      $items_state = $melDefaults['event_highlights']['items_state'] ?? '[]';
+    }
+
+    $form['mel']['body'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('About the event'),
+      '#default_value' => $melDefaults['body'] ?? '',
+      '#attributes' => ['class' => ['mel-input', 'mel-input--body']],
+    ];
+
+    $form['mel']['field_event_intro'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('What to expect'),
+      '#default_value' => $melDefaults['field_event_intro'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['event_highlights'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-section--card', 'mel-event-highlights-editor']],
+      'items_state' => [
+        '#type' => 'hidden',
+        '#default_value' => is_string($items_state) ? $items_state : '[]',
+        '#attributes' => [
+          'id' => 'mel-event-highlights-json',
+          'data-mel-highlights-state' => '1',
+        ],
+      ],
+    ];
+
+    $form['mel']['field_tags'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Tags'),
+      '#target_type' => 'taxonomy_term',
+      '#tags' => TRUE,
+      '#selection_handler' => 'default',
+      '#selection_settings' => [
+        'target_bundles' => ['tags' => 'tags'],
+      ],
+      '#default_value' => $melDefaults['field_tags'] ?? [],
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_sales_start'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('Ticket sales start'),
+      '#default_value' => $melDefaults['field_sales_start'] ?? NULL,
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_sales_end'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('Ticket sales end'),
+      '#default_value' => $melDefaults['field_sales_end'] ?? NULL,
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_contact_email'] = [
+      '#type' => 'email',
+      '#title' => $this->t('Contact email'),
+      '#default_value' => $melDefaults['field_contact_email'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_contact_phone'] = [
+      '#type' => 'tel',
+      '#title' => $this->t('Contact phone'),
+      '#default_value' => $melDefaults['field_contact_phone'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_age_policy'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Age policy'),
+      '#options' => $this->listStringFieldOptions('field_age_policy') ?: [
+        'all_ages' => $this->t('All ages'),
+        '18_plus' => $this->t('18+'),
+        '16_plus' => $this->t('16+'),
+        'under_18_with_guardian' => $this->t('Under 18 with guardian'),
+        'custom' => $this->t('Custom'),
+      ],
+      '#default_value' => $melDefaults['field_age_policy'] ?? 'all_ages',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_age_policy_note'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Age policy note'),
+      '#default_value' => $melDefaults['field_age_policy_note'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_age_restriction'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Age suitability'),
+      '#options' => $this->listStringFieldOptions('field_age_restriction'),
+      '#empty_option' => $this->t('- None -'),
+      '#empty_value' => '',
+      '#default_value' => $melDefaults['field_age_restriction'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_refund_policy'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Refund policy'),
+      '#options' => $this->listStringFieldOptions('field_refund_policy'),
+      '#empty_option' => $this->t('- Not specified -'),
+      '#empty_value' => '',
+      '#default_value' => $melDefaults['field_refund_policy'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_accessibility'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Accessibility features'),
+      '#target_type' => 'taxonomy_term',
+      '#tags' => TRUE,
+      '#selection_handler' => 'default',
+      '#selection_settings' => [
+        'target_bundles' => ['accessibility' => 'accessibility'],
+      ],
+      '#default_value' => $melDefaults['field_accessibility'] ?? [],
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_accessibility_contact'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Accessibility contact'),
+      '#default_value' => $melDefaults['field_accessibility_contact'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_accessibility_directions'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Accessible directions'),
+      '#default_value' => $melDefaults['field_accessibility_directions'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_accessibility_entry'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Entry and access'),
+      '#default_value' => $melDefaults['field_accessibility_entry'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_accessibility_parking'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Accessible parking'),
+      '#default_value' => $melDefaults['field_accessibility_parking'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Form;
 
-use Drupal\Component\Utility\Tags;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -17,6 +16,7 @@ use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event\Service\TicketTypeManager;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_location\Service\LocationProviderManager;
 use Drupal\myeventlane_vendor\Ticketing\EventTicketsBuilder;
@@ -55,6 +55,8 @@ final class EventStudioForm extends FormBase {
 
   protected LoggerInterface $logger;
 
+  protected EventStudioMelPayloadService $melPayloadService;
+
   /**
    * {@inheritdoc}
    */
@@ -72,6 +74,7 @@ final class EventStudioForm extends FormBase {
     $instance->eventTicketsBuilder = $container->get('myeventlane_vendor.ticket_builder');
     $instance->ticketTypeManager = $container->get('myeventlane_event.ticket_type_manager');
     $instance->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
+    $instance->melPayloadService = $container->get('myeventlane_event_studio.mel_payload');
     return $instance;
   }
 
@@ -91,7 +94,7 @@ final class EventStudioForm extends FormBase {
    * subclass properties can still be uninitialized on some paths; repull then.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->eventTicketsBuilder, $this->ticketTypeManager, $this->logger)) {
+    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->eventTicketsBuilder, $this->ticketTypeManager, $this->logger, $this->melPayloadService)) {
       return;
     }
     $container = \Drupal::getContainer();
@@ -121,6 +124,9 @@ final class EventStudioForm extends FormBase {
     }
     if (!isset($this->logger)) {
       $this->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
+    }
+    if (!isset($this->melPayloadService)) {
+      $this->melPayloadService = $container->get('myeventlane_event_studio.mel_payload');
     }
   }
 
@@ -1150,7 +1156,7 @@ final class EventStudioForm extends FormBase {
       }
     }
 
-    $payload = $this->buildPayloadFromMel($form_state);
+    $payload = $this->melPayloadService->buildFromFormState($form_state, $this->entityTypeManager);
     $result = $this->saveService->save($payload, $existing, $this->currentUser, FALSE);
     if ($result['errors'] !== []) {
       foreach ($result['errors'] as $msg) {
@@ -1229,37 +1235,6 @@ final class EventStudioForm extends FormBase {
     catch (\JsonException) {
       return '[]';
     }
-  }
-
-  /**
-   * Decodes `mel.event_highlights.items_state` and normalizes via helper.
-   *
-   * @param array<string, mixed> $mel
-   *   Submitted mel form values.
-   *
-   * @return list<array{text: string, icon: string, weight: int}>
-   *   Normalized highlight rows for the save payload.
-   */
-  private function decodeAndNormalizeEventHighlightsFromMel(array $mel): array {
-    if (!isset($mel['event_highlights']['items_state'])) {
-      return [];
-    }
-    $raw = trim((string) $mel['event_highlights']['items_state']);
-    if ($raw === '') {
-      return [];
-    }
-    try {
-      $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
-    }
-    catch (\JsonException) {
-      return [];
-    }
-    if (!is_array($decoded)) {
-      return [];
-    }
-    $allowed = $this->eventHighlightHelper->getAllowedIconKeys();
-
-    return $this->eventHighlightHelper->normalizeHighlights($decoded, $allowed);
   }
 
   private function encodeStudioTiersJsonForEvent(NodeInterface $event): string {
@@ -1363,253 +1338,6 @@ final class EventStudioForm extends FormBase {
       . '<li><span class="mel-ticket-summary__k">' . $this->t('External URL') . '</span> ' . $ext . '</li>'
       . $paid_note
       . '</ul>';
-  }
-
-  /**
-   * Builds the flat save payload from submitted `mel` values only.
-   *
-   * @return array<string, mixed>
-   */
-  private function buildPayloadFromMel(FormStateInterface $form_state): array {
-    $mel = $form_state->getValue('mel');
-    if (!is_array($mel)) {
-      $mel = [];
-    }
-
-    $choice = (string) ($mel['venue_mode'] ?? 'one_off');
-    $venue_id = NULL;
-    if ($choice === 'saved' && !empty($mel['venue_saved'])) {
-      $raw = $mel['venue_saved'];
-      if (is_array($raw) && isset($raw[0]['target_id'])) {
-        $venue_id = (int) $raw[0]['target_id'];
-      }
-      elseif (is_numeric($raw)) {
-        $venue_id = (int) $raw;
-      }
-      elseif (is_string($raw)) {
-        $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($raw);
-        $venue_id = $eid !== NULL ? (int) $eid : NULL;
-      }
-    }
-
-    $new_name = '';
-    if ($choice === 'create') {
-      $new_name = trim((string) ($mel['venue_create_name'] ?? ''));
-    }
-
-    $field_location = $choice === 'saved' ? [] : ($mel['field_location'] ?? '');
-
-    $ticket_type = (string) ($mel['field_event_type'] ?? 'rsvp');
-    $capacity_raw = $mel['rsvp_capacity'] ?? '';
-    $capacity = NULL;
-    if ($ticket_type === 'rsvp') {
-      if ($capacity_raw === '' || $capacity_raw === NULL) {
-        $capacity = NULL;
-      }
-      else {
-        $cap = (int) $capacity_raw;
-        $capacity = $cap > 0 ? $cap : NULL;
-      }
-    }
-
-    $external_url = trim((string) ($mel['external_url'] ?? ''));
-    $collect_per_ticket = !empty($mel['collect_attendee_questions']);
-
-    $image_fids = $mel['field_event_image'] ?? [];
-    $image_fid = 0;
-    if (is_array($image_fids) && $image_fids !== []) {
-      $image_fid = (int) reset($image_fids);
-    }
-
-    $tiers_raw = $mel['studio_ticket_tiers'] ?? '';
-    $studio_ticket_tiers = [];
-    if (is_string($tiers_raw) && $tiers_raw !== '') {
-      try {
-        $decoded = json_decode($tiers_raw, TRUE, 512, JSON_THROW_ON_ERROR);
-        if (is_array($decoded)) {
-          foreach ($decoded as $item) {
-            if (is_array($item)) {
-              $studio_ticket_tiers[] = $this->normalizeStudioTierRow($item);
-            }
-          }
-        }
-      }
-      catch (\JsonException) {
-        $studio_ticket_tiers = [];
-      }
-    }
-
-    $payload = [
-      'title' => $mel['title'] ?? '',
-      'summary' => $mel['summary'] ?? '',
-      'body' => $mel['body'] ?? '',
-      'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? '')),
-      'field_event_image' => $image_fid,
-      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? '')),
-      'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? '')),
-      'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? '')),
-      'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? ''),
-      'field_tags' => $this->extractMultipleEntityIds($mel['field_tags'] ?? ''),
-      'field_accessibility' => $this->extractMultipleEntityIds($mel['field_accessibility'] ?? ''),
-      'field_accessibility_contact' => trim((string) ($mel['field_accessibility_contact'] ?? '')),
-      'field_accessibility_directions' => trim((string) ($mel['field_accessibility_directions'] ?? '')),
-      'field_accessibility_entry' => trim((string) ($mel['field_accessibility_entry'] ?? '')),
-      'field_accessibility_parking' => trim((string) ($mel['field_accessibility_parking'] ?? '')),
-      'field_product_target' => $this->extractSingleEntityId($mel['field_product_target'] ?? NULL),
-      'field_ticket_types' => $this->extractMultipleEntityIds($mel['field_ticket_types'] ?? ''),
-      'studio_ticket_tiers' => $studio_ticket_tiers,
-      'venue_choice' => $choice,
-      'venue_id' => $venue_id,
-      'new_venue_name' => $new_name,
-      'field_location' => $field_location,
-      'field_event_start' => $this->normalizeDatetimeValue($mel['start_date'] ?? NULL),
-      'field_event_end' => $this->normalizeDatetimeValue($mel['end_date'] ?? NULL),
-      'field_sales_start' => $this->normalizeDatetimeValue($mel['field_sales_start'] ?? NULL),
-      'field_sales_end' => $this->normalizeDatetimeValue($mel['field_sales_end'] ?? NULL),
-      'field_age_policy' => trim((string) ($mel['field_age_policy'] ?? 'all_ages')),
-      'field_age_policy_note' => trim((string) ($mel['field_age_policy_note'] ?? '')),
-      'field_age_restriction' => trim((string) ($mel['field_age_restriction'] ?? '')),
-      'field_refund_policy' => trim((string) ($mel['field_refund_policy'] ?? '')),
-      'field_event_type' => $ticket_type,
-      'ticket_type' => $ticket_type,
-      'capacity' => $capacity,
-      'external_url' => $external_url,
-      'collect_per_ticket' => $collect_per_ticket,
-      'collect_attendee_questions' => $collect_per_ticket,
-      'enable_donations' => !empty($mel['enable_donations']),
-      'donation_enabled' => !empty($mel['enable_donations']),
-      'donation_amount' => ($mel['donation_amount'] ?? '') !== '' ? (string) $mel['donation_amount'] : NULL,
-      'donation_options' => trim((string) ($mel['donation_options'] ?? '')),
-      'donation_label' => trim((string) ($mel['donation_label'] ?? 'Support this event')) ?: 'Support this event',
-      'status' => !empty($mel['status']),
-      'field_location_latitude' => $mel['field_location_latitude'] ?? NULL,
-      'field_location_longitude' => $mel['field_location_longitude'] ?? NULL,
-      'event_highlights' => $this->decodeAndNormalizeEventHighlightsFromMel($mel),
-      'event_highlights_items_state' => trim((string) (($mel['event_highlights'] ?? [])['items_state'] ?? '')),
-    ];
-
-    $nid = (int) ($form_state->getValue('nid') ?? 0);
-    if ($nid > 0) {
-      $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
-      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event' && $loaded->hasField('field_ticket_types')) {
-        $payload['field_ticket_types'] = [];
-        foreach ($loaded->get('field_ticket_types')->getValue() as $row) {
-          $tid = (int) ($row['target_id'] ?? 0);
-          if ($tid > 0) {
-            $payload['field_ticket_types'][] = $tid;
-          }
-        }
-      }
-    }
-
-    return $payload;
-  }
-
-  /**
-   * @param array<string, mixed> $row
-   *
-   * @return array<string, mixed>
-   */
-  private function normalizeStudioTierRow(array $row): array {
-    $row['capacity'] = max(1, (int) ($row['capacity'] ?? 0));
-    return $row;
-  }
-
-  /**
-   * @return list<int>
-   */
-  private function extractMultipleEntityIds(mixed $raw): array {
-    if ($raw === NULL || $raw === '') {
-      return [];
-    }
-    if (is_array($raw)) {
-      $ids = [];
-      foreach ($raw as $item) {
-        if (is_array($item) && isset($item['target_id'])) {
-          $tid = (int) $item['target_id'];
-          if ($tid > 0) {
-            $ids[] = $tid;
-          }
-        }
-        elseif (is_numeric($item)) {
-          $tid = (int) $item;
-          if ($tid > 0) {
-            $ids[] = $tid;
-          }
-        }
-        elseif (is_string($item)) {
-          $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($item);
-          if ($eid !== NULL) {
-            $ids[] = (int) $eid;
-          }
-        }
-      }
-      return array_values(array_unique(array_filter($ids)));
-    }
-    if (is_string($raw)) {
-      $ids = [];
-      foreach (Tags::explode($raw) as $part) {
-        $part = trim($part);
-        if ($part === '') {
-          continue;
-        }
-        $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($part);
-        if ($eid !== NULL) {
-          $ids[] = (int) $eid;
-        }
-      }
-      return array_values(array_unique(array_filter($ids)));
-    }
-    return [];
-  }
-
-  private function extractSingleEntityId(mixed $raw): ?int {
-    if ($raw === NULL || $raw === '') {
-      return NULL;
-    }
-    if (is_numeric($raw)) {
-      $id = (int) $raw;
-      return $id > 0 ? $id : NULL;
-    }
-    if (is_string($raw)) {
-      $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($raw);
-      return $eid !== NULL ? (int) $eid : NULL;
-    }
-    if (is_array($raw) && isset($raw[0]['target_id'])) {
-      $id = (int) $raw[0]['target_id'];
-      return $id > 0 ? $id : NULL;
-    }
-    return NULL;
-  }
-
-  private function normalizeDatetimeValue(mixed $value): ?string {
-    if ($value === NULL || $value === '') {
-      return NULL;
-    }
-    if ($value instanceof DrupalDateTime) {
-      return $value->format('Y-m-d\TH:i:s');
-    }
-    if (is_array($value) && isset($value['object']) && $value['object'] instanceof DrupalDateTime) {
-      return $value['object']->format('Y-m-d\TH:i:s');
-    }
-    if (is_array($value)) {
-      $date = trim((string) ($value['date'] ?? ''));
-      $time = trim((string) ($value['time'] ?? ''));
-      if ($date === '') {
-        return NULL;
-      }
-      if ($time === '') {
-        $time = '00:00:00';
-      }
-      try {
-        $dt = new DrupalDateTime($date . 'T' . $time);
-        return $dt->format('Y-m-d\TH:i:s');
-      }
-      catch (\Throwable) {
-        return NULL;
-      }
-    }
-    return is_string($value) ? $value : NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event\Service\TicketTypeManager;
+use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
@@ -57,6 +58,8 @@ final class EventStudioForm extends FormBase {
 
   protected EventStudioMelPayloadService $melPayloadService;
 
+  protected EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer;
+
   /**
    * {@inheritdoc}
    */
@@ -75,6 +78,7 @@ final class EventStudioForm extends FormBase {
     $instance->ticketTypeManager = $container->get('myeventlane_event.ticket_type_manager');
     $instance->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
     $instance->melPayloadService = $container->get('myeventlane_event_studio.mel_payload');
+    $instance->entityAutocompleteMelNormalizer = $container->get('myeventlane_event_studio.entity_autocomplete_mel_normalizer');
     return $instance;
   }
 
@@ -94,7 +98,7 @@ final class EventStudioForm extends FormBase {
    * subclass properties can still be uninitialized on some paths; repull then.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->eventTicketsBuilder, $this->ticketTypeManager, $this->logger, $this->melPayloadService)) {
+    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->eventTicketsBuilder, $this->ticketTypeManager, $this->logger, $this->melPayloadService, $this->entityAutocompleteMelNormalizer)) {
       return;
     }
     $container = \Drupal::getContainer();
@@ -127,6 +131,9 @@ final class EventStudioForm extends FormBase {
     }
     if (!isset($this->melPayloadService)) {
       $this->melPayloadService = $container->get('myeventlane_event_studio.mel_payload');
+    }
+    if (!isset($this->entityAutocompleteMelNormalizer)) {
+      $this->entityAutocompleteMelNormalizer = $container->get('myeventlane_event_studio.entity_autocomplete_mel_normalizer');
     }
   }
 
@@ -386,6 +393,13 @@ final class EventStudioForm extends FormBase {
       && $event->get('field_product_target')->isEmpty()) {
       $needs_ticket_product = TRUE;
     }
+
+    $venue_default = $this->entityAutocompleteMelNormalizer->normalizeSingle($venue_default, 'myeventlane_venue', 'mel.venue_saved');
+    $product_default = $this->entityAutocompleteMelNormalizer->normalizeSingle($product_default, 'commerce_product', 'mel.field_product_target');
+    $ticket_types_default = $this->entityAutocompleteMelNormalizer->normalizeTags($ticket_types_default, 'mel_ticket_type', 'mel.field_ticket_types');
+    $category_default = $this->entityAutocompleteMelNormalizer->normalizeTags($category_default, 'taxonomy_term', 'mel.field_category');
+    $tags_default = $this->entityAutocompleteMelNormalizer->normalizeTags($tags_default, 'taxonomy_term', 'mel.field_tags');
+    $field_accessibility_default = $this->entityAutocompleteMelNormalizer->normalizeTags($field_accessibility_default, 'taxonomy_term', 'mel.field_accessibility');
 
     $studio_tiers_json = $this->encodeStudioTiersJsonForEvent($event);
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Wizard step: publishing (live / draft).
+ */
+final class EventStudioPublishForm extends EventStudioBaseForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'mel_event_studio_wizard_publish';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'entity.node.canonical';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPreviousRouteName(): ?string {
+    return 'myeventlane_event_studio.edit_preview';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'publish';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['mel']['status'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Published'),
+      '#default_value' => !empty($melDefaults['status']),
+      '#attributes' => ['class' => ['mel-checkbox-publish']],
+    ];
+
+    $form['actions']['continue']['#value'] = $this->t('Save and view event');
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Final step: non-draft save so publish flag persists as in full Event Studio.
+   */
+  public function submitContinue(array &$form, FormStateInterface $form_state): void {
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid < 1) {
+      return;
+    }
+    $storage = $this->entityTypeManager->getStorage('node');
+    $loaded = $storage->load($nid);
+    if (!$loaded instanceof NodeInterface) {
+      return;
+    }
+    $this->assertVendorEvent($loaded);
+
+    $baseline = $this->wizardMelBaseline->getBaselineMel($loaded);
+    $submitted = $form_state->getValue('mel') ?? [];
+    if (!is_array($submitted)) {
+      $submitted = [];
+    }
+    $merged = $this->mergeMel($baseline, $submitted);
+    $form_state->setValue('mel', $merged);
+
+    $payload = $this->melPayloadService->buildFromFormState($form_state, $this->entityTypeManager);
+    $result = $this->saveService->save($payload, $loaded, $this->currentUser(), FALSE);
+
+    if ($result['errors'] !== []) {
+      foreach ($result['errors'] as $msg) {
+        $this->messenger()->addError($msg);
+      }
+      return;
+    }
+
+    $saved = $result['node'];
+    if (!$saved instanceof NodeInterface) {
+      $this->messenger()->addError($this->t('Could not save the event.'));
+      return;
+    }
+
+    $this->messenger()->addStatus($this->t('Event saved.'));
+    $form_state->setRedirectUrl(Url::fromRoute('entity.node.canonical', ['node' => $saved->id()]));
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_vendor\Ticketing\EventTicketsBuilder;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Wizard step: tickets — reuses EventTicketsBuilder (same as Event Studio).
+ */
+final class EventStudioTicketsForm extends EventStudioBaseForm {
+
+  protected EventTicketsBuilder $eventTicketsBuilder;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->eventTicketsBuilder = $container->get('myeventlane_vendor.ticket_builder');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'mel_event_studio_wizard_tickets';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.edit_description';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPreviousRouteName(): ?string {
+    return 'myeventlane_event_studio.edit_datetime';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'tickets';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form_state->set('event', $node);
+    $form_state->set('studio_node', $node);
+
+    $form['mel']['tickets_intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('How will people join?'),
+      '#attributes' => ['class' => ['mel-tickets-intro']],
+    ];
+
+    $form['mel']['field_event_type'] = [
+      '#type' => 'radios',
+      '#title' => '',
+      '#options' => [
+        'rsvp' => $this->t('Free RSVP'),
+        'paid' => $this->t('Paid tickets'),
+        'external' => $this->t('External link'),
+      ],
+      '#default_value' => $melDefaults['field_event_type'] ?? 'rsvp',
+      '#attributes' => ['class' => ['mel-radios', 'mel-radios--tickets']],
+    ];
+
+    $form['mel']['studio_ticket_tiers'] = [
+      '#type' => 'hidden',
+      '#default_value' => $melDefaults['studio_ticket_tiers'] ?? '[]',
+      '#attributes' => [
+        'id' => 'mel-studio-ticket-tiers-json',
+        'data-mel-studio-ticket-tiers' => '1',
+      ],
+    ];
+
+    $form_state->set('mel_ticket_builder_value_prefix', ['mel', 'embedded_ticket_wizard']);
+    $form['mel']['embedded_ticket_wizard'] = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+      '#attributes' => ['class' => ['mel-ticket-wizard-embed']],
+    ];
+    $this->eventTicketsBuilder->build($form['mel']['embedded_ticket_wizard'], $form_state, $node);
+
+    $form['mel']['rsvp_capacity'] = [
+      '#type' => 'number',
+      '#title' => $this->t('RSVP capacity'),
+      '#min' => 0,
+      '#default_value' => $melDefaults['rsvp_capacity'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[field_event_type]"]' => ['value' => 'rsvp'],
+        ],
+      ],
+    ];
+
+    $form['mel']['field_product_target'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Ticket product'),
+      '#target_type' => 'commerce_product',
+      '#selection_handler' => 'default',
+      '#selection_settings' => [
+        'target_bundles' => ['ticket' => 'ticket'],
+      ],
+      '#default_value' => $melDefaults['field_product_target'] ?? NULL,
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[field_event_type]"]' => ['value' => 'paid'],
+        ],
+      ],
+    ];
+
+    $form['mel']['external_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Booking or registration URL'),
+      '#default_value' => $melDefaults['external_url'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[field_event_type]"]' => ['value' => 'external'],
+        ],
+      ],
+    ];
+
+    $form['mel']['collect_attendee_questions'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Collect extra attendee details'),
+      '#default_value' => !empty($melDefaults['collect_attendee_questions']),
+    ];
+
+    $form['#attached']['library'][] = 'myeventlane_vendor/ticket_cards';
+    $form['#attached']['library'][] = 'core/drupal.ajax';
+  }
+
+  /**
+   * Ticket builder AJAX actions (same contract as EventStudioForm).
+   */
+  public function handleAction(array &$form, FormStateInterface $form_state): void {
+    $event = $form_state->get('studio_node');
+    if (!$event instanceof NodeInterface) {
+      return;
+    }
+    $this->eventTicketsBuilder->handleAction($form, $form_state, $event);
+    $nid = (int) $event->id();
+    if ($nid > 0) {
+      $fresh = $this->entityTypeManager->getStorage('node')->load($nid);
+      if ($fresh instanceof NodeInterface) {
+        $form_state->set('studio_node', $fresh);
+        $form_state->set('event', $fresh);
+      }
+    }
+  }
+
+  /**
+   * AJAX replace target for the embedded ticket builder shell.
+   */
+  public function ajaxRebuildTicketBuilder(array &$form, FormStateInterface $form_state): array {
+    return $form['mel']['embedded_ticket_wizard']['builder_shell'] ?? [];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EntityAutocompleteMelNormalizer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EntityAutocompleteMelNormalizer.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Ensures entity_autocomplete #default_value matches what core expects (entities only).
+ *
+ * Dev databases can hold orphaned references or odd state; staging may not. Normalizing
+ * avoids InvalidArgumentException in EntityAutocomplete::valueCallback().
+ */
+final class EntityAutocompleteMelNormalizer {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  public function normalizeSingle(mixed $value, string $entity_type_id, string $context_key): ?EntityInterface {
+    if ($value === NULL || $value === '') {
+      return NULL;
+    }
+    if ($value instanceof EntityInterface) {
+      if ($value->getEntityTypeId() === $entity_type_id) {
+        return $value;
+      }
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return NULL;
+    }
+    if (is_numeric($value)) {
+      $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $value);
+      if ($entity instanceof EntityInterface) {
+        return $entity;
+      }
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return NULL;
+    }
+    $this->logDiscard($context_key, $entity_type_id, $value);
+    return NULL;
+  }
+
+  /**
+   * @return array<int, EntityInterface>
+   */
+  public function normalizeTags(mixed $value, string $entity_type_id, string $context_key): array {
+    if ($value === NULL || $value === []) {
+      return [];
+    }
+    if ($value instanceof EntityInterface) {
+      if ($value->getEntityTypeId() === $entity_type_id) {
+        return [$value];
+      }
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return [];
+    }
+    if (!is_array($value)) {
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return [];
+    }
+    $out = [];
+    $dropped = 0;
+    foreach ($value as $item) {
+      if ($item instanceof EntityInterface && $item->getEntityTypeId() === $entity_type_id) {
+        $out[] = $item;
+        continue;
+      }
+      if (is_numeric($item)) {
+        $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $item);
+        if ($entity instanceof EntityInterface) {
+          $out[] = $entity;
+        }
+        else {
+          $dropped++;
+        }
+        continue;
+      }
+      if ($item !== NULL && $item !== '') {
+        $dropped++;
+      }
+    }
+    if ($dropped > 0) {
+      $this->logger->warning('Dropped @count invalid tag default value(s) for @key (entity type @type).', [
+        '@count' => (string) $dropped,
+        '@key' => $context_key,
+        '@type' => $entity_type_id,
+      ]);
+    }
+    return $out;
+  }
+
+  private function logDiscard(string $context_key, string $entity_type_id, mixed $value): void {
+    $info = is_object($value) ? get_debug_type($value) : gettype($value);
+    $this->logger->warning('Discarded invalid entity_autocomplete default for @key (expected entity type @type): @info', [
+      '@key' => $context_key,
+      '@type' => $entity_type_id,
+      '@info' => $info,
+    ]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Component\Utility\Tags;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds the flat save payload from submitted `mel` values (shared with Event Studio + wizard).
+ */
+final class EventStudioMelPayloadService {
+
+  public function __construct(
+    private readonly EventHighlightHelper $eventHighlightHelper,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildFromFormState(FormStateInterface $form_state, EntityTypeManagerInterface $entityTypeManager): array {
+    $mel = $form_state->getValue('mel');
+    if (!is_array($mel)) {
+      $mel = [];
+    }
+
+    $choice = (string) ($mel['venue_mode'] ?? 'one_off');
+    $venue_id = NULL;
+    if ($choice === 'saved' && !empty($mel['venue_saved'])) {
+      $raw = $mel['venue_saved'];
+      if (is_array($raw) && isset($raw[0]['target_id'])) {
+        $venue_id = (int) $raw[0]['target_id'];
+      }
+      elseif (is_numeric($raw)) {
+        $venue_id = (int) $raw;
+      }
+      elseif (is_string($raw)) {
+        $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($raw);
+        $venue_id = $eid !== NULL ? (int) $eid : NULL;
+      }
+    }
+
+    $new_name = '';
+    if ($choice === 'create') {
+      $new_name = trim((string) ($mel['venue_create_name'] ?? ''));
+    }
+
+    $field_location = $choice === 'saved' ? [] : ($mel['field_location'] ?? '');
+
+    $ticket_type = (string) ($mel['field_event_type'] ?? 'rsvp');
+    $capacity_raw = $mel['rsvp_capacity'] ?? '';
+    $capacity = NULL;
+    if ($ticket_type === 'rsvp') {
+      if ($capacity_raw === '' || $capacity_raw === NULL) {
+        $capacity = NULL;
+      }
+      else {
+        $cap = (int) $capacity_raw;
+        $capacity = $cap > 0 ? $cap : NULL;
+      }
+    }
+
+    $external_url = trim((string) ($mel['external_url'] ?? ''));
+    $collect_per_ticket = !empty($mel['collect_attendee_questions']);
+
+    $image_fids = $mel['field_event_image'] ?? [];
+    $image_fid = 0;
+    if (is_array($image_fids) && $image_fids !== []) {
+      $image_fid = (int) reset($image_fids);
+    }
+
+    $tiers_raw = $mel['studio_ticket_tiers'] ?? '';
+    $studio_ticket_tiers = [];
+    if (is_string($tiers_raw) && $tiers_raw !== '') {
+      try {
+        $decoded = json_decode($tiers_raw, TRUE, 512, JSON_THROW_ON_ERROR);
+        if (is_array($decoded)) {
+          foreach ($decoded as $item) {
+            if (is_array($item)) {
+              $studio_ticket_tiers[] = $this->normalizeStudioTierRow($item);
+            }
+          }
+        }
+      }
+      catch (\JsonException) {
+        $studio_ticket_tiers = [];
+      }
+    }
+
+    $payload = [
+      'title' => $mel['title'] ?? '',
+      'summary' => $mel['summary'] ?? '',
+      'body' => $mel['body'] ?? '',
+      'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? '')),
+      'field_event_image' => $image_fid,
+      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? '')),
+      'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? '')),
+      'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? '')),
+      'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? ''),
+      'field_tags' => $this->extractMultipleEntityIds($mel['field_tags'] ?? ''),
+      'field_accessibility' => $this->extractMultipleEntityIds($mel['field_accessibility'] ?? ''),
+      'field_accessibility_contact' => trim((string) ($mel['field_accessibility_contact'] ?? '')),
+      'field_accessibility_directions' => trim((string) ($mel['field_accessibility_directions'] ?? '')),
+      'field_accessibility_entry' => trim((string) ($mel['field_accessibility_entry'] ?? '')),
+      'field_accessibility_parking' => trim((string) ($mel['field_accessibility_parking'] ?? '')),
+      'field_product_target' => $this->extractSingleEntityId($mel['field_product_target'] ?? NULL),
+      'field_ticket_types' => $this->extractMultipleEntityIds($mel['field_ticket_types'] ?? ''),
+      'studio_ticket_tiers' => $studio_ticket_tiers,
+      'venue_choice' => $choice,
+      'venue_id' => $venue_id,
+      'new_venue_name' => $new_name,
+      'field_location' => $field_location,
+      'field_event_start' => $this->normalizeDatetimeValue($mel['start_date'] ?? NULL),
+      'field_event_end' => $this->normalizeDatetimeValue($mel['end_date'] ?? NULL),
+      'field_sales_start' => $this->normalizeDatetimeValue($mel['field_sales_start'] ?? NULL),
+      'field_sales_end' => $this->normalizeDatetimeValue($mel['field_sales_end'] ?? NULL),
+      'field_age_policy' => trim((string) ($mel['field_age_policy'] ?? 'all_ages')),
+      'field_age_policy_note' => trim((string) ($mel['field_age_policy_note'] ?? '')),
+      'field_age_restriction' => trim((string) ($mel['field_age_restriction'] ?? '')),
+      'field_refund_policy' => trim((string) ($mel['field_refund_policy'] ?? '')),
+      'field_event_type' => $ticket_type,
+      'ticket_type' => $ticket_type,
+      'capacity' => $capacity,
+      'external_url' => $external_url,
+      'collect_per_ticket' => $collect_per_ticket,
+      'collect_attendee_questions' => $collect_per_ticket,
+      'enable_donations' => !empty($mel['enable_donations']),
+      'donation_enabled' => !empty($mel['enable_donations']),
+      'donation_amount' => ($mel['donation_amount'] ?? '') !== '' ? (string) $mel['donation_amount'] : NULL,
+      'donation_options' => trim((string) ($mel['donation_options'] ?? '')),
+      'donation_label' => trim((string) ($mel['donation_label'] ?? 'Support this event')) ?: 'Support this event',
+      'status' => !empty($mel['status']),
+      'field_location_latitude' => $mel['field_location_latitude'] ?? NULL,
+      'field_location_longitude' => $mel['field_location_longitude'] ?? NULL,
+      'event_highlights' => $this->decodeAndNormalizeEventHighlightsFromMel($mel),
+      'event_highlights_items_state' => trim((string) (($mel['event_highlights'] ?? [])['items_state'] ?? '')),
+    ];
+
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid > 0) {
+      $loaded = $entityTypeManager->getStorage('node')->load($nid);
+      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event' && $loaded->hasField('field_ticket_types')) {
+        $payload['field_ticket_types'] = [];
+        foreach ($loaded->get('field_ticket_types')->getValue() as $row) {
+          $tid = (int) ($row['target_id'] ?? 0);
+          if ($tid > 0) {
+            $payload['field_ticket_types'][] = $tid;
+          }
+        }
+      }
+    }
+
+    return $payload;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   *
+   * @return array<string, mixed>
+   */
+  private function normalizeStudioTierRow(array $row): array {
+    $row['capacity'] = max(1, (int) ($row['capacity'] ?? 0));
+    return $row;
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function extractMultipleEntityIds(mixed $raw): array {
+    if ($raw === NULL || $raw === '') {
+      return [];
+    }
+    if (is_array($raw)) {
+      $ids = [];
+      foreach ($raw as $item) {
+        if (is_array($item) && isset($item['target_id'])) {
+          $tid = (int) $item['target_id'];
+          if ($tid > 0) {
+            $ids[] = $tid;
+          }
+        }
+        elseif (is_numeric($item)) {
+          $tid = (int) $item;
+          if ($tid > 0) {
+            $ids[] = $tid;
+          }
+        }
+        elseif (is_string($item)) {
+          $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($item);
+          if ($eid !== NULL) {
+            $ids[] = (int) $eid;
+          }
+        }
+      }
+      return array_values(array_unique(array_filter($ids)));
+    }
+    if (is_string($raw)) {
+      $ids = [];
+      foreach (Tags::explode($raw) as $part) {
+        $part = trim($part);
+        if ($part === '') {
+          continue;
+        }
+        $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($part);
+        if ($eid !== NULL) {
+          $ids[] = (int) $eid;
+        }
+      }
+      return array_values(array_unique(array_filter($ids)));
+    }
+    return [];
+  }
+
+  private function extractSingleEntityId(mixed $raw): ?int {
+    if ($raw === NULL || $raw === '') {
+      return NULL;
+    }
+    if (is_numeric($raw)) {
+      $id = (int) $raw;
+      return $id > 0 ? $id : NULL;
+    }
+    if (is_string($raw)) {
+      $eid = EntityAutocomplete::extractEntityIdFromAutocompleteInput($raw);
+      return $eid !== NULL ? (int) $eid : NULL;
+    }
+    if (is_array($raw) && isset($raw[0]['target_id'])) {
+      $id = (int) $raw[0]['target_id'];
+      return $id > 0 ? $id : NULL;
+    }
+    return NULL;
+  }
+
+  private function normalizeDatetimeValue(mixed $value): ?string {
+    if ($value === NULL || $value === '') {
+      return NULL;
+    }
+    if ($value instanceof DrupalDateTime) {
+      return $value->format('Y-m-d\TH:i:s');
+    }
+    if (is_array($value) && isset($value['object']) && $value['object'] instanceof DrupalDateTime) {
+      return $value['object']->format('Y-m-d\TH:i:s');
+    }
+    if (is_array($value)) {
+      $date = trim((string) ($value['date'] ?? ''));
+      $time = trim((string) ($value['time'] ?? ''));
+      if ($date === '') {
+        return NULL;
+      }
+      if ($time === '') {
+        $time = '00:00:00';
+      }
+      try {
+        $dt = new DrupalDateTime($date . 'T' . $time);
+        return $dt->format('Y-m-d\TH:i:s');
+      }
+      catch (\Throwable) {
+        return NULL;
+      }
+    }
+    return is_string($value) ? $value : NULL;
+  }
+
+  /**
+   * @param array<string, mixed> $mel
+   *
+   * @return list<array{text: string, icon: string, weight: int}>
+   */
+  private function decodeAndNormalizeEventHighlightsFromMel(array $mel): array {
+    if (!isset($mel['event_highlights']['items_state'])) {
+      return [];
+    }
+    $raw = trim((string) $mel['event_highlights']['items_state']);
+    if ($raw === '') {
+      return [];
+    }
+    try {
+      $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException) {
+      return [];
+    }
+    if (!is_array($decoded)) {
+      return [];
+    }
+    $allowed = $this->eventHighlightHelper->getAllowedIconKeys();
+
+    return $this->eventHighlightHelper->normalizeHighlights($decoded, $allowed);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
@@ -16,6 +16,7 @@ final class EventStudioWizardMelBaseline {
 
   public function __construct(
     private readonly FormBuilderInterface $formBuilder,
+    private readonly EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer,
   ) {}
 
   /**
@@ -28,7 +29,12 @@ final class EventStudioWizardMelBaseline {
       return [];
     }
 
-    return $this->extractDefaultsRecursive($mel);
+    $baseline = $this->extractDefaultsRecursive($mel);
+    if (!is_array($baseline)) {
+      return [];
+    }
+
+    return $this->normalizeBaselineMel($baseline);
   }
 
   /**
@@ -53,6 +59,39 @@ final class EventStudioWizardMelBaseline {
       $out[$key] = $this->extractDefaultsRecursive($child);
     }
     return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $mel
+   *
+   * @return array<string, mixed>
+   */
+  private function normalizeBaselineMel(array $mel): array {
+    $single = [
+      'venue_saved' => 'myeventlane_venue',
+      'field_product_target' => 'commerce_product',
+    ];
+    foreach ($single as $key => $entity_type_id) {
+      if (!array_key_exists($key, $mel)) {
+        continue;
+      }
+      $mel[$key] = $this->entityAutocompleteMelNormalizer->normalizeSingle($mel[$key], $entity_type_id, 'mel.' . $key);
+    }
+
+    $tags = [
+      'field_ticket_types' => 'mel_ticket_type',
+      'field_category' => 'taxonomy_term',
+      'field_tags' => 'taxonomy_term',
+      'field_accessibility' => 'taxonomy_term',
+    ];
+    foreach ($tags as $key => $entity_type_id) {
+      if (!array_key_exists($key, $mel)) {
+        continue;
+      }
+      $mel[$key] = $this->entityAutocompleteMelNormalizer->normalizeTags($mel[$key], $entity_type_id, 'mel.' . $key);
+    }
+
+    return $mel;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Render\Element;
+use Drupal\myeventlane_event_studio\Form\EventStudioForm;
+use Drupal\node\NodeInterface;
+
+/**
+ * Derives default `mel` values from the canonical Event Studio form (single source of truth).
+ */
+final class EventStudioWizardMelBaseline {
+
+  public function __construct(
+    private readonly FormBuilderInterface $formBuilder,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function getBaselineMel(NodeInterface $node): array {
+    $form = $this->formBuilder->getForm(EventStudioForm::class, $node);
+    $mel = $form['mel'] ?? [];
+    if (!is_array($mel)) {
+      return [];
+    }
+
+    return $this->extractDefaultsRecursive($mel);
+  }
+
+  /**
+   * @param array<string, mixed> $element
+   *
+   * @return mixed
+   */
+  private function extractDefaultsRecursive(array $element): mixed {
+    if (array_key_exists('#default_value', $element)) {
+      return $element['#default_value'];
+    }
+    $children = Element::children($element);
+    if ($children === []) {
+      return NULL;
+    }
+    $out = [];
+    foreach ($children as $key) {
+      $child = $element[$key];
+      if (!is_array($child)) {
+        continue;
+      }
+      $out[$key] = $this->extractDefaultsRecursive($child);
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-nav.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-nav.html.twig
@@ -1,34 +1,31 @@
 {#
 /**
  * @file
- * Event Studio — horizontal overview navigation (vendor edit flow).
+ * Event Studio — left sidebar step navigation (anchors + mel-event-studio.js scroll-spy).
  *
- * Wired by mel-event-studio.js: data-mel-overview values drive step jumps and scroll.
- * Not the legacy Form API wizard; Studio-specific classes only.
+ * Keeps #mel-wizard-nav and a.mel-nav-link for initMelWizard() / setWizardNavActive().
  */
 #}
-<nav class="mel-event-studio-nav" id="mel-event-studio-nav" aria-label="{{ 'Event overview'|t }}">
+<nav class="mel-sidebar-nav mel-event-studio-nav mel-studio-nav mel-wizard-nav" id="mel-wizard-nav" aria-label="{{ 'Event overview'|t }}">
   <p class="mel-event-studio-nav__label">{{ 'Overview'|t }}</p>
-  <div class="mel-event-studio-nav__scroll">
-    <div class="mel-event-studio-nav__track" role="tablist">
-      <button type="button" class="mel-event-studio-nav__item" data-mel-overview="basic" data-mel-step-index="0" role="tab" aria-selected="true">
-        {{ 'Basic info'|t }}
-      </button>
-      <button type="button" class="mel-event-studio-nav__item" data-mel-overview="date_location" data-mel-step-index="1" role="tab" aria-selected="false">
-        {{ 'Date & Location'|t }}
-      </button>
-      <button type="button" class="mel-event-studio-nav__item" data-mel-overview="tickets" data-mel-step-index="3" role="tab" aria-selected="false">
-        {{ 'Tickets / RSVP'|t }}
-      </button>
-      <button type="button" class="mel-event-studio-nav__item" data-mel-overview="description" role="tab" aria-selected="false">
-        {{ 'Description'|t }}
-      </button>
-      <button type="button" class="mel-event-studio-nav__item" data-mel-overview="preview" role="tab" aria-selected="false">
-        {{ 'Preview'|t }}
-      </button>
-      <button type="button" class="mel-event-studio-nav__item mel-event-studio-nav__item--publish" data-mel-overview="publish" data-mel-step-index="4" role="tab" aria-selected="false">
-        {{ 'Publish'|t }}
-      </button>
-    </div>
-  </div>
+  <ul class="mel-sidebar-nav__list">
+    <li>
+      <a href="#mel-step-basic" class="mel-nav-item mel-nav-link mel-event-studio-nav__item is-active active" data-step="basic" role="tab" aria-selected="true">{{ 'Basic info'|t }}</a>
+    </li>
+    <li>
+      <a href="#mel-step-datetime" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="datetime" role="tab" aria-selected="false">{{ 'Date & Location'|t }}</a>
+    </li>
+    <li>
+      <a href="#mel-step-tickets" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="tickets" role="tab" aria-selected="false">{{ 'Tickets / RSVP'|t }}</a>
+    </li>
+    <li>
+      <a href="#mel-step-description" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="description" role="tab" aria-selected="false">{{ 'Description'|t }}</a>
+    </li>
+    <li>
+      <a href="#mel-step-preview" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="preview" role="tab" aria-selected="false">{{ 'Preview'|t }}</a>
+    </li>
+    <li>
+      <a href="#mel-step-publish" class="mel-nav-item mel-nav-link mel-event-studio-nav__item mel-event-studio-nav__item--publish" data-step="publish" role="tab" aria-selected="false">{{ 'Publish'|t }}</a>
+    </li>
+  </ul>
 </nav>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Horizontal step navigation for route-based Event Studio wizard.
+ */
+#}
+{% if node %}
+  <nav class="mel-nav mel-wizard-nav mel-event-studio-wizard-nav" aria-label="{{ 'Event steps'|t }}">
+    <a href="{{ path('myeventlane_event_studio.edit_basic', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'basic' %} is-active{% endif %}">{{ 'Basic'|t }}</a>
+    <a href="{{ path('myeventlane_event_studio.edit_datetime', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'datetime' %} is-active{% endif %}">{{ 'Date & location'|t }}</a>
+    <a href="{{ path('myeventlane_event_studio.edit_tickets', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'tickets' %} is-active{% endif %}">{{ 'Tickets'|t }}</a>
+    <a href="{{ path('myeventlane_event_studio.edit_description', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'description' %} is-active{% endif %}">{{ 'Description'|t }}</a>
+    <a href="{{ path('myeventlane_event_studio.edit_preview', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'preview' %} is-active{% endif %}">{{ 'Preview'|t }}</a>
+    <a href="{{ path('myeventlane_event_studio.edit_publish', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'publish' %} is-active{% endif %}">{{ 'Publish'|t }}</a>
+  </nav>
+{% endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-preview.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Preview step — read-only; continue via link to publish step.
+ */
+#}
+<div class="mel-event-studio-wizard-preview">
+  {{ include('@myeventlane_event_studio/mel-event-studio-wizard-nav.html.twig', { node: node, current_step: 'preview' }) }}
+
+  <div class="mel-wizard-preview-card">
+    <h2 class="mel-wizard-preview-card__title">{{ node.label }}</h2>
+    <p class="mel-wizard-preview-card__hint">{{ 'Review your event on the public page, or continue to publishing options.'|t }}</p>
+    <p>
+      <a href="{{ url('entity.node.canonical', {'node': node.id}) }}" class="button button--primary" target="_blank" rel="noopener noreferrer">{{ 'View public page'|t }}</a>
+    </p>
+    <p>
+      <a href="{{ path('myeventlane_event_studio.edit_publish', {'node': node.id}) }}" class="button">{{ 'Continue to publish'|t }}</a>
+    </p>
+    <p>
+      <a href="{{ path('myeventlane_event_studio.edit_description', {'node': node.id}) }}">{{ 'Back'|t }}</a>
+    </p>
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -133,7 +133,7 @@
 
     {# FORM ZONE — wizard + actions (single root <form> above; not a nested form). #}
     <div class="mel-studio-form-wrapper mel-event-studio__form-full mel-studio-main-full">
-      <div class="mel-wizard mel-studio--scroll-all">
+      <div class="mel-wizard">
         {# —— Basic —— #}
         <section id="mel-step-basic" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="basic" role="tabpanel" aria-labelledby="mel-basic-heading">
           <section class="mel-section mel-section--card mel-section--builder mel-section--basic" aria-labelledby="mel-basic-heading">

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -116,20 +116,12 @@
       </div>
     </div>
 
-    {# Overview navigation — anchor targets + data-step for scroll-spy (mel-event-studio.js). #}
-    <nav class="mel-event-studio-nav mel-studio-nav mel-wizard-nav" id="mel-wizard-nav" aria-label="{{ 'Event overview'|t }}">
-      <p class="mel-event-studio-nav__label">{{ 'Overview'|t }}</p>
-      <div class="mel-event-studio-nav__scroll">
-        <div class="mel-event-studio-nav__track" role="tablist">
-          <a href="#mel-step-basic" class="mel-nav-link mel-event-studio-nav__item is-active active" data-step="basic" role="tab" aria-selected="true">{{ 'Basic info'|t }}</a>
-          <a href="#mel-step-datetime" class="mel-nav-link mel-event-studio-nav__item" data-step="datetime" role="tab" aria-selected="false">{{ 'Date & Location'|t }}</a>
-          <a href="#mel-step-tickets" class="mel-nav-link mel-event-studio-nav__item" data-step="tickets" role="tab" aria-selected="false">{{ 'Tickets / RSVP'|t }}</a>
-          <a href="#mel-step-description" class="mel-nav-link mel-event-studio-nav__item" data-step="description" role="tab" aria-selected="false">{{ 'Description'|t }}</a>
-          <a href="#mel-step-preview" class="mel-nav-link mel-event-studio-nav__item" data-step="preview" role="tab" aria-selected="false">{{ 'Preview'|t }}</a>
-          <a href="#mel-step-publish" class="mel-nav-link mel-event-studio-nav__item mel-event-studio-nav__item--publish" data-step="publish" role="tab" aria-selected="false">{{ 'Publish'|t }}</a>
-        </div>
-      </div>
-    </nav>
+    {# Two-column shell: sticky sidebar nav + main form (mel-event-studio.js uses #mel-wizard-nav a.mel-nav-link). #}
+    <div class="mel-studio-layout">
+      <aside class="mel-studio-sidebar" aria-label="{{ 'Event steps'|t }}">
+        {% include '@myeventlane_event_studio/mel-event-studio-nav.html.twig' %}
+      </aside>
+      <main class="mel-studio-content">
 
     {# FORM ZONE — wizard + actions (single root <form> above; not a nested form). #}
     <div class="mel-studio-form-wrapper mel-event-studio__form-full mel-studio-main-full">
@@ -242,6 +234,7 @@
               <p class="mel-section__hint">{{ 'Set how people join. For saved events, use the full ticket builder for the same controls as the legacy wizard.'|t }}</p>
             </header>
 
+            <div class="mel-ticket-section">
             {{ element.mel.tickets_intro }}
             {{ element.mel.field_event_type }}
             {{ element.mel.studio_ticket_tiers }}
@@ -270,6 +263,7 @@
             <div class="mel-form-grid">
               {{ element.mel.field_sales_start }}
               {{ element.mel.field_sales_end }}
+            </div>
             </div>
 
             <div class="mel-step-actions">
@@ -400,6 +394,9 @@
       <div class="mel-event-studio__footer-actions mel-actions">
         {{ element.actions }}
       </div>
+    </div>
+
+      </main>
     </div>
   </div>
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
@@ -1,5 +1,5 @@
 // ==========================================================================
-// Event Studio — layout v2 (top preview + horizontal tabs + full-width form)
+// Event Studio — top preview + sticky sidebar nav + full-width main column
 // Complements module css/mel-event-studio.css (library mel_event_studio).
 // ==========================================================================
 
@@ -119,17 +119,37 @@ form.mel-event-studio-form {
   min-width: 0;
 }
 
-// Module CSS defines .mel-studio-layout (2-col at 960px); neutralize if present anywhere.
+// Two-column Studio shell: sticky sidebar + scrollable main (form stays one <form>).
 .mel-event-studio .mel-studio-layout {
-  display: block !important;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 24px;
   width: 100%;
   max-width: 100%;
+  box-sizing: border-box;
 }
 
 .mel-event-studio__layout {
   display: block;
   width: 100%;
   max-width: 100%;
+}
+
+.mel-event-studio .mel-studio-sidebar {
+  flex: 0 0 220px;
+  width: 220px;
+  max-width: 100%;
+  position: sticky;
+  top: 100px;
+  align-self: flex-start;
+  height: fit-content;
+  z-index: 2;
+}
+
+.mel-event-studio .mel-studio-content {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 // Vendor workspace.css targets .mel-studio-main inside shell; Event Studio must not pick up that grid.
@@ -139,12 +159,247 @@ form.mel-event-studio-form {
   grid-template-columns: none !important;
 }
 
-// Vendor studio layout also uses .mel-studio-nav for a sidebar; reset when it is the Event Studio tab bar.
-.vendor-workspace--studio .mel-event-studio .mel-studio-nav.mel-wizard-nav {
+// Event Studio sidebar nav (distinct from vendor workspace rail).
+.vendor-workspace--studio .mel-event-studio .mel-studio-sidebar .mel-studio-nav.mel-wizard-nav {
   overflow: visible;
   height: auto;
   padding: 0;
   background: transparent;
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar step list (#mel-wizard-nav)
+// ---------------------------------------------------------------------------
+
+.mel-event-studio .mel-sidebar-nav {
+  background: #fff;
+  border-radius: 16px;
+  padding: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--mel-studio-border, #e2e8f0);
+}
+
+.mel-event-studio .mel-sidebar-nav .mel-event-studio-nav__label {
+  margin: 0 0 8px 4px;
+}
+
+.mel-event-studio .mel-sidebar-nav__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mel-event-studio .mel-sidebar-nav__list li {
+  margin-bottom: 6px;
+}
+
+.mel-event-studio .mel-sidebar-nav__list li:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: #333;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  border: 1px solid transparent;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item:hover {
+  background: #f5f7ff;
+  color: var(--mel-studio-text, #0f172a);
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item.is-active,
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item.active {
+  background: #f26d5b;
+  color: #fff;
+  border-color: #f26d5b;
+}
+
+.mel-event-studio .mel-sidebar-nav a.mel-nav-item:focus-visible {
+  outline: 2px solid var(--mel-studio-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .mel-event-studio .mel-studio-layout {
+    flex-direction: column;
+  }
+
+  .mel-event-studio .mel-studio-sidebar {
+    position: static;
+    width: 100%;
+    flex: none;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tickets region — calm surface + button hierarchy (maps to existing .mel-btn classes)
+// ---------------------------------------------------------------------------
+
+.mel-event-studio .mel-ticket-section {
+  margin-top: 0.5rem;
+  padding: 1rem 1.1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--mel-studio-border, #e2e8f0);
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.mel-event-studio .mel-ticket-section .mel-tickets-intro {
+  margin-top: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-builder,
+.mel-event-studio .mel-ticket-section .mel-ticket-wizard-embed {
+  background: #fff;
+  border-color: #eee;
+  box-shadow: none;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-controls {
+  margin-bottom: 12px;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-controls--primary {
+  gap: 10px;
+}
+
+// Utility aliases (Studio ticket toolbar)
+.mel-event-studio .mel-ticket-section .btn-primary,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__paid,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls [name='ticket_save_sync'] {
+  background: #f26d5b !important;
+  color: #fff !important;
+  border-radius: 10px !important;
+  padding: 12px 14px !important;
+  font-weight: 600 !important;
+  border: none !important;
+}
+
+.mel-event-studio .mel-ticket-section .btn-secondary,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__rsvp {
+  background: #eef2ff !important;
+  color: #4f46e5 !important;
+  border-radius: 10px !important;
+  padding: 10px 12px !important;
+  font-weight: 600 !important;
+  border: none !important;
+}
+
+.mel-event-studio .mel-ticket-section .btn-ghost,
+.mel-event-studio .mel-ticket-section .mel-ticket-controls__external {
+  background: transparent !important;
+  border: 1px dashed #ddd !important;
+  color: #666 !important;
+  border-radius: 10px !important;
+  padding: 10px 12px !important;
+  font-weight: 500 !important;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card {
+  border-radius: 16px;
+  border: 1px solid #eee;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: #fff;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__title {
+  font-weight: 600;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__price {
+  color: #6e7ef2;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+  color: #666;
+  margin-top: 8px;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__meta li {
+  margin: 0;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__actions {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+  align-self: flex-start;
+  border: 1px solid var(--mel-studio-border, #e2e8f0);
+  border-radius: 12px;
+  background: #fff;
+  min-width: 2.5rem;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] {
+  padding: 8px;
+  min-width: 11rem;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger {
+  list-style: none;
+  cursor: pointer;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  margin: 0;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--mel-studio-text, #0f172a);
+  font-size: 1.25rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] .mel-ticket-card__overflow-trigger {
+  margin-bottom: 6px;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn {
+  width: 100%;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button:first-of-type,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn:first-of-type,
+.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn:first-of-type {
+  margin-top: 0;
 }
 
 // Basic step: title field + AI button (vendor theme loads this partial too).
@@ -568,43 +823,8 @@ form.mel-event-studio-form .mel-event-studio,
 }
 
 // ---------------------------------------------------------------------------
-// Guided wizard (step nav + panels; progress = event strength above)
+// Guided wizard (step panels; nav = left sidebar #mel-wizard-nav)
 // ---------------------------------------------------------------------------
-
-.mel-wizard-nav,
-.mel-studio-nav.mel-wizard-nav {
-  display: flex;
-  gap: 8px;
-  margin: 16px 0;
-  flex-wrap: wrap;
-}
-
-.mel-wizard-nav button,
-.mel-studio-nav.mel-wizard-nav button {
-  flex: 1;
-  min-width: 0;
-  margin: 0;
-  padding: 10px;
-  border-radius: 10px;
-  background: #eef2ff;
-  border: none;
-  cursor: pointer;
-  font: inherit;
-  font-weight: 600;
-  color: var(--mel-studio-text, #0f172a);
-}
-
-.mel-wizard-nav button.active,
-.mel-studio-nav.mel-wizard-nav button.active {
-  background: #f26d5b;
-  color: white;
-}
-
-.mel-wizard-nav button:focus-visible,
-.mel-studio-nav.mel-wizard-nav button:focus-visible {
-  outline: 2px solid var(--mel-studio-focus, #2563eb);
-  outline-offset: 2px;
-}
 
 .mel-wizard {
   width: 100%;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new route-based edit flow that saves event data on each step and refactors payload construction into shared services, which could affect vendor event editing/publishing behavior and redirects. UI/UX changes (sidebar navigation, scrolling, ticket actions menu) also risk regressions across vendor theme CSS/JS cascades.
> 
> **Overview**
> Vendor Event Studio editing is reworked into a **route-based wizard** (`/vendor/events/{node}/edit/*`) with new step forms for basic info, date/location, tickets, description, preview, and publish; the legacy `edit` route now **redirects to** `edit_basic`, and preview is served by a new controller.
> 
> Payload building is centralized in a new `EventStudioMelPayloadService` and autocomplete defaults are hardened via `EntityAutocompleteMelNormalizer` (used by both the existing full Studio form and the new wizard baseline extractor), reducing duplicated parsing logic.
> 
> The Event Studio UI shifts to a **sticky left sidebar nav** and module-owned “shell” CSS (to win vendor theme cascade), updates JS to use window scrolling with a fixed header offset, and collapses ticket card secondary actions into a compact overflow menu.
> 
> Config updates add `myeventlane_auth` settings, tweak Gin toolbar/density and login assets, make Klaro/Posthog consent callback resilient to uninitialized `window.posthog`, and adjust role dependency ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d783fd2fe108e9aa87740c6ca1790a82b146dd98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->