### PR TITLE
Feature/event save interested

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -124,9 +124,6 @@ module:
   myeventlane_help_shared: 0
   myeventlane_launch: 0
   myeventlane_location: 0
-  # Later than most feature modules (e.g. pro) so hook_mail_alter can apply
-  # the shared HTML email shell after Pro and other alters.
-  myeventlane_messaging: 20
   myeventlane_metrics: 0
   myeventlane_notifications: 0
   myeventlane_page_visuals: 0
@@ -193,6 +190,7 @@ module:
   pathauto: 1
   views: 10
   paragraphs: 11
+  myeventlane_messaging: 20
   myeventlane_legal: 100
   standard: 1000
 theme:

--- a/config/sync/views.view.front_featured_events.yml
+++ b/config/sync/views.view.front_featured_events.yml
@@ -157,7 +157,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled

--- a/config/sync/views.view.mel_home_events.yml
+++ b/config/sync/views.view.mel_home_events.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.node.event.field_promoted
     - field.storage.node.field_event_end
     - field.storage.node.field_event_start
+    - field.field.node.event.field_product_target
     - field.storage.node.field_event_state
-    - field.storage.node.field_event_type
+    - field.storage.node.field_product_target
     - field.storage.node.field_promoted
     - node.type.event
   module:
@@ -140,7 +141,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -318,7 +319,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: true
+          distinct: false
           replica: false
           query_tags: {  }
       relationships: {  }
@@ -366,12 +367,246 @@ display:
     display_plugin: embed
     position: 10
     display_options:
+      title: 'Discover (embed homepage)'
       pager:
         type: some
         options:
           offset: 0
           items_per_page: 6
       filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            editorial-published: editorial-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
         field_promoted_value:
           id: field_promoted_value
           table: node__field_promoted
@@ -379,6 +614,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: field_promoted
           plugin_id: boolean
           operator: '!='
           value: '1'
@@ -410,11 +647,29 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
       row:
         type: 'entity:node'
         options:
           relationship: none
           view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      defaults:
+        query: false
+        pager: false
+        row: false
+        filters: false
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -456,7 +711,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: event_card_compact
+          view_mode: teaser
       display_extenders: {  }
       block_description: 'Newest events (compact). Not geo-filtered yet.'
       block_category: MyEventLane
@@ -480,6 +735,170 @@ display:
           offset: 0
           items_per_page: 6
       filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            editorial-published: editorial-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
         field_event_start_value:
           id: field_event_start_value
           table: node__field_event_start
@@ -487,6 +906,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
           plugin_id: datetime
           operator: between
           value:
@@ -506,13 +927,71 @@ display:
             remember: false
             multiple: false
           is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
       row:
         type: 'entity:node'
         options:
           relationship: none
           view_mode: event_card_compact
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      defaults:
+        query: false
+        pager: false
+        row: false
+        filters: false
       display_extenders: {  }
-      block_description: 'Tonight / today rail (compact)'
+      block_description: 'Tonight / today rail (teaser cards)'
       block_category: MyEventLane
     cache_metadata:
       max-age: -1
@@ -534,26 +1013,296 @@ display:
           offset: 0
           items_per_page: 6
       filters:
-        field_event_type:
-          id: field_event_type
-          table: node__field_event_type
-          field: field_event_type
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
           relationship: none
           group_type: group
-          plugin_id: list_field
-          operator: or
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
           value:
-            rsvp: rsvp
-            both: both
+            editorial-published: editorial-published
           group: 1
           exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_product_target_target_id:
+          id: field_product_target_target_id
+          table: node__field_product_target
+          field: field_product_target_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_product_target
+          plugin_id: numeric
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
       row:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: event_card_compact
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      defaults:
+        query: false
+        pager: false
+        row: false
+        filters: false
       display_extenders: {  }
-      block_description: 'Free & RSVP (compact); currently based on event type, not Commerce pricing'
+      block_description: 'Free & RSVP: Ticket Product (field_product_target) empty; aligns with EventStateResolver::hasProductTarget'
       block_category: MyEventLane
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -6,8 +6,10 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.field_category
     - field.storage.node.field_event_end
+    - field.field.node.event.field_product_target
     - field.storage.node.field_event_state
     - field.storage.node.field_event_type
+    - field.storage.node.field_product_target
     - node.type.event
     - system.menu.main
     - taxonomy.vocabulary.accessibility
@@ -219,7 +221,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -566,7 +568,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -917,7 +919,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -1252,7 +1254,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -1676,7 +1678,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -1835,19 +1837,38 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_event_type:
-          id: field_event_type
-          table: node__field_event_type
-          field: field_event_type
+        field_product_target_target_id:
+          id: field_product_target_target_id
+          table: node__field_product_target
+          field: field_product_target_target_id
           relationship: none
           group_type: group
-          plugin_id: list_field
-          operator: or
+          admin_label: ''
+          entity_type: node
+          entity_field: field_product_target
+          plugin_id: numeric
+          operator: empty
           value:
-            rsvp: rsvp
-            both: both
+            min: ''
+            max: ''
+            value: ''
           group: 1
           exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
         field_accessibility_target_id:
           id: field_accessibility_target_id
           table: node__field_accessibility
@@ -2042,7 +2063,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -2139,6 +2160,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
           plugin_id: datetime
           operator: between
           value:
@@ -2421,7 +2444,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled
@@ -2518,6 +2541,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
           plugin_id: datetime
           operator: between
           value:
@@ -2844,7 +2869,7 @@ display:
           entity_type: node
           entity_field: field_event_state
           plugin_id: list_field
-          operator: 'not'
+          operator: not
           value:
             draft: draft
             cancelled: cancelled

--- a/web/modules/custom/myeventlane_views/myeventlane_views.module
+++ b/web/modules/custom/myeventlane_views/myeventlane_views.module
@@ -52,8 +52,9 @@ function myeventlane_views_views_post_execute(ViewExecutable $view): void {
  * - Ensures null field values are converted to empty strings.
  */
 function myeventlane_views_views_pre_render(ViewExecutable $view): void {
-  // Sort upcoming_events: featured first, preserve existing order within groups.
-  if ($view->id() === 'upcoming_events' && !empty($view->result)) {
+  // Sort upcoming_events and mel_home_events: featured first, preserve
+  // start-date order within ties (same as public discovery).
+  if (in_array($view->id(), ['upcoming_events', 'mel_home_events'], TRUE) && !empty($view->result)) {
     usort($view->result, function ($a, $b) {
       $promo_a = 0;
       $promo_b = 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates multiple Drupal Views that drive public/homepage event listings, changing filtering and card rendering; mistakes could hide events or change ordering. No auth/security logic is touched, but the changes affect high-visibility content queries.
> 
> **Overview**
> **Event discovery Views are tightened and aligned.** `mel_home_events` gains explicit published/type/moderation/state/upcoming filters (including OR-group logic for `field_event_end >= now` vs `mel_event_no_end_upcoming`) on the `embed_discover` and `tonight` displays, and disables `distinct` in the default query.
> 
> **“Free & RSVP” filtering is redefined.** Both `mel_home_events` (`under_20`) and `upcoming_events` (`page_free`) switch to treating events as free/RSVP when `field_product_target` is empty, adding the required config dependencies.
> 
> **Presentation/order tweaks.** Several displays switch from `event_card_compact` to `teaser` view mode, and `myeventlane_views_views_pre_render()` now also sorts `mel_home_events` results by `field_promoted` (featured first). `core.extension.yml` reorders `myeventlane_messaging` module weight, and multiple Views configs normalize the `operator: not` YAML value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f01cf9f6382d99b8013e3b25109d21ba3ff288cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->