### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -240,5 +240,6 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@logger.factory'
+      - '@lock'
       - '@current_user'
       - '@datetime.time'

--- a/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
+++ b/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_core\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -51,6 +52,13 @@ final class OnboardingManager {
   private ?TimeInterface $time;
 
   /**
+   * Lock backend (serialises vendor-track state creation per uid).
+   *
+   * @var \Drupal\Core\Lock\LockBackendInterface
+   */
+  private LockBackendInterface $lock;
+
+  /**
    * Whether we have already logged duplicate state this request.
    *
    * @var array<string, true>
@@ -63,6 +71,7 @@ final class OnboardingManager {
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
+    LockBackendInterface $lock,
     ?AccountProxyInterface $current_user = NULL,
     ?TimeInterface $time = NULL,
   ) {
@@ -70,6 +79,7 @@ final class OnboardingManager {
     $this->loggerFactory = $logger_factory;
     $this->currentUser = $current_user;
     $this->time = $time;
+    $this->lock = $lock;
   }
 
   /**
@@ -122,23 +132,33 @@ final class OnboardingManager {
    *   The newest state, or NULL if none exists.
    */
   public function loadLatestStateForVendor(int $vendor_id): ?OnboardingStateInterface {
+    if ($vendor_id <= 0) {
+      return NULL;
+    }
+
     $storage = $this->getStorage();
     $ids = $storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('vendor_id', $vendor_id)
       ->condition('track', OnboardingStateInterface::TRACK_VENDOR)
-      ->sort('id', 'DESC')
       ->execute();
     if (empty($ids)) {
       return NULL;
     }
-    $count = count($ids);
-    if ($count > 1) {
-      $this->logDuplicateOnce('vendor', (string) $vendor_id);
+
+    $entities = $storage->loadMultiple($ids);
+    $sorted = $this->sortVendorTrackStatesNewestFirst($entities);
+    $canonical = $sorted[0] ?? NULL;
+    if (!$canonical instanceof OnboardingStateInterface) {
+      return NULL;
     }
-    $newest_id = reset($ids);
-    $state = $storage->load($newest_id);
-    return $state instanceof OnboardingStateInterface ? $state : NULL;
+
+    if (count($sorted) > 1) {
+      $this->logDuplicateOnce('vendor', (string) $vendor_id);
+      $this->deleteOlderVendorTrackStatesAfterCanonical($canonical, array_slice($sorted, 1), 'vendor', (string) $vendor_id);
+    }
+
+    return $canonical;
   }
 
   /**
@@ -162,21 +182,25 @@ final class OnboardingManager {
       ->accessCheck(FALSE)
       ->condition('uid', $uid)
       ->condition('track', OnboardingStateInterface::TRACK_VENDOR)
-      ->sort('created', 'DESC')
       ->execute();
 
     if (empty($ids)) {
       return NULL;
     }
 
-    $count = count($ids);
-    if ($count > 1) {
-      $this->logDuplicateOnce('vendor_uid', (string) $uid);
+    $entities = $storage->loadMultiple($ids);
+    $sorted = $this->sortVendorTrackStatesNewestFirst($entities);
+    $canonical = $sorted[0] ?? NULL;
+    if (!$canonical instanceof OnboardingStateInterface) {
+      return NULL;
     }
 
-    $newest_id = reset($ids);
-    $state = $storage->load($newest_id);
-    return $state instanceof OnboardingStateInterface ? $state : NULL;
+    if (count($sorted) > 1) {
+      $this->logDuplicateOnce('vendor_uid', (string) $uid);
+      $this->deleteOlderVendorTrackStatesAfterCanonical($canonical, array_slice($sorted, 1), 'vendor_uid', (string) $uid);
+    }
+
+    return $canonical;
   }
 
   /**
@@ -201,17 +225,34 @@ final class OnboardingManager {
       return $existing;
     }
 
-    $storage = $this->getStorage();
-    $state = $storage->create([
-      'uid' => $uid,
-      'track' => OnboardingStateInterface::TRACK_VENDOR,
-      'stage' => 'probe',
-      'completed' => FALSE,
-    ]);
-    $state->setOwnerId($uid);
-    $state->setFlags([]);
-    $state->save();
-    return $state;
+    $lock_name = 'myeventlane_onboarding_vendor_uid_' . (string) $uid;
+    $acquired = $this->lock->acquire($lock_name, 30.0);
+    if (!$acquired) {
+      $this->logger()->warning('Onboarding vendor state lock not acquired uid=@uid; reloading state.', ['@uid' => (string) $uid]);
+    }
+    try {
+      $existing = $this->loadVendorStateByUid($uid);
+      if ($existing !== NULL) {
+        return $existing;
+      }
+
+      $storage = $this->getStorage();
+      $state = $storage->create([
+        'uid' => $uid,
+        'track' => OnboardingStateInterface::TRACK_VENDOR,
+        'stage' => 'probe',
+        'completed' => FALSE,
+      ]);
+      $state->setOwnerId($uid);
+      $state->setFlags([]);
+      $state->save();
+      return $state;
+    }
+    finally {
+      if ($acquired) {
+        $this->lock->release($lock_name);
+      }
+    }
   }
 
   /**
@@ -626,6 +667,65 @@ final class OnboardingManager {
       return $map[$stage] ?? ['route_name' => NULL, 'title' => ''];
     }
     return ['route_name' => NULL, 'title' => ''];
+  }
+
+  /**
+   * Sorts vendor-track states by created (newest first), then id.
+   *
+   * @param array<int|string, mixed> $entities
+   *   Result of entity storage loadMultiple().
+   *
+   * @return list<\Drupal\myeventlane_core\Entity\OnboardingStateInterface>
+   */
+  private function sortVendorTrackStatesNewestFirst(array $entities): array {
+    $list = [];
+    foreach ($entities as $entity) {
+      if ($entity instanceof OnboardingStateInterface) {
+        $list[] = $entity;
+      }
+    }
+    usort($list, function (OnboardingStateInterface $a, OnboardingStateInterface $b) {
+      $ca = (int) ($a->get('created')->value ?? 0);
+      $cb = (int) ($b->get('created')->value ?? 0);
+      if ($ca !== $cb) {
+        return $cb <=> $ca;
+      }
+      return (int) $b->id() <=> (int) $a->id();
+    });
+    return $list;
+  }
+
+  /**
+   * Deletes duplicate vendor-track states, keeping the canonical row.
+   *
+   * @param list<\Drupal\myeventlane_core\Entity\OnboardingStateInterface> $older
+   *   Older states to remove (must not include $canonical).
+   */
+  private function deleteOlderVendorTrackStatesAfterCanonical(OnboardingStateInterface $canonical, array $older, string $log_track, string $log_key): void {
+    foreach ($older as $state) {
+      if (!$state instanceof OnboardingStateInterface) {
+        continue;
+      }
+      if ((int) $state->id() === (int) $canonical->id()) {
+        continue;
+      }
+      $id = (int) $state->id();
+      try {
+        $state->delete();
+        $this->logger()->warning('Removed duplicate vendor-track onboarding state id=@id (@track @key); kept=@keep.', [
+          '@id' => (string) $id,
+          '@track' => $log_track,
+          '@key' => $log_key,
+          '@keep' => (string) $canonical->id(),
+        ]);
+      }
+      catch (\Throwable $e) {
+        $this->logger()->error('Failed deleting duplicate onboarding state id=@id: @message', [
+          '@id' => (string) $id,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -11,3 +11,12 @@ mel_event_studio:
     - core/drupal
     - core/once
     - myeventlane_location/address_autocomplete
+
+# Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
+mel_event_studio_shell_only:
+  css:
+    theme:
+      css/mel-event-studio-nav.css: {}
+      css/mel-event-studio-shell.css: { weight: 200 }
+  dependencies:
+    - core/drupal

--- a/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
+++ b/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
@@ -1,19 +1,32 @@
 /**
  * @file
- * Vendor onboarding: focus first field (HTML5 validity gating disabled — see onboard_debug).
+ * Vendor onboarding: focus first field; gate primary submit on HTML5 validity.
  */
 (function (Drupal, once) {
   'use strict';
 
   Drupal.behaviors.melVendorOnboard = {
     attach(context) {
-      once('mel-onboard-autofocus', '.mel-page--vendor-onboard .mel-onboard-card', context).forEach((card) => {
-        const focusable = card.querySelector(
+      once('mel-onboard-autofocus', '.mel-page--vendor-onboard .mel-es-workspace__main form.mel-onboard-form', context).forEach((form) => {
+        const focusable = form.querySelector(
           'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
         );
         if (focusable) {
           focusable.focus({ preventScroll: true });
         }
+      });
+
+      once('mel-onboard-validity', '.mel-page--vendor-onboard form.mel-onboard-form', context).forEach((form) => {
+        const submit = form.querySelector('input[type="submit"].form-submit, button[type="submit"]');
+        if (!submit) {
+          return;
+        }
+        const sync = () => {
+          submit.disabled = !form.checkValidity();
+        };
+        form.addEventListener('input', sync);
+        form.addEventListener('change', sync);
+        sync();
       });
     },
   };

--- a/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
@@ -31,19 +31,38 @@ final class VendorConsoleAccess {
   ];
 
   /**
+   * Cache contexts for onboarding path override (path + role; avoid stale forbid).
+   *
+   * @var array<string>
+   */
+  private const ONBOARDING_CACHE_CONTEXTS = [
+    'url.path',
+    'user.roles',
+  ];
+
+  /**
    * Checks access for vendor console routes.
    */
   public static function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResult {
-    $request = \Drupal::requestStack()->getCurrentRequest();
-    $host = $request?->getHost() ?? '';
+    $request = \Drupal::request();
     $path = $request?->getPathInfo() ?? '';
+    $host = $request?->getHost() ?? '';
 
-    $route_name = $route_match->getRouteName();
-
-    // Allow onboarding routes always.
-    if ($route_name === 'myeventlane_vendor.onboard' || str_starts_with((string) $route_name, 'myeventlane_vendor.onboard.')) {
-      self::logDecision($account, $host, $path, 'allowed_onboarding');
-      return AccessResult::allowed()->addCacheContexts(self::CACHE_CONTEXTS);
+    // Path-based onboarding bypass: must run before any vendor permission logic.
+    // Route name alone is unreliable (subrequests, delegates, altered routes).
+    if (str_starts_with($path, '/vendor/onboard')) {
+      if ($account->isAnonymous()) {
+        self::logDecision($account, $host, $path, 'forbidden_anonymous');
+        return AccessResult::forbidden()->addCacheContexts(self::ONBOARDING_CACHE_CONTEXTS);
+      }
+      \Drupal::logger('mel_vendor_access_debug')->notice(
+        'Onboarding access override hit path=@path uid=@uid',
+        [
+          '@path' => $path,
+          '@uid' => (string) $account->id(),
+        ]
+      );
+      return AccessResult::allowed()->addCacheContexts(self::ONBOARDING_CACHE_CONTEXTS);
     }
 
     // Block anonymous.

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -1676,6 +1676,14 @@ final class VendorDashboardController extends VendorConsoleBaseController {
           $status['status'] = 'connected';
           $status['status_label'] = (string) $this->t('Payouts enabled');
         }
+        elseif ($connected) {
+          // Charges enabled: same seller-ready signal as assertStripeConnected; do not require payouts.
+          $status['stripe_phase'] = 'payouts_ready';
+          $status['is_onboarding_complete'] = TRUE;
+          $status['connected'] = TRUE;
+          $status['status'] = 'connected';
+          $status['status_label'] = (string) $this->t('Connected');
+        }
         elseif ($status['account_id']) {
           $status['stripe_phase'] = 'needs_completion';
           $status['status'] = 'pending';

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
@@ -80,7 +80,9 @@ final class VendorOnboardStripeController extends ControllerBase {
       );
     }
 
-    // Stripe UI phases: not connected | connected incomplete | payouts enabled.
+    // Stripe UI phases: not connected | Connect account incomplete (no charges yet) | ready to sell.
+    // charges_enabled is sufficient for event creation (same as assertStripeConnected). Payouts can lag
+    // or remain pending without blocking onboarding — do not treat payouts_enabled as the only "done" signal.
     $isConnected = FALSE;
     $payoutsEnabled = FALSE;
     $accountId = '';
@@ -108,23 +110,40 @@ final class VendorOnboardStripeController extends ControllerBase {
       }
     }
 
+    // Ready for onboarding: charges enabled OR payouts enabled (either implies seller path is usable).
+    $stripe_ready_for_onboarding = $payoutsEnabled || $isConnected;
     $stripe_phase = 'needs_connect';
-    if ($payoutsEnabled) {
+    if ($stripe_ready_for_onboarding) {
       $stripe_phase = 'payouts_ready';
     }
-    elseif ($isConnected || $accountId !== '') {
+    elseif ($accountId !== '') {
       $stripe_phase = 'needs_completion';
     }
 
     $stripe_state = [
       'is_connected' => $accountId !== '',
       'payouts_enabled' => $payoutsEnabled,
-      'is_onboarding_complete' => $payoutsEnabled,
+      // Step complete when charges are on (matches advanceStage + pre-regression UX), not only payouts.
+      'is_onboarding_complete' => $isConnected,
     ];
+
+    $uid = (int) $currentUser->id();
+    if ($uid === 1) {
+      $this->getLogger('myeventlane_vendor')->notice('[MEL_STRIPE_VERIFY] uid=@uid vendor_id=@vid store_id=@sid stripe_account=@acct charges_enabled=@ch payouts=@po onboarding_complete_shown=@oc phase=@ph', [
+        '@uid' => (string) $uid,
+        '@vid' => (string) $vendor->id(),
+        '@sid' => (string) $store->id(),
+        '@acct' => $accountId !== '' ? $accountId : '(empty)',
+        '@ch' => $isConnected ? '1' : '0',
+        '@po' => $payoutsEnabled ? '1' : '0',
+        '@oc' => !empty($stripe_state['is_onboarding_complete']) ? '1' : '0',
+        '@ph' => $stripe_phase,
+      ]);
+    }
 
     // Non-blocking: load/refresh onboarding state; advance when Stripe already connected.
     try {
-      $user = $this->entityTypeManager()->getStorage('user')->load((int) $currentUser->id());
+      $user = $this->entityTypeManager()->getStorage('user')->load($uid);
       if ($user instanceof \Drupal\user\UserInterface && $vendor->id()) {
         $state = $this->onboardingManager->loadOrCreateVendor($user, $vendor);
         $this->onboardingManager->refreshFlags($state);
@@ -161,13 +180,16 @@ final class VendorOnboardStripeController extends ControllerBase {
     ];
 
     if ($stripe_phase === 'payouts_ready') {
+      $done_text = $payoutsEnabled
+        ? $this->t('Your Stripe account can receive funds from ticket sales.')
+        : $this->t('Stripe is connected. You can accept payments for your events.');
       $content['done'] = [
         '#type' => 'container',
         '#attributes' => [
           'class' => ['mel-stripe-onboard-card-copy'],
         ],
         'message' => [
-          '#markup' => '<p>' . $this->t('Your Stripe account can receive funds from ticket sales.') . '</p>',
+          '#markup' => '<p>' . $done_text . '</p>',
         ],
       ];
       $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_vendor.onboard.first_event')->toString();
@@ -271,6 +293,9 @@ final class VendorOnboardStripeController extends ControllerBase {
   /**
    * Gets the vendor entity for the current user.
    *
+   * Prefers owning vendor (uid), then membership (field_vendor_users), matching
+   * OnboardingManager::ensureVendorExists and vendor theme onboarding stages.
+   *
    * @return \Drupal\myeventlane_vendor\Entity\Vendor|null
    *   The vendor entity, or NULL if not found.
    */
@@ -283,16 +308,26 @@ final class VendorOnboardStripeController extends ControllerBase {
     }
 
     $vendorStorage = $this->entityTypeManager()->getStorage('myeventlane_vendor');
-    $query = $vendorStorage->getQuery()
-      ->accessCheck(FALSE)
-      ->range(0, 1);
-    $group = $query->orConditionGroup()
-      ->condition('uid', $userId)
-      ->condition('field_vendor_users', $userId);
-    $vendorIds = $query->condition($group)->execute();
 
-    if (!empty($vendorIds)) {
-      $vendor = $vendorStorage->load(reset($vendorIds));
+    $owner_ids = $vendorStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $userId)
+      ->range(0, 1)
+      ->execute();
+    if (!empty($owner_ids)) {
+      $vendor = $vendorStorage->load(reset($owner_ids));
+      if ($vendor instanceof Vendor) {
+        return $vendor;
+      }
+    }
+
+    $member_ids = $vendorStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_vendor_users', $userId)
+      ->range(0, 1)
+      ->execute();
+    if (!empty($member_ids)) {
+      $vendor = $vendorStorage->load(reset($member_ids));
       if ($vendor instanceof Vendor) {
         return $vendor;
       }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Entity\OnboardingStateInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
@@ -99,10 +100,8 @@ final class VendorOnboardProfileForm extends FormBase {
     $form['#attributes']['class'][] = 'mel-onboard-form';
     $form['#attributes']['class'][] = 'mel-onboard-form-root';
     $form['#attributes']['class'][] = 'mel-onboard-profile-form';
-    $form['#attributes']['class'][] = 'mel-onboard-card';
-    $form['#attributes']['class'][] = 'mel-onboard-card--main';
 
-    $next_route = 'myeventlane_vendor.onboard.stripe';
+    $next_route = 'myeventlane_vendor.onboard.first_event';
     $state = $this->onboardingManager->loadVendorStateByUid((int) $this->currentUser->id());
     if ($state !== NULL) {
       $nr = $this->onboardingManager->getNextVendorOnboardRouteForAuthenticated($state);
@@ -111,11 +110,11 @@ final class VendorOnboardProfileForm extends FormBase {
       }
     }
     $continue_label = $this->t('Continue');
-    if (str_contains($next_route, 'stripe')) {
-      $continue_label = $this->t('Continue to payments');
-    }
-    elseif (str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
+    if (str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
       $continue_label = $this->t('Continue to event setup');
+    }
+    elseif (str_contains($next_route, 'stripe')) {
+      $continue_label = $this->t('Continue to payments');
     }
 
     $form['step_content'] = [
@@ -167,9 +166,9 @@ final class VendorOnboardProfileForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
-    $name = trim((string) ($form_state->getValue('name') ?? ''));
+    $name = trim((string) ($form_state->getValue(['step_content', 'name']) ?? ''));
     if ($name === '') {
-      $form_state->setErrorByName('name', $this->t('Organiser name is required.'));
+      $form_state->setError($form['step_content']['name'], $this->t('Organiser name is required.'));
     }
   }
 
@@ -177,16 +176,13 @@ final class VendorOnboardProfileForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    $this->getLogger('onboard_debug')->notice('VendorOnboardProfileForm submit triggered for uid @uid.', [
-      '@uid' => (string) $this->currentUser->id(),
-    ]);
     /** @var \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor */
     $vendor = $form_state->get('vendor');
     if (!$vendor instanceof Vendor) {
       return;
     }
 
-    $name = trim((string) ($form_state->getValue('name') ?? ''));
+    $name = trim((string) ($form_state->getValue(['step_content', 'name']) ?? ''));
     $vendor->setName($name);
 
     try {
@@ -217,12 +213,16 @@ final class VendorOnboardProfileForm extends FormBase {
       return;
     }
 
-    $account = $this->currentUser->getAccount();
-
     $user = $this->entityTypeManager->getStorage('user')->load($uid);
     if (!$user instanceof UserInterface) {
       return;
     }
+
+    $this->onboardingManager->ensureVendorAccess($user);
+    $this->getLogger('myeventlane_vendor')->notice(
+      'ensureVendorAccess executed during profile submit uid=@uid',
+      ['@uid' => (string) $uid],
+    );
 
     $state = $this->onboardingManager->loadVendorStateByUid($uid);
     if ($state === NULL) {
@@ -232,22 +232,29 @@ final class VendorOnboardProfileForm extends FormBase {
       $state->setVendorId((int) $vendor->id());
       $state->save();
     }
-    $this->onboardingManager->advanceStage($state, 'listen');
-    $this->getLogger('onboard_debug')->notice('STEP COMPLETE: profile step advanced to listen for uid @uid.', [
-      '@uid' => (string) $uid,
-    ]);
+
+    // Move to "first event" stage (ask); Stripe (listen) stays skippable and reachable from nav later.
+    $order = OnboardingStateInterface::STAGE_ORDER;
+    $current_idx = array_search($state->getStage(), $order, TRUE);
+    $ask_idx = array_search('ask', $order, TRUE);
+    if ($current_idx !== FALSE && $ask_idx !== FALSE && $current_idx < $ask_idx) {
+      $this->onboardingManager->advanceStage($state, 'ask');
+    }
 
     $next = $this->onboardingManager->getNextAction($state);
-    $next_route = !empty($next['route_name']) ? $next['route_name'] : 'myeventlane_vendor.onboard.stripe';
+    $next_route = !empty($next['route_name']) ? $next['route_name'] : 'myeventlane_vendor.onboard.first_event';
 
-    $this->getLogger('myeventlane_vendor')->info('onboard step2 submit ok uid=@uid vendor_id=@vid next_route=@route', [
-      '@uid' => $uid,
-      '@vid' => $vendor->id(),
-      '@route' => $next_route,
-    ]);
-
-    $this->messenger()->addStatus($this->t('Saved. Next: Connect payouts.'));
+    $this->messenger()->addStatus($this->t('Saved. Next: create your first event.'));
     $form_state->setRedirect($next_route);
+
+    $this->getLogger('myeventlane_vendor')->notice(
+      'VendorOnboardProfileForm submitForm completed: redirect=@route uid=@uid vendor_id=@vid',
+      [
+        '@route' => $next_route,
+        '@uid' => (string) $uid,
+        '@vid' => (string) $vendor->id(),
+      ],
+    );
   }
 
 }

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -19,6 +19,53 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
+ * Whether the current route is organiser onboarding (restricted shell nav).
+ */
+function _myeventlane_vendor_theme_is_vendor_onboard_route(?string $route_name): bool {
+  return is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor.onboard');
+}
+
+/**
+ * Whether the current user may access a named route (Drupal access manager).
+ */
+function _myeventlane_vendor_theme_named_route_accessible(string $route_name, array $parameters = []): bool {
+  try {
+    return \Drupal::accessManager()
+      ->checkNamedRoute($route_name, $parameters, \Drupal::currentUser(), TRUE)
+      ->isAllowed();
+  }
+  catch (\Exception $e) {
+    return FALSE;
+  }
+}
+
+/**
+ * Home URL for sidebar brand (dashboard if allowed, else onboarding profile, else front).
+ */
+function _myeventlane_vendor_theme_vendor_brand_home_url(): string {
+  if (_myeventlane_vendor_theme_named_route_accessible('myeventlane_vendor.console.dashboard', [])) {
+    try {
+      return Url::fromRoute('myeventlane_vendor.console.dashboard')->toString();
+    }
+    catch (\Exception $e) {
+    }
+  }
+  if (_myeventlane_vendor_theme_named_route_accessible('myeventlane_vendor.onboard.profile', [])) {
+    try {
+      return Url::fromRoute('myeventlane_vendor.onboard.profile')->toString();
+    }
+    catch (\Exception $e) {
+    }
+  }
+  try {
+    return Url::fromRoute('<front>')->toString();
+  }
+  catch (\Exception $e) {
+    return '/';
+  }
+}
+
+/**
  * Implements hook_page_attachments_alter().
  *
  * Themes do not implement hook_page_attachments(); this alter strips accidental
@@ -291,9 +338,10 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
     ]);
   }
 
-  // Safe inbox URL for sidebar fallbacks (avoid Twig path() when module/routes absent).
+  // Safe inbox URL for sidebar fallbacks (omit when user cannot access the route).
   $variables['page']['vendor_notification_inbox_url'] = NULL;
-  if (\Drupal::moduleHandler()->moduleExists('myeventlane_notifications')) {
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_notifications')
+    && _myeventlane_vendor_theme_named_route_accessible('myeventlane_notifications.inbox', [])) {
     try {
       $variables['page']['vendor_notification_inbox_url'] = \Drupal\Core\Url::fromRoute('myeventlane_notifications.inbox')->toString();
     }
@@ -310,6 +358,12 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
     $route_name,
     $route_match
   );
+  $variables['page']['vendor_shell_brand_url'] = _myeventlane_vendor_theme_vendor_brand_home_url();
+
+  // Event Studio shell CSS (mel-es-workspace) for organiser onboarding — reuse module CSS, no wizard JS.
+  if ($is_vendor_onboard) {
+    $variables['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio_shell_only';
+  }
 
   // Legacy step-wizard sidebar: staff/support only (vendors are redirected to Event Studio).
   $variables['page']['wizard_steps'] = [];
@@ -1710,19 +1764,75 @@ function _myeventlane_vendor_theme_get_active_section(?string $route_name): stri
 }
 
 /**
- * Builds sidebar navigation with Dashboard wizard submenu links.
- *
- * @param string $active_section
- *   The active top-level section key.
- * @param string|null $route_name
- *   The current route name.
- * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
- *   The current route match.
+ * Onboarding-safe shell nav: core destinations only; each requires route access.
  *
  * @return array<int, array<string, mixed>>
  *   Sidebar items for vendor shell.
  */
-function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_section, ?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
+function _myeventlane_vendor_theme_build_onboarding_shell_nav_items(string $active_section, ?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
+  $wizard_children = _myeventlane_vendor_theme_build_event_wizard_submenu($route_name, $route_match);
+  $candidates = [
+    [
+      'key' => 'dashboard',
+      'label' => t('Dashboard'),
+      'icon' => 'dashboard',
+      'route' => 'myeventlane_vendor.console.dashboard',
+    ],
+    [
+      'key' => 'events',
+      'label' => t('Events'),
+      'icon' => 'events',
+      'route' => 'myeventlane_vendor.console.events',
+      'children' => $wizard_children,
+    ],
+    [
+      'key' => 'payouts',
+      'label' => t('Payouts'),
+      'icon' => 'payouts',
+      'route' => 'myeventlane_vendor.console.payouts',
+    ],
+    [
+      'key' => 'settings',
+      'label' => t('Settings'),
+      'icon' => 'settings',
+      'route' => 'myeventlane_vendor.console.settings',
+    ],
+    [
+      'key' => 'help',
+      'label' => t('Help'),
+      'icon' => 'help',
+      'route' => 'myeventlane_help_centre.home',
+      'path_fallback' => '/help',
+    ],
+  ];
+  $built = [];
+  foreach ($candidates as $item) {
+    $route = (string) $item['route'];
+    if (!_myeventlane_vendor_theme_named_route_accessible($route, [])) {
+      continue;
+    }
+    $url = _myeventlane_vendor_theme_safe_route_url($route);
+    if ($url === NULL && !empty($item['path_fallback'])) {
+      $url = (string) $item['path_fallback'];
+    }
+    if ($url === NULL) {
+      continue;
+    }
+    $item['url'] = $url;
+    $item['is_disabled'] = FALSE;
+    $item['is_active'] = ($active_section === $item['key']);
+    $built[] = $item;
+  }
+  return $built;
+}
+
+/**
+ * Full vendor console shell nav; omits items the account cannot access.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Sidebar items for vendor shell.
+ */
+function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $active_section, ?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
   $wizard_children = _myeventlane_vendor_theme_build_event_wizard_submenu($route_name, $route_match);
   $items = [
     [
@@ -1797,9 +1907,6 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
 
   $built = [];
   foreach ($items as $item) {
-    $url = NULL;
-    $is_disabled = FALSE;
-
     if ($item['key'] === 'refund_requests') {
       if (!\Drupal::moduleHandler()->moduleExists('myeventlane_refunds')) {
         continue;
@@ -1809,6 +1916,9 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
       }
       $event_id = _myeventlane_vendor_theme_resolve_event_id($route_match);
       if ($event_id === NULL) {
+        continue;
+      }
+      if (!_myeventlane_vendor_theme_named_route_accessible('myeventlane_refunds.vendor_refund_requests', ['node' => $event_id])) {
         continue;
       }
       $url = _myeventlane_vendor_theme_safe_route_url('myeventlane_refunds.vendor_refund_requests', ['node' => $event_id]);
@@ -1822,7 +1932,18 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
       continue;
     }
 
+    if ($item['key'] === 'orders') {
+      $item['url'] = NULL;
+      $item['is_disabled'] = TRUE;
+      $item['is_active'] = ($active_section === $item['key']);
+      $built[] = $item;
+      continue;
+    }
+
     if (!empty($item['route'])) {
+      if (!_myeventlane_vendor_theme_named_route_accessible((string) $item['route'], [])) {
+        continue;
+      }
       $url = _myeventlane_vendor_theme_safe_route_url((string) $item['route']);
       if ($url === NULL && !empty($item['path_fallback'])) {
         $url = (string) $item['path_fallback'];
@@ -1830,7 +1951,7 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
       $is_disabled = $url === NULL;
     }
     else {
-      $is_disabled = TRUE;
+      continue;
     }
     $item['url'] = $url;
     $item['is_disabled'] = $is_disabled;
@@ -1839,6 +1960,26 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
   }
 
   return $built;
+}
+
+/**
+ * Builds sidebar navigation with Dashboard wizard submenu links.
+ *
+ * @param string $active_section
+ *   The active top-level section key.
+ * @param string|null $route_name
+ *   The current route name.
+ * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+ *   The current route match.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Sidebar items for vendor shell.
+ */
+function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_section, ?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
+  if (_myeventlane_vendor_theme_is_vendor_onboard_route($route_name)) {
+    return _myeventlane_vendor_theme_build_onboarding_shell_nav_items($active_section, $route_name, $route_match);
+  }
+  return _myeventlane_vendor_theme_build_full_vendor_shell_nav_items($active_section, $route_name, $route_match);
 }
 
 /**
@@ -1855,6 +1996,10 @@ function _myeventlane_vendor_theme_build_vendor_shell_nav_items(string $active_s
 function _myeventlane_vendor_theme_build_event_wizard_submenu(?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
   $event_id = _myeventlane_vendor_theme_resolve_event_id($route_match);
   if ($event_id === NULL) {
+    return [];
+  }
+
+  if (!_myeventlane_vendor_theme_named_route_accessible('myeventlane_event_studio.edit', ['node' => $event_id])) {
     return [];
   }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_vendor-onboard-shell.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_vendor-onboard-shell.scss
@@ -13,13 +13,14 @@ body.mel-page--vendor-onboard {
     background: $ml-vendor-bg;
   }
 
+  // Full-width main column: inner layout uses Event Studio .mel-es-workspace (sidebar + 720px main).
   .mel-vendor-shell__content.mel-vendor-main {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     align-items: stretch;
     width: 100%;
-    max-width: 45rem; // guided column — matches former .mel-vendor-inner
+    max-width: none;
     margin: 0;
     padding-top: $spacing-6;
     padding-bottom: $spacing-12;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-onboard-studio-nav.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-onboard-studio-nav.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Onboarding step navigation — same structure/BEM as mel-event-studio-nav.html.twig
+ *
+ * Variables:
+ * - stages: from _myeventlane_vendor_theme_build_onboarding_stages() — key, label, url,
+ *   is_complete, is_current, is_locked
+ */
+#}
+<nav class="mel-es-nav mel-sidebar-nav mel-event-studio-nav mel-studio-nav mel-wizard-nav mel-onboard-studio-nav" id="mel-onboard-wizard-nav" aria-label="{{ 'Organiser setup'|t }}">
+  <p class="mel-event-studio-nav__label">{{ 'Steps'|t }}</p>
+  <ul class="mel-sidebar-nav__list">
+    {% for stage in stages %}
+      <li>
+        {% if stage.url and not stage.is_locked %}
+          <a href="{{ stage.url }}" class="mel-nav-item mel-nav-link mel-event-studio-nav__item{% if stage.is_current %} is-active active{% endif %}{% if stage.is_complete %} mel-event-studio-nav__item--complete{% endif %}" data-onboard-stage="{{ stage.key }}"{% if stage.is_current %} aria-current="page"{% endif %}>{{ stage.label }}</a>
+        {% else %}
+          <span class="mel-nav-item mel-nav-link mel-event-studio-nav__item mel-event-studio-nav__item--locked{% if stage.is_current %} is-active active{% endif %}"{% if stage.is_locked %} aria-disabled="true"{% endif %}>{{ stage.label }}{% if stage.is_locked %} <span class="visually-hidden">({{ 'Locked'|t }})</span>{% endif %}</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
@@ -1,37 +1,36 @@
 {#
 /**
  * @file
- * Vendor onboarding profile form — shell main column only (no duplicate page wrappers).
+ * Vendor onboarding profile form — Event Studio mel-es-workspace layout (sidebar + main).
+ *
+ * Same outer pattern as mel-event-studio.html.twig (mel-event-studio + mel-es-workspace).
+ * Single root form; no nested forms.
  */
 #}
-{% if journey_steps is defined and journey_steps %}
-  {% include '@myeventlane_vendor_theme/components/onboarding-journey-steps.html.twig' with { journey_steps: journey_steps } only %}
-{% elseif onboarding_stages is defined and onboarding_stages %}
-  {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
-{% else %}
-  <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
-    <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
-    <div class="mel-onboard-progress-steps">
-      {% for i in 1..total_steps %}
-        <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
-          <span class="mel-onboard-progress-step-number">{{ i }}</span>
-        </div>
-      {% endfor %}
-    </div>
+<div class="mel-event-studio mel-event-studio--onboard mel-onboard-es" data-mel-onboard-es="1">
+  <div class="mel-es-workspace">
+    <aside class="mel-es-workspace__sidebar" aria-label="{{ 'Onboarding steps'|t }}">
+      {% if onboarding_stages is defined and onboarding_stages %}
+        {% include '@myeventlane_vendor_theme/components/mel-onboard-studio-nav.html.twig' with { stages: onboarding_stages } only %}
+      {% endif %}
+    </aside>
+    <main class="mel-es-workspace__main">
+      {% if onboarding_progress_label %}
+        <p class="mel-onboard-progress-text mel-es-onboard__progress-label">{{ onboarding_progress_label }}</p>
+      {% endif %}
+
+      <header class="mel-onboard-header">
+        <h1 class="mel-onboard-title">{{ step_title }}</h1>
+        {% if step_description %}
+          <p class="mel-onboard-description">{{ step_description }}</p>
+        {% endif %}
+      </header>
+
+      <div class="mel-es-card mel-onboard-es-form-card">
+        <form{{ attributes }}>
+          {{ children }}
+        </form>
+      </div>
+    </main>
   </div>
-{% endif %}
-
-{% if onboarding_progress_label %}
-  <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
-{% endif %}
-
-<header class="mel-onboard-header">
-  <h1 class="mel-onboard-title">{{ step_title }}</h1>
-  {% if step_description %}
-    <p class="mel-onboard-description">{{ step_description }}</p>
-  {% endif %}
-</header>
-
-<form{{ attributes }}>
-  {{ children }}
-</form>
+</div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
@@ -14,24 +14,15 @@
   {% endif %}
 
   <div class="mel-sidebar__brand">
-    <a href="{{ path('myeventlane_vendor.console.dashboard') }}" class="mel-sidebar__logo" aria-label="{{ 'Vendor dashboard'|t }}">
+    <a href="{{ page.vendor_shell_brand_url|default(path('myeventlane_vendor.console.dashboard')) }}" class="mel-sidebar__logo" aria-label="{{ 'Vendor dashboard'|t }}">
       <span class="mel-sidebar__logo-mark">M</span>
       <span class="mel-sidebar__logo-text">MyEventLane</span>
     </a>
   </div>
 
-  {% set nav_items = page.vendor_shell_nav_items|default([
-    { key: 'dashboard', label: 'Dashboard'|t, icon: 'dashboard', url: path('myeventlane_vendor.console.dashboard'), is_active: page.active_section|default('dashboard') == 'dashboard', is_disabled: false },
-    { key: 'notifications', label: 'Notifications'|t, icon: 'notifications', url: page.vendor_notification_inbox_url|default(null), is_active: page.active_section|default('dashboard') == 'notifications', is_disabled: page.vendor_notification_inbox_url|default(null) is empty },
-    { key: 'events', label: 'Events'|t, icon: 'events', url: path('myeventlane_vendor.console.events'), is_active: page.active_section|default('dashboard') == 'events', is_disabled: false },
-    { key: 'orders', label: 'Orders'|t, icon: 'orders', url: null, is_active: page.active_section|default('dashboard') == 'orders', is_disabled: true },
-    { key: 'attendees', label: 'Attendees'|t, icon: 'attendees', url: path('myeventlane_checkout_flow.vendor_attendees'), is_active: page.active_section|default('dashboard') == 'attendees', is_disabled: false },
-    { key: 'audience', label: 'Audience'|t, icon: 'audience', url: path('myeventlane_vendor.console.audience'), is_active: page.active_section|default('dashboard') == 'audience', is_disabled: false },
-    { key: 'payouts', label: 'Payouts'|t, icon: 'payouts', url: path('myeventlane_vendor.console.payouts'), is_active: page.active_section|default('dashboard') == 'payouts', is_disabled: false },
-    { key: 'growth', label: 'Growth'|t, icon: 'growth', url: path('myeventlane_vendor.console.boost'), is_active: page.active_section|default('dashboard') == 'growth', is_disabled: false },
-    { key: 'settings', label: 'Settings'|t, icon: 'settings', url: path('myeventlane_vendor.console.settings'), is_active: page.active_section|default('dashboard') == 'settings', is_disabled: false },
-    { key: 'help', label: 'Help'|t, icon: 'help', url: path('myeventlane_help_centre.home'), is_active: page.active_section|default('dashboard') == 'help', is_disabled: false }
-  ]) %}
+  {# Nav items MUST come from myeventlane_vendor_theme_preprocess_page — never use |default(hardcoded):
+     Twig's default() treats [] as empty and would replace PHP-built onboarding-safe nav. #}
+  {% set nav_items = page.vendor_shell_nav_items is defined ? page.vendor_shell_nav_items : [] %}
 
   <ul class="mel-sidebar__nav" role="list">
     {% for item in nav_items %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Vendor onboarding step — shell main column only (no duplicate layout wrappers).
+ * Vendor onboarding step — Event Studio mel-es-workspace (inner step sidebar + main).
  */
 #}
 {% set step_number = form['#step_number'] ?? 1 %}
@@ -21,58 +21,54 @@
   {% set back_route = 'myeventlane_vendor.onboard.boost' %}
 {% endif %}
 
-{% if journey_steps is defined and journey_steps %}
-  {% include '@myeventlane_vendor_theme/components/onboarding-journey-steps.html.twig' with { journey_steps: journey_steps } only %}
-{% elseif onboarding_stages is defined and onboarding_stages %}
-  {% include '@myeventlane_vendor_theme/components/onboarding-progress.html.twig' with { stages: onboarding_stages } %}
-{% else %}
-  <div class="mel-onboard-progress" role="progressbar" aria-valuenow="{{ step_number }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}" aria-label="{{ 'Onboarding progress'|t }}">
-    <div class="mel-onboard-progress-bar" style="width: {{ (step_number / total_steps * 100)|round }}%"></div>
-    <div class="mel-onboard-progress-steps">
-      {% for i in 1..total_steps %}
-        <div class="mel-onboard-progress-step {{ i <= step_number ? 'mel-onboard-progress-step--active' : '' }} {{ i == step_number ? 'mel-onboard-progress-step--current' : '' }}">
-          <span class="mel-onboard-progress-step-number">{{ i }}</span>
+<div class="mel-event-studio mel-event-studio--onboard mel-onboard-es" data-mel-onboard-es="1">
+  <div class="mel-es-workspace">
+    <aside class="mel-es-workspace__sidebar" aria-label="{{ 'Onboarding steps'|t }}">
+      {% if onboarding_stages is defined and onboarding_stages %}
+        {% include '@myeventlane_vendor_theme/components/mel-onboard-studio-nav.html.twig' with { stages: onboarding_stages } only %}
+      {% endif %}
+    </aside>
+    <main class="mel-es-workspace__main">
+      {% if onboarding_progress_label %}
+        <p class="mel-onboard-progress-text mel-es-onboard__progress-label">{{ onboarding_progress_label }}</p>
+      {% endif %}
+
+      {% if stripe_state %}
+        <div class="mel-stripe-onboard-summary mel-es-card" role="status">
+          {% if stripe_state.payouts_enabled %}
+            <p class="mel-stripe-onboard-summary__line mel-stripe-onboard-summary__line--ok">{{ 'Payouts enabled'|t }} <span aria-hidden="true">✅</span></p>
+          {% elseif stripe_state.is_onboarding_complete %}
+            <p class="mel-stripe-onboard-summary__line mel-stripe-onboard-summary__line--ok">{{ 'Stripe is connected — you can accept ticket payments.'|t }}</p>
+          {% elseif stripe_state.is_connected %}
+            <p class="mel-stripe-onboard-summary__line">{{ 'Continue setting up payments in Stripe to enable payouts.'|t }}</p>
+          {% else %}
+            <p class="mel-stripe-onboard-summary__line">{{ 'Connect Stripe to accept ticket payments.'|t }}</p>
+          {% endif %}
         </div>
-      {% endfor %}
-    </div>
+      {% endif %}
+
+      <header class="mel-onboard-header">
+        <h1 class="mel-onboard-title">{{ step_title }}</h1>
+        {% if step_description %}
+          <p class="mel-onboard-description">{{ step_description }}</p>
+        {% endif %}
+      </header>
+
+      {% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
+      {% if form.form_token is defined %}{{ form.form_token }}{% endif %}
+      {% if form.form_id is defined %}{{ form.form_id }}{% endif %}
+      {{ form.step_content|default(form['#content']) }}
+
+      {% if onboard_footer %}
+        <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+          <a href="{{ onboard_footer.back_url }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+          <a href="{{ onboard_footer.continue_url }}" class="mel-btn mel-btn--primary mel-onboard-footer__continue">{{ onboard_footer.continue_label }}</a>
+        </div>
+      {% elseif back_route %}
+        <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+          <a href="{{ path(back_route) }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+        </div>
+      {% endif %}
+    </main>
   </div>
-{% endif %}
-
-{% if onboarding_progress_label %}
-  <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
-{% endif %}
-
-{% if stripe_state %}
-  <div class="mel-stripe-onboard-summary" role="status">
-    {% if stripe_state.payouts_enabled %}
-      <p class="mel-stripe-onboard-summary__line mel-stripe-onboard-summary__line--ok">{{ 'Payouts enabled'|t }} <span aria-hidden="true">✅</span></p>
-    {% elseif stripe_state.is_connected %}
-      <p class="mel-stripe-onboard-summary__line">{{ 'Continue setting up payments in Stripe to enable payouts.'|t }}</p>
-    {% else %}
-      <p class="mel-stripe-onboard-summary__line">{{ 'Connect Stripe to accept ticket payments.'|t }}</p>
-    {% endif %}
-  </div>
-{% endif %}
-
-<header class="mel-onboard-header">
-  <h1 class="mel-onboard-title">{{ step_title }}</h1>
-  {% if step_description %}
-    <p class="mel-onboard-description">{{ step_description }}</p>
-  {% endif %}
-</header>
-
-{% if form.form_build_id is defined %}{{ form.form_build_id }}{% endif %}
-{% if form.form_token is defined %}{{ form.form_token }}{% endif %}
-{% if form.form_id is defined %}{{ form.form_id }}{% endif %}
-{{ form.step_content|default(form['#content']) }}
-
-{% if onboard_footer %}
-  <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
-    <a href="{{ onboard_footer.back_url }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
-    <a href="{{ onboard_footer.continue_url }}" class="mel-btn mel-btn--primary mel-onboard-footer__continue">{{ onboard_footer.continue_label }}</a>
-  </div>
-{% elseif back_route %}
-  <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
-    <a href="{{ path(back_route) }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
-  </div>
-{% endif %}
+</div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches onboarding state persistence (adds locking and deletes duplicate rows) and changes vendor-console access/onboarding routing, which could affect user flow and permissions if misconfigured. UI/layout changes are moderate but coupled to these behavior changes.
> 
> **Overview**
> Vendor onboarding is moved onto the Event Studio shell/layout: a new CSS-only library `mel_event_studio_shell_only` is attached on onboarding routes, onboarding step templates are reworked to use `mel-es-workspace` with a new sidebar nav component, and the vendor sidebar now relies solely on PHP-built, access-checked nav/brand URLs.
> 
> Onboarding flow logic is adjusted so profile submit grants vendor access, advances directly to the "first event" stage (making Stripe more skippable), and the Stripe step treats `charges_enabled` as sufficient to mark the step complete (with updated dashboard/status messaging).
> 
> Onboarding state handling is hardened by adding a per-uid lock around vendor state creation and by canonicalizing vendor-track state lookup to deterministically pick the newest by `created`/`id` and proactively delete older duplicates; vendor-console access also adds a path-based `/vendor/onboard` bypass with dedicated cache contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2537c7210c4a7300143aaa6b5aedd7b2508538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->