### PR TITLE
Feature/navigation access fix

### DIFF
--- a/web/modules/custom/myeventlane_api/myeventlane_api.services.yml
+++ b/web/modules/custom/myeventlane_api/myeventlane_api.services.yml
@@ -14,6 +14,7 @@ services:
     class: Drupal\myeventlane_api\Service\EventSerializer
     arguments:
       - '@myeventlane_event_state.resolver'
+      - '@myeventlane_core.event_state_resolver'
       - '@myeventlane_metrics.service'
 
   myeventlane_api.audit_logger:

--- a/web/modules/custom/myeventlane_api/src/Service/EventSerializer.php
+++ b/web/modules/custom/myeventlane_api/src/Service/EventSerializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_api\Service;
 
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
 use Drupal\myeventlane_metrics\Service\EventMetricsServiceInterface;
 use Drupal\node\NodeInterface;
@@ -19,6 +20,7 @@ final class EventSerializer {
    */
   public function __construct(
     private readonly EventStateResolverInterface $eventStateResolver,
+    private readonly EventStateResolver $eventDomainStateResolver,
     private readonly EventMetricsServiceInterface $eventMetricsService,
   ) {}
 
@@ -98,7 +100,7 @@ final class EventSerializer {
       ? $event->get('field_event_type')->value
       : NULL;
 
-    $has_product = $event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty();
+    $has_product = $this->eventDomainStateResolver->hasProductTarget($event);
     $has_external_url = $event->hasField('field_external_url') && !$event->get('field_external_url')->isEmpty();
 
     $cta_mode = 'none';

--- a/web/modules/custom/myeventlane_api/src/Service/EventSerializer.php
+++ b/web/modules/custom/myeventlane_api/src/Service/EventSerializer.php
@@ -100,7 +100,7 @@ final class EventSerializer {
       ? $event->get('field_event_type')->value
       : NULL;
 
-    $has_product = $this->eventDomainStateResolver->hasProductTarget($event);
+    $has_product = $this->eventDomainStateResolver->getEventDomainState($event)['has_product'];
     $has_external_url = $event->hasField('field_external_url') && !$event->get('field_external_url')->isEmpty();
 
     $cta_mode = 'none';

--- a/web/modules/custom/myeventlane_core/src/Plugin/Block/OrganiserContextBlock.php
+++ b/web/modules/custom/myeventlane_core/src/Plugin/Block/OrganiserContextBlock.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Organiser context block for site header.
  *
- * A) If user has organiser role: show organiser tools menu.
+ * A) If user can access the vendor dashboard: show organiser tools menu.
  * B) Else if viewing event/organiser page: show "Hosted by {Name}".
  *
  * @Block(
@@ -71,11 +71,11 @@ final class OrganiserContextBlock extends BlockBase implements ContainerFactoryP
     }
 
     $cache_metadata = new CacheableMetadata();
-    $cache_metadata->addCacheContexts(['user.roles', 'route']);
+    $cache_metadata->addCacheContexts(['user.roles', 'user.permissions', 'route']);
     $cache_tags = [];
 
-    // A) User has organiser role (access vendor console).
-    if ($this->currentUser->hasPermission('access vendor console')) {
+    // A) Logged-in organiser tools: same gate as /vendor/dashboard (see VendorConsoleAccess).
+    if ($this->currentUser->hasPermission('access vendor dashboard')) {
       $vendor = $this->getVendorForUser((int) $this->currentUser->id());
       if ($vendor) {
         $cache_tags[] = 'myeventlane_vendor:' . $vendor->id();
@@ -100,7 +100,7 @@ final class OrganiserContextBlock extends BlockBase implements ContainerFactoryP
       }
     }
 
-    $build['#cache']['contexts'] = ['user.roles', 'route'];
+    $build['#cache']['contexts'] = ['user.roles', 'user.permissions', 'route'];
     $build['#cache']['tags'] = array_unique($cache_tags);
 
     return $build;

--- a/web/modules/custom/myeventlane_core/src/Service/EventStateResolver.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventStateResolver.php
@@ -242,6 +242,30 @@ final class EventStateResolver {
   }
 
   /**
+   * Returns the canonical event domain state snapshot for templates and UIs.
+   *
+   * @param \Drupal\node\NodeInterface $event
+   *   The event node.
+   *
+   * @return array{
+   *   has_product: bool,
+   *   is_boosted: bool,
+   *   rsvp_state: string,
+   *   capacity: int
+   * }
+   *   Normalised state from field-based resolver methods. Capacity uses venue
+   *   field only (same as effectiveVenueCapacity with no wizard values).
+   */
+  public function getEventDomainState(NodeInterface $event): array {
+    return [
+      'has_product' => $this->hasProductTarget($event),
+      'is_boosted' => $this->isEventBoosted($event),
+      'rsvp_state' => $this->effectiveRsvpCapacityState([], $event),
+      'capacity' => $this->effectiveVenueCapacity([], $event),
+    ];
+  }
+
+  /**
    * Maps a string to a known event type, or returns empty.
    */
   private function normalizeEventType(string $raw): string {

--- a/web/modules/custom/myeventlane_dashboard/templates/myeventlane-vendor-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_dashboard/templates/myeventlane-vendor-dashboard.html.twig
@@ -286,17 +286,33 @@
               </div>
             </div>
 
-            <div class="mel-event-status">
-              {% if event.event_mode == 'rsvp' %}
-                {{ 'RSVP'|t }}
-              {% elseif event.event_mode == 'paid' %}
-                {{ 'Tickets'|t }}
-              {% elseif event.event_mode == 'external' %}
-                {{ 'External'|t }}
-              {% elseif event.event_mode == 'both' %}
-                {{ 'Both'|t }}
+            <div class="mel-event-status mel-vendor-row-ui">
+              {% if event.event_ui is defined and event.event_ui is iterable
+                and (
+                  (event.event_ui.show_cta|default(true) and (event.event_ui.cta_label|default('')|striptags|length > 0))
+                  or (event.event_ui.status_label|default('')|striptags|length > 0)
+                )
+              %}
+                {% if (event.event_ui.cta_label|default('')|striptags|length > 0) %}
+                <span class="mel-vendor-row-cta mel-vendor-row-cta--{{ event.event_ui.cta_type|default('secondary')|e('html_attr') }}{% if event.event_ui.is_sold_out|default(false) %} is-sold-out{% endif %}">
+                  {{ event.event_ui.cta_label }}
+                </span>
+                {% endif %}
+                {% if (event.event_ui.status_label|default(''))|striptags|length > 0 %}
+                  <span class="mel-vendor-row-pill mel-vendor-row-pill--{{ event.event_ui.status_type|default('muted')|e('html_attr') }}">{{ event.event_ui.status_label }}</span>
+                {% endif %}
               {% else %}
-                {{ event.event_mode|default('Draft'|t)|capitalize }}
+                {% if event.event_mode == 'rsvp' %}
+                  {{ 'RSVP'|t }}
+                {% elseif event.event_mode == 'paid' %}
+                  {{ 'Tickets'|t }}
+                {% elseif event.event_mode == 'external' %}
+                  {{ 'External'|t }}
+                {% elseif event.event_mode == 'both' %}
+                  {{ 'Both'|t }}
+                {% else %}
+                  {{ event.event_mode|default('Draft'|t)|capitalize }}
+                {% endif %}
               {% endif %}
             </div>
           </a>

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -901,6 +901,8 @@ function myeventlane_event_preprocess_node(array &$variables): void {
 
   $view_mode = (string) ($variables['view_mode'] ?? 'default');
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
+  // Semantic CTA and badges: always set for the event bundle (all view modes: full,
+  // teaser, event_card, etc.); do not scope to a single view mode here.
   $variables['event_ui'] = myeventlane_event_finalize_event_ui(
     $node,
     $variables['event_domain_state'] ?? $domain_state,

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -840,12 +840,32 @@ function myeventlane_event_preprocess_node(array &$variables): void {
   $variables['event_cta'] = $ctaResolver->getResolvedCta($node);
   $variables['mel_is_bookable'] = $ctaResolver->isBookable($node);
 
+  $domainStateResolver = \Drupal::hasService('myeventlane_core.event_state_resolver')
+    ? \Drupal::service('myeventlane_core.event_state_resolver')
+    : NULL;
+  if ($domainStateResolver) {
+    $variables['mel_event_state_snapshot'] = [
+      'has_product' => $domainStateResolver->hasProductTarget($node),
+      'is_boosted' => $domainStateResolver->isEventBoosted($node),
+      'rsvp_state' => $domainStateResolver->effectiveRsvpCapacityState([], $node),
+      'capacity' => $domainStateResolver->effectiveVenueCapacity([], $node),
+    ];
+  }
+  else {
+    $variables['mel_event_state_snapshot'] = [
+      'has_product' => FALSE,
+      'is_boosted' => FALSE,
+      'rsvp_state' => 'unset',
+      'capacity' => 0,
+    ];
+  }
+
   $salesStart = $stateResolver->getSalesStart($node);
   $variables['mel_sales_start_formatted'] = $salesStart ? date('F j, Y g:ia', $salesStart) : NULL;
 
   // Lowest enabled ticket price for "Tickets from $X" (paid) or "Free" (RSVP).
   $variables['mel_tickets_from'] = NULL;
-  if ($node->hasField('field_product_target') && !$node->get('field_product_target')->isEmpty()) {
+  if ($domainStateResolver?->hasProductTarget($node)) {
     $product = $node->get('field_product_target')->entity;
     if ($product && $product->getEntityTypeId() === 'commerce_product') {
       $variations = $product->getVariations();

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -844,28 +844,25 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     ? \Drupal::service('myeventlane_core.event_state_resolver')
     : NULL;
   if ($domainStateResolver) {
-    $variables['mel_event_state_snapshot'] = [
-      'has_product' => $domainStateResolver->hasProductTarget($node),
-      'is_boosted' => $domainStateResolver->isEventBoosted($node),
-      'rsvp_state' => $domainStateResolver->effectiveRsvpCapacityState([], $node),
-      'capacity' => $domainStateResolver->effectiveVenueCapacity([], $node),
-    ];
+    $domain_state = $domainStateResolver->getEventDomainState($node);
   }
   else {
-    $variables['mel_event_state_snapshot'] = [
+    $domain_state = [
       'has_product' => FALSE,
       'is_boosted' => FALSE,
       'rsvp_state' => 'unset',
       'capacity' => 0,
     ];
   }
+  $variables['event_domain_state'] = $domain_state;
+  $variables['mel_event_state_snapshot'] = $domain_state;
 
   $salesStart = $stateResolver->getSalesStart($node);
   $variables['mel_sales_start_formatted'] = $salesStart ? date('F j, Y g:ia', $salesStart) : NULL;
 
   // Lowest enabled ticket price for "Tickets from $X" (paid) or "Free" (RSVP).
   $variables['mel_tickets_from'] = NULL;
-  if ($domainStateResolver?->hasProductTarget($node)) {
+  if (!empty($variables['mel_event_state_snapshot']['has_product'])) {
     $product = $node->get('field_product_target')->entity;
     if ($product && $product->getEntityTypeId() === 'commerce_product') {
       $variations = $product->getVariations();
@@ -901,6 +898,202 @@ function myeventlane_event_preprocess_node(array &$variables): void {
   if ($variables['cta_type'] === EventCtaResolver::CTA_EXTERNAL) {
     $variables['mel_tickets_from'] = NULL;
   }
+
+  $view_mode = (string) ($variables['view_mode'] ?? 'default');
+  $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
+  $variables['event_ui'] = myeventlane_event_finalize_event_ui(
+    $node,
+    $variables['event_domain_state'] ?? $domain_state,
+    (string) $variables['cta_type'],
+    (string) $variables['mel_event_state'],
+    $event_cta,
+    $view_mode
+  );
+}
+
+/**
+ * Enriches vendor dashboard rows with event_domain_state and event_ui (public parity).
+ *
+ * @param array $variables
+ *   Theme render variables; updates upcoming_events rows in place.
+ */
+function myeventlane_event_enrich_vendor_dashboard_event_rows(array &$variables): void {
+  $upcoming = $variables['upcoming_events'] ?? NULL;
+  if (!is_array($upcoming) || $upcoming === []) {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_event.cta_resolver') || !\Drupal::hasService('myeventlane_event_state.resolver') || !\Drupal::hasService('myeventlane_core.event_state_resolver')) {
+    return;
+  }
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $ctaResolver = \Drupal::service('myeventlane_event.cta_resolver');
+  $stateResolver = \Drupal::service('myeventlane_event_state.resolver');
+  $domainStateResolver = \Drupal::service('myeventlane_core.event_state_resolver');
+
+  foreach ($upcoming as $key => $row) {
+    if (!is_array($row) || empty($row['id'])) {
+      continue;
+    }
+    $node = $node_storage->load((int) $row['id']);
+    if (!$node instanceof NodeInterface) {
+      continue;
+    }
+    $domain = $row['event_domain_state'] ?? $domainStateResolver->getEventDomainState($node);
+    if (!is_array($domain) || $domain === []) {
+      $domain = [
+        'has_product' => FALSE,
+        'is_boosted' => FALSE,
+        'rsvp_state' => 'unset',
+        'capacity' => 0,
+      ];
+    }
+    $ct = (string) $ctaResolver->getCtaType($node);
+    $mels = (string) $stateResolver->resolveState($node);
+    $ec = $ctaResolver->getResolvedCta($node);
+    $upcoming[$key] = is_array($row) ? $row : [];
+    $upcoming[$key]['event_domain_state'] = $domain;
+    $upcoming[$key]['event_ui'] = myeventlane_event_finalize_event_ui($node, $domain, $ct, $mels, is_array($ec) ? $ec : [], 'event_card');
+  }
+  $variables['upcoming_events'] = $upcoming;
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for myeventlane_vendor_dashboard.
+ */
+function myeventlane_event_preprocess_myeventlane_vendor_dashboard(array &$variables): void {
+  myeventlane_event_enrich_vendor_dashboard_event_rows($variables);
+}
+
+/**
+ * Map event_domain_state + CTA to semantic UI (Twig: labels and types only).
+ */
+function myeventlane_event_finalize_event_ui(
+  NodeInterface $node,
+  array $domain,
+  string $ctaType,
+  string $melState,
+  array $eventCta,
+  string $viewMode = 'default',
+): array {
+  $defaults = static function () {
+    return [
+      'cta_label' => (string) t('View details'),
+      'cta_type' => 'secondary',
+      'status_label' => NULL,
+      'status_type' => 'muted',
+      'is_sold_out' => FALSE,
+      'show_cta' => TRUE,
+      'capacity_hint' => NULL,
+      'image_badge_label' => NULL,
+      'image_badge_type' => NULL,
+    ];
+  };
+
+  $hasProduct = !empty($domain['has_product']);
+  $isBoosted = !empty($domain['is_boosted']);
+  $rsvpState = (string) ($domain['rsvp_state'] ?? 'unset');
+  $capacity = (int) ($domain['capacity'] ?? 0);
+  $ecLabel = trim((string) ($eventCta['label'] ?? ''));
+  $isCardContext = in_array($viewMode, myeventlane_event_get_event_card_view_modes(), TRUE);
+  $isWaitlist = $melState === 'sold_out'
+    && $ctaType === EventCtaResolver::CTA_RSVP
+    && !empty($eventCta['url'])
+    && empty($eventCta['disabled']);
+
+  $isSoldOut =
+    ($rsvpState === 'closed')
+    || ($rsvpState === 'limited' && $capacity === 0)
+    || ($melState === 'sold_out');
+
+  $showCta = $ctaType !== EventCtaResolver::CTA_NONE
+    && $melState !== 'draft';
+  if (!$showCta) {
+    $out = $defaults();
+    $out['show_cta'] = FALSE;
+    $out['cta_label'] = '';
+    $out['cta_type'] = 'disabled';
+    if ($isBoosted) {
+      $out['status_label'] = (string) t('Featured');
+      $out['status_type'] = 'highlight';
+      $out['image_badge_label'] = (string) t('Featured');
+      $out['image_badge_type'] = 'apricot';
+    }
+    return $out;
+  }
+
+  $out = $defaults();
+  if ($isSoldOut) {
+    $out['is_sold_out'] = TRUE;
+    $out['status_label'] = (string) t('Sold out');
+    $out['status_type'] = 'warning';
+    $out['image_badge_label'] = (string) t('Sold out');
+    $out['image_badge_type'] = 'warning';
+    if ($isWaitlist) {
+      // Waitlist: sold-out badge + copy; CTA is secondary and remains clickable.
+      $out['cta_label'] = $ecLabel !== '' ? (string) $eventCta['label'] : (string) t('Join waitlist');
+      $out['cta_type'] = 'secondary';
+    }
+    else {
+      $out['cta_label'] = (string) t('Sold out');
+      $out['cta_type'] = 'disabled';
+    }
+  }
+  elseif (in_array($melState, ['ended', 'cancelled'], TRUE)) {
+    $out['cta_label'] = (string) t('View details');
+    $out['cta_type'] = 'secondary';
+  }
+  elseif ($isCardContext && $melState === 'scheduled' && $ctaType === EventCtaResolver::CTA_PAID) {
+    $out['cta_label'] = (string) t('View details');
+    $out['cta_type'] = 'secondary';
+  }
+  elseif ($melState === 'scheduled' && $ctaType === EventCtaResolver::CTA_PAID) {
+    $out['cta_label'] = $ecLabel !== '' ? (string) $eventCta['label'] : (string) t('View details');
+    $out['cta_type'] = 'secondary';
+  }
+  elseif ($ctaType === EventCtaResolver::CTA_EXTERNAL) {
+    $out['cta_label'] = $ecLabel !== '' ? (string) $eventCta['label'] : (string) t('View details');
+    $out['cta_type'] = empty($eventCta['disabled'] ?? FALSE) && !empty($eventCta['url']) ? 'secondary' : 'disabled';
+  }
+  elseif ($hasProduct) {
+    $out['cta_label'] = (string) t('Buy tickets');
+    $out['cta_type'] = 'primary';
+  }
+  else {
+    $out['cta_label'] = (string) t('RSVP free');
+    $out['cta_type'] = 'primary';
+  }
+
+  if (!$isWaitlist && $out['is_sold_out'] === FALSE && $rsvpState === 'limited' && $capacity > 0 && $capacity < 20) {
+    $out['capacity_hint'] = (string) t('Limited spots remaining');
+  }
+  if (
+    $out['is_sold_out'] === FALSE
+    && $isBoosted
+    && ($out['image_badge_label'] ?? NULL) === NULL
+  ) {
+    $out['status_label'] = (string) t('Featured');
+    $out['status_type'] = 'highlight';
+    $out['image_badge_label'] = (string) t('Featured');
+    $out['image_badge_type'] = 'apricot';
+  }
+  return $out;
+}
+
+/**
+ * View modes that use the event card CTA phrasing.
+ *
+ * @return list<string>
+ */
+function myeventlane_event_get_event_card_view_modes(): array {
+  return [
+    'card',
+    'event_card',
+    'teaser',
+    'teaser_featured',
+    'event_card_poster',
+    'event_card_compact',
+    'event_home_card',
+  ];
 }
 
 /**

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -997,15 +997,7 @@ function myeventlane_event_finalize_event_ui(
   $capacity = (int) ($domain['capacity'] ?? 0);
   $ecLabel = trim((string) ($eventCta['label'] ?? ''));
   $isCardContext = in_array($viewMode, myeventlane_event_get_event_card_view_modes(), TRUE);
-  $isWaitlist = $melState === 'sold_out'
-    && $ctaType === EventCtaResolver::CTA_RSVP
-    && !empty($eventCta['url'])
-    && empty($eventCta['disabled']);
-
-  $isSoldOut =
-    ($rsvpState === 'closed')
-    || ($rsvpState === 'limited' && $capacity === 0)
-    || ($melState === 'sold_out');
+  $isSoldOut = (($eventCta['type'] ?? NULL) === EventCtaResolver::CTA_SOLD_OUT);
 
   $showCta = $ctaType !== EventCtaResolver::CTA_NONE
     && $melState !== 'draft';
@@ -1030,15 +1022,8 @@ function myeventlane_event_finalize_event_ui(
     $out['status_type'] = 'warning';
     $out['image_badge_label'] = (string) t('Sold out');
     $out['image_badge_type'] = 'warning';
-    if ($isWaitlist) {
-      // Waitlist: sold-out badge + copy; CTA is secondary and remains clickable.
-      $out['cta_label'] = $ecLabel !== '' ? (string) $eventCta['label'] : (string) t('Join waitlist');
-      $out['cta_type'] = 'secondary';
-    }
-    else {
-      $out['cta_label'] = (string) t('Sold out');
-      $out['cta_type'] = 'disabled';
-    }
+    $out['cta_label'] = (string) ($eventCta['label'] ?? '');
+    $out['cta_type'] = 'secondary';
   }
   elseif (in_array($melState, ['ended', 'cancelled'], TRUE)) {
     $out['cta_label'] = (string) t('View details');
@@ -1065,7 +1050,7 @@ function myeventlane_event_finalize_event_ui(
     $out['cta_type'] = 'primary';
   }
 
-  if (!$isWaitlist && $out['is_sold_out'] === FALSE && $rsvpState === 'limited' && $capacity > 0 && $capacity < 20) {
+  if (!$isSoldOut && $rsvpState === 'limited' && $capacity > 0 && $capacity < 20) {
     $out['capacity_hint'] = (string) t('Limited spots remaining');
   }
   if (

--- a/web/modules/custom/myeventlane_event/src/Service/EventCtaResolver.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventCtaResolver.php
@@ -38,6 +38,13 @@ final class EventCtaResolver {
   public const CTA_NONE = 'none';
 
   /**
+   * Value of getResolvedCta() `type` when the CTA row is the sold-out / waitlist band.
+   *
+   * (Distinct from cta_type: paid/rsvp/external; this is the row semantic for Twig/event_ui.)
+   */
+  public const CTA_SOLD_OUT = 'sold_out';
+
+  /**
    * Constructs EventCtaResolver.
    *
    * @param \Drupal\myeventlane_event\Service\EventModeManager $modeManager
@@ -87,7 +94,7 @@ final class EventCtaResolver {
    * @param \Drupal\node\NodeInterface $event
    *   The event node.
    *
-   * @return array{cta_type: string, label: string, url: string|null, disabled: bool, helper: string|null}
+   * @return array{cta_type: string, type: string|null, label: string, url: string|null, disabled: bool, helper: string|null, remaining: int|null}
    *   Single CTA structure. Twig uses this only; no logic in templates.
    */
   public function getResolvedCta(NodeInterface $event): array {
@@ -96,6 +103,7 @@ final class EventCtaResolver {
 
     $base = [
       'cta_type' => $ctaType,
+      'type' => NULL,
       'label' => '',
       'url' => NULL,
       'disabled' => TRUE,
@@ -109,6 +117,7 @@ final class EventCtaResolver {
     }
 
     if ($state === 'sold_out') {
+      $base['type'] = self::CTA_SOLD_OUT;
       if ($ctaType === self::CTA_RSVP) {
         $avail = $this->modeManager->getRsvpAvailability($event);
         if (isset($avail['spots_remaining']) && $avail['spots_remaining'] === 0) {
@@ -180,6 +189,7 @@ final class EventCtaResolver {
         }
       }
       elseif (isset($avail['spots_remaining']) && $avail['spots_remaining'] === 0) {
+        $base['type'] = self::CTA_SOLD_OUT;
         $base['label'] = (string) \t('Join waitlist');
         $base['url'] = Url::fromRoute('myeventlane_event_attendees.waitlist_signup', ['node' => $event->id()])->toString();
         $base['disabled'] = FALSE;

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -93,6 +93,5 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_event_studio.highlight_helper'
       - '@tempstore.private'
-      - '@logger.factory'
     tags:
       - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -93,5 +93,6 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_event_studio.highlight_helper'
       - '@tempstore.private'
+      - '@logger.factory'
     tags:
       - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -8,7 +8,6 @@ use Drupal\Component\Utility\Tags;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
@@ -29,7 +28,6 @@ final class EventStudioAutosaveController {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly EventHighlightHelper $eventHighlightHelper,
     private readonly PrivateTempStoreFactory $privateTempStoreFactory,
-    private readonly LoggerChannelFactoryInterface $loggerFactory,
   ) {}
 
   public function handle(Request $request): JsonResponse {
@@ -39,11 +37,6 @@ final class EventStudioAutosaveController {
 
     $account = $this->currentUser;
     $params = $request->request->all();
-
-    // TEMP mel_debug: remove after verifying autosave mel_autosave_ts + stale compare.
-    $this->loggerFactory->get('mel_debug')->notice('TS: @ts', [
-      '@ts' => (string) ($request->request->get('mel_autosave_ts') ?? ''),
-    ]);
 
     $storage = $this->entityTypeManager->getStorage('node');
     $node = NULL;
@@ -63,11 +56,6 @@ final class EventStudioAutosaveController {
       $store = $this->privateTempStoreFactory->get('myeventlane_event_studio_autosave');
       $stored_ts = $store->get('node.' . $node->id());
       if ($stored_ts !== NULL && is_numeric($stored_ts) && $incoming_autosave_ts < (float) $stored_ts) {
-        // TEMP mel_debug: remove after verifying stale detection.
-        $this->loggerFactory->get('mel_debug')->notice('COMPARE incoming=@in stored=@st', [
-          '@in' => (string) $incoming_autosave_ts,
-          '@st' => (string) $stored_ts,
-        ]);
         return new JsonResponse([
           'ok' => FALSE,
           'latest_ts' => (float) $stored_ts,
@@ -107,15 +95,6 @@ final class EventStudioAutosaveController {
     if ($saved_node !== NULL && $incoming_autosave_ts !== NULL) {
       $store = $this->privateTempStoreFactory->get('myeventlane_event_studio_autosave');
       $store->set('node.' . $saved_node->id(), (float) $incoming_autosave_ts);
-      // TEMP mel_debug: remove after verifying tempstore write path.
-      $this->loggerFactory->get('mel_debug')->notice('SET TS nid=@nid ts=@ts', [
-        '@nid' => (string) $saved_node->id(),
-        '@ts' => (string) $incoming_autosave_ts,
-      ]);
-    }
-    elseif ($incoming_autosave_ts !== NULL) {
-      // TEMP mel_debug: should not happen when errors are empty; indicates save() returned no node.
-      $this->loggerFactory->get('mel_debug')->notice('SKIP SET: no saved node in result while TS present');
     }
 
     return new JsonResponse([

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -23,16 +23,14 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 final class EventStudioAutosaveController {
 
-  public static function create(ContainerInterface $container) {
-  return new static(
-    $container->get('entity_type.manager'),
-    $container->get('current_user'),
-    $container->get('request_stack'),
-    $container->get('logger.factory'),
-    $container->get('datetime.time'),
-    $container->get('your.new_service') // <-- MUST exist
-    );
-  }
+  public function __construct(
+    private readonly EventStudioSaveService $saveService,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EventHighlightHelper $eventHighlightHelper,
+    private readonly PrivateTempStoreFactory $privateTempStoreFactory,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
 
   public function handle(Request $request): JsonResponse {
     if (!$request->isMethod('POST')) {

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -910,6 +910,31 @@ function myeventlane_vendor_update_10018(): string {
 }
 
 /**
+ * Ensure access vendor dashboard is on vendor and staff roles (idempotent).
+ */
+function myeventlane_vendor_update_10019(): string {
+  $role_storage = \Drupal::entityTypeManager()->getStorage('user_role');
+  $permission = 'access vendor dashboard';
+  foreach (['vendor', 'staff'] as $role_id) {
+    $role = $role_storage->load($role_id);
+    if ($role === NULL) {
+      \Drupal::logger('myeventlane_vendor')->notice('MEL: access vendor dashboard: role not found, grant skipped (@role).', [
+        '@role' => $role_id,
+      ]);
+      continue;
+    }
+    if ($role->isAdmin()) {
+      continue;
+    }
+    if (!$role->hasPermission($permission)) {
+      $role->grantPermission($permission);
+      $role->save();
+    }
+  }
+  return 'Access vendor dashboard is granted to vendor and staff when those roles exist. Administrator is unchanged (is_admin / all perms at runtime).';
+}
+
+/**
  * Implements hook_uninstall().
  */
 function myeventlane_vendor_uninstall(): void {

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
@@ -14,7 +14,12 @@ myeventlane_vendor.admin_link:
   parent: myeventlane_core.config
   weight: 25
 
-# User account menu (source of truth: route access on each link).
+# User account menu. Visibility matches route access: SystemMenuBlock uses
+# menu.default_tree_manipulators:checkAccess, which calls
+# AccessManager::checkNamedRoute() (same as visiting the URL). Vendor gating
+# for those routes is implemented in myeventlane_vendor.access.vendor_console
+# using the *target* route’s path, so it stays correct for menu/cross-URL
+# access checks, not just the current browser path.
 myeventlane_vendor.menu_account.dashboard:
   title: 'Dashboard'
   route_name: myeventlane_vendor.console.dashboard

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
@@ -13,3 +13,25 @@ myeventlane_vendor.admin_link:
   route_name: myeventlane_vendor.settings
   parent: myeventlane_core.config
   weight: 25
+
+# User account menu (source of truth: route access on each link).
+myeventlane_vendor.menu_account.dashboard:
+  title: 'Dashboard'
+  route_name: myeventlane_vendor.console.dashboard
+  menu_name: account
+  weight: -50
+myeventlane_vendor.menu_account.events:
+  title: 'My events'
+  route_name: myeventlane_vendor.console.events
+  menu_name: account
+  weight: -49
+myeventlane_vendor.menu_account.create_event:
+  title: 'Create event'
+  route_name: myeventlane_vendor.console.events_add
+  menu_name: account
+  weight: -48
+myeventlane_vendor.menu_account.settings:
+  title: 'Settings'
+  route_name: myeventlane_vendor.console.settings
+  menu_name: account
+  weight: -47

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.permissions.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.permissions.yml
@@ -6,6 +6,11 @@ access vendor console:
   title: 'Access vendor console'
   description: 'View and manage vendor console pages on vendor domain.'
 
+access vendor dashboard:
+  title: 'Access Vendor Dashboard'
+  description: 'Allows users to access the vendor dashboard page.'
+  restrict access: false
+
 use pro financial analytics:
   title: 'Use Pro financial analytics'
   description: 'Access Pro-only financial analytics routes and insights.'

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -291,6 +291,10 @@ myeventlane_vendor.shell.vendor_root:
   requirements:
     _access: 'TRUE'
 
+# Access to this route: require "access vendor dashboard" in addition to other
+# VendorConsoleAccess rules. We cannot add _permission here without breaking
+# the "administer nodes" bypass, which is enforced before the dashboard
+# permission gate inside VendorConsoleAccess.
 myeventlane_vendor.console.dashboard:
   path: '/vendor/dashboard'
   defaults:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -178,6 +178,7 @@ services:
       - '@?myeventlane_capacity.service'
       - '@myeventlane_onboarding.manager'
       - '@myeventlane_event_state.resolver'
+      - '@myeventlane_core.event_state_resolver'
       - '@state'
       - '@logger.channel.mel_debug'
       - '@?myeventlane_ai.usage_tracker'
@@ -205,7 +206,7 @@ services:
 
   myeventlane_vendor.controller.vendor_event_overview:
     class: Drupal\myeventlane_vendor\Controller\VendorEventOverviewController
-    arguments: ['@myeventlane_core.domain_detector', '@current_user', '@messenger', '@myeventlane_vendor.service.metrics_aggregator', '@myeventlane_vendor.service.event_tabs', '@myeventlane_event.cta_resolver', '@myeventlane_boost.help_content', '@date.formatter', '@?myeventlane_pro.active_resolver', '@?myeventlane_donations.vendor_mel_pct_contribution', '@?myeventlane_refunds.processor']
+    arguments: ['@myeventlane_core.domain_detector', '@current_user', '@messenger', '@myeventlane_vendor.service.metrics_aggregator', '@myeventlane_vendor.service.event_tabs', '@myeventlane_event.cta_resolver', '@myeventlane_core.event_state_resolver', '@myeventlane_boost.help_content', '@date.formatter', '@?myeventlane_pro.active_resolver', '@?myeventlane_donations.vendor_mel_pct_contribution', '@?myeventlane_refunds.processor']
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
@@ -11,15 +11,22 @@ use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_core\VendorConsoleTrust;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Route as SymfonyRoute;
 
 /**
  * Access check for vendor console routes.
  *
- * Applies to paths under the /vendor namespace (/vendor, /vendor/…), and
- * to vendor Stripe UI routes at /stripe/… (vendor host) which are not
- * under the /vendor/ prefix. For any other request path, this check returns
- * neutral so /create-event, /user, /my-account, and similar routes are not
- * subject to organiser gating.
+ * Decisions on namespace, Stripe allow-list, and onboarding are based on the
+ * path of the route under access check (the access target), not the browser's
+ * current request path. That way AccessManager::checkNamedRoute() — used when
+ * building menu trees — agrees with a normal page request to the same path.
+ * Otherwise a menu link to /vendor/… could be treated as a non-vendor "skip"
+ * while the user is viewing /user, /, etc.
+ *
+ * Routes whose path is not in the vendor console namespace return neutral so
+ * /create-event, /user, /api/…, and similar routes that attach this check are
+ * not subject to organiser gating here (those route paths are not /vendor/…
+ * and keep the early neutral return).
  *
  * Allows users with the "access vendor console" permission or the "vendor"
  * organiser role (config: user.role.vendor). The role check matches the gate
@@ -34,10 +41,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * to onboarding and Stripe connect paths, plus Event Studio under
  * /vendor/events/* and (when this access check applies) selected routes so
  * organiser flows are not dead-locked before completion.
- *
- * Note: this checker returns neutral for non-/vendor request paths, so
- * /create-event is not gated here; the create-event allow branch still applies
- * to any future route that attaches this check with a /create-event path.
  */
 final class VendorConsoleAccess {
 
@@ -62,7 +65,7 @@ final class VendorConsoleAccess {
    * Checks access for vendor console routes.
    */
   public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResult {
-    $path = $this->getPathForRequest();
+    $path = $this->getPathForAccessTarget($route_match);
     if (str_starts_with($path, '/stripe/')) {
       $this->logger->notice('MEL: forcing allow for Stripe route uid=@uid', [
         '@uid' => (string) $account->id(),
@@ -172,6 +175,21 @@ final class VendorConsoleAccess {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Returns the path of the route being access-checked.
+   */
+  private function getPathForAccessTarget(RouteMatchInterface $route_match): string {
+    $route = $route_match->getRouteObject();
+    if ($route instanceof SymfonyRoute) {
+      $pattern = (string) $route->getPath();
+      if ($pattern !== '' && $pattern[0] !== '/') {
+        $pattern = '/' . $pattern;
+      }
+      return $pattern === '' ? '/' : $pattern;
+    }
+    return $this->getPathForRequest();
   }
 
   private function getPathForRequest(): string {

--- a/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php
@@ -26,6 +26,10 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * subscriber so organiser accounts are not denied when permission resolution
  * lags role assignment.
  *
+ * The vendor dashboard route (myeventlane_vendor.console.dashboard) requires
+ * the "access vendor dashboard" permission (after onboarding) so menu links
+ * and direct URLs stay aligned with the same check.
+ *
  * In addition, vendor-track onboarding with completed = FALSE is restricted
  * to onboarding and Stripe connect paths, plus Event Studio under
  * /vendor/events/* and (when this access check applies) selected routes so
@@ -118,6 +122,17 @@ final class VendorConsoleAccess {
       return AccessResult::forbidden()
         ->addCacheContexts(self::CACHE_CONTEXTS)
         ->addCacheableDependency($state);
+    }
+
+    if ($route_match->getRouteName() === 'myeventlane_vendor.console.dashboard') {
+      if (!$account->hasPermission('access vendor dashboard')) {
+        $this->logDecision($account, $path, 'forbidden_no_vendor_dashboard');
+        return AccessResult::forbidden()
+          ->addCacheContexts(self::CACHE_CONTEXTS);
+      }
+      $this->logDecision($account, $path, 'allowed_vendor_dashboard');
+      return AccessResult::allowed()
+        ->addCacheContexts(self::CACHE_CONTEXTS);
     }
 
     if (VendorConsoleTrust::accountIsTrustedForVendorConsole($account)) {

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_ai\Service\AiUsageTracker;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
+use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\State\StateInterface;
@@ -99,6 +100,11 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   protected EventStateResolverInterface $eventStateResolver;
 
   /**
+   * Domain event state: product, RSVP/capacity, boost/promo (myeventlane_core).
+   */
+  protected EventStateResolver $eventDomainStateResolver;
+
+  /**
    * AI usage tracker (optional, for vendor AI panel).
    */
   protected ?AiUsageTracker $aiUsageTracker;
@@ -170,6 +176,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     ?EventCapacityServiceInterface $capacity_service,
     OnboardingManager $onboarding_manager,
     EventStateResolverInterface $event_state_resolver,
+    EventStateResolver $event_domain_state_resolver,
     StateInterface $state,
     LoggerInterface $mel_debug_logger,
     ?AiUsageTracker $ai_usage_tracker = NULL,
@@ -194,6 +201,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $this->capacityService = $capacity_service;
     $this->onboardingManager = $onboarding_manager;
     $this->eventStateResolver = $event_state_resolver;
+    $this->eventDomainStateResolver = $event_domain_state_resolver;
     $this->state = $state;
     $this->melDebugLogger = $mel_debug_logger;
     $this->aiUsageTracker = $ai_usage_tracker;
@@ -226,6 +234,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $container->has('myeventlane_capacity.service') ? $container->get('myeventlane_capacity.service') : NULL,
       $container->get('myeventlane_onboarding.manager'),
       $container->get('myeventlane_event_state.resolver'),
+      $container->get('myeventlane_core.event_state_resolver'),
       $container->get('state'),
       $container->get('logger.channel.mel_debug'),
       $container->has('myeventlane_ai.usage_tracker') ? $container->get('myeventlane_ai.usage_tracker') : NULL,
@@ -1092,6 +1101,22 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       }
 
       $eventId = $dto->id;
+      $eventNode = NULL;
+      try {
+        $loaded = $this->entityTypeManager->getStorage('node')->load($eventId);
+        if ($loaded instanceof NodeInterface) {
+          $eventNode = $loaded;
+        }
+      }
+      catch (\Throwable) {
+        $eventNode = NULL;
+      }
+      $eventDomainState = [
+        'has_product' => $eventNode ? $this->eventDomainStateResolver->hasProductTarget($eventNode) : FALSE,
+        'is_boosted' => $eventNode ? $this->eventDomainStateResolver->isEventBoosted($eventNode) : FALSE,
+        'rsvp_state' => $eventNode ? $this->eventDomainStateResolver->effectiveRsvpCapacityState([], $eventNode) : 'unset',
+        'capacity' => $eventNode ? $this->eventDomainStateResolver->effectiveVenueCapacity([], $eventNode) : 0,
+      ];
       $eventImageUrl = $dto->image_url;
 
       $startDate = $dto->start_timestamp > 0 ? date('M j, Y', $dto->start_timestamp) : '';
@@ -1230,7 +1255,6 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       if ($this->boostPerformance !== NULL) {
         $boostPerformancePayload = [];
         try {
-          $eventNode = $this->entityTypeManager->getStorage('node')->load($eventId);
           if ($eventNode instanceof NodeInterface) {
             $boostPerformancePayload = $this->boostPerformance->getPerformanceForEvent($eventNode);
           }
@@ -1276,6 +1300,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'export_csv_url' => $exportCsvUrl,
         'waitlist' => $waitlistAnalytics,
         'rsvp' => $stats,
+        'event_domain_state' => $eventDomainState,
         'boost' => $boost,
         'boost_wizard_url' => $boostWizardUrl,
         'view_url' => Url::fromRoute('entity.node.canonical', ['node' => $eventId])->toString(),

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -621,7 +621,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
    * Shell-level dashboard entrypoint for /dashboard and /vendor.
    */
   public function entrypointRedirect(): RedirectResponse {
-    if ($this->currentUser->hasPermission('access vendor console')) {
+    if ($this->currentUser->hasPermission('access vendor dashboard')) {
       $target = Url::fromRoute('myeventlane_vendor.console.dashboard')->toString();
       return new RedirectResponse($target, 302);
     }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -1111,12 +1111,14 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       catch (\Throwable) {
         $eventNode = NULL;
       }
-      $eventDomainState = [
-        'has_product' => $eventNode ? $this->eventDomainStateResolver->hasProductTarget($eventNode) : FALSE,
-        'is_boosted' => $eventNode ? $this->eventDomainStateResolver->isEventBoosted($eventNode) : FALSE,
-        'rsvp_state' => $eventNode ? $this->eventDomainStateResolver->effectiveRsvpCapacityState([], $eventNode) : 'unset',
-        'capacity' => $eventNode ? $this->eventDomainStateResolver->effectiveVenueCapacity([], $eventNode) : 0,
-      ];
+      $eventDomainState = $eventNode instanceof NodeInterface
+        ? $this->eventDomainStateResolver->getEventDomainState($eventNode)
+        : [
+          'has_product' => FALSE,
+          'is_boosted' => FALSE,
+          'rsvp_state' => 'unset',
+          'capacity' => 0,
+        ];
       $eventImageUrl = $dto->image_url;
 
       $startDate = $dto->start_timestamp > 0 ? date('M j, Y', $dto->start_timestamp) : '';

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
@@ -10,6 +10,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_event\Service\EventCtaResolver;
 use Drupal\myeventlane_boost\Service\BoostHelpContent;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
@@ -33,6 +34,7 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
     private readonly MetricsAggregator $metricsAggregator,
     private readonly VendorEventTabsService $eventTabsService,
     private readonly EventCtaResolver $ctaResolver,
+    private readonly EventStateResolver $eventDomainStateResolver,
     private readonly BoostHelpContent $boostHelpContent,
     private readonly DateFormatterInterface $dateFormatter,
     private readonly ?ProActiveResolver $proActiveResolver = NULL,
@@ -189,6 +191,7 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
       '#show_support_card' => $mission['show_support_card'],
       '#pro_upgrade_url' => $pro_upgrade_url,
       '#refund_analytics' => $refundAnalytics,
+      '#event_domain_state' => $mission['event_domain_state'],
       '#cache' => [
         'tags' => $event->getCacheTags(),
         'contexts' => $event->getCacheContexts(),
@@ -598,6 +601,12 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
       'boost_card' => $boost_card,
       'support_card' => $support_card,
       'show_support_card' => $show_support_card,
+      'event_domain_state' => [
+        'has_product' => $this->eventDomainStateResolver->hasProductTarget($event),
+        'is_boosted' => $this->eventDomainStateResolver->isEventBoosted($event),
+        'rsvp_state' => $this->eventDomainStateResolver->effectiveRsvpCapacityState([], $event),
+        'capacity' => $this->eventDomainStateResolver->effectiveVenueCapacity([], $event),
+      ],
     ];
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
@@ -601,12 +601,7 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
       'boost_card' => $boost_card,
       'support_card' => $support_card,
       'show_support_card' => $show_support_card,
-      'event_domain_state' => [
-        'has_product' => $this->eventDomainStateResolver->hasProductTarget($event),
-        'is_boosted' => $this->eventDomainStateResolver->isEventBoosted($event),
-        'rsvp_state' => $this->eventDomainStateResolver->effectiveRsvpCapacityState([], $event),
-        'capacity' => $this->eventDomainStateResolver->effectiveVenueCapacity([], $event),
-      ],
+      'event_domain_state' => $this->eventDomainStateResolver->getEventDomainState($event),
     ];
   }
 

--- a/web/modules/custom/myeventlane_vendor/tests/src/Kernel/VendorConsoleAccessKernelTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Kernel/VendorConsoleAccessKernelTest.php
@@ -163,10 +163,42 @@ final class VendorConsoleAccessKernelTest extends KernelTestBase {
     $this->popRequest();
 
     $this->pushPathRequest('/vendor/onboard/profile');
-    $profile_match = new RouteMatch('myeventlane_vendor.onboard.profile', [], new Route('/vendor/onboard/profile'));
+    $profile_match = new RouteMatch('myeventlane_vendor.onboard.profile', new Route('/vendor/onboard/profile'), []);
     $this->assertTrue(
       $this->access()->access($profile_match, $user)->isAllowed()
     );
+    $this->popRequest();
+  }
+
+  /**
+   * When the current request is not a vendor path, access must still be decided
+   * for the *target* route. Menu links run AccessManager::checkNamedRoute() while
+   * the user may be on /, /user, or any public path; we must not early-neutral.
+   *
+   * @covers ::access
+   */
+  public function testDashboardAllowedForVendorUserWhenRequestPathIsPublic(): void {
+    $this->ensureVendorRoleExists();
+    $this->pushPathRequest('/node/1');
+    $user = $this->createUserWithRoles(['authenticated', MelVendorOrganiserRole::MACHINE_NAME]);
+    $this->assertTrue(
+      $this->access()->access($this->dashboardRouteMatch(), $user)->isAllowed()
+    );
+    $this->popRequest();
+  }
+
+  /**
+   * Anonymous: dashboard target while browsing a public path must be forbidden
+   * (forbidden, not neutral), matching menu and page access.
+   *
+   * @covers ::access
+   */
+  public function testAnonymousTargetDashboardForbiddenNotNeutralWhenRequestPathIsPublic(): void {
+    $this->pushPathRequest('/node/1');
+    $anon = User::getAnonymousUser();
+    $result = $this->access()->access($this->dashboardRouteMatch(), $anon);
+    $this->assertTrue($result->isForbidden());
+    $this->assertFalse($result->isNeutral());
     $this->popRequest();
   }
 
@@ -176,7 +208,7 @@ final class VendorConsoleAccessKernelTest extends KernelTestBase {
 
   private function dashboardRouteMatch(): RouteMatch {
     $route = new Route('/vendor/dashboard');
-    return new RouteMatch('myeventlane_vendor.console.dashboard', [], $route);
+    return new RouteMatch('myeventlane_vendor.console.dashboard', $route, []);
   }
 
   private function pushPathRequest(string $path): void {

--- a/web/modules/custom/myeventlane_vendor/tests/src/Kernel/VendorConsoleAccessKernelTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Kernel/VendorConsoleAccessKernelTest.php
@@ -97,17 +97,35 @@ final class VendorConsoleAccessKernelTest extends KernelTestBase {
   }
 
   /**
-   * access vendor console permission only → allowed.
+   * access vendor console but not "access vendor dashboard" → dashboard forbidden.
    *
    * @covers ::access
    */
-  public function testAuthenticatedUserWithAccessVendorConsolePermissionOnlyAllowed(): void {
+  public function testConsolePermissionWithoutDashboardPermissionOnDashboardDenied(): void {
     $this->ensureConsolePermissionRole();
     $this->pushPathRequest('/vendor/dashboard');
     $user = $this->createUserWithRoles(['authenticated', 'console_perm_only']);
     $this->assertTrue(VendorConsoleTrust::accountIsTrustedForVendorConsole($user));
-    $result = $this->access()->access($this->dashboardRouteMatch(), $user);
-    $this->assertTrue($result->isAllowed());
+    $this->assertFalse($user->hasPermission('access vendor dashboard'));
+    $this->assertTrue(
+      $this->access()->access($this->dashboardRouteMatch(), $user)->isForbidden()
+    );
+    $this->popRequest();
+  }
+
+  /**
+   * "access vendor dashboard" only (no trust) → allowed on /vendor/dashboard.
+   *
+   * @covers ::access
+   */
+  public function testAuthenticatedUserWithAccessVendorDashboardPermissionOnlyAllowedOnDashboard(): void {
+    $this->ensureDashboardPermissionRole();
+    $this->pushPathRequest('/vendor/dashboard');
+    $user = $this->createUserWithRoles(['authenticated', 'dashboard_perm_only']);
+    $this->assertFalse(VendorConsoleTrust::accountIsTrustedForVendorConsole($user));
+    $this->assertTrue(
+      $this->access()->access($this->dashboardRouteMatch(), $user)->isAllowed()
+    );
     $this->popRequest();
   }
 
@@ -189,14 +207,24 @@ final class VendorConsoleAccessKernelTest extends KernelTestBase {
   }
 
   private function ensureVendorRoleExists(): void {
-    if (Role::load(MelVendorOrganiserRole::MACHINE_NAME)) {
+    $id = MelVendorOrganiserRole::MACHINE_NAME;
+    $role = Role::load($id);
+    if ($role) {
+      if (!$role->hasPermission('access vendor dashboard')) {
+        $role->grantPermission('access vendor dashboard');
+        $role->save();
+      }
       return;
     }
     $role = Role::create([
-      'id' => MelVendorOrganiserRole::MACHINE_NAME,
+      'id' => $id,
       'label' => 'Vendor',
     ]);
     $role->save();
+    user_role_grant_permissions($id, [
+      'access vendor console',
+      'access vendor dashboard',
+    ]);
   }
 
   private function ensureConsolePermissionRole(): void {
@@ -209,6 +237,18 @@ final class VendorConsoleAccessKernelTest extends KernelTestBase {
     ]);
     $role->save();
     user_role_grant_permissions('console_perm_only', ['access vendor console']);
+  }
+
+  private function ensureDashboardPermissionRole(): void {
+    if (Role::load('dashboard_perm_only')) {
+      return;
+    }
+    $role = Role::create([
+      'id' => 'dashboard_perm_only',
+      'label' => 'Dashboard perm only',
+    ]);
+    $role->save();
+    user_role_grant_permissions('dashboard_perm_only', ['access vendor dashboard']);
   }
 
   private function ensureSiteAdminRole(): void {

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -189,7 +189,7 @@ function myeventlane_theme_preprocess_site_header(array &$variables): void {
     $organiser_block = $block_manager->createInstance('myeventlane_organiser_context', []);
     if ($organiser_block->access(\Drupal::currentUser())) {
       $build = $organiser_block->build();
-      if (\Drupal::currentUser()->hasPermission('access vendor console') && !empty($build)) {
+      if (\Drupal::currentUser()->hasPermission('access vendor dashboard') && !empty($build)) {
         $variables['organiser_context'] = [];
       }
       else {
@@ -261,56 +261,6 @@ function myeventlane_theme_preprocess_site_header(array &$variables): void {
 }
 
 /**
- * Implements hook_preprocess_menu__account().
- *
- * Injects organiser links (Dashboard, My events, Create event, Settings) into
- * the account dropdown when the user has access to the vendor console.
- */
-function myeventlane_theme_preprocess_menu__account(array &$variables): void {
-  if (!\Drupal::currentUser()->hasPermission('access vendor console')) {
-    return;
-  }
-
-  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_vendor')) {
-    return;
-  }
-
-  $organiser_links = [
-    ['title' => t('Dashboard'), 'route' => 'myeventlane_vendor.console.dashboard'],
-    ['title' => t('My events'), 'route' => 'myeventlane_vendor.console.events'],
-    ['title' => t('Create event'), 'route' => 'myeventlane_vendor.console.create_event'],
-    ['title' => t('Settings'), 'route' => 'myeventlane_vendor.console.settings'],
-  ];
-
-  $injected = [];
-  foreach ($organiser_links as $link) {
-    try {
-      $url = Url::fromRoute($link['route']);
-      if ($url->access()) {
-        $injected[] = [
-          'title' => $link['title'],
-          'url' => $url,
-          'attributes' => new Attribute(['class' => ['mel-account-menu-item']]),
-          'below' => [],
-          'in_active_trail' => FALSE,
-          'is_expanded' => FALSE,
-          'is_collapsed' => FALSE,
-        ];
-      }
-    }
-    catch (\Exception $e) {
-      // Route may not exist.
-    }
-  }
-
-  if (!empty($injected) && !empty($variables['items'])) {
-    $items = $variables['items'];
-    $first = array_shift($items);
-    $variables['items'] = array_merge([$first], $injected, $items);
-  }
-}
-
-/**
  * Implements hook_preprocess_menu__main().
  *
  * Transforms the "Vendors" menu item into a dropdown with child links.
@@ -321,9 +271,8 @@ function myeventlane_theme_preprocess_menu__main(array &$variables): void {
     return;
   }
 
-  // Check if current user is a vendor (has access to vendor console).
   $current_user = \Drupal::currentUser();
-  $is_vendor = $current_user->hasPermission('access vendor console');
+  $is_vendor = $current_user->hasPermission('access vendor dashboard');
 
   // Find and transform the Vendors menu item.
   foreach ($variables['items'] as $key => &$item) {
@@ -1530,6 +1479,9 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
 
   // Check if this is an event node.
   if ($node && $node->bundle() === 'event') {
+    $eventDomainStateResolver = \Drupal::hasService('myeventlane_core.event_state_resolver')
+      ? \Drupal::service('myeventlane_core.event_state_resolver')
+      : NULL;
     // For form view mode, suggest the form template
     if ($view_mode === 'form' || (isset($variables['form']) && $variables['form'])) {
       $variables['attributes']['class'][] = 'mel-node-form';
@@ -1721,7 +1673,9 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         default => 'default',
       };
 
-      $variables['is_promoted'] = $node->hasField('field_promoted') && !$node->get('field_promoted')->isEmpty() && (bool) $node->get('field_promoted')->value;
+      $variables['is_promoted'] = $eventDomainStateResolver
+        ? $eventDomainStateResolver->isEventBoosted($node)
+        : ($node->hasField('field_promoted') && !$node->get('field_promoted')->isEmpty() && (bool) $node->get('field_promoted')->value);
 
       // Poster cards: compact overlay pill (Free / Tickets / $$).
       $variables['mel_poster_price_pill'] = NULL;
@@ -1932,8 +1886,11 @@ function _myeventlane_theme_get_event_badge_text(\Drupal\node\NodeInterface $nod
   }
 
   // Check if product exists and get price
+  $domain = \Drupal::hasService('myeventlane_core.event_state_resolver')
+    ? \Drupal::service('myeventlane_core.event_state_resolver')
+    : NULL;
   $product = NULL;
-  if ($node->hasField('field_product_target') && !$node->get('field_product_target')->isEmpty()) {
+  if ($domain?->hasProductTarget($node)) {
     $product = $node->get('field_product_target')->entity;
   }
 

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1648,18 +1648,29 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         $ec_sched = $variables['event_cta'] ?? [];
         $variables['card_status_secondary'] = trim((string) ($ec_sched['label'] ?? ''));
       }
-      $ec = $variables['event_cta'] ?? [];
-      $cta_label = trim((string) ($ec['label'] ?? ''));
-      if ($state === 'scheduled' && $cta_type === EventCtaResolver::CTA_PAID) {
-        $cta_label = (string) t('View details');
+      $event_ui = is_array($variables['event_ui'] ?? NULL) ? $variables['event_ui'] : NULL;
+      if ($event_ui !== NULL && $event_ui !== []) {
+        if (empty($event_ui['show_cta'])) {
+          $variables['card_cta_label'] = '';
+        }
+        else {
+          $variables['card_cta_label'] = trim((string) ($event_ui['cta_label'] ?? ''));
+        }
       }
-      elseif (in_array($state, ['cancelled', 'ended'], TRUE)) {
-        $cta_label = (string) t('View details');
+      else {
+        $ec = $variables['event_cta'] ?? [];
+        $cta_label = trim((string) ($ec['label'] ?? ''));
+        if ($state === 'scheduled' && $cta_type === EventCtaResolver::CTA_PAID) {
+          $cta_label = (string) t('View details');
+        }
+        elseif (in_array($state, ['cancelled', 'ended'], TRUE)) {
+          $cta_label = (string) t('View details');
+        }
+        elseif ($cta_label === '') {
+          $cta_label = (string) t('View details');
+        }
+        $variables['card_cta_label'] = $cta_label;
       }
-      elseif ($cta_label === '') {
-        $cta_label = (string) t('View details');
-      }
-      $variables['card_cta_label'] = $cta_label;
 
       $badge_for_modifier = $variables['mel_card_badge_text'];
       $variables['card_status_modifier'] = match (TRUE) {
@@ -1673,9 +1684,15 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         default => 'default',
       };
 
-      $variables['is_promoted'] = $eventDomainStateResolver
-        ? $eventDomainStateResolver->isEventBoosted($node)
-        : ($node->hasField('field_promoted') && !$node->get('field_promoted')->isEmpty() && (bool) $node->get('field_promoted')->value);
+      $domain_state_for_badge = $variables['event_domain_state'] ?? NULL;
+      if (is_array($domain_state_for_badge) && !empty($domain_state_for_badge['is_boosted'])) {
+        $variables['is_promoted'] = TRUE;
+      }
+      else {
+        $variables['is_promoted'] = $eventDomainStateResolver
+          ? $eventDomainStateResolver->isEventBoosted($node)
+          : ($node->hasField('field_promoted') && !$node->get('field_promoted')->isEmpty() && (bool) $node->get('field_promoted')->value);
+      }
 
       // Poster cards: compact overlay pill (Free / Tickets / $$).
       $variables['mel_poster_price_pill'] = NULL;
@@ -1775,6 +1792,21 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       // Add taxonomy term cache tag if category exists
       if ($category_term ?? NULL) {
         $variables['#cache']['tags'][] = 'taxonomy_term:' . $category_term->id();
+      }
+    }
+
+    if ($view_mode === 'full' && $node?->bundle() === 'event') {
+      $variables['mel_event_selling_fast'] = FALSE;
+      if (\Drupal::hasService('myeventlane_capacity.service')) {
+        $capacity = \Drupal::service('myeventlane_capacity.service');
+        $total_cap = $capacity->getCapacityTotal($node);
+        $remaining = $capacity->getRemaining($node);
+        if ($total_cap !== NULL && $remaining !== NULL && $remaining > 0) {
+          $threshold = max(3, (int) floor($total_cap * 0.15));
+          if ($remaining <= $threshold) {
+            $variables['mel_event_selling_fast'] = TRUE;
+          }
+        }
       }
     }
   }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -431,7 +431,7 @@ function myeventlane_theme_preprocess_commerce_checkout_pane(array &$variables):
  */
 function myeventlane_theme_preprocess_region__header(array &$variables): void {
   $current_user = \Drupal::currentUser();
-  $variables['is_vendor'] = $current_user->hasPermission('access vendor console');
+  $variables['is_vendor'] = $current_user->hasPermission('access vendor dashboard');
 }
 
 /**
@@ -877,7 +877,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     }
   }
   $variables['mel_footer_categories'] = $categories;
-  $variables['mel_is_organiser'] = \Drupal::currentUser()->hasPermission('access vendor console');
+  $variables['mel_is_organiser'] = \Drupal::currentUser()->hasPermission('access vendor dashboard');
   
   // Check if vendor settings route exists for header menu.
   $route_exists = FALSE;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -120,6 +120,31 @@
   max-width: calc(100% - 24px);
 }
 
+// Outrank .mel-pill--on-image / .mel-pill (listing + hero) without !important.
+.mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--highlight,
+.mel-event-hero-card .mel-pill--on-image.mel-event-card__state-pill--highlight {
+  background: color-mix(in srgb, #f5c98d 45%, #fff 55%);
+  color: mel.$mel-ds-color-text;
+  border: 1px solid color-mix(in srgb, #e8a85c 30%, transparent);
+  border-radius: 16px;
+}
+
+.mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--warning,
+.mel-event-hero-card .mel-pill--on-image.mel-event-card__state-pill--warning {
+  background: color-mix(in srgb, #f0a090 32%, #fff 68%);
+  color: color-mix(in srgb, #8a3224 85%, #000 15%);
+  border: 1px solid color-mix(in srgb, #e08a7a 35%, transparent);
+  border-radius: 16px;
+}
+
+.mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--apricot,
+.mel-event-hero-card .mel-pill--on-image.mel-event-card__state-pill--apricot {
+  background: color-mix(in srgb, #f4d4a8 50%, #fff 50%);
+  color: mel.$mel-ds-color-text;
+  border: 1px solid color-mix(in srgb, #e8a85c 32%, transparent);
+  border-radius: 16px;
+}
+
 .mel-event-card__overlay {
   position: absolute;
   inset: 0;
@@ -272,6 +297,27 @@
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.65) inset;
 }
 
+// event_ui: semantic CTA (coral primary, lavender secondary, muted sold)
+.mel-event-card__cta-chip--coral {
+  background: var(--mel-coral, #f26d5b);
+  border: 1px solid color-mix(in srgb, #f26d5b 45%, #fff 55%);
+  color: #fff;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset;
+}
+
+.mel-event-card__cta-chip--lavender {
+  background: color-mix(in srgb, #b8a5d6 30%, #fff 70%);
+  border: 1px solid color-mix(in srgb, #8b7ab8 25%, transparent);
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-event-card__cta-chip--disabled {
+  background: color-mix(in srgb, mel.$mel-ds-color-muted 20%, #fff 80%);
+  color: color-mix(in srgb, mel.$mel-ds-color-text 60%, #fff 40%);
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
+  box-shadow: none;
+}
+
 .mel-event-card__tertiary {
   margin-top: 10px;
   padding-top: 8px;
@@ -284,7 +330,23 @@
 .mel-event-card__urgency {
   font-size: 13px;
   font-weight: 600;
-  color: #e74c3c;
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-event-card__capacity-hint,
+.mel-event-card__tertiary--context .mel-event-card__urgency {
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 600;
+  color: color-mix(in srgb, mel.$mel-ds-color-text 72%, #fff 28%);
+  margin: 4px 0 0;
+}
+
+.mel-event-card__tertiary--context {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .mel-event-card__social {
@@ -599,6 +661,25 @@
   color: mel.$mel-ds-color-text;
   border: 1px solid rgba(255, 255, 255, 0.5);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+// Outrank .mel-btn--cta (gradient) on the hero CTA span (see mel-event-card.html.twig).
+.mel-event-hero-card .mel-btn.mel-event-hero-card__cta-chip--coral {
+  background: var(--mel-coral, #f26d5b);
+  color: #fff;
+  border-color: color-mix(in srgb, #fff 35%, #f26d5b 65%);
+}
+
+.mel-event-hero-card .mel-btn.mel-event-hero-card__cta-chip--lavender {
+  background: color-mix(in srgb, #b8a5d6 32%, #fff 68%);
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-event-hero-card .mel-btn.mel-event-hero-card__cta-chip--disabled {
+  background: rgba(255, 255, 255, 0.5);
+  color: color-mix(in srgb, mel.$mel-ds-color-text 55%, #fff 45%);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: none;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -17,6 +17,13 @@
 
 .mel-event--v2 {
   padding: space-tokens.mel-space(4) 0 space-tokens.mel-space(6);
+
+  // Sticky mobile CTA clears content; reserve space (thumb zone + copy above button).
+  &:has(> .mel-mobile-cta) {
+    @include breakpoints.mel-break(lg, max) {
+      padding-bottom: calc(#{space-tokens.mel-space(6)} + 8.5rem + env(safe-area-inset-bottom, 0));
+    }
+  }
 }
 
 // Spacing between featured-style hero and meta bar (hero chrome = .mel-event-hero-card via @extend in _event-card.scss).
@@ -49,6 +56,11 @@
   align-items: flex-end;
   gap: 10px;
   min-width: 0;
+
+  @include breakpoints.mel-break(md, max) {
+    align-items: stretch;
+    text-align: center;
+  }
 }
 
 .mel-event-meta-bar__cta-eyebrow {
@@ -58,6 +70,10 @@
   font-size: typography.mel-font-size(base);
   font-weight: typography.$mel-font-bold;
   color: colors.$mel-color-text;
+
+  @include breakpoints.mel-break(md, max) {
+    text-align: center;
+  }
 }
 
 .mel-event-meta-bar__cta-below {
@@ -67,6 +83,128 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
+
+  @include breakpoints.mel-break(md, max) {
+    text-align: center;
+    align-items: center;
+  }
+}
+
+// Domain-driven urgency (small, secondary; seats left / limited).
+.mel-event-meta-bar__urgency {
+  margin: 0;
+  max-width: 20rem;
+  text-align: inherit;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-medium;
+  line-height: 1.35;
+  color: color-mix(in srgb, colors.$mel-color-text 72%, #fff 28%);
+}
+
+// Sold out + waitlist (replaces primary coral CTA in sold-out state).
+.mel-event-cta-soldout {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  width: 100%;
+
+  @include breakpoints.mel-break(md, max) {
+    align-items: stretch;
+  }
+}
+
+.mel-event-cta-soldout__headline {
+  margin: 0;
+  width: 100%;
+  text-align: right;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-extrabold;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
+
+  @include breakpoints.mel-break(md, max) {
+    text-align: center;
+  }
+}
+
+.mel-event-cta-soldout__sub {
+  margin: 0;
+  text-align: right;
+  max-width: 20rem;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  line-height: 1.4;
+
+  @include breakpoints.mel-break(md, max) {
+    text-align: center;
+    max-width: none;
+  }
+}
+
+.mel-event-cta-soldout__muted {
+  margin: 0;
+  text-align: right;
+  font-size: typography.mel-font-size(base);
+  color: colors.$mel-color-text-muted;
+
+  @include breakpoints.mel-break(md, max) {
+    text-align: center;
+  }
+}
+
+// Subtle trust line (below urgency / CTA; muted grey, not marketing-heavy).
+.mel-event-meta-bar__trust {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: baseline;
+  gap: 0.2rem 0.35rem;
+  margin: 0;
+  padding: 4px 0 0;
+  max-width: 100%;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: colors.$mel-color-text-muted;
+
+  @include breakpoints.mel-break(md, max) {
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+.mel-event-meta-bar__trust-item,
+.mel-event-meta-bar__trust-sep,
+.mel-event-meta-bar__trust-link {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+.mel-event-meta-bar__trust-sep {
+  user-select: none;
+  color: color-mix(in srgb, colors.$mel-color-text-muted 50%, #fff 50%);
+}
+
+.mel-event-meta-bar__trust-link {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, colors.$mel-color-text-muted 50%, #fff 50%);
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: colors.$mel-color-text;
+    }
+  }
+
+  &:focus-visible {
+    @include colors.mel-focus-ring;
+    border-radius: 2px;
+  }
 }
 
 .mel-event-meta-bar__selling-fast {
@@ -114,6 +252,14 @@
     background: color-mix(in srgb, #b8a5d6 22%, #fff 78%);
     color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
     border: 1px solid color-mix(in srgb, #8b7ab8 14%, transparent);
+  }
+
+  @include breakpoints.mel-break(md, max) {
+    .mel-btn--cta,
+    .mel-btn--waitlist {
+      width: 100%;
+      justify-content: center;
+    }
   }
 }
 
@@ -407,7 +553,7 @@
   right: 0;
   bottom: 0;
   padding:
-    space-tokens.mel-space(3)
+    space-tokens.mel-space(2)
     space-tokens.mel-space(3)
     calc(#{space-tokens.mel-space(3)} + env(safe-area-inset-bottom));
   background: rgba(250, 247, 251, 0.85);
@@ -418,6 +564,93 @@
 
   @include breakpoints.mel-break(lg) {
     display: none;
+  }
+}
+
+.mel-mobile-cta__inner {
+  max-width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.4rem;
+}
+
+.mel-mobile-cta__eyebrow {
+  margin: 0;
+  text-align: center;
+  font-size: typography.mel-font-size(base);
+  font-weight: typography.$mel-font-bold;
+  color: colors.$mel-color-text;
+}
+
+.mel-mobile-cta__urgency {
+  margin: 0;
+  text-align: center;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-medium;
+  line-height: 1.35;
+  color: color-mix(in srgb, colors.$mel-color-text 72%, #fff 28%);
+}
+
+.mel-mobile-cta__soldout-head {
+  margin: 0 0 0.1rem;
+  text-align: center;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-extrabold;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
+}
+
+.mel-mobile-cta__helper {
+  margin: 0;
+  text-align: center;
+  font-size: typography.mel-font-size(sm);
+  color: color-mix(in srgb, colors.$mel-color-text 72%, #fff 28%);
+}
+
+.mel-mobile-cta__waitlist-sub {
+  margin: 0;
+  text-align: center;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  line-height: 1.35;
+}
+
+.mel-mobile-cta__waitlist-sub--muted {
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-mobile-cta__trust {
+  margin: 0.1rem 0 0;
+  text-align: center;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-mobile-cta__trust-t,
+.mel-mobile-cta__trust-d,
+.mel-mobile-cta__trust-link {
+  display: inline;
+  color: inherit;
+  font: inherit;
+}
+
+.mel-mobile-cta__trust-link {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, colors.$mel-color-text-muted 50%, #fff 50%);
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: colors.$mel-color-text;
+    }
+  }
+
+  &:focus-visible {
+    @include colors.mel-focus-ring;
+    border-radius: 2px;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -42,11 +42,85 @@
   }
 }
 
-// Buy Tickets in highlight panel: red with white text.
-.mel-event-meta-bar__cta .mel-btn--cta {
-  background: var(--mel-accent);
-  color: colors.$mel-color-text-inverse;
-  border: none;
+// CTA: coral = primary (Buy/RSVP); lavender = secondary; sold-out = disabled only (no coral).
+.mel-event-meta-bar__cta--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mel-event-meta-bar__cta-eyebrow {
+  margin: 0;
+  width: 100%;
+  text-align: right;
+  font-size: typography.mel-font-size(base);
+  font-weight: typography.$mel-font-bold;
+  color: colors.$mel-color-text;
+}
+
+.mel-event-meta-bar__cta-below {
+  width: 100%;
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.mel-event-meta-bar__selling-fast {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-event--v2 .mel-event-meta-bar__cta {
+  .mel-btn--coral-cta {
+    min-height: 44px;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+    background: var(--mel-coral, #f26d5b);
+    color: colors.$mel-color-text-inverse;
+    border: 1px solid color-mix(in srgb, #f26d5b 50%, #fff 50%);
+    border-radius: 16px;
+  }
+
+  .mel-btn--lavender-cta {
+    min-height: 44px;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+    background: color-mix(in srgb, #b8a5d6 32%, #fff 68%);
+    color: colors.$mel-color-text;
+    border: 1px solid color-mix(in srgb, #8b7ab8 20%, transparent);
+    border-radius: 16px;
+  }
+
+  .mel-btn--state-soldout {
+    min-height: 44px;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+    background: color-mix(in srgb, colors.$mel-color-text-muted 14%, #fff 86%);
+    color: color-mix(in srgb, colors.$mel-color-text 58%, #fff 42%);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: none;
+  }
+
+  .mel-btn--cta-locked {
+    min-height: 44px;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+    background: color-mix(in srgb, #b8a5d6 22%, #fff 78%);
+    color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
+    border: 1px solid color-mix(in srgb, #8b7ab8 14%, transparent);
+  }
+}
+
+.mel-event-meta-bar__capacity-hint {
+  margin: 8px 0 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
 }
 
 .mel-event-meta-bar__items {
@@ -351,14 +425,16 @@
   display: flex;
   width: 100%;
   justify-content: center;
+  align-items: center;
   min-height: 44px;
   padding: 0.9rem 1.2rem;
-  border-radius: radii.$mel-radius-full;
-  background: colors.$mel-color-primary;
-  color: colors.$mel-color-text-inverse;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: #f3f4f6;
+  color: colors.$mel-color-text;
   font-weight: typography.$mel-font-bold;
   text-decoration: none;
-  box-shadow: shadows.$mel-shadow-md;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.6) inset;
   transition:
     transform var(--mel-motion-fast) var(--mel-ease-out),
     box-shadow var(--mel-motion-fast) var(--mel-ease-out),
@@ -366,7 +442,7 @@
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      box-shadow: shadows.$mel-shadow-lg;
+      box-shadow: shadows.$mel-shadow-md;
       transform: translateY(-1px);
     }
   }
@@ -378,6 +454,31 @@
   &:focus-visible {
     @include colors.mel-focus-ring;
   }
+}
+
+.mel-event--v2 .mel-mobile-cta .mel-mobile-cta__button--coral {
+  background: var(--mel-coral, #f26d5b);
+  color: colors.$mel-color-text-inverse;
+}
+
+.mel-event--v2 .mel-mobile-cta .mel-mobile-cta__button--lavender {
+  background: color-mix(in srgb, #b8a5d6 35%, #fff 65%);
+  color: colors.$mel-color-text;
+}
+
+.mel-event--v2 .mel-mobile-cta .mel-mobile-cta__button--soldout {
+  background: color-mix(in srgb, colors.$mel-color-text-muted 14%, #fff 86%);
+  color: color-mix(in srgb, colors.$mel-color-text 58%, #fff 42%);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.mel-event--v2 .mel-mobile-cta .mel-mobile-cta__button--locked {
+  background: color-mix(in srgb, #b8a5d6 22%, #fff 78%);
+  color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
+  border-color: color-mix(in srgb, #8b7ab8 14%, transparent);
+  cursor: not-allowed;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-events.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-events.scss
@@ -151,6 +151,75 @@
   margin-top: 0;
 }
 
+// Public-parity CTA + status (event_ui) on vendor list rows
+.mel-vendor-row-ui {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 0;
+  text-align: right;
+}
+
+.mel-vendor-row-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  border: 1px solid #e0e7f1;
+  background: #f8f9fd;
+  color: #1f2937;
+}
+
+.mel-vendor-row-cta--primary {
+  background: var(--mel-coral, #f26d5b);
+  border-color: #f4a99a;
+  color: #fff;
+}
+
+// Secondary: waitlist, view details (not coral).
+.mel-vendor-row-cta--secondary {
+  background: #ede6f5;
+  border-color: #cec4e0;
+  color: #3d3258;
+  font-weight: 700;
+}
+
+.mel-vendor-row-cta--disabled,
+.mel-vendor-row-cta.is-sold-out {
+  background: #f3f4f6;
+  color: #6b7280;
+  border-color: #e5e7eb;
+  font-weight: 600;
+}
+
+.mel-vendor-row-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid #e5e7eb;
+  color: #374151;
+  background: #fff;
+}
+
+.mel-vendor-row-pill--highlight {
+  background: #ffefd9;
+  border-color: #f0c896;
+}
+
+.mel-vendor-row-pill--warning {
+  background: #fde8e3;
+  border-color: #edb5a8;
+}
+
 .mel-event-navigator {
   padding: 24px;
   border-right: 1px solid #e9edf3;

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -5,6 +5,8 @@
  *
  * Node listings: preprocess supplies card_* (myeventlane_theme_preprocess_node).
  * Views field rows: pass title, url, image, date_full, location, category, ticket_type, etc.
+ * Image pill badges use `event_ui` (see myeventlane_event_finalize_event_ui in myeventlane_event).
+ * @see myeventlane_event.module — myeventlane_event_preprocess_node() (event_ui for all view modes).
  */
 #}
 {% set variant = variant|default('standard') %}
@@ -57,7 +59,7 @@
 {% set category_class = category_slug is defined and category_slug ? ('mel-pill--cat-' ~ category_slug) : '' %}
 
 {% set _state_badge_type = 'highlight' %}
-{# Priority: sold out > event_ui image badge (e.g. featured) > category > is_promoted. #}
+{# Image pill: event_ui only — is_sold_out > image_badge (boost/Featured from myeventlane_event_finalize_event_ui) > category. #}
 {% set _image_badge_label = null %}
 {% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
   {% set _image_badge_label = 'Sold out'|t %}
@@ -69,9 +71,6 @@
 {% elseif _category and _category.label %}
   {% set _image_badge_label = _category.label %}
   {% set _state_badge_type = 'category' %}
-{% elseif is_promoted %}
-  {% set _image_badge_label = 'Featured'|t %}
-  {% set _state_badge_type = 'highlight' %}
 {% endif %}
 
 {% if variant == 'featured_hero' %}

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -19,15 +19,29 @@
 {% set _status_primary = card_status_primary|default('') %}
 {% set _status_secondary = card_status_secondary|default('') %}
 {% set _status_mod = card_status_modifier|default('default') %}
+{# Sold-out is communicated by top badge + CTA; avoid duplicate "Sold out" in body. #}
+{% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) and (_status_mod|default('') == 'sold-out') %}
+  {% set _status_primary = '' %}
+  {% set _status_secondary = '' %}
+{% endif %}
 
-{% set _cta = card_cta_label|default('') %}
-{% if _cta == '' %}
-  {% if _type == 'rsvp' %}
-    {% set _cta = 'RSVP free'|t %}
-  {% elseif _type == 'external' %}
-    {% set _cta = 'View details'|t %}
-  {% else %}
-    {% set _cta = 'Buy tickets'|t %}
+{% if event_ui is defined and (event_ui.show_cta|default(true)) is same as(false) %}
+  {% set _cta = '' %}
+  {% set _mel_cta_semantic = 'hidden' %}
+{% else %}
+  {% set _mel_cta_semantic = event_ui is defined ? event_ui.cta_type|default('primary') : 'primary' %}
+  {% set _cta = card_cta_label|default('') %}
+  {% if _cta == '' and event_ui is defined and (event_ui.cta_label|default(''))|trim|length > 0 %}
+    {% set _cta = event_ui.cta_label %}
+  {% endif %}
+  {% if _cta == '' %}
+    {% if _type == 'rsvp' %}
+      {% set _cta = 'RSVP free'|t %}
+    {% elseif _type == 'external' %}
+      {% set _cta = 'View details'|t %}
+    {% else %}
+      {% set _cta = 'Buy tickets'|t %}
+    {% endif %}
   {% endif %}
 {% endif %}
 
@@ -42,12 +56,22 @@
 {% endif %}
 {% set category_class = category_slug is defined and category_slug ? ('mel-pill--cat-' ~ category_slug) : '' %}
 
-{# One image-area badge: category first, else Featured when promoted. #}
+{% set _state_badge_type = 'highlight' %}
+{# Priority: sold out > event_ui image badge (e.g. featured) > category > is_promoted. #}
 {% set _image_badge_label = null %}
-{% if _category and _category.label %}
+{% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
+  {% set _image_badge_label = 'Sold out'|t %}
+  {% set _state_badge_type = 'warning' %}
+{% elseif event_ui is defined and event_ui.image_badge_label|default('')|trim|length > 0 %}
+  {% set _image_badge_label = event_ui.image_badge_label %}
+  {% set _st = event_ui.image_badge_type|default('apricot') %}
+  {% set _state_badge_type = _st == 'highlight' ? 'apricot' : _st %}
+{% elseif _category and _category.label %}
   {% set _image_badge_label = _category.label %}
+  {% set _state_badge_type = 'category' %}
 {% elseif is_promoted %}
   {% set _image_badge_label = 'Featured'|t %}
+  {% set _state_badge_type = 'highlight' %}
 {% endif %}
 
 {% if variant == 'featured_hero' %}
@@ -65,7 +89,7 @@
         {% endif %}
         <div class="mel-event-hero-card__overlay" aria-hidden="true"></div>
         {% if _image_badge_label %}
-          <span class="mel-event-hero-card__badge mel-pill mel-pill--category mel-pill--on-image {{ category_class }}" aria-hidden="true">
+          <span class="mel-event-hero-card__badge mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ _state_badge_type|e('html_attr') }}{% if _state_badge_type == 'category' %} {{ category_class }}{% endif %}" aria-hidden="true">
             <span class="mel-pill__label">{{ _image_badge_label }}</span>
           </span>
         {% endif %}
@@ -88,7 +112,9 @@
           <p class="mel-event-hero-card__status-note">{{ _status_secondary }}</p>
         {% endif %}
 
-        <span class="mel-btn mel-btn--cta mel-event-hero-card__cta-chip" aria-hidden="true">{{ _cta }}</span>
+        {% if _mel_cta_semantic|default('primary') != 'hidden' and _cta|trim|length > 0 %}
+        <span class="mel-btn mel-btn--cta mel-event-hero-card__cta-chip{% if _mel_cta_semantic == 'primary' %} mel-event-hero-card__cta-chip--coral{% elseif _mel_cta_semantic == 'disabled' %} mel-event-hero-card__cta-chip--disabled{% else %} mel-event-hero-card__cta-chip--lavender{% endif %}" aria-hidden="true">{{ _cta }}</span>
+        {% endif %}
       </div>
     </a>
   </article>
@@ -126,7 +152,7 @@
       {% endif %}
 
       {% if _image_badge_label %}
-        <span class="mel-event-card__image-badge mel-pill mel-pill--category mel-pill--on-image {{ category_class }}" aria-hidden="true">
+        <span class="mel-event-card__image-badge mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ _state_badge_type|e('html_attr') }}{% if _state_badge_type == 'category' %} {{ category_class }}{% endif %}" aria-hidden="true">
           <span class="mel-pill__label">{{ _image_badge_label }}</span>
         </span>
       {% endif %}
@@ -158,14 +184,19 @@
         </div>
       {% endif %}
 
-      <div class="mel-event-card__cta-row">
-        <span class="mel-event-card__cta-chip" aria-hidden="true">{{ _cta }}</span>
-      </div>
+      {% if _mel_cta_semantic|default('primary') != 'hidden' %}
+        <div class="mel-event-card__cta-row">
+          <span class="mel-event-card__cta-chip{% if _mel_cta_semantic == 'primary' %} mel-event-card__cta-chip--coral{% elseif _mel_cta_semantic == 'disabled' %} mel-event-card__cta-chip--disabled{% else %} mel-event-card__cta-chip--lavender{% endif %}" aria-hidden="true">{{ _cta }}</span>
+        </div>
+      {% endif %}
 
-      {% if _low_stock or _attendance %}
-        <div class="mel-event-card__tertiary">
+      {% if (event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0)) or _low_stock or _attendance %}
+        <div class="mel-event-card__tertiary mel-event-card__tertiary--context">
+          {% if event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) %}
+            <p class="mel-event-card__capacity-hint" role="status">{{ event_ui.capacity_hint }}</p>
+          {% endif %}
           {% if _low_stock %}
-            <span class="mel-event-card__urgency">{{ 'Selling fast'|t }}</span>
+            <p class="mel-event-card__urgency" role="status">{{ 'Selling fast'|t }}</p>
           {% endif %}
           {% if _attendance %}
             <span class="mel-event-card__social">{{ '@count going'|t({'@count': _attendance}) }}</span>

--- a/web/themes/custom/myeventlane_theme/templates/myeventlane-vendor-dashboard.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/myeventlane-vendor-dashboard.html.twig
@@ -106,17 +106,33 @@
                     <span>${{ row.revenue|default(0)|number_format(2) }}</span>
                   </div>
                 </div>
-                <div class="mel-event-status">
-                  {% if row.event_mode == 'rsvp' %}
-                    {{ 'RSVP'|t }}
-                  {% elseif row.event_mode == 'paid' %}
-                    {{ 'Tickets'|t }}
-                  {% elseif row.event_mode == 'external' %}
-                    {{ 'External'|t }}
-                  {% elseif row.event_mode == 'both' %}
-                    {{ 'Both'|t }}
+                <div class="mel-event-status mel-vendor-row-ui">
+                  {% if row.event_ui is defined and row.event_ui is iterable
+                    and (
+                      (row.event_ui.show_cta|default(true) and (row.event_ui.cta_label|default('')|striptags|length > 0))
+                      or (row.event_ui.status_label|default('')|striptags|length > 0)
+                    )
+                  %}
+                    {% if (row.event_ui.cta_label|default('')|striptags|length > 0) %}
+                    <span class="mel-vendor-row-cta mel-vendor-row-cta--{{ row.event_ui.cta_type|default('secondary')|e('html_attr') }}{% if row.event_ui.is_sold_out|default(false) %} is-sold-out{% endif %}">
+                      {{ row.event_ui.cta_label }}
+                    </span>
+                    {% endif %}
+                    {% if (row.event_ui.status_label|default(''))|striptags|length > 0 %}
+                      <span class="mel-vendor-row-pill mel-vendor-row-pill--{{ row.event_ui.status_type|default('muted')|e('html_attr') }}">{{ row.event_ui.status_label }}</span>
+                    {% endif %}
                   {% else %}
-                    {{ row.event_mode|default('Draft'|t)|capitalize }}
+                    {% if row.event_mode == 'rsvp' %}
+                      {{ 'RSVP'|t }}
+                    {% elseif row.event_mode == 'paid' %}
+                      {{ 'Tickets'|t }}
+                    {% elseif row.event_mode == 'external' %}
+                      {{ 'External'|t }}
+                    {% elseif row.event_mode == 'both' %}
+                      {{ 'Both'|t }}
+                    {% else %}
+                      {{ row.event_mode|default('Draft'|t)|capitalize }}
+                    {% endif %}
                   {% endif %}
                 </div>
               </a>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -53,11 +53,11 @@
 {% endif %}
 {% set mel_gcal_href = '' %}
 {% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
-  {% set mel_cal_start = node.field_event_start.value|date('Ymd\\THis') %}
+  {% set mel_cal_start = node.field_event_start.value|date('Ymd\THis') %}
   {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
-    {% set mel_cal_end = node.field_event_end.value|date('Ymd\\THis') %}
+    {% set mel_cal_end = node.field_event_end.value|date('Ymd\THis') %}
   {% else %}
-    {% set mel_cal_end = node.field_event_start.value|date_modify('+2 hours')|date('Ymd\\THis') %}
+    {% set mel_cal_end = node.field_event_start.value|date_modify('+2 hours')|date('Ymd\THis') %}
   {% endif %}
   {% set mel_canon = url('entity.node.canonical', { 'node': node.id() }, { 'absolute': true }) %}
   {% set mel_gcal_href = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=' ~ (label|url_encode) ~ '&dates=' ~ mel_cal_start ~ '/' ~ mel_cal_end ~ '&details=' ~ (mel_canon|url_encode) %}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -12,9 +12,15 @@
 #}
 {{ attach_library('myeventlane_theme/myeventlane_event_full') }}
 {# Google Maps in Event Information card uses iframe embed (no API key). JS map library only if needed elsewhere. #}
+{% set mel_cta_text = (event_ui is defined and (event_ui.cta_label|default(''))|striptags|length > 0) ? event_ui.cta_label : (event_cta and event_cta.label ? event_cta.label : '') %}
+{% set mel_cta_type_ui = event_ui is defined ? (event_ui.cta_type|default('primary')) : 'primary' %}
 
-{# Promoted / Boosted flag (data already managed by Boost system). #}
-{% set is_promoted = node.hasField('field_promoted') and (node.field_promoted.value|default('0') == '1') %}
+{# Promoted / featured: event_domain_state.is_boosted (canonical) then field fallback. #}
+{% if event_domain_state is defined and event_domain_state is iterable and (event_domain_state['is_boosted']|default(false) == true or event_domain_state['is_boosted']|default(0) == 1) %}
+  {% set is_promoted = true %}
+{% else %}
+  {% set is_promoted = node.hasField('field_promoted') and (node.field_promoted.value|default('0') == '1') %}
+{% endif %}
 {# Registration status chip: cta_type + labels aligned with EventCtaResolver and public event cards. #}
 {% set mel_mode_chip = '' %}
 {% if cta_type is defined and cta_type == 'paid' %}
@@ -38,7 +44,13 @@
         {% endif %}
       </div>
       <div class="mel-event-hero__overlay" aria-hidden="true"></div>
-      {% if mel_category_label %}
+      {% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
+        <div class="mel-event-hero__chip">
+          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--warning" aria-hidden="true">
+            <span class="mel-pill__label">{{ 'Sold out'|t }}</span>
+          </span>
+        </div>
+      {% elseif mel_category_label %}
         <div class="mel-event-hero__chip">
           <span class="mel-pill mel-pill--category mel-pill--on-image mel-pill--cat-{{ mel_category_slug|default('default') }}" aria-hidden="true">
             <span class="mel-pill__label">{{ mel_category_label }}</span>
@@ -57,8 +69,10 @@
         {% if hero_venue %}
           <p class="mel-event-hero__venue">{{ hero_venue }}</p>
         {% endif %}
-        {% if hero_status %}
-          <p class="mel-event-hero__status mel-event-card__status mel-event-card__status--{{ hero_status_modifier|default('default') }}">{{ hero_status }}</p>
+        {% if (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) or hero_status %}
+          {% set _hero_status_mod = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? 'sold-out' : (hero_status_modifier|default('default')) %}
+          {% set _hero_status_text = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? (event_ui.status_label|default('')|striptags|length > 0 ? event_ui.status_label : ('Sold out'|t)) : hero_status %}
+          <p class="mel-event-hero__status mel-event-card__status mel-event-card__status--{{ _hero_status_mod }}">{{ _hero_status_text }}</p>
         {% endif %}
       </div>
     </section>
@@ -66,11 +80,11 @@
     {# Meta row + CTA #}
     <section class="mel-event-meta-bar" aria-label="{{ 'Event summary'|t }}">
       <div class="mel-event-meta-bar__items">
-        {% if is_promoted and not (mel_category_label is defined and mel_category_label) %}
+        {% if (not (event_ui is defined and (event_ui.is_sold_out|default(false) == true))) and (not (mel_category_label is defined and mel_category_label)) and ((event_ui is defined and (event_ui.status_type|default('') == 'highlight')) or is_promoted) %}
           <div class="mel-event-meta">
-            <span class="mel-featured-badge mel-featured-badge--inline" role="note" aria-label="{{ 'Featured event'|t }}">
+            <span class="mel-featured-badge mel-featured-badge--inline" role="note" aria-label="{{ 'Featured'|t }}">
               <span class="mel-featured-badge__icon" aria-hidden="true">✨</span>
-              <span class="mel-featured-badge__text">{{ 'Featured event'|t }}</span>
+              <span class="mel-featured-badge__text">{% if event_ui is defined and (event_ui.status_label|default('')|striptags|length > 0) and (not (event_ui.is_sold_out|default(false) == true)) %}{{ event_ui.status_label }}{% else %}{{ 'Featured'|t }}{% endif %}</span>
             </span>
           </div>
         {% endif %}
@@ -141,18 +155,29 @@
         {% endif %}
       </div>
 
-      <div class="mel-event-meta-bar__cta">
-        {% if event_cta and event_cta.label %}
-          {% if event_cta.url %}
-            <a class="mel-btn mel-btn--cta mel-btn--pill" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ event_cta.label }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+      <div class="mel-event-meta-bar__cta mel-event-meta-bar__cta--stacked">
+        {% if ((event_ui is not defined) or (event_ui.show_cta|default(true))) and mel_cta_text|striptags|length > 0 %}
+          {% if cta_type is defined and cta_type == 'paid' and mel_tickets_from is defined and mel_tickets_from|striptags|length > 0 and mel_cta_type_ui == 'primary' %}
+            <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Pricing'|t }}">{{ mel_tickets_from }}</p>
+          {% elseif cta_type is defined and cta_type == 'rsvp' and (not (event_ui is defined and (event_ui.is_sold_out|default(false) == true))) and mel_cta_type_ui == 'primary' %}
+            <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Registration'|t }}">{{ 'Free RSVP'|t }}</p>
+          {% endif %}
+          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+            <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui == 'primary' %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
           {% else %}
-            <button class="mel-btn mel-btn--cta mel-btn--pill" type="button" disabled aria-disabled="true">
-              {{ event_cta.label }}
-            </button>
+            <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui == 'disabled' %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
           {% endif %}
-          {% if event_cta.helper %}
-            <p class="mel-event-meta-bar__cta-helper" aria-live="polite">{{ event_cta.helper }}</p>
-          {% endif %}
+          <div class="mel-event-meta-bar__cta-below" role="status">
+            {% if event_cta and event_cta.helper %}
+              <p class="mel-event-meta-bar__cta-helper" aria-live="polite">{{ event_cta.helper }}</p>
+            {% endif %}
+            {% if event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) %}
+              <p class="mel-event-meta-bar__capacity-hint">{{ event_ui.capacity_hint }}</p>
+            {% endif %}
+            {% if mel_event_selling_fast|default(false) %}
+              <p class="mel-event-meta-bar__selling-fast">{{ 'Selling fast'|t }}</p>
+            {% endif %}
+          </div>
         {% endif %}
       </div>
     </section>
@@ -470,17 +495,7 @@
       <aside class="mel-event-layout__sidebar" aria-label="{{ 'Tickets and event information'|t }}">
         <div class="mel-card mel-card--surface mel-card--sticky">
           <div class="mel-card__header">
-            <h2 class="mel-card__title">
-              {% if cta_type is defined and cta_type == 'rsvp' %}
-                {{ 'RSVP free'|t }}
-              {% elseif cta_type is defined and cta_type == 'paid' %}
-                {{ 'Buy tickets'|t }}
-              {% elseif cta_type is defined and cta_type == 'external' %}
-                {{ 'View details'|t }}
-              {% else %}
-                {{ 'View details'|t }}
-              {% endif %}
-            </h2>
+            <h2 class="mel-card__title">{% if mel_cta_text|striptags|length > 0 %}{{ mel_cta_text }}{% else %}{% if cta_type is defined and cta_type == 'rsvp' %}{{ 'RSVP free'|t }}{% elseif cta_type is defined and cta_type == 'paid' %}{{ 'Buy tickets'|t }}{% else %}{{ 'View details'|t }}{% endif %}{% endif %}</h2>
           </div>
           <div class="mel-card__body">
             {% if mel_tickets_from is defined and mel_tickets_from %}
@@ -592,13 +607,13 @@
     </div>
   </div>
 
-  {# Mobile sticky CTA #}
-  {% if event_cta and event_cta.label %}
+  {# Mobile sticky CTA: label + state from event_ui. #}
+  {% if ((event_ui is not defined) or (event_ui.show_cta|default(true))) and mel_cta_text|striptags|length > 0 %}
     <div class="mel-mobile-cta" role="region" aria-label="{{ 'Ticket actions'|t }}">
-      {% if event_cta.url %}
-        <a class="mel-mobile-cta__button" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ event_cta.label }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+      {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+        <a class="mel-mobile-cta__button mel-mobile-cta__button--{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui == 'primary' %} mel-mobile-cta__button--coral{% else %} mel-mobile-cta__button--lavender{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
       {% else %}
-        <button class="mel-mobile-cta__button" type="button" disabled aria-disabled="true">{{ event_cta.label }}</button>
+        <button class="mel-mobile-cta__button{% if mel_cta_type_ui == 'disabled' %} mel-mobile-cta__button--soldout{% else %} mel-mobile-cta__button--lavender mel-mobile-cta__button--locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
       {% endif %}
     </div>
   {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -32,6 +32,40 @@
 {% endif %}
 {% set mel_cta_is_external = cta_type is defined and cta_type == 'external' %}
 
+{% set mel_eds = (event_domain_state is defined and event_domain_state is iterable) ? event_domain_state : {} %}
+{% set mel_eds_cap = mel_eds['capacity']|default(0) %}
+{% set mel_eds_rsvp = mel_eds['rsvp_state']|default('unset') %}
+{% set mel_eds_has_product = (mel_eds['has_product']|default(0) == 1) or (mel_eds['has_product']|default(false) is same as(true)) %}
+{% set mel_cta_urgency = '' %}
+{% if (event_ui is not defined) or (not (event_ui.is_sold_out|default(false) == true)) %}
+  {% if mel_eds_rsvp is same as('limited') and mel_eds_cap > 0 and mel_eds_cap < 10 %}
+    {% set mel_cta_urgency = 'Only @c spots left'|t({ '@c': mel_eds_cap }) %}
+  {% elseif mel_eds_rsvp is same as('limited') and mel_eds_cap > 0 and mel_eds_cap < 20 %}
+    {% set mel_cta_urgency = 'Limited spots remaining'|t %}
+  {% endif %}
+{% endif %}
+{% if mel_eds_has_product and mel_tickets_from is defined and (mel_tickets_from|striptags|length > 0) %}
+  {% set mel_context_above = mel_tickets_from %}
+{% elseif (not mel_eds_has_product) and cta_type is defined and cta_type is same as('rsvp') %}
+  {% set mel_context_above = 'Free RSVP'|t %}
+{% else %}
+  {% set mel_context_above = '' %}
+{% endif %}
+{% set mel_gcal_href = '' %}
+{% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
+  {% set mel_cal_start = node.field_event_start.value|date('Ymd\\THis') %}
+  {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
+    {% set mel_cal_end = node.field_event_end.value|date('Ymd\\THis') %}
+  {% else %}
+    {% set mel_cal_end = node.field_event_start.value|date_modify('+2 hours')|date('Ymd\\THis') %}
+  {% endif %}
+  {% set mel_canon = url('entity.node.canonical', { 'node': node.id() }, { 'absolute': true }) %}
+  {% set mel_gcal_href = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=' ~ (label|url_encode) ~ '&dates=' ~ mel_cal_start ~ '/' ~ mel_cal_end ~ '&details=' ~ (mel_canon|url_encode) %}
+{% endif %}
+{% set mel_trust_checkout = (cta_type is not defined) or (not (cta_type is same as('external'))) %}
+{% set mel_show_booking_cta = (event_ui is not defined) or (event_ui.show_cta|default(true)) %}
+{% set mel_cta_is_soldout_ui = event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
+
 <article{{ attributes.addClass('mel-event', 'mel-event--v2') }}>
   <div class="mel-container">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
@@ -156,28 +190,71 @@
       </div>
 
       <div class="mel-event-meta-bar__cta mel-event-meta-bar__cta--stacked">
-        {% if ((event_ui is not defined) or (event_ui.show_cta|default(true))) and mel_cta_text|striptags|length > 0 %}
-          {% if cta_type is defined and cta_type == 'paid' and mel_tickets_from is defined and mel_tickets_from|striptags|length > 0 and mel_cta_type_ui == 'primary' %}
-            <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Pricing'|t }}">{{ mel_tickets_from }}</p>
-          {% elseif cta_type is defined and cta_type == 'rsvp' and (not (event_ui is defined and (event_ui.is_sold_out|default(false) == true))) and mel_cta_type_ui == 'primary' %}
-            <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Registration'|t }}">{{ 'Free RSVP'|t }}</p>
-          {% endif %}
-          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-            <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui == 'primary' %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+        {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
+          {% if mel_cta_is_soldout_ui %}
+            <div class="mel-event-cta-soldout" role="group" aria-label="{{ 'Registration'|t }}">
+              <p class="mel-event-cta-soldout__headline" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
+              {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+                <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--lavender-cta mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+                <p class="mel-event-cta-soldout__sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
+              {% else %}
+                <p class="mel-event-cta-soldout__muted" role="status">{{ mel_cta_text }}</p>
+              {% endif %}
+            </div>
+            <ul class="mel-event-meta-bar__trust" aria-label="{{ 'Trust'|t }}">
+              {% if mel_trust_checkout %}
+                <li class="mel-event-meta-bar__trust-item">{{ 'Secure checkout'|t }}</li>
+                <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
+              {% endif %}
+              <li class="mel-event-meta-bar__trust-item">{{ 'Instant confirmation'|t }}</li>
+              <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
+              <li class="mel-event-meta-bar__trust-item">
+                {% if mel_gcal_href|length > 0 %}
+                  <a class="mel-event-meta-bar__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
+                {% else %}
+                  {{ 'Add to calendar'|t }}
+                {% endif %}
+              </li>
+            </ul>
           {% else %}
-            <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui == 'disabled' %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
+            {% if mel_context_above|default('')|striptags|length > 0 and (mel_cta_type_ui is same as('primary')) %}
+              <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Pricing'|t }}">{{ mel_context_above }}</p>
+            {% endif %}
+            {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+              <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+            {% else %}
+              <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui is same as('disabled') %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
+            {% endif %}
+            <div class="mel-event-meta-bar__cta-below" role="status">
+              {% if (mel_cta_urgency|default('')|striptags|length > 0) %}
+                <p class="mel-event-meta-bar__urgency" aria-live="polite">{{ mel_cta_urgency }}</p>
+              {% endif %}
+              {% if cta_type is defined and cta_type is same as('paid') and event_cta and event_cta.helper|default('')|striptags|length > 0 %}
+                <p class="mel-event-meta-bar__cta-helper" aria-live="polite">{{ event_cta.helper }}</p>
+              {% endif %}
+              {% if (event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (mel_cta_urgency|default('')|striptags|length == 0) %}
+                <p class="mel-event-meta-bar__capacity-hint">{{ event_ui.capacity_hint }}</p>
+              {% endif %}
+              {% if mel_event_selling_fast|default(false) %}
+                <p class="mel-event-meta-bar__selling-fast">{{ 'Selling fast'|t }}</p>
+              {% endif %}
+            </div>
+            <ul class="mel-event-meta-bar__trust" aria-label="{{ 'Trust'|t }}">
+              {% if mel_trust_checkout %}
+                <li class="mel-event-meta-bar__trust-item">{{ 'Secure checkout'|t }}</li>
+                <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
+              {% endif %}
+              <li class="mel-event-meta-bar__trust-item">{{ 'Instant confirmation'|t }}</li>
+              <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
+              <li class="mel-event-meta-bar__trust-item">
+                {% if mel_gcal_href|length > 0 %}
+                  <a class="mel-event-meta-bar__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
+                {% else %}
+                  {{ 'Add to calendar'|t }}
+                {% endif %}
+              </li>
+            </ul>
           {% endif %}
-          <div class="mel-event-meta-bar__cta-below" role="status">
-            {% if event_cta and event_cta.helper %}
-              <p class="mel-event-meta-bar__cta-helper" aria-live="polite">{{ event_cta.helper }}</p>
-            {% endif %}
-            {% if event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) %}
-              <p class="mel-event-meta-bar__capacity-hint">{{ event_ui.capacity_hint }}</p>
-            {% endif %}
-            {% if mel_event_selling_fast|default(false) %}
-              <p class="mel-event-meta-bar__selling-fast">{{ 'Selling fast'|t }}</p>
-            {% endif %}
-          </div>
         {% endif %}
       </div>
     </section>
@@ -607,14 +684,50 @@
     </div>
   </div>
 
-  {# Mobile sticky CTA: label + state from event_ui. #}
-  {% if ((event_ui is not defined) or (event_ui.show_cta|default(true))) and mel_cta_text|striptags|length > 0 %}
+  {# Mobile sticky CTA: same messaging as meta bar; thumb-friendly full-width bottom bar. #}
+  {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
     <div class="mel-mobile-cta" role="region" aria-label="{{ 'Ticket actions'|t }}">
-      {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-        <a class="mel-mobile-cta__button mel-mobile-cta__button--{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui == 'primary' %} mel-mobile-cta__button--coral{% else %} mel-mobile-cta__button--lavender{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-      {% else %}
-        <button class="mel-mobile-cta__button{% if mel_cta_type_ui == 'disabled' %} mel-mobile-cta__button--soldout{% else %} mel-mobile-cta__button--lavender mel-mobile-cta__button--locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
-      {% endif %}
+      <div class="mel-mobile-cta__inner">
+        {% if mel_cta_is_soldout_ui %}
+          <p class="mel-mobile-cta__soldout-head" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
+        {% endif %}
+        {% if (not mel_cta_is_soldout_ui) and (mel_context_above|default('')|striptags|length > 0) and (mel_cta_type_ui is same as('primary')) %}
+          <p class="mel-mobile-cta__eyebrow">{{ mel_context_above }}</p>
+        {% endif %}
+        {% if not mel_cta_is_soldout_ui and (mel_cta_urgency|default('')|striptags|length > 0) %}
+          <p class="mel-mobile-cta__urgency" aria-live="polite">{{ mel_cta_urgency }}</p>
+        {% endif %}
+        {% if mel_cta_is_soldout_ui %}
+          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+            <a class="mel-mobile-cta__button mel-mobile-cta__button--lavender mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+            <p class="mel-mobile-cta__waitlist-sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
+          {% else %}
+            <p class="mel-mobile-cta__waitlist-sub mel-mobile-cta__waitlist-sub--muted" role="status">{{ mel_cta_text }}</p>
+          {% endif %}
+        {% else %}
+          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+            <a class="mel-mobile-cta__button mel-mobile-cta__button--{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-mobile-cta__button--coral{% else %} mel-mobile-cta__button--lavender{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+          {% else %}
+            <button class="mel-mobile-cta__button{% if mel_cta_type_ui is same as('disabled') %} mel-mobile-cta__button--soldout{% else %} mel-mobile-cta__button--lavender mel-mobile-cta__button--locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
+          {% endif %}
+          {% if cta_type is defined and cta_type is same as('paid') and event_cta and event_cta.helper|default('')|striptags|length > 0 %}
+            <p class="mel-mobile-cta__helper" aria-live="polite">{{ event_cta.helper }}</p>
+          {% endif %}
+        {% endif %}
+        <p class="mel-mobile-cta__trust" aria-label="{{ 'Trust'|t }}">
+          {% if mel_trust_checkout %}
+            <span class="mel-mobile-cta__trust-t">{{ 'Secure checkout'|t }}</span>
+            <span class="mel-mobile-cta__trust-d" aria-hidden="true">·</span>
+          {% endif %}
+          <span class="mel-mobile-cta__trust-t">{{ 'Instant confirmation'|t }}</span>
+          <span class="mel-mobile-cta__trust-d" aria-hidden="true">·</span>
+          {% if mel_gcal_href|length > 0 %}
+            <a class="mel-mobile-cta__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
+          {% else %}
+            <span class="mel-mobile-cta__trust-t">{{ 'Add to calendar'|t }}</span>
+          {% endif %}
+        </p>
+      </div>
     </div>
   {% endif %}
 </article>

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1234,6 +1234,7 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'show_support_card' => FALSE,
         'pro_upgrade_url' => NULL,
         'refund_analytics' => NULL,
+        'event_domain_state' => [],
       ],
       'template' => 'event/mel-event-overview-page',
     ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new permission gate for `/vendor/dashboard` and changes how vendor-console access is evaluated (based on the target route path), which can affect navigation visibility and route access decisions. Also refactors event CTA/status rendering across public cards, full event pages, and vendor dashboards, so regressions are possible in edge states like sold-out/scheduled/external events.
> 
> **Overview**
> Aligns vendor navigation and access control around a new `access vendor dashboard` permission. `/vendor/dashboard` now requires this permission (enforced inside `VendorConsoleAccess`), menu links for vendor routes are added to the account menu, and header/vendor UI gating + cache contexts are updated to account for permission-based visibility.
> 
> Centralizes *event domain state* (product presence, boost, RSVP capacity) via `myeventlane_core`’s `EventStateResolver::getEventDomainState()`, and threads that snapshot into the API serializer, vendor controllers, and theming. Builds a new `event_ui` payload (semantic CTA/status/badges, sold-out handling, capacity hints) and updates vendor dashboard rows, public event cards, and the full event page templates/styles to render from this unified UI state.
> 
> Cleans up vendor event studio autosave by removing temporary debug logging and switching the controller to a proper constructor injection pattern, while keeping stale-autosave detection via tempstore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cc22142203832279e6876e87ffb33365b12037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->