### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: Y-Xpk050V3opj3WiFb4oUbVT9S7fDA1XLpigO-qVMVQ
 langcode: en
 anonymous: Anonymous
-verify_mail: true
+verify_mail: false
 notify:
   cancel_confirm: true
   password_reset: true

--- a/web/modules/custom/myeventlane_vendor/css/onboarding.css
+++ b/web/modules/custom/myeventlane_vendor/css/onboarding.css
@@ -20,18 +20,26 @@
   --mel-onboard-max: 720px;
 }
 
-/* Vendor shell: constrain onboarding main column (sidebar is existing shell aside). */
-body.mel-page--vendor-onboard .mel-vendor-shell__content {
-  max-width: var(--mel-onboard-max);
+/* Vendor shell: main column is full width; inner rail (.mel-vendor-inner) constrains copy beside sidebar. */
+body.mel-page--vendor-onboard .mel-vendor-shell__content.mel-vendor-content {
+  max-width: none;
   margin-inline: 0;
   width: 100%;
 }
 
 @media (max-width: 767px) {
-  body.mel-page--vendor-onboard .mel-vendor-shell__content {
-    max-width: none;
+  body.mel-page--vendor-onboard .mel-vendor-shell__content.mel-vendor-content {
     padding-inline: var(--mel-onboard-space-md);
   }
+}
+
+body.mel-page--vendor-onboard .mel-vendor .mel-vendor-workspace.mel-onboard-wrapper {
+  display: block;
+  min-height: 0;
+  height: auto;
+  padding: 0;
+  background: transparent;
+  grid-template-columns: unset;
 }
 
 .mel-vendor-workspace {
@@ -40,8 +48,9 @@ body.mel-page--vendor-onboard .mel-vendor-shell__content {
 }
 
 .mel-vendor-main--onboard {
-  max-width: var(--mel-onboard-max);
-  padding: var(--mel-onboard-space-lg) var(--mel-onboard-space-md) var(--mel-onboard-space-2xl);
+  max-width: none;
+  width: 100%;
+  padding: var(--mel-onboard-space-lg) 0 var(--mel-onboard-space-2xl);
   margin-inline: 0;
 }
 
@@ -61,6 +70,67 @@ body.mel-page--vendor-onboard .mel-vendor-shell__content {
   max-width: var(--mel-onboard-max);
   margin: 0;
   width: 100%;
+}
+
+.mel-vendor-content .mel-container,
+.mel-vendor-inner .mel-container {
+  margin: 0;
+  max-width: none;
+}
+
+.mel-onboard-flow {
+  width: 100%;
+}
+
+.mel-onboard-progress-text {
+  margin: 0 0 var(--mel-onboard-space-md);
+  font-size: 0.9375rem;
+  color: var(--mel-onboard-muted);
+}
+
+.mel-onboard-steps {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.mel-onboard-steps__sep {
+  color: #bbb;
+  user-select: none;
+}
+
+.mel-step {
+  color: #888;
+}
+
+.mel-step--active {
+  color: var(--mel-onboard-coral);
+  font-weight: 600;
+}
+
+.mel-step--complete {
+  color: #16a34a;
+}
+
+.mel-stripe-onboard-summary {
+  margin-bottom: var(--mel-onboard-space-md);
+  padding: var(--mel-onboard-space-md);
+  border-radius: var(--mel-onboard-radius);
+  background: #f9fafb;
+  border: 1px solid var(--mel-onboard-border);
+}
+
+.mel-stripe-onboard-summary__line {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--mel-onboard-text);
+}
+
+.mel-stripe-onboard-summary__line--ok {
+  font-weight: 600;
 }
 
 .mel-onboard-progress {
@@ -234,8 +304,13 @@ body.mel-page--vendor-onboard .mel-vendor-shell__content {
   background: var(--mel-onboard-surface);
   border: 1px solid var(--mel-onboard-border);
   border-radius: var(--mel-onboard-radius);
-  box-shadow: var(--mel-onboard-shadow);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
   padding: var(--mel-onboard-space-xl);
+  margin-top: var(--mel-onboard-space-lg);
+}
+
+.mel-onboard-card--main {
+  margin-top: var(--mel-onboard-space-md);
 }
 
 .mel-onboard-footer {
@@ -247,9 +322,21 @@ body.mel-page--vendor-onboard .mel-vendor-shell__content {
   align-items: center;
   gap: var(--mel-onboard-space-md);
   margin-top: var(--mel-onboard-space-lg);
-  padding: var(--mel-onboard-space-md) 0 0;
-  background: linear-gradient(to top, var(--mel-onboard-bg) 70%, transparent);
-  border-top: 1px solid var(--mel-onboard-border);
+  padding: 12px 0 0;
+  background: #fff;
+  border-top: 1px solid #eee;
+}
+
+.mel-onboard-footer--split {
+  justify-content: space-between;
+}
+
+.mel-onboard-footer--sticky {
+  position: sticky;
+  bottom: 0;
+  padding: 12px;
+  margin-top: var(--mel-onboard-space-lg);
+  border-radius: 0 0 var(--mel-onboard-radius) var(--mel-onboard-radius);
 }
 
 .mel-onboard-footer .form-actions {

--- a/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
+++ b/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Vendor onboarding: focus first field, gate primary submit on HTML5 validity.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.melVendorOnboard = {
+    attach(context) {
+      once('mel-onboard-autofocus', '.mel-page--vendor-onboard .mel-onboard-card', context).forEach((card) => {
+        const focusable = card.querySelector(
+          'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
+        );
+        if (focusable) {
+          focusable.focus({ preventScroll: true });
+        }
+      });
+
+      once('mel-onboard-validity', '.mel-page--vendor-onboard .mel-onboard-form-root', context).forEach((form) => {
+        const submit = form.querySelector('input[type="submit"].form-submit, button[type="submit"]');
+        if (!submit) {
+          return;
+        }
+        const sync = () => {
+          submit.disabled = !form.checkValidity();
+        };
+        form.addEventListener('input', sync);
+        form.addEventListener('change', sync);
+        sync();
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
@@ -26,8 +26,11 @@ onboarding:
   css:
     component:
       css/onboarding.css: {}
+  js:
+    js/vendor-onboard.js: {}
   dependencies:
     - core/drupal
+    - core/once
     - myeventlane_vendor_theme/global-styling
 
 bulk_actions:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
@@ -83,12 +83,13 @@ final class VendorOnboardStripeController extends ControllerBase {
     // Stripe UI phases: not connected | connected incomplete | payouts enabled.
     $isConnected = FALSE;
     $payoutsEnabled = FALSE;
+    $accountId = '';
     if ($store->hasField('field_stripe_payouts_enabled') && !$store->get('field_stripe_payouts_enabled')->isEmpty()) {
       $payoutsEnabled = (bool) $store->get('field_stripe_payouts_enabled')->value;
     }
     if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
-      $accountId = $store->get('field_stripe_account_id')->value;
-      if (!empty($accountId)) {
+      $accountId = trim((string) $store->get('field_stripe_account_id')->value);
+      if ($accountId !== '') {
         if ($store->hasField('field_stripe_charges_enabled') && !$store->get('field_stripe_charges_enabled')->isEmpty()) {
           $isConnected = (bool) $store->get('field_stripe_charges_enabled')->value;
         }
@@ -111,9 +112,15 @@ final class VendorOnboardStripeController extends ControllerBase {
     if ($payoutsEnabled) {
       $stripe_phase = 'payouts_ready';
     }
-    elseif ($isConnected || ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty())) {
+    elseif ($isConnected || $accountId !== '') {
       $stripe_phase = 'needs_completion';
     }
+
+    $stripe_state = [
+      'is_connected' => $accountId !== '',
+      'payouts_enabled' => $payoutsEnabled,
+      'is_onboarding_complete' => $payoutsEnabled,
+    ];
 
     // Non-blocking: load/refresh onboarding state; advance when Stripe already connected.
     try {
@@ -145,25 +152,26 @@ final class VendorOnboardStripeController extends ControllerBase {
       'absolute' => TRUE,
     ]);
 
+    $back_url = Url::fromRoute('myeventlane_vendor.onboard.profile')->toString();
+
+    $onboard_footer = [
+      'back_url' => $back_url,
+      'continue_url' => $connectUrl->toString(),
+      'continue_label' => $this->t('Connect Stripe'),
+    ];
+
     if ($stripe_phase === 'payouts_ready') {
-      $content['status'] = [
+      $content['done'] = [
         '#type' => 'container',
         '#attributes' => [
-          'class' => ['mel-stripe-phase', 'mel-stripe-phase--success'],
+          'class' => ['mel-stripe-onboard-card-copy'],
         ],
         'message' => [
-          '#markup' => '<p><strong>' . $this->t('Payouts enabled') . '</strong> ' . $this->t('Your Stripe account can receive funds from ticket sales.') . '</p>',
+          '#markup' => '<p>' . $this->t('Your Stripe account can receive funds from ticket sales.') . '</p>',
         ],
       ];
-
-      $content['continue'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Continue to event setup'),
-        '#url' => Url::fromRoute('myeventlane_vendor.onboard.first_event'),
-        '#attributes' => [
-          'class' => ['mel-btn', 'mel-btn--primary', 'mel-btn-lg'],
-        ],
-      ];
+      $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_vendor.onboard.first_event')->toString();
+      $onboard_footer['continue_label'] = $this->t('Continue to event setup');
     }
     elseif ($stripe_phase === 'needs_completion') {
       $content['status'] = [
@@ -175,14 +183,7 @@ final class VendorOnboardStripeController extends ControllerBase {
           '#markup' => '<p><strong>' . $this->t('Finish setting up Stripe') . '</strong> ' . $this->t('Complete the remaining steps in Stripe to enable payouts.') . '</p>',
         ],
       ];
-      $content['resume'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Resume Stripe setup'),
-        '#url' => $connectUrl,
-        '#attributes' => [
-          'class' => ['mel-btn', 'mel-btn--primary', 'mel-btn-lg'],
-        ],
-      ];
+      $onboard_footer['continue_label'] = $this->t('Continue setting up payments');
     }
     else {
       $content['intro'] = [
@@ -210,15 +211,6 @@ final class VendorOnboardStripeController extends ControllerBase {
           ],
         ],
       ];
-
-      $content['connect'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Connect Stripe to receive payments'),
-        '#url' => $connectUrl,
-        '#attributes' => [
-          'class' => ['mel-btn', 'mel-btn--primary', 'mel-btn-lg'],
-        ],
-      ];
     }
 
     return [
@@ -228,6 +220,8 @@ final class VendorOnboardStripeController extends ControllerBase {
       '#step_title' => $this->t('Set up payments'),
       '#step_description' => $this->t('Connect your Stripe account to accept payments for your events. This process takes about 5 minutes.'),
       '#content' => $content,
+      '#stripe_state' => $stripe_state,
+      '#onboard_footer' => $onboard_footer,
       '#attached' => [
         'library' => ['myeventlane_vendor/onboarding'],
       ],

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
@@ -51,7 +51,9 @@ final class EventStudioVendorOnboardingGateSubscriber implements EventSubscriber
     }
 
     $is_studio = $route_name === 'myeventlane_event_studio.create'
-      || str_starts_with($route_name, 'myeventlane_event_studio.edit');
+      || str_starts_with($route_name, 'myeventlane_event_studio.edit')
+      || $route_name === 'myeventlane_vendor.manage_event.edit'
+      || $route_name === 'myeventlane_vendor.console.event_editor';
     if (!$is_studio) {
       return;
     }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
@@ -93,7 +94,7 @@ final class VendorOnboardProfileForm extends FormBase {
     $form['#step_number'] = 2;
     $form['#total_steps'] = 7;
     $form['#step_title'] = $this->t('Set up your organiser profile');
-    $form['#step_description'] = $this->t('Tell people about your organisation. This information will appear on your public organiser page.');
+    $form['#step_description'] = $this->t('This helps people discover and trust your events.');
     $form['#attached']['library'][] = 'myeventlane_vendor/onboarding';
     $form['#attributes']['class'][] = 'mel-onboard-form';
     $form['#attributes']['class'][] = 'mel-onboard-profile-form';
@@ -117,7 +118,7 @@ final class VendorOnboardProfileForm extends FormBase {
     $form['step_content'] = [
       '#type' => 'container',
       '#attributes' => [
-        'class' => ['mel-onboard-card'],
+        'class' => ['mel-onboard-step-fields'],
       ],
     ];
     $form['step_content']['name'] = [
@@ -130,17 +131,30 @@ final class VendorOnboardProfileForm extends FormBase {
       '#maxlength' => 255,
     ];
     $form['step_content']['name']['#attributes']['placeholder'] = $this->t('Enter your organiser name');
+    $form['step_content']['name']['#attributes']['autofocus'] = 'autofocus';
 
     $form['step_content']['actions'] = [
       '#type' => 'actions',
       '#attributes' => [
-        'class' => ['mel-onboard-footer'],
+        'class' => ['mel-onboard-footer', 'mel-onboard-footer--split'],
+      ],
+    ];
+    $form['step_content']['actions']['back'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Back'),
+      '#url' => Url::fromRoute('myeventlane_vendor.onboard.account'),
+      '#weight' => -10,
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--secondary', 'mel-btn-secondary', 'mel-onboard-footer__back'],
       ],
     ];
     $form['step_content']['actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $continue_label,
       '#button_type' => 'primary',
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--primary', 'mel-onboard-footer__continue'],
+      ],
     ];
 
     return $form;

--- a/web/modules/custom/myeventlane_vendor/templates/components/onboarding-journey-steps.html.twig
+++ b/web/modules/custom/myeventlane_vendor/templates/components/onboarding-journey-steps.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Compact 4-step journey strip (module fallback; mirrors vendor theme).
+ */
+#}
+{% if journey_steps %}
+  <div class="mel-onboard-steps" role="list" aria-label="{{ 'Onboarding steps'|t }}">
+    {% for step in journey_steps %}
+      <span role="listitem" class="mel-step{% if step.is_current %} mel-step--active{% endif %}{% if step.is_complete %} mel-step--complete{% endif %}">
+        {{ step.label }}
+      </span>
+      {% if not loop.last %}
+        <span class="mel-onboard-steps__sep" aria-hidden="true">→</span>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/web/modules/custom/myeventlane_vendor/templates/vendor-onboard-step.html.twig
+++ b/web/modules/custom/myeventlane_vendor/templates/vendor-onboard-step.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Vendor onboarding step (module fallback when vendor theme override absent).
+ * Vendor onboarding step — fallback when vendor theme override is absent.
  */
 #}
 {% set step_number = form['#step_number'] ?? 1 %}
@@ -21,8 +21,12 @@
   {% set back_route = 'myeventlane_vendor.onboard.boost' %}
 {% endif %}
 
-<div class="mel-vendor-workspace mel-onboard-wrapper mel-onboard-wrapper--vendor">
-  <main class="mel-vendor-main mel-vendor-main--onboard">
+<div class="mel-onboard-flow">
+  {% if journey_steps is defined and journey_steps %}
+    {% include '@myeventlane_vendor/components/onboarding-journey-steps.html.twig' with { journey_steps: journey_steps } only %}
+  {% elseif onboarding_stages is defined and onboarding_stages %}
+    {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
+  {% else %}
     <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
       <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
       <div class="mel-onboard-progress-steps">
@@ -33,27 +37,46 @@
         {% endfor %}
       </div>
     </div>
+  {% endif %}
 
-    <header class="mel-onboard-header">
-      <h1 class="mel-onboard-title">{{ step_title }}</h1>
-      {% if step_description %}
-        <p class="mel-onboard-description">{{ step_description }}</p>
+  {% if onboarding_progress_label %}
+    <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
+  {% endif %}
+
+  {% if stripe_state %}
+    <div class="mel-stripe-onboard-summary" role="status">
+      {% if stripe_state.payouts_enabled %}
+        <p class="mel-stripe-onboard-summary__line mel-stripe-onboard-summary__line--ok">{{ 'Payouts enabled'|t }} <span aria-hidden="true">✅</span></p>
+      {% elseif stripe_state.is_connected %}
+        <p class="mel-stripe-onboard-summary__line">{{ 'Continue setting up payments in Stripe to enable payouts.'|t }}</p>
+      {% else %}
+        <p class="mel-stripe-onboard-summary__line">{{ 'Connect Stripe to accept ticket payments.'|t }}</p>
       {% endif %}
-    </header>
-
-    <div class="mel-onboard-content">
-      {% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
-      {% if form.form_token is defined %}{{ form.form_token }}{% endif %}
-      {% if form.form_id is defined %}{{ form.form_id }}{% endif %}
-      {{ form.step_content|default(form['#content']) }}
     </div>
+  {% endif %}
 
-    {% if back_route %}
-      <div class="mel-onboard-nav">
-        <a href="{{ path(back_route) }}" class="mel-btn mel-btn-ghost">
-          {{ 'Back'|t }}
-        </a>
-      </div>
+  <header class="mel-onboard-header">
+    <h1 class="mel-onboard-title">{{ step_title }}</h1>
+    {% if step_description %}
+      <p class="mel-onboard-description">{{ step_description }}</p>
     {% endif %}
-  </main>
+  </header>
+
+  <div class="mel-onboard-card mel-onboard-card--main">
+    {% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
+    {% if form.form_token is defined %}{{ form.form_token }}{% endif %}
+    {% if form.form_id is defined %}{{ form.form_id }}{% endif %}
+    {{ form.step_content|default(form['#content']) }}
+  </div>
+
+  {% if onboard_footer %}
+    <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+      <a href="{{ onboard_footer.back_url }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+      <a href="{{ onboard_footer.continue_url }}" class="mel-btn mel-btn--primary mel-onboard-footer__continue">{{ onboard_footer.continue_label }}</a>
+    </div>
+  {% elseif back_route %}
+    <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+      <a href="{{ path(back_route) }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+    </div>
+  {% endif %}
 </div>

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -310,6 +310,9 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
     $route_match
   );
 
+  $is_vendor_onboard = is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor.onboard');
+  $variables['page']['vendor_onboard_inner'] = $is_vendor_onboard;
+
   // Legacy step-wizard sidebar: staff/support only (vendors are redirected to Event Studio).
   $variables['page']['wizard_steps'] = [];
   $account = $current_user;
@@ -433,8 +436,9 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
   // --- Vendor Alert Strip (STAGE A: data model, stub logic) ---
   // Exposes $page['vendor_alert'] when an alert applies. Only ONE alert at a time.
   // If no alert applies, vendor_alert is not set.
+  // Suppress on vendor onboarding routes: Stripe CTAs live in the guided flow (no duplicate banner).
   $vendor_alert = _myeventlane_vendor_theme_get_vendor_alert($current_user);
-  if ($vendor_alert !== NULL) {
+  if ($vendor_alert !== NULL && !$is_vendor_onboard) {
     $variables['page']['vendor_alert'] = $vendor_alert;
   }
 
@@ -715,6 +719,11 @@ function myeventlane_vendor_theme_preprocess_form__vendor_onboard_profile_form(a
     default => NULL,
   };
   $variables['onboarding_stages'] = _myeventlane_vendor_theme_build_onboarding_stages('myeventlane_vendor.onboard.profile');
+  $journey = _myeventlane_vendor_theme_onboarding_journey_meta('myeventlane_vendor.onboard.profile');
+  $variables['journey_steps'] = $journey['journey_steps'];
+  $variables['onboarding_progress_label'] = $journey['progress_label'];
+  $variables['onboarding_stage'] = $journey['onboarding_stage'];
+  $variables['completed_step_keys'] = $journey['completed_step_keys'];
 }
 
 /**
@@ -729,6 +738,15 @@ function myeventlane_vendor_theme_preprocess_vendor_onboard_step(array &$variabl
     ? 'myeventlane_vendor.onboard.stripe'
     : $route;
   $variables['onboarding_stages'] = _myeventlane_vendor_theme_build_onboarding_stages($effective_route);
+  $journey = _myeventlane_vendor_theme_onboarding_journey_meta(is_string($effective_route) ? $effective_route : NULL);
+  $variables['journey_steps'] = $journey['journey_steps'];
+  $variables['onboarding_progress_label'] = $journey['progress_label'];
+  $variables['onboarding_stage'] = $journey['onboarding_stage'];
+  $variables['completed_step_keys'] = $journey['completed_step_keys'];
+
+  $element = $variables['form'] ?? [];
+  $variables['stripe_state'] = is_array($element) ? ($element['#stripe_state'] ?? NULL) : NULL;
+  $variables['onboard_footer'] = is_array($element) ? ($element['#onboard_footer'] ?? NULL) : NULL;
 }
 
 /**
@@ -856,6 +874,90 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
   }
 
   return $stages;
+}
+
+/**
+ * Builds compact journey metadata (4 core steps) for guided onboarding UX.
+ *
+ * @return array
+ *   Journey variables for Twig (steps, progress label, stage, completed keys).
+ */
+function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_route = NULL): array {
+  $route = $effective_route ?? (string) (\Drupal::routeMatch()->getRouteName() ?? '');
+  if ($route === 'myeventlane_vendor.onboard.branding') {
+    $route = 'myeventlane_vendor.onboard.stripe';
+  }
+
+  $journey_routes = [
+    'myeventlane_vendor.onboard.account' => 0,
+    'myeventlane_vendor.onboard' => 0,
+    'myeventlane_vendor.onboard.profile' => 1,
+    'myeventlane_vendor.onboard.stripe' => 2,
+    'myeventlane_vendor.onboard.first_event' => 3,
+  ];
+  $current_index = $journey_routes[$route] ?? 0;
+
+  $journey_ids = ['probe', 'present', 'listen', 'ask'];
+  $uid = (int) \Drupal::currentUser()->id();
+  $state = NULL;
+  if ($uid > 0 && \Drupal::hasService('myeventlane_onboarding.manager')) {
+    /** @var \Drupal\myeventlane_core\Service\OnboardingManager $manager */
+    $manager = \Drupal::service('myeventlane_onboarding.manager');
+    $state = $manager->loadVendorStateByUid($uid);
+  }
+
+  $stage_order = \Drupal\myeventlane_core\Entity\OnboardingStateInterface::STAGE_ORDER;
+  $state_idx = NULL;
+  if ($state !== NULL) {
+    $state_idx = array_search($state->getStage(), $stage_order, TRUE);
+    $state_idx = $state_idx !== FALSE ? (int) $state_idx : 0;
+  }
+
+  $journey_to_stage_idx = [0 => 0, 1 => 1, 2 => 2, 3 => 3];
+  $steps = [];
+  $completed_keys = [];
+  foreach ($journey_ids as $i => $id) {
+    $mapped = $journey_to_stage_idx[$i] ?? $i;
+    $is_current = ($i === $current_index);
+    $is_complete = FALSE;
+    if ($state !== NULL && $state->isCompleted()) {
+      $is_complete = TRUE;
+    }
+    elseif ($state_idx !== NULL) {
+      $is_complete = $state_idx > $mapped;
+    }
+    else {
+      $is_complete = $i < $current_index;
+    }
+    $label = match ($id) {
+      'probe' => t('Get started'),
+      'present' => t('Profile'),
+      'listen' => t('Payments'),
+      'ask' => t('First event'),
+      default => $id,
+    };
+    if ($is_complete) {
+      $completed_keys[] = $id;
+    }
+    $steps[] = [
+      'id' => $id,
+      'label' => $label,
+      'is_current' => $is_current,
+      'is_complete' => $is_complete,
+    ];
+  }
+
+  $progress_label = t('Step @current of @total', [
+    '@current' => (string) ($current_index + 1),
+    '@total' => '4',
+  ]);
+
+  return [
+    'journey_steps' => $steps,
+    'progress_label' => $progress_label,
+    'onboarding_stage' => $state?->getStage(),
+    'completed_step_keys' => $completed_keys,
+  ];
 }
 
 /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_vendor-onboard-shell.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_vendor-onboard-shell.scss
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Vendor onboarding shell — sidebar + main column alignment (guided flow).
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/breakpoints' as *;
+
+// Onboarding uses the existing mel-vendor-shell grid; this styles the main column + inner rail.
+body.mel-page--vendor-onboard {
+  .mel-vendor-shell {
+    min-height: 100vh;
+    background: $ml-vendor-bg;
+  }
+
+  .mel-vendor-shell__content.mel-vendor-content {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    padding-left: $spacing-4;
+    padding-right: $spacing-4;
+
+    @include respond-to(md) {
+      padding-left: $spacing-6;
+      padding-right: $spacing-8;
+    }
+  }
+
+  .mel-vendor-inner {
+    width: 100%;
+    max-width: 45rem; // 720px — guided column beside sidebar
+    padding-top: $spacing-6;
+    padding-bottom: $spacing-12;
+  }
+
+  .mel-vendor-content .mel-container {
+    margin: 0;
+    max-width: none;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -65,6 +65,7 @@
   @include meta.load-css('components/mel-top-boost-opportunity');
   @include meta.load-css('components/onboarding-panel');
   @include meta.load-css('components/onboarding-flow');
+  @include meta.load-css('components/vendor-onboard-shell');
   @include meta.load-css('components/auth');
   @include meta.load-css('components/vendor-order-view');
   @include meta.load-css('components/boost-metrics');

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/onboarding-journey-steps.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/onboarding-journey-steps.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Compact 4-step journey strip (Get started → Profile → Payments → First event).
+ *
+ * Variables:
+ * - journey_steps: array of { id, label, is_current, is_complete }
+ */
+#}
+{% if journey_steps %}
+  <div class="mel-onboard-steps" role="list" aria-label="{{ 'Onboarding steps'|t }}">
+    {% for step in journey_steps %}
+      <span role="listitem" class="mel-step{% if step.is_current %} mel-step--active{% endif %}{% if step.is_complete %} mel-step--complete{% endif %}">
+        {{ step.label }}
+      </span>
+      {% if not loop.last %}
+        <span class="mel-onboard-steps__sep" aria-hidden="true">→</span>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
@@ -1,44 +1,42 @@
 {#
 /**
  * @file
- * Vendor onboarding profile form — workspace shell + card + sticky actions.
+ * Vendor onboarding profile form — guided flow inside vendor shell main column.
  */
 #}
 {% set back_route = back_route ?? null %}
-<div class="mel-vendor-workspace mel-onboard-wrapper mel-onboard-wrapper--vendor">
-  <main class="mel-vendor-main mel-vendor-main--onboard">
-    {% if onboarding_stages is defined and onboarding_stages %}
-      {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
-    {% else %}
-      <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
-        <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
-        <div class="mel-onboard-progress-steps">
-          {% for i in 1..total_steps %}
-            <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
-              <span class="mel-onboard-progress-step-number">{{ i }}</span>
-            </div>
-          {% endfor %}
-        </div>
+<div class="mel-onboard-flow">
+  {% if journey_steps is defined and journey_steps %}
+    {% include '@myeventlane_vendor_theme/components/onboarding-journey-steps.html.twig' with { journey_steps: journey_steps } only %}
+  {% elseif onboarding_stages is defined and onboarding_stages %}
+    {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
+  {% else %}
+    <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
+      <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
+      <div class="mel-onboard-progress-steps">
+        {% for i in 1..total_steps %}
+          <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
+            <span class="mel-onboard-progress-step-number">{{ i }}</span>
+          </div>
+        {% endfor %}
       </div>
+    </div>
+  {% endif %}
+
+  {% if onboarding_progress_label %}
+    <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
+  {% endif %}
+
+  <header class="mel-onboard-header">
+    <h1 class="mel-onboard-title">{{ step_title }}</h1>
+    {% if step_description %}
+      <p class="mel-onboard-description">{{ step_description }}</p>
     {% endif %}
+  </header>
 
-    <header class="mel-onboard-header">
-      <h1 class="mel-onboard-title">{{ step_title }}</h1>
-      {% if step_description %}
-        <p class="mel-onboard-description">{{ step_description }}</p>
-      {% endif %}
-    </header>
-
+  <div class="mel-onboard-card mel-onboard-card--main">
     <form{{ attributes.addClass('mel-onboard-form-root') }}>
       {{ children }}
     </form>
-
-    {% if back_route %}
-      <div class="mel-onboard-nav">
-        <a href="{{ path(back_route) }}" class="mel-btn mel-btn-ghost">
-          {{ 'Back'|t }}
-        </a>
-      </div>
-    {% endif %}
-  </main>
+  </div>
 </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -62,33 +62,42 @@
       } only %}
     {% endif %}
 
-    <main class="mel-vendor-shell__content" role="main">
-      {% if page.highlighted %}
-        {{ page.highlighted }}
-      {% endif %}
-
-      {% if page.sidebar_help %}
-        <div class="mel-shell-layout mel-shell-layout--with-utility">
-          <div class="mel-shell-layout__main">
-            {% if is_dashboard_route %}
-              <section class="mel-dashboard-page">
-                {{ page.content }}
-              </section>
-            {% else %}
-              {{ page.content }}
-            {% endif %}
-          </div>
-          <aside class="mel-shell-layout__utility-rail" data-help-sidebar>
-            {{ page.sidebar_help }}
-          </aside>
+    <main class="mel-vendor-shell__content{% if page.vendor_onboard_inner %} mel-vendor-content{% endif %}" role="main">
+      {% if page.vendor_onboard_inner %}
+        <div class="mel-vendor-inner">
+          {% if page.highlighted %}
+            {{ page.highlighted }}
+          {% endif %}
+          {{ page.content }}
         </div>
       {% else %}
-        {% if is_dashboard_route %}
-          <section class="mel-dashboard-page">
-            {{ page.content }}
-          </section>
+        {% if page.highlighted %}
+          {{ page.highlighted }}
+        {% endif %}
+
+        {% if page.sidebar_help %}
+          <div class="mel-shell-layout mel-shell-layout--with-utility">
+            <div class="mel-shell-layout__main">
+              {% if is_dashboard_route %}
+                <section class="mel-dashboard-page">
+                  {{ page.content }}
+                </section>
+              {% else %}
+                {{ page.content }}
+              {% endif %}
+            </div>
+            <aside class="mel-shell-layout__utility-rail" data-help-sidebar>
+              {{ page.sidebar_help }}
+            </aside>
+          </div>
         {% else %}
-          {{ page.content }}
+          {% if is_dashboard_route %}
+            <section class="mel-dashboard-page">
+              {{ page.content }}
+            </section>
+          {% else %}
+            {{ page.content }}
+          {% endif %}
         {% endif %}
       {% endif %}
     </main>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Vendor onboarding step — aligned with Event Studio shell (left-aligned main, max width).
+ * Vendor onboarding step — guided column inside vendor shell (sidebar + main).
  */
 #}
 {% set step_number = form['#step_number'] ?? 1 %}
@@ -21,43 +21,62 @@
   {% set back_route = 'myeventlane_vendor.onboard.boost' %}
 {% endif %}
 
-<div class="mel-vendor-workspace mel-onboard-wrapper mel-onboard-wrapper--vendor">
-  <main class="mel-vendor-main mel-vendor-main--onboard">
-    {% if onboarding_stages is defined and onboarding_stages %}
-      {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
-    {% else %}
-      <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
-        <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
-        <div class="mel-onboard-progress-steps">
-          {% for i in 1..total_steps %}
-            <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
-              <span class="mel-onboard-progress-step-number">{{ i }}</span>
-            </div>
-          {% endfor %}
-        </div>
+<div class="mel-onboard-flow">
+  {% if journey_steps is defined and journey_steps %}
+    {% include '@myeventlane_vendor_theme/components/onboarding-journey-steps.html.twig' with { journey_steps: journey_steps } only %}
+  {% elseif onboarding_stages is defined and onboarding_stages %}
+    {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
+  {% else %}
+    <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
+      <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
+      <div class="mel-onboard-progress-steps">
+        {% for i in 1..total_steps %}
+          <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
+            <span class="mel-onboard-progress-step-number">{{ i }}</span>
+          </div>
+        {% endfor %}
       </div>
-    {% endif %}
-
-    <header class="mel-onboard-header">
-      <h1 class="mel-onboard-title">{{ step_title }}</h1>
-      {% if step_description %}
-        <p class="mel-onboard-description">{{ step_description }}</p>
-      {% endif %}
-    </header>
-
-    <div class="mel-onboard-content">
-      {% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
-      {% if form.form_token is defined %}{{ form.form_token }}{% endif %}
-      {% if form.form_id is defined %}{{ form.form_id }}{% endif %}
-      {{ form.step_content|default(form['#content']) }}
     </div>
+  {% endif %}
 
-    {% if back_route %}
-      <div class="mel-onboard-nav">
-        <a href="{{ path(back_route) }}" class="mel-btn mel-btn-ghost">
-          {{ 'Back'|t }}
-        </a>
-      </div>
+  {% if onboarding_progress_label %}
+    <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
+  {% endif %}
+
+  {% if stripe_state %}
+    <div class="mel-stripe-onboard-summary" role="status">
+      {% if stripe_state.payouts_enabled %}
+        <p class="mel-stripe-onboard-summary__line mel-stripe-onboard-summary__line--ok">{{ 'Payouts enabled'|t }} <span aria-hidden="true">✅</span></p>
+      {% elseif stripe_state.is_connected %}
+        <p class="mel-stripe-onboard-summary__line">{{ 'Continue setting up payments in Stripe to enable payouts.'|t }}</p>
+      {% else %}
+        <p class="mel-stripe-onboard-summary__line">{{ 'Connect Stripe to accept ticket payments.'|t }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <header class="mel-onboard-header">
+    <h1 class="mel-onboard-title">{{ step_title }}</h1>
+    {% if step_description %}
+      <p class="mel-onboard-description">{{ step_description }}</p>
     {% endif %}
-  </main>
+  </header>
+
+  <div class="mel-onboard-card mel-onboard-card--main">
+    {% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
+    {% if form.form_token is defined %}{{ form.form_token }}{% endif %}
+    {% if form.form_id is defined %}{{ form.form_id }}{% endif %}
+    {{ form.step_content|default(form['#content']) }}
+  </div>
+
+  {% if onboard_footer %}
+    <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+      <a href="{{ onboard_footer.back_url }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+      <a href="{{ onboard_footer.continue_url }}" class="mel-btn mel-btn--primary mel-onboard-footer__continue">{{ onboard_footer.continue_label }}</a>
+    </div>
+  {% elseif back_route %}
+    <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+      <a href="{{ path(back_route) }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates vendor onboarding templates/CSS/JS and Stripe-step controller render data, which can affect onboarding navigation and completion signals; also flips `user.settings` `verify_mail` to false, impacting account email verification behavior.
> 
> **Overview**
> **Vendor onboarding UI has been reworked into a guided, shell-aligned flow.** Templates now render a compact 4-step *journey strip* (with fallback to the old progress bar), wrap step content in a main card, and add a sticky split footer for Back/Continue CTAs; the vendor theme page layout adds an inner constrained rail for onboarding routes and suppresses the vendor alert banner during onboarding.
> 
> **Stripe onboarding step behavior is simplified and surfaced to Twig.** `VendorOnboardStripeController` now normalizes the Stripe account id, derives a `#stripe_state` summary, and drives footer CTA URLs/labels via `#onboard_footer` instead of per-phase links in content.
> 
> **Polish and gating updates.** Adds a small Drupal behavior (`vendor-onboard.js`) to autofocus the first field and disable submit until HTML5-valid, expands the onboarding gate subscriber to cover additional Event Studio/editor routes, adjusts onboarding CSS styling, and sets `user.settings.yml` `verify_mail: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115ce75ee136c2461fd95773f800db84e2558be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->