### PR TITLE
Feature/event save interested

### DIFF
--- a/config/sync/views.view.front_featured_events.yml
+++ b/config/sync/views.view.front_featured_events.yml
@@ -157,7 +157,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled

--- a/config/sync/views.view.mel_docs_register.yml
+++ b/config/sync/views.view.mel_docs_register.yml
@@ -564,7 +564,7 @@ display:
           entity_type: node
           entity_field: field_help_status
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             draft: draft
             review: review

--- a/config/sync/views.view.mel_help_attendee_help.yml
+++ b/config/sync/views.view.mel_help_attendee_help.yml
@@ -81,7 +81,7 @@ display:
           entity_type: node
           entity_field: field_audience
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             public: public
           group: 1

--- a/config/sync/views.view.mel_help_organiser_help.yml
+++ b/config/sync/views.view.mel_help_organiser_help.yml
@@ -81,7 +81,7 @@ display:
           entity_type: node
           entity_field: field_audience
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             public: public
           group: 1

--- a/config/sync/views.view.mel_help_policies_help.yml
+++ b/config/sync/views.view.mel_help_policies_help.yml
@@ -85,7 +85,7 @@ display:
           entity_type: node
           entity_field: field_audience
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             public: public
           group: 1

--- a/config/sync/views.view.mel_help_vendor_help.yml
+++ b/config/sync/views.view.mel_help_vendor_help.yml
@@ -81,7 +81,7 @@ display:
           entity_type: node
           entity_field: field_audience
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             vendor: vendor
           group: 1

--- a/config/sync/views.view.mel_home_events.yml
+++ b/config/sync/views.view.mel_home_events.yml
@@ -140,7 +140,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -541,7 +541,7 @@ display:
           relationship: none
           group_type: group
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             rsvp: rsvp
             both: both

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -219,7 +219,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -566,7 +566,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -917,7 +917,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -1252,7 +1252,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -1676,7 +1676,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -1842,7 +1842,7 @@ display:
           relationship: none
           group_type: group
           plugin_id: list_field
-          operator: in
+          operator: or
           value:
             rsvp: rsvp
             both: both
@@ -2042,7 +2042,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -2421,7 +2421,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled
@@ -2844,7 +2844,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not in'
+          operator: 'not'
           value:
             draft: draft
             cancelled: cancelled

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -122,7 +122,8 @@ final class EventRecommendationService {
           ];
         }
 
-        if ($hours > 0 && $hours < 48) {
+        $weekday = (int) date('N', $start);
+        if ($hours > 0 && $hours < 48 && ($weekday === 6 || $weekday === 7)) {
           return [
             'type' => 'weekend',
             'label' => (string) $t->translate('This weekend'),

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1094,7 +1094,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
             $tags = (array) ($variables['elements']['#cache']['tags'] ?? []);
             $variables['elements']['#cache']['tags'] = Cache::mergeTags($tags, $append_tags);
           }
-          elseif (isset($variables['#cache'])) {
+          elseif (isset($variables['#cache']) && is_array($variables['#cache'])) {
             $tags = (array) ($variables['#cache']['tags'] ?? []);
             $variables['#cache']['tags'] = Cache::mergeTags($tags, $append_tags);
           }

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -854,7 +854,7 @@ function myeventlane_event_entity_view_alter(array &$build, EntityInterface $ent
     }
     $build['#cache']['contexts'] = array_values(array_unique(array_merge(
       $contexts,
-      ['route.name'],
+      ['route'],
     )));
   }
   catch (\Throwable $e) {
@@ -1076,7 +1076,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           }
           $variables['elements']['#cache']['contexts'] = array_values(array_unique(array_merge(
             $recommendation_contexts,
-            ['route.name'],
+            ['route'],
           )));
         }
         elseif (isset($variables['#cache']) && is_array($variables['#cache'])) {
@@ -1086,7 +1086,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           }
           $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
             $recommendation_contexts,
-            ['route.name'],
+            ['route'],
           )));
         }
         if ($append_tags !== []) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates multiple Drupal View filter operators and cache contexts, which can change which events/help articles appear and how event card renders are cached across routes.
> 
> **Overview**
> **Adjusts Drupal Views filtering logic** by changing several list-field filter operators (e.g., event state exclusions and event/help audience/status/type filters) in synced view configs, which can alter the result sets shown on the homepage and help centre listings.
> 
> **Refines event recommendation labeling and caching** by restricting the `This weekend` recommendation context to events within 48 hours that actually start on Saturday/Sunday, and by updating event card cache contexts from `route.name` to `route` (plus a small guard to only merge cache tags into array `#cache` structures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51db8f84e2b84459f8bb64a76c31aabe5dae7039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->