### PR TITLE
Update composer.json and composer.lock to upgrade drupal/commerce_str…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "drupal/commerce": "^3.0@beta",
     "drupal/commerce_paypal": "^2.0",
     "drupal/commerce_recurring": "^1.0@RC",
-    "drupal/commerce_stripe": "^1.0",
+    "drupal/commerce_stripe": "^2",
     "drupal/conditional_fields": "^4.0@alpha",
     "drupal/core-composer-scaffold": "^11.2",
     "drupal/core-project-message": "^11.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26aed5ae95ecd7ab569d779ab6b6ff62",
+    "content-hash": "e7fcd57523d6ff372e1b923825243f15",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2068,17 +2068,17 @@
         },
         {
             "name": "drupal/commerce",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/commerce.git",
-                "reference": "3.3.4"
+                "reference": "3.3.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/commerce-3.3.4.zip",
-                "reference": "3.3.4",
-                "shasum": "ca35edc7c1c39d419d388f8233eafc0a968a96df"
+                "url": "https://ftp.drupal.org/files/projects/commerce-3.3.5.zip",
+                "reference": "3.3.5",
+                "shasum": "fc970e106c47c47cb9ea1215c73115b1ed402e9a"
             },
             "require": {
                 "commerceguys/intl": "^2.0.6",
@@ -2114,8 +2114,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2148,7 +2148,7 @@
         },
         {
             "name": "drupal/commerce_number_pattern",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "require": {
                 "drupal/commerce": "*",
                 "drupal/commerce_store": "*",
@@ -2157,8 +2157,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2191,7 +2191,7 @@
         },
         {
             "name": "drupal/commerce_order",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "require": {
                 "drupal/commerce": "*",
                 "drupal/commerce_number_pattern": "*",
@@ -2205,8 +2205,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2239,7 +2239,7 @@
         },
         {
             "name": "drupal/commerce_payment",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "require": {
                 "drupal/commerce": "*",
                 "drupal/commerce_order": "*",
@@ -2249,8 +2249,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2283,17 +2283,17 @@
         },
         {
             "name": "drupal/commerce_paypal",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/commerce_paypal.git",
-                "reference": "2.1.1"
+                "reference": "2.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/commerce_paypal-2.1.1.zip",
-                "reference": "2.1.1",
-                "shasum": "c08e8a4c8e16cc9555ebdd2d1513f07aa39b8114"
+                "url": "https://ftp.drupal.org/files/projects/commerce_paypal-2.1.2.zip",
+                "reference": "2.1.2",
+                "shasum": "e35dca0ca7c8ac0c10f390f9eaf3502e7553e022"
             },
             "require": {
                 "drupal/commerce": "^2.40 || ^3",
@@ -2309,8 +2309,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.1",
-                    "datestamp": "1772020814",
+                    "version": "2.1.2",
+                    "datestamp": "1776953529",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2347,7 +2347,7 @@
         },
         {
             "name": "drupal/commerce_price",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "require": {
                 "drupal/commerce": "*",
                 "drupal/core": "^10.3 || ^11"
@@ -2355,8 +2355,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2484,7 +2484,7 @@
         },
         {
             "name": "drupal/commerce_store",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "require": {
                 "drupal/commerce": "*",
                 "drupal/commerce_price": "*",
@@ -2493,8 +2493,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "3.3.4",
-                    "datestamp": "1774453529",
+                    "version": "3.3.5",
+                    "datestamp": "1776700408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2527,35 +2527,36 @@
         },
         {
             "name": "drupal/commerce_stripe",
-            "version": "1.3.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/commerce_stripe.git",
-                "reference": "8.x-1.3"
+                "reference": "2.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/commerce_stripe-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "c875d8812faf772e37e59bc19f2e34841eb539a3"
+                "url": "https://ftp.drupal.org/files/projects/commerce_stripe-2.2.1.zip",
+                "reference": "2.2.1",
+                "shasum": "9c8469cafe966b659498778fa26103b325ab6491"
             },
             "require": {
-                "drupal/commerce": "^2.40 || ^3",
+                "drupal/commerce": "^3",
                 "drupal/commerce_payment": "*",
-                "drupal/core": "^9.3 || ^10 || ^11",
+                "drupal/core": "^10.3 || ^11",
                 "ext-curl": "*",
                 "php": ">=8.1",
-                "stripe/stripe-php": "^7.25 || ^15"
+                "stripe/stripe-php": "^15"
             },
             "require-dev": {
                 "drupal/advancedqueue": "^1.0",
-                "drush/drush": "^11.0 || ^12.0 || ^13.0"
+                "drupal/commerce_shipping": "^2.0 || ^3",
+                "drush/drush": "^12.0 || ^13.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1740200450",
+                    "version": "2.2.1",
+                    "datestamp": "1771369614",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2701,16 +2702,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "11.3.7",
+            "version": "11.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "bb36d7d09b0132185bd33be730ec2e6d35c2d627"
+                "reference": "d40f45fa436fb089cd54029d2dab387c3040fc2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/bb36d7d09b0132185bd33be730ec2e6d35c2d627",
-                "reference": "bb36d7d09b0132185bd33be730ec2e6d35c2d627",
+                "url": "https://api.github.com/repos/drupal/core/zipball/d40f45fa436fb089cd54029d2dab387c3040fc2c",
+                "reference": "d40f45fa436fb089cd54029d2dab387c3040fc2c",
                 "shasum": ""
             },
             "require": {
@@ -2868,13 +2869,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/11.3.7"
+                "source": "https://github.com/drupal/core/tree/11.3.8"
             },
-            "time": "2026-04-15T15:47:32+00:00"
+            "time": "2026-04-20T07:33:20+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "11.3.7",
+            "version": "11.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2918,13 +2919,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.7"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.8"
             },
             "time": "2026-02-10T11:39:53+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "11.3.7",
+            "version": "11.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -2959,13 +2960,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-project-message/tree/11.3.7"
+                "source": "https://github.com/drupal/core-project-message/tree/11.3.8"
             },
             "time": "2025-02-03T10:59:29+00:00"
         },
         {
             "name": "drupal/core-recipe-unpack",
-            "version": "11.3.7",
+            "version": "11.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recipe-unpack.git",
@@ -3003,29 +3004,29 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.3.7"
+                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.3.8"
             },
             "time": "2025-10-28T11:20:22+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "11.3.7",
+            "version": "11.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94"
+                "reference": "9c1fa4615a7542504be882eed0c6763b445fb852"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94",
-                "reference": "fb5d6475f4f564d5fa8a8846e4b5e1b97cdfeb94",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/9c1fa4615a7542504be882eed0c6763b445fb852",
+                "reference": "9c1fa4615a7542504be882eed0c6763b445fb852",
                 "shasum": ""
             },
             "require": {
                 "asm89/stack-cors": "~v2.3.0",
                 "composer/semver": "~3.4.4",
                 "doctrine/lexer": "~3.0.1",
-                "drupal/core": "11.3.7",
+                "drupal/core": "11.3.8",
                 "egulias/email-validator": "~4.0.4",
                 "guzzlehttp/guzzle": "~7.10.0",
                 "guzzlehttp/promises": "~2.3.0",
@@ -3087,9 +3088,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/11.3.7"
+                "source": "https://github.com/drupal/core-recommended/tree/11.3.8"
             },
-            "time": "2026-04-15T15:47:32+00:00"
+            "time": "2026-04-20T07:33:20+00:00"
         },
         {
             "name": "drupal/crop",
@@ -5567,17 +5568,17 @@
         },
         {
             "name": "drupal/twig_tweak",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/twig_tweak.git",
-                "reference": "3.4.1"
+                "reference": "3.4.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/twig_tweak-3.4.1.zip",
-                "reference": "3.4.1",
-                "shasum": "ceaa5ea8f357ce8827c728f22871265f0f7cd74f"
+                "url": "https://ftp.drupal.org/files/projects/twig_tweak-3.4.2.zip",
+                "reference": "3.4.2",
+                "shasum": "c31272a550c05981ca21b1eacc37abfe62cf2598"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11.0",
@@ -5591,8 +5592,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.4.1",
-                    "datestamp": "1748530577",
+                    "version": "3.4.2",
+                    "datestamp": "1776781834",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5612,10 +5613,6 @@
                 {
                     "name": "anybody",
                     "homepage": "https://www.drupal.org/user/291091"
-                },
-                {
-                    "name": "chesn0k",
-                    "homepage": "https://www.drupal.org/user/3650191"
                 },
                 {
                     "name": "chi",
@@ -6526,16 +6523,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.16",
+            "version": "v0.3.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2"
+                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/11e7d5f93803a2190b00e145142cb00a33d17ad2",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
                 "shasum": ""
             },
             "require": {
@@ -6579,9 +6576,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.16"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
             },
-            "time": "2026-03-23T14:35:33+00:00"
+            "time": "2026-04-20T16:07:33+00:00"
         },
         {
             "name": "league/container",
@@ -6787,16 +6784,16 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "682f1098a8fddbaf43edac2306a691c7ad508ec5"
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/682f1098a8fddbaf43edac2306a691c7ad508ec5",
-                "reference": "682f1098a8fddbaf43edac2306a691c7ad508ec5",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
                 "shasum": ""
             },
             "require": {
@@ -6853,7 +6850,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.1"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
             },
             "funding": [
                 {
@@ -6861,7 +6858,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-10T09:58:31+00:00"
+            "time": "2026-04-11T18:38:28+00:00"
         },
         {
             "name": "markbaker/complex",
@@ -7039,16 +7036,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.17.5",
+            "version": "v1.17.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f"
+                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/e19a8bd896b7f04941a38fd38a140c9a6531c84f",
-                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/b8b4184b1e6912669f9af155caef9050509d9f18",
+                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18",
                 "shasum": ""
             },
             "require": {
@@ -7061,7 +7058,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17.5-dev"
+                    "dev-master": "1.17.6-dev"
                 }
             },
             "autoload": {
@@ -7082,9 +7079,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.17.5"
+                "source": "https://github.com/mck89/peast/tree/v1.17.6"
             },
-            "time": "2026-03-15T10:47:07+00:00"
+            "time": "2026-04-24T08:04:05+00:00"
         },
         {
             "name": "mglaman/drupal-check",
@@ -7803,16 +7800,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.5.0",
+            "version": "5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba"
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/eecd31b885a1c8192f12738130f85bbc6e8906ba",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
                 "shasum": ""
             },
             "require": {
@@ -7906,9 +7903,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.5.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.7.0"
             },
-            "time": "2026-03-01T00:58:56+00:00"
+            "time": "2026-04-20T02:42:17+00:00"
         },
         {
             "name": "phpowermove/docblock",

--- a/web/modules/custom/myeventlane_core/myeventlane_core.info.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.info.yml
@@ -10,3 +10,4 @@ dependencies:
   - mel_ticket:mel_ticket
   - flag:flag
   - drupal:system
+  - drupal:views

--- a/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
@@ -119,3 +119,11 @@ myeventlane_core.organiser_login_switch:
     _title: 'Switch account'
   requirements:
     _user_is_logged_in: 'TRUE'
+
+# Category discovery chip listing fragment (AJAX; reuses upcoming_events displays).
+myeventlane_core.event_filter:
+  path: '/mel/filter-events'
+  defaults:
+    _controller: 'myeventlane_core.event_filter_controller:filter'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -26,6 +26,12 @@ services:
       - '@string_translation'
       - '@current_route_match'
 
+  myeventlane_core.event_filter_controller:
+    class: Drupal\myeventlane_core\Controller\EventFilterController
+    arguments:
+      - '@renderer'
+      - '@logger.channel.myeventlane_core'
+
   myeventlane_core.optional_service_resolver:
     class: Drupal\myeventlane_core\Service\OptionalServiceResolver
 

--- a/web/modules/custom/myeventlane_core/src/Controller/EventFilterController.php
+++ b/web/modules/custom/myeventlane_core/src/Controller/EventFilterController.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * HTML fragments for MEL category discovery chips (uses existing view displays; no new tables).
+ */
+final class EventFilterController extends ControllerBase {
+
+  public function __construct(
+    private readonly RendererInterface $renderer,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Returns rendered rows + pager for the category context (AJAX list swap).
+   */
+  public function filter(Request $request): Response {
+    $type = (string) $request->query->get('type', 'all');
+    $category = $request->query->get('category');
+    if ($category === NULL || $category === '') {
+      $this->logger->warning('MEL chip filter request missing category query param.');
+      return new Response('Bad Request', 400);
+    }
+    $tid = (string) $category;
+    if (!is_numeric($tid)) {
+      $this->logger->warning('MEL chip filter invalid category: @v', ['@v' => $tid]);
+      return new Response('Bad Request', 400);
+    }
+
+    $request->attributes->set('mel_chip_listing_fragment', TRUE);
+    if ($type === 'trending') {
+      $request->attributes->set('mel_chip_trending', TRUE);
+    }
+
+    try {
+      $view = Views::getView('upcoming_events');
+      if ($view === NULL) {
+        $this->logger->error('MEL chip filter: view upcoming_events is missing.');
+        return new Response('Not Found', 404);
+      }
+
+      $build = $this->buildView($view, $type, $tid);
+      $html = (string) $this->renderer->renderRoot($build);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('MEL chip filter failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return new Response('Error', 500);
+    }
+    finally {
+      $request->attributes->remove('mel_chip_listing_fragment');
+      $request->attributes->remove('mel_chip_trending');
+    }
+
+    return new Response($html, 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   A render array with a #type view element.
+   */
+  private function buildView(ViewExecutable $view, string $type, string $tid): array {
+    $allowed = [
+      'all' => 'all',
+      'now' => 'now',
+      'weekend' => 'weekend',
+      'free' => 'free',
+      'trending' => 'trending',
+    ];
+    if (!isset($allowed[$type])) {
+      $type = 'all';
+    }
+
+    switch ($type) {
+      case 'now':
+        $view->setDisplay('page_today');
+        $view->setExposedInput(['category' => [$tid]]);
+
+        return $this->viewElement($view, 'page_today', []);
+
+      case 'weekend':
+        $view->setDisplay('page_this_weekend');
+        $view->setExposedInput(['category' => [$tid]]);
+
+        return $this->viewElement($view, 'page_this_weekend', []);
+
+      case 'free':
+        $view->setDisplay('page_free');
+        $view->setExposedInput(['category' => [$tid]]);
+
+        return $this->viewElement($view, 'page_free', []);
+
+      case 'trending':
+        $view->setDisplay('page_category');
+
+        return $this->viewElement($view, 'page_category', [$tid]);
+
+      case 'all':
+      default:
+        $view->setDisplay('page_category');
+
+        return $this->viewElement($view, 'page_category', [$tid]);
+    }
+  }
+
+  /**
+   * @param array<int|string> $args
+   *   Arguments passed to ViewExecutable::preview().
+   *
+   * @return array<string, mixed>
+   */
+  private function viewElement(ViewExecutable $view, string $display_id, array $args): array {
+    return [
+      '#type' => 'view',
+      '#name' => 'upcoming_events',
+      '#view' => $view,
+      '#display_id' => $display_id,
+      '#arguments' => $args,
+      '#embed' => TRUE,
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -44,6 +44,38 @@ final class EventRecommendationService {
   }
 
   /**
+   * Suggests the default discovery chip (category listing / homepage context).
+   *
+   * Uses `field_event_type` (not Commerce ticket rows): `rsvp` maps to the “free” chip.
+   */
+  public function getDefaultChip(?NodeInterface $context = NULL): string {
+    $now = $this->time->getRequestTime();
+
+    if (!$context) {
+      return 'all';
+    }
+
+    $save_count = $this->eventSaveCount->getSaveCount((int) $context->id());
+    if ($save_count > 10) {
+      return 'trending';
+    }
+
+    if ($context->hasField('field_event_start') && !$context->get('field_event_start')->isEmpty()) {
+      $start = strtotime((string) $context->get('field_event_start')->value);
+      if ($start > $now && ($start - $now) < 21600) {
+        return 'now';
+      }
+    }
+
+    if ($context->hasField('field_event_type') && !$context->get('field_event_type')->isEmpty()
+      && (string) $context->get('field_event_type')->value === 'rsvp') {
+      return 'free';
+    }
+
+    return 'all';
+  }
+
+  /**
    * Explains why an event card is surfaced (home, list, event page, search).
    *
    * @param int|null $prefetchedSaveCount

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1436,3 +1436,23 @@ function _myeventlane_event_format_price_simple(string $number, string $currency
   }
   return $formatted_number . ' ' . $currency_code;
 }
+
+/**
+ * Implements hook_preprocess_views_view() for default discovery chip.
+ */
+function myeventlane_event_preprocess_views_view(array &$variables): void {
+  if (($variables['view'] ?? NULL)?->id() !== 'upcoming_events') {
+    return;
+  }
+  if (($variables['view']?->current_display ?? '') !== 'page_category') {
+    return;
+  }
+  /** @var \Drupal\myeventlane_core\Service\EventRecommendationService $service */
+  $service = \Drupal::service('myeventlane_core.event_recommendation');
+  $context = NULL;
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface && $node->bundle() === 'event') {
+    $context = $node;
+  }
+  $variables['default_chip'] = $service->getDefaultChip($context);
+}

--- a/web/modules/custom/myeventlane_views/myeventlane_views.module
+++ b/web/modules/custom/myeventlane_views/myeventlane_views.module
@@ -52,9 +52,35 @@ function myeventlane_views_views_post_execute(ViewExecutable $view): void {
  * - Ensures null field values are converted to empty strings.
  */
 function myeventlane_views_views_pre_render(ViewExecutable $view): void {
+  $request = \Drupal::request();
+  if ($request->attributes->get('mel_chip_trending') && $view->id() === 'upcoming_events' && !empty($view->result)) {
+    /** @var \Drupal\myeventlane_core\Service\EventSaveCountService $save */
+    $save = \Drupal::service('myeventlane_core.event_save_count');
+    usort($view->result, function ($a, $b) use ($save) {
+      $id_a = isset($a->_entity) ? (int) $a->_entity->id() : 0;
+      $id_b = isset($b->_entity) ? (int) $b->_entity->id() : 0;
+      $s_a = $id_a > 0 ? $save->getSaveCount($id_a) : 0;
+      $s_b = $id_b > 0 ? $save->getSaveCount($id_b) : 0;
+      if ($s_a !== $s_b) {
+        return $s_b <=> $s_a;
+      }
+      $promo_a = 0;
+      $promo_b = 0;
+      if (isset($a->_entity) && $a->_entity->hasField('field_promoted') && !$a->_entity->get('field_promoted')->isEmpty()) {
+        $promo_a = (int) $a->_entity->get('field_promoted')->value;
+      }
+      if (isset($b->_entity) && $b->_entity->hasField('field_promoted') && !$b->_entity->get('field_promoted')->isEmpty()) {
+        $promo_b = (int) $b->_entity->get('field_promoted')->value;
+      }
+      if ($promo_a !== $promo_b) {
+        return $promo_b - $promo_a;
+      }
+      return 0;
+    });
+  }
   // Sort upcoming_events and mel_home_events: featured first, preserve
   // start-date order within ties (same as public discovery).
-  if (in_array($view->id(), ['upcoming_events', 'mel_home_events'], TRUE) && !empty($view->result)) {
+  elseif (in_array($view->id(), ['upcoming_events', 'mel_home_events'], TRUE) && !empty($view->result)) {
     usort($view->result, function ($a, $b) {
       $promo_a = 0;
       $promo_b = 0;

--- a/web/themes/custom/myeventlane_theme/js/mel-chips.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-chips.js
@@ -1,0 +1,68 @@
+/**
+ * @file
+ * AJAX chip filter for category discovery (no full page reload).
+ */
+(function (Drupal, once, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.melChips = {
+    attach(context) {
+      once('mel-chips-bar', '[data-chip-bar]', context).forEach((bar) => {
+        const categoryTid = bar.getAttribute('data-category-tid');
+        if (!categoryTid) {
+          return;
+        }
+
+        const getRegion = () => {
+          if (bar.nextElementSibling && bar.nextElementSibling.hasAttribute('data-mel-filter-results')) {
+            return bar.nextElementSibling;
+          }
+          const root = bar.closest('.view') || document;
+          return root.querySelector('[data-mel-filter-results]');
+        };
+
+        bar.querySelectorAll('.mel-chip').forEach((btn) => {
+          btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const current = e.currentTarget;
+            bar.querySelectorAll('.mel-chip').forEach((c) => c.classList.remove('is-active'));
+            current.classList.add('is-active');
+            const type = current.getAttribute('data-chip') || 'all';
+            const region = getRegion();
+            if (!region) {
+              return;
+            }
+            region.classList.add('is-loading');
+            const url = new URL('/mel/filter-events', window.location.origin);
+            url.searchParams.set('type', type);
+            url.searchParams.set('category', categoryTid);
+            fetch(url.toString(), { credentials: 'same-origin' })
+              .then((res) => {
+                if (!res.ok) {
+                  throw new Error('MEL filter failed: ' + res.status);
+                }
+                return res.text();
+              })
+              .then((html) => {
+                const tmp = document.createElement('div');
+                tmp.innerHTML = html;
+                const next = tmp.querySelector('[data-mel-filter-results]');
+                if (next) {
+                  region.replaceWith(next);
+                  Drupal.attachBehaviors(next, drupalSettings);
+                } else {
+                  region.classList.remove('is-loading');
+                }
+              })
+              .catch((err) => {
+                if (window.console && console.error) {
+                  console.error(err);
+                }
+                region.classList.remove('is-loading');
+              });
+          });
+        });
+      });
+    }
+  };
+})(Drupal, once, drupalSettings);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -84,6 +84,15 @@ mel-events-discovery:
     - myeventlane_theme/global-styling
     - core/drupal
 
+# Category discovery chip bar (AJAX, no full page reload).
+mel-chips:
+  js:
+    js/mel-chips.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+    - core/drupalSettings
+
 # Homepage discover — chips + Views exposed form submit (use_ajax on embed_discover).
 mel-filters:
   js:

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2190,6 +2190,7 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
         $variables['term'] = $term;
       }
     }
+    $variables['mel_chip_listing_fragment'] = (bool) \Drupal::request()->attributes->get('mel_chip_listing_fragment');
   }
 
   if ($view->id() === 'upcoming_events' && in_array($view->current_display, ['page_events', 'page_category', 'page_today', 'page_this_weekend', 'page_free'], TRUE)) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_chips.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_chips.scss
@@ -87,6 +87,24 @@
   }
 }
 
+// Category discovery chip bar: premium accent + smooth interaction (MEL v2)
+.mel-chip-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2);
+  margin-bottom: spacing.mel-space(4);
+}
+
+.mel-chip-bar .mel-chip {
+  transition: all 0.2s ease;
+}
+
+.mel-chip-bar .mel-chip.is-active {
+  background: #f26d5b;
+  border-color: #f26d5b;
+  color: #fff;
+}
+
 // Primary accent
 .mel-chip--primary {
   background: colors.$mel-color-primary;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -933,6 +933,16 @@
   opacity: 1;
 }
 
+// MEL category chip AJAX: instant feedback (matches discovery listing wrapper).
+.view [data-mel-filter-results] {
+  transition: opacity 0.2s ease;
+}
+
+.view [data-mel-filter-results].is-loading {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mel-skeleton,
   .mel-event-card--skeleton .mel-skeleton {

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -1,42 +1,76 @@
 {#
 /**
  * @file
- * upcoming_events — page_category: discovery copy + scrollable chips + grid.
+ * upcoming_events — page_category: discovery copy + chip bar + grid.
  */
 #}
-{{ attach_library('myeventlane_theme/mel-events-discovery') }}
-
-{% if term %}
-  <p class="mel-category-discovery__lede">
-    {{ "Find something you'll love"|t }}
-  </p>
-  <p class="mel-discovery-subtitle">
-    {{ 'Events picked for you in @name'|t({'@name': term.label}) }}
-  </p>
-
-  <div class="mel-filter-chip-row" role="navigation" aria-label="{{ 'Discover events'|t }}">
-    <a
-      href="{{ path('view.upcoming_events.page_category', { 'arg_0': term.id }) }}"
-      class="mel-filter-chip mel-filter-chip--active"
-    >{{ 'All'|t }}</a>
-    <a href="{{ path('view.upcoming_events.page_today') }}" class="mel-filter-chip">{{ '🔥 Happening now'|t }}</a>
-    <a href="{{ path('view.upcoming_events.page_this_weekend') }}" class="mel-filter-chip">{{ '🎉 This weekend'|t }}</a>
-    <a href="{{ path('view.upcoming_events.page_free') }}" class="mel-filter-chip">{{ '💸 Free events'|t }}</a>
-    <a href="{{ path('<front>') }}" class="mel-filter-chip">{{ '💖 Trending'|t }}</a>
-  </div>
+{% if not mel_chip_listing_fragment|default(false) %}
+  {{ attach_library('myeventlane_theme/mel-events-discovery') }}
+  {{ attach_library('myeventlane_theme/mel-chips') }}
 {% endif %}
 
-{% if view.result %}
-  {{ rows }}
-{% else %}
-  <div class="mel-empty-state mel-empty-state--listing">
-    <div class="mel-empty-state__image">
-      <img src="{{ base_path }}{{ directory }}/images/mel/empty/mel-empty-events.png" alt="" role="presentation" width="240" height="240" loading="lazy" onerror="this.style.display='none'">
+{% if mel_chip_listing_fragment|default(false) %}
+  <div data-mel-filter-results>
+    <div class="view-content" data-mel-chip-listing>
+    {% if view.result %}
+      {{ rows }}
+    {% else %}
+      {{ empty }}
+    {% endif %}
     </div>
-    <h3 class="mel-empty-state__title">{{ 'No events in this category'|t }}</h3>
-    <p class="mel-empty-state__text">{{ 'Check back soon for new events, or browse other categories.'|t }}</p>
-    <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-btn mel-btn-accent">{{ 'Browse all events'|t }}</a>
+    {{ pager }}
+  </div>
+{% else %}
+  {% if term %}
+    <p class="mel-category-discovery__lede">
+      {{ "Find something you'll love"|t }}
+    </p>
+    <p class="mel-discovery-subtitle">
+      {{ 'Events picked for you in @name'|t({'@name': term.label}) }}
+    </p>
+
+    <div
+      class="mel-chip-bar"
+      data-chip-bar
+      data-category-tid="{{ term.id }}"
+    >
+      {% set chips = {
+        'all': 'All',
+        'now': '🔥 Happening now',
+        'weekend': '🎉 This weekend',
+        'free': '💸 Free events',
+        'trending': '💖 Trending'
+      } %}
+
+      {% for key, label in chips %}
+        <button
+          type="button"
+          class="mel-chip{{ key == (default_chip|default('all')) ? ' is-active' }}"
+          data-chip="{{ key }}"
+        >
+          {{ label|t }}
+        </button>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <div data-mel-filter-results>
+  {% if view.result %}
+    <div class="view-content" data-mel-chip-listing>
+    {{ rows }}
+    </div>
+  {% else %}
+    <div class="view-content" data-mel-chip-listing>
+    <div class="mel-empty-state mel-empty-state--listing">
+      <div class="mel-empty-state__image">
+        <img src="{{ base_path }}{{ directory }}/images/mel/empty/mel-empty-events.png" alt="" role="presentation" width="240" height="240" loading="lazy" onerror="this.style.display='none'">
+      </div>
+      <h3 class="mel-empty-state__title">{{ 'No events in this category'|t }}</h3>
+      <p class="mel-empty-state__text">{{ 'Check back soon for new events, or browse other categories.'|t }}</p>
+      <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-btn mel-btn-accent">{{ 'Browse all events'|t }}</a>
+    </div>
+    </div>
+  {% endif %}
+  {{ pager }}
   </div>
 {% endif %}
-
-{{ pager }}


### PR DESCRIPTION
…ipe to version 2, drupal/commerce to version 3.3.5, and drupal/commerce_paypal to version 2.1.2, along with corresponding updates to other related packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: upgrades payment-related dependencies (Commerce/Stripe/PayPal) and introduces a new AJAX endpoint plus custom view sorting, which could affect checkout integrations and event listing behavior if assumptions about Views displays/params change.
> 
> **Overview**
> Upgrades key dependencies, notably `drupal/commerce` to `3.3.5`, `drupal/commerce_paypal` to `2.1.2`, and **bumps `drupal/commerce_stripe` from `^1` to `^2`** (with updated core/Stripe PHP requirements reflected in `composer.lock`).
> 
> Adds an **AJAX-powered “discovery chips” filter** for category listings: introduces `/mel/filter-events` (`EventFilterController`) to return rendered `upcoming_events` view fragments (rows + pager), updates the `upcoming_events--page-category` Twig template to render a chip bar and swapable results region, and adds a new theme library (`mel-chips.js` + small SCSS) for client-side fetching/loading states.
> 
> Extends Views integration to support the chip UX: `myeventlane_event` sets a `default_chip` variable for `upcoming_events.page_category`, and `myeventlane_views` adds a request-flagged “trending” sort that orders results by save count (then promoted) when the controller marks the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb7ead15c5218991d377ee9b9bde7ef761ef59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->