### PR TITLE
Feature/mel v2 unified event studio

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -103,22 +103,7 @@ final class VendorOnboardProfileForm extends FormBase {
     $form['#attributes']['class'][] = 'mel-onboard-form';
     $form['#attributes']['class'][] = 'mel-onboard-form-root';
     $form['#attributes']['class'][] = 'mel-onboard-profile-form';
-
-    $next_route = 'myeventlane_event_studio.create';
-    $state = $this->onboardingManager->loadVendorStateByUid((int) $this->currentUser->id());
-    if ($state !== NULL) {
-      $nr = $this->onboardingManager->getNextVendorOnboardRouteForAuthenticated($state);
-      if (is_string($nr) && $nr !== '') {
-        $next_route = $nr;
-      }
-    }
-    $continue_label = $this->t('Continue');
-    if (str_contains($next_route, 'event_studio') || str_contains($next_route, 'first_event') || str_contains($next_route, 'first-event')) {
-      $continue_label = $this->t('Continue to create your event');
-    }
-    elseif (str_contains($next_route, 'stripe')) {
-      $continue_label = $this->t('Continue to payments');
-    }
+    $form['#attributes']['novalidate'] = 'novalidate';
 
     $form['step_content'] = [
       '#type' => 'container',
@@ -153,13 +138,12 @@ final class VendorOnboardProfileForm extends FormBase {
         'class' => ['mel-btn', 'mel-btn--secondary', 'mel-btn-secondary', 'mel-onboard-footer__back'],
       ],
     ];
-    $form['step_content']['actions']['submit'] = [
+
+    $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $continue_label,
+      '#value' => $this->t('Continue'),
       '#button_type' => 'primary',
-      '#attributes' => [
-        'class' => ['mel-btn', 'mel-btn--primary', 'mel-onboard-footer__continue'],
-      ],
+      '#submit' => ['::submitForm'],
     ];
 
     return $form;
@@ -179,6 +163,8 @@ final class VendorOnboardProfileForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->getLogger('myeventlane_vendor')->error('SUBMIT HIT HARD DEBUG');
+
     /** @var \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor */
     $vendor = $form_state->get('vendor');
     if (!$vendor instanceof Vendor) {
@@ -202,7 +188,7 @@ final class VendorOnboardProfileForm extends FormBase {
 
     if ($vendor->hasField('field_vendor_users')) {
       $current_users = $vendor->get('field_vendor_users')->getValue();
-      $user_ids = array_column($current_users, 'target_id');
+      $user_ids = array_map(static fn ($id): int => (int) $id, array_column($current_users, 'target_id'));
       $uid = (int) $this->currentUser->id();
       if ($uid > 0 && !in_array($uid, $user_ids, TRUE)) {
         $vendor->get('field_vendor_users')->appendItem(['target_id' => $uid]);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
@@ -760,6 +762,15 @@ function myeventlane_vendor_theme_theme_suggestions_form_alter(array &$suggestio
  * Passes step metadata from the form element for the onboarding layout.
  */
 function myeventlane_vendor_theme_preprocess_form__vendor_onboard_profile_form(array &$variables): void {
+  // form--vendor-onboard-profile-form.html.twig expects {{ form }}; core only
+  // provides children + attributes. Build the same output as core form.html.twig.
+  $attributes = $variables['attributes'] ?? [];
+  if (!($attributes instanceof Attribute)) {
+    $attributes = new Attribute(is_array($attributes) ? $attributes : []);
+  }
+  $children = $variables['children'] ?? '';
+  $variables['form'] = Markup::create('<form' . $attributes . '>' . $children . '</form>');
+
   $element = $variables['element'];
   $variables['step_number'] = $element['#step_number'] ?? 2;
   $variables['total_steps'] = $element['#total_steps'] ?? 7;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/form/form--vendor-onboard-profile-form.html.twig
@@ -1,35 +1,42 @@
 {#
 /**
- * @file
- * Vendor onboarding profile form — Event Studio layout.
+ * Vendor onboarding profile form — FIXED VERSION
  *
- * Drupal Form API provides attributes + children only (no "form" variable).
- * Root MUST be a single <form{{ attributes }}> like core form.html.twig —
- * {{ children }} is every child of the root form (fields + hidden + actions).
+ * CRITICAL:
+ * - DO NOT add <form> tag manually
+ * - DO NOT use {{ form }}
+ * - Drupal already renders the form via {{ children }}
  */
 #}
-<form{{ attributes }}>
-  <div class="mel-event-studio mel-event-studio--onboard mel-onboard-es">
-    <div class="mel-es-workspace">
-      <aside class="mel-es-workspace__sidebar">
-        {% if onboarding_stages is defined %}
-          {% include '@myeventlane_vendor_theme/components/mel-onboard-studio-nav.html.twig' with { stages: onboarding_stages } only %}
+
+{{ attach_library('myeventlane_vendor/onboarding') }}
+
+<div class="mel-event-studio mel-event-studio--onboard mel-onboard-es">
+  <div class="mel-es-workspace">
+
+    <aside class="mel-es-workspace__sidebar">
+      {% if onboarding_stages is defined and onboarding_stages %}
+        {% include '@myeventlane_vendor_theme/components/mel-onboard-studio-nav.html.twig' with { stages: onboarding_stages } only %}
+      {% endif %}
+    </aside>
+
+    <main class="mel-es-workspace__main">
+
+      {% if onboarding_progress_label %}
+        <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
+      {% endif %}
+
+      <header class="mel-onboard-header">
+        <h1>{{ step_title }}</h1>
+        {% if step_description %}
+          <p>{{ step_description }}</p>
         {% endif %}
-      </aside>
-      <main class="mel-es-workspace__main">
-        {% if onboarding_progress_label %}
-          <p class="mel-onboard-progress-text">{{ onboarding_progress_label }}</p>
-        {% endif %}
-        <header class="mel-onboard-header">
-          <h1>{{ step_title }}</h1>
-          {% if step_description %}
-            <p>{{ step_description }}</p>
-          {% endif %}
-        </header>
-        <div class="mel-es-card mel-onboard-es-form-card">
-          {{ children }}
-        </div>
-      </main>
-    </div>
+      </header>
+
+      <div class="mel-es-card">
+        {{ children }}
+      </div>
+
+    </main>
   </div>
-</form>
+</div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the onboarding profile form is rendered and where the submit button is attached, which can affect form token rendering and submission behavior. Also introduces an unconditional error-level debug log on submit that could pollute logs in production.
> 
> **Overview**
> Fixes the vendor onboarding Step 2 (profile) Event Studio layout by moving form-tag generation into theme preprocessing and updating the Twig template to render only `{{ children }}` (no manual `<form>`), while still attaching the onboarding library.
> 
> Simplifies the form build by removing dynamic “continue” label logic, adding `novalidate`, moving the submit button to top-level `actions`, and tightening vendor user ID handling by casting `field_vendor_users` IDs to ints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd0f4496a3683f1ae4d3a50b45964f9a19e7e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->