### PR TITLE
Add logger service to EventStudioAutosaveController for error handling

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -93,5 +93,6 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_event_studio.highlight_helper'
       - '@tempstore.private'
+      - '@logger.factory'
     tags:
       - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -8,6 +8,7 @@ use Drupal\Component\Utility\Tags;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
@@ -28,6 +29,7 @@ final class EventStudioAutosaveController {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly EventHighlightHelper $eventHighlightHelper,
     private readonly PrivateTempStoreFactory $privateTempStoreFactory,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
   ) {}
 
   public function handle(Request $request): JsonResponse {
@@ -75,6 +77,9 @@ final class EventStudioAutosaveController {
         $decoded_event_highlights = $this->decodeEventHighlightsFromMel($mel['event_highlights']);
       }
       catch (\InvalidArgumentException $e) {
+        $this->loggerFactory->get('myeventlane_event_studio')->warning('Autosave event highlights rejected: @message', [
+          '@message' => $e->getMessage(),
+        ]);
         return new JsonResponse([
           'ok' => FALSE,
           'errors' => [$e->getMessage()],


### PR DESCRIPTION
- Updated services.yml to include logger.factory.
- Modified EventStudioAutosaveController to inject LoggerChannelFactoryInterface.
- Implemented logging of warnings when event highlights are rejected during autosave.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds dependency injection and a warning log when autosave highlight payload decoding fails; request/response behavior is otherwise unchanged.
> 
> **Overview**
> Adds `logger.factory` injection to `EventStudioAutosaveController` via `myeventlane_event_studio.services.yml`.
> 
> When `event_highlights` decoding/validation throws `InvalidArgumentException` during autosave, the controller now logs a warning to the `myeventlane_event_studio` channel before returning the existing `422` error response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0066475ed6208a61c3a8affeffdfc749803a5661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->