### PR TITLE
Feature/event save interested

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -11,6 +11,10 @@ services:
     class: Drupal\myeventlane_core\Service\EventViewerCountService
     arguments: ['@state', '@datetime.time']
 
+  myeventlane_core.event_interest:
+    class: Drupal\myeventlane_core\Service\EventInterestService
+    arguments: ['@datetime.time']
+
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
 

--- a/web/modules/custom/myeventlane_core/src/Service/EventInterestService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventInterestService.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+
+/**
+ * Derives a single public interest label from save count, viewer count, and node age.
+ */
+final class EventInterestService {
+
+  public function __construct(
+    private readonly TimeInterface $time,
+  ) {
+  }
+
+  /**
+   * Returns at most one label; priority order: high demand → selling fast → popular → just added.
+   *
+   * @return array{label: string, type: 'high'|'urgent'|'social'|'new'}|array{}
+   */
+  public function getInterestState(int $saveCount, int $viewerCount, int $createdTime): array {
+    $now = $this->time->getCurrentTime();
+    $age = $now - $createdTime;
+
+    if ($saveCount >= 20 && $viewerCount >= 5) {
+      return [
+        'label' => '🔥 High demand',
+        'type' => 'high',
+      ];
+    }
+
+    if ($viewerCount >= 5) {
+      return [
+        'label' => '🔥 Selling fast',
+        'type' => 'urgent',
+      ];
+    }
+
+    if ($saveCount >= 10) {
+      return [
+        'label' => '💖 Popular',
+        'type' => 'social',
+      ];
+    }
+
+    if ($age < 172800) {
+      return [
+        'label' => '✨ Just added',
+        'type' => 'new',
+      ];
+    }
+
+    return [];
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Service/EventViewerCountService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventViewerCountService.php
@@ -24,8 +24,18 @@ final class EventViewerCountService {
    * Appends a view timestamp; keeps only the last 10 minutes of data.
    */
   public function recordView(int $nid): void {
+    $this->recordViewAndGetCount($nid);
+  }
+
+  /**
+   * Records this request and returns the in-window count in one state round-trip.
+   *
+   * Prefer this over recordView() + getViewerCount() in the same request to avoid
+   * redundant get/set cycles on the State entry.
+   */
+  public function recordViewAndGetCount(int $nid): int {
     if ($nid < 1) {
-      return;
+      return 0;
     }
     $now = $this->time->getRequestTime();
     $key = $this->key($nid);
@@ -33,6 +43,7 @@ final class EventViewerCountService {
     $views = is_array($raw) ? $this->prune($raw, $now) : [];
     $views[] = $now;
     $this->state->set($key, array_values($views));
+    return count($views);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -930,8 +930,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       /** @var \Drupal\myeventlane_core\Service\EventViewerCountService $viewer_service */
       $viewer_service = \Drupal::service('myeventlane_core.event_viewer_count');
       $nid = (int) $node->id();
-      $viewer_service->recordView($nid);
-      $viewer_count = $viewer_service->getViewerCount($nid);
+      $viewer_count = $viewer_service->recordViewAndGetCount($nid);
       $variables['event_viewer_count_total'] = $viewer_count;
       if ($viewer_count > 1) {
         $variables['event_viewer_count'] = [
@@ -955,6 +954,15 @@ function myeventlane_event_preprocess_node(array &$variables): void {
         '@message' => $e->getMessage(),
       ]);
     }
+  }
+  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_interest')) {
+    /** @var \Drupal\myeventlane_core\Service\EventInterestService $interest_service */
+    $interest_service = \Drupal::service('myeventlane_core.event_interest');
+    $variables['event_interest'] = $interest_service->getInterestState(
+      (int) ($variables['event_save_count_total'] ?? 0),
+      (int) ($variables['event_viewer_count_total'] ?? 0),
+      (int) $node->getCreatedTime()
+    );
   }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
   // Semantic CTA and badges: always set for the event bundle (all view modes: full,
@@ -1040,6 +1048,7 @@ function myeventlane_event_finalize_event_ui(
       'status_label' => NULL,
       'status_type' => 'muted',
       'is_sold_out' => FALSE,
+      'is_limited' => FALSE,
       'show_cta' => TRUE,
       'capacity_hint' => NULL,
       'image_badge_label' => NULL,
@@ -1067,6 +1076,17 @@ function myeventlane_event_finalize_event_ui(
       $out['status_type'] = 'highlight';
       $out['image_badge_label'] = (string) t('Featured');
       $out['image_badge_type'] = 'apricot';
+    }
+    if (!$isSoldOut && $rsvpState === 'limited') {
+      $out['is_limited'] = TRUE;
+    }
+    if (
+      !$isSoldOut
+      && $rsvpState === 'limited'
+      && $capacity > 0
+      && $capacity < 20
+    ) {
+      $out['capacity_hint'] = (string) t('Limited spots remaining');
     }
     return $out;
   }
@@ -1106,7 +1126,15 @@ function myeventlane_event_finalize_event_ui(
     $out['cta_type'] = 'primary';
   }
 
-  if (!$isSoldOut && $rsvpState === 'limited' && $capacity > 0 && $capacity < 20) {
+  if (!$isSoldOut && $rsvpState === 'limited') {
+    $out['is_limited'] = TRUE;
+  }
+  if (
+    !$isSoldOut
+    && $rsvpState === 'limited'
+    && $capacity > 0
+    && $capacity < 20
+  ) {
     $out['capacity_hint'] = (string) t('Limited spots remaining');
   }
   if (

--- a/web/themes/custom/myeventlane_theme/js/event-full-trust-rotator.js
+++ b/web/themes/custom/myeventlane_theme/js/event-full-trust-rotator.js
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * Rotates trust line items in the event full booking panel.
+ */
+((Drupal, once) => {
+  'use strict';
+
+  const INTERVAL_MS = 3000;
+
+  Drupal.behaviors.melEventFullTrustRotator = {
+    attach(context) {
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        return;
+      }
+
+      once('melEventFullTrustRotator', '.mel-trust-rotator[data-rotate]', context).forEach((el) => {
+        const items = el.querySelectorAll('.mel-trust-item');
+        if (items.length < 2) {
+          return;
+        }
+        let i = 0;
+        window.setInterval(() => {
+          if (!el.isConnected) {
+            return;
+          }
+          const prev = i;
+          items[prev].classList.remove('is-active');
+          i = (i + 1) % items.length;
+          items[i].classList.add('is-active');
+        }, INTERVAL_MS);
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -116,6 +116,8 @@ myeventlane_event_full:
     - core/once
     - myeventlane_location/event_map
     - myeventlane_theme/global-styling
+  js:
+    js/event-full-trust-rotator.js: { attributes: { defer: true } }
 
 # Commerce pages: toast-style add-to-cart messages (attached via page_attachments).
 mel_toasts:

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -149,7 +149,7 @@
 }
 
 // Mobile: keep booking CTA in the thumb zone while the sidebar is in view.
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-event--v2 .mel-card--sticky .mel-booking-panel__cta {
     position: sticky;
     bottom: 0;
@@ -189,6 +189,49 @@
   flex-direction: column;
   gap: 12px;
   min-width: 0;
+}
+
+// ---------------------------------------------------------------------------
+// Trust line rotator (one line visible; no duplicate static viewer / email rows)
+// ---------------------------------------------------------------------------
+
+.mel-trust-rotator {
+  min-height: 1.4rem;
+  position: relative;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #7c8791;
+  font-weight: typography.$mel-font-medium;
+}
+
+.mel-trust-rotator .mel-trust-item {
+  display: none;
+}
+
+.mel-trust-rotator .mel-trust-item.is-active {
+  display: block;
+}
+
+.mel-trust-item__text {
+  display: block;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-trust-rotator[data-rotate] {
+    .mel-trust-item {
+      display: block;
+      position: static;
+    }
+
+    .mel-trust-item + .mel-trust-item {
+      margin-top: 0.4rem;
+    }
+  }
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__item {
@@ -250,6 +293,31 @@
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__item--viewer strong {
   color: #F26D5B;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--high,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--high strong {
+  color: #E5533D;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--urgent,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--urgent strong {
+  color: #F26D5B;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--social,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--social strong {
+  color: #6E7EF2;
+}
+
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--new,
+.mel-event--v2 .mel-card--sticky .mel-booking-panel__item--interest.mel-booking-panel__item--new strong {
+  color: #2c3e50;
 }
 
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__capacity {
@@ -1017,15 +1085,11 @@
   left: 0;
   right: 0;
   bottom: 0;
-  padding:
-    space-tokens.mel-space(2)
-    space-tokens.mel-space(3)
-    calc(#{space-tokens.mel-space(3)} + env(safe-area-inset-bottom));
-  background: rgba(250, 247, 251, 0.85);
-  backdrop-filter: blur(12px);
+  padding: 12px 12px calc(12px + env(safe-area-inset-bottom, 0));
+  background: #fff;
   border-top: 1px solid rgba(0, 0, 0, 0.06);
-  z-index: 50;
-  box-shadow: 0 -12px 30px rgba(0, 0, 0, 0.08);
+  z-index: 100;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.06);
 
   @include breakpoints.mel-break(lg) {
     display: none;
@@ -1177,6 +1241,42 @@
   color: color-mix(in srgb, colors.$mel-color-text 78%, #fff 22%);
   border-color: color-mix(in srgb, #8b7ab8 14%, transparent);
   cursor: not-allowed;
+}
+
+// Shared CTA partial: coral/lavender via .mel-btn--* (replaces --coral / --lavender modifiers on the link only).
+.mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn--coral-cta {
+  background: var(--mel-coral, #f26d5b);
+  color: colors.$mel-color-text-inverse;
+}
+
+.mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn--lavender-cta,
+.mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn--waitlist {
+  background: color-mix(in srgb, #b8a5d6 35%, #fff 65%);
+  color: colors.$mel-color-text;
+}
+
+// CTA press micro-feedback: wins over .mel-mobile-cta__button:active translateY.
+.mel-event--v2 .mel-booking-panel__cta .mel-btn,
+.mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn {
+  transition: transform 0.12s ease, box-shadow var(--mel-motion-fast) var(--mel-ease-out), background-color
+    var(--mel-motion-fast) var(--mel-ease-out);
+}
+
+.mel-event--v2 .mel-booking-panel__cta .mel-btn:active,
+.mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn:active {
+  transform: scale(0.97) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event--v2 .mel-booking-panel__cta .mel-btn,
+  .mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn {
+    transition: none;
+  }
+
+  .mel-event--v2 .mel-booking-panel__cta .mel-btn:active,
+  .mel-event--v2 .mel-mobile-cta a.mel-mobile-cta__button.mel-btn:active {
+    transform: none;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -234,6 +234,47 @@
   }
 }
 
+// ---------------------------------------------------------------------------
+// Decision prompts (max 2 items; complements trust rotator, no duplicate copy)
+// ---------------------------------------------------------------------------
+.mel-decision-prompts {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #E9E3DE;
+}
+
+.mel-decision-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-bottom: 10px;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.mel-decision-item:hover {
+  transform: translateY(-1px);
+}
+
+.mel-decision-item strong {
+  font-size: 13px;
+  color: #24303A;
+}
+
+.mel-decision-item p {
+  font-size: 12px;
+  color: #7C8791;
+  margin: 0;
+}
+
+.mel-decision-item--urgent strong {
+  color: #F26D5B;
+}
+
+.mel-decision-prompts .mel-icon {
+  font-size: 14px;
+  line-height: 1.2;
+}
+
 .mel-event--v2 .mel-card--sticky .mel-booking-panel__item {
   display: flex;
   gap: 12px;

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -531,6 +531,14 @@
                 {% endif %}
 
                 <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
+                  {% set _mel_trust_capacity_highlight = event_ui is defined
+                    and (mel_cta_urgency|default('')|striptags|length == 0)
+                    and (not mel_event_selling_fast|default(false))
+                    and (not (event_ui.is_sold_out|default(false) is same as(true)))
+                    and (
+                      (event_ui.is_limited|default(false))
+                      or (event_ui.capacity_hint|default('')|striptags|length > 0)
+                    ) %}
                   <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
                     <div class="mel-trust-item is-active" data-trust-item>
                       {% if event_viewer_count is not empty %}
@@ -546,14 +554,48 @@
                       <span class="mel-trust-item__text">✉️ {{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
                     </div>
                   </div>
-                  {% if event_ui is defined
-                    and (mel_cta_urgency|default('')|striptags|length == 0)
-                    and (not mel_event_selling_fast|default(false))
-                    and (not (event_ui.is_sold_out|default(false) is same as(true)))
-                    and (
-                      (event_ui.is_limited|default(false))
-                      or (event_ui.capacity_hint|default('')|striptags|length > 0)
-                    ) %}
+                  {% set _show_mel_decision_prompts = (not logged_in)
+                    or (event_ui is defined and (event_ui.is_free|default(false) == true))
+                    or (event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not _mel_trust_capacity_highlight)) %}
+                  {% if _show_mel_decision_prompts %}
+                    {% set _decision_count = 0 %}
+                    <div class="mel-decision-prompts">
+                      {% if _decision_count < 2 and (not logged_in) %}
+                        {% set _decision_count = _decision_count + 1 %}
+                        <div class="mel-decision-item">
+                          <span class="mel-icon">👤</span>
+                          <div>
+                            <strong>{{ 'First time here?'|t }}</strong>
+                            <p>{{ 'Book in seconds — no account needed'|t }}</p>
+                          </div>
+                        </div>
+                      {% endif %}
+                      {% if _decision_count < 2 and event_ui is defined and (event_ui.is_free|default(false) == true) %}
+                        {% set _decision_count = _decision_count + 1 %}
+                        <div class="mel-decision-item">
+                          <span class="mel-icon">🎟</span>
+                          <div>
+                            <strong>{{ 'Free event'|t }}</strong>
+                            <p>{{ 'No payment required'|t }}</p>
+                          </div>
+                        </div>
+                      {% endif %}
+                      {% if _decision_count < 2
+                        and event_ui is defined
+                        and (event_ui.capacity_hint|default('')|striptags|length > 0)
+                        and (not _mel_trust_capacity_highlight) %}
+                        {% set _decision_count = _decision_count + 1 %}
+                        <div class="mel-decision-item mel-decision-item--urgent">
+                          <span class="mel-icon">⚡</span>
+                          <div>
+                            <strong>{{ event_ui.capacity_hint }}</strong>
+                            <p>{{ "Don't miss out"|t }}</p>
+                          </div>
+                        </div>
+                      {% endif %}
+                    </div>
+                  {% endif %}
+                  {% if _mel_trust_capacity_highlight %}
                     <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
                       <span class="mel-icon" aria-hidden="true">⚡</span>
                       <div>
@@ -711,7 +753,7 @@
           <p class="mel-mobile-cta__eyebrow">{{ mel_context_above }}</p>
         {% endif %}
         {% include '@myeventlane_theme/node/partial--event-full-booking-cta.html.twig' with { 'mel_cta_slot': 'mobile' } %}
-        {% if mel_cta_is_soldout_ui and logged_in and event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+        {% if mel_cta_is_soldout_ui and event_cta and (event_cta.url|default('')|striptags|length > 0) %}
           <p class="mel-mobile-cta__waitlist-sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
         {% endif %}
       </div>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -65,7 +65,8 @@
 {% set mel_trust_checkout = (cta_type is not defined) or (not (cta_type is same as('external'))) %}
 {% set mel_show_booking_cta = (event_ui is not defined) or (event_ui.show_cta|default(true)) %}
 {% set mel_cta_is_soldout_ui = event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
-{% set _support_urgent = (mel_cta_urgency|default('')|striptags|length > 0) or (mel_event_selling_fast|default(false)) %}
+{# Spots-left urgency only; “Selling fast” is covered by the trust rotator (avoids duplicate messaging). #}
+{% set _support_urgent = (mel_cta_urgency|default('')|striptags|length > 0) %}
 {# Sticky booking panel: single source for “Tickets from …” / free RSVP (see mel_context_above at top of template). #}
 {% set mel_sidebar_pricing = (mel_tickets_from is defined and (mel_tickets_from|default('')|striptags|trim) is not empty) ? mel_tickets_from : (mel_context_above|default('')) %}
 
@@ -523,37 +524,35 @@
                 {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
                   <div class="mel-booking-panel__cta">
                     <div class="mel-event-sticky-cta mel-event-sticky-cta--sidebar" role="group" aria-label="{{ 'Register or buy tickets'|t }}">
-                      {% if mel_cta_is_soldout_ui %}
-                        <div class="mel-event-cta-soldout" role="group" aria-label="{{ 'Registration'|t }}">
-                          <p class="mel-event-cta-soldout__headline" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
-                          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-                            <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--lavender-cta mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-                            <p class="mel-event-cta-soldout__sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
-                          {% else %}
-                            <p class="mel-event-cta-soldout__muted" role="status">{{ mel_cta_text }}</p>
-                          {% endif %}
-                        </div>
-                      {% else %}
-                        {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-                          <a class="mel-btn mel-btn--cta mel-btn--pill mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta{% else %} mel-btn--lavender-cta{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-                        {% else %}
-                          <button class="mel-btn mel-btn--cta mel-btn--pill{% if mel_cta_type_ui is same as('disabled') %} mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
-                        {% endif %}
-                      {% endif %}
+                      {% include '@myeventlane_theme/node/partial--event-full-booking-cta.html.twig' with { 'mel_cta_slot': 'sidebar' } %}
                     </div>
                   </div>
                   <hr class="mel-booking-panel__rule" role="separator" />
                 {% endif %}
 
                 <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
+                  <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
+                    <div class="mel-trust-item is-active" data-trust-item>
+                      {% if event_viewer_count is not empty %}
+                        <span class="mel-trust-item__text">{{ event_viewer_count }}</span>
+                      {% else %}
+                        <span class="mel-trust-item__text">🔥 {{ 'Popular on MyEventLane'|t }}</span>
+                      {% endif %}
+                    </div>
+                    <div class="mel-trust-item" data-trust-item>
+                      <span class="mel-trust-item__text">⚡ {{ 'Selling fast'|t }}</span>
+                    </div>
+                    <div class="mel-trust-item" data-trust-item>
+                      <span class="mel-trust-item__text">✉️ {{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
+                    </div>
+                  </div>
                   {% if event_ui is defined
+                    and (mel_cta_urgency|default('')|striptags|length == 0)
+                    and (not mel_event_selling_fast|default(false))
+                    and (not (event_ui.is_sold_out|default(false) is same as(true)))
                     and (
                       (event_ui.is_limited|default(false))
-                      or ((event_ui.capacity_hint|default('')|striptags|length > 0)
-                        and (mel_cta_urgency|default('')|striptags|length == 0)
-                        and (not mel_event_selling_fast|default(false))
-                        and (not (event_ui.is_sold_out|default(false) is same as(true)))
-                      )
+                      or (event_ui.capacity_hint|default('')|striptags|length > 0)
                     ) %}
                     <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
                       <span class="mel-icon" aria-hidden="true">⚡</span>
@@ -569,13 +568,8 @@
                     <div class="mel-booking-panel__item">
                       <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
                       <div>
-                        {% if mel_cta_urgency|default('')|striptags|length > 0 %}
-                          <strong>{{ mel_cta_urgency }}</strong>
-                          <p>{{ 'Secure your spot today'|t }}</p>
-                        {% elseif mel_event_selling_fast|default(false) %}
-                          <strong>{{ 'Selling fast'|t }}</strong>
-                          <p>{{ 'Ticket demand is high — book soon to secure your place.'|t }}</p>
-                        {% endif %}
+                        <strong>{{ mel_cta_urgency }}</strong>
+                        <p>{{ 'Secure your spot today'|t }}</p>
                       </div>
                     </div>
                   {% endif %}
@@ -587,19 +581,6 @@
                       </div>
                     </div>
                   {% endif %}
-                  <div class="mel-booking-panel__item">
-                    <span class="mel-booking-panel__item-icon" aria-hidden="true">✉️</span>
-                    <div>
-                      <strong>{{ 'Instant confirmation'|t }}</strong>
-                      <p>
-                        {%- if mel_trust_checkout -%}
-                          {{ 'You’ll receive confirmation by email'|t }}
-                        {%- else -%}
-                          {{ 'You’ll get a confirmation email'|t }}
-                        {%- endif -%}
-                      </p>
-                    </div>
-                  </div>
                   {% if mel_gcal_href|length > 0 %}
                     <div class="mel-booking-panel__item">
                       <span class="mel-booking-panel__item-icon" aria-hidden="true">📅</span>
@@ -609,11 +590,9 @@
                       </div>
                     </div>
                   {% endif %}
-                  {% if event_viewer_count_total|default(0) > 1 and event_viewer_count is not empty %}
-                    <div class="mel-booking-panel__item mel-booking-panel__item--viewer">
-                      <div>
-                        <strong>{{ event_viewer_count }}</strong>
-                      </div>
+                  {% if event_interest is defined and event_interest.label is defined %}
+                    <div class="mel-booking-panel__item mel-booking-panel__item--interest mel-booking-panel__item--{{ event_interest.type }}">
+                      <strong>{{ event_interest.label }}</strong>
                     </div>
                   {% endif %}
                 </div>
@@ -724,29 +703,16 @@
     </div>
   </div>
 
-  {# Mobile sticky CTA: same messaging as meta bar; thumb-friendly full-width bottom bar. #}
+  {# Mobile sticky CTA: same primary action as sidebar (partial); thumb-friendly full-width bar. #}
   {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
     <div class="mel-mobile-cta" role="region" aria-label="{{ 'Ticket actions'|t }}">
       <div class="mel-mobile-cta__inner">
-        {% if mel_cta_is_soldout_ui %}
-          <p class="mel-mobile-cta__soldout-head" aria-label="{{ 'Sold out'|t }}">{{ 'SOLD OUT'|t }}</p>
-        {% endif %}
         {% if (not mel_cta_is_soldout_ui) and (mel_context_above|default('')|striptags|length > 0) and (mel_cta_type_ui is same as('primary')) %}
           <p class="mel-mobile-cta__eyebrow">{{ mel_context_above }}</p>
         {% endif %}
-        {% if mel_cta_is_soldout_ui %}
-          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-            <a class="mel-mobile-cta__button mel-mobile-cta__button--lavender mel-btn--waitlist" href="{{ event_cta.url }}">{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-            <p class="mel-mobile-cta__waitlist-sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
-          {% else %}
-            <p class="mel-mobile-cta__waitlist-sub mel-mobile-cta__waitlist-sub--muted" role="status">{{ mel_cta_text }}</p>
-          {% endif %}
-        {% else %}
-          {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
-            <a class="mel-mobile-cta__button mel-mobile-cta__button--{{ mel_cta_type_ui|e('html_attr') }}{% if mel_cta_type_ui is same as('primary') %} mel-mobile-cta__button--coral{% else %} mel-mobile-cta__button--lavender{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ mel_cta_text }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}</a>
-          {% else %}
-            <button class="mel-mobile-cta__button{% if mel_cta_type_ui is same as('disabled') %} mel-mobile-cta__button--soldout{% else %} mel-mobile-cta__button--lavender mel-mobile-cta__button--locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
-          {% endif %}
+        {% include '@myeventlane_theme/node/partial--event-full-booking-cta.html.twig' with { 'mel_cta_slot': 'mobile' } %}
+        {% if mel_cta_is_soldout_ui and logged_in and event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+          <p class="mel-mobile-cta__waitlist-sub" role="note">{{ 'Be the first notified if spots open'|t }}</p>
         {% endif %}
       </div>
     </div>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-cta.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-cta.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Event full — primary booking action: shared by sidebar and mobile (single source, no logic fork).
+ *
+ * @var string mel_cta_slot
+ *   "sidebar" or "mobile" — only affects layout class names; same hrefs and state machine.
+ */
+#}
+{% set mel_has_ticket = event_ui is defined and (event_ui.user_has_ticket|default(false) is same as(true)) %}
+{% set mel_cta_sold = event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
+{% if mel_cta_slot|default('sidebar') == 'mobile' %}
+  {% set mel_cta_class_base = 'mel-btn mel-btn--cta mel-btn--pill mel-mobile-cta__button' %}
+{% else %}
+  {% set mel_cta_class_base = 'mel-btn mel-btn--cta mel-btn--pill' %}
+{% endif %}
+
+{% if logged_in and mel_has_ticket %}
+  <button class="{{ mel_cta_class_base }} mel-btn--disabled" type="button" disabled="disabled" aria-disabled="true" aria-label="{{ "You're going"|t }}">
+    {{ "You're going ✓"|t }}
+  </button>
+{% elseif mel_cta_sold %}
+  {% if event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+    <a class="{{ mel_cta_class_base }} mel-btn--secondary mel-btn--lavender-cta mel-btn--waitlist" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>
+      {{ 'Join waitlist'|t }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}
+    </a>
+  {% else %}
+    <p class="{% if mel_cta_slot|default('sidebar') == 'mobile' %}mel-mobile-cta__waitlist-sub mel-mobile-cta__waitlist-sub--muted{% else %}mel-event-cta-soldout__muted{% endif %}" role="status">{{ mel_cta_text }}</p>
+  {% endif %}
+{% elseif event_cta and (event_cta.url|default('')|striptags|length > 0) %}
+  {% if logged_in %}
+    <a class="{{ mel_cta_class_base }} mel-btn--primary{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta mel-btn--cta-semantic-primary{% else %} mel-btn--lavender-cta mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>
+      {{ 'Continue booking'|t }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}
+    </a>
+  {% else %}
+    <a class="{{ mel_cta_class_base }} mel-btn--primary{% if mel_cta_type_ui is same as('primary') %} mel-btn--coral-cta mel-btn--cta-semantic-primary{% else %} mel-btn--lavender-cta mel-btn--cta-semantic-{{ mel_cta_type_ui|e('html_attr') }}{% endif %}" href="{{ event_cta.url }}"{% if mel_cta_is_external %} target="_blank" rel="noopener noreferrer"{% endif %}>
+      {{ 'Continue to book'|t }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}
+    </a>
+  {% endif %}
+{% else %}
+  <button class="{{ mel_cta_class_base }}{% if mel_cta_type_ui is same as('disabled') %} mel-btn--disabled mel-btn--state-soldout{% else %} mel-btn--lavender-cta mel-btn--cta-locked{% endif %}" type="button" disabled="disabled" aria-disabled="true">{{ mel_cta_text }}</button>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes event full-page rendering logic and introduces new state-write behavior (viewer counting) that could affect caching/performance or user-facing CTAs if miscomputed.
> 
> **Overview**
> Introduces a new `EventInterestService` (wired via `myeventlane_core.services.yml`) that derives a single interest label (e.g. high demand/selling fast/popular/just added) from save count, viewer count, and node age, and exposes it to the event full template via `myeventlane_event_preprocess_node`.
> 
> Optimizes viewer counting by adding `EventViewerCountService::recordViewAndGetCount()` and switching the event preprocess to use it (avoids `State` get/set twice per request).
> 
> Refactors the event full booking CTA into a shared Twig partial used by both sidebar and mobile, and updates the booking panel UI: adds a rotating trust-line component (new JS behavior + CSS), adds optional decision prompts, tweaks limited-capacity UI (`is_limited` + hint), and updates mobile CTA styling/press feedback and reduced-motion handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54377275c05c7cd739387105fc1e583495648c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->