### PR TITLE
Refactor media query breakpoints in _event-full.scss for improved res…

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -936,7 +936,7 @@
   gap: 16px;
 }
 
-@media (max-width: 1024px) {
+@media (width <= 1024px) {
   .mel-grid--3col,
   .mel-grid--events.mel-grid--3col,
   .mel-grid.mel-grid--events.mel-grid--3col {
@@ -944,7 +944,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (width <= 640px) {
   .mel-grid--3col,
   .mel-grid--events.mel-grid--3col,
   .mel-grid.mel-grid--events.mel-grid--3col {
@@ -1844,10 +1844,10 @@
 // Browse / category — filter chip links (scoped; not global link styles)
 // ---------------------------------------------------------------------------
 
-.mel-filter-chip,
-.mel-filter-chip a {
-  text-decoration: none !important;
-  border-bottom: none !important;
+.mel-event--v2 .mel-filter-chip,
+.mel-event--v2 .mel-filter-chip a {
+  text-decoration: none;
+  border-bottom: none;
 }
 
 .mel-filter-chip a:hover,


### PR DESCRIPTION
…ponsiveness and update filter chip styles for specific event version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that updates media query syntax and narrows filter chip link overrides to `.mel-event--v2`. Main risk is minor visual regressions at responsive breakpoints or differences where legacy pages relied on the previous unscoped chip styles.
> 
> **Overview**
> **Responsive related-events grid:** switches the `@media (max-width: ...)` breakpoints to CSS range queries (`@media (width <= ...)`) for the fixed 3/2/1-column `.mel-grid--3col` layout.
> 
> **Filter chip styling:** limits the `text-decoration`/`border-bottom` link reset for `.mel-filter-chip` to `.mel-event--v2` and removes the previous `!important` overrides, reducing unintended global impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc3a17d7c73e615db250ea37a7ecaf2fd773cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->