### PR TITLE
Refactor view configuration for mel_home_events and enhance event urg…

### DIFF
--- a/config/sync/views.view.mel_home_events.yml
+++ b/config/sync/views.view.mel_home_events.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - core.entity_view_mode.node.event_card_compact
     - field.field.node.event.field_promoted
     - field.storage.node.field_event_end
     - field.storage.node.field_event_start
@@ -51,6 +50,19 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        field_promoted_value:
+          id: field_promoted_value
+          table: node__field_promoted
+          field: field_promoted_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_event_start_value:
           id: field_event_start_value
           table: node__field_event_start
@@ -247,7 +259,7 @@ display:
             max: ''
             value: now
             type: offset
-          group: 1
+          group: 2
           exposed: false
           expose:
             operator_id: ''
@@ -554,7 +566,7 @@ display:
             max: ''
             value: now
             type: offset
-          group: 1
+          group: 2
           exposed: false
           expose:
             operator_id: ''
@@ -691,17 +703,28 @@ display:
           offset: 0
           items_per_page: 6
       sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
+        field_promoted_value:
+          id: field_promoted_value
+          table: node__field_promoted
+          field: field_promoted_value
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
+          plugin_id: boolean
           order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
           expose:
             label: ''
             field_identifier: ''
@@ -911,7 +934,7 @@ display:
           plugin_id: datetime
           operator: between
           value:
-            min: 'today midnight'
+            min: now
             max: 'tomorrow midnight'
             type: offset
           group: 1
@@ -976,7 +999,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: event_card_compact
+          view_mode: teaser
       query:
         type: views_query
         options:
@@ -991,7 +1014,7 @@ display:
         row: false
         filters: false
       display_extenders: {  }
-      block_description: 'Tonight / today rail (teaser cards)'
+      block_description: "Tonight: near-term (start to tomorrow midnight) + not ended; teaser cards, aligned with Discover / Free & RSVP"
       block_category: MyEventLane
     cache_metadata:
       max-age: -1
@@ -1193,7 +1216,7 @@ display:
             max: ''
             value: now
             type: offset
-          group: 1
+          group: 2
           exposed: false
           expose:
             operator_id: ''

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -865,6 +865,20 @@ function myeventlane_event_entity_view_alter(array &$build, EntityInterface $ent
 }
 
 /**
+ * Implements hook_preprocess_views_view().
+ *
+ * @see myeventlane_event_preprocess_node
+ */
+function myeventlane_event_preprocess_views_view(array &$variables): void {
+  $active = &drupal_static('myeventlane_event_mel_home_tonight_rail_active', FALSE);
+  $active = FALSE;
+  $view = $variables['view'] ?? NULL;
+  if ($view && $view->id() === 'mel_home_events' && $view->current_display === 'tonight') {
+    $active = TRUE;
+  }
+}
+
+/**
  * Implements hook_preprocess_node().
  */
 function myeventlane_event_preprocess_node(array &$variables): void {
@@ -1105,6 +1119,51 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       \Drupal::logger('myeventlane_event')->error('Event recommendations: @message', [
         '@message' => $e->getMessage(),
       ]);
+    }
+  }
+  $variables['mel_tonight_urgency_label'] = NULL;
+  if ((bool) drupal_static('myeventlane_event_mel_home_tonight_rail_active', FALSE)
+    && $view_mode === 'teaser' && $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()
+  ) {
+    $start_value = (string) $node->get('field_event_start')->value;
+    $start_raw = $start_value !== '' ? strtotime($start_value) : FALSE;
+    $start_ts = ($start_raw !== FALSE) ? (int) $start_raw : 0;
+    $now = (int) \Drupal::time()->getRequestTime();
+    $end_ts = NULL;
+    if ($node->hasField('field_event_end') && !$node->get('field_event_end')->isEmpty()) {
+      $end_value = (string) $node->get('field_event_end')->value;
+      if ($end_value !== '') {
+        $et = strtotime($end_value);
+        if ($et !== FALSE) {
+          $end_ts = (int) $et;
+        }
+      }
+    }
+    if ($start_ts > 0) {
+      if ($start_ts <= $now && ($end_ts === NULL || $end_ts > $now)) {
+        $variables['mel_tonight_urgency_label'] = t('Happening today');
+      }
+      elseif ($start_ts > $now) {
+        $variables['mel_tonight_urgency_label'] = t('Starts soon');
+      }
+    }
+    if ($variables['mel_tonight_urgency_label'] !== NULL) {
+      if (isset($variables['elements']['#cache']) && is_array($variables['elements']['#cache'])) {
+        $c =& $variables['elements']['#cache'];
+        $c['contexts'] = array_values(array_unique(array_merge(
+          (array) ($c['contexts'] ?? []),
+          ['timezone'],
+        )));
+        $c['max-age'] = 60;
+      }
+      if (isset($variables['#cache']) && is_array($variables['#cache'])) {
+        $c2 =& $variables['#cache'];
+        $c2['contexts'] = array_values(array_unique(array_merge(
+          (array) ($c2['contexts'] ?? []),
+          ['timezone'],
+        )));
+        $c2['max-age'] = 60;
+      }
     }
   }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -926,59 +926,54 @@
   color: #6e7ef2;
 }
 
-.mel-event--v2 .mel-event-layout__main .mel-return-primary {
-  margin-bottom: 20px;
-  animation: mel-fade-in 0.4s ease;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .mel-event--v2 .mel-event-layout__main .mel-return-primary {
-    animation: none;
-  }
-}
-
-@keyframes mel-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.mel-event--v2 .mel-event-layout__main .mel-return-primary__label {
-  font-size: 12px;
-  font-weight: 600;
-  color: #6e7ef2;
-  margin-bottom: 6px;
-}
-
-.mel-event--v2 .mel-event-layout__main .mel-return-primary .mel-event-card {
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
-  transform: scale(1.02);
-}
-
-.mel-event--v2 .mel-event-layout__main .mel-return-grid {
+// Related events: fixed 3/2/1 columns; `.mel-grid--3col` beats `.mel-grid--events` auto-fit when both apply.
+.mel-grid--3col,
+.mel-grid--events.mel-grid--3col,
+.mel-grid.mel-grid--events.mel-grid--3col {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 16px;
 }
 
-.mel-event--v2 .mel-event-layout__main .mel-return-grid > * {
-  min-width: 0;
+@media (max-width: 1024px) {
+  .mel-grid--3col,
+  .mel-grid--events.mel-grid--3col,
+  .mel-grid.mel-grid--events.mel-grid--3col {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-.mel-event--v2 .mel-event-layout__main .mel-return-grid .mel-event-card {
+@media (max-width: 640px) {
+  .mel-grid--3col,
+  .mel-grid--events.mel-grid--3col,
+  .mel-grid.mel-grid--events.mel-grid--3col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mel-grid--3col .mel-event-card,
+.mel-grid--events.mel-grid--3col .mel-event-card,
+.mel-grid.mel-grid--events.mel-grid--3col .mel-event-card {
   width: 100%;
-  opacity: 0.92;
-  transition: opacity 0.2s ease;
+  height: 100%;
 }
 
-.mel-event--v2 .mel-event-layout__main .mel-return-grid .mel-event-card:hover {
-  opacity: 1;
+// Image wrapper: aspect; img fills and covers (avoids height drift in grid).
+.mel-grid--3col .mel-event-card__image,
+.mel-grid--events.mel-grid--3col .mel-event-card__image,
+.mel-grid.mel-grid--events.mel-grid--3col .mel-event-card__image {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  position: relative;
+}
+
+.mel-grid--3col .mel-event-card__image .mel-event-card__image-element,
+.mel-grid--events.mel-grid--3col .mel-event-card__image .mel-event-card__image-element,
+.mel-grid.mel-grid--events.mel-grid--3col .mel-event-card__image .mel-event-card__image-element {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .mel-save-reinforcement {

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
@@ -122,6 +122,11 @@
   width: 100%;
 }
 
+// Single line under a rail (homepage framing; reuses .mel-section__link).
+.mel-section__content-footer {
+  margin-top: mel.$mel-ds-space-md;
+}
+
 // Hero lives in `{% block hero %}` above `<main>`; first home rail is inside `.mel-page--home`.
 .mel-main .mel-page--home > .mel-section:first-of-type {
   padding-top: 12px;

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -171,6 +171,9 @@
           {{ recommendation_context.label }}
         </div>
       {% endif %}
+      {% if mel_tonight_urgency_label|default('')|trim|length > 0 %}
+        <p class="mel-card-reason mel-card-reason--tonight" role="status">{{ mel_tonight_urgency_label }}</p>
+      {% endif %}
       <h3 class="mel-event-card__title">{{ _title }}</h3>
 
       {% if _time %}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -413,15 +413,10 @@
               <p>{{ 'More events like this in your area'|t }}</p>
             </div>
 
-            {% set primary = mel_related_events|first %}
-            <div class="mel-return-primary">
-              <div class="mel-return-primary__label">{{ 'Recommended for you'|t }}</div>
-              {{ primary }}
-            </div>
-
-            <div class="mel-return-grid">
-              {% for event in mel_related_events|slice(1) %}
-                {{ event }}
+            {# .mel-event-grid is homepage-only (opacity:0 until skeleton.js sets data-loaded; omit here or cards stay invisible). #}
+            <div class="mel-grid mel-grid--events mel-grid--3col">
+              {% for item in mel_related_events %}
+                {{ item }}
               {% endfor %}
             </div>
 

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -56,7 +56,7 @@
         section_class: 'mel-section--discover',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Discover events'|t,
+        title: 'Find something you’ll love'|t,
         subtitle: 'Browse what’s happening near you.'|t,
         link_url: path('view.upcoming_events.page_events'),
         link_text: 'See all'|t,
@@ -66,15 +66,21 @@
     {% endif %}
 
     {% if mel_home_tonight_markup|trim %}
+      {% set mel_home_tonight_section_content %}
+        <div class="mel-section__discover-view">
+          {{ mel_home_tonight_markup }}
+        </div>
+        <div class="mel-section__content-footer">
+          <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-section__link">{{ 'See all upcoming events →'|t }}</a>
+        </div>
+      {% endset %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--time mel-section--tonight-urgent',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'On tonight'|t,
-        subtitle: 'Starting today — don\'t miss out.'|t,
-        link_url: path('view.upcoming_events.page_today'),
-        link_text: 'See tonight\'s events'|t,
-        content: mel_home_tonight_markup
+        title: 'Going out tonight?'|t,
+        subtitle: 'These events are happening soon — don’t miss out.'|t,
+        content: mel_home_tonight_section_content
       } %}
     {% endif %}
 


### PR DESCRIPTION
…ency display. Removed unused view mode, added sorting by promoted status, and updated block description. Implemented preprocessing for urgency labels based on event start and end times in the node template. Adjusted SCSS for event grid layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes homepage Views sorting/filtering (which affects what events are shown) and introduces time-dependent labels with short-lived caching that could impact render caching correctness/performance.
> 
> **Overview**
> **Homepage rails (`mel_home_events`) are retuned** to sort by `field_promoted` first and then event start time, and the *Tonight* window is tightened to start at `now` (not “today midnight”) while keeping “not ended” logic via filter group changes.
> 
> **Tonight teaser cards gain a dynamic urgency reason** (`Starts soon` / `Happening today`) via a new `hook_preprocess_views_view()` flag + `hook_preprocess_node()` computation, rendered in `mel-event-card.html.twig` with cache contexts updated (adds `timezone`) and `max-age` reduced when the label is present.
> 
> **Theme/layout tweaks**: front page copy and Tonight rail framing are updated (new footer link under the rail), related-events on event full page switches to a unified 3/2/1 responsive grid, and corresponding SCSS adds `.mel-grid--3col` plus a new `.mel-section__content-footer` style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50e1055da19f003e00b0fe51d307bf1e0c801a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->