### PR TITLE
Feature/event save interested

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -8,7 +8,6 @@ dependencies:
     - commerce_order
     - commerce_product
     - contact
-    - flag
     - klaro
     - media
     - myeventlane_checkin
@@ -32,9 +31,7 @@ permissions:
   - 'access site-wide contact form'
   - 'create platform_donation commerce_order'
   - 'create rsvp_donation commerce_order'
-  - 'flag event_save'
   - 'search content'
-  - 'unflag event_save'
   - 'update platform_donation commerce_order'
   - 'update rsvp_donation commerce_order'
   - 'use klaro'

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -7,6 +7,10 @@ services:
     class: Drupal\myeventlane_core\Service\EventSaveCountService
     arguments: ['@entity_type.manager']
 
+  myeventlane_core.event_viewer_count:
+    class: Drupal\myeventlane_core\Service\EventViewerCountService
+    arguments: ['@state', '@datetime.time']
+
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
 

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -3,6 +3,10 @@ services:
   myeventlane_core.entity_id_normalizer:
     class: Drupal\myeventlane_core\Service\EntityIdNormalizer
 
+  myeventlane_core.event_save_count:
+    class: Drupal\myeventlane_core\Service\EventSaveCountService
+    arguments: ['@entity_type.manager']
+
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
 

--- a/web/modules/custom/myeventlane_core/src/Service/EventSaveCountService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventSaveCountService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Counts "event_save" flag records for an event (node) ID.
+ */
+final class EventSaveCountService {
+
+  public function __construct(
+    private EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * Returns how many users (or sessions) have saved the given event.
+   */
+  public function getSaveCount(int $nodeId): int {
+    if ($nodeId < 1 || !$this->entityTypeManager->hasDefinition('flagging')) {
+      return 0;
+    }
+
+    $query = $this->entityTypeManager
+      ->getStorage('flagging')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('flag_id', 'event_save')
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', (string) $nodeId);
+
+    return (int) $query->count()->execute();
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Service/EventViewerCountService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventViewerCountService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\State\StateInterface;
+
+/**
+ * Tracks recent page view timestamps per event in State for a soft viewer count.
+ */
+final class EventViewerCountService {
+
+  private const WINDOW = 600;
+
+  public function __construct(
+    private StateInterface $state,
+    private TimeInterface $time,
+  ) {
+  }
+
+  /**
+   * Appends a view timestamp; keeps only the last 10 minutes of data.
+   */
+  public function recordView(int $nid): void {
+    if ($nid < 1) {
+      return;
+    }
+    $now = $this->time->getRequestTime();
+    $key = $this->key($nid);
+    $raw = $this->state->get($key, []);
+    $views = is_array($raw) ? $this->prune($raw, $now) : [];
+    $views[] = $now;
+    $this->state->set($key, array_values($views));
+  }
+
+  /**
+   * Counts “views” in the last ~10 minutes and persists a pruned list.
+   */
+  public function getViewerCount(int $nid): int {
+    if ($nid < 1) {
+      return 0;
+    }
+    $now = $this->time->getRequestTime();
+    $key = $this->key($nid);
+    $raw = $this->state->get($key, []);
+    if (!is_array($raw)) {
+      return 0;
+    }
+    $views = $this->prune($raw, $now);
+    $this->state->set($key, array_values($views));
+    return count($views);
+  }
+
+  private function key(int $nid): string {
+    return 'mel_event_views_' . $nid;
+  }
+
+  /**
+   * @param list<mixed> $views
+   *
+   * @return list<int>
+   */
+  private function prune(array $views, int $now): array {
+    $out = [];
+    $cut = $now - self::WINDOW;
+    foreach ($views as $t) {
+      if (!is_int($t) && !(is_string($t) && is_numeric($t))) {
+        continue;
+      }
+      $ts = (int) $t;
+      if ($ts > $cut) {
+        $out[] = $ts;
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -900,6 +900,28 @@ function myeventlane_event_preprocess_node(array &$variables): void {
   }
 
   $view_mode = (string) ($variables['view_mode'] ?? 'default');
+  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_save_count')) {
+    /** @var \Drupal\myeventlane_core\Service\EventSaveCountService $save_count_service */
+    $save_count_service = \Drupal::service('myeventlane_core.event_save_count');
+    $count = $save_count_service->getSaveCount((int) $node->id());
+    $variables['event_save_count_total'] = $count;
+    if ($count > 0) {
+      $variables['event_save_count'] = [
+        '#markup' => \Drupal::translation()->formatPlural(
+          $count,
+          '1 person saved this',
+          '@count people saved this',
+        ),
+        '#cache' => [
+          'contexts' => ['languages:language_interface'],
+          'tags' => ['flagging_list'],
+        ],
+      ];
+    }
+    else {
+      $variables['event_save_count'] = NULL;
+    }
+  }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
   // Semantic CTA and badges: always set for the event bundle (all view modes: full,
   // teaser, event_card, etc.); do not scope to a single view mode here.

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -7,6 +7,7 @@
 declare(strict_types=1);
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
@@ -914,12 +915,45 @@ function myeventlane_event_preprocess_node(array &$variables): void {
         ),
         '#cache' => [
           'contexts' => ['languages:language_interface'],
-          'tags' => ['flagging_list'],
+          'tags' => Cache::mergeTags($node->getCacheTags(), ['flagging_list']),
         ],
       ];
     }
     else {
       $variables['event_save_count'] = NULL;
+    }
+  }
+  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_viewer_count')) {
+    $variables['event_viewer_count_total'] = 0;
+    $variables['event_viewer_count'] = NULL;
+    try {
+      /** @var \Drupal\myeventlane_core\Service\EventViewerCountService $viewer_service */
+      $viewer_service = \Drupal::service('myeventlane_core.event_viewer_count');
+      $nid = (int) $node->id();
+      $viewer_service->recordView($nid);
+      $viewer_count = $viewer_service->getViewerCount($nid);
+      $variables['event_viewer_count_total'] = $viewer_count;
+      if ($viewer_count > 1) {
+        $variables['event_viewer_count'] = [
+          '#markup' => \Drupal::translation()->formatPlural(
+            $viewer_count,
+            '🔥 1 person viewing now',
+            '🔥 @count people viewing now',
+          ),
+          '#cache' => [
+            'contexts' => ['languages:language_interface'],
+            'tags' => [
+              'node:' . $node->id(),
+            ],
+            'max-age' => 60,
+          ],
+        ];
+      }
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_event')->error('Event viewer count: @message', [
+        '@message' => $e->getMessage(),
+      ]);
     }
   }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -243,6 +243,15 @@
   color: #f26d5b;
 }
 
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--viewer {
+  font-size: 14px;
+  color: #24303A;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--viewer strong {
+  color: #F26D5B;
+}
+
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__capacity {
   margin: 0 0 2px;
   color: #24303a;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -68,9 +68,9 @@
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__price {
-  font-size: typography.mel-font-size(md);
-  font-weight: typography.$mel-font-semibold;
-  color: colors.$mel-color-navy;
+  font-size: 20px;
+  font-weight: 700;
+  color: #24303a;
   line-height: 1.25;
 }
 
@@ -80,8 +80,9 @@
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__chip {
   display: block;
-  font-size: 13px;
-  color: #7c8791;
+  font-size: 12px;
+  color: #9aa5b1;
+  margin-bottom: 4px;
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__cta {
@@ -92,6 +93,7 @@
   width: 100%;
   display: inline-flex;
   justify-content: center;
+  font-weight: 600;
   box-sizing: border-box;
 }
 
@@ -135,6 +137,26 @@
   width: auto;
   margin: 0;
   align-self: center;
+}
+
+// Booking sidebar save: tactile press on Flag link (see also .mel-event--v2 .mel-event-save .flag a).
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save .flag-event_save a {
+  transition: transform 0.15s ease;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__save .flag-event_save a:active {
+  transform: scale(0.9);
+}
+
+// Mobile: keep booking CTA in the thumb zone while the sidebar is in view.
+@media (max-width: 768px) {
+  .mel-event--v2 .mel-card--sticky .mel-booking-panel__cta {
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    padding: 12px;
+    z-index: 20;
+  }
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__save-text strong {
@@ -192,11 +214,33 @@
   font-weight: typography.$mel-font-medium;
 }
 
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--highlight {
+  background: #fff6e6;
+  padding: 8px;
+  border-radius: 8px;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--highlight .mel-icon {
+  flex: 0 0 auto;
+  line-height: 1.25;
+  font-size: 1.125rem;
+  user-select: none;
+}
+
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__item-icon {
   flex: 0 0 auto;
   line-height: 1.25;
   font-size: 1.125rem;
   user-select: none;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--social {
+  font-size: 14px;
+  color: #24303A;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--social .mel-icon {
+  color: #f26d5b;
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__capacity {

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -65,7 +65,7 @@
 {% set mel_trust_checkout = (cta_type is not defined) or (not (cta_type is same as('external'))) %}
 {% set mel_show_booking_cta = (event_ui is not defined) or (event_ui.show_cta|default(true)) %}
 {% set mel_cta_is_soldout_ui = event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
-{% set _support_urgent = (mel_cta_urgency|default('')|striptags|length > 0) or (mel_event_selling_fast|default(false)) or ((event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (mel_cta_urgency|default('')|striptags|length == 0) and (not (event_ui.is_sold_out|default(false) is same as(true)))) %}
+{% set _support_urgent = (mel_cta_urgency|default('')|striptags|length > 0) or (mel_event_selling_fast|default(false)) %}
 {# Sticky booking panel: single source for “Tickets from …” / free RSVP (see mel_context_above at top of template). #}
 {% set mel_sidebar_pricing = (mel_tickets_from is defined and (mel_tickets_from|default('')|striptags|trim) is not empty) ? mel_tickets_from : (mel_context_above|default('')) %}
 
@@ -503,14 +503,14 @@
           </div>
           <div class="mel-card__body">
             <div class="mel-booking-panel" role="region" aria-label="{{ 'Book this event'|t }}">
-              {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
-                <div class="mel-booking-panel__price" aria-label="{{ 'Price'|t }}">
-                  {{ mel_sidebar_pricing }}
-                </div>
-              {% endif %}
               {% if mel_mode_chip %}
                 <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
                   <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
+                </div>
+              {% endif %}
+              {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
+                <div class="mel-booking-panel__price" aria-label="{{ 'Price'|t }}">
+                  {{ mel_sidebar_pricing }}
                 </div>
               {% endif %}
               {% if content.field_product_target is defined %}
@@ -546,6 +546,25 @@
                 {% endif %}
 
                 <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
+                  {% if event_ui is defined
+                    and (
+                      (event_ui.is_limited|default(false))
+                      or ((event_ui.capacity_hint|default('')|striptags|length > 0)
+                        and (mel_cta_urgency|default('')|striptags|length == 0)
+                        and (not mel_event_selling_fast|default(false))
+                        and (not (event_ui.is_sold_out|default(false) is same as(true)))
+                      )
+                    ) %}
+                    <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
+                      <span class="mel-icon" aria-hidden="true">⚡</span>
+                      <div>
+                        <p class="mel-booking-panel__capacity" role="status">
+                          <strong>{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</strong>
+                        </p>
+                        <p>{{ 'Secure your spot today'|t }}</p>
+                      </div>
+                    </div>
+                  {% endif %}
                   {% if _support_urgent %}
                     <div class="mel-booking-panel__item">
                       <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
@@ -556,10 +575,15 @@
                         {% elseif mel_event_selling_fast|default(false) %}
                           <strong>{{ 'Selling fast'|t }}</strong>
                           <p>{{ 'Ticket demand is high — book soon to secure your place.'|t }}</p>
-                        {% elseif (event_ui is defined) and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not (event_ui.is_sold_out|default(false) is same as(true))) %}
-                          <p class="mel-booking-panel__capacity" role="status">{{ event_ui.capacity_hint }}</p>
-                          <p>{{ 'Secure your spot today'|t }}</p>
                         {% endif %}
+                      </div>
+                    </div>
+                  {% endif %}
+                  {% if event_save_count_total|default(0) > 0 and event_save_count is not empty %}
+                    <div class="mel-booking-panel__item mel-booking-panel__item--social">
+                      <span class="mel-icon" aria-hidden="true">💖</span>
+                      <div>
+                        <strong>{{ event_save_count }}</strong>
                       </div>
                     </div>
                   {% endif %}
@@ -593,8 +617,8 @@
                       {{ event_flag_event_save }}
                     </div>
                     <div class="mel-booking-panel__save-text">
-                      <strong>{{ 'Save for later'|t }}</strong>
-                      <p>{{ 'Save this event to find it easily later.'|t }}</p>
+                      <strong>{{ 'Don’t miss this'|t }}</strong>
+                      <p>{{ 'Save this event to come back later'|t }}</p>
                     </div>
                   </div>
                 {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -609,6 +609,13 @@
                       </div>
                     </div>
                   {% endif %}
+                  {% if event_viewer_count_total|default(0) > 1 and event_viewer_count is not empty %}
+                    <div class="mel-booking-panel__item mel-booking-panel__item--viewer">
+                      <div>
+                        <strong>{{ event_viewer_count }}</strong>
+                      </div>
+                    </div>
+                  {% endif %}
                 </div>
                 {% if event_flag_event_save %}
                   <hr class="mel-booking-panel__rule" role="separator" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new per-node counting logic (Flagging queries and State writes) into event page rendering, which can impact cache behavior and performance under traffic. Also changes anonymous role permissions, potentially affecting who can use the save feature.
> 
> **Overview**
> Adds two new services: `EventSaveCountService` (counts `event_save` flaggings) and `EventViewerCountService` (stores per-event view timestamps in State to compute a 10‑minute “viewing now” count).
> 
> Updates `myeventlane_event_preprocess_node()` and the event full Twig sidebar to surface **social proof** (“X people saved this”) and **live viewers** (“Y people viewing now”), with new cache tags/contexts and a short max-age for the viewer metric.
> 
> Adjusts anonymous role config to drop the `flag` module dependency and remove `flag/unflag event_save` permissions, and tweaks event full sidebar styling/UX (CTA stickiness on mobile, highlight blocks, and updated save copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb11103b9136e0a3f73565e6804730d69cff412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->