### PR TITLE
Refactor vendor onboarding form and JavaScript behavior. Updated the …

### DIFF
--- a/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
+++ b/web/modules/custom/myeventlane_vendor/js/vendor-onboard.js
@@ -1,21 +1,18 @@
 /**
  * @file
- * Temporary onboarding debug listeners (profile step) — remove when stable.
+ * Vendor onboarding: focus organiser name on profile step.
  */
 (function (Drupal, once) {
   'use strict';
 
-  Drupal.behaviors.vendorOnboardDebug = {
+  Drupal.behaviors.vendorOnboard = {
     attach: function (context) {
-      once('vendor-onboard-debug-form', 'form.mel-onboard-form', context).forEach(function (form) {
-        form.addEventListener('submit', function () {
-          console.log('FORM SUBMIT EVENT FIRED');
-        });
-      });
-      once('vendor-onboard-debug-submit', 'form.mel-onboard-form #edit-submit', context).forEach(function (el) {
-        el.addEventListener('click', function () {
-          console.log('CLICK WORKING');
-        });
+      once(
+        'vendor-onboard-focus-name',
+        'form.mel-onboard-form input[name="step_content[name]"]',
+        context,
+      ).forEach(function (input) {
+        input.focus();
       });
     },
   };

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -1,74 +1,265 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\myeventlane_vendor\Form;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_core\Entity\OnboardingStateInterface;
+use Drupal\myeventlane_core\Service\OnboardingManager;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class VendorOnboardProfileForm extends FormBase {
+/**
+ * Dedicated onboarding Step 2 form: organiser profile (name only).
+ *
+ * Replaces the Vendor entity edit form at /vendor/onboard/profile.
+ * Uses default form rendering (no custom #theme) so form_build_id, form_token,
+ * form_id and field name attributes render correctly.
+ */
+final class VendorOnboardProfileForm extends FormBase {
 
-  public function getFormId() {
+  /**
+   * The onboarding manager.
+   */
+  private readonly OnboardingManager $onboardingManager;
+
+  /**
+   * The entity type manager.
+   */
+  private readonly EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The current user.
+   */
+  private readonly AccountProxyInterface $currentUser;
+
+  /**
+   * The vendor store subscriber (ensures store exists for new vendors).
+   */
+  private readonly VendorStoreSubscriber $vendorStoreSubscriber;
+
+  /**
+   * Constructs the form.
+   */
+  public function __construct(
+    OnboardingManager $onboarding_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountProxyInterface $current_user,
+    VendorStoreSubscriber $vendor_store_subscriber,
+  ) {
+    $this->onboardingManager = $onboarding_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->currentUser = $current_user;
+    $this->vendorStoreSubscriber = $vendor_store_subscriber;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_onboarding.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('myeventlane_vendor.vendor_store_subscriber'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
     return 'vendor_onboard_profile_form';
   }
 
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    if ($this->currentUser->isAnonymous()) {
+      return $form;
+    }
 
+    $account = $this->currentUser->getAccount();
+    $vendor = $this->onboardingManager->ensureVendorExists($account);
+    $form_state->set('vendor', $vendor);
+
+    // Nested step_content/* elements; required so getValue(['step_content', 'name']) matches input.
+    $form['#tree'] = TRUE;
+
+    // Step metadata for form--vendor-onboard-profile-form.html.twig preprocess.
     $form['#step_number'] = 2;
-    $form['#total_steps'] = 6;
-    $form['#step_title'] = $this->t('Set up your organiser profile');
-    $form['#step_description'] = $this->t('Tell people about your organisation. This information will appear on your public organiser page.');
+    $form['#total_steps'] = 7;
+    $form['#step_title'] = $this->t('Let’s set up your organiser profile 👋');
+    $form['#step_description'] = $this->t('This helps people trust your events.');
+    $form['#attached']['library'][] = 'myeventlane_vendor/onboarding';
+    $form['#attributes']['class'][] = 'mel-onboard-form';
+    $form['#attributes']['class'][] = 'mel-onboard-form-root';
+    $form['#attributes']['class'][] = 'mel-onboard-profile-form';
+
+    $next_route = 'myeventlane_event_studio.create';
+    $state = $this->onboardingManager->loadVendorStateByUid((int) $this->currentUser->id());
+    if ($state !== NULL) {
+      $nr = $this->onboardingManager->getNextVendorOnboardRouteForAuthenticated($state);
+      if (is_string($nr) && $nr !== '') {
+        $next_route = $nr;
+      }
+    }
+    $continue_label = $this->t('Continue');
+    if (str_contains($next_route, 'event_studio') || str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
+      $continue_label = $this->t('Continue to create your event');
+    }
+    elseif (str_contains($next_route, 'stripe')) {
+      $continue_label = $this->t('Continue to payments');
+    }
 
     $form['step_content'] = [
       '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-onboard-step-fields'],
+      ],
     ];
-
     $form['step_content']['name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Organiser name'),
+      '#description' => $this->t('The public name for your organisation (e.g., "Sydney Music Festival").'),
+      '#description_display' => 'after',
       '#required' => TRUE,
+      '#default_value' => $vendor->getName(),
+      '#maxlength' => 255,
+    ];
+    $form['step_content']['name']['#attributes']['placeholder'] = $this->t('Enter your organiser name');
+    $form['step_content']['name']['#attributes']['autofocus'] = 'autofocus';
+
+    $form['step_content']['actions'] = [
+      '#type' => 'actions',
       '#attributes' => [
-        'placeholder' => $this->t('Enter your organiser name'),
+        'class' => ['mel-onboard-footer', 'mel-onboard-footer--split'],
       ],
     ];
-
-    $form['actions'] = [
-      '#type' => 'actions',
+    $form['step_content']['actions']['back'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Back'),
+      '#url' => Url::fromRoute('myeventlane_vendor.onboard.account'),
+      '#weight' => -10,
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--secondary', 'mel-btn-secondary', 'mel-onboard-footer__back'],
+      ],
     ];
-
-    $form['actions']['submit'] = [
+    $form['step_content']['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Continue'),
+      '#value' => $continue_label,
       '#button_type' => 'primary',
+      '#attributes' => [
+        'class' => ['mel-btn', 'mel-btn--primary', 'mel-onboard-footer__continue'],
+      ],
     ];
-
-    $form['#attributes']['class'][] = 'mel-onboard-form';
-    $form['#method'] = 'post';
-
-    $form['#attached']['library'][] = 'myeventlane_vendor/onboarding';
 
     return $form;
   }
 
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    $name = $form_state->getValue(['step_content', 'name']);
-
-    if (empty($name)) {
-      $form_state->setErrorByName('step_content][name', $this->t('Name is required.'));
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $name = trim((string) ($form_state->getValue(['step_content', 'name']) ?? ''));
+    if ($name === '') {
+      $form_state->setError($form['step_content']['name'], $this->t('Organiser name is required.'));
     }
   }
 
-  public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->logger('myeventlane_vendor')->notice('FORM SUBMITTED WORKING');
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor */
+    $vendor = $form_state->get('vendor');
+    if (!$vendor instanceof Vendor) {
+      return;
+    }
 
-    $name = $form_state->getValue(['step_content', 'name']);
+    $name = trim((string) ($form_state->getValue(['step_content', 'name']) ?? ''));
+    $vendor->setName($name);
 
-    $this->logger('myeventlane_vendor')->notice('Profile saved with name: @name', [
-      '@name' => $name,
+    try {
+      if ($vendor->hasField('field_vendor_store') && $vendor->get('field_vendor_store')->isEmpty()) {
+        $this->vendorStoreSubscriber->onVendorInsertFromHook($vendor);
+      }
+    }
+    catch (\Throwable $e) {
+      $this->getLogger('myeventlane_vendor')->error('onboarding step2: failed ensuring store for vendor @vid: @m', [
+        '@vid' => $vendor->id() ?: '0',
+        '@m' => $e->getMessage(),
+      ]);
+    }
+
+    if ($vendor->hasField('field_vendor_users')) {
+      $current_users = $vendor->get('field_vendor_users')->getValue();
+      $user_ids = array_column($current_users, 'target_id');
+      $uid = (int) $this->currentUser->id();
+      if ($uid > 0 && !in_array($uid, $user_ids, TRUE)) {
+        $vendor->get('field_vendor_users')->appendItem(['target_id' => $uid]);
+      }
+    }
+
+    $vendor->save();
+
+    $uid = (int) $this->currentUser->id();
+    if ($uid <= 0) {
+      return;
+    }
+
+    $user = $this->entityTypeManager->getStorage('user')->load($uid);
+    if (!$user instanceof UserInterface) {
+      return;
+    }
+
+    $this->onboardingManager->ensureVendorAccess($user);
+    $this->getLogger('myeventlane_vendor')->notice(
+      'ensureVendorAccess executed during profile submit uid=@uid',
+      ['@uid' => (string) $uid],
+    );
+
+    $state = $this->onboardingManager->loadVendorStateByUid($uid);
+    if ($state === NULL) {
+      $state = $this->onboardingManager->createVendorStateForUid($uid);
+    }
+    if ($state->getVendorId() !== (int) $vendor->id()) {
+      $state->setVendorId((int) $vendor->id());
+      $state->save();
+    }
+
+    // Move to "first event" stage (ask); Stripe (listen) stays skippable and reachable from nav later.
+    $order = OnboardingStateInterface::STAGE_ORDER;
+    $current_idx = array_search($state->getStage(), $order, TRUE);
+    $ask_idx = array_search('ask', $order, TRUE);
+    if ($current_idx !== FALSE && $ask_idx !== FALSE && $current_idx < $ask_idx) {
+      $this->onboardingManager->advanceStage($state, 'ask');
+    }
+
+    $next = $this->onboardingManager->getNextAction($state);
+    $next_route = !empty($next['route_name']) ? $next['route_name'] : 'myeventlane_event_studio.create';
+
+    $this->messenger()->addStatus($this->t('Saved. Next: create your event in Event Studio.'));
+    $form_state->setRedirect($next_route, [], [
+      'query' => ['mel_first_event' => '1'],
     ]);
 
-    // TODO: Save to vendor entity here.
-
-    $form_state->setRedirect('myeventlane_vendor.onboard.stripe');
+    $this->getLogger('myeventlane_vendor')->notice(
+      'VendorOnboardProfileForm submitForm completed: redirect=@route uid=@uid vendor_id=@vid',
+      [
+        '@route' => $next_route,
+        '@uid' => (string) $uid,
+        '@vid' => (string) $vendor->id(),
+      ],
+    );
   }
 
 }


### PR DESCRIPTION
…VendorOnboardProfileForm to enhance structure and added strict types. Improved user experience by focusing on the organiser name input during the profile step. Adjusted form attributes and labels for clarity and consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core onboarding step-2 submit behavior, including vendor persistence, store/user linkage, stage advancement, and redirect routing, which could affect onboarding progression for existing users. JS behavior change is low risk but relies on specific field name selectors.
> 
> **Overview**
> Refactors vendor onboarding **Step 2 (organiser profile)** into a dedicated `VendorOnboardProfileForm` with strict types, DI, and default form rendering, including updated step metadata (now `7` total steps), copy, CSS classes, and a back/continue footer with dynamic continue labels.
> 
> On submit, the form now **persists the organiser name to the Vendor**, ensures a vendor store exists, appends the current user to `field_vendor_users`, syncs/creates onboarding state (including vendor ID), advances the stage to `ask` when appropriate, and redirects to the computed next route (defaulting to Event Studio) with `mel_first_event=1`.
> 
> Replaces temporary JS debug listeners with a single `Drupal.behaviors.vendorOnboard` that focuses the organiser name input on attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c91f8d4548561ba81f7b292a31958cadaee67a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->