### PR TITLE
Feature/event save interested

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1044,7 +1044,12 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     try {
       /** @var \Drupal\myeventlane_core\Service\EventRecommendationService $recommendation */
       $recommendation = \Drupal::service('myeventlane_core.event_recommendation');
-      $related_rows = $recommendation->getRankedRelatedEvents($node, 3);
+      $referenceCategoryIds = NULL;
+      $term = \Drupal::routeMatch()->getParameter('taxonomy_term');
+      if ($term instanceof TermInterface) {
+        $referenceCategoryIds = [(int) $term->id()];
+      }
+      $related_rows = $recommendation->getRankedRelatedEvents($node, 3, $referenceCategoryIds);
       if ($related_rows !== []) {
         $view_builder = \Drupal::entityTypeManager()->getViewBuilder('node');
         $builds = [];
@@ -1061,6 +1066,29 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           $append_tags = Cache::mergeTags($append_tags, $related->getCacheTags());
         }
         $variables['mel_related_events'] = $builds;
+        if (isset($variables['elements']['#cache'])) {
+          if (!is_array($variables['elements']['#cache'])) {
+            $variables['elements']['#cache'] = [];
+          }
+          $recommendation_contexts = $variables['elements']['#cache']['contexts'] ?? [];
+          if (!is_array($recommendation_contexts)) {
+            $recommendation_contexts = [];
+          }
+          $variables['elements']['#cache']['contexts'] = array_values(array_unique(array_merge(
+            $recommendation_contexts,
+            ['route.name'],
+          )));
+        }
+        elseif (isset($variables['#cache']) && is_array($variables['#cache'])) {
+          $recommendation_contexts = $variables['#cache']['contexts'] ?? [];
+          if (!is_array($recommendation_contexts)) {
+            $recommendation_contexts = [];
+          }
+          $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
+            $recommendation_contexts,
+            ['route.name'],
+          )));
+        }
         if ($append_tags !== []) {
           if (isset($variables['elements']['#cache'])) {
             $tags = (array) ($variables['elements']['#cache']['tags'] ?? []);

--- a/web/modules/custom/myeventlane_views/src/Plugin/views/filter/MelEventNoEndUpcoming.php
+++ b/web/modules/custom/myeventlane_views/src/Plugin/views/filter/MelEventNoEndUpcoming.php
@@ -95,7 +95,7 @@ final class MelEventNoEndUpcoming extends FilterPluginBase {
    * {@inheritdoc}
    */
   public function adminSummary(): string {
-    return $this->t('Empty end date and start >= now');
+    return (string) $this->t('Empty end date and start >= now');
   }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts event-page recommendation inputs and render cache contexts; incorrect cache context handling could cause stale or fragmented caches, but changes are localized to theming/preprocess and Views admin output.
> 
> **Overview**
> Related events on the event `full` view are now *category-context aware*: when a `taxonomy_term` is present in the current route, its term ID is passed into `EventRecommendationService::getRankedRelatedEvents(...)` to influence ranking/balancing.
> 
> To prevent cached event pages/cards from reusing recommendations across different routes, the preprocess logic now adds `route.name` to the relevant render cache contexts when related events are attached.
> 
> Minor cleanup: the Views filter `MelEventNoEndUpcoming::adminSummary()` now explicitly casts the translated string to `string`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7700f22ba5bd9edc2212b2db7bed358958b7c2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->