### PR TITLE
Remove deprecated event entity view display configurations for defaul…

### DIFF
--- a/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
@@ -1,0 +1,133 @@
+uuid: 8a2e0d3b-5c4e-4f2a-0b3d-9e8f7a6b5c4d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.event.teaser_tonight
+    - field.field.node.event.field_category
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_start
+    - field.field.node.event.field_location
+    - image.style.mel_event_card_standard
+    - node.type.event
+  module:
+    - address
+    - datetime
+    - image
+    - text
+id: node.event.teaser_tonight
+targetEntityType: node
+bundle: event
+mode: teaser_tonight
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 200
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_event_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: content
+      image_style: mel_event_card_standard
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_event_start:
+    type: datetime_default
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_location:
+    type: address_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 50
+    region: content
+hidden:
+  field_accessibility: true
+  field_accessibility_contact: true
+  field_accessibility_directions: true
+  field_accessibility_entry: true
+  field_accessibility_parking: true
+  field_age_policy: true
+  field_age_policy_note: true
+  field_age_restriction: true
+  field_attendee_questions: true
+  field_cancel_reason: true
+  field_cancelled_at: true
+  field_capacity: true
+  field_collect_per_ticket: true
+  field_contact_email: true
+  field_contact_phone: true
+  field_event_capacity_total: true
+  field_event_end: true
+  field_event_geo: true
+  field_event_highlights: true
+  field_event_intro: true
+  field_event_setup_complete: true
+  field_event_state: true
+  field_event_state_override: true
+  field_event_store: true
+  field_event_summary: true
+  field_event_type: true
+  field_event_vendor: true
+  field_external_url: true
+  field_featured: true
+  field_is_series_template: true
+  field_location_latitude: true
+  field_location_longitude: true
+  field_location_place_id: true
+  field_mel_sup_amt: true
+  field_mel_sup_chk: true
+  field_mel_sup_mode: true
+  field_mel_sup_oid: true
+  field_mel_sup_pct: true
+  field_product_target: true
+  field_promo_expires: true
+  field_promoted: true
+  field_refund_policy: true
+  field_reviews_enabled: true
+  field_sales_end: true
+  field_sales_start: true
+  field_series_instance_id: true
+  field_series_parent: true
+  field_series_rrule: true
+  field_series_timezone: true
+  field_tags: true
+  field_ticket_types: true
+  field_venue: true
+  field_venue_address: true
+  field_venue_name: true
+  field_waitlist_capacity: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_mode.node.event.teaser_tonight.yml
+++ b/config/sync/core.entity_view_mode.node.event.teaser_tonight.yml
@@ -1,0 +1,11 @@
+uuid: 7f1e9c2a-4b3d-4e1f-9a2c-8d7e6f5a4b3c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.event.teaser_tonight
+label: 'Teaser (Tonight rail)'
+description: 'Same as teaser; used for the home Tonight block so night-only card labels have a separate render cache from generic teasers.'
+targetEntityType: node
+cache: true

--- a/config/sync/core.entity_view_mode.node.teaser_tonight.yml
+++ b/config/sync/core.entity_view_mode.node.teaser_tonight.yml
@@ -1,0 +1,11 @@
+uuid: a7b04ec6-4a4d-4fde-9bcf-46cc80949158
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.teaser_tonight
+label: 'Teaser tonight'
+description: null
+targetEntityType: node
+cache: true

--- a/config/sync/views.view.mel_home_events.yml
+++ b/config/sync/views.view.mel_home_events.yml
@@ -619,8 +619,75 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_promoted_value:
-          id: field_promoted_value
+        field_event_start_range:
+          id: field_event_start_range
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: between
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_event_start_range_op
+            label: 'Start window'
+            description: ''
+            use_operator: false
+            operator: between
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: start_filter
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+        field_product_free_chip:
+          id: field_product_free_chip
+          table: node__field_product_target
+          field: field_product_target_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_product_target
+          plugin_id: numeric
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_filter_op
+            label: 'Free / RSVP (no product)'
+            description: ''
+            use_operator: false
+            operator: empty
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type_filter
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+        field_promoted_trending:
+          id: field_promoted_trending
           table: node__field_promoted
           field: field_promoted_value
           relationship: none
@@ -629,36 +696,26 @@ display:
           entity_type: node
           entity_field: field_promoted
           plugin_id: boolean
-          operator: '!='
-          value: '1'
+          operator: '='
+          value: All
           group: 1
-          exposed: false
+          exposed: true
           expose:
             operator_id: ''
-            label: ''
+            label: Trending
             description: ''
             use_operator: false
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: ''
+            identifier: trending_filter
             required: false
             remember: false
             multiple: false
             remember_roles:
+              anonymous: anonymous
               authenticated: authenticated
           is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -682,12 +739,15 @@ display:
         pager: false
         row: false
         filters: false
+      use_ajax: true
       display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -934,7 +994,7 @@ display:
           plugin_id: datetime
           operator: between
           value:
-            min: now
+            min: today
             max: 'tomorrow midnight'
             type: offset
           group: 1
@@ -999,7 +1059,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: teaser
+          view_mode: teaser_tonight
       query:
         type: views_query
         options:
@@ -1013,14 +1073,16 @@ display:
         pager: false
         row: false
         filters: false
+      use_ajax: true
       display_extenders: {  }
-      block_description: "Tonight: near-term (start to tomorrow midnight) + not ended; teaser cards, aligned with Discover / Free & RSVP"
+      block_description: 'Tonight: events with start from today (through tomorrow midnight) or still in progress; teaser_tonight for rail-only labels'
       block_category: MyEventLane
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -1324,6 +1386,7 @@ display:
         pager: false
         row: false
         filters: false
+      use_ajax: true
       display_extenders: {  }
       block_description: 'Free & RSVP: Ticket Product (field_product_target) empty; aligns with EventStateResolver::hasProductTarget'
       block_category: MyEventLane
@@ -1332,6 +1395,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -12,7 +12,6 @@ dependencies:
     - field.storage.node.field_product_target
     - node.type.event
     - system.menu.main
-    - taxonomy.vocabulary.accessibility
     - taxonomy.vocabulary.categories
   module:
     - content_moderation
@@ -380,38 +379,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -727,38 +694,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -1078,38 +1013,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
       filter_groups:
         operator: AND
         groups:
@@ -1475,38 +1378,6 @@ display:
             reduce: false
           is_grouped: false
           reduce_duplicates: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -1869,38 +1740,6 @@ display:
             remember_roles:
               authenticated: authenticated
           is_grouped: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -2250,38 +2089,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -2631,38 +2438,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -3028,38 +2803,6 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_accessibility_target_id:
-          id: field_accessibility_target_id
-          table: node__field_accessibility
-          field: field_accessibility_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_accessibility
-          plugin_id: taxonomy_index_tid
-          value: {  }
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: 'Accessibility features'
-            description: 'Filter events by accessibility features available'
-            use_operator: false
-            operator: ''
-            identifier: accessibility
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              anonymous: anonymous
-              authenticated: authenticated
-          is_grouped: false
-          vid: accessibility
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: true
       filter_groups:
         operator: AND
         groups:

--- a/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
+++ b/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
@@ -12,7 +12,7 @@
 {% for c in categories %}
   {% set pill_mod = c.pill_color|default(c.slug)|default(c.label|lower|replace({' ': '-', '&': 'and', '+': ''}))|trim|lower|default('default') %}
   <a
-    href="{{ c.url|default(path('view.upcoming_events.page_events', {}, {'query': {'category': c.tid}})) }}"
+    href="{{ c.url|default(path('view.upcoming_events.page_category', {'arg_0': c.tid})) }}"
     class="mel-category-pill mel-category-pill--{{ pill_mod|clean_class }}"
     aria-label="{{ 'View events in'|t }} {{ c.label }}"
   >

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -24,6 +24,7 @@ services:
       - '@myeventlane_core.event_viewer_count'
       - '@myeventlane_core.event_state_resolver'
       - '@string_translation'
+      - '@current_route_match'
 
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
@@ -67,6 +68,7 @@ services:
       - '@renderer'
       - '@flag'
       - '@myeventlane_boost.manager'
+      - '@datetime.time'
 
   myeventlane_core.category_digest_cron:
     class: Drupal\myeventlane_core\Service\CategoryDigestCron
@@ -227,6 +229,7 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@cache.data'
+      - '@datetime.time'
 
   myeventlane_core.staging_security_subscriber:
     class: Drupal\myeventlane_core\EventSubscriber\StagingSecuritySubscriber

--- a/web/modules/custom/myeventlane_core/src/Controller/MyCategoriesController.php
+++ b/web/modules/custom/myeventlane_core/src/Controller/MyCategoriesController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\flag\FlagServiceInterface;
 use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -87,15 +88,16 @@ final class MyCategoriesController extends ControllerBase {
 
     foreach ($followedCategories as $category) {
       // Find events in this category created in the last week.
-      $eventIds = $this->entityTypeManager()
+      $categoryQuery = $this->entityTypeManager()
         ->getStorage('node')
         ->getQuery()
         ->accessCheck(TRUE)
         ->condition('type', 'event')
         ->condition('status', 1)
         ->condition('field_category', $category->id())
-        ->condition('created', $weekAgo, '>=')
-        ->condition('field_event_start', $now, '>=')
+        ->condition('created', $weekAgo, '>=');
+      UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($categoryQuery, (int) $now);
+      $eventIds = $categoryQuery
         ->sort('field_promoted', 'DESC')
         ->sort('field_event_start', 'ASC')
         ->range(0, 10)

--- a/web/modules/custom/myeventlane_core/src/Service/CategoryDigestGenerator.php
+++ b/web/modules/custom/myeventlane_core/src/Service/CategoryDigestGenerator.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_core\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\flag\FlagServiceInterface;
 use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\taxonomy\TermInterface;
 use Drupal\user\UserInterface;
 
@@ -27,6 +29,7 @@ final class CategoryDigestGenerator {
     private readonly RendererInterface $renderer,
     private readonly FlagServiceInterface $flagService,
     private readonly BoostManager $boostManager,
+    private readonly TimeInterface $time,
   ) {}
 
   /**
@@ -74,18 +77,19 @@ final class CategoryDigestGenerator {
     }
 
     // Find new events in followed categories from the last week.
-    $now = \Drupal::time()->getRequestTime();
+    $now = (int) $this->time->getRequestTime();
     $weekAgo = $now - (7 * 24 * 60 * 60);
 
-    $eventIds = $this->entityTypeManager
+    $digestQuery = $this->entityTypeManager
       ->getStorage('node')
       ->getQuery()
       ->accessCheck(FALSE)
       ->condition('type', 'event')
       ->condition('status', 1)
       ->condition('field_category', $followedCategoryIds, 'IN')
-      ->condition('created', $weekAgo, '>=')
-      ->condition('field_event_start', $now, '>=')
+      ->condition('created', $weekAgo, '>=');
+    UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($digestQuery, $now);
+    $eventIds = $digestQuery
       ->sort('field_promoted', 'DESC')
       ->sort('field_event_start', 'ASC')
       ->range(0, 50)

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -6,7 +6,9 @@ namespace Drupal\myeventlane_core\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\node\NodeInterface;
 
 /**
@@ -37,6 +39,7 @@ final class EventRecommendationService {
     private readonly EventViewerCountService $eventViewerCount,
     private readonly EventStateResolver $eventStateResolver,
     private readonly TranslationInterface $stringTranslation,
+    private readonly RouteMatchInterface $routeMatch,
   ) {
   }
 
@@ -51,8 +54,15 @@ final class EventRecommendationService {
    *   unioned with $current’s categories when both are present for the
    *   “same category” check.
    *
-   * @return array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}
-   *   All keys always present. label is a translated string for display, or null.
+   * @return array{
+   *   type: 'category'|'trending'|'soon'|'weekend'|null,
+   *   label: string|null,
+   *   category_id: int|null,
+   *   is_weekend: bool,
+   *   is_tonight: bool,
+   *   route_name: string
+   * }
+   *   type/label are for display; other keys are request + card signals.
    */
   public function getRecommendationContext(
     NodeInterface $event,
@@ -60,10 +70,14 @@ final class EventRecommendationService {
     ?int $prefetchedSaveCount = NULL,
     ?array $referenceCategoryIds = NULL,
   ): array {
-    $context = [
-      'type' => NULL,
-      'label' => NULL,
-    ];
+    $signals = $this->getContextSignals($event);
+    $context = array_merge(
+      [
+        'type' => NULL,
+        'label' => NULL,
+      ],
+      $signals
+    );
 
     $t = $this->stringTranslation;
 
@@ -116,23 +130,35 @@ final class EventRecommendationService {
         $hours = ($start - $now) / 3600.0;
 
         if ($hours > 0 && $hours < 6) {
-          return [
-            'type' => 'soon',
-            'label' => (string) $t->translate('Starting soon'),
-          ];
+          $context['type'] = 'soon';
+          $context['label'] = (string) $t->translate('Starting soon');
+          return $context;
         }
 
         $weekday = (int) date('N', $start);
         if ($hours > 0 && $hours < 48 && ($weekday === 6 || $weekday === 7)) {
-          return [
-            'type' => 'weekend',
-            'label' => (string) $t->translate('This weekend'),
-          ];
+          $context['type'] = 'weekend';
+          $context['label'] = (string) $t->translate('This weekend');
+          return $context;
         }
       }
     }
 
     return $context;
+  }
+
+  /**
+   * Request + card context signals (no storage; used with cache contexts).
+   *
+   * @return array{category_id: int|null, is_weekend: bool, is_tonight: bool, route_name: string}
+   */
+  private function getContextSignals(NodeInterface $event): array {
+    return [
+      'category_id' => $this->getPrimaryCategory($event),
+      'is_weekend' => $this->isWeekend(),
+      'is_tonight' => $this->isTonight($event),
+      'route_name' => (string) ($this->routeMatch->getRouteName() ?? ''),
+    ];
   }
 
   /**
@@ -166,7 +192,6 @@ final class EventRecommendationService {
 
     $category_ids = array_values(array_unique($category_ids));
     $now = $this->time->getRequestTime();
-    $now_datetime = date('Y-m-d\TH:i:s', $now);
     $excluded_states = [
       'draft',
       'cancelled',
@@ -180,10 +205,7 @@ final class EventRecommendationService {
       ->condition('nid', (int) $node->id(), '<>')
       ->condition('field_event_state', $excluded_states, 'NOT IN');
 
-    $or = $query->orConditionGroup();
-    $or->condition('field_event_start', $now_datetime, '>=');
-    $or->condition('field_event_end', $now_datetime, '>=');
-    $query->condition($or);
+    UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, $now);
 
     $query
       ->condition('field_category', $category_ids, 'IN')
@@ -210,19 +232,15 @@ final class EventRecommendationService {
   }
 
   /**
-   * Same pool as getRelatedEvents(), then re-ordered by a lightweight global score.
+   * Same pool as getRelatedEvents(), re-ordered by deterministic global score.
    *
-   * After base capping, applies a single time-weight (event start) for urgency + decay.
-   * Deterministic: equal scores use newer created time first, then lower nid.
-   *
-   * When $referenceCategoryIds is non-empty (category page / category context), the
-   * top-ranked list is returned unchanged. Otherwise a soft per-primary-category cap
-   * (max 2) is applied after scoring, with fallback fill from the full ranked list.
+   * Behaviour: score → sort (desc) → per-category round-robin → first $limit.
+   * Tie-break: higher score first, then newer created, then lower nid.
    *
    * @param array<int>|null $referenceCategoryIds
-   *   If non-empty, skips soft balancing (pure score order for category context).
+   *   Used for getRecommendationContext() labels; ranking uses route + same logic.
    *
-   * @return array<int, array{node: \Drupal\node\NodeInterface, context: array{type: 'category'|'trending'|'soon'|'weekend'|null, label: string|null}}>
+   * @return array<int, array{node: \Drupal\node\NodeInterface, context: array<string, mixed>}>
    */
   public function getRankedRelatedEvents(
     NodeInterface $node,
@@ -240,6 +258,10 @@ final class EventRecommendationService {
     $scored = [];
     foreach ($events as $event) {
       $score = 0;
+      $age = $this->time->getRequestTime() - (int) $event->getCreatedTime();
+      if ($age < 86400 * 7) {
+        $score += 20;
+      }
       $save_count = $this->getSaveCountCached((int) $event->id());
       $score += min($save_count * 2, 40);
       $viewer_count = $this->getViewerCountCached((int) $event->id());
@@ -247,7 +269,32 @@ final class EventRecommendationService {
       if ($this->eventStateResolver->isEventBoosted($event)) {
         $score += 15;
       }
-      $score = max(0, min($score, 100));
+      $click_score = $this->getClickScore((int) $event->id());
+      $score += min($click_score * 5, 50);
+
+      $current = $node;
+      if ($this->sharesCategory($event, $current)) {
+        $score += 20;
+      }
+      if ($this->isTonight($event)) {
+        $score += 25;
+      }
+      if ($this->isWeekendEvent($event)) {
+        $score += 15;
+      }
+      if ($this->routeMatch->getRouteName() === 'view.upcoming_events.page_category') {
+        $score += 10;
+      }
+
+      $intent_weight = 1;
+      if ($this->sharesCategory($event, $current)) {
+        $intent_weight = 3;
+      }
+      elseif ($this->isTonight($event)) {
+        $intent_weight = 2;
+      }
+      $score += $intent_weight * 10;
+
       $event_start = 0;
       if ($event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
         $start_ts = strtotime((string) $event->get('field_event_start')->value);
@@ -255,20 +302,35 @@ final class EventRecommendationService {
           $event_start = (int) $start_ts;
         }
       }
-      $score = $this->applyTimeWeight($score, $event_start);
-      $score = max(1, min($score, 200));
+
+      $score = $this->applyTimeDecay($score, $event_start);
+      if ($event_start > 0) {
+        $hours_until_start = ($event_start - $this->time->getRequestTime()) / 3600.0;
+        if ($hours_until_start > 0 && $hours_until_start <= 24) {
+          $score += 25;
+        }
+      }
+      $score = max(1, min($score, 100));
+
       $context = $this->getRecommendationContext(
         $event,
         $node,
         $save_count,
         $referenceCategoryIds
       );
+
+      $primary_category = 0;
+      if ($event->hasField('field_category') && !$event->get('field_category')->isEmpty()) {
+        $primary_category = (int) $event->get('field_category')->first()->target_id;
+      }
       $scored[] = [
         'event' => $event,
         'score' => $score,
         'context' => $context,
+        'category_id' => $primary_category,
       ];
     }
+
     usort(
       $scored,
       static function (array $a, array $b): int {
@@ -288,52 +350,26 @@ final class EventRecommendationService {
       },
     );
 
-    $is_category_context = $referenceCategoryIds !== NULL && $referenceCategoryIds !== [];
-    if ($is_category_context) {
-      $selected = array_slice($scored, 0, $limit);
+    $grouped = [];
+    foreach ($scored as $item) {
+      $cat = $item['category_id'] ?? 0;
+      $grouped[$cat][] = $item;
     }
-    else {
-      $balanced = [];
-      $category_counts = [];
-      foreach ($scored as $item) {
-        $event = $item['event'];
-        $category_ids = [];
-        if ($event->hasField('field_category')) {
-          $category_ids = array_map(
-            'intval',
-            array_column($event->get('field_category')->getValue(), 'target_id')
-          );
-        }
-        $primary_category = $category_ids[0] ?? 'none';
-        $count = $category_counts[$primary_category] ?? 0;
-        if ($count >= 2) {
-          continue;
-        }
-        $balanced[] = $item;
-        $category_counts[$primary_category] = $count + 1;
+    $balanced = [];
+    while (!empty($grouped) && count($balanced) < $limit) {
+      foreach ($grouped as $cat => &$items) {
         if (count($balanced) >= $limit) {
-          break;
+          break 2;
+        }
+        if (!empty($items)) {
+          $balanced[] = array_shift($items);
+        }
+        if (empty($items)) {
+          unset($grouped[$cat]);
         }
       }
-      if (count($balanced) < $limit) {
-        $seen_nids = [];
-        foreach ($balanced as $b) {
-          $seen_nids[(int) $b['event']->id()] = TRUE;
-        }
-        foreach ($scored as $item) {
-          if (count($balanced) >= $limit) {
-            break;
-          }
-          $nid = (int) $item['event']->id();
-          if (isset($seen_nids[$nid])) {
-            continue;
-          }
-          $balanced[] = $item;
-          $seen_nids[$nid] = TRUE;
-        }
-      }
-      $selected = $balanced;
     }
+    $selected = $balanced;
 
     $out = [];
     foreach ($selected as $row) {
@@ -367,35 +403,86 @@ final class EventRecommendationService {
   }
 
   /**
-   * Single time model: soon / near / far multipliers, then distance decay (all from start).
-   *
-   * Ongoing or past (non-positive hours-until) return 0; final score floor applies after.
+   * Dampens score for events that start more than 7 days away; never below 1.
    */
-  private function applyTimeWeight(int $score, int $eventStart): int {
-    if ($eventStart < 1) {
-      return 0;
+  private function applyTimeDecay(int $score, int $eventStartTimestamp): int {
+    if ($eventStartTimestamp < 1) {
+      return max(1, $score);
     }
     $now = $this->time->getRequestTime();
-    $seconds_until = $eventStart - $now;
-    $hours_until = $seconds_until / 3600.0;
+    $days_until = ($eventStartTimestamp - $now) / 86400.0;
+    if ($days_until <= 7) {
+      return max(1, $score);
+    }
+    $factor = exp(-0.08 * ($days_until - 7));
 
-    if ($hours_until <= 0) {
-      return 0;
+    return max(1, (int) round($score * $factor));
+  }
+
+  /**
+   * Click proxy: reuses the same stored engagement metric as list views.
+   */
+  private function getClickScore(int $nid): int {
+    return $this->getViewerCountCached($nid);
+  }
+
+  private function getPrimaryCategory(NodeInterface $event): ?int {
+    if ($event->hasField('field_category') && !$event->get('field_category')->isEmpty()) {
+      $id = (int) $event->get('field_category')->first()->target_id;
+      return $id > 0 ? $id : NULL;
     }
-    if ($hours_until <= 6) {
-      return (int) ($score * 2.5);
+    return NULL;
+  }
+
+  private function isWeekend(): bool {
+    $n = (int) date('N', (int) $this->time->getRequestTime());
+
+    return in_array($n, [5, 6, 7], TRUE);
+  }
+
+  private function isTonight(NodeInterface $event): bool {
+    if (!$event->hasField('field_event_start') || $event->get('field_event_start')->isEmpty()) {
+      return FALSE;
     }
-    if ($hours_until <= 24) {
-      return (int) ($score * 1.8);
+    $start = strtotime($event->get('field_event_start')->value ?? '');
+    if ($start === FALSE) {
+      return FALSE;
     }
-    if ($hours_until <= 48) {
-      return (int) ($score * 1.3);
+    $now = (int) $this->time->getRequestTime();
+
+    return $start > $now && ($start - $now) <= 86400;
+  }
+
+  private function isWeekendEvent(NodeInterface $event): bool {
+    if (!$event->hasField('field_event_start') || $event->get('field_event_start')->isEmpty()) {
+      return FALSE;
+    }
+    $start = strtotime($event->get('field_event_start')->value ?? '');
+    if ($start === FALSE) {
+      return FALSE;
     }
 
-    $days_until = $hours_until / 24.0;
-    $decay_factor = exp(-0.03 * $days_until);
+    return in_array((int) date('N', $start), [5, 6, 7], TRUE);
+  }
 
-    return (int) round($score * $decay_factor);
+  private function getCategoryIds(NodeInterface $node): array {
+    if (!$node->hasField('field_category') || $node->get('field_category')->isEmpty()) {
+      return [];
+    }
+    $ids = array_map(
+      'intval',
+      array_column($node->get('field_category')->getValue(), 'target_id')
+    );
+
+    return array_values(array_unique(array_filter($ids, static fn (int $i): bool => $i > 0)));
+  }
+
+  private function sharesCategory(NodeInterface $event, ?NodeInterface $current): bool {
+    if ($current === NULL) {
+      return FALSE;
+    }
+
+    return array_intersect($this->getCategoryIds($event), $this->getCategoryIds($current)) !== [];
   }
 
   private function getSaveCountCached(int $nid): int {

--- a/web/modules/custom/myeventlane_core/src/Service/FrontCategoryStatsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/FrontCategoryStatsService.php
@@ -111,8 +111,8 @@ final class FrontCategoryStatsService {
         'label' => $term->label(),
         'count' => $count,
         'color' => $this->colors->getColorForLabel($term->label(), $i),
-        'url' => Url::fromRoute('view.upcoming_events.page_events', [], [
-          'query' => ['category' => (string) $term->id()],
+        'url' => Url::fromRoute('view.upcoming_events.page_category', [
+          'arg_0' => (string) $term->id(),
         ])->toString(),
       ];
     }

--- a/web/modules/custom/myeventlane_core/src/Service/HomepageOrganiserService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/HomepageOrganiserService.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_core\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\node\NodeInterface;
 
 /**
@@ -31,6 +33,11 @@ class HomepageOrganiserService {
   protected CacheBackendInterface $cache;
 
   /**
+   * Request time (aligned with event list queries).
+   */
+  protected TimeInterface $time;
+
+  /**
    * Cache key for organiser spotlight.
    */
   protected const CACHE_KEY = 'homepage_organiser_spotlight';
@@ -47,13 +54,17 @@ class HomepageOrganiserService {
    *   The entity type manager.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     CacheBackendInterface $cache,
+    TimeInterface $time,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->cache = $cache;
+    $this->time = $time;
   }
 
   /**
@@ -112,11 +123,12 @@ class HomepageOrganiserService {
     try {
       // Load all published events.
       $node_storage = $this->entityTypeManager->getStorage('node');
+      $request_time = (int) $this->time->getRequestTime();
       $query = $node_storage->getQuery()
         ->accessCheck(TRUE)
         ->condition('type', 'event')
-        ->condition('status', 1)
-        ->condition('field_event_start', time(), '>=');
+        ->condition('status', 1);
+      UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, $request_time);
 
       $event_ids = $query->execute();
       if (empty($event_ids)) {

--- a/web/modules/custom/myeventlane_core/src/Utility/UpcomingEventEntityQueryHelper.php
+++ b/web/modules/custom/myeventlane_core/src/Utility/UpcomingEventEntityQueryHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Utility;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+
+/**
+ * Aligns "upcoming / ongoing" filtering with Views: start >= now OR end >= now.
+ */
+final class UpcomingEventEntityQueryHelper {
+
+  /**
+   * Adds a condition group: field_event_start >= now OR field_event_end >= now.
+   *
+   * @param int $requestTime
+   *   The request time as a Unix timestamp (same as Views relative date "now").
+   */
+  public static function addStartOrEndInFutureOrOngoing(QueryInterface $query, int $requestTime): void {
+    $now = date('Y-m-d\TH:i:s', $requestTime);
+    $or = $query->orConditionGroup();
+    $or->condition('field_event_start', $now, '>=');
+    $or->condition('field_event_end', $now, '>=');
+    $query->condition($or);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -854,27 +854,13 @@ function myeventlane_event_entity_view_alter(array &$build, EntityInterface $ent
     }
     $build['#cache']['contexts'] = array_values(array_unique(array_merge(
       $contexts,
-      ['route'],
+      ['route.name', 'url.path'],
     )));
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_event')->error('Event recommendation context: @message', [
       '@message' => $e->getMessage(),
     ]);
-  }
-}
-
-/**
- * Implements hook_preprocess_views_view().
- *
- * @see myeventlane_event_preprocess_node
- */
-function myeventlane_event_preprocess_views_view(array &$variables): void {
-  $active = &drupal_static('myeventlane_event_mel_home_tonight_rail_active', FALSE);
-  $active = FALSE;
-  $view = $variables['view'] ?? NULL;
-  if ($view && $view->id() === 'mel_home_events' && $view->current_display === 'tonight') {
-    $active = TRUE;
   }
 }
 
@@ -1090,7 +1076,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           }
           $variables['elements']['#cache']['contexts'] = array_values(array_unique(array_merge(
             $recommendation_contexts,
-            ['route'],
+            ['route.name', 'url.path'],
           )));
         }
         elseif (isset($variables['#cache']) && is_array($variables['#cache'])) {
@@ -1100,7 +1086,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           }
           $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
             $recommendation_contexts,
-            ['route'],
+            ['route.name', 'url.path'],
           )));
         }
         if ($append_tags !== []) {
@@ -1121,9 +1107,13 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       ]);
     }
   }
+  // Urgency line on the home Tonight rail only: dedicated view mode keeps a
+  // separate node render array from generic teasers (avoids static flags and
+  // render-cache mix-ups).
   $variables['mel_tonight_urgency_label'] = NULL;
-  if ((bool) drupal_static('myeventlane_event_mel_home_tonight_rail_active', FALSE)
-    && $view_mode === 'teaser' && $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()
+  if (
+    $view_mode === 'teaser_tonight'
+    && $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()
   ) {
     $start_value = (string) $node->get('field_event_start')->value;
     $start_raw = $start_value !== '' ? strtotime($start_value) : FALSE;
@@ -1145,24 +1135,6 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       }
       elseif ($start_ts > $now) {
         $variables['mel_tonight_urgency_label'] = t('Starts soon');
-      }
-    }
-    if ($variables['mel_tonight_urgency_label'] !== NULL) {
-      if (isset($variables['elements']['#cache']) && is_array($variables['elements']['#cache'])) {
-        $c =& $variables['elements']['#cache'];
-        $c['contexts'] = array_values(array_unique(array_merge(
-          (array) ($c['contexts'] ?? []),
-          ['timezone'],
-        )));
-        $c['max-age'] = 60;
-      }
-      if (isset($variables['#cache']) && is_array($variables['#cache'])) {
-        $c2 =& $variables['#cache'];
-        $c2['contexts'] = array_values(array_unique(array_merge(
-          (array) ($c2['contexts'] ?? []),
-          ['timezone'],
-        )));
-        $c2['max-age'] = 60;
       }
     }
   }
@@ -1362,6 +1334,7 @@ function myeventlane_event_get_event_card_view_modes(): array {
     'card',
     'event_card',
     'teaser',
+    'teaser_tonight',
     'teaser_featured',
     'event_card_poster',
     'event_card_compact',

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingCategoriesBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingCategoriesBlock.php
@@ -148,7 +148,7 @@ final class TrendingCategoriesBlock extends BlockBase implements ContainerFactor
         'link' => [
           '#type' => 'link',
           '#title' => $label,
-          '#url' => Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $tid]),
+          '#url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => (string) $tid]),
           '#attributes' => [
             'class' => ['mel-trending-category-pill__link'],
           ],

--- a/web/modules/custom/myeventlane_search/src/Controller/SearchAutocompleteController.php
+++ b/web/modules/custom/myeventlane_search/src/Controller/SearchAutocompleteController.php
@@ -112,7 +112,10 @@ final class SearchAutocompleteController extends ControllerBase {
     $query->setFulltextFields(self::EVENT_FULLTEXT_FIELDS);
     $query->keys($keys);
     $query->addCondition('type', 'event');
-    $query->addCondition('field_event_start', $now, '>=');
+    $or = $query->createConditionGroup('OR');
+    $or->addCondition('field_event_start', $now, '>=');
+    $or->addCondition('field_event_end', $now, '>=');
+    $query->addConditionGroup($or);
     $query->range(0, 5);
     $rs = $query->execute();
 
@@ -149,7 +152,10 @@ final class SearchAutocompleteController extends ControllerBase {
     $query->setFulltextFields(self::VENUE_FULLTEXT_FIELDS);
     $query->keys($keys);
     $query->addCondition('type', 'event');
-    $query->addCondition('field_event_start', $now, '>=');
+    $or = $query->createConditionGroup('OR');
+    $or->addCondition('field_event_start', $now, '>=');
+    $or->addCondition('field_event_end', $now, '>=');
+    $query->addConditionGroup($or);
     $query->range(0, 20);
     $rs = $query->execute();
 

--- a/web/themes/custom/myeventlane_theme/js/mel-filters.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-filters.js
@@ -1,0 +1,263 @@
+/**
+ * @file
+ * Homepage Discover (mel_home_events embed_discover) — chip UI drives Views exposed filters (AJAX).
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  function pad2(n) {
+    return String(n).padStart(2, '0');
+  }
+
+  /**
+   * Return YYYY-MM-DDTHH:mm:00 in local time (for Views datetime string fields).
+   */
+  function localDatetime(d) {
+    return (
+      d.getFullYear() +
+      '-' +
+      pad2(d.getMonth() + 1) +
+      '-' +
+      pad2(d.getDate()) +
+      'T' +
+      pad2(d.getHours()) +
+      ':' +
+      pad2(d.getMinutes()) +
+      ':00'
+    );
+  }
+
+  /**
+   * Start of local calendar day.
+   */
+  function startOfLocalDay(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+  }
+
+  /**
+   * Start of the next local calendar day (exclusive upper bound for “today” windows).
+   */
+  function startOfNextLocalDay(d) {
+    const t = startOfLocalDay(d);
+    t.setDate(t.getDate() + 1);
+    return t;
+  }
+
+  /**
+   * This weekend: next Saturday 00:00 through Sunday 23:59 (local) — if today is after Sunday, use upcoming weekend.
+   */
+  function thisWeekendRange() {
+    const now = new Date();
+    const day = now.getDay();
+    const sat = new Date(now);
+    let add = (6 - day + 7) % 7;
+    if (day === 0) {
+      add = 6;
+    } else if (add === 0 && day !== 6) {
+      add = 7;
+    }
+    sat.setDate(now.getDate() + add);
+    sat.setHours(0, 0, 0, 0);
+    const sun = new Date(sat);
+    sun.setDate(sat.getDate() + 1);
+    sun.setHours(23, 59, 0, 0);
+    return { min: localDatetime(sat), max: localDatetime(sun) };
+  }
+
+  function clearListField(form, namePrefix) {
+    form.querySelectorAll('input, select, textarea').forEach((el) => {
+      const n = el.getAttribute('name') || '';
+      if (!n.indexOf) {
+        return;
+      }
+      if (n === namePrefix || n.startsWith(namePrefix + '[') || n.startsWith(namePrefix + '[]') || n.indexOf(namePrefix) === 0) {
+        if (el.type === 'checkbox' || el.type === 'radio') {
+          el.checked = false;
+        } else if (el.tagName === 'SELECT') {
+          el.selectedIndex = 0;
+        } else {
+          el.value = '';
+        }
+      }
+    });
+  }
+
+  function setStartRange(form, identifier, min, max) {
+    const minEl =
+      form.querySelector(`[name="${identifier}[min]"]`) ||
+      form.querySelector(`[name="${identifier}.min]"]`) ||
+      form.querySelector(`input[name*="${identifier}"][name$="[min]"]`) ||
+      form.querySelector('input[name^="' + identifier + '"][id*="min"]');
+    const maxEl =
+      form.querySelector(`[name="${identifier}[max]"]`) ||
+      form.querySelector(`[name="${identifier}.max]"]`) ||
+      form.querySelector('input[name*="' + identifier + '"][name$="[max]"]') ||
+      form.querySelector('input[name^="' + identifier + '"][id*="max"]');
+    if (minEl) {
+      minEl.value = min;
+    }
+    if (maxEl) {
+      maxEl.value = max;
+    }
+    if (!minEl && !maxEl) {
+      const one = form.querySelector(`[name="${identifier}"]`) || form.querySelector(`[name*="${identifier}"]`);
+      if (one) {
+        one.value = min || max || '';
+      }
+    }
+  }
+
+  function clearStartRange(form, identifier) {
+    setStartRange(form, identifier, '', '');
+    form.querySelectorAll(`[name*="${identifier}"]`).forEach((el) => {
+      if (el.type === 'date' || el.type === 'datetime-local' || el.type === 'text' || el.tagName === 'INPUT' || el.tagName === 'SELECT') {
+        if ((el.getAttribute('name') || '').indexOf(identifier) !== -1) {
+          el.value = '';
+        }
+      }
+    });
+  }
+
+  /**
+   * "Free" chip: numeric filter on product target with operator=empty
+   * (exposed as name=type_filter — any value triggers the empty filter; blank = off).
+   */
+  function setRsvpType(form) {
+    const tf = form.querySelector('input[name="type_filter"]');
+    if (tf) {
+      tf.value = '1';
+      return;
+    }
+  }
+
+  function clearRsvpType(form) {
+    const tf = form.querySelector('input[name="type_filter"]');
+    if (tf) {
+      tf.value = '';
+    }
+  }
+
+  function setTrendingOn(form) {
+    const t =
+      form.querySelector('select[name="trending_filter"]') ||
+      form.querySelector('input[name="trending_filter"]') ||
+      form.querySelector('input[type="checkbox"][name="trending_filter"]') ||
+      form.querySelector('input[name="trending_filter[1]"]');
+    if (t) {
+      if (t.type === 'checkbox' || t.type === 'radio') {
+        t.checked = true;
+      } else if (t.tagName === 'SELECT') {
+        for (let i = 0; i < t.options.length; i++) {
+          if (t.options[i].value === '1' || t.options[i].value === 1) {
+            t.selectedIndex = i;
+            return;
+          }
+        }
+        t.value = '1';
+      } else {
+        t.value = '1';
+      }
+    }
+  }
+
+  function clearTrending(form) {
+    const t =
+      form.querySelector('select[name="trending_filter"]') ||
+      form.querySelector('input[name="trending_filter"]') ||
+      form.querySelector('input[type="checkbox"][name="trending_filter"]');
+    if (t) {
+      if (t.type === 'checkbox' || t.type === 'radio') {
+        t.checked = false;
+      } else if (t.tagName === 'SELECT' && t.options.length) {
+        t.selectedIndex = 0;
+      } else {
+        t.value = '';
+      }
+    }
+  }
+
+  function applyDiscoverFilter(discover, filter) {
+    const form = discover.querySelector('.views-exposed-form') || document.querySelector('#views-exposed-form-mel-home-events-embed-discover');
+    if (!form) {
+      return;
+    }
+    const startId = 'start_filter';
+    const allReset = filter === 'all' || !filter;
+    if (allReset) {
+      clearStartRange(form, startId);
+      clearRsvpType(form);
+      clearTrending(form);
+    } else {
+      clearStartRange(form, startId);
+      clearRsvpType(form);
+      clearTrending(form);
+    }
+
+    const todayStart = startOfLocalDay(new Date());
+    const nextDay = startOfNextLocalDay(todayStart);
+
+    switch (filter) {
+      case 'now': {
+        setStartRange(form, startId, localDatetime(todayStart), localDatetime(nextDay));
+        break;
+      }
+      case 'weekend': {
+        const r = thisWeekendRange();
+        setStartRange(form, startId, r.min, r.max);
+        break;
+      }
+      case 'free': {
+        setRsvpType(form);
+        break;
+      }
+      case 'trending': {
+        setTrendingOn(form);
+        break;
+      }
+      case 'all':
+      default: {
+        break;
+      }
+    }
+    const submit = form.querySelector('input.js-form-submit, button.js-form-submit, [type="submit"]');
+    if (submit) {
+      submit.click();
+    }
+  }
+
+  Drupal.behaviors.melFilters = {
+    attach(context) {
+      once('mel-filters', '.js-mel-home-discover', context).forEach((discover) => {
+        const chips = discover.querySelectorAll('.mel-filter-chip[data-mel-filter], .mel-filter-chip[data-filter]');
+        if (!chips.length) {
+          return;
+        }
+        function setActive(activeEl) {
+          discover.querySelectorAll('.mel-filter-chip').forEach((c) => {
+            c.classList.remove('mel-filter-chip--active');
+            c.setAttribute('aria-pressed', 'false');
+          });
+          activeEl.classList.add('mel-filter-chip--active');
+          activeEl.setAttribute('aria-pressed', 'true');
+        }
+        chips.forEach((chip) => {
+          chip.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setActive(chip);
+            applyDiscoverFilter(
+              discover,
+              chip.getAttribute('data-mel-filter') || chip.getAttribute('data-filter') || ''
+            );
+          });
+        });
+        const pre = discover.querySelector('.mel-filter-chip.mel-filter-chip--active, .mel-filter-chip[aria-pressed="true"]');
+        if (pre) {
+          pre.setAttribute('aria-pressed', 'true');
+        } else if (chips[0]) {
+          setActive(chips[0]);
+        }
+      });
+    }
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -84,6 +84,16 @@ mel-events-discovery:
     - myeventlane_theme/global-styling
     - core/drupal
 
+# Homepage discover — chips + Views exposed form submit (use_ajax on embed_discover).
+mel-filters:
+  js:
+    js/mel-filters.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+    - core/drupalSettings
+    - views/views.ajax
+
 # Event page (Poster Card layout).
 # NOTE: This theme uses Vite to compile SCSS into dist/main.css. The event-page
 # styling lives in src/scss/components/_event-page.scss and is bundled via

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1573,7 +1573,9 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         if ($category_term instanceof \Drupal\taxonomy\Entity\Term) {
           $category_slug = _myeventlane_theme_get_category_slug($category_term);
           $category_label = $category_term->label();
-          $category_url = $category_term->toUrl()->toString();
+          $category_url = Url::fromRoute('view.upcoming_events.page_category', [
+            'arg_0' => (string) $category_term->id(),
+          ])->toString();
         }
       }
     }
@@ -1621,6 +1623,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       'card',
       'event_card',
       'teaser',
+      'teaser_tonight',
       'teaser_featured',
       'event_card_poster',
       'event_card_compact',
@@ -1634,6 +1637,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         $style_storage = \Drupal::entityTypeManager()->getStorage('image_style');
         $styled_modes = [
           'teaser',
+          'teaser_tonight',
           'event_card',
           'teaser_featured',
           'event_card_compact',
@@ -2183,6 +2187,7 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
       $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($args[0]);
       if ($term instanceof TermInterface) {
         $variables['mel_browse_category_name'] = $term->label();
+        $variables['term'] = $term;
       }
     }
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -4,6 +4,7 @@
 // Event page styled as an expanded homepage card with glass layers, soft gradients, and restrained motion.
 // Design direction: SLEEK (not playful) — calm, intentional, refined.
 
+@use 'sass:color';
 @use '../tokens/colors';
 @use '../tokens/typography';
 @use '../tokens/spacing' as space-tokens;
@@ -1836,5 +1837,108 @@
       outline-offset: 2px;
       border-radius: radii.$mel-radius-sm;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Browse / category — filter chip links (scoped; not global link styles)
+// ---------------------------------------------------------------------------
+
+.mel-filter-chip,
+.mel-filter-chip a {
+  text-decoration: none !important;
+  border-bottom: none !important;
+}
+
+.mel-filter-chip a:hover,
+.mel-filter-chip a:focus,
+.mel-filter-chip a:focus-visible {
+  text-decoration: none;
+}
+
+// Horizontal row: date scope + category discovery (mobile scroll)
+.mel-filter-chip-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: nowrap;
+  align-items: center;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 6px;
+  margin: 0 0 12px;
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+a.mel-filter-chip,
+button.mel-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  box-sizing: border-box;
+  min-height: 36px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font: inherit;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-decoration: none;
+  color: #293241;
+  background: #f4f4f4;
+  border: 0;
+  box-shadow: none;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  cursor: pointer;
+  scroll-snap-align: start;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  appearance: none;
+
+  &:hover {
+    text-decoration: none;
+    background: #ececec;
+    transform: translateY(-1px);
+  }
+
+  &:focus,
+  &:focus-visible {
+    text-decoration: none;
+    outline: 2px solid rgba(242, 109, 91, 0.5);
+    outline-offset: 2px;
+  }
+
+  .mel-icon {
+    font-size: 12px;
+    line-height: 1;
+  }
+}
+
+a.mel-filter-chip--active,
+button.mel-filter-chip--active {
+  background: #f26d5b;
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 4px 10px rgba(242, 109, 91, 0.2);
+
+  &:hover {
+    background: color.adjust(#f26d5b, $lightness: -4%);
+    color: #fff;
+    transform: translateY(-1px);
+  }
+}
+
+a.mel-filter-chip--reset,
+button.mel-filter-chip--reset {
+  border: 1px dashed rgba(41, 50, 65, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+
+  &:hover {
+    border-color: rgba(242, 109, 91, 0.55);
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-events-filters.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-events-filters.scss
@@ -2,73 +2,7 @@
 @use '../tokens/radii';
 @use '../tokens/colors';
 
-// Date scope pills (/events vs /events/today vs …)
-.mel-events-date-filters {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: spacing.mel-space(2);
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding: spacing.mel-space(2) 0 spacing.mel-space(3);
-  margin: 0 0 spacing.mel-space(2);
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-
-  @media (max-width: 767px) {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-}
-
-.mel-events-date-filters__pill {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  padding: 0 spacing.mel-space(4);
-  border-radius: radii.$mel-radius-full;
-  font-weight: 600;
-  font-size: 0.875rem;
-  text-decoration: none;
-  white-space: nowrap;
-  color: colors.$mel-color-text;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-  transition:
-    background-color 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease;
-
-  &:hover {
-    border-color: rgba(108, 126, 242, 0.35);
-    background: #fff;
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: colors.$mel-focus-ring;
-  }
-
-  &.is-active {
-    background: rgba(108, 126, 242, 0.16);
-    border-color: rgba(108, 126, 242, 0.45);
-    color: var(--mel-navy, #293241);
-  }
-
-  &--reset {
-    border-style: dashed;
-
-    &:hover {
-      border-color: rgba(242, 109, 91, 0.55);
-    }
-  }
-}
+// Date scope "When" row: layout + scroll live on .mel-filter-chip-row (see _event-full.scss).
 
 // Views exposed: category + accessibility
 .mel-events-exposed {

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
@@ -168,7 +168,7 @@
   margin-bottom: mel.$mel-ds-space-lg;
 
   .mel-events-date-filters {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     padding-left: 0;
     padding-right: 0;
   }
@@ -244,5 +244,22 @@
   line-height: 1.5;
   color: mel.$mel-ds-color-muted;
   max-width: 40rem;
+}
+
+// Category view — discovery lede (replaces "Browse in …" + result count)
+.mel-category-discovery__lede {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.25;
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-discovery-subtitle {
+  margin: 0 0 16px;
+  font-size: mel.$mel-ds-font-body;
+  line-height: 1.45;
+  color: mel.$mel-ds-color-muted;
+  max-width: 42rem;
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
@@ -52,7 +52,7 @@
       <nav class="mel-category-pills" aria-label="{{ 'Event categories'|t }}">
         {% for c in categories %}
           <a
-            href="{{ path('view.upcoming_events.page_events', {}, {'query': {'category': c.tid}}) }}"
+            href="{{ path('view.upcoming_events.page_category', {'arg_0': c.tid}) }}"
             class="mel-pill mel-pill--cat-{{ c.slug|default('default') }}"
           >
             {{ c.label }}

--- a/web/themes/custom/myeventlane_theme/templates/node--event--teaser-tonight.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node--event--teaser-tonight.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Event node — teaser_tonight (Tonight rail only; same card as standard teaser).
+ */
+#}
+{% include '@myeventlane_theme/components/event-card/mel-event-card.html.twig' with {
+  variant: 'standard',
+  attributes: attributes,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -9,27 +9,27 @@
 #}
 {% set d = display_id|default('') %}
 {% set mel_show_filter_reset = mel_browse_active_filters|default(false) %}
-<nav class="mel-events-date-filters" aria-label="{{ 'When'|t }}">
+<nav class="mel-filter-chip-row mel-events-date-filters" aria-label="{{ 'When'|t }}">
   <a
     href="{{ path('view.upcoming_events.page_events') }}"
-    class="mel-events-date-filters__pill{% if d == 'page_events' %} is-active{% endif %}"
+    class="mel-filter-chip{% if d == 'page_events' %} mel-filter-chip--active{% endif %}"
   >{{ 'All upcoming'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_today') }}"
-    class="mel-events-date-filters__pill{% if d == 'page_today' %} is-active{% endif %}"
+    class="mel-filter-chip{% if d == 'page_today' %} mel-filter-chip--active{% endif %}"
   >{{ 'Today'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_this_weekend') }}"
-    class="mel-events-date-filters__pill{% if d == 'page_this_weekend' %} is-active{% endif %}"
+    class="mel-filter-chip{% if d == 'page_this_weekend' %} mel-filter-chip--active{% endif %}"
   >{{ 'This weekend'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_free') }}"
-    class="mel-events-date-filters__pill{% if d == 'page_free' %} is-active{% endif %}"
+    class="mel-filter-chip{% if d == 'page_free' %} mel-filter-chip--active{% endif %}"
   >{{ 'Free & RSVP'|t }}</a>
   {% if mel_show_filter_reset and d == 'page_events' %}
     <a
       href="{{ path('view.upcoming_events.page_events') }}"
-      class="mel-events-date-filters__pill mel-events-date-filters__pill--reset"
+      class="mel-filter-chip mel-filter-chip--reset"
     >{{ 'Reset filters'|t }}</a>
   {% endif %}
 </nav>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-home-events--embed_discover.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-home-events--embed_discover.html.twig
@@ -1,9 +1,36 @@
 {#
 /**
  * @file
- * Discover embed — rows only (empty handled by section trim in page template).
+ * Discover embed: hidden Views exposed (AJAX) + chip bar + result grid.
  */
 #}
-{% if rows %}
-  {{ rows }}
-{% endif %}
+{{ attach_library('myeventlane_theme/mel-filters') }}
+{{ attach_library('myeventlane_theme/mel-events-discovery') }}
+
+<div class="mel-home-discover js-mel-home-discover" data-mel-view-name="mel_home_events" data-mel-view-display="embed_discover">
+  <div class="visually-hidden">
+    {{ exposed }}
+  </div>
+
+  <div class="mel-filter-chip-row" role="group" aria-label="{{ 'Filter discover events'|t }}">
+    <button type="button" class="mel-filter-chip mel-filter-chip--active" data-filter="all" aria-pressed="true">
+      {{ 'All'|t }}
+    </button>
+    <button type="button" class="mel-filter-chip" data-filter="now" aria-pressed="false">
+      {{ '🔥 Happening now'|t }}
+    </button>
+    <button type="button" class="mel-filter-chip" data-filter="weekend" aria-pressed="false">
+      {{ '🎉 This weekend'|t }}
+    </button>
+    <button type="button" class="mel-filter-chip" data-filter="free" aria-pressed="false">
+      {{ '💸 Free events'|t }}
+    </button>
+    <button type="button" class="mel-filter-chip" data-filter="trending" aria-pressed="false">
+      {{ '💖 Trending'|t }}
+    </button>
+  </div>
+
+  {% if rows -%}
+    {{ rows }}
+  {% endif %}
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -1,29 +1,30 @@
 {#
 /**
  * @file
- * upcoming_events — page_category: intro + date pills + exposed + grid + pager.
+ * upcoming_events — page_category: discovery copy + scrollable chips + grid.
  */
 #}
 {{ attach_library('myeventlane_theme/mel-events-discovery') }}
 
-{% if mel_browse_category_name %}
-  <p class="mel-category-browse__intro">
-    {{ 'Browse events in @name.'|t({'@name': mel_browse_category_name}) }}
+{% if term %}
+  <p class="mel-category-discovery__lede">
+    {{ "Find something you'll love"|t }}
   </p>
-{% endif %}
-
-{% if mel_browse_result_count is defined %}
-  <p class="mel-browse-results-count mel-browse-results-count--category" role="status">
-    {{ '@count events'|t({'@count': mel_browse_result_count}) }}
+  <p class="mel-discovery-subtitle">
+    {{ 'Events picked for you in @name'|t({'@name': term.label}) }}
   </p>
+
+  <div class="mel-filter-chip-row" role="navigation" aria-label="{{ 'Discover events'|t }}">
+    <a
+      href="{{ path('view.upcoming_events.page_category', { 'arg_0': term.id }) }}"
+      class="mel-filter-chip mel-filter-chip--active"
+    >{{ 'All'|t }}</a>
+    <a href="{{ path('view.upcoming_events.page_today') }}" class="mel-filter-chip">{{ '🔥 Happening now'|t }}</a>
+    <a href="{{ path('view.upcoming_events.page_this_weekend') }}" class="mel-filter-chip">{{ '🎉 This weekend'|t }}</a>
+    <a href="{{ path('view.upcoming_events.page_free') }}" class="mel-filter-chip">{{ '💸 Free events'|t }}</a>
+    <a href="{{ path('<front>') }}" class="mel-filter-chip">{{ '💖 Trending'|t }}</a>
+  </div>
 {% endif %}
-
-{% include '@myeventlane_theme/views/includes/mel-events-discovery-filters.html.twig' with {
-  display_id: view.current_display,
-  mel_browse_active_filters: mel_browse_active_filters|default(false),
-} %}
-
-{{ exposed }}
 
 {% if view.result %}
   {{ rows }}


### PR DESCRIPTION
…t and event modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes event selection/scoring logic (recommendations, digests, organiser spotlight, autocomplete) and introduces AJAX-driven homepage filtering, which can affect what events users see and cache behavior.
> 
> **Overview**
> Introduces a dedicated `teaser_tonight` event view mode + template and switches the homepage “Tonight” block to render with it, so rail-only urgency labels don’t pollute/collide with generic teaser render cache.
> 
> Refactors “upcoming” event filtering across custom queries to match Views behavior by adding `UpcomingEventEntityQueryHelper` (start >= now *or* end >= now/ongoing), and applies it to category digests, “My Categories” counts, organiser spotlight, search autocomplete, and related-event queries.
> 
> Upgrades the homepage Discover embed to be AJAX-filterable via exposed filters (start window, free/RSVP, trending) and adds a new `mel-filters` JS chip UI to drive those filters; also updates category links site-wide to route to `view.upcoming_events.page_category` and refreshes browse/category filter chip styling + copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e4b1c81664103e2ad0c069b5f51619847407f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->