### PR TITLE
Refactor onboarding logic and remove debug logging. Updated stage com…

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -179,11 +179,6 @@ final class VendorOnboardProfileForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    $this->getLogger('onboard_debug')->notice(
-      'VALUES: <pre>@v</pre>',
-      ['@v' => print_r($form_state->getValues(), TRUE)]
-    );
-
     /** @var \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor */
     $vendor = $form_state->get('vendor');
     if (!$vendor instanceof Vendor) {

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -887,6 +887,8 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
     $terms_accepted = $legal_gatekeeper->hasVendorAcceptedTerms();
   }
 
+  $flags = $state ? $state->getFlags() : [];
+
   $stages = [];
   $current_stage_index = array_search($current_stage, $stage_order, TRUE);
   $current_stage_index = $current_stage_index !== FALSE ? $current_stage_index : 0;
@@ -899,9 +901,20 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string $current_route
         $stage_complete = TRUE;
       }
       else {
+        // Canonical STAGE_ORDER has listen before ask; display_order swaps them for UX.
+        // Do not mark Payments (listen) complete just because stage is ask — optional Stripe.
         $state_stage_index = array_search($state->getStage(), $stage_order, TRUE);
         $key_stage_index = array_search($key, $stage_order, TRUE);
-        $stage_complete = ($state_stage_index !== FALSE && $key_stage_index !== FALSE && $key_stage_index < $state_stage_index);
+        if ($key === 'listen') {
+          $stage_complete = !empty($flags['stripe_connected']);
+        }
+        elseif ($key === 'ask') {
+          $ask_index = array_search('ask', $stage_order, TRUE);
+          $stage_complete = ($state_stage_index !== FALSE && $ask_index !== FALSE && $state_stage_index > $ask_index);
+        }
+        else {
+          $stage_complete = ($state_stage_index !== FALSE && $key_stage_index !== FALSE && $key_stage_index < $state_stage_index);
+        }
       }
     }
     // Payments are optional: do not lock later steps when Stripe is missing.
@@ -977,6 +990,8 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
     $state_idx = $state_idx !== FALSE ? (int) $state_idx : 0;
   }
 
+  $journey_flags = ($state !== NULL) ? $state->getFlags() : [];
+
   $steps = [];
   $completed_keys = [];
   foreach ($journey_ids as $i => $id) {
@@ -987,7 +1002,17 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
       $is_complete = TRUE;
     }
     elseif ($state_idx !== NULL && $key_stage_index !== FALSE) {
-      $is_complete = $state_idx > $key_stage_index;
+      // Match _myeventlane_vendor_theme_build_onboarding_stages(): listen is optional; ask vs listen order in UI.
+      if ($id === 'listen') {
+        $is_complete = !empty($journey_flags['stripe_connected']);
+      }
+      elseif ($id === 'ask') {
+        $ask_index = array_search('ask', $stage_order, TRUE);
+        $is_complete = ($ask_index !== FALSE && $state_idx > $ask_index);
+      }
+      else {
+        $is_complete = $state_idx > $key_stage_index;
+      }
     }
     else {
       $is_complete = $i < $current_index;


### PR DESCRIPTION
…pletion criteria to account for optional payments and adjusted the handling of flags in the onboarding process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding progress/completion logic used for gating UX; incorrect flag/stage indexing could misreport progress or unlock/lock steps unexpectedly. No auth or payment processing changes, but it depends on `stripe_connected` flag correctness.
> 
> **Overview**
> Removes verbose debug logging from `VendorOnboardProfileForm::submitForm()`.
> 
> Refactors vendor onboarding progress calculation to treat Payments (`listen`) as **optional**: the UI now marks `listen` complete only when the `stripe_connected` flag is set, and avoids erroneously completing `listen` when the current stage is `ask` due to the UI’s swapped stage display order.
> 
> Mirrors the same updated completion rules in `_myeventlane_vendor_theme_onboarding_journey_meta()` so the journey stepper and stage indicator stay consistent, and explicitly loads onboarding `flags` from state when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e832c9756a1ed9f1470bf2597f740e46aaa78614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->