### PR TITLE
Feature/event save interested

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -23,6 +23,7 @@ services:
       - '@myeventlane_core.event_save_count'
       - '@myeventlane_core.event_viewer_count'
       - '@myeventlane_core.event_state_resolver'
+      - '@string_translation'
 
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_core\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -15,13 +16,110 @@ final class EventRecommendationService {
 
   private const int MAX_RELATED_CANDIDATES = 50;
 
+  /**
+   * In-request cache of flagging counts to avoid repeated queries per card.
+   *
+   * @var array<int, int>
+   */
+  private array $saveCountByNid = [];
+
+  /**
+   * In-request cache of viewer counts to avoid repeated queries.
+   *
+   * @var array<int, int>
+   */
+  private array $viewerCountByNid = [];
+
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TimeInterface $time,
     private readonly EventSaveCountService $eventSaveCount,
     private readonly EventViewerCountService $eventViewerCount,
     private readonly EventStateResolver $eventStateResolver,
+    private readonly TranslationInterface $stringTranslation,
   ) {
+  }
+
+  /**
+   * Explains why an event card is surfaced (home, list, event page, search).
+   *
+   * @param int|null $prefetchedSaveCount
+   *   When the caller already loaded save count (e.g. ranking), pass to avoid
+   *   a second read; otherwise a single cached read is used per request.
+   * @param array<int>|null $referenceCategoryIds
+   *   Category term IDs (e.g. the taxonomy term of the current category page);
+   *   only used for the “same category” case when $current is NULL.
+   *
+   * @return array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}
+   *   All keys always present. label is a translated string for display, or null.
+   */
+  public function getRecommendationContext(
+    NodeInterface $event,
+    ?NodeInterface $current = NULL,
+    ?int $prefetchedSaveCount = NULL,
+    ?array $referenceCategoryIds = NULL,
+  ): array {
+    $context = [
+      'type' => NULL,
+      'label' => NULL,
+    ];
+
+    $t = $this->stringTranslation;
+
+    $reference_for_category = NULL;
+    if ($current && $current->hasField('field_category') && !$current->get('field_category')->isEmpty()) {
+      $reference_for_category = array_map(
+        'intval',
+        array_column($current->get('field_category')->getValue(), 'target_id')
+      );
+    }
+    elseif ($referenceCategoryIds !== NULL && $referenceCategoryIds !== []) {
+      $reference_for_category = array_values(array_unique(array_map('intval', $referenceCategoryIds)));
+    }
+
+    if ($reference_for_category !== NULL && $event->hasField('field_category') && !$event->get('field_category')->isEmpty()) {
+      $event_categories = array_map(
+        'intval',
+        array_column($event->get('field_category')->getValue(), 'target_id')
+      );
+      if (array_intersect($event_categories, $reference_for_category) !== []) {
+        $context['type'] = 'category';
+        $context['label'] = (string) $t->translate('Because you liked this category');
+        return $context;
+      }
+    }
+
+    $save_count = $prefetchedSaveCount ?? $this->getSaveCountCached((int) $event->id());
+    if ($save_count > 10) {
+      $context['type'] = 'trending';
+      $context['label'] = (string) $t->translate('Trending right now');
+      return $context;
+    }
+
+    if ($event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
+      $value = (string) $event->get('field_event_start')->value;
+      $start = strtotime($value);
+      if ($start > 0) {
+        $now = $this->time->getRequestTime();
+        $hours = ($start - $now) / 3600.0;
+
+        if ($hours > 0 && $hours < 6) {
+          return [
+            'type' => 'soon',
+            'label' => (string) $t->translate('Starting soon'),
+          ];
+        }
+
+        if ($hours > 0 && $hours < 48) {
+          return [
+            'type' => 'weekend',
+            'label' => (string) $t->translate('This weekend'),
+          ];
+        }
+      }
+    }
+
+    return $context;
   }
 
   /**
@@ -66,8 +164,14 @@ final class EventRecommendationService {
       ->condition('type', 'event')
       ->condition('status', 1)
       ->condition('nid', (int) $node->id(), '<>')
-      ->condition('field_event_state', $excluded_states, 'NOT IN')
-      ->condition('field_event_start', $now, '>=')
+      ->condition('field_event_state', $excluded_states, 'NOT IN');
+
+    $or = $query->orConditionGroup();
+    $or->condition('field_event_start', $now, '>=');
+    $or->condition('field_event_end', $now, '>=');
+    $query->condition($or);
+
+    $query
       ->condition('field_category', $category_ids, 'IN')
       ->sort('created', 'DESC')
       ->range(0, $limit);
@@ -94,9 +198,10 @@ final class EventRecommendationService {
   /**
    * Same pool as getRelatedEvents(), then re-ordered by a lightweight global score.
    *
+   * After base capping, applies a single time-weight (event start) for urgency + decay.
    * Deterministic: equal scores use newer created time first, then lower nid.
    *
-   * @return array<int, \Drupal\node\NodeInterface>
+   * @return array<int, array{node: \Drupal\node\NodeInterface, context: array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}}>
    */
   public function getRankedRelatedEvents(NodeInterface $node, int $limit = 3): array {
     if ($limit < 1) {
@@ -107,24 +212,36 @@ final class EventRecommendationService {
     if ($events === []) {
       return [];
     }
-    $now = $this->time->getRequestTime();
     $scored = [];
     foreach ($events as $event) {
       $score = 0;
-      $age = $now - $event->getCreatedTime();
-      if ($age < 86400 * 7) {
-        $score += 20;
-      }
-      $save_count = $this->eventSaveCount->getSaveCount((int) $event->id());
+      $save_count = $this->getSaveCountCached((int) $event->id());
       $score += min($save_count * 2, 40);
-      $viewer_count = $this->eventViewerCount->getViewerCount((int) $event->id());
+      $viewer_count = $this->getViewerCountCached((int) $event->id());
       $score += min($viewer_count * 3, 30);
       if ($this->eventStateResolver->isEventBoosted($event)) {
         $score += 15;
       }
+      $score = max(0, min($score, 100));
+      $event_start = 0;
+      if ($event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
+        $start_ts = strtotime((string) $event->get('field_event_start')->value);
+        if ($start_ts > 0) {
+          $event_start = (int) $start_ts;
+        }
+      }
+      $score = $this->applyTimeWeight($score, $event_start);
+      $score = max(1, min($score, 200));
+      $context = $this->getRecommendationContext(
+        $event,
+        $node,
+        $save_count,
+        NULL
+      );
       $scored[] = [
         'event' => $event,
         'score' => $score,
+        'context' => $context,
       ];
     }
     usort(
@@ -148,9 +265,79 @@ final class EventRecommendationService {
     $top = array_slice($scored, 0, $limit);
     $out = [];
     foreach ($top as $row) {
-      $out[] = $row['event'];
+      $out[] = [
+        'node' => $row['event'],
+        'context' => $row['context'],
+      ];
     }
     return $out;
+  }
+
+  /**
+   * Merges recommendation context onto a node view build (e.g. from entity_view).
+   */
+  public function attachListCardContextToBuild(
+    array &$build,
+    NodeInterface $node,
+    ?NodeInterface $routeContextEvent = NULL,
+    ?array $referenceCategoryIds = NULL,
+  ): void {
+    if (array_key_exists('#recommendation_context', $build)) {
+      return;
+    }
+    $context = $this->getRecommendationContext(
+      $node,
+      $routeContextEvent,
+      NULL,
+      $referenceCategoryIds
+    );
+    $build['#recommendation_context'] = $context;
+  }
+
+  /**
+   * Single time model: soon / near / far multipliers, then distance decay (all from start).
+   *
+   * Ongoing or past (non-positive hours-until) return 0; final score floor applies after.
+   */
+  private function applyTimeWeight(int $score, int $eventStart): int {
+    if ($eventStart < 1) {
+      return 0;
+    }
+    $now = $this->time->getRequestTime();
+    $seconds_until = $eventStart - $now;
+    $hours_until = $seconds_until / 3600.0;
+
+    if ($hours_until <= 0) {
+      return 0;
+    }
+    if ($hours_until <= 6) {
+      return (int) ($score * 2.5);
+    }
+    if ($hours_until <= 24) {
+      return (int) ($score * 1.8);
+    }
+    if ($hours_until <= 48) {
+      return (int) ($score * 1.3);
+    }
+
+    $days_until = $hours_until / 24.0;
+    $decay_factor = exp(-0.03 * $days_until);
+
+    return (int) round($score * $decay_factor);
+  }
+
+  private function getSaveCountCached(int $nid): int {
+    if (!array_key_exists($nid, $this->saveCountByNid)) {
+      $this->saveCountByNid[$nid] = $this->eventSaveCount->getSaveCount($nid);
+    }
+    return $this->saveCountByNid[$nid];
+  }
+
+  private function getViewerCountCached(int $nid): int {
+    if (!array_key_exists($nid, $this->viewerCountByNid)) {
+      $this->viewerCountByNid[$nid] = $this->eventViewerCount->getViewerCount($nid);
+    }
+    return $this->viewerCountByNid[$nid];
   }
 
 }

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -48,7 +48,8 @@ final class EventRecommendationService {
    *   a second read; otherwise a single cached read is used per request.
    * @param array<int>|null $referenceCategoryIds
    *   Category term IDs (e.g. the taxonomy term of the current category page);
-   *   only used for the “same category” case when $current is NULL.
+   *   unioned with $current’s categories when both are present for the
+   *   “same category” check.
    *
    * @return array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}
    *   All keys always present. label is a translated string for display, or null.
@@ -66,15 +67,26 @@ final class EventRecommendationService {
 
     $t = $this->stringTranslation;
 
-    $reference_for_category = NULL;
+    $from_current = NULL;
     if ($current && $current->hasField('field_category') && !$current->get('field_category')->isEmpty()) {
-      $reference_for_category = array_map(
+      $from_current = array_map(
         'intval',
         array_column($current->get('field_category')->getValue(), 'target_id')
       );
     }
-    elseif ($referenceCategoryIds !== NULL && $referenceCategoryIds !== []) {
-      $reference_for_category = array_values(array_unique(array_map('intval', $referenceCategoryIds)));
+    $from_page = NULL;
+    if ($referenceCategoryIds !== NULL && $referenceCategoryIds !== []) {
+      $from_page = array_values(array_unique(array_map('intval', $referenceCategoryIds)));
+    }
+    $reference_for_category = NULL;
+    if ($from_current !== NULL && $from_page !== NULL) {
+      $reference_for_category = array_values(array_unique([...$from_current, ...$from_page]));
+    }
+    elseif ($from_current !== NULL) {
+      $reference_for_category = $from_current;
+    }
+    elseif ($from_page !== NULL) {
+      $reference_for_category = $from_page;
     }
 
     if ($reference_for_category !== NULL && $event->hasField('field_category') && !$event->get('field_category')->isEmpty()) {
@@ -248,7 +260,7 @@ final class EventRecommendationService {
         $event,
         $node,
         $save_count,
-        NULL
+        $referenceCategoryIds
       );
       $scored[] = [
         'event' => $event,

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -153,6 +153,7 @@ final class EventRecommendationService {
 
     $category_ids = array_values(array_unique($category_ids));
     $now = $this->time->getRequestTime();
+    $now_datetime = date('Y-m-d\TH:i:s', $now);
     $excluded_states = [
       'draft',
       'cancelled',
@@ -167,8 +168,8 @@ final class EventRecommendationService {
       ->condition('field_event_state', $excluded_states, 'NOT IN');
 
     $or = $query->orConditionGroup();
-    $or->condition('field_event_start', $now, '>=');
-    $or->condition('field_event_end', $now, '>=');
+    $or->condition('field_event_start', $now_datetime, '>=');
+    $or->condition('field_event_end', $now_datetime, '>=');
     $query->condition($or);
 
     $query
@@ -201,9 +202,20 @@ final class EventRecommendationService {
    * After base capping, applies a single time-weight (event start) for urgency + decay.
    * Deterministic: equal scores use newer created time first, then lower nid.
    *
+   * When $referenceCategoryIds is non-empty (category page / category context), the
+   * top-ranked list is returned unchanged. Otherwise a soft per-primary-category cap
+   * (max 2) is applied after scoring, with fallback fill from the full ranked list.
+   *
+   * @param array<int>|null $referenceCategoryIds
+   *   If non-empty, skips soft balancing (pure score order for category context).
+   *
    * @return array<int, array{node: \Drupal\node\NodeInterface, context: array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}}>
    */
-  public function getRankedRelatedEvents(NodeInterface $node, int $limit = 3): array {
+  public function getRankedRelatedEvents(
+    NodeInterface $node,
+    int $limit = 3,
+    ?array $referenceCategoryIds = NULL,
+  ): array {
     if ($limit < 1) {
       return [];
     }
@@ -262,9 +274,56 @@ final class EventRecommendationService {
         return (int) $aEvent->id() <=> (int) $bEvent->id();
       },
     );
-    $top = array_slice($scored, 0, $limit);
+
+    $is_category_context = $referenceCategoryIds !== NULL && $referenceCategoryIds !== [];
+    if ($is_category_context) {
+      $selected = array_slice($scored, 0, $limit);
+    }
+    else {
+      $balanced = [];
+      $category_counts = [];
+      foreach ($scored as $item) {
+        $event = $item['event'];
+        $category_ids = [];
+        if ($event->hasField('field_category')) {
+          $category_ids = array_map(
+            'intval',
+            array_column($event->get('field_category')->getValue(), 'target_id')
+          );
+        }
+        $primary_category = $category_ids[0] ?? 'none';
+        $count = $category_counts[$primary_category] ?? 0;
+        if ($count >= 2) {
+          continue;
+        }
+        $balanced[] = $item;
+        $category_counts[$primary_category] = $count + 1;
+        if (count($balanced) >= $limit) {
+          break;
+        }
+      }
+      if (count($balanced) < $limit) {
+        $seen_nids = [];
+        foreach ($balanced as $b) {
+          $seen_nids[(int) $b['event']->id()] = TRUE;
+        }
+        foreach ($scored as $item) {
+          if (count($balanced) >= $limit) {
+            break;
+          }
+          $nid = (int) $item['event']->id();
+          if (isset($seen_nids[$nid])) {
+            continue;
+          }
+          $balanced[] = $item;
+          $seen_nids[$nid] = TRUE;
+        }
+      }
+      $selected = $balanced;
+    }
+
     $out = [];
-    foreach ($top as $row) {
+    foreach ($selected as $row) {
       $out[] = [
         'node' => $row['event'],
         'context' => $row['context'],

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
@@ -802,6 +803,68 @@ function myeventlane_event_entity_presave(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_entity_view_alter().
+ *
+ * Attaches recommendation reason labels to all event “card” view builds (search,
+ * Views, blocks, event page) without per-call Twig or duplicate flagging queries
+ * (service caches per request).
+ */
+function myeventlane_event_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display): void {
+  if (!\Drupal::hasService('myeventlane_core.event_recommendation')) {
+    return;
+  }
+  if (!$entity instanceof NodeInterface || $entity->bundle() !== 'event') {
+    return;
+  }
+  if (!in_array($display->getMode(), myeventlane_event_get_event_card_view_modes(), TRUE)) {
+    return;
+  }
+  if (array_key_exists('#recommendation_context', $build)) {
+    return;
+  }
+  $routeContextEvent = NULL;
+  $route = \Drupal::routeMatch();
+  $route_node = $route->getParameter('node');
+  if ($route_node instanceof NodeInterface && $route_node->bundle() === 'event' && (int) $route_node->id() !== (int) $entity->id()) {
+    $routeContextEvent = $route_node;
+  }
+  $referenceCategoryIds = NULL;
+  $term = $route->getParameter('taxonomy_term');
+  if ($term instanceof TermInterface) {
+    $referenceCategoryIds = [(int) $term->id()];
+  }
+  try {
+    /** @var \Drupal\myeventlane_core\Service\EventRecommendationService $recommendation */
+    $recommendation = \Drupal::service('myeventlane_core.event_recommendation');
+    $recommendation->attachListCardContextToBuild(
+      $build,
+      $entity,
+      $routeContextEvent,
+      $referenceCategoryIds
+    );
+    if (!isset($build['#cache'])) {
+      $build['#cache'] = [];
+    }
+    if (!is_array($build['#cache'])) {
+      $build['#cache'] = [];
+    }
+    $contexts = $build['#cache']['contexts'] ?? [];
+    if (!is_array($contexts)) {
+      $contexts = [];
+    }
+    $build['#cache']['contexts'] = array_values(array_unique(array_merge(
+      $contexts,
+      ['route.name'],
+    )));
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_event')->error('Event recommendation context: @message', [
+      '@message' => $e->getMessage(),
+    ]);
+  }
+}
+
+/**
  * Implements hook_preprocess_node().
  */
 function myeventlane_event_preprocess_node(array &$variables): void {
@@ -813,6 +876,18 @@ function myeventlane_event_preprocess_node(array &$variables): void {
   if ($node->bundle() !== 'event') {
     return;
   }
+
+  $elements = is_array($variables['elements'] ?? NULL) ? $variables['elements'] : [];
+  $recommendation_context = $elements['#recommendation_context'] ?? NULL;
+  $variables['recommendation_context'] = is_array($recommendation_context)
+    ? $recommendation_context + [
+      'type' => NULL,
+      'label' => NULL,
+    ]
+    : [
+      'type' => NULL,
+      'label' => NULL,
+    ];
 
   // Categories metadata for theming (name + color).
   $categories = [];
@@ -969,12 +1044,19 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     try {
       /** @var \Drupal\myeventlane_core\Service\EventRecommendationService $recommendation */
       $recommendation = \Drupal::service('myeventlane_core.event_recommendation');
-      $related_nodes = $recommendation->getRankedRelatedEvents($node, 3);
-      if ($related_nodes !== []) {
+      $related_rows = $recommendation->getRankedRelatedEvents($node, 3);
+      if ($related_rows !== []) {
         $view_builder = \Drupal::entityTypeManager()->getViewBuilder('node');
         $builds = [];
         $append_tags = [];
-        foreach ($related_nodes as $related) {
+        foreach ($related_rows as $row) {
+          if (!is_array($row) || !isset($row['node'], $row['context'])) {
+            continue;
+          }
+          $related = $row['node'];
+          if (!$related instanceof NodeInterface) {
+            continue;
+          }
           $builds[] = $view_builder->view($related, 'event_card');
           $append_tags = Cache::mergeTags($append_tags, $related->getCacheTags());
         }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -222,6 +222,31 @@
   min-width: 0;
 }
 
+// Recommendation / discovery reason (EventRecommendationService).
+.mel-card-reason {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  line-height: 1.2;
+  color: mel.$mel-ds-color-muted;
+}
+
+.mel-card-reason--trending {
+  color: #F26D5B;
+}
+
+.mel-card-reason--category {
+  color: #6E7EF2;
+}
+
+.mel-card-reason--soon {
+  color: #F5C04C;
+}
+
+.mel-card-reason--weekend {
+  color: #2eb88a;
+}
+
 .mel-event-card__title {
   font-size: 18px;
   font-weight: 700;

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -95,6 +95,9 @@
       </div>
 
       <div class="mel-event-hero-card__content">
+        {% if recommendation_context is defined and recommendation_context.label|default('')|trim|length > 0 %}
+          <p class="mel-card-reason mel-card-reason--{{ recommendation_context.type|default('')|e('html_attr') }}">{{ recommendation_context.label }}</p>
+        {% endif %}
         <h2 class="mel-event-hero-card__title">{{ _title }}</h2>
 
         {% if _time %}
@@ -163,6 +166,11 @@
     </div>
 
     <div class="mel-event-card__body mel-event-card__content">
+      {% if recommendation_context is defined and recommendation_context.label|default('')|trim|length > 0 %}
+        <div class="mel-card-reason mel-card-reason--{{ recommendation_context.type|default('')|e('html_attr') }}">
+          {{ recommendation_context.label }}
+        </div>
+      {% endif %}
       <h3 class="mel-event-card__title">{{ _title }}</h3>
 
       {% if _time %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes recommendation selection/ranking logic and alters event card rendering via `hook_entity_view_alter()`, which can affect what events are surfaced and cached across routes.
> 
> **Overview**
> Adds a per-card **recommendation context** (type + translated label) surfaced on event cards (hero + standard) to explain why an event is shown (same category, trending, starting soon, this weekend).
> 
> Updates `EventRecommendationService` to cache save/view counts per request, apply time-weighted scoring, balance non-category lists across primary categories, and broaden the “upcoming” related-events query to include events with `field_event_end` in the future.
> 
> Wires the context into all event card view builds via `myeventlane_event_entity_view_alter()` (including cache context updates), exposes it to Twig in `myeventlane_event_preprocess_node()`, and adds styling for the new reason label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68441dc420d4c88cbd4b54cc25046fe5e8f0baa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->