### PR TITLE
Enhance vendor onboarding process by improving lock acquisition logic…

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
+++ b/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
@@ -228,7 +228,17 @@ final class OnboardingManager {
     $lock_name = 'myeventlane_onboarding_vendor_uid_' . (string) $uid;
     $acquired = $this->lock->acquire($lock_name, 30.0);
     if (!$acquired) {
-      $this->logger()->warning('Onboarding vendor state lock not acquired uid=@uid; reloading state.', ['@uid' => (string) $uid]);
+      $this->lock->wait($lock_name, 30);
+      $acquired = $this->lock->acquire($lock_name, 30.0);
+    }
+    if (!$acquired) {
+      $this->logger()->warning('Onboarding vendor state lock not acquired uid=@uid after wait; reloading state.', ['@uid' => (string) $uid]);
+      $existing = $this->loadVendorStateByUid($uid);
+      if ($existing !== NULL) {
+        return $existing;
+      }
+      $this->logger()->error('Onboarding vendor state could not be created: lock unavailable uid=@uid', ['@uid' => (string) $uid]);
+      throw new \RuntimeException('Could not acquire lock to create vendor onboarding state.');
     }
     try {
       $existing = $this->loadVendorStateByUid($uid);
@@ -249,9 +259,7 @@ final class OnboardingManager {
       return $state;
     }
     finally {
-      if ($acquired) {
-        $this->lock->release($lock_name);
-      }
+      $this->lock->release($lock_name);
     }
   }
 
@@ -506,6 +514,23 @@ final class OnboardingManager {
   }
 
   /**
+   * Whether vendor onboarding is far enough along to use Event Studio / create events.
+   *
+   * Stripe (stage listen) is optional and must not block entry. Users who have
+   * finished the organiser profile advance to ask (or beyond); probe/present
+   * mean account/profile work is still required.
+   */
+  public function isVendorEventStudioUnlocked(OnboardingStateInterface $state): bool {
+    if ($state->getTrack() !== OnboardingStateInterface::TRACK_VENDOR) {
+      return FALSE;
+    }
+    if ($state->isCompleted()) {
+      return TRUE;
+    }
+    return !in_array($state->getStage(), ['probe', 'present'], TRUE);
+  }
+
+  /**
    * Whether the user has at least one completed Commerce order (lightweight count).
    *
    * Used for customer UX signals (e.g. post-login hub) without loading orders.
@@ -659,8 +684,9 @@ final class OnboardingManager {
       $map = [
         'probe' => ['route_name' => 'myeventlane_vendor.onboard.account', 'title' => 'Create account'],
         'present' => ['route_name' => 'myeventlane_vendor.onboard.profile', 'title' => 'Set up profile'],
-        'listen' => ['route_name' => 'myeventlane_vendor.onboard.stripe', 'title' => 'Set up payments'],
-        'ask' => ['route_name' => 'myeventlane_vendor.onboard.first_event', 'title' => 'Create first event'],
+        // Payments are optional; progression continues in Event Studio after profile.
+        'listen' => ['route_name' => 'myeventlane_event_studio.create', 'title' => 'Create your event'],
+        'ask' => ['route_name' => 'myeventlane_event_studio.create', 'title' => 'Create your event'],
         'invite' => ['route_name' => 'myeventlane_vendor.onboard.boost', 'title' => 'Promote with Boost'],
         'complete' => ['route_name' => NULL, 'title' => ''],
       ];

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -538,3 +538,33 @@
 .mel-event-studio .mel-publish-warning__cta {
   display: inline-flex;
 }
+
+.mel-event-studio .mel-publish-warning--stripe {
+  background: #f0f7ff;
+  border-color: #93c5fd;
+}
+
+/* First-event onboarding banner (post–profile entry) */
+.mel-event-studio .mel-es-first-event-banner {
+  margin: 0 0 16px;
+  padding: 16px 20px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255, 107, 107, 0.12) 0%, rgba(255, 255, 255, 0.95) 100%);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.06), 0 2px 4px -2px rgba(0, 0, 0, 0.06);
+}
+
+.mel-event-studio .mel-es-first-event-banner__title {
+  margin: 0 0 4px;
+  font-family: 'Nunito', system-ui, sans-serif;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.mel-event-studio .mel-es-first-event-banner__sub {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: #64748b;
+  line-height: 1.45;
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -5,6 +5,8 @@ services:
       - '@current_user'
       - '@myeventlane_vendor.user_vendor_membership_query'
       - '@myeventlane_onboarding.manager'
+      - '@entity_type.manager'
+      - '@request_stack'
 
   myeventlane_event_studio.vendor_legacy_wizard_redirect_subscriber:
     class: Drupal\myeventlane_event_studio\EventSubscriber\VendorLegacyWizardRedirectSubscriber

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\OnboardingManager;
+use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Theme preprocess helpers for Event Studio templates.
@@ -19,6 +23,8 @@ final class EventStudioPreprocess {
     private readonly AccountInterface $currentUser,
     private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
     private readonly OnboardingManager $onboardingManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly RequestStack $requestStack,
   ) {}
 
   /**
@@ -29,24 +35,57 @@ final class EventStudioPreprocess {
    */
   public function preprocess(array &$variables): void {
     $variables['mel_publish_blocked'] = FALSE;
+    $variables['mel_publish_stripe_gate'] = FALSE;
+    $variables['mel_stripe_connected'] = FALSE;
+    $variables['mel_show_first_event_banner'] = FALSE;
 
     $uid = (int) $this->currentUser->id();
-    if ($uid > 0) {
-      $vendor_ids = $this->userVendorMembershipQuery->getVendorIdsForUser($uid);
-      if ($vendor_ids === []) {
-        $variables['mel_publish_blocked'] = TRUE;
+    $vendor_ids = $uid > 0 ? $this->userVendorMembershipQuery->getVendorIdsForUser($uid) : [];
+
+    if ($uid > 0 && $vendor_ids === []) {
+      $variables['mel_publish_blocked'] = TRUE;
+    }
+
+    $stripe_connected = FALSE;
+    $state = NULL;
+    if ($uid > 0 && $vendor_ids !== []) {
+      $state = $this->onboardingManager->loadVendorStateByUid($uid);
+      $vendor = $this->entityTypeManager->getStorage('myeventlane_vendor')->load(reset($vendor_ids));
+      if ($state !== NULL && $vendor instanceof Vendor) {
+        $user = $this->entityTypeManager->getStorage('user')->load($uid);
+        if ($user instanceof UserInterface) {
+          $state = $this->onboardingManager->loadOrCreateVendor($user, $vendor);
+          $this->onboardingManager->refreshFlags($state);
+          $stripe_connected = !empty($state->getFlags()['stripe_connected']);
+        }
       }
-      else {
-        $state = $this->onboardingManager->loadVendorStateByUid($uid);
-        $complete = $state !== NULL
-          && $state->getStage() === 'complete'
-          && $state->isCompleted();
-        $variables['mel_publish_blocked'] = !$complete;
+    }
+
+    $variables['mel_stripe_connected'] = $stripe_connected;
+
+    $mode = (string) ($variables['mode'] ?? '');
+    $request = $this->requestStack->getCurrentRequest();
+    $first_flag = $request && (string) $request->query->get('mel_first_event') === '1';
+    if ($mode === 'create' && $state !== NULL && !$state->isCompleted()) {
+      if ($first_flag || $state->getStage() === 'ask') {
+        $variables['mel_show_first_event_banner'] = TRUE;
       }
     }
 
     $element = $variables['element'] ?? [];
     $node = $element['#mel_studio_node'] ?? NULL;
+
+    if ($node instanceof NodeInterface && $node->bundle() === 'event' && $vendor_ids !== []) {
+      $event_type = '';
+      if ($node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()) {
+        $event_type = (string) $node->get('field_event_type')->value;
+      }
+      $is_paid = in_array($event_type, ['paid', 'both'], TRUE);
+      if ($is_paid && !$stripe_connected) {
+        $variables['mel_publish_blocked'] = TRUE;
+        $variables['mel_publish_stripe_gate'] = TRUE;
+      }
+    }
 
     $actions = [
       'view' => NULL,

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -35,6 +35,13 @@
       </div>
     </div>
 
+    {% if mel_show_first_event_banner %}
+      <div class="mel-es-first-event-banner" role="status">
+        <p class="mel-es-first-event-banner__title">{{ '✨ You’re creating your first event'|t }}</p>
+        <p class="mel-es-first-event-banner__sub">{{ 'You can add payments later.'|t }}</p>
+      </div>
+    {% endif %}
+
     {# TOP ZONE — preview anchor for section nav #}
     <div class="mel-studio-top" id="mel-studio-preview-panel">
       <div class="mel-studio-top__preview">
@@ -397,18 +404,27 @@
                 <p class="mel-section__hint">{{ 'When you are ready, mark the event live. You can return here anytime.'|t }}</p>
               </header>
               {% if mel_publish_blocked %}
-                <div class="mel-publish-warning" role="region" aria-label="{{ 'Organiser setup required'|t }}">
-                  <h3 class="mel-publish-warning__title">{{ 'Before you publish your event'|t }}</h3>
-                  <p class="mel-publish-warning__lead">{{ 'To publish, you’ll need to complete your organiser setup.'|t }}</p>
-                  <ul class="mel-publish-warning__list">
-                    <li>{{ 'Add organiser profile'|t }}</li>
-                    <li>{{ 'Connect payments'|t }}</li>
-                    <li>{{ 'Confirm event details'|t }}</li>
-                  </ul>
-                  <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
-                    {{ 'Complete setup'|t }}
-                  </a>
-                </div>
+                {% if mel_publish_stripe_gate %}
+                  <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Connect payments to publish'|t }}">
+                    <h3 class="mel-publish-warning__title">{{ 'Almost ready to go live 🚀'|t }}</h3>
+                    <p class="mel-publish-warning__lead">{{ 'To sell tickets, you’ll need to connect payments.'|t }}</p>
+                    <a href="{{ path('myeventlane_vendor.onboard.stripe') }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
+                      {{ 'Connect payments'|t }}
+                    </a>
+                  </div>
+                {% else %}
+                  <div class="mel-publish-warning" role="region" aria-label="{{ 'Organiser setup required'|t }}">
+                    <h3 class="mel-publish-warning__title">{{ 'Before you publish your event'|t }}</h3>
+                    <p class="mel-publish-warning__lead">{{ 'To publish, you’ll need to complete your organiser setup.'|t }}</p>
+                    <ul class="mel-publish-warning__list">
+                      <li>{{ 'Add organiser profile'|t }}</li>
+                      <li>{{ 'Confirm event details'|t }}</li>
+                    </ul>
+                    <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
+                      {{ 'Complete setup'|t }}
+                    </a>
+                  </div>
+                {% endif %}
               {% endif %}
               {{ element.mel.status }}
             </section>

--- a/web/modules/custom/myeventlane_legal/src/Form/VendorTermsForm.php
+++ b/web/modules/custom/myeventlane_legal/src/Form/VendorTermsForm.php
@@ -56,9 +56,35 @@ final class VendorTermsForm extends FormBase {
 
     $form['#attached']['library'][] = 'myeventlane_vendor/onboarding';
 
+    $form['hero'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-onboard-terms-hero']],
+    ];
+    $form['hero']['headline'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h1',
+      '#value' => $this->t('Welcome to hosting on MyEventLane 🎉'),
+      '#attributes' => ['class' => ['mel-onboard-terms-hero__headline']],
+    ];
+    $form['hero']['lead'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Before you start, just a couple of quick things:'),
+      '#attributes' => ['class' => ['mel-onboard-terms-hero__lead']],
+    ];
+    $form['hero']['bullets'] = [
+      '#theme' => 'item_list',
+      '#items' => [
+        $this->t('Be respectful'),
+        $this->t('Follow local laws'),
+        $this->t('Keep your community safe'),
+      ],
+      '#attributes' => ['class' => ['mel-onboard-terms-hero__bullets']],
+    ];
+
     $form['legal'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Agreements'),
+      '#title' => $this->t('Legal agreements'),
       '#attributes' => ['class' => ['mel-vendor-terms']],
     ];
     $form['legal']['vendor_terms_agreed'] = [
@@ -83,8 +109,9 @@ final class VendorTermsForm extends FormBase {
     $form['actions'] = ['#type' => 'actions'];
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Accept and continue'),
+      '#value' => $this->t('Agree & Continue'),
       '#button_type' => 'primary',
+      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
     ];
 
     return $form;

--- a/web/modules/custom/myeventlane_vendor/css/onboarding.css
+++ b/web/modules/custom/myeventlane_vendor/css/onboarding.css
@@ -577,3 +577,49 @@ body.mel-page--vendor-onboard .mel-vendor .mel-vendor-workspace.mel-onboard-wrap
   color: var(--mel-onboard-muted);
   font-size: 0.875rem;
 }
+
+/* Terms step — MEL personality (legal checkboxes unchanged). */
+.mel-onboard-terms-hero {
+  max-width: var(--mel-onboard-max);
+  margin: 0 auto var(--mel-onboard-space-xl);
+  padding: var(--mel-onboard-space-xl) var(--mel-onboard-space-lg);
+  background: var(--mel-onboard-surface);
+  border-radius: var(--mel-onboard-radius);
+  box-shadow: var(--mel-onboard-shadow);
+  border: 1px solid var(--mel-onboard-border);
+}
+
+.mel-onboard-terms-hero__headline {
+  margin: 0 0 var(--mel-onboard-space-md);
+  font-family: 'Nunito', system-ui, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--mel-onboard-text);
+  line-height: 1.25;
+}
+
+.mel-onboard-terms-hero__lead {
+  margin: 0 0 var(--mel-onboard-space-md);
+  font-size: 1rem;
+  color: var(--mel-onboard-muted);
+  line-height: 1.5;
+}
+
+.mel-onboard-terms-hero__bullets {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--mel-onboard-text);
+  line-height: 1.6;
+}
+
+.mel-onboard-footer--triple {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mel-onboard-space-md);
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.mel-onboard-footer--triple .mel-onboard-footer__skip {
+  margin-inline-end: auto;
+}

--- a/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
+++ b/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
@@ -1,33 +1,10 @@
-/**
- * @file
- * Vendor onboarding: focus first field; gate primary submit on HTML5 validity.
- */
-(function (Drupal, once) {
-  'use strict';
-
-  Drupal.behaviors.melVendorOnboard = {
-    attach(context) {
-      once('mel-onboard-autofocus', '.mel-page--vendor-onboard .mel-es-workspace__main form.mel-onboard-form', context).forEach((form) => {
-        const focusable = form.querySelector(
-          'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
-        );
-        if (focusable) {
-          focusable.focus({ preventScroll: true });
-        }
-      });
-
-      once('mel-onboard-validity', '.mel-page--vendor-onboard form.mel-onboard-form', context).forEach((form) => {
-        const submit = form.querySelector('input[type="submit"].form-submit, button[type="submit"]');
-        if (!submit) {
-          return;
-        }
-        const sync = () => {
-          submit.disabled = !form.checkValidity();
-        };
-        form.addEventListener('input', sync);
-        form.addEventListener('change', sync);
-        sync();
-      });
-    },
+(function (Drupal) {
+  Drupal.behaviors.vendorOnboard = {
+    attach: function (context) {
+      const input = context.querySelector('input[name*="name"]');
+      if (input) {
+        input.focus();
+      }
+    }
   };
-})(Drupal, once);
+})(Drupal);

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -44,6 +44,7 @@ services:
       - '@string_translation'
       - '@myeventlane_core.entity_id_normalizer'
       - '@?myeventlane_event_studio.repository'
+      - '@myeventlane_onboarding.manager'
 
   myeventlane_vendor.vendor_console_page_preprocess:
     class: Drupal\myeventlane_vendor\Hook\VendorConsolePagePreprocess

--- a/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
@@ -164,7 +164,7 @@ class CreateEventGatewayController extends ControllerBase {
       $state = $this->onboardingManager->loadOrCreateVendor($account, $vendor);
     }
 
-    $is_complete = $state->getStage() === 'complete' && $state->isCompleted();
+    $is_complete = $this->onboardingManager->isVendorEventStudioUnlocked($state);
 
     if (!$is_complete) {
       if ($draft_nid !== NULL) {

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
@@ -128,18 +128,6 @@ final class VendorOnboardStripeController extends ControllerBase {
     ];
 
     $uid = (int) $currentUser->id();
-    if ($uid === 1) {
-      $this->getLogger('myeventlane_vendor')->notice('[MEL_STRIPE_VERIFY] uid=@uid vendor_id=@vid store_id=@sid stripe_account=@acct charges_enabled=@ch payouts=@po onboarding_complete_shown=@oc phase=@ph', [
-        '@uid' => (string) $uid,
-        '@vid' => (string) $vendor->id(),
-        '@sid' => (string) $store->id(),
-        '@acct' => $accountId !== '' ? $accountId : '(empty)',
-        '@ch' => $isConnected ? '1' : '0',
-        '@po' => $payoutsEnabled ? '1' : '0',
-        '@oc' => !empty($stripe_state['is_onboarding_complete']) ? '1' : '0',
-        '@ph' => $stripe_phase,
-      ]);
-    }
 
     // Non-blocking: load/refresh onboarding state; advance when Stripe already connected.
     try {
@@ -172,17 +160,18 @@ final class VendorOnboardStripeController extends ControllerBase {
     ]);
 
     $back_url = Url::fromRoute('myeventlane_vendor.onboard.profile')->toString();
+    $skip_url = Url::fromRoute('myeventlane_event_studio.create')->toString();
 
     $onboard_footer = [
       'back_url' => $back_url,
       'continue_url' => $connectUrl->toString(),
       'continue_label' => $this->t('Connect Stripe'),
+      'skip_url' => $skip_url,
+      'skip_label' => $this->t('Skip for now'),
     ];
 
     if ($stripe_phase === 'payouts_ready') {
-      $done_text = $payoutsEnabled
-        ? $this->t('Your Stripe account can receive funds from ticket sales.')
-        : $this->t('Stripe is connected. You can accept payments for your events.');
+      $done_text = $this->t('✅ You\'re ready to accept payments');
       $content['done'] = [
         '#type' => 'container',
         '#attributes' => [
@@ -192,8 +181,9 @@ final class VendorOnboardStripeController extends ControllerBase {
           '#markup' => '<p>' . $done_text . '</p>',
         ],
       ];
-      $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_vendor.onboard.first_event')->toString();
-      $onboard_footer['continue_label'] = $this->t('Continue to event setup');
+      $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_event_studio.create')->toString();
+      $onboard_footer['continue_label'] = $this->t('Continue to Event Studio');
+      unset($onboard_footer['skip_url'], $onboard_footer['skip_label']);
     }
     elseif ($stripe_phase === 'needs_completion') {
       $content['status'] = [
@@ -214,7 +204,7 @@ final class VendorOnboardStripeController extends ControllerBase {
           'class' => ['mel-onboard-stripe-intro'],
         ],
         'text' => [
-          '#markup' => '<p>' . $this->t('Connect Stripe to receive payments. Stripe is a secure payment processor used by millions of businesses.') . '</p>',
+          '#markup' => '<p>' . $this->t('💸 Want to sell tickets? Connect Stripe to get paid directly.') . '</p>',
         ],
       ];
 
@@ -239,8 +229,8 @@ final class VendorOnboardStripeController extends ControllerBase {
       '#theme' => 'vendor_onboard_step',
       '#step_number' => 3,
       '#total_steps' => 7,
-      '#step_title' => $this->t('Set up payments'),
-      '#step_description' => $this->t('Connect your Stripe account to accept payments for your events. This process takes about 5 minutes.'),
+      '#step_title' => $this->t('Payments (optional)'),
+      '#step_description' => $this->t('Connect Stripe when you want to sell tickets — or skip and add it later.'),
       '#content' => $content,
       '#stripe_state' => $stripe_state,
       '#onboard_footer' => $onboard_footer,

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
@@ -78,11 +78,10 @@ final class EventStudioVendorOnboardingGateSubscriber implements EventSubscriber
     }
 
     $state = $this->onboardingManager->loadVendorStateByUid($uid);
-    $is_complete = $state !== NULL
-      && $state->getStage() === 'complete'
-      && $state->isCompleted();
+    $is_unlocked = $state !== NULL
+      && $this->onboardingManager->isVendorEventStudioUnlocked($state);
 
-    if (!$is_complete) {
+    if (!$is_unlocked) {
       $this->redirectToGateway($event, $uid, 'onboarding_incomplete');
     }
   }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -91,17 +91,20 @@ final class VendorOnboardProfileForm extends FormBase {
     $vendor = $this->onboardingManager->ensureVendorExists($account);
     $form_state->set('vendor', $vendor);
 
+    // Nested step_content/* elements; required so getValue(['step_content', 'name']) matches input.
+    $form['#tree'] = TRUE;
+
     // Step metadata for form--vendor-onboard-profile-form.html.twig preprocess.
     $form['#step_number'] = 2;
     $form['#total_steps'] = 7;
-    $form['#step_title'] = $this->t('Set up your organiser profile');
-    $form['#step_description'] = $this->t('This helps people discover and trust your events.');
+    $form['#step_title'] = $this->t('Let’s set up your organiser profile 👋');
+    $form['#step_description'] = $this->t('This helps people trust your events.');
     $form['#attached']['library'][] = 'myeventlane_vendor/onboarding';
     $form['#attributes']['class'][] = 'mel-onboard-form';
     $form['#attributes']['class'][] = 'mel-onboard-form-root';
     $form['#attributes']['class'][] = 'mel-onboard-profile-form';
 
-    $next_route = 'myeventlane_vendor.onboard.first_event';
+    $next_route = 'myeventlane_event_studio.create';
     $state = $this->onboardingManager->loadVendorStateByUid((int) $this->currentUser->id());
     if ($state !== NULL) {
       $nr = $this->onboardingManager->getNextVendorOnboardRouteForAuthenticated($state);
@@ -110,8 +113,8 @@ final class VendorOnboardProfileForm extends FormBase {
       }
     }
     $continue_label = $this->t('Continue');
-    if (str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
-      $continue_label = $this->t('Continue to event setup');
+    if (str_contains($next_route, 'event_studio') || str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
+      $continue_label = $this->t('Continue to create your event');
     }
     elseif (str_contains($next_route, 'stripe')) {
       $continue_label = $this->t('Continue to payments');
@@ -176,6 +179,11 @@ final class VendorOnboardProfileForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->getLogger('onboard_debug')->notice(
+      'VALUES: <pre>@v</pre>',
+      ['@v' => print_r($form_state->getValues(), TRUE)]
+    );
+
     /** @var \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor */
     $vendor = $form_state->get('vendor');
     if (!$vendor instanceof Vendor) {
@@ -242,10 +250,12 @@ final class VendorOnboardProfileForm extends FormBase {
     }
 
     $next = $this->onboardingManager->getNextAction($state);
-    $next_route = !empty($next['route_name']) ? $next['route_name'] : 'myeventlane_vendor.onboard.first_event';
+    $next_route = !empty($next['route_name']) ? $next['route_name'] : 'myeventlane_event_studio.create';
 
-    $this->messenger()->addStatus($this->t('Saved. Next: create your first event.'));
-    $form_state->setRedirect($next_route);
+    $this->messenger()->addStatus($this->t('Saved. Next: create your event in Event Studio.'));
+    $form_state->setRedirect($next_route, [], [
+      'query' => ['mel_first_event' => '1'],
+    ]);
 
     $this->getLogger('myeventlane_vendor')->notice(
       'VendorOnboardProfileForm submitForm completed: redirect=@route uid=@uid vendor_id=@vid',

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorThemePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorThemePagePreprocess.php
@@ -11,6 +11,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
+use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_core\Service\OptionalServiceResolver;
 use Drupal\myeventlane_event_studio\DTO\MelEventData;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
@@ -54,6 +55,7 @@ final class VendorThemePagePreprocess {
     TranslationInterface $stringTranslation,
     private readonly EntityIdNormalizer $entityIdNormalizer,
     private readonly ?EventRepository $eventRepository,
+    private readonly OnboardingManager $onboardingManager,
   ) {
     $this->setStringTranslation($stringTranslation);
   }
@@ -175,7 +177,12 @@ final class VendorThemePagePreprocess {
 
     $route_name = $this->routeMatch->getRouteName();
     $variables['page']['active_section'] = $this->getActiveSection($route_name);
-    $variables['page']['vendor_shell_nav_items'] = $this->buildVendorShellNavItems($variables['page']['active_section'], $route_name);
+    if ($this->isOnboardingShellRoute($route_name)) {
+      $variables['page']['vendor_shell_nav_items'] = $this->buildOnboardingShellNavItems($route_name);
+    }
+    else {
+      $variables['page']['vendor_shell_nav_items'] = $this->buildVendorShellNavItems($variables['page']['active_section'], $route_name);
+    }
     $variables['page']['shell_page_title'] = $this->getShellPageTitle($route_name);
     $variables['page']['shell_page_subtitle'] = $this->getShellPageSubtitle($route_name);
     $variables['page']['shell_primary_action'] = $this->getShellPrimaryAction();
@@ -412,6 +419,98 @@ final class VendorThemePagePreprocess {
       $item['url'] = $url;
       $item['is_disabled'] = $is_disabled;
       $item['is_active'] = $active_section === $item['key'];
+      $built[] = $item;
+    }
+
+    return $built;
+  }
+
+  /**
+   * Whether the vendor shell should show onboarding-only navigation.
+   */
+  private function isOnboardingShellRoute(?string $route_name): bool {
+    if ($route_name === NULL || $route_name === '') {
+      return FALSE;
+    }
+    if (str_starts_with($route_name, 'myeventlane_vendor.onboard')) {
+      return TRUE;
+    }
+    if ($route_name === 'myeventlane_legal.vendor_terms') {
+      return TRUE;
+    }
+    if ($route_name === 'myeventlane_event_studio.create' && $this->currentUser->isAuthenticated()) {
+      $request = $this->requestStack->getCurrentRequest();
+      if ($request && (string) $request->query->get('mel_first_event') === '1') {
+        return TRUE;
+      }
+      $uid = (int) $this->currentUser->id();
+      if ($uid > 0) {
+        $state = $this->onboardingManager->loadVendorStateByUid($uid);
+        // First-event creation step only (not every "incomplete" onboarding visit).
+        if ($state !== NULL && $state->getStage() === 'ask' && !$state->isCompleted()) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Linear onboarding nav: Terms → Profile → Event Studio → Payments → Wrap-up.
+   *
+   * Does not replace dashboard nav when not on onboarding routes.
+   *
+   * @return array<int, array<string, mixed>>
+   *   Same shape as buildVendorShellNavItems().
+   */
+  private function buildOnboardingShellNavItems(?string $route_name): array {
+    $items = [
+      [
+        'key' => 'onboard_terms',
+        'label' => $this->t('Terms'),
+        'icon' => 'settings',
+        'route' => 'myeventlane_legal.vendor_terms',
+      ],
+      [
+        'key' => 'onboard_profile',
+        'label' => $this->t('Profile'),
+        'icon' => 'settings',
+        'route' => 'myeventlane_vendor.onboard.profile',
+      ],
+      [
+        'key' => 'onboard_event',
+        'label' => $this->t('Create event'),
+        'icon' => 'events',
+        'route' => 'myeventlane_event_studio.create',
+      ],
+      [
+        'key' => 'onboard_payments',
+        'label' => $this->t('Payments'),
+        'icon' => 'payouts',
+        'route' => 'myeventlane_vendor.onboard.stripe',
+      ],
+      [
+        'key' => 'onboard_publish',
+        'label' => $this->t('Publish'),
+        'icon' => 'events',
+        'route' => 'myeventlane_vendor.onboard.complete',
+      ],
+    ];
+
+    $built = [];
+    foreach ($items as $item) {
+      $url = NULL;
+      $is_disabled = FALSE;
+      try {
+        $url = Url::fromRoute((string) $item['route'])->toString();
+      }
+      catch (\Throwable) {
+        $is_disabled = TRUE;
+      }
+      $item['url'] = $url;
+      $item['is_disabled'] = $is_disabled;
+      $item['is_active'] = $route_name === $item['route'];
+      $item['children'] = [];
       $built[] = $item;
     }
 

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -819,11 +819,15 @@ function myeventlane_vendor_theme_preprocess_vendor_onboard_step(array &$variabl
  */
 function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route): array {
   $stage_order = \Drupal\myeventlane_core\Entity\OnboardingStateInterface::STAGE_ORDER;
+  // Visual order: create the event before optional payments (canonical stage keys unchanged).
+  $display_order = ['probe', 'present', 'ask', 'listen', 'invite', 'complete'];
   $route_to_stage = [
+    'myeventlane_legal.vendor_terms' => 'probe',
     'myeventlane_vendor.onboard.account' => 'probe',
     'myeventlane_vendor.onboard.profile' => 'present',
     'myeventlane_vendor.onboard.stripe' => 'listen',
     'myeventlane_vendor.onboard.first_event' => 'ask',
+    'myeventlane_event_studio.create' => 'ask',
     'myeventlane_vendor.onboard.boost' => 'invite',
     'myeventlane_vendor.onboard.complete' => 'complete',
   ];
@@ -831,7 +835,7 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
     'probe' => t('Get started'),
     'present' => t('Profile'),
     'listen' => t('Payments'),
-    'ask' => t('First event'),
+    'ask' => t('Create event'),
     'invite' => t('Boost'),
     'complete' => t('Complete'),
   ];
@@ -839,16 +843,15 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
     'probe' => 'myeventlane_vendor.onboard.account',
     'present' => 'myeventlane_vendor.onboard.profile',
     'listen' => 'myeventlane_vendor.onboard.stripe',
-    'ask' => 'myeventlane_vendor.onboard.first_event',
+    'ask' => 'myeventlane_event_studio.create',
     'invite' => 'myeventlane_vendor.onboard.boost',
     'complete' => 'myeventlane_vendor.onboard.complete',
   ];
 
   $current_stage = $route_to_stage[$current_route] ?? 'probe';
-  $listen_index = array_search('listen', $stage_order, TRUE);
-  $listen_index = $listen_index !== FALSE ? $listen_index : 2;
+  $present_index = array_search('present', $stage_order, TRUE);
+  $present_index = $present_index !== FALSE ? $present_index : 1;
 
-  $flags = ['stripe_connected' => FALSE];
   $terms_accepted = FALSE;
   $state = NULL;
 
@@ -879,19 +882,16 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
       if ($user instanceof \Drupal\user\UserInterface) {
         $state = $onboarding_manager->loadOrCreateVendor($user, $vendor);
         $onboarding_manager->refreshFlags($state);
-        $flags = $state->getFlags();
       }
     }
     $terms_accepted = $legal_gatekeeper->hasVendorAcceptedTerms();
   }
 
-  $stripe_connected = !empty($flags['stripe_connected']);
-
   $stages = [];
   $current_stage_index = array_search($current_stage, $stage_order, TRUE);
   $current_stage_index = $current_stage_index !== FALSE ? $current_stage_index : 0;
 
-  foreach ($stage_order as $index => $key) {
+  foreach ($display_order as $index => $key) {
     $stage_current = ($key === $current_stage);
     $stage_complete = FALSE;
     if ($state) {
@@ -900,13 +900,14 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
       }
       else {
         $state_stage_index = array_search($state->getStage(), $stage_order, TRUE);
-        $stage_complete = ($state_stage_index !== FALSE && $index < $state_stage_index);
+        $key_stage_index = array_search($key, $stage_order, TRUE);
+        $stage_complete = ($state_stage_index !== FALSE && $key_stage_index !== FALSE && $key_stage_index < $state_stage_index);
       }
     }
-    // Stripe lock: stage index > listen AND !stripe_connected.
-    $stripe_locked = ($index > $listen_index) && !$stripe_connected;
-    // Terms lock: stage index > listen AND stripe_connected AND !terms_accepted.
-    $terms_locked = ($index > $listen_index) && $stripe_connected && !$terms_accepted;
+    // Payments are optional: do not lock later steps when Stripe is missing.
+    $stripe_locked = FALSE;
+    $key_stage_index_for_terms = array_search($key, $stage_order, TRUE);
+    $terms_locked = ($key_stage_index_for_terms !== FALSE && $key_stage_index_for_terms > $present_index) && !$terms_accepted;
     $is_locked = $stripe_locked || $terms_locked;
 
     $url = '';
@@ -945,20 +946,23 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
   }
 
   $route_to_stage = [
+    'myeventlane_legal.vendor_terms' => 'probe',
     'myeventlane_vendor.onboard' => 'probe',
     'myeventlane_vendor.onboard.account' => 'probe',
     'myeventlane_vendor.onboard.profile' => 'present',
     'myeventlane_vendor.onboard.stripe' => 'listen',
     'myeventlane_vendor.onboard.first_event' => 'ask',
+    'myeventlane_event_studio.create' => 'ask',
     'myeventlane_vendor.onboard.boost' => 'invite',
     'myeventlane_vendor.onboard.complete' => 'complete',
   ];
   $stage = $route_to_stage[$route] ?? 'probe';
   $stage_order = \Drupal\myeventlane_core\Entity\OnboardingStateInterface::STAGE_ORDER;
-  $current_index = array_search($stage, $stage_order, TRUE);
+  $display_order = ['probe', 'present', 'ask', 'listen', 'invite', 'complete'];
+  $current_index = array_search($stage, $display_order, TRUE);
   $current_index = $current_index !== FALSE ? (int) $current_index : 0;
 
-  $journey_ids = $stage_order;
+  $journey_ids = $display_order;
   $uid = (int) \Drupal::currentUser()->id();
   $state = NULL;
   if ($uid > 0 && \Drupal::hasService('myeventlane_onboarding.manager')) {
@@ -977,12 +981,13 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
   $completed_keys = [];
   foreach ($journey_ids as $i => $id) {
     $is_current = ($i === $current_index);
+    $key_stage_index = array_search($id, $stage_order, TRUE);
     $is_complete = FALSE;
     if ($state !== NULL && $state->isCompleted()) {
       $is_complete = TRUE;
     }
-    elseif ($state_idx !== NULL) {
-      $is_complete = $state_idx > $i;
+    elseif ($state_idx !== NULL && $key_stage_index !== FALSE) {
+      $is_complete = $state_idx > $key_stage_index;
     }
     else {
       $is_complete = $i < $current_index;
@@ -991,7 +996,7 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
       'probe' => t('Get started'),
       'present' => t('Profile'),
       'listen' => t('Payments'),
-      'ask' => t('First event'),
+      'ask' => t('Create event'),
       'invite' => t('Boost'),
       'complete' => t('Complete'),
       default => $id,
@@ -1007,7 +1012,7 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
     ];
   }
 
-  $total_steps = count($stage_order);
+  $total_steps = count($display_order);
   $progress_label = t('Step @current of @total', [
     '@current' => (string) ($current_index + 1),
     '@total' => (string) $total_steps,

--- a/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/vendor-onboard-step.html.twig
@@ -60,8 +60,11 @@
       {{ form.step_content|default(form['#content']) }}
 
       {% if onboard_footer %}
-        <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split">
+        <div class="mel-onboard-footer mel-onboard-footer--sticky mel-onboard-footer--split{% if onboard_footer.skip_url %} mel-onboard-footer--triple{% endif %}">
           <a href="{{ onboard_footer.back_url }}" class="mel-btn mel-btn--secondary mel-btn-secondary mel-onboard-footer__back">{{ 'Back'|t }}</a>
+          {% if onboard_footer.skip_url %}
+            <a href="{{ onboard_footer.skip_url }}" class="mel-btn mel-btn--secondary mel-onboard-footer__skip">{{ onboard_footer.skip_label|default('Skip for now'|t) }}</a>
+          {% endif %}
           <a href="{{ onboard_footer.continue_url }}" class="mel-btn mel-btn--primary mel-onboard-footer__continue">{{ onboard_footer.continue_label }}</a>
         </div>
       {% elseif back_route %}


### PR DESCRIPTION
… and adding new event studio features. Introduced a method to check if vendor onboarding is advanced enough for event creation. Updated CSS for first-event onboarding banner and modified service dependencies for better functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendor onboarding gating and redirects (including optional Stripe), which can affect who can access Event Studio and when publishing is blocked. Also modifies lock acquisition behavior and adds verbose onboarding logging that could increase noise or leak form values in logs.
> 
> **Overview**
> Vendor onboarding progression is updated so **Event Studio unlocks after the organiser profile step** and Stripe/payments no longer block entry; `OnboardingManager::isVendorEventStudioUnlocked()` centralizes this check and is used by the create-event gateway and Event Studio access subscriber.
> 
> Event Studio now shows a **“first event” banner** when entering via onboarding, and publish warnings are split so **paid events require Stripe to publish** while non-paid events only require organiser setup.
> 
> Onboarding UX is refreshed: the Stripe step is explicitly *optional* with a skip action and updated copy, the onboarding progress/nav order is adjusted to show “Create event” before payments, vendor terms gets a new hero section + styling, and vendor onboarding JS is simplified. Lock acquisition for vendor state creation now waits/retries and throws if the lock remains unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947baa86529fdfdc3eac8961d560b6aef8d341fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->