### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -2193,13 +2193,13 @@
                 break;
               }
             }
-            if (idx >= 0 && entry.isIntersecting) {
+            if (idx >= 0 && entry.intersectionRatio >= 0.1) {
               setWizardNavActive(form, idx);
               setWizardStepIndex(form, idx);
             }
           });
         },
-        { rootMargin: '-40% 0px -50% 0px', threshold: [0, 0.01, 0.1, 0.25, 0.5, 0.75, 1] },
+        { rootMargin: '-40% 0px -50% 0px', threshold: 0.1 },
       );
       steps.forEach(function (s) {
         io.observe(s);

--- a/web/modules/custom/myeventlane_legal/myeventlane_legal.services.yml
+++ b/web/modules/custom/myeventlane_legal/myeventlane_legal.services.yml
@@ -14,6 +14,7 @@ services:
       - '@current_user'
       - '@datetime.time'
       - '@request_stack'
+      - '@logger.factory'
 
   myeventlane_legal.consent_helper:
     class: Drupal\myeventlane_legal\Service\RsvpSubmissionConsentHelper

--- a/web/modules/custom/myeventlane_legal/src/Form/UserRegisterLegalAlter.php
+++ b/web/modules/custom/myeventlane_legal/src/Form/UserRegisterLegalAlter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_legal\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -24,6 +25,7 @@ final class UserRegisterLegalAlter {
     private readonly AccountProxyInterface $currentUser,
     private readonly TimeInterface $time,
     private readonly RequestStack $requestStack,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
   ) {}
 
   /**
@@ -86,6 +88,10 @@ final class UserRegisterLegalAlter {
    */
   public function validateLegalConsent(array &$form, FormStateInterface $form_state): void {
     $this->mergeLegalConsentFromRequest($form_state);
+    $this->normalizeLegalConsentNestedValues($form_state);
+    $this->loggerFactory->get('mel_debug')->notice('Consent value: <pre>@v</pre>', [
+      '@v' => print_r($form_state->getValue('legal_consent'), TRUE),
+    ]);
     $terms = (bool) $form_state->getValue(['legal_consent', 'customer_terms_agreed']);
     $privacy = (bool) $form_state->getValue(['legal_consent', 'privacy_agreed']);
     if (!$terms) {
@@ -101,16 +107,30 @@ final class UserRegisterLegalAlter {
    *
    * Some browsers/themes submit multipart registration forms such that checkbox
    * values are present in the request but not yet reflected in form state.
+   *
+   * Symfony InputBag::get() only returns scalars and throws BadRequestException
+   * when the key holds an array (e.g. legal_consent[customer_terms_agreed]).
+   * Always read nested POST via Request::request->all().
    */
   private function mergeLegalConsentFromRequest(FormStateInterface $form_state): void {
     $request = $this->requestStack->getCurrentRequest();
     if (!$request || $request->getMethod() !== 'POST') {
       return;
     }
-    // Prefer ParameterBag::get() so nested keys survive multipart POST reliably.
-    $legal = $request->request->get('legal_consent');
+    $all = $request->request->all();
+    $legal = $all['legal_consent'] ?? NULL;
     if (!is_array($legal)) {
       return;
+    }
+    // Malformed client input: legal_consent[] yields a list, not a keyed tree.
+    if ($legal !== [] && array_is_list($legal)) {
+      $first = reset($legal);
+      $on = ($first === NULL || $first === '' || $first === '0' || $first === 0 || $first === FALSE) ? 0 : 1;
+      $legal = [
+        'customer_terms_agreed' => $on,
+        'privacy_agreed' => $on,
+        'marketing_opt_in' => 0,
+      ];
     }
     $merged = $form_state->getValue('legal_consent');
     $merged = is_array($merged) ? $merged : [];
@@ -120,9 +140,33 @@ final class UserRegisterLegalAlter {
         continue;
       }
       $v = $legal[$key];
+      if (is_array($v)) {
+        $v = reset($v);
+      }
       $merged[$key] = ($v === NULL || $v === '' || $v === '0' || $v === 0 || $v === FALSE) ? 0 : 1;
     }
     $form_state->setValue('legal_consent', $merged);
+  }
+
+  /**
+   * Ensures each legal_consent child is 0/1, never a nested array.
+   */
+  private function normalizeLegalConsentNestedValues(FormStateInterface $form_state): void {
+    $legal = $form_state->getValue('legal_consent');
+    if (!is_array($legal)) {
+      return;
+    }
+    foreach (['customer_terms_agreed', 'privacy_agreed', 'marketing_opt_in'] as $key) {
+      if (!array_key_exists($key, $legal)) {
+        continue;
+      }
+      $v = $legal[$key];
+      if (is_array($v)) {
+        $v = reset($v);
+        $legal[$key] = ($v === NULL || $v === '' || $v === '0' || $v === 0 || $v === FALSE) ? 0 : 1;
+      }
+    }
+    $form_state->setValue('legal_consent', $legal);
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches user registration consent validation and adds request parsing/normalization plus new logging, which could affect signup flows and potentially expose consent payloads in logs. The Event Studio change is low risk but alters scroll-based navigation behavior.
> 
> **Overview**
> Improves Event Studio wizard step highlighting by switching the `IntersectionObserver` activation to require a minimum `intersectionRatio` (0.1) and simplifying the observer threshold configuration, reducing jitter from tiny intersections.
> 
> Hardens registration legal consent handling by reading nested POST data via `Request::request->all()`, coercing malformed/list checkbox submissions, and normalizing any nested checkbox values to strict 0/1 before validation. The registration alter service now receives `logger.factory` and emits a debug log of the resolved `legal_consent` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc433cbf130a20f81f74d7e89ec898a1b8a6d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->