### PR TITLE
Add EventRecommendationService and related events display

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -15,6 +15,10 @@ services:
     class: Drupal\myeventlane_core\Service\EventInterestService
     arguments: ['@datetime.time']
 
+  myeventlane_core.event_recommendation:
+    class: Drupal\myeventlane_core\Service\EventRecommendationService
+    arguments: ['@entity_type.manager']
+
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
 

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Fetches a small set of same-category public events (Invite Them Back / next step).
+ */
+final class EventRecommendationService {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * Returns published event nodes (excluding the source) in any of the same categories.
+   *
+   * @return array<int, \Drupal\node\NodeInterface>
+   *   Newest first. Empty if the source has no category or no matches.
+   */
+  public function getRelatedEvents(NodeInterface $node, int $limit = 3): array {
+    if ($limit < 1) {
+      return [];
+    }
+    if ($node->bundle() !== 'event' || !$node->isPublished()) {
+      return [];
+    }
+    if ($limit > 3) {
+      $limit = 3;
+    }
+
+    $category_ids = [];
+    if ($node->hasField('field_category') && !$node->get('field_category')->isEmpty()) {
+      foreach ($node->get('field_category') as $item) {
+        if ($item->target_id) {
+          $category_ids[] = (int) $item->target_id;
+        }
+      }
+    }
+    if ($category_ids === []) {
+      return [];
+    }
+
+    $category_ids = array_values(array_unique($category_ids));
+    $storage = $this->entityTypeManager->getStorage('node');
+    $query = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'event')
+      ->condition('status', 1)
+      ->condition('nid', (int) $node->id(), '<>')
+      ->condition('field_category', $category_ids, 'IN')
+      ->sort('created', 'DESC')
+      ->range(0, $limit);
+
+    $nids = $query->execute();
+    if (!is_array($nids) || $nids === []) {
+      return [];
+    }
+
+    $nodes = $storage->loadMultiple($nids);
+    if (!is_array($nodes)) {
+      return [];
+    }
+
+    $out = [];
+    foreach ($nids as $nid) {
+      if (isset($nodes[$nid]) && $nodes[$nid] instanceof NodeInterface) {
+        $out[] = $nodes[$nid];
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -964,6 +964,39 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       (int) $node->getCreatedTime()
     );
   }
+  $variables['mel_related_events'] = NULL;
+  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_recommendation')) {
+    try {
+      /** @var \Drupal\myeventlane_core\Service\EventRecommendationService $recommendation */
+      $recommendation = \Drupal::service('myeventlane_core.event_recommendation');
+      $related_nodes = $recommendation->getRelatedEvents($node, 3);
+      if ($related_nodes !== []) {
+        $view_builder = \Drupal::entityTypeManager()->getViewBuilder('node');
+        $builds = [];
+        $append_tags = [];
+        foreach ($related_nodes as $related) {
+          $builds[] = $view_builder->view($related, 'event_card');
+          $append_tags = Cache::mergeTags($append_tags, $related->getCacheTags());
+        }
+        $variables['mel_related_events'] = $builds;
+        if ($append_tags !== []) {
+          if (isset($variables['elements']['#cache'])) {
+            $tags = (array) ($variables['elements']['#cache']['tags'] ?? []);
+            $variables['elements']['#cache']['tags'] = Cache::mergeTags($tags, $append_tags);
+          }
+          elseif (isset($variables['#cache'])) {
+            $tags = (array) ($variables['#cache']['tags'] ?? []);
+            $variables['#cache']['tags'] = Cache::mergeTags($tags, $append_tags);
+          }
+        }
+      }
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_event')->error('Event recommendations: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
   // Semantic CTA and badges: always set for the event bundle (all view modes: full,
   // teaser, event_card, etc.); do not scope to a single view mode here.

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -897,9 +897,98 @@
   }
 }
 
-// Mobile: visual order 1) event column content 2) RSVP / sticky sidebar 3) "More in …"
-// (DOM keeps main + sidebar; only Event Full has __sidebar — booking uses __side, unchanged.)
-// Uses display:contents on __main so .mel-event-related and aside can be flex-ordered.
+// Next-step related events in main column; matches homepage / listing card rhythm.
+.mel-event--v2 .mel-event-layout__main .mel-return-block {
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid #e9e3de;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-header h3 {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #24303a;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-header p {
+  font-size: 14px;
+  color: #7c8791;
+  margin: 0 0 16px;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-cta {
+  margin-top: 20px;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-cta .mel-link {
+  font-size: 13px;
+  color: #6e7ef2;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-primary {
+  margin-bottom: 20px;
+  animation: mel-fade-in 0.4s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event--v2 .mel-event-layout__main .mel-return-primary {
+    animation: none;
+  }
+}
+
+@keyframes mel-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-primary__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6e7ef2;
+  margin-bottom: 6px;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-primary .mel-event-card {
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+  transform: scale(1.02);
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-grid > * {
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-grid .mel-event-card {
+  width: 100%;
+  opacity: 0.92;
+  transition: opacity 0.2s ease;
+}
+
+.mel-event--v2 .mel-event-layout__main .mel-return-grid .mel-event-card:hover {
+  opacity: 1;
+}
+
+.mel-save-reinforcement {
+  font-size: 12px;
+  color: #7c8791;
+  margin-top: 6px;
+}
+
+// Mobile: visual order 1) main column (including .mel-return-block after organiser) 2) RSVP / sticky sidebar.
+// Uses display:contents on __main so main sections and aside can be flex-ordered.
 @media (width <= 768px) {
   .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) {
     display: flex;
@@ -913,10 +1002,6 @@
 
   .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__sidebar {
     order: 2;
-  }
-
-  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) .mel-event-related {
-    order: 3;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -406,6 +406,31 @@
           </section>
         {% endif %}
 
+        {% if mel_related_events is not empty %}
+          <div class="mel-return-block" aria-labelledby="mel-return-heading">
+            <div class="mel-return-header">
+              <h3 id="mel-return-heading">{{ 'What to do next'|t }}</h3>
+              <p>{{ 'More events like this in your area'|t }}</p>
+            </div>
+
+            {% set primary = mel_related_events|first %}
+            <div class="mel-return-primary">
+              <div class="mel-return-primary__label">{{ 'Recommended for you'|t }}</div>
+              {{ primary }}
+            </div>
+
+            <div class="mel-return-grid">
+              {% for event in mel_related_events|slice(1) %}
+                {{ event }}
+              {% endfor %}
+            </div>
+
+            <div class="mel-return-cta">
+              <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-link">{{ 'Browse all events'|t }} →</a>
+            </div>
+          </div>
+        {% endif %}
+
         <nav class="mel-event-support-zone mel-mt-5" aria-label="{{ 'Help and policies'|t }}">
           <ul class="mel-event-support-zone__list">
             <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a></li>
@@ -472,29 +497,6 @@
 
         {# Note: We intentionally do NOT render field_ticket_types or field_attendee_questions on Event Full.
            These are configuration inputs, not attendee-facing content. #}
-
-        {# Same-category upcoming events: single drupal_view() (no drupal_view_result). #}
-        {% if node.hasField('field_category') and not node.field_category.isEmpty %}
-          {% set primary_category_tid = node.field_category.0.target_id %}
-          {% set primary_category_name = mel_category_label|default('')|trim %}
-          {% if primary_category_name is empty and node.field_category.0.entity %}
-            {% set primary_category_name = node.field_category.0.entity.label %}
-          {% endif %}
-          {% if primary_category_tid and primary_category_name %}
-            {% set related_events_markup %}
-              {{ drupal_view('upcoming_events', 'related_by_category', primary_category_tid, node.id()) }}
-            {% endset %}
-            {% if related_events_markup|trim %}
-              <section class="mel-event-related mel-mt-5" aria-labelledby="mel-event-related-heading">
-                <div class="mel-section-head">
-                  <h2 id="mel-event-related-heading" class="mel-section-head__title">{{ 'More in @category'|t({'@category': primary_category_name}) }}</h2>
-                  <a class="mel-link" href="{{ path('view.upcoming_events.page_category', {'arg_0': primary_category_tid}) }}">{{ 'View all'|t }}</a>
-                </div>
-                {{ related_events_markup }}
-              </section>
-            {% endif %}
-          {% endif %}
-        {% endif %}
       </div>
 
       <aside class="mel-event-layout__sidebar" aria-label="{{ 'Tickets and event information'|t }}">
@@ -644,6 +646,11 @@
                     <div id="mel-event-full-save" class="mel-event-save mel-booking-panel__save-flag" role="group" aria-label="{{ 'Save for later'|t }}">
                       {{ event_flag_event_save }}
                     </div>
+                    {% if event_save_count_total|default(0) > 5 %}
+                      <div class="mel-save-reinforcement">
+                        <small>{{ '💖 @count people saved this'|t({ '@count': event_save_count_total|default(0) }) }}</small>
+                      </div>
+                    {% endif %}
                     <div class="mel-booking-panel__save-text">
                       <strong>{{ 'Don’t miss this'|t }}</strong>
                       <p>{{ 'Save this event to come back later'|t }}</p>


### PR DESCRIPTION
- Introduced EventRecommendationService to provide related event recommendations.
- Updated myeventlane_event.module to fetch and display related events in the full view mode.
- Enhanced the event full template to include a section for recommended events with appropriate styling in _event-full.scss.
- Improved cache handling for related events to optimize performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new entity query and render block on event full pages and updates cache tags, which could impact performance and cache invalidation correctness if misconfigured.
> 
> **Overview**
> Adds a new `EventRecommendationService` (wired via `myeventlane_core.services.yml`) that queries for up to 3 other published `event` nodes sharing any `field_category` term (excluding the current node).
> 
> Updates `myeventlane_event_preprocess_node()` to fetch and render these recommendations as `event_card` builds, attach related nodes’ cache tags to the page, and fail safely with logging.
> 
> Replaces the prior Twig-driven related-events `drupal_view()` section with a new “What to do next” recommendations block, adds corresponding styling in `_event-full.scss`, and adds a small sidebar “saved by @count people” reinforcement when `event_save_count_total > 5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2853375db74f33040ca2030a73cb85a3ddc64556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->