### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -339,11 +339,10 @@ function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateI
  *
  * Destination policy remains exclusively in PostLoginRouter (MelPostLoginController).
  *
- * Drupal core only calls user_login_finalize() during registration when
- * user.settings:verify_mail is FALSE (see RegisterForm::save()). The repo default in
- * config/sync is verify_mail: false so create-event signup can redirect here in the
- * same request. Production may override with $config in settings.php using
- * MEL_REQUIRE_VERIFY_MAIL=1 if email verification is required (no immediate login).
+ * When user.settings:verify_mail is TRUE, RegisterForm::save() does not call
+ * user_login_finalize(); the user is not authenticated in this request. In that
+ * case we store pending_mel_intent in user.data for the new account; hook_user_login()
+ * and PostLoginRouter merge it on first login (see IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT).
  */
 function myeventlane_auth_user_register_form_post_save_redirect(array &$form, FormStateInterface $form_state): void {
   if ($form_state->get('is_vendor_registration')) {
@@ -364,6 +363,32 @@ function myeventlane_auth_user_register_form_post_save_redirect(array &$form, Fo
   }
 
   if (!\Drupal::currentUser()->isAuthenticated()) {
+    $uid = (int) $form_state->getValue('uid');
+    if ($uid <= 0) {
+      $account = $form_state->get('user');
+      if ($account instanceof UserInterface) {
+        $uid = (int) $account->id();
+      }
+    }
+    if ($uid > 0) {
+      /** @var \Drupal\user\UserDataInterface $user_data */
+      $user_data = \Drupal::service('user.data');
+      $user_data->set(
+        'myeventlane_auth',
+        $uid,
+        IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT,
+        IdentityIntentResolver::INTENT_CREATE_EVENT,
+      );
+      \Drupal::logger('myeventlane_auth')->notice(
+        'MEL auth handoff: stored pending_mel_intent create_event uid=@uid (verify_mail; login deferred)',
+        ['@uid' => (string) $uid],
+      );
+    }
+    else {
+      \Drupal::logger('myeventlane_auth')->warning(
+        'MEL auth handoff: create_event registration could not resolve uid for pending_mel_intent.',
+      );
+    }
     return;
   }
 
@@ -537,6 +562,21 @@ function myeventlane_auth_user_login(UserInterface $account): void {
 
   $intent = myeventlane_auth_resolve_mel_intent_for_login_request($request);
 
+  /** @var \Drupal\myeventlane_auth\Service\IdentityIntentResolver $resolver */
+  $resolver = \Drupal::service('myeventlane_auth.identity_intent_resolver');
+  if ($resolver->normalizeIntent($intent) === IdentityIntentResolver::INTENT_BROWSE) {
+    /** @var \Drupal\user\UserDataInterface $user_data */
+    $user_data = \Drupal::service('user.data');
+    $pending = $user_data->get(
+      'myeventlane_auth',
+      (int) $account->id(),
+      IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT,
+    );
+    if ($pending === IdentityIntentResolver::INTENT_CREATE_EVENT) {
+      $intent = IdentityIntentResolver::INTENT_CREATE_EVENT;
+    }
+  }
+
   $internal = myeventlane_auth_destination_to_internal_path($request, $raw_dest);
   if ($internal === NULL || myeventlane_auth_should_skip_mel_hub_wrap($internal)) {
     $session->save();
@@ -547,6 +587,15 @@ function myeventlane_auth_user_login(UserInterface $account): void {
     'destination' => $internal,
     'intent' => $intent,
   ]);
+  if ($resolver->normalizeIntent($intent) === IdentityIntentResolver::INTENT_CREATE_EVENT) {
+    /** @var \Drupal\user\UserDataInterface $user_data */
+    $user_data = \Drupal::service('user.data');
+    $user_data->delete(
+      'myeventlane_auth',
+      (int) $account->id(),
+      IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT,
+    );
+  }
   $session->save();
 }
 

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.services.yml
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.services.yml
@@ -36,6 +36,7 @@ services:
       - '@myeventlane_auth.identity_intent_resolver'
       - '@logger.channel.myeventlane_auth'
       - '@myeventlane_core.route_helper'
+      - '@user.data'
 
   myeventlane_auth.customer_identity_bridge:
     class: Drupal\myeventlane_auth\Service\CustomerIdentityBridge

--- a/web/modules/custom/myeventlane_auth/src/Service/IdentityIntentResolver.php
+++ b/web/modules/custom/myeventlane_auth/src/Service/IdentityIntentResolver.php
@@ -25,6 +25,12 @@ final class IdentityIntentResolver {
   public const INTENT_CREATE_EVENT = 'create_event';
 
   /**
+   * user.data name: intent to apply on first login when verify_mail prevented
+   * immediate registration redirect (see myeventlane_auth_user_register_form_post_save_redirect).
+   */
+  public const USER_DATA_PENDING_MEL_INTENT = 'pending_mel_intent';
+
+  /**
    * @var list<string>
    */
   private const KNOWN = [

--- a/web/modules/custom/myeventlane_auth/src/Service/PostLoginRouter.php
+++ b/web/modules/custom/myeventlane_auth/src/Service/PostLoginRouter.php
@@ -11,6 +11,7 @@ use Drupal\myeventlane_auth\PostLoginDecision;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_core\Service\RouteHelper;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\user\UserDataInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -26,6 +27,7 @@ final class PostLoginRouter {
     private readonly IdentityIntentResolver $identityIntentResolver,
     private readonly LoggerChannelInterface $logger,
     private readonly RouteHelper $routeHelper,
+    private readonly UserDataInterface $userData,
   ) {}
 
   /**
@@ -58,6 +60,10 @@ final class PostLoginRouter {
         $intent,
         PostLoginDecision::FALLBACK_FRONT_INVALID_ACCOUNT,
       );
+    }
+
+    if ($intent === IdentityIntentResolver::INTENT_BROWSE) {
+      $intent = $this->applyPendingCreateEventIntentFromUserData($uid, $intent);
     }
 
     if ($intent === IdentityIntentResolver::INTENT_CREATE_EVENT) {
@@ -103,6 +109,30 @@ final class PostLoginRouter {
       $intent,
       PostLoginDecision::VENDOR_COMPLETE_DASHBOARD,
     );
+  }
+
+  /**
+   * Applies create_event from registration when verify_mail deferred login (user.data).
+   */
+  private function applyPendingCreateEventIntentFromUserData(int $uid, string $intent): string {
+    $pending = $this->userData->get(
+      'myeventlane_auth',
+      $uid,
+      IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT,
+    );
+    if ($pending !== IdentityIntentResolver::INTENT_CREATE_EVENT) {
+      return $intent;
+    }
+    $this->userData->delete(
+      'myeventlane_auth',
+      $uid,
+      IdentityIntentResolver::USER_DATA_PENDING_MEL_INTENT,
+    );
+    $this->logger->notice(
+      'PostLoginRouter: consumed pending_mel_intent create_event uid=@uid',
+      ['@uid' => (string) $uid],
+    );
+    return IdentityIntentResolver::INTENT_CREATE_EVENT;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
@@ -124,6 +124,15 @@ class CreateEventGatewayController extends ControllerBase {
       }
       $this->onboardingManager->recordCreateEventGatewayMilestone($state, 'event_started');
 
+      $account = $current_user->getAccount();
+      if ($account instanceof UserInterface) {
+        $this->onboardingManager->ensureVendorAccess($account);
+        $this->getLogger('myeventlane_vendor')->notice(
+          'ensureVendorAccess executed uid=@uid (create-event gateway, no vendor entity yet)',
+          ['@uid' => (string) $uid],
+        );
+      }
+
       $this->getLogger('myeventlane_vendor')->notice(
         'Create-event gateway: no vendor → redirecting to onboarding profile uid=@uid',
         ['@uid' => (string) $uid],

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
@@ -304,26 +303,13 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
 
   // Determine active section from route.
   $route_name = $route_match->getRouteName();
+  $is_vendor_onboard = is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor.onboard');
   $variables['page']['active_section'] = _myeventlane_vendor_theme_get_active_section($route_name);
   $variables['page']['vendor_shell_nav_items'] = _myeventlane_vendor_theme_build_vendor_shell_nav_items(
     $variables['page']['active_section'],
     $route_name,
     $route_match
   );
-
-  // Sidebar region: shell navigation is not a Twig include — render via page.sidebar
-  // so the page template uses standard Drupal regions (blocks may extend this later).
-  $sidebar_region = $variables['page']['sidebar'] ?? [];
-  $sidebar_empty = $sidebar_region === [] || $sidebar_region === NULL
-    || (is_array($sidebar_region) && Element::children($sidebar_region) === []);
-  if ($sidebar_empty) {
-    $page_for_shell = $variables['page'];
-    unset($page_for_shell['sidebar']);
-    $variables['page']['sidebar'] = [
-      '#theme' => 'vendor_sidebar',
-      'page' => $page_for_shell,
-    ];
-  }
 
   // Legacy step-wizard sidebar: staff/support only (vendors are redirected to Event Studio).
   $variables['page']['wizard_steps'] = [];
@@ -675,15 +661,15 @@ function myeventlane_vendor_theme_theme_suggestions_page_alter(array &$suggestio
   // Add page suggestions based on route.
   $route_name = \Drupal::routeMatch()->getRouteName();
 
+  if (is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor')) {
+    $suggestions[] = 'page__vendor';
+  }
+
   if (in_array($route_name, _myeventlane_vendor_theme_event_builder_layout_routes(), TRUE)) {
     $suggestions[] = 'page__vendor__event_wizard';
   }
   elseif ($route_name === 'myeventlane_vendor.dashboard') {
     $suggestions[] = 'page__vendor__dashboard';
-  }
-  elseif (is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor.onboard')) {
-    // Single shell template for all organiser onboarding routes (same as dashboard/events).
-    $suggestions[] = 'page__vendor';
   }
   elseif (str_starts_with($route_name ?? '', 'myeventlane_vendor.')) {
     $route_parts = explode('.', $route_name);

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -3,8 +3,8 @@
  * @file
  * Shared vendor shell layout for MyEventLane.
  *
- * Uses Drupal regions: page.sidebar (shell nav), page.content (main).
- * Same main column path for dashboard, onboarding, and console routes.
+ * Shell navigation is always the sidebar partial (same markup as dashboard).
+ * Main column: page.content.
  */
 #}
 {{ attach_library('myeventlane_vendor_theme/footer-internal') }}
@@ -15,7 +15,7 @@
 
 <div class="mel-vendor-shell{% if page.wizard_sidebar_active %} mel-vendor-shell--wizard-sidebar{% endif %}">
   <aside id="mel-vendor-sidebar" class="mel-vendor-shell__sidebar mel-vendor-sidebar" role="navigation" aria-label="{{ 'Vendor navigation'|t }}" data-sidebar>
-    {{ page.sidebar }}
+    {% include '@myeventlane_vendor_theme/includes/sidebar.html.twig' with { page: page } %}
   </aside>
 
   <div class="mel-vendor-shell__main">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes post-registration/login routing by persisting intent in `user.data` when email verification defers login, which could affect authentication redirect behavior. Also alters vendor theme page suggestion/sidebar rendering, impacting vendor UI consistency.
> 
> **Overview**
> Ensures the **`create_event` auth handoff survives registrations where `verify_mail` defers login** by storing a `pending_mel_intent` in `user.data` after registration and consuming/clearing it on first login in both `hook_user_login()` and `PostLoginRouter`.
> 
> Updates the create-event onboarding path to proactively call `ensureVendorAccess()` when a user hits the create-event gateway without a vendor membership.
> 
> Simplifies vendor shell rendering by always including the sidebar Twig partial (instead of relying on `page.sidebar` render array injection) and broadens the `page__vendor` theme suggestion to all `myeventlane_vendor*` routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c78c05c72ed1a8ad85e2bc7c06f8e126a631ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->