### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -38,6 +38,7 @@ services:
     class: Drupal\myeventlane_event\Service\EventWizardPublishValidator
     arguments:
       - '@logger.factory'
+      - '@myeventlane_event.event_product_manager'
 
   myeventlane_event.event_form_ticket_builder_callbacks:
     class: Drupal\myeventlane_event\Form\EventFormTicketBuilderCallbacks

--- a/web/modules/custom/myeventlane_event/src/Service/EventProductManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventProductManager.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_event\Service;
 
 use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,6 +39,40 @@ final class EventProductManager {
     private readonly LockBackendInterface $lock,
     private readonly TicketTypeManager $ticketTypeManager,
   ) {}
+
+  /**
+   * Ensures a linked ticket product's field_event matches this event (wizard publish guard).
+   *
+   * @return string|null
+   *   A translated error message when invalid; NULL when OK or no product linked.
+   */
+  public function validateTicketProductEventIntegrity(NodeInterface $event): ?string {
+    if (!$event->hasField('field_product_target') || $event->get('field_product_target')->isEmpty()) {
+      return NULL;
+    }
+    $product = $event->get('field_product_target')->entity;
+    if (!$product instanceof ProductInterface) {
+      return (string) $this->t('The linked ticket product could not be loaded.');
+    }
+    if (!$product->hasField('field_event')) {
+      return NULL;
+    }
+    if ($product->get('field_event')->isEmpty()) {
+      return (string) $this->t('The ticket product is not linked to this event. Save the event or run a ticket sync, then try again.');
+    }
+    if ((int) $product->get('field_event')->target_id !== (int) $event->id()) {
+      $this->loggerFactory->get('myeventlane_event')->error(
+        'Ticket product integrity failed: event @eid points to product @pid with field_event=@other.',
+        [
+          '@eid' => (string) $event->id(),
+          '@pid' => (string) $product->id(),
+          '@other' => (string) ($product->get('field_event')->target_id ?? '0'),
+        ]
+      );
+      return (string) $this->t('The ticket product does not belong to this event. Remove the product link or contact support.');
+    }
+    return NULL;
+  }
 
   /**
    * Syncs products for an event based on explicit intent.
@@ -170,24 +205,23 @@ final class EventProductManager {
    *   TRUE if sync completed successfully.
    */
   private function syncRsvpProduct(NodeInterface $event): bool {
-    // Check if product already exists and is linked.
     if (!$event->get('field_product_target')->isEmpty()) {
       $product = $event->get('field_product_target')->entity;
-      if ($product && $product->isPublished()) {
-        // Ensure bidirectional link.
-        if ($product->hasField('field_event')) {
-          $productEventId = $product->get('field_event')->target_id;
-          if ($productEventId != $event->id()) {
-            $product->set('field_event', ['target_id' => $event->id()]);
-            $product->save();
-
-            $this->loggerFactory->get('myeventlane_event')->notice(
-              'Linked RSVP product @pid to event @eid',
-              ['@pid' => $product->id(), '@eid' => $event->id()]
-            );
-          }
+      if ($product instanceof ProductInterface && $product->isPublished()) {
+        if ($this->ticketProductOwnsEvent($product, $event)) {
+          $this->ensureProductFieldEventMatches($product, $event);
+          return TRUE;
         }
-        return TRUE;
+        $this->loggerFactory->get('myeventlane_event')->warning(
+          'RSVP event @eid referenced product @pid not owned by this event (field_event mismatch or missing). Clearing link; creating a dedicated product.',
+          [
+            '@eid' => (string) $event->id(),
+            '@pid' => (string) $product->id(),
+          ]
+        );
+        $event->set('field_product_target', []);
+        EventNodeRevisionSave::prepare($event, 'Removed ticket product not owned by this event.');
+        $event->save();
       }
     }
 
@@ -208,6 +242,36 @@ final class EventProductManager {
     );
 
     return TRUE;
+  }
+
+  /**
+   * TRUE when this product is the ticket product for the given event (field_event match or self-heal empty).
+   */
+  private function ticketProductOwnsEvent(ProductInterface $product, NodeInterface $event): bool {
+    if (!$product->hasField('field_event')) {
+      return FALSE;
+    }
+    if ($product->get('field_event')->isEmpty()) {
+      $product->set('field_event', ['target_id' => $event->id()]);
+      $product->save();
+      $this->loggerFactory->get('myeventlane_event')->notice(
+        'Set field_event on ticket product @pid to event @eid (was empty).',
+        ['@pid' => (string) $product->id(), '@eid' => (string) $event->id()]
+      );
+      return TRUE;
+    }
+    return (int) $product->get('field_event')->target_id === (int) $event->id();
+  }
+
+  /**
+   * Sets field_event when empty (never reassigns another event's product — mismatch is handled elsewhere).
+   */
+  private function ensureProductFieldEventMatches(ProductInterface $product, NodeInterface $event): void {
+    if (!$product->hasField('field_event') || !$product->get('field_event')->isEmpty()) {
+      return;
+    }
+    $product->set('field_event', ['target_id' => $event->id()]);
+    $product->save();
   }
 
   /**
@@ -252,6 +316,7 @@ final class EventProductManager {
         'uid' => $event->getOwnerId(),
       ]);
       $product->save();
+      $this->ensureProductFieldEventMatches($product, $event);
 
       $this->loggerFactory->get('myeventlane_event')->notice(
         'Created RSVP product @pid for event @eid (@title)',

--- a/web/modules/custom/myeventlane_event/src/Service/EventWizardPublishValidator.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventWizardPublishValidator.php
@@ -23,6 +23,7 @@ final class EventWizardPublishValidator {
    */
   public function __construct(
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly EventProductManager $eventProductManager,
   ) {}
 
   /**
@@ -97,6 +98,11 @@ final class EventWizardPublishValidator {
       if ($event->hasField('field_rsvp_target') && $this->resolveRsvpTarget($event, $form_state) === NULL) {
         $errors[] = (string) t('RSVP events need an RSVP target set.');
       }
+    }
+
+    $productIntegrity = $this->eventProductManager->validateTicketProductEventIntegrity($event);
+    if ($productIntegrity !== NULL) {
+      $errors[] = $productIntegrity;
     }
 
     return $errors;

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_event\Service;
 
 use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -108,8 +109,21 @@ final class TicketTypeManager {
   private function getOrCreateTicketProduct(NodeInterface $event): ?object {
     if ($event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
       $product = $event->get('field_product_target')->entity;
-      if ($product && $product->bundle() === 'ticket') {
-        return $product;
+      if ($product instanceof ProductInterface && $product->bundle() === 'ticket') {
+        if ($this->ticketProductOwnsEvent($product, $event)) {
+          $this->ensureProductFieldEventMatches($product, $event);
+          return $product;
+        }
+        $this->loggerFactory->get('myeventlane_event')->warning(
+          'Paid sync: event @eid had field_product_target product @pid not owned by this event; clearing and creating a dedicated product.',
+          [
+            '@eid' => (string) $event->id(),
+            '@pid' => (string) $product->id(),
+          ]
+        );
+        $event->set('field_product_target', []);
+        EventNodeRevisionSave::prepare($event, 'Removed ticket product not owned by this event.');
+        $event->save();
       }
     }
 
@@ -129,6 +143,7 @@ final class TicketTypeManager {
       'uid' => $event->getOwnerId(),
     ]);
     $product->save();
+    $this->ensureProductFieldEventMatches($product, $event);
 
     $event->set('field_product_target', ['target_id' => $product->id()]);
     EventNodeRevisionSave::prepare($event, 'Linked ticket product to event.');
@@ -140,6 +155,36 @@ final class TicketTypeManager {
     );
 
     return $product;
+  }
+
+  /**
+   * TRUE when field_event is empty (self-healed) or matches this event.
+   */
+  private function ticketProductOwnsEvent(ProductInterface $product, NodeInterface $event): bool {
+    if (!$product->hasField('field_event')) {
+      return FALSE;
+    }
+    if ($product->get('field_event')->isEmpty()) {
+      $product->set('field_event', ['target_id' => $event->id()]);
+      $product->save();
+      $this->loggerFactory->get('myeventlane_event')->notice(
+        'Set field_event on ticket product @pid to event @eid (was empty).',
+        ['@pid' => (string) $product->id(), '@eid' => (string) $event->id()]
+      );
+      return TRUE;
+    }
+    return (int) $product->get('field_event')->target_id === (int) $event->id();
+  }
+
+  /**
+   * Sets field_event when empty (mismatch → clear link + new product in getOrCreateTicketProduct).
+   */
+  private function ensureProductFieldEventMatches(ProductInterface $product, NodeInterface $event): void {
+    if (!$product->hasField('field_event') || !$product->get('field_event')->isEmpty()) {
+      return;
+    }
+    $product->set('field_event', ['target_id' => $event->id()]);
+    $product->save();
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -77,10 +77,6 @@
   padding: 4px 0;
 }
 
-.mel-event-studio .mel-advanced .mel-es-card {
-  margin-top: 16px;
-}
-
 /* -------------------------------------------------------------------------- */
 /* MEL cards (.mel-es-card + legacy .mel-section--card inside workspace)       */
 /* -------------------------------------------------------------------------- */
@@ -96,8 +92,23 @@
   box-sizing: border-box;
 }
 
-.mel-event-studio .mel-es-card:last-child,
-.mel-event-studio .mel-es-stack > .mel-section--card:last-child {
+/* Nested cards inside "More options" — blend into .mel-advanced (#fafafa), not white tiles. */
+.mel-event-studio .mel-advanced .mel-es-card,
+.mel-event-studio .mel-advanced .mel-section--card {
+  margin-top: 16px;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  border-radius: 12px;
+}
+
+.mel-event-studio .mel-advanced > .mel-es-card:last-of-type {
+  margin-bottom: 0;
+}
+
+/* Stacks end with .mel-step-actions, so cards are never :last-child. Pure
+   section:last-of-type fails when a section is followed by details.mel-advanced. */
+.mel-event-studio .mel-es-stack:has(> .mel-step-actions:last-child) > :nth-last-child(2) {
   margin-bottom: 0;
 }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -677,6 +677,30 @@
     return { ok: true };
   }
 
+  /**
+   * Ticket builder controls submit the same Event Studio form as Save; highlight
+   * validation must not block those AJAX submits (only the main publish/save).
+   */
+  function isTicketBuilderSubmitter(submitter) {
+    if (!submitter || !submitter.name) {
+      return false;
+    }
+    var n = submitter.name;
+    if (n.indexOf('ticket_') === 0) {
+      return true;
+    }
+    if (/^save_\d+$/.test(n)) {
+      return true;
+    }
+    if (/^cancel_\d+$/.test(n)) {
+      return true;
+    }
+    if (/^edit_\d+$/.test(n)) {
+      return true;
+    }
+    return false;
+  }
+
   function parseHighlightsHiddenWithStatus(raw) {
     if (!raw || !String(raw).trim()) {
       return { rows: [], parseError: false };
@@ -2128,6 +2152,10 @@
         if (!cont || !form.contains(cont)) {
           return;
         }
+        // Wizard "Continue" is always type=button. Never intercept real submits.
+        if (cont.tagName !== 'BUTTON' || String(cont.type || '').toLowerCase() !== 'button') {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
         melContinueToNextSection(form, cont);
@@ -2358,8 +2386,17 @@
           });
         }
 
-        form.addEventListener('submit', function () {
+        form.addEventListener('submit', function (e) {
           syncAiControlsToForm(form);
+          // Temporary: remove after verifying publish reaches the server (Drupal submit handler).
+          if (
+            !e.defaultPrevented &&
+            !isTicketBuilderSubmitter(e.submitter) &&
+            typeof console !== 'undefined' &&
+            console.log
+          ) {
+            console.log('FORM SUBMIT FIRED');
+          }
         });
 
         form.addEventListener('click', function (e) {
@@ -2648,11 +2685,18 @@
       }
       forceSyncTicketTiersBeforeSubmit(form);
       forceSyncHighlightsBeforeSubmit(form);
+      if (isTicketBuilderSubmitter(e.submitter)) {
+        return;
+      }
       var rows = collectHighlightsFromDom(form);
       var hv = validateHighlightRows(rows);
       if (!hv.ok) {
         e.preventDefault();
         setHighlightsError(form, hv.message);
+        var hlRoot = form.querySelector('[data-mel-highlights-builder]');
+        if (hlRoot && typeof hlRoot.scrollIntoView === 'function') {
+          hlRoot.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
         var errBox = getHighlightsErrorEl();
         if (errBox && typeof errBox.focus === 'function') {
           if (!errBox.hasAttribute('tabindex')) {
@@ -2660,6 +2704,7 @@
           }
           errBox.focus();
         }
+        return;
       }
     },
     true,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -10,9 +10,9 @@ myeventlane_event_studio.edit:
   path: '/vendor/events/{node}/edit'
   defaults:
     _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::buildEdit'
-    _title: 'Edit Event'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::editTitle'
   requirements:
-    _permission: 'access content'
+    _entity_access: 'node.update'
     node: \d+
   options:
     parameters:

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Form\EventStudioForm;
 use Drupal\node\NodeInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -30,16 +28,28 @@ final class EventStudioController extends ControllerBase {
     return $form;
   }
 
-  public function buildEdit(NodeInterface $node): RedirectResponse {
+  public function buildEdit(NodeInterface $node): array {
     if ($node->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
-    $this->getLogger('myeventlane_event_studio')->notice('Vendor Event Studio entry: route=myeventlane_event_studio.edit redirect=edit_basic event_id=@eid uid=@uid', [
+    $this->getLogger('myeventlane_event_studio')->notice('Vendor Event Studio entry: route=myeventlane_event_studio.edit event_id=@eid uid=@uid', [
       '@eid' => (string) $node->id(),
       '@uid' => (string) $this->currentUser()->id(),
     ]);
-    $url = Url::fromRoute('myeventlane_event_studio.edit_basic', ['node' => $node->id()])->setAbsolute();
-    return new RedirectResponse($url->toString());
+    $form = $this->formBuilder()->getForm(EventStudioForm::class, $node);
+    $form['#theme_wrappers'] = [];
+    $form['#theme'] = 'mel_event_studio';
+    $form['#mel_studio_mode'] = 'edit';
+    $form['#attached']['library'] ??= [];
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio';
+    return $form;
+  }
+
+  public function editTitle(NodeInterface $node): string {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    return (string) $this->t('Event Studio — @title', ['@title' => $node->getTitle()]);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -12,6 +12,7 @@ use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -31,6 +32,20 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     'myeventlane_event.wizard.review',
     'myeventlane_event.wizard.publish',
     'myeventlane_event.wizard.success',
+  ];
+
+  /**
+   * Route-based step forms under /vendor/events/{node}/edit/... (superseded by unified studio).
+   *
+   * @var list<string>
+   */
+  private const STUDIO_LEGACY_STEP_ROUTES = [
+    'myeventlane_event_studio.edit_basic',
+    'myeventlane_event_studio.edit_datetime',
+    'myeventlane_event_studio.edit_tickets',
+    'myeventlane_event_studio.edit_description',
+    'myeventlane_event_studio.edit_preview',
+    'myeventlane_event_studio.edit_publish',
   ];
 
   public function __construct(
@@ -53,7 +68,8 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       return;
     }
     $route = (string) ($request->attributes->get('_route') ?? '');
-    if (!in_array($route, self::WIZARD_STEP_ROUTES, TRUE)) {
+    $redirect_routes = array_merge(self::WIZARD_STEP_ROUTES, self::STUDIO_LEGACY_STEP_ROUTES);
+    if (!in_array($route, $redirect_routes, TRUE)) {
       return;
     }
 
@@ -65,16 +81,7 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       return;
     }
 
-    $event_param = $request->attributes->get('event');
-    $node = NULL;
-    if ($event_param instanceof NodeInterface) {
-      $node = $event_param;
-    }
-    elseif (is_numeric($event_param) && (int) $event_param > 0) {
-      $loaded = $this->entityTypeManager->getStorage('node')->load((int) $event_param);
-      $node = $loaded instanceof NodeInterface ? $loaded : NULL;
-    }
-
+    $node = $this->resolveEventNode($request);
     if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
       return;
     }
@@ -87,6 +94,25 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     ]);
 
     $event->setResponse(new RedirectResponse($url, 302));
+  }
+
+  /**
+   * Resolves an event node from legacy wizard (`event`) or studio step (`node`) parameters.
+   */
+  private function resolveEventNode(Request $request): ?NodeInterface {
+    foreach (['event', 'node'] as $key) {
+      $param = $request->attributes->get($key);
+      if ($param instanceof NodeInterface && $param->bundle() === 'event') {
+        return $param;
+      }
+      if (is_numeric($param) && (int) $param > 0) {
+        $loaded = $this->entityTypeManager->getStorage('node')->load((int) $param);
+        if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+          return $loaded;
+        }
+      }
+    }
+    return NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -153,6 +153,27 @@ final class EventStudioForm extends FormBase {
     $form['#attributes']['data-mel-event-studio-form'] = '1';
     $form['#attributes']['id'] = 'event-studio-form';
 
+    // AJAX rebuilds do not receive $route_node; cached form state can lose studio_node. Ticket
+    // builder actions then exit early in handleAction() with no save. Rehydrate from hidden nid.
+    $user_input = $form_state->getUserInput();
+    $nid_from_request = 0;
+    if (is_array($user_input) && isset($user_input['nid'])) {
+      $nid_from_request = (int) $user_input['nid'];
+    }
+    if ($nid_from_request > 0) {
+      $existing = $form_state->get('studio_node');
+      $needs_hydrate = !$existing instanceof NodeInterface
+        || (!$existing->isNew() && (int) $existing->id() !== $nid_from_request);
+      if ($needs_hydrate) {
+        $loaded = $this->entityTypeManager->getStorage('node')->load($nid_from_request);
+        if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+          if ((int) $loaded->getOwnerId() === (int) $this->currentUser->id() || $this->currentUser->hasPermission('administer nodes')) {
+            $form_state->set('studio_node', $loaded);
+          }
+        }
+      }
+    }
+
     if (!$form_state->has('studio_node')) {
       if ($route_node instanceof NodeInterface) {
         if ((int) $route_node->getOwnerId() !== (int) $this->currentUser->id() && !$this->currentUser->hasPermission('administer nodes')) {
@@ -1198,6 +1219,8 @@ final class EventStudioForm extends FormBase {
     $this->ensureInjectedServices();
     $event = $form_state->get('studio_node');
     if (!$event instanceof NodeInterface) {
+      $this->logger->error('Event Studio ticket builder: studio_node missing from form state; ticket action skipped. Check nid rehydration on AJAX rebuild.');
+      $this->messenger()->addError($this->t('Could not attach tickets to this event (session state). Reload the page and try again.'));
       return;
     }
     $this->eventTicketsBuilder->handleAction($form, $form_state, $event);

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
@@ -1,16 +1,19 @@
 {#
 /**
  * @file
- * Horizontal step navigation for route-based Event Studio wizard.
+ * Horizontal step navigation for route-based Event Studio wizard (admin-only step forms).
+ *
+ * Links target the unified Event Studio route with section anchors matching mel-event-studio.html.twig.
  */
 #}
 {% if node %}
+  {% set studio_base = path('myeventlane_event_studio.edit', {'node': node.id}) %}
   <nav class="mel-nav mel-wizard-nav mel-event-studio-wizard-nav" aria-label="{{ 'Event steps'|t }}">
-    <a href="{{ path('myeventlane_event_studio.edit_basic', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'basic' %} is-active{% endif %}">{{ 'Basic'|t }}</a>
-    <a href="{{ path('myeventlane_event_studio.edit_datetime', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'datetime' %} is-active{% endif %}">{{ 'Date & location'|t }}</a>
-    <a href="{{ path('myeventlane_event_studio.edit_tickets', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'tickets' %} is-active{% endif %}">{{ 'Tickets'|t }}</a>
-    <a href="{{ path('myeventlane_event_studio.edit_description', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'description' %} is-active{% endif %}">{{ 'Description'|t }}</a>
-    <a href="{{ path('myeventlane_event_studio.edit_preview', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'preview' %} is-active{% endif %}">{{ 'Preview'|t }}</a>
-    <a href="{{ path('myeventlane_event_studio.edit_publish', {'node': node.id}) }}" class="mel-nav__link{% if current_step == 'publish' %} is-active{% endif %}">{{ 'Publish'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-basic" class="mel-nav__link{% if current_step == 'basic' %} is-active{% endif %}">{{ 'Basic'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-datetime" class="mel-nav__link{% if current_step == 'datetime' %} is-active{% endif %}">{{ 'Date & location'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-tickets" class="mel-nav__link{% if current_step == 'tickets' %} is-active{% endif %}">{{ 'Tickets'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-description" class="mel-nav__link{% if current_step == 'description' %} is-active{% endif %}">{{ 'Description'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-preview" class="mel-nav__link{% if current_step == 'preview' %} is-active{% endif %}">{{ 'Preview'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-publish" class="mel-nav__link{% if current_step == 'publish' %} is-active{% endif %}">{{ 'Publish'|t }}</a>
   </nav>
 {% endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -19,7 +19,7 @@
       {% if mode == 'create' %}
         {{ 'Create Event'|t }}
       {% else %}
-        {{ 'Edit Event'|t }}
+        {{ 'Event Studio'|t }}
       {% endif %}
     </h1>
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
@@ -262,8 +262,8 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
   private function buildHeaderActions(NodeInterface $event): array {
     $actions = [
       [
-        'label' => (string) $this->t('Edit event'),
-        'url' => Url::fromRoute('myeventlane_vendor.console.event_editor', ['event' => $event->id()])->toString(),
+        'label' => (string) $this->t('Open Event Studio'),
+        'url' => Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event->id()])->toString(),
         'class' => 'mel-btn--primary',
       ],
       [

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventSettingsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventSettingsController.php
@@ -40,7 +40,7 @@ final class VendorEventSettingsController extends VendorConsoleBaseController {
 
     $header_actions = [
       [
-        'label' => $this->t('Edit Event'),
+        'label' => $this->t('Open Event Studio'),
         'url' => Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event_id])->toString(),
         'class' => 'mel-btn mel-btn--primary',
       ],

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorThemePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorThemePagePreprocess.php
@@ -438,7 +438,7 @@ final class VendorThemePagePreprocess {
 
     return [
       [
-        'label' => (string) $this->t('Event builder'),
+        'label' => (string) $this->t('Event Studio'),
         'url' => $url,
         'is_disabled' => $url === NULL,
         'is_active' => $is_active,

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -160,7 +160,12 @@ final class EventTicketsBuilder {
         'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
       ],
       '#limit_validation_errors' => [],
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-ticket-controls__rsvp']],
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--primary', 'mel-ticket-controls__rsvp'],
+        // Event Studio nests this builder in a form with required mel[title] etc.; without
+        // formnovalidate the browser blocks AJAX before Drupal runs (standalone /tickets has no such fields).
+        'formnovalidate' => 'formnovalidate',
+      ],
       '#access' => !$adding_new,
     ];
 
@@ -174,7 +179,10 @@ final class EventTicketsBuilder {
         'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
       ],
       '#limit_validation_errors' => [],
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-ticket-controls__paid']],
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--primary', 'mel-ticket-controls__paid'],
+        'formnovalidate' => 'formnovalidate',
+      ],
       '#access' => !$adding_new,
     ];
 
@@ -188,7 +196,10 @@ final class EventTicketsBuilder {
         'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
       ],
       '#limit_validation_errors' => [],
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-ticket-controls__external']],
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--secondary', 'mel-ticket-controls__external'],
+        'formnovalidate' => 'formnovalidate',
+      ],
       '#access' => !$adding_new,
     ];
 
@@ -202,7 +213,10 @@ final class EventTicketsBuilder {
         'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
       ],
       '#limit_validation_errors' => [],
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary']],
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--secondary'],
+        'formnovalidate' => 'formnovalidate',
+      ],
     ];
 
     $form['builder_shell']['order'] = [
@@ -433,7 +447,10 @@ final class EventTicketsBuilder {
             'wrapper' => self::BUILDER_WRAPPER_ID,
           ],
           '#limit_validation_errors' => $limit_edit,
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--primary'],
+            'formnovalidate' => 'formnovalidate',
+          ],
         ];
 
         $form['builder_shell']['list'][$tid]['edit']['actions']['cancel'] = [
@@ -446,7 +463,10 @@ final class EventTicketsBuilder {
             'wrapper' => self::BUILDER_WRAPPER_ID,
           ],
           '#limit_validation_errors' => $limit_edit,
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--ghost']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--ghost'],
+            'formnovalidate' => 'formnovalidate',
+          ],
         ];
       }
       else {
@@ -496,7 +516,7 @@ final class EventTicketsBuilder {
         $name === 'ticket_begin_add_external' => $this->beginAddWithKind($form_state, 'external'),
         $name === 'ticket_cancel_add' => $this->cancelAdd($form_state),
         $name === 'ticket_create' => $this->createTicket($form_state, $event),
-        $name === 'ticket_save_sync' => $this->saveAndSync($event),
+        $name === 'ticket_save_sync' => $this->performSaveAndSync($form_state, $event),
         $name === 'ticket_reorder' => $this->reorderTickets($form_state, $event),
         str_starts_with($name, 'edit_') => $this->beginInlineEdit($form_state, $name),
         str_starts_with($name, 'cancel_') => $this->cancelInlineEdit($form_state),
@@ -601,12 +621,13 @@ final class EventTicketsBuilder {
           '#title' => $this->t('Capacity'),
           '#min' => 1,
           '#default_value' => (string) ($form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields', 'capacity')) ?? ''),
+          // Must use core #states "or" shape; nesting "or" inside the selector value breaks
+          // drupal.states.js so RSVP capacity never shows/submits and create fails validation.
           '#states' => [
             'visible' => [
-              $ticket_kind_input => [
-                ['value' => 'paid'],
-                'or',
-                ['value' => 'rsvp'],
+              'or' => [
+                [$ticket_kind_input => ['value' => 'paid']],
+                [$ticket_kind_input => ['value' => 'rsvp']],
               ],
             ],
           ],
@@ -640,7 +661,10 @@ final class EventTicketsBuilder {
             'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
           ],
           '#limit_validation_errors' => [$this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields')],
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--primary'],
+            'formnovalidate' => 'formnovalidate',
+          ],
         ],
         'cancel' => [
           '#type' => 'submit',
@@ -652,7 +676,10 @@ final class EventTicketsBuilder {
             'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
           ],
           '#limit_validation_errors' => [],
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--ghost']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--ghost'],
+            'formnovalidate' => 'formnovalidate',
+          ],
         ],
       ],
     ];
@@ -754,7 +781,10 @@ final class EventTicketsBuilder {
         '#limit_validation_errors' => [
           $this->valuePath($form_state, 'builder_shell', 'list', (string) $tid, 'edit'),
         ],
-        '#attributes' => ['class' => ['mel-btn', 'mel-btn--ghost']],
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--ghost'],
+          'formnovalidate' => 'formnovalidate',
+        ],
         '#access' => !$archive_only,
       ],
       'full_edit' => [
@@ -776,7 +806,10 @@ final class EventTicketsBuilder {
           'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
         ],
         '#limit_validation_errors' => [],
-        '#attributes' => ['class' => ['mel-btn', 'mel-btn--ghost']],
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--ghost'],
+          'formnovalidate' => 'formnovalidate',
+        ],
         '#access' => !$archive_only,
       ],
       'archive' => [
@@ -789,7 +822,10 @@ final class EventTicketsBuilder {
           'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
         ],
         '#limit_validation_errors' => [],
-        '#attributes' => ['class' => ['mel-btn', 'mel-btn--ghost']],
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--ghost'],
+          'formnovalidate' => 'formnovalidate',
+        ],
       ],
       'remove' => [
         '#type' => 'submit',
@@ -801,7 +837,10 @@ final class EventTicketsBuilder {
           'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
         ],
         '#limit_validation_errors' => [],
-        '#attributes' => ['class' => ['mel-btn', 'mel-btn--danger']],
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--danger'],
+          'formnovalidate' => 'formnovalidate',
+        ],
         '#access' => !$archive_only,
       ],
     ];
@@ -838,13 +877,40 @@ final class EventTicketsBuilder {
     $form_state->set('editing_ticket_id', NULL);
   }
 
-  private function createTicket(FormStateInterface $form_state, NodeInterface $event): void {
+  private function createTicket(FormStateInterface $form_state, NodeInterface $event, bool $quiet = FALSE): void {
     $values = $form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields')) ?? [];
     $payload = $this->normalisePayload($values, $event, TRUE);
     $this->lifecycle->createAttachAndSync($event, $payload);
-    $this->messenger->addStatus($this->t('Ticket created.'));
+    if (!$quiet) {
+      $this->messenger->addStatus($this->t('Ticket created.'));
+    }
     $form_state->set('mel_ticket_adding_new', FALSE);
     $form_state->set('mel_ticket_prefill_kind', NULL);
+  }
+
+  /**
+   * Syncs Commerce for paid tiers; if a new-tier form is open with a title, saves it first.
+   *
+   * Vendors often click "Save & sync" instead of "Create ticket"; without this, nothing persists.
+   */
+  private function performSaveAndSync(FormStateInterface $form_state, NodeInterface $event): void {
+    if ($form_state->get('mel_ticket_adding_new')) {
+      $values = $form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields')) ?? [];
+      $title = trim((string) ($values['title'] ?? ''));
+      if ($title !== '') {
+        try {
+          $this->createTicket($form_state, $event, TRUE);
+          $this->messenger->addStatus($this->t('Tickets saved and synced.'));
+        }
+        catch (\InvalidArgumentException $e) {
+          $this->messenger->addError($this->t('Could not save ticket: @message', ['@message' => $e->getMessage()]));
+        }
+        return;
+      }
+      $this->messenger->addWarning($this->t('Enter a ticket title and price or capacity as needed, then use Save & sync again — or use Create ticket.'));
+    }
+    $this->lifecycle->syncPaidTiers($event);
+    $this->messenger->addStatus($this->t('Tickets saved and synced.'));
   }
 
   private function saveInlineEdit(FormStateInterface $form_state, NodeInterface $event, string $name): void {
@@ -1215,11 +1281,6 @@ final class EventTicketsBuilder {
       return ((float) $as_int === $item) ? $as_int : NULL;
     }
     return NULL;
-  }
-
-  private function saveAndSync(NodeInterface $event): void {
-    $this->lifecycle->syncPaidTiers($event);
-    $this->messenger->addStatus($this->t('Tickets saved and synced.'));
   }
 
   private function normalisePayload(array $values, NodeInterface $event, bool $is_new): array {

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
@@ -57,7 +57,7 @@
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
                   </svg>
-                  {{ 'Edit Event'|t }}
+                  {{ 'Open Event Studio'|t }}
                 </a>
                 {% if event.is_series_template|default(false) and event.series_url is defined and event.series_url %}
                 <a href="{{ event.series_url }}" class="mel-actions-menu__item">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-performance.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-performance.html.twig
@@ -46,7 +46,7 @@
         {% endif %}
         <div class="mel-event-perf__actions">
           <a href="{{ event.manage_url }}" class="mel-event-perf__action">{{ 'View'|t }}</a>
-          <a href="{{ event.edit_url }}" class="mel-event-perf__action">{{ 'Edit'|t }}</a>
+          <a href="{{ event.edit_url }}" class="mel-event-perf__action">{{ 'Open Event Studio'|t }}</a>
           {% if event.boost_wizard_url is defined and event.boost_wizard_url %}
             <a href="{{ event.boost_wizard_url }}" class="mel-boost-button mel-event-perf__action mel-event-perf__action--boost" aria-label="{{ 'Boost this event'|t }}">🚀 {{ 'Boost This Event'|t }}</a>
           {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/mel-event-settings-page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/mel-event-settings-page.html.twig
@@ -83,7 +83,7 @@
       <h2 class="mel-settings-card__title" id="mel-event-details-heading">{{ 'Event details'|t }}</h2>
 
       {% if edit_url %}
-        <a href="{{ edit_url }}" class="mel-settings-card__link">{{ 'Edit'|t }}</a>
+        <a href="{{ edit_url }}" class="mel-settings-card__link">{{ 'Open Event Studio'|t }}</a>
       {% endif %}
     </div>
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
@@ -36,7 +36,7 @@
 
     <div class="mel-card__actions">
       <a href="{{ path('myeventlane_vendor.console.event_overview', {'event': node.id}) }}" class="mel-btn mel-btn--primary mel-btn--sm">{{ 'Manage'|t }}</a>
-      <a href="{{ path('entity.node.edit_form', {'node': node.id}) }}" class="mel-btn mel-btn--ghost mel-btn--sm">{{ 'Edit'|t }}</a>
+      <a href="{{ path('myeventlane_event_studio.edit', {'node': node.id}) }}" class="mel-btn mel-btn--ghost mel-btn--sm">{{ 'Open Event Studio'|t }}</a>
     </div>
   </div>
 </article>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches vendor-facing routing, access control, and ticketing/Commerce product linking logic; mistakes could block editing/publishing or associate events with the wrong ticket products. Changes are localized but affect critical user flows (Event Studio edit + ticket sync).
> 
> **Overview**
> Moves vendors onto the unified `Event Studio` edit experience: `/vendor/events/{node}/edit` now renders the full studio form (with dynamic title + `node.update` access), legacy step routes/nav are redirected or updated to point to section anchors, and vendor UIs are relabeled to **Open Event Studio**.
> 
> Hardens ticketing integrity and UX: publish validation now blocks when a linked Commerce ticket product doesn’t belong to the event, ticket/product sync self-heals missing `field_event` or clears mismatched product links before creating dedicated products, and the embedded ticket builder is made more reliable in Event Studio (AJAX state rehydration via hidden `nid`, `formnovalidate` on ticket controls, fixed `#states` OR logic, and “Save & sync” saves an in-progress new tier before syncing).
> 
> Improves client-side studio behavior and styling: highlight validation no longer blocks ticket-builder submits and scrolls/focuses the error region, wizard continue handling avoids intercepting real submits, and nested “More options” cards are restyled to blend into the advanced panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a59d0cf78b30458202c085748ccfe917c47240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->