### PR TITLE
Feature/event save interested

### DIFF
--- a/config/sync/flag.flag.event_save.yml
+++ b/config/sync/flag.flag.event_save.yml
@@ -1,0 +1,31 @@
+uuid: 1817a488-92ba-4cee-a891-f1012d1e378c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+  module:
+    - flag
+id: event_save
+label: 'Save Event'
+bundles:
+  - event
+entity_type: node
+global: false
+flag_short: Save
+flag_long: 'Save this event to your list for later'
+flag_message: 'Event saved to your list'
+unflag_short: Remove
+unflag_long: 'Remove this event from your saved list'
+unflag_message: 'Removed from your saved list'
+unflag_denied_text: ''
+weight: 0
+flag_type: 'entity:node'
+link_type: ajax_link
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions: {  }
+linkTypeConfig: {  }

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -8,6 +8,7 @@ dependencies:
     - commerce_order
     - commerce_product
     - contact
+    - flag
     - klaro
     - media
     - myeventlane_checkin
@@ -31,7 +32,9 @@ permissions:
   - 'access site-wide contact form'
   - 'create platform_donation commerce_order'
   - 'create rsvp_donation commerce_order'
+  - 'flag event_save'
   - 'search content'
+  - 'unflag event_save'
   - 'update platform_donation commerce_order'
   - 'update rsvp_donation commerce_order'
   - 'use klaro'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -10,6 +10,7 @@ dependencies:
     - commerce_product
     - contact
     - file
+    - flag
     - klaro
     - media
     - myeventlane_checkin
@@ -46,6 +47,7 @@ permissions:
   - 'create rsvp_donation commerce_order'
   - 'delete own files'
   - 'delete own social auth profile'
+  - 'flag event_save'
   - 'manage own commerce_payment_method'
   - 'post comments'
   - request_refunds
@@ -53,6 +55,7 @@ permissions:
   - 'search content'
   - 'skip comment approval'
   - 'toggle check-in status'
+  - 'unflag event_save'
   - 'update own customer profile'
   - 'update platform_donation commerce_order'
   - 'update rsvp_donation commerce_order'

--- a/config/sync/views.view.mel_saved_events.yml
+++ b/config/sync/views.view.mel_saved_events.yml
@@ -1,0 +1,168 @@
+uuid: d49c93d8-a025-4fa2-a910-76dde7a8deac
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.card
+    - flag.flag.event_save
+    - node.type.event
+  module:
+    - content_moderation
+    - flag
+    - node
+    - user
+id: mel_saved_events
+label: 'Saved events'
+module: views
+description: 'Events the current user saved via the event_save flag.'
+tag: myeventlane
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Saved events'
+      fields: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 24
+      exposed_form:
+        type: basic
+        options: {  }
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p class="mel-saved-events-empty">You have not saved any events yet. <a href="/events">Browse all events</a>.</p>'
+            format: full_html
+          tokenize: false
+      sorts:
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            event: event
+          group: 1
+          exposed: false
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            editorial-published: editorial-published
+          group: 1
+          exposed: false
+      style:
+        type: default
+        options: {  }
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: card
+      query:
+        type: views_query
+        options: {  }
+      relationships:
+        flag_relationship:
+          id: flag_relationship
+          table: node_field_data
+          field: flag_relationship
+          relationship: none
+          group_type: group
+          admin_label: 'Flag (event save)'
+          plugin_id: flag_relationship
+          required: true
+          flag: event_save
+          user_scope: current
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: 'Saved events'
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: my-saved-events
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -48,11 +48,23 @@ final class AccountLinksService {
       }
     }
 
+    $savedEventsUrl = '/my-saved-events';
+    try {
+      $savedEventsUrl = Url::fromRoute('view.mel_saved_events.page_1')->toString();
+    }
+    catch (\Throwable) {
+    }
+
     return [
       [
         'title' => $this->t('Dashboard'),
         'url' => Url::fromRoute('myeventlane_account.dashboard')->toString(),
         'active' => $active === 'dashboard',
+      ],
+      [
+        'title' => $this->t('Saved events'),
+        'url' => $savedEventsUrl,
+        'active' => FALSE,
       ],
       [
         'title' => $this->t('Profile & Settings'),

--- a/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
@@ -1,4 +1,10 @@
 # User account menu links.
+myeventlane_core.my_saved_events:
+  title: 'Saved events'
+  description: 'Events you have saved to your list in MyEventLane.'
+  route_name: view.mel_saved_events.page_1
+  menu_name: account
+  weight: 5
 myeventlane_core.my_categories:
   title: 'My Categories'
   description: 'View categories you follow and new events'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -1871,6 +1871,12 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'style' => 'primary',
       ],
       [
+        'label' => (string) $this->t('Saved events'),
+        'url' => $this->safeRouteUrl('view.mel_saved_events.page_1') ?? '/my-saved-events',
+        'icon' => 'calendar',
+        'style' => 'secondary',
+      ],
+      [
         'label' => 'Manage Payouts',
         'url' => '/vendor/payouts',
         'icon' => 'dollar',

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1470,6 +1470,42 @@ function _myeventlane_theme_vite_manifest(): ?array {
   $manifest = json_decode($json, TRUE);
   return $cached = is_array($manifest) ? $manifest : NULL;
 }
+
+/**
+ * Build render array for the event_save flag link (AJAX) for an event node.
+ *
+ * Uses Flag's flag.link_builder lazy builder (not twig_tweak::drupal_entity,
+ * which only renders config/view of entities, not the flag action link).
+ */
+function _myeventlane_theme_event_event_save_flag_link($node): ?array {
+  if (!is_object($node) || !method_exists($node, 'bundle') || $node->bundle() !== 'event' || !\Drupal::moduleHandler()->moduleExists('flag') || !\Drupal::hasService('flag.link_builder') || !\Drupal::hasService('flag')) {
+    return NULL;
+  }
+  /** @var \Drupal\flag\FlagService $flagService */
+  $flagService = \Drupal::service('flag');
+  $flag = $flagService->getFlagById('event_save');
+  if (!$flag) {
+    return NULL;
+  }
+  if (!in_array('event', $flag->getBundles(), TRUE) && !empty($flag->getBundles())) {
+    return NULL;
+  }
+  $nid = (int) $node->id();
+  $build = [
+    '#lazy_builder' => [
+      'flag.link_builder:build',
+      [
+        'node',
+        (string) $nid,
+        'event_save',
+        'default',
+      ],
+    ],
+    '#create_placeholder' => FALSE,
+  ];
+  return $build;
+}
+
 /**
  * Implements hook_preprocess_node().
  *
@@ -1787,6 +1823,15 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         $variables['#cache']['tags'][] = sprintf('event_metrics:%d', (int) $node->id());
       }
 
+      $event_flag = _myeventlane_theme_event_event_save_flag_link($node);
+      $variables['event_flag_event_save'] = $event_flag;
+      if ($event_flag) {
+        if (!isset($variables['#cache']['contexts'])) {
+          $variables['#cache']['contexts'] = [];
+        }
+        $variables['#cache']['contexts'][] = 'user';
+      }
+
       // Add cache contexts/tags
       if (!isset($variables['#cache']['contexts'])) {
         $variables['#cache']['contexts'] = [];
@@ -1813,6 +1858,14 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
             $variables['mel_event_selling_fast'] = TRUE;
           }
         }
+      }
+      $event_flag = _myeventlane_theme_event_event_save_flag_link($node);
+      $variables['event_flag_event_save'] = $event_flag;
+      if ($event_flag) {
+        if (!isset($variables['#cache']['contexts'])) {
+          $variables['#cache']['contexts'] = [];
+        }
+        $variables['#cache']['contexts'][] = 'user';
       }
     }
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -779,7 +779,7 @@
 // ---------------------------------------------------------------------------
 
 .mel-skeleton {
-  background: linear-gradient(90deg, #f6f6f6 20%, #eeeeee 50%, #f6f6f6 80%);
+  background: linear-gradient(90deg, #f6f6f6 20%, #eee 50%, #f6f6f6 80%);
   background-size: 400% 100%;
   animation: mel-skeleton-loading 1.4s ease-in-out infinite;
   border-radius: 12px;
@@ -914,5 +914,41 @@
   .mel-event-grid[data-loaded="true"] {
     animation: none;
   }
+}
+
+// Save / interested (Flag module link on listing cards; top-right overlay on article).
+.mel-event-card__save {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+}
+
+.mel-event-card__save .flag a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.15s ease;
+  text-decoration: none;
+  color: color-mix(in srgb, mel.$mel-ds-color-text 85%, transparent);
+}
+
+.mel-event-card__save .flag a:hover,
+.mel-event-card__save .flag a:focus-visible {
+  transform: scale(1.1);
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-event-card__save .flag.action-unflag a,
+.mel-event-card__save .flag a.is-active {
+  background: #f26d5b;
+  color: #fff;
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -886,6 +886,14 @@
   pointer-events: none;
 }
 
+// Skeleton flow (skeleton.js): only grids with `data-loaded` opt in. Do not set opacity on
+// unqualified .mel-event-grid—search, popular block, and saved-event markup omit the attribute
+// and must stay visible; noscript never flips `data-loaded` to true, so a global opacity: 0
+// would leave those grids permanently invisible.
+.mel-event-grid:not([data-loaded]) {
+  opacity: 1;
+}
+
 // Hide real grid until script reveals it (avoids double skeleton + cards on first paint).
 .mel-event-grid[data-loaded="false"] {
   display: none;
@@ -916,39 +924,86 @@
   }
 }
 
-// Save / interested (Flag module link on listing cards; top-right overlay on article).
+// Save for later: heart-only (Flag “Save/Remove” hidden; see flag.html.twig: .flag.flag-{id} .action-flag|.action-unflag)
 .mel-event-card__save {
   position: absolute;
   top: 8px;
   right: 8px;
   z-index: 3;
+  pointer-events: auto;
 }
 
 .mel-event-card__save .flag a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 36px;
-  min-height: 36px;
+  position: relative;
+  box-sizing: border-box;
   width: 36px;
   height: 36px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  transition: transform 0.15s ease;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 8px rgba(36, 48, 58, 0.08);
   text-decoration: none;
-  color: color-mix(in srgb, mel.$mel-ds-color-text 85%, transparent);
+  line-height: 0;
+  font-size: 0.001px;
+  color: transparent;
+  text-shadow: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+// Hollow heart: not yet saved
+.mel-event-card__save .flag a::before {
+  content: '\2661';
+  // ♡
+  position: static;
+  font-size: 18px;
+  line-height: 1;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #7C8791;
+  -webkit-font-smoothing: antialiased;
+}
+
+// Filled heart: saved (flag shows action unflag, or link gets .is-active from AJAX)
+.mel-event-card__save .flag.action-unflag a::before,
+.mel-event-card__save .flag a.is-active::before {
+  content: '\2665';
+  // ♥
+  color: #F26D5B;
+}
+
+.mel-event-card__save .flag a.is-active,
+.mel-event-card__save .flag.action-unflag a {
+  color: transparent;
+  background: #fff;
 }
 
 .mel-event-card__save .flag a:hover,
 .mel-event-card__save .flag a:focus-visible {
   transform: scale(1.1);
-  color: mel.$mel-ds-color-text;
 }
 
-.mel-event-card__save .flag.action-unflag a,
-.mel-event-card__save .flag a.is-active {
-  background: #f26d5b;
-  color: #fff;
+.mel-event-card__save .flag a:active {
+  transform: scale(0.9);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-card__save .flag a {
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .mel-event-card__save .flag a:hover,
+  .mel-event-card__save .flag a:focus-visible,
+  .mel-event-card__save .flag a:active {
+    transform: none;
+  }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -63,6 +63,42 @@
   }
 }
 
+// Flag “Save” control (event full meta bar, above primary CTA).
+.mel-event-save {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.mel-event--v2 .mel-event-save .flag a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0 0.75rem;
+  width: auto;
+  border-radius: 999px;
+  background: colors.$mel-color-surface;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  color: color-mix(in srgb, colors.$mel-color-text 88%, #fff 12%);
+  font-weight: typography.$mel-font-bold;
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.mel-event--v2 .mel-event-save .flag a:hover,
+.mel-event--v2 .mel-event-save .flag a:focus-visible {
+  transform: scale(1.04);
+  color: colors.$mel-color-text;
+}
+
+.mel-event--v2 .mel-event-save .flag.action-unflag a,
+.mel-event--v2 .mel-event-save .flag a.is-active {
+  background: #f26d5b;
+  color: #fff;
+}
+
 .mel-event-meta-bar__cta-eyebrow {
   margin: 0;
   width: 100%;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -49,6 +49,203 @@
   }
 }
 
+// Sticky RSVP card: primary CTA, trust/urgency, save (moved from main flow — single decision surface).
+// Sidebar is full width when the layout stacks (single column).
+.mel-event--v2 .mel-event-layout__sidebar {
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
+// Sticky card: full booking flow (one price, one CTA, trust, save).
+.mel-event--v2 .mel-card--sticky .mel-booking-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__price {
+  font-size: typography.mel-font-size(md);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-navy;
+  line-height: 1.25;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__product {
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__chip {
+  display: block;
+  font-size: 13px;
+  color: #7c8791;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__cta {
+  width: 100%;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__cta .mel-btn {
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+// Primary CTA stack: left text; full-width pill, centered label.
+.mel-event--v2 .mel-card--sticky .mel-card__body .mel-event-sticky-cta--sidebar,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__cta .mel-event-sticky-cta,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__cta .mel-event-sticky-cta--sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  text-align: left;
+  width: 100%;
+  min-width: 0;
+  margin-top: 0;
+  box-sizing: border-box;
+}
+
+// Heart + text save row
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 12px;
+  background: #fcecef;
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save-flag,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save .mel-event-save {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  max-width: none;
+  width: auto;
+  margin: 0;
+  align-self: center;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save-text strong {
+  display: block;
+  font-size: 14px;
+  line-height: 1.3;
+  color: #24303a;
+  font-weight: typography.$mel-font-extrabold;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save-text p {
+  margin: 2px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #7c8791;
+  font-weight: typography.$mel-font-medium;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__rule {
+  border: 0;
+  border-top: 1px solid colors.$mel-color-border;
+  margin: 0;
+  width: 100%;
+  align-self: stretch;
+  flex-shrink: 0;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__trust {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item strong {
+  display: block;
+  font-size: 14px;
+  line-height: 1.3;
+  color: #24303a;
+  font-weight: typography.$mel-font-extrabold;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item p {
+  font-size: 13px;
+  color: #7c8791;
+  margin: 2px 0 0;
+  line-height: 1.4;
+  font-weight: typography.$mel-font-medium;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item-icon {
+  flex: 0 0 auto;
+  line-height: 1.25;
+  font-size: 1.125rem;
+  user-select: none;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__capacity {
+  margin: 0 0 2px;
+  color: #24303a;
+  font-size: 14px;
+  line-height: 1.35;
+  font-weight: typography.$mel-font-bold;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__action {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  margin: 0 0 2px;
+  font-size: 14px;
+  font-weight: typography.$mel-font-extrabold;
+  line-height: 1.2;
+  color: colors.$mel-color-primary;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__action:hover,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__action:focus-visible {
+  text-decoration: none;
+  color: color-mix(in srgb, colors.$mel-color-primary 90%, #000 10%);
+  outline: none;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__action:focus-visible {
+  box-shadow: 0 0 0 2px rgba(110, 126, 242, 0.4);
+  border-radius: 4px;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__subline {
+  margin: 0;
+  color: #7c8791;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-event-sticky-cta--sidebar .mel-btn,
+.mel-event--v2 .mel-card--sticky .mel-event-sticky-cta .mel-btn {
+  width: 100%;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
 // CTA: coral = primary (Buy/RSVP); lavender = secondary; sold-out = disabled only (no coral).
 .mel-event-meta-bar__cta--stacked {
   display: flex;
@@ -63,40 +260,105 @@
   }
 }
 
-// Flag “Save” control (event full meta bar, above primary CTA).
+// Save for later: same heart control as cards; optional copy below the icon (not a CTA).
 .mel-event-save {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  align-items: flex-end;
+  align-self: flex-end;
+  gap: 4px;
+  max-width: 7rem;
   width: 100%;
 }
 
+.mel-event--v2 .mel-event-save .mel-event-save-label {
+  margin: 0;
+  text-align: right;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-medium;
+  line-height: 1.25;
+  color: color-mix(in srgb, colors.$mel-color-text 62%, #fff 38%);
+  pointer-events: none;
+  user-select: none;
+}
+
+@include breakpoints.mel-break(md, max) {
+  .mel-event--v2 .mel-event-save,
+  .mel-event--v2 .mel-event-save .mel-event-save-label {
+    text-align: center;
+    align-self: center;
+    max-width: none;
+  }
+}
+
+// Heart chip (icon-only: hide Flag link copy); 44px minimum touch target (WCAG).
 .mel-event--v2 .mel-event-save .flag a {
-  display: inline-flex;
+  position: relative;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 36px;
-  min-height: 36px;
-  padding: 0 0.75rem;
-  width: auto;
-  border-radius: 999px;
-  background: colors.$mel-color-surface;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 8px rgba(36, 48, 58, 0.08);
   text-decoration: none;
-  color: color-mix(in srgb, colors.$mel-color-text 88%, #fff 12%);
-  font-weight: typography.$mel-font-bold;
-  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease;
+  line-height: 0;
+  font-size: 0.001px;
+  color: transparent;
+  text-shadow: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.mel-event--v2 .mel-event-save .flag a::before {
+  content: '\2661';
+  font-size: 20px;
+  line-height: 1;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #7C8791;
+  -webkit-font-smoothing: antialiased;
+}
+
+.mel-event--v2 .mel-event-save .flag.action-unflag a::before,
+.mel-event--v2 .mel-event-save .flag a.is-active::before {
+  content: '\2665';
+  color: #F26D5B;
+}
+
+.mel-event--v2 .mel-event-save .flag a.is-active,
+.mel-event--v2 .mel-event-save .flag.action-unflag a {
+  color: transparent;
+  background: #fff;
 }
 
 .mel-event--v2 .mel-event-save .flag a:hover,
 .mel-event--v2 .mel-event-save .flag a:focus-visible {
-  transform: scale(1.04);
-  color: colors.$mel-color-text;
+  transform: scale(1.1);
 }
 
-.mel-event--v2 .mel-event-save .flag.action-unflag a,
-.mel-event--v2 .mel-event-save .flag a.is-active {
-  background: #f26d5b;
-  color: #fff;
+.mel-event--v2 .mel-event-save .flag a:active {
+  transform: scale(0.9);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event--v2 .mel-event-save .flag a {
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .mel-event--v2 .mel-event-save .flag a:hover,
+  .mel-event--v2 .mel-event-save .flag a:focus-visible,
+  .mel-event--v2 .mel-event-save .flag a:active {
+    transform: none;
+  }
 }
 
 .mel-event-meta-bar__cta-eyebrow {
@@ -250,7 +512,9 @@
   color: colors.$mel-color-text-muted;
 }
 
-.mel-event--v2 .mel-event-meta-bar__cta {
+.mel-event--v2 .mel-event-meta-bar__cta,
+.mel-event--v2 .mel-card--sticky .mel-event-sticky-cta,
+.mel-event--v2 .mel-card--sticky .mel-event-sticky-cta--sidebar {
   .mel-btn--coral-cta {
     min-height: 44px;
     padding-left: 1.25rem;
@@ -296,6 +560,95 @@
       width: 100%;
       justify-content: center;
     }
+  }
+}
+
+// <=768: one decision column — CTA full width, left in sticky sidebar (overrides .mel-event-meta-bar__cta--stacked
+// defaults: align flex-end, md;max: text center).
+@media (width <= 768px) {
+  // Sidebar card: column + stretch so CTA and meta utilities align to the same left edge.
+  .mel-event--v2 .mel-card--sticky {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+  }
+
+  // Sticky CTA: align block to start; booking panel __cta uses flex gap, no extra top margin.
+  .mel-event--v2 .mel-card--sticky .mel-card__body .mel-event-sticky-cta,
+  .mel-event--v2 .mel-card--sticky .mel-card__body .mel-event-sticky-cta--sidebar {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    justify-content: flex-start;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    text-align: left;
+    margin-top: 12px;
+  }
+
+  .mel-event--v2 .mel-card--sticky .mel-card__body .mel-booking-panel__cta .mel-event-sticky-cta,
+  .mel-event--v2 .mel-card--sticky .mel-card__body .mel-booking-panel__cta .mel-event-sticky-cta--sidebar {
+    margin-top: 0;
+  }
+
+  // If a bar CTA returns: only the meta row (not inside .mel-card--sticky).
+  .mel-event--v2 .mel-event-meta-bar .mel-event-meta-bar__cta,
+  .mel-event--v2 .mel-event-meta-bar .mel-event-meta-bar__cta--stacked {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    text-align: left;
+  }
+
+  .mel-event--v2 .mel-event-meta-bar__cta-eyebrow,
+  .mel-event--v2 .mel-card--sticky .mel-event-meta-bar__cta-eyebrow {
+    text-align: left;
+  }
+
+  .mel-event--v2 .mel-card--sticky .mel-card__body .mel-event-cta-soldout {
+    align-items: flex-start;
+  }
+
+  .mel-event--v2 .mel-card--sticky .mel-event-cta-soldout__headline,
+  .mel-event--v2 .mel-card--sticky .mel-event-cta-soldout__sub,
+  .mel-event--v2 .mel-card--sticky .mel-event-cta-soldout__muted {
+    text-align: left;
+  }
+
+  // Save row: left-anchored; vertical centering of heart + text.
+  .mel-event--v2 .mel-card--sticky .mel-booking-panel__save {
+    align-self: stretch;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .mel-event--v2 .mel-card--sticky .mel-booking-panel__save .mel-event-save {
+    align-items: center;
+    align-self: flex-start;
+  }
+
+  .mel-event--v2 .mel-card--sticky .mel-event-save .mel-event-save-label {
+    text-align: left;
+  }
+
+  .mel-event--v2 .mel-event-meta-bar__cta a.mel-btn,
+  .mel-event--v2 .mel-event-meta-bar__cta button.mel-btn,
+  .mel-event--v2 .mel-card--sticky .mel-event-sticky-cta a.mel-btn,
+  .mel-event--v2 .mel-card--sticky .mel-event-sticky-cta button.mel-btn,
+  .mel-event--v2 .mel-card--sticky .mel-event-sticky-cta--sidebar a.mel-btn,
+  .mel-event--v2 .mel-card--sticky .mel-event-sticky-cta--sidebar button.mel-btn {
+    display: inline-flex;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
   }
 }
 
@@ -379,6 +732,29 @@
   @include breakpoints.mel-break(lg) {
     grid-template-columns: minmax(0, 1fr) 360px;
     align-items: start;
+  }
+}
+
+// Mobile: visual order 1) event column content 2) RSVP / sticky sidebar 3) "More in …"
+// (DOM keeps main + sidebar; only Event Full has __sidebar — booking uses __side, unchanged.)
+// Uses display:contents on __main so .mel-event-related and aside can be flex-ordered.
+@media (width <= 768px) {
+  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) {
+    display: flex;
+    flex-direction: column;
+    gap: space-tokens.mel-space(5);
+  }
+
+  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__main {
+    display: contents;
+  }
+
+  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__sidebar {
+    order: 2;
+  }
+
+  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) .mel-event-related {
+    order: 3;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -133,7 +133,7 @@
 <article class="{{ card_classes|join(' ') }}">
 {% endif %}
   {% if event_flag_event_save and node is defined and node.id %}
-    <div class="mel-event-card__save" role="group" aria-label="{{ 'Save event'|t }}">
+    <div class="mel-event-card__save">
       {{ event_flag_event_save }}
     </div>
   {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -132,6 +132,11 @@
 {% else %}
 <article class="{{ card_classes|join(' ') }}">
 {% endif %}
+  {% if event_flag_event_save and node is defined and node.id %}
+    <div class="mel-event-card__save" role="group" aria-label="{{ 'Save event'|t }}">
+      {{ event_flag_event_save }}
+    </div>
+  {% endif %}
   <a href="{{ _url }}" class="mel-event-card__link" aria-label="{{ _title ~ ' — ' ~ _cta }}">
     <div class="mel-event-card__image">
       {% if _img %}

--- a/web/themes/custom/myeventlane_theme/templates/html.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/html.html.twig
@@ -14,7 +14,7 @@
     <noscript>
       <style>
         .mel-event-skeleton[data-skeleton] { display: none !important; }
-        .mel-event-grid[data-loaded="false"] { display: grid !important; }
+        .mel-event-grid[data-loaded="false"] { display: grid !important; opacity: 1 !important; }
       </style>
     </noscript>
     {{ page_top }}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -190,6 +190,11 @@
       </div>
 
       <div class="mel-event-meta-bar__cta mel-event-meta-bar__cta--stacked">
+        {% if event_flag_event_save %}
+        <div class="mel-event-save" role="group" aria-label="{{ 'Save event'|t }}">
+          {{ event_flag_event_save }}
+        </div>
+        {% endif %}
         {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
           {% if mel_cta_is_soldout_ui %}
             <div class="mel-event-cta-soldout" role="group" aria-label="{{ 'Registration'|t }}">

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -65,6 +65,9 @@
 {% set mel_trust_checkout = (cta_type is not defined) or (not (cta_type is same as('external'))) %}
 {% set mel_show_booking_cta = (event_ui is not defined) or (event_ui.show_cta|default(true)) %}
 {% set mel_cta_is_soldout_ui = event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
+{% set _support_urgent = (mel_cta_urgency|default('')|striptags|length > 0) or (mel_event_selling_fast|default(false)) or ((event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (mel_cta_urgency|default('')|striptags|length == 0) and (not (event_ui.is_sold_out|default(false) is same as(true)))) %}
+{# Sticky booking panel: single source for “Tickets from …” / free RSVP (see mel_context_above at top of template). #}
+{% set mel_sidebar_pricing = (mel_tickets_from is defined and (mel_tickets_from|default('')|striptags|trim) is not empty) ? mel_tickets_from : (mel_context_above|default('')) %}
 
 <article{{ attributes.addClass('mel-event', 'mel-event--v2') }}>
   <div class="mel-container">
@@ -111,17 +114,9 @@
       </div>
     </section>
 
-    {# Meta row + CTA #}
+    {# Meta row: when / where (primary CTA + trust live in the sticky sidebar card) #}
     <section class="mel-event-meta-bar" aria-label="{{ 'Event summary'|t }}">
       <div class="mel-event-meta-bar__items">
-        {% if (not (event_ui is defined and (event_ui.is_sold_out|default(false) == true))) and (not (mel_category_label is defined and mel_category_label)) and ((event_ui is defined and (event_ui.status_type|default('') == 'highlight')) or is_promoted) %}
-          <div class="mel-event-meta">
-            <span class="mel-featured-badge mel-featured-badge--inline" role="note" aria-label="{{ 'Featured'|t }}">
-              <span class="mel-featured-badge__icon" aria-hidden="true">✨</span>
-              <span class="mel-featured-badge__text">{% if event_ui is defined and (event_ui.status_label|default('')|striptags|length > 0) and (not (event_ui.is_sold_out|default(false) == true)) %}{{ event_ui.status_label }}{% else %}{{ 'Featured'|t }}{% endif %}</span>
-            </span>
-          </div>
-        {% endif %}
         {% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
           <div class="mel-event-meta">
             <span class="mel-event-meta__icon" aria-hidden="true"></span>
@@ -189,79 +184,6 @@
         {% endif %}
       </div>
 
-      <div class="mel-event-meta-bar__cta mel-event-meta-bar__cta--stacked">
-        {% if event_flag_event_save %}
-        <div class="mel-event-save" role="group" aria-label="{{ 'Save event'|t }}">
-          {{ event_flag_event_save }}
-        </div>
-        {% endif %}
-        {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
-          {% if mel_cta_is_soldout_ui %}
-            <div class="mel-event-cta-soldout" role="group" aria-label="{{ 'Registration'|t }}">
-              <p class="mel-event-cta-soldout__headline" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
-              {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-                <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--lavender-cta mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-                <p class="mel-event-cta-soldout__sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
-              {% else %}
-                <p class="mel-event-cta-soldout__muted" role="status">{{ mel_cta_text }}</p>
-              {% endif %}
-            </div>
-            <ul class="mel-event-meta-bar__trust" aria-label="{{ 'Trust'|t }}">
-              {% if mel_trust_checkout %}
-                <li class="mel-event-meta-bar__trust-item">{{ 'Secure checkout'|t }}</li>
-                <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
-              {% endif %}
-              <li class="mel-event-meta-bar__trust-item">{{ 'Instant confirmation'|t }}</li>
-              <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
-              <li class="mel-event-meta-bar__trust-item">
-                {% if mel_gcal_href|length > 0 %}
-                  <a class="mel-event-meta-bar__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
-                {% else %}
-                  {{ 'Add to calendar'|t }}
-                {% endif %}
-              </li>
-            </ul>
-          {% else %}
-            {% if mel_context_above|default('')|striptags|length > 0 and (mel_cta_type_ui is same as('primary')) %}
-              <p class="mel-event-meta-bar__cta-eyebrow" aria-label="{{ 'Pricing'|t }}">{{ mel_context_above }}</p>
-            {% endif %}
-            {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-              <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-            {% else %}
-              <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui is same as('disabled') %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
-            {% endif %}
-            <div class="mel-event-meta-bar__cta-below" role="status">
-              {% if (mel_cta_urgency|default('')|striptags|length > 0) %}
-                <p class="mel-event-meta-bar__urgency" aria-live="polite">{{ mel_cta_urgency }}</p>
-              {% endif %}
-              {% if cta_type is defined and cta_type is same as('paid') and event_cta and event_cta.helper|default('')|striptags|length > 0 %}
-                <p class="mel-event-meta-bar__cta-helper" aria-live="polite">{{ event_cta.helper }}</p>
-              {% endif %}
-              {% if (event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (mel_cta_urgency|default('')|striptags|length == 0) %}
-                <p class="mel-event-meta-bar__capacity-hint">{{ event_ui.capacity_hint }}</p>
-              {% endif %}
-              {% if mel_event_selling_fast|default(false) %}
-                <p class="mel-event-meta-bar__selling-fast">{{ 'Selling fast'|t }}</p>
-              {% endif %}
-            </div>
-            <ul class="mel-event-meta-bar__trust" aria-label="{{ 'Trust'|t }}">
-              {% if mel_trust_checkout %}
-                <li class="mel-event-meta-bar__trust-item">{{ 'Secure checkout'|t }}</li>
-                <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
-              {% endif %}
-              <li class="mel-event-meta-bar__trust-item">{{ 'Instant confirmation'|t }}</li>
-              <li class="mel-event-meta-bar__trust-sep" aria-hidden="true">·</li>
-              <li class="mel-event-meta-bar__trust-item">
-                {% if mel_gcal_href|length > 0 %}
-                  <a class="mel-event-meta-bar__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
-                {% else %}
-                  {{ 'Add to calendar'|t }}
-                {% endif %}
-              </li>
-            </ul>
-          {% endif %}
-        {% endif %}
-      </div>
     </section>
 
     {# Cancelled banner #}
@@ -580,22 +502,104 @@
             <h2 class="mel-card__title">{% if mel_cta_text|striptags|length > 0 %}{{ mel_cta_text }}{% else %}{% if cta_type is defined and cta_type == 'rsvp' %}{{ 'RSVP free'|t }}{% elseif cta_type is defined and cta_type == 'paid' %}{{ 'Buy tickets'|t }}{% else %}{{ 'View details'|t }}{% endif %}{% endif %}</h2>
           </div>
           <div class="mel-card__body">
-            {% if mel_tickets_from is defined and mel_tickets_from %}
-              <p class="mel-tickets-from mel-mb-2" aria-label="{{ 'Price'|t }}">
-                {{ mel_tickets_from }}
-              </p>
-            {% endif %}
-            {% if mel_mode_chip %}
-              <div class="mel-mb-2" aria-label="{{ 'Registration type'|t }}">
-                <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
-              </div>
-            {% endif %}
+            <div class="mel-booking-panel" role="region" aria-label="{{ 'Book this event'|t }}">
+              {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
+                <div class="mel-booking-panel__price" aria-label="{{ 'Price'|t }}">
+                  {{ mel_sidebar_pricing }}
+                </div>
+              {% endif %}
+              {% if mel_mode_chip %}
+                <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
+                  <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
+                </div>
+              {% endif %}
+              {% if content.field_product_target is defined %}
+                <div class="mel-booking-panel__product">
+                  {{ content.field_product_target }}
+                </div>
+              {% endif %}
 
-            {% if content.field_product_target is defined %}
-              {{ content.field_product_target }}
-            {% endif %}
+              {% if mel_event_state is not defined or mel_event_state != 'cancelled' %}
+                {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
+                  <div class="mel-booking-panel__cta">
+                    <div class="mel-event-sticky-cta mel-event-sticky-cta--sidebar" role="group" aria-label="{{ 'Register or buy tickets'|t }}">
+                      {% if mel_cta_is_soldout_ui %}
+                        <div class="mel-event-cta-soldout" role="group" aria-label="{{ 'Registration'|t }}">
+                          <p class="mel-event-cta-soldout__headline" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
+                          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+                            <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--lavender-cta mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+                            <p class="mel-event-cta-soldout__sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
+                          {% else %}
+                            <p class="mel-event-cta-soldout__muted" role="status">{{ mel_cta_text }}</p>
+                          {% endif %}
+                        </div>
+                      {% else %}
+                        {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+                          <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
+                        {% else %}
+                          <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui is same as('disabled') %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
+                        {% endif %}
+                      {% endif %}
+                    </div>
+                  </div>
+                  <hr class="mel-booking-panel__rule" role="separator" />
+                {% endif %}
 
-            {# Primary CTA lives in the meta bar above; sidebar stays summary-only (no duplicate button). #}
+                <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
+                  {% if _support_urgent %}
+                    <div class="mel-booking-panel__item">
+                      <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
+                      <div>
+                        {% if mel_cta_urgency|default('')|striptags|length > 0 %}
+                          <strong>{{ mel_cta_urgency }}</strong>
+                          <p>{{ 'Secure your spot today'|t }}</p>
+                        {% elseif mel_event_selling_fast|default(false) %}
+                          <strong>{{ 'Selling fast'|t }}</strong>
+                          <p>{{ 'Ticket demand is high — book soon to secure your place.'|t }}</p>
+                        {% elseif (event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not (event_ui.is_sold_out|default(false) is same as(true))) %}
+                          <p class="mel-booking-panel__capacity" role="status">{{ event_ui.capacity_hint }}</p>
+                          <p>{{ 'Secure your spot today'|t }}</p>
+                        {% endif %}
+                      </div>
+                    </div>
+                  {% endif %}
+                  <div class="mel-booking-panel__item">
+                    <span class="mel-booking-panel__item-icon" aria-hidden="true">✉️</span>
+                    <div>
+                      <strong>{{ 'Instant confirmation'|t }}</strong>
+                      <p>
+                        {%- if mel_trust_checkout -%}
+                          {{ 'You’ll receive confirmation by email'|t }}
+                        {%- else -%}
+                          {{ 'You’ll get a confirmation email'|t }}
+                        {%- endif -%}
+                      </p>
+                    </div>
+                  </div>
+                  {% if mel_gcal_href|length > 0 %}
+                    <div class="mel-booking-panel__item">
+                      <span class="mel-booking-panel__item-icon" aria-hidden="true">📅</span>
+                      <div>
+                        <a class="mel-booking-panel__action" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
+                        <p class="mel-booking-panel__subline">{{ 'Google · Outlook · iCal'|t }}</p>
+                      </div>
+                    </div>
+                  {% endif %}
+                </div>
+                {% if event_flag_event_save %}
+                  <hr class="mel-booking-panel__rule" role="separator" />
+                  <div class="mel-booking-panel__save" role="group" aria-label="{{ 'Save for later'|t }}">
+                    <div id="mel-event-full-save" class="mel-event-save mel-booking-panel__save-flag" role="group" aria-label="{{ 'Save for later'|t }}">
+                      {{ event_flag_event_save }}
+                    </div>
+                    <div class="mel-booking-panel__save-text">
+                      <strong>{{ 'Save for later'|t }}</strong>
+                      <p>{{ 'Save this event to find it easily later.'|t }}</p>
+                    </div>
+                  </div>
+                {% endif %}
+              {% endif %}
+            </div>
           </div>
         </div>
 
@@ -699,9 +703,6 @@
         {% if (not mel_cta_is_soldout_ui) and (mel_context_above|default('')|striptags|length > 0) and (mel_cta_type_ui is same as('primary')) %}
           <p class="mel-mobile-cta__eyebrow">{{ mel_context_above }}</p>
         {% endif %}
-        {% if not mel_cta_is_soldout_ui and (mel_cta_urgency|default('')|striptags|length > 0) %}
-          <p class="mel-mobile-cta__urgency" aria-live="polite">{{ mel_cta_urgency }}</p>
-        {% endif %}
         {% if mel_cta_is_soldout_ui %}
           {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
             <a class="mel-mobile-cta__button mel-mobile-cta__button--lavender mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
@@ -715,23 +716,7 @@
           {% else %}
             <button class="mel-mobile-cta__button{% if mel_cta_type_ui is same as('disabled') %} mel-mobile-cta__button--soldout{% else %} mel-mobile-cta__button--lavender mel-mobile-cta__button--locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
           {% endif %}
-          {% if cta_type is defined and cta_type is same as('paid') and event_cta and event_cta.helper|default('')|striptags|length > 0 %}
-            <p class="mel-mobile-cta__helper" aria-live="polite">{{ event_cta.helper }}</p>
-          {% endif %}
         {% endif %}
-        <p class="mel-mobile-cta__trust" aria-label="{{ 'Trust'|t }}">
-          {% if mel_trust_checkout %}
-            <span class="mel-mobile-cta__trust-t">{{ 'Secure checkout'|t }}</span>
-            <span class="mel-mobile-cta__trust-d" aria-hidden="true">·</span>
-          {% endif %}
-          <span class="mel-mobile-cta__trust-t">{{ 'Instant confirmation'|t }}</span>
-          <span class="mel-mobile-cta__trust-d" aria-hidden="true">·</span>
-          {% if mel_gcal_href|length > 0 %}
-            <a class="mel-mobile-cta__trust-link" href="{{ mel_gcal_href }}">{{ 'Add to calendar'|t }}</a>
-          {% else %}
-            <span class="mel-mobile-cta__trust-t">{{ 'Add to calendar'|t }}</span>
-          {% endif %}
-        </p>
       </div>
     </div>
   {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Template for Saved events (mel_saved_events, page) — grid of event cards.
+ * View title is output by views-view.html.twig (view wrapper).
+ */
+#}
+{% if rows %}
+  <div class="mel-event-grid mel-grid mel-grid--events">
+    {% for row in rows %}
+      {{- row.content -}}
+    {% endfor %}
+  </div>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new per-user flagging behavior and a user-scoped View/route, plus significant theme/template/CSS updates to the event full page layout; main risk is broken caching/permissions or UI regressions around AJAX flag links and the new sticky sidebar booking panel.
> 
> **Overview**
> Adds a new Flag config `event_save` (AJAX link) and a user-scoped View `mel_saved_events` exposed at `/my-saved-events` to list the current user’s saved `event` nodes.
> 
> Updates roles (`anonymous`, `authenticated`) to allow `flag/unflag event_save`, and wires **Saved events** navigation into the account menu, customer account sidebar links, and vendor dashboard quick actions.
> 
> Enhances theming to render the flag link on event cards and the event full page (new lazy-builder helper + cache context), adds a custom Views template for the saved-events grid, and significantly refactors the event full sidebar into a sticky “booking panel” with new SCSS for the heart-style save control and mobile ordering/touch-target tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15df2f1c96365804c04c87277f0cc1059b6cbaf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->