### PR TITLE
Global SCSS cleanup: media queries + remove !important

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/_tokens.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/_tokens.scss
@@ -9,7 +9,7 @@
 .mel-text-coral { color: var(--mel-coral); }
 
 .visually-hidden {
-  position: absolute !important;
+  position: absolute;
   height: 1px; width: 1px;
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);

--- a/web/themes/custom/myeventlane_theme/src/scss/auth-pages.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/auth-pages.scss
@@ -27,7 +27,7 @@ $mel-auth-break-mobile: 900px;
   display: grid;
   grid-template-columns: 1fr 1fr;
 
-  @media (max-width: $mel-auth-break-mobile) {
+  @media (width <= $mel-auth-break-mobile) {
     grid-template-columns: 1fr;
   }
 
@@ -66,7 +66,7 @@ $mel-auth-break-mobile: 900px;
       margin-right: auto;
       padding: spacing.mel-space(3);
 
-      @media (max-width: $mel-auth-break-mobile) {
+      @media (width <= $mel-auth-break-mobile) {
         padding: spacing.mel-space(3) spacing.mel-space(2);
       }
     }
@@ -77,7 +77,7 @@ $mel-auth-break-mobile: 900px;
     position: relative;
     background: colors.$mel-color-bg;
 
-    @media (max-width: $mel-auth-break-mobile) {
+    @media (width <= $mel-auth-break-mobile) {
       display: none;
     }
 
@@ -119,13 +119,13 @@ $mel-auth-break-mobile: 900px;
     box-shadow: shadows.$mel-shadow-lg;
     padding: spacing.mel-space(6);
 
-    @media (max-width: $mel-auth-break-mobile) {
+    @media (width <= $mel-auth-break-mobile) {
       padding: spacing.mel-space(4) spacing.mel-space(3);
     }
   }
 
   // -------------------------------------------------------------------------
-  // MEL form styles nested under .user-form-page (no !important)
+  // MEL form styles nested under .user-form-page (no)
   // -------------------------------------------------------------------------
 
   .mel-auth-form-wrapper,
@@ -238,7 +238,7 @@ $mel-auth-break-mobile: 900px;
     gap: spacing.mel-space(3);
     align-items: center;
 
-    @media (max-width: $mel-auth-break-mobile) {
+    @media (width <= $mel-auth-break-mobile) {
       flex-direction: column;
       align-items: stretch;
     }
@@ -268,7 +268,7 @@ $mel-auth-break-mobile: 900px;
     background-color: colors.$mel-color-secondary;
     color: colors.$mel-color-on-primary;
 
-    @media (min-width: $mel-auth-break-mobile + 1px) {
+    @media (width >= $mel-auth-break-mobile + 1px) {
       width: auto;
       min-width: 12rem;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/base/_global.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_global.scss
@@ -43,7 +43,7 @@ h3 {
   margin-bottom: var(--mel-space-2);
 }
 
-@media (min-width: 900px) {
+@media (width >= 900px) {
   h1 {
     font-size: 2.4rem;
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/base/_layout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_layout.scss
@@ -13,7 +13,7 @@
   padding: 0 16px;
 }
 
-@media (min-width: 900px) {
+@media (width >= 900px) {
   .mel-container {
     max-width: var(--mel-max);
     padding: 0 24px;
@@ -24,7 +24,7 @@
   padding: 28px 0;
 }
 
-@media (min-width: 900px) {
+@media (width >= 900px) {
   .mel-section {
     padding: 44px 0;
   }
@@ -33,7 +33,7 @@
 .mel-section + .mel-section {
   padding-top: 16px;
 
-  @media (min-width: 900px) {
+  @media (width >= 900px) {
     padding-top: 20px;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/commerce/_commerce.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/commerce/_commerce.scss
@@ -88,7 +88,7 @@
 /* Checkout: avoid dropdown overlapping panes; icon still links to /cart */
 body.mel-commerce-checkout .site-header__cart .mel-mini-cart,
 body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
-  display: none !important;
+  display: none;
 }
 
 .mel-mini-cart-header {
@@ -250,7 +250,7 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
   .commerce-cart-block__contents,
   .cart-block__contents,
   [class*='cart-block__contents'] {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -276,13 +276,13 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
   }
 
   /* Give checkout more room on large screens */
-  @media (min-width: 1200px) {
+  @media (width >= 1200px) {
     .region-content > * {
       max-width: 1320px;
     }
   }
 
-  @media (min-width: 1400px) {
+  @media (width >= 1400px) {
     .region-content > * {
       max-width: 1440px;
     }
@@ -780,7 +780,7 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
     align-items: start;
   }
 
-  @media (min-width: 1400px) {
+  @media (width >= 1400px) {
     .mel-checkout__grid:not(.mel-checkout__grid--sidebar-flow),
     .mel-checkout__layout,
     .layout-checkout-form:not(.mel-checkout-complete-layout) {
@@ -804,7 +804,7 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
     width: 380px;
   }
 
-  @media (min-width: 1400px) {
+  @media (width >= 1400px) {
     .mel-checkout__aside,
     .mel-checkout__summary,
     .mel-checkout__sidebar,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_attendees-kpi-bar.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_attendees-kpi-bar.scss
@@ -71,5 +71,5 @@
 
 .mel-attendees-empty__body {
   text-align: center;
-  padding: spacing.mel-space(6) spacing.mel-space(5) !important;
+  padding: spacing.mel-space(6) spacing.mel-space(5);
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_cart.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_cart.scss
@@ -336,16 +336,16 @@
     min-height: auto;
     padding: spacing.mel-space(1) spacing.mel-space(2);
     margin: 0;
-    background: none !important;
-    border: none !important;
-    box-shadow: none !important;
-    color: colors.$mel-color-primary !important;
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: colors.$mel-color-primary;
     font-weight: typography.$mel-font-semibold;
     text-decoration: underline;
     text-underline-offset: 2px;
 
     &:hover {
-      color: colors.$mel-color-secondary !important;
+      color: colors.$mel-color-secondary;
     }
   }
 }
@@ -356,7 +356,7 @@
   .mel-commerce-cart .mel-cart .mel-cart-actions {
     .form-actions input.form-submit:not(.button--primary),
     .form-actions button:not(.button--primary) {
-      flex: 0 0 auto !important;
+      flex: 0 0 auto;
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -299,8 +299,8 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   &.mel-checkout-pane--payment {
     .commerce-payment-form__payment-method,
     .commerce-payment-form__payment-details {
-      display: block !important;
-      visibility: visible !important;
+      display: block;
+      visibility: visible;
     }
   }
 }
@@ -511,31 +511,31 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .StripeElement--focus,
 .StripeElement--invalid,
 .StripeElement--complete {
-  display: block !important;
-  width: 100% !important;
-  padding: spacing.mel-space(3) spacing.mel-space(4) !important;
-  font-family: typography.$mel-font-family !important;
-  font-size: typography.mel-font-size(base) !important;
-  color: colors.$mel-color-text !important;
-  background: colors.$mel-color-surface !important;
-  border: 2px solid colors.$mel-color-border !important;
-  border-radius: radii.$mel-radius-md !important;
-  box-sizing: border-box !important;
-  height: auto !important;
-  min-height: 44px !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-  transition: border-color $mel-checkout-transition, box-shadow $mel-checkout-transition, background-color $mel-checkout-transition !important;
+  display: block;
+  width: 100%;
+  padding: spacing.mel-space(3) spacing.mel-space(4);
+  font-family: typography.$mel-font-family;
+  font-size: typography.mel-font-size(base);
+  color: colors.$mel-color-text;
+  background: colors.$mel-color-surface;
+  border: 2px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-md;
+  box-sizing: border-box;
+  height: auto;
+  min-height: 44px;
+  opacity: 1;
+  visibility: visible;
+  transition: border-color $mel-checkout-transition, box-shadow $mel-checkout-transition, background-color $mel-checkout-transition;
 }
 
 .StripeElement--focus {
-  border-color: colors.$mel-color-primary !important;
-  box-shadow: 0 0 0 4px rgba(colors.$mel-color-primary, 0.14) !important;
-  background: colors.$mel-color-surface !important;
+  border-color: colors.$mel-color-primary;
+  box-shadow: 0 0 0 4px rgba(colors.$mel-color-primary, 0.14);
+  background: colors.$mel-color-surface;
 }
 
 .StripeElement--invalid {
-  border-color: colors.$mel-color-error !important;
+  border-color: colors.$mel-color-error;
 }
 
 // Stripe iframe containers
@@ -545,35 +545,35 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .commerce-payment-form__payment-method,
 .commerce-payment-form__payment-details {
   iframe {
-    display: block !important;
-    width: 100% !important;
-    height: auto !important;
-    min-height: 44px !important;
-    opacity: 1 !important;
-    visibility: visible !important;
-    border: none !important;
+    display: block;
+    width: 100%;
+    height: auto;
+    min-height: 44px;
+    opacity: 1;
+    visibility: visible;
+    border: none;
   }
 }
 
 // Payment method form items
 .commerce-payment-form__payment-method,
 .commerce-payment-form__payment-details {
-  display: block !important;
-  width: 100% !important;
-  margin-top: 10px !important;
+  display: block;
+  width: 100%;
+  margin-top: 10px;
 
   .form-item {
-    margin-bottom: 8px !important;
+    margin-bottom: 8px;
   }
 
   input,
   iframe {
-    display: block !important;
-    width: 100% !important;
-    height: auto !important;
-    min-height: 44px !important;
-    opacity: 1 !important;
-    visibility: visible !important;
+    display: block;
+    width: 100%;
+    height: auto;
+    min-height: 44px;
+    opacity: 1;
+    visibility: visible;
   }
 }
 
@@ -588,41 +588,41 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 [id*="security-code-element"],
 .commerce-payment-form__payment-details > div,
 .commerce-payment-form__payment-details > fieldset {
-  display: block !important;
-  width: 100% !important;
-  min-height: 44px !important;
-  opacity: 1 !important;
-  visibility: visible !important;
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  opacity: 1;
+  visibility: visible;
 }
 
 // Specific mount points for Stripe Elements
 #card-number-element,
 #expiration-element,
 #security-code-element {
-  display: block !important;
-  width: 100% !important;
-  min-height: 44px !important;
-  padding: spacing.mel-space(3) spacing.mel-space(4) !important;
-  background: colors.$mel-color-surface !important;
-  border: 2px solid colors.$mel-color-border !important;
-  border-radius: radii.$mel-radius-md !important;
-  box-sizing: border-box !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-  position: relative !important;
-  z-index: 1 !important;
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  padding: spacing.mel-space(3) spacing.mel-space(4);
+  background: colors.$mel-color-surface;
+  border: 2px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-md;
+  box-sizing: border-box;
+  opacity: 1;
+  visibility: visible;
+  position: relative;
+  z-index: 1;
   
   // Ensure Stripe iframes inside are visible
   iframe {
-    display: block !important;
-    width: 100% !important;
-    height: 100% !important;
-    min-height: 20px !important;
-    opacity: 1 !important;
-    visibility: visible !important;
-    border: none !important;
-    position: relative !important;
-    z-index: 2 !important;
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 20px;
+    opacity: 1;
+    visibility: visible;
+    border: none;
+    position: relative;
+    z-index: 2;
   }
 }
 
@@ -632,11 +632,11 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .payment_information {
   // Error messages should appear below fields, not covering them
   .form-item--error-message {
-    position: static !important;
-    z-index: 0 !important;
-    margin-top: spacing.mel-space(2) !important;
-    margin-bottom: spacing.mel-space(2) !important;
-    display: block !important;
+    position: static;
+    z-index: 0;
+    margin-top: spacing.mel-space(2);
+    margin-bottom: spacing.mel-space(2);
+    display: block;
   }
   
   // Ensure input fields are visible and above error messages
@@ -648,17 +648,17 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   [id*="card-number"],
   [id*="card-expiry"],
   [id*="card-cvc"] {
-    position: relative !important;
-    z-index: 1 !important;
-    display: block !important;
-    opacity: 1 !important;
-    visibility: visible !important;
+    position: relative;
+    z-index: 1;
+    display: block;
+    opacity: 1;
+    visibility: visible;
   }
   
   // Hide error messages that are positioned over input fields
   .form-item--error-message[style*="position: absolute"],
   .form-item--error-message[style*="position:absolute"] {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -791,7 +791,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   min-height: 48px;
   font-weight: typography.$mel-font-bold;
   letter-spacing: 0.01em;
-  background: linear-gradient(135deg, colors.$mel-color-secondary 0%, colors.$mel-color-primary 100%) !important;
+  background: linear-gradient(135deg, colors.$mel-color-secondary 0%, colors.$mel-color-primary 100%);
   box-shadow: 0 4px 12px rgba(108, 126, 242, 0.25);
   transition: transform $mel-checkout-transition, box-shadow $mel-checkout-transition;
 
@@ -941,7 +941,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
 /* FORM COMPRESSION */
 .mel-checkout .form-item {
-  margin-bottom: 8px !important;
+  margin-bottom: 8px;
 }
 
 .mel-checkout .form-item label {
@@ -1019,18 +1019,18 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   .form-item,
   .field--type-string,
   .field--type-address {
-    margin-bottom: 8px !important;
+    margin-bottom: 8px;
   }
 
   fieldset {
-    margin-bottom: 8px !important;
-    padding: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
+    margin-bottom: 8px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
 
     &:last-child {
-      margin-bottom: 0 !important;
+      margin-bottom: 0;
     }
 
     > legend {
@@ -1042,10 +1042,10 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   }
 
   .form-wrapper {
-    margin-bottom: 8px !important;
+    margin-bottom: 8px;
 
     &:last-child {
-      margin-bottom: 0 !important;
+      margin-bottom: 0;
     }
   }
 }
@@ -1226,7 +1226,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
     padding: 14px 20px;
     border-radius: radii.$mel-radius-md;
     background: linear-gradient(135deg, colors.$mel-color-secondary 0%, colors.$mel-color-primary 100%);
-    color: colors.$mel-color-text-inverse !important;
+    color: colors.$mel-color-text-inverse;
     font-size: typography.mel-font-size(base);
     font-weight: typography.$mel-font-bold;
     border: none;
@@ -1345,23 +1345,23 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
     min-height: auto;
     padding: spacing.mel-space(1) spacing.mel-space(2);
     margin: 0;
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    color: colors.$mel-color-primary !important;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    color: colors.$mel-color-primary;
     font-weight: typography.$mel-font-semibold;
     text-decoration: underline;
     text-underline-offset: 2px;
 
     &:hover {
-      color: colors.$mel-color-secondary !important;
+      color: colors.$mel-color-secondary;
       transform: none;
     }
   }
 }
 
 /* MOBILE — Touch-friendly, clean stacking */
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-checkout {
     display: block;
   }
@@ -1493,14 +1493,14 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   .mel-checkout-cta [type='submit'].button--primary,
   .mel-checkout__actions .button--primary,
   .mel-checkout__actions [type='submit'].button--primary {
-    transition: none !important;
+    transition: none;
   }
 
   .mel-checkout-cta .button--primary:hover,
   .mel-checkout-cta [type='submit'].button--primary:hover,
   .mel-checkout__actions .button--primary:hover,
   .mel-checkout__actions [type='submit'].button--primary:hover {
-    transform: none !important;
+    transform: none;
   }
 }
 
@@ -1614,7 +1614,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   display: grid;
   gap: spacing.mel-space(4);
 
-  @media (min-width: 960px) {
+  @media (width >= 960px) {
     grid-template-columns: minmax(0, 1fr) 340px;
     align-items: start;
   }
@@ -1668,7 +1668,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   align-items: start;
 }
 
-@media (min-width: 960px) {
+@media (width >= 960px) {
   .mel-commerce-checkout .mel-checkout-complete-layout.layout-checkout-form {
     grid-template-columns: minmax(0, 1fr) 380px;
   }
@@ -1737,7 +1737,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   .mel-checkout__grid--sidebar-flow {
     gap: spacing.mel-space(2);
 
-    @media (min-width: 960px) {
+    @media (width >= 960px) {
       grid-template-columns: minmax(0, 1fr) 300px;
     }
   }
@@ -1904,7 +1904,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   }
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-commerce-checkout .mel-checkout--compact-flow {
     .mel-checkout-section--cta {
       margin-top: spacing.mel-space(1);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -148,7 +148,7 @@
   }
 }
 
-// Outrank .mel-pill--on-image / .mel-pill (listing + hero) without !important.
+// Outrank .mel-pill--on-image / .mel-pill (listing + hero) without.
 .mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--highlight,
 .mel-event-hero-card .mel-pill--on-image.mel-event-card__state-pill--highlight {
   background: color-mix(in srgb, #f5c98d 45%, #fff 55%);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-form.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-form.scss
@@ -110,8 +110,8 @@
       }
       
       .ui-autocomplete {
-        z-index: 10000 !important;
-        position: absolute !important;
+        z-index: 10000;
+        position: absolute;
         max-height: 300px;
         overflow-y: auto;
         background: #ffffff;
@@ -185,12 +185,12 @@
     .filter-help,
     .filter-guidelines,
     .filter-guidelines-item {
-      display: none !important;
+      display: none;
     }
   }
 
   .form-item--text-format-wrapper .filter-wrapper {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -210,7 +210,7 @@
     
     // Only force-hide if explicitly marked (for fallback JS)
     &[data-force-hidden="true"] {
-      display: none !important;
+      display: none;
     }
     
     // Let conditional_fields handle visibility via inline styles
@@ -325,7 +325,7 @@
     .form-item-country-code,
     select[name*="country_code"],
     select[name*="[country_code]"] {
-      display: none !important;
+      display: none;
     }
 
     .myeventlane-location-address-search {
@@ -392,8 +392,8 @@
     z-index: 10;
     
     .ui-autocomplete {
-      z-index: 10000 !important;
-      position: absolute !important;
+      z-index: 10000;
+      position: absolute;
       max-height: 300px;
       overflow-y: auto;
       background: #ffffff;
@@ -412,7 +412,7 @@
 // Mobile
 // ---------------------------------------------------------------------------
 
-@media (max-width: 767px) {
+@media (width <= 767px) {
   .mel-event-form-vendor {
     .mel-form-card {
       margin-left: calc(-1 * spacing.mel-space(3));

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page.scss
@@ -268,7 +268,7 @@
   }
 }
 
-@media (max-width: 900px) {
+@media (width <= 900px) {
   .mel-event__hero {
     height: 320px;
     border-radius: 0 0 24px 24px;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-studio.scss
@@ -11,9 +11,9 @@ body.mel-event-studio-page {
   .region-content,
   .gin-content,
   .dialog-off-canvas-main-canvas {
-    max-width: 100% !important;
-    width: 100% !important;
-    margin: 0 !important;
+    max-width: 100%;
+    width: 100%;
+    margin: 0;
     padding-left: 16px;
     padding-right: 16px;
     box-sizing: border-box;
@@ -22,7 +22,7 @@ body.mel-event-studio-page {
   .container,
   .container-lg,
   .container-md {
-    max-width: 100% !important;
+    max-width: 100%;
   }
 }
 
@@ -131,7 +131,7 @@ form.mel-event-studio-form {
   width: 100%;
 }
 
-@media (max-width: 600px) {
+@media (width <= 600px) {
   .mel-basic-title-with-ai {
     grid-template-columns: 1fr;
   }
@@ -141,7 +141,7 @@ form.mel-event-studio-form {
   padding-top: 1.75rem;
 }
 
-@media (max-width: 600px) {
+@media (width <= 600px) {
   .mel-basic-title-with-ai .mel-ai-autofill {
     padding-top: 0;
   }
@@ -219,7 +219,7 @@ form.mel-event-studio-form {
 }
 
 /* Mobile fallback */
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-studio-top {
     grid-template-columns: 1fr;
   }
@@ -407,7 +407,7 @@ form.mel-event-studio-form {
 }
 
 .mel-layout-grid {
-  grid-template-columns: 1fr !important;
+  grid-template-columns: 1fr;
 }
 
 /* Kill ALL width constraints (form wraps .mel-event-studio, not the other way around) */
@@ -416,8 +416,8 @@ form.mel-event-studio-form .mel-event-studio,
 .mel-studio-main-full,
 .mel-event-studio__form-full,
 .mel-studio-form-wrapper {
-  width: 100% !important;
-  max-width: 100% !important;
+  width: 100%;
+  max-width: 100%;
 }
 
 /* Ensure steps expand (wizard visibility still toggled inline by JS) */
@@ -434,7 +434,7 @@ form.mel-event-studio-form .mel-event-studio,
 
 /* Remove card-style narrowing */
 .mel-step > div {
-  max-width: none !important;
+  max-width: none;
 }
 
 /* Prevent flex/grid shrink */
@@ -504,7 +504,7 @@ form.mel-event-studio-form .mel-event-studio,
   gap: 12px;
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-form-grid {
     grid-template-columns: 1fr;
   }
@@ -580,7 +580,7 @@ form.mel-event-studio-form .mel-event-studio,
 }
 
 .mel-ai-diff-modal[hidden] {
-  display: none !important;
+  display: none;
 }
 
 .mel-ai-diff-modal__overlay {
@@ -645,7 +645,7 @@ form.mel-event-studio-form .mel-event-studio,
   margin-top: 16px;
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .mel-ai-diff {
     grid-template-columns: 1fr;
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-wizard.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-wizard.scss
@@ -242,7 +242,7 @@
   padding: 32px;
   background: #fef5ec;
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     grid-template-columns: 1fr;
     padding: 16px;
   }
@@ -258,7 +258,7 @@
     max-width: 1100px;
     margin: 0 auto;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       grid-template-columns: 1fr;
       gap: 16px;
     }
@@ -276,7 +276,7 @@
     position: sticky;
     top: 24px;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: none;
     }
   }
@@ -332,7 +332,7 @@
   .mel-event-form__mobile-steps {
     display: none;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: flex;
       gap: 8px;
       overflow-x: auto;
@@ -373,7 +373,7 @@
     padding: 32px;
     animation: melFadeUp 0.25s ease-out;
 
-    @media (max-width: 600px) {
+    @media (width <= 600px) {
       padding: 20px;
     }
 
@@ -396,7 +396,7 @@
     font-weight: 600;
     line-height: 1.2;
 
-    @media (max-width: 600px) {
+    @media (width <= 600px) {
       font-size: 1.4rem;
     }
   }
@@ -482,12 +482,12 @@
     gap: 12px;
     flex-wrap: wrap;
 
-    @media (max-width: 600px) {
+    @media (width <= 600px) {
       flex-direction: column-reverse;
     }
 
     &--sticky {
-      @media (max-width: 600px) {
+      @media (width <= 600px) {
         position: sticky;
         bottom: 0;
         background: #ffffff;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event.scss
@@ -19,7 +19,7 @@
   height: 420px;
   object-fit: cover;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     height: 300px;
   }
 }
@@ -31,7 +31,7 @@
   right: 48px;
   color: #fff;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     bottom: 32px;
     left: 24px;
     right: 24px;
@@ -45,7 +45,7 @@
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
   line-height: 1.2;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     font-size: 1.75rem;
   }
 }
@@ -83,8 +83,8 @@
 
 .mel-event-sidebar__calendar-link {
   display: inline-block;
-  padding: 6px 10px !important;
-  font-size: 0.8125rem !important;
+  padding: 6px 10px;
+  font-size: 0.8125rem;
   text-align: center;
   border-radius: 6px;
   background: #fff;
@@ -92,7 +92,7 @@
   color: #293241;
   text-decoration: none;
   font-weight: 500;
-  min-height: auto !important;
+  min-height: auto;
   transition: background-color 0.2s ease, border-color 0.2s ease;
 
   &:hover {
@@ -145,7 +145,7 @@
   grid-template-columns: 1fr;
   gap: 1rem;
 
-  @media (min-width: 960px) {
+  @media (width >= 960px) {
     grid-template-columns: 1.45fr 0.75fr;
     gap: 1.25rem;
     align-items: start;
@@ -163,7 +163,7 @@
 .mel-sticky {
   position: static;
 
-  @media (min-width: 960px) {
+  @media (width >= 960px) {
     position: sticky;
     top: 92px;
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_featured-carousel.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_featured-carousel.scss
@@ -52,9 +52,9 @@
   }
 
   &__track {
-    display: flex !important;
-    flex-direction: row !important;
-    flex-wrap: nowrap !important;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
     gap: 20px;
     width: 100%;
     overflow-x: auto;
@@ -72,12 +72,12 @@
   // Homepage unformatted uses __item; legacy carousel view uses __slide.
   &__slide,
   &__item {
-    flex: 0 0 min(320px, 88vw) !important;
+    flex: 0 0 min(320px, 88vw);
     min-width: 0;
     scroll-snap-align: start;
 
-    @media (min-width: 1024px) {
-      flex: 0 0 360px !important;
+    @media (width >= 1024px) {
+      flex: 0 0 360px;
     }
 
     // =========================================================================
@@ -85,18 +85,18 @@
     // =========================================================================
 
     .mel-event-card {
-      position: relative !important;
-      width: 100% !important;
-      min-height: 300px !important;
-      border-radius: 20px !important;
-      overflow: hidden !important;
+      position: relative;
+      width: 100%;
+      min-height: 300px;
+      border-radius: 20px;
+      overflow: hidden;
       box-shadow:
         0 4px 24px rgba(0, 0, 0, 0.08),
-        0 12px 48px rgba(0, 0, 0, 0.12) !important;
-      display: block !important;
+        0 12px 48px rgba(0, 0, 0, 0.12);
+      display: block;
 
       @include breakpoints.mel-break(md) {
-        min-height: 340px !important;
+        min-height: 340px;
       }
     }
 
@@ -104,25 +104,25 @@
     // Full-bleed image covering entire card
     // -------------------------------------------------------------------------
     .mel-event-card__image {
-      position: absolute !important;
-      top: 0 !important;
-      left: 0 !important;
-      right: 0 !important;
-      bottom: 0 !important;
-      width: 100% !important;
-      height: 100% !important;
-      aspect-ratio: unset !important;
-      max-height: none !important;
-      z-index: 0 !important;
-      margin: 0 !important;
-      padding: 0 !important;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+      aspect-ratio: unset;
+      max-height: none;
+      z-index: 0;
+      margin: 0;
+      padding: 0;
 
       img,
       .mel-event-card__image-element {
-        width: 100% !important;
-        height: 100% !important;
-        object-fit: cover !important;
-        filter: brightness(0.95) !important;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        filter: brightness(0.95);
         transition: filter 0.4s ease, transform 0.4s ease;
       }
     }
@@ -130,13 +130,13 @@
     // Hover: brighten and subtle zoom
     .mel-event-card:hover .mel-event-card__image img,
     .mel-event-card:hover .mel-event-card__image .mel-event-card__image-element {
-      filter: brightness(1) !important;
+      filter: brightness(1);
       transform: scale(1.02);
     }
 
     // Hide sparkle badge
     .mel-featured-badge {
-      display: none !important;
+      display: none;
     }
 
     // Hide CTA / badge / editorial chrome (carousel uses glass overlay copy)
@@ -147,13 +147,13 @@
     .mel-event-card__overlay,
     .mel-event-card__tag,
     .mel-card-badge {
-      display: none !important;
+      display: none;
     }
 
     // Hide category / featured pill on image (copy lives in glass panel)
     .mel-event-card__category-pill,
     .mel-event-card__image-badge {
-      display: none !important;
+      display: none;
     }
 
     // =========================================================================
@@ -168,32 +168,32 @@
     // =========================================================================
 
     .mel-event-card__content {
-      position: absolute !important;
-      bottom: 0 !important;
-      left: 12px !important;
-      right: 12px !important;
-      z-index: 10 !important;
-      padding: 18px 24px !important;
-      margin: 0 0 12px 0 !important;
-      border-radius: 16px !important;
-      overflow: hidden !important;
+      position: absolute;
+      bottom: 0;
+      left: 12px;
+      right: 12px;
+      z-index: 10;
+      padding: 18px 24px;
+      margin: 0 0 12px 0;
+      border-radius: 16px;
+      overflow: hidden;
 
       // --- LIQUID GLASS REFRACTION ---
       // SVG filter for true refraction (Chrome/Edge) + CSS blur fallback
-      background: rgba(255, 255, 255, 0.12) !important;
+      background: rgba(255, 255, 255, 0.12);
 
       // Fallback for Safari/Firefox: standard blur
-      backdrop-filter: blur(24px) saturate(180%) brightness(1.1) !important;
-      -webkit-backdrop-filter: blur(24px) saturate(180%) brightness(1.1) !important;
+      backdrop-filter: blur(24px) saturate(180%) brightness(1.1);
+      -webkit-backdrop-filter: blur(24px) saturate(180%) brightness(1.1);
 
       // SVG filter override for Chromium (true refraction + blur)
       @supports (backdrop-filter: url(#a)) {
-        backdrop-filter: url(#mel-liquid-glass) saturate(180%) brightness(1.1) !important;
+        backdrop-filter: url(#mel-liquid-glass) saturate(180%) brightness(1.1);
       }
 
       // --- GLASS EDGE ---
       // Thin border all around with brighter top edge
-      border: 1px solid rgba(255, 255, 255, 0.25) !important;
+      border: 1px solid rgba(255, 255, 255, 0.25);
 
       // --- DEPTH + SPECULAR HIGHLIGHTS ---
       box-shadow:
@@ -233,11 +233,11 @@
     .mel-event-card__title {
       position: relative;
       z-index: 2;
-      font-size: 22px !important;
-      font-weight: 800 !important;
+      font-size: 22px;
+      font-weight: 800;
       line-height: 1.2;
-      margin: 0 0 10px 0 !important;
-      color: #000 !important;
+      margin: 0 0 10px 0;
+      color: #000;
       text-shadow:
         0 1px 4px rgba(255, 255, 255, 0.9),
         0 2px 8px rgba(255, 255, 255, 0.6);
@@ -247,13 +247,13 @@
     .mel-event-card__meta {
       position: relative;
       z-index: 2;
-      font-size: 14px !important;
-      font-weight: 600 !important;
-      color: #000 !important;
-      display: flex !important;
-      flex-direction: column !important;
-      gap: 6px !important;
-      margin: 0 !important;
+      font-size: 14px;
+      font-weight: 600;
+      color: #000;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin: 0;
       text-shadow:
         0 1px 4px rgba(255, 255, 255, 0.9),
         0 2px 8px rgba(255, 255, 255, 0.6);
@@ -265,26 +265,26 @@
     .mel-event-card__status-secondary {
       position: relative;
       z-index: 2;
-      font-size: 14px !important;
-      font-weight: 600 !important;
-      color: #000 !important;
-      margin: 0 0 6px 0 !important;
+      font-size: 14px;
+      font-weight: 600;
+      color: #000;
+      margin: 0 0 6px 0;
       text-shadow:
         0 1px 4px rgba(255, 255, 255, 0.9),
         0 2px 8px rgba(255, 255, 255, 0.6);
     }
 
     .mel-event-card__status-row {
-      margin-bottom: 8px !important;
+      margin-bottom: 8px;
     }
 
     .mel-event-card__status {
-      font-size: 14px !important;
-      font-weight: 700 !important;
+      font-size: 14px;
+      font-weight: 700;
     }
 
     .mel-event-card__location-slot {
-      min-height: 0 !important;
+      min-height: 0;
     }
 
     // Featured label
@@ -295,7 +295,7 @@
       font-weight: 600;
       letter-spacing: 0.12em;
       text-transform: uppercase;
-      color: rgba(0, 0, 0, 0.7) !important;
+      color: rgba(0, 0, 0, 0.7);
       margin-bottom: 8px;
       text-shadow:
         0 1px 4px rgba(255, 255, 255, 0.9),
@@ -310,8 +310,8 @@
     // =========================================================================
     .mel-event-card--light-bg .mel-event-card__content {
       // Darker tinted glass on light backgrounds for contrast
-      background: rgba(0, 0, 0, 0.15) !important;
-      border-color: rgba(0, 0, 0, 0.1) !important;
+      background: rgba(0, 0, 0, 0.15);
+      border-color: rgba(0, 0, 0, 0.1);
       box-shadow:
         0 8px 32px rgba(0, 0, 0, 0.12),
         inset 0 1px 1px 0 rgba(255, 255, 255, 0.3),
@@ -319,14 +319,14 @@
     }
 
     .mel-event-card--light-bg .mel-event-card__title {
-      color: #000 !important;
+      color: #000;
       text-shadow:
         0 1px 3px rgba(255, 255, 255, 0.6);
       -webkit-text-stroke: 0;
     }
 
     .mel-event-card--light-bg .mel-event-card__meta {
-      color: #000 !important;
+      color: #000;
       text-shadow:
         0 1px 2px rgba(255, 255, 255, 0.5);
     }
@@ -335,13 +335,13 @@
     .mel-event-card--light-bg .mel-event-card__location,
     .mel-event-card--light-bg .mel-event-card__status-row,
     .mel-event-card--light-bg .mel-event-card__status-secondary {
-      color: #000 !important;
+      color: #000;
       text-shadow:
         0 1px 2px rgba(255, 255, 255, 0.5);
     }
 
     .mel-event-card--light-bg .mel-event-card__content .mel-event-card__title::before {
-      color: rgba(0, 0, 0, 0.7) !important;
+      color: rgba(0, 0, 0, 0.7);
       text-shadow:
         0 1px 2px rgba(255, 255, 255, 0.4);
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_header.scss
@@ -347,7 +347,7 @@
 .mel-nav-toggle-checkbox:checked ~ .mel-region-header header .mel-nav-mobile-wrapper,
 header:has(~ .mel-nav-toggle-checkbox:checked) .mel-nav-mobile-wrapper,
 .mel-nav-mobile-wrapper.is-open {
-  transform: translateX(0) !important; // Force it to work
+  transform: translateX(0); // Force it to work
 }
 
 .mel-nav-mobile-header {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_help-centre.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_help-centre.scss
@@ -393,7 +393,7 @@
   color: var(--mel-help-text-soft);
 }
 
-@media (min-width: 48rem) {
+@media (width >= 48rem) {
   .mel-help-home {
     padding: 1.5rem 1.25rem 3rem;
   }
@@ -420,7 +420,7 @@
   }
 }
 
-@media (min-width: 72rem) {
+@media (width >= 72rem) {
   .mel-help-home__grid--articles,
   .mel-help-home__grid--categories {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -658,7 +658,7 @@
   );
 }
 
-@media (min-width: 48rem) {
+@media (width >= 48rem) {
   .mel-page--help-article .mel-main {
     padding-left: var(--mel-space-5, 26px);
     padding-right: var(--mel-space-5, 26px);
@@ -852,7 +852,7 @@
     grid-template-columns: 1fr;
     gap: var(--mel-space-3, 14px);
 
-    @media (min-width: 36rem) {
+    @media (width >= 36rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
@@ -1240,7 +1240,7 @@
   color: var(--mel-navy, #293241);
 
   &[hidden] {
-    display: none !important;
+    display: none;
   }
 
   .mel-help-assistant__answer {
@@ -1297,7 +1297,7 @@
   .mel-help-suggestions,
   .mel-help-input,
   .mel-help-actions {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -1350,7 +1350,7 @@
   min-height: 2.75rem;
   border-radius: 999px;
   background: var(--mel-primary, #6c7ef2);
-  color: #fff !important;
+  color: #fff;
   font-weight: 700;
   font-size: 0.9375rem;
   text-decoration: none;
@@ -1358,7 +1358,7 @@
 
   &:hover {
     opacity: 0.92;
-    color: #fff !important;
+    color: #fff;
   }
 
   &:focus-visible {
@@ -1367,7 +1367,7 @@
   }
 }
 
-@media (min-width: 48rem) {
+@media (width >= 48rem) {
   .view-mel-help-attendee-help,
   .view-mel-help-organiser-help,
   .view-mel-help-vendor-help,
@@ -1463,7 +1463,7 @@
 .mel-contextual-help {
   margin: 0 0 1rem;
 
-  @media (max-width: 47.99rem) {
+  @media (width <= 47.99rem) {
     margin-bottom: 1.125rem;
   }
 }
@@ -1602,7 +1602,7 @@
   gap: var(--mel-space-4, 18px);
   text-align: center;
 
-  @media (min-width: 640px) {
+  @media (width >= 640px) {
     flex-direction: row;
     align-items: flex-start;
     text-align: left;
@@ -1665,15 +1665,15 @@
 }
 
 .mel-ai-panel .visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .mel-ai-progress {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_klaro-consent.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_klaro-consent.scss
@@ -46,7 +46,7 @@
 /* Modal body */
 .klaro .cookie-modal .cm-body,
 .klaro .cm-modal .cm-body {
-  background: #ffffff !important;
+  background: #ffffff;
   overflow-y: auto;
 }
 
@@ -82,8 +82,8 @@
 .klaro button.cm-btn,
 .klaro .cm-btn,
 .klaro a.cm-link {
-  border-radius: 999px !important;
-  padding: 0.7rem 1.05rem !important;
+  border-radius: 999px;
+  padding: 0.7rem 1.05rem;
   font-weight: 600;
   line-height: 1;
   min-height: 44px; /* touch target */
@@ -92,25 +92,25 @@
 /* Accept / primary */
 .klaro .cm-btn-success,
 .klaro .cm-btn.cm-btn-success {
-  background: rgba(108, 126, 242, 0.95) !important;
-  border: 1px solid rgba(0, 0, 0, 0.08) !important;
-  color: #{colors.$mel-color-text} !important;
+  background: rgba(108, 126, 242, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #{colors.$mel-color-text};
 }
 
 /* Decline / secondary */
 .klaro .cm-btn-decline,
 .klaro .cm-btn.cm-btn-decline {
-  background: rgba(255, 255, 255, 0.92) !important;
-  border: 1px solid rgba(0, 0, 0, 0.14) !important;
-  color: inherit !important;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  color: inherit;
 }
 
 /* Settings / info button */
 .klaro .cm-btn-info,
 .klaro .cm-btn.cm-btn-info {
-  background: rgba(255, 255, 255, 0.95) !important;
-  border: 2px solid rgba(255, 255, 255, 0.9) !important;
-  color: #{colors.$mel-color-navy} !important;
+  background: rgba(255, 255, 255, 0.95);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  color: #{colors.$mel-color-navy};
 }
 
 /* Links */
@@ -141,7 +141,7 @@
 }
 
 /* Mobile layout */
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .klaro .cookie-notice,
   .klaro .cookie-modal .cm-modal,
   .klaro .context-notice {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-events-filters.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-events-filters.scss
@@ -23,7 +23,7 @@
   padding-bottom: 2px;
   -webkit-overflow-scrolling: touch;
 
-  @media (max-width: 767px) {
+  @media (width <= 767px) {
     flex-direction: column;
     align-items: stretch;
     overflow-x: visible;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-header-footer.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-header-footer.scss
@@ -28,7 +28,7 @@
     color: inherit;
   }
 
-  @media (min-width: 768px) {
+  @media (width >= 768px) {
     padding-inline: var(--mel-space-5);
   }
 }
@@ -60,7 +60,7 @@
     color: inherit;
   }
 
-  @media (min-width: 768px) {
+  @media (width >= 768px) {
     padding-inline: var(--mel-space-5);
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-page-header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-page-header.scss
@@ -13,7 +13,7 @@
     background-position: 0 0, center;
 
     // Mobile-specific hero image when --mel-hero-bg-mobile is set.
-    @media (max-width: 767px) {
+    @media (width <= 767px) {
       background-image: linear-gradient(
           135deg,
           rgba(254, 245, 236, 0.5) 0%,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mobile-drawer.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mobile-drawer.scss
@@ -127,11 +127,11 @@
     font-weight: 700;
     font-size: 0.9rem;
     background: var(--mel-coral, #f26d5b);
-    color: #fff !important;
+    color: #fff;
 
     &:hover {
       filter: brightness(0.95);
-      color: #fff !important;
+      color: #fff;
     }
 
     &:focus-visible {
@@ -196,7 +196,7 @@
     width: 100%;
     padding: 12px 16px;
     background: var(--mel-coral, #f26d5b);
-    color: #fff !important;
+    color: #fff;
     font-weight: 700;
     font-size: 0.95rem;
     text-decoration: none;
@@ -209,7 +209,7 @@
 
     &:hover {
       background: var(--mel-coral-hover, #e05a48);
-      color: #fff !important;
+      color: #fff;
     }
 
     &:focus-visible {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_public-trust.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_public-trust.scss
@@ -38,7 +38,7 @@
   grid-template-columns: 1fr;
   gap: var(--space-md, 1rem);
 
-  @media (min-width: 40rem) {
+  @media (width >= 40rem) {
     grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_rsvp.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_rsvp.scss
@@ -667,7 +667,7 @@
   padding: spacing.mel-space(5);
   box-shadow: shadows.$mel-shadow-sm;
 
-  @media (min-width: 768px) {
+  @media (width >= 768px) {
     padding: 1rem;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
@@ -55,7 +55,7 @@
     align-items: center;
     gap: 16px;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: none;
     }
 
@@ -114,7 +114,7 @@
     display: flex;
     align-items: center;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: none;
     }
   }
@@ -167,7 +167,7 @@
   }
 
   &__organiser {
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: none;
     }
   }
@@ -243,7 +243,7 @@
   &__burger {
     display: none;
 
-    @media (max-width: 900px) {
+    @media (width <= 900px) {
       display: flex;
       align-items: center;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_support.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_support.scss
@@ -47,7 +47,7 @@
 }
 
 .mel-support-panel--hidden {
-  display: none !important;
+  display: none;
 }
 
 .mel-support-ai,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_tables.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_tables.scss
@@ -387,7 +387,7 @@
 // Responsive: Card View on Mobile
 // ---------------------------------------------------------------------------
 
-@media (max-width: 767px) {
+@media (width <= 767px) {
   .mel-table--responsive {
     thead {
       display: none;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-detail.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-detail.scss
@@ -26,7 +26,7 @@
       object-fit: cover;
     }
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       height: 200px;
     }
   }
@@ -84,7 +84,7 @@
       }
     }
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       flex-direction: column;
       align-items: center;
       text-align: center;
@@ -234,7 +234,7 @@
   }
 
   // Responsive adjustments
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .mel-vendor-content {
       padding: mel-space(3);
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-events.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-events.scss
@@ -357,13 +357,13 @@
   font-size: 13px;
 }
 
-@media (max-width: 1440px) {
+@media (width <= 1440px) {
   .vendor-workspace {
     grid-template-columns: 220px 280px minmax(0, 1fr) 300px;
   }
 }
 
-@media (max-width: 1240px) {
+@media (width <= 1240px) {
   .vendor-workspace {
     grid-template-columns: 220px minmax(0, 1fr);
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-studio-editor.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_vendor-studio-editor.scss
@@ -107,7 +107,7 @@
 
 }
 
-@media (max-width: 980px) {
+@media (width <= 980px) {
   .mel-studio-editor {
     width: 100vw;
     min-width: 0;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_wizard-step-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_wizard-step-card.scss
@@ -123,7 +123,7 @@
     justify-content: center;
     padding: 32px 16px;
 
-    @media (max-width: 480px) {
+    @media (width <= 480px) {
       padding-top: 16px;
     }
   }
@@ -136,7 +136,7 @@
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
     padding: 32px;
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       padding: 24px 16px;
     }
 
@@ -325,7 +325,7 @@
       padding: 12px;
     }
 
-    @media (max-width: 480px) {
+    @media (width <= 480px) {
       .ck-editor__editable {
         min-height: 140px;
       }
@@ -423,7 +423,7 @@
       line-height: 1.5;
     }
 
-    @media (max-width: 480px) {
+    @media (width <= 480px) {
       select {
         font-size: 16px;
         padding: 12px;
@@ -478,7 +478,7 @@
       border-radius: 12px;
     }
 
-    @media (max-width: 480px) {
+    @media (width <= 480px) {
       textarea {
         min-height: 120px;
       }
@@ -559,7 +559,7 @@
   // -------------------------------------------------------------------------
   // PHASE V — Mobile density polish
   // -------------------------------------------------------------------------
-  @media (max-width: 480px) {
+  @media (width <= 480px) {
     .mel-wizard-frame {
       padding: 16px;
     }
@@ -627,7 +627,7 @@
   padding: 32px;
   text-align: center;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     padding: 24px 16px;
   }
 }
@@ -677,7 +677,7 @@
   line-height: 1.6;
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .mel-event-wizard-success__actions {
     flex-direction: column;
     align-items: stretch;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_wizard.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_wizard.scss
@@ -32,7 +32,7 @@
   padding: 32px;
   background: var(--mel-bg);
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     grid-template-columns: 1fr;
     padding: 16px;
   }
@@ -45,7 +45,7 @@
   gap: 32px;
   width: 100%;
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     grid-template-columns: 1fr;
     gap: 16px;
   }
@@ -64,7 +64,7 @@
   position: sticky;
   top: 24px;
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     display: none;
   }
 }
@@ -117,7 +117,7 @@
 .mel-event-form__mobile-steps {
   display: none;
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     display: flex;
     gap: 8px;
     overflow-x: auto;
@@ -159,7 +159,7 @@
   padding: 0;
   animation: melFadeUp 0.25s ease-out;
 
-  @media (max-width: 600px) {
+  @media (width <= 600px) {
     border-radius: var(--mel-radius-md);
   }
 
@@ -180,7 +180,7 @@
   max-width: 1100px;
   margin: 0 auto;
 
-  @media (max-width: 900px) {
+  @media (width <= 900px) {
     grid-template-columns: 1fr;
     gap: 16px;
   }
@@ -201,7 +201,7 @@
   font-weight: 600;
   line-height: 1.2;
 
-  @media (max-width: 600px) {
+  @media (width <= 600px) {
     font-size: 1.4rem;
   }
 }
@@ -239,12 +239,12 @@
   gap: 12px;
   flex-wrap: wrap;
 
-  @media (max-width: 600px) {
+  @media (width <= 600px) {
     flex-direction: column-reverse;
   }
 
   &--sticky {
-    @media (max-width: 600px) {
+    @media (width <= 600px) {
       position: sticky;
       bottom: 0;
       background: var(--mel-card);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/card-carousel/card-carousel.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/card-carousel/card-carousel.scss
@@ -45,7 +45,7 @@
     right: -16px;
   }
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .swiper-button-prev,
     .swiper-button-next {
       display: none;

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_homepage-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_homepage-hero.scss
@@ -9,7 +9,7 @@
   flex-wrap: wrap;
   padding: 4rem 0;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     gap: 2rem;
     padding: 2.5rem 0;
   }
@@ -30,7 +30,7 @@
     max-width: 440px;
     min-width: 320px;
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       max-width: 100%;
     }
 
@@ -52,7 +52,7 @@
     margin: 0 0 1rem 0;
     line-height: 1.1;
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       font-size: 2.125rem;
     }
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_homepage.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_homepage.scss
@@ -149,7 +149,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .homepage-hero {
     flex-direction: row;
     justify-content: space-between;

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
@@ -77,7 +77,7 @@
   margin-bottom: 16px;
   gap: mel.$mel-ds-space-md;
 
-  @media (max-width: 640px) {
+  @media (width <= 640px) {
     flex-direction: column;
     align-items: stretch;
 
@@ -160,7 +160,7 @@
     }
   }
 
-  @media (max-width: 640px) {
+  @media (width <= 640px) {
     align-items: stretch;
 
     .mel-link {
@@ -179,6 +179,6 @@
   .views-row,
   div[class*='view'],
   div[class*='views'] {
-    display: contents !important;
+    display: contents;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_page-home.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_page-home.scss
@@ -154,7 +154,7 @@
   &--food-and-drink { background-color: #fbc6c6; color: #000; }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .home-hero {
     flex-direction: row;
     justify-content: space-between;
@@ -196,7 +196,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .home-info {
     flex-direction: row;
     justify-content: space-between;

--- a/web/themes/custom/myeventlane_theme/src/scss/onboarding/_onboarding-forms.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/onboarding/_onboarding-forms.scss
@@ -7,7 +7,7 @@
   display: flex;
   gap: .5rem;
 
-  @media (max-width: 640px) {
+  @media (width <= 640px) {
     position: sticky;
     bottom: 0;
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_contact.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_contact.scss
@@ -241,7 +241,7 @@
   display: flex;
   flex-direction: column;
   gap: spacing.mel-space(2);
-  margin-top: spacing.mel-space(3) !important;
+  margin-top: spacing.mel-space(3);
 
   a {
     color: colors.$mel-color-primary;

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_event.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_event.scss
@@ -8,7 +8,7 @@
   gap: 18px;
 }
 
-@media (min-width: 980px) {
+@media (width >= 980px) {
   .mel-event__hero-grid {
     grid-template-columns: 1.1fr .9fr .8fr;
     align-items: start;
@@ -160,7 +160,7 @@
   outline-offset: 3px;
 }
 
-@media (max-width: 899px) {
+@media (width <= 899px) {
   .mel-sticky-cta { display: block; }
   .mel-event__ticketbox { position: static; }
 }
@@ -171,6 +171,6 @@
   .mel-event__actions a.button,
   .mel-ticketbox,
   .mel-sticky-cta {
-    transition: none !important;
+    transition: none;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -52,7 +52,7 @@
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 12px;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     grid-template-columns: 1fr;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front.scss
@@ -37,12 +37,12 @@
   .mel-grid.mel-grid--events,
   .mel-grid.mel-grid--featured,
   .view-content {
-    display: grid !important;
-    grid-template-columns: repeat(3, 1fr) !important;
-    gap: 24px !important;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
 
     @include breakpoints.mel-break(md, max) {
-      grid-template-columns: 1fr !important;
+      grid-template-columns: 1fr;
     }
 
     // Limit to max 3 events

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_homepage.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_homepage.scss
@@ -19,7 +19,7 @@
     align-items: center;
   }
   
-  @media (min-width: 900px) {
+  @media (width >= 900px) {
     .mel-hero {
       grid-template-columns: 1.1fr 0.9fr;
     }
@@ -140,7 +140,7 @@
     min-height: 44px; /* WCAG touch target */
   }
   
-  @media (max-width: 767px) {
+  @media (width <= 767px) {
     .mel-category-strip {
       scrollbar-width: none;
       -ms-overflow-style: none;
@@ -156,20 +156,20 @@
   --------------------------------------------------------- */
   
   .mel-sticker-wall {
-    display: grid !important;
-    gap: var(--mel-space-4) !important;
+    display: grid;
+    gap: var(--mel-space-4);
     align-items: start;
   
     /* Mobile first */
-    grid-template-columns: 1fr !important;
+    grid-template-columns: 1fr;
 
     /*
      * Inner listing grid (.mel-grid) must span full sticker-wall width.
      */
     > .mel-grid {
-      grid-column: 1 / -1 !important;
-      width: 100% !important;
-      max-width: 100% !important;
+      grid-column: 1 / -1;
+      width: 100%;
+      max-width: 100%;
     }
     
     /* Remove ANY wrapper divs that break the grid - make them invisible to grid */
@@ -178,15 +178,15 @@
     .views-row,
     div[class*="view"],
     div[class*="views"] {
-      display: contents !important;
+      display: contents;
     }
     
     /* Ensure all direct children are grid items */
     > * {
-      display: block !important;
-      width: 100% !important;
-      min-width: 0 !important;
-      max-width: 100% !important;
+      display: block;
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
     }
     
     /* Ensure event cards are grid items - target them directly */
@@ -194,25 +194,25 @@
     .mel-event-card,
     article[class*="card"],
     article[class*="event"] {
-      display: block !important;
-      width: 100% !important;
-      min-width: 0 !important;
-      max-width: 100% !important;
-      grid-column: auto !important;
+      display: block;
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
+      grid-column: auto;
     }
   }
   
   /* Tablet */
-  @media (min-width: 640px) {
+  @media (width >= 640px) {
     .mel-sticker-wall {
-      grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
   
   /* Desktop */
-  @media (min-width: 1024px) {
+  @media (width >= 1024px) {
     .mel-sticker-wall {
-      grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
   
@@ -226,17 +226,17 @@
 
   /* Popular block brings its own grid; do not force scroller column layout. */
   .mel-row--popular-this-week .mel-row__scroller {
-    display: block !important;
-    overflow: visible !important;
-    padding-bottom: 0 !important;
+    display: block;
+    overflow: visible;
+    padding-bottom: 0;
   }
   
   /* Mobile: horizontal scroll
      Desktop: grid
   */
   .mel-row__scroller {
-    display: grid !important;
-    gap: 10px !important;
+    display: grid;
+    gap: 10px;
   
     /* Mobile behaviour */
     grid-auto-flow: column;
@@ -251,15 +251,15 @@
     .views-row,
     div[class*="view"],
     div[class*="views"] {
-      display: contents !important;
+      display: contents;
     }
     
     /* Ensure all direct children are grid items */
     > * {
-      display: block !important;
-      width: 100% !important;
-      min-width: 260px !important;
-      max-width: 100% !important;
+      display: block;
+      width: 100%;
+      min-width: 260px;
+      max-width: 100%;
     }
     
     /* Ensure event cards are grid items - target them directly */
@@ -267,50 +267,50 @@
     .mel-event-card,
     article[class*="card"],
     article[class*="event"] {
-      display: block !important;
-      width: 100% !important;
-      min-width: 0 !important;
-      max-width: 100% !important;
-      grid-column: auto !important;
+      display: block;
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
+      grid-column: auto;
     }
   }
   
-  @media (min-width: 640px) {
+  @media (width >= 640px) {
     .mel-row__scroller {
-      grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-      grid-auto-flow: initial !important;
-      grid-auto-columns: initial !important;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-auto-flow: initial;
+      grid-auto-columns: initial;
     }
     
     .mel-row__scroller > * {
-      min-width: 0 !important;
+      min-width: 0;
     }
     
     .mel-row__scroller .mel-card,
     .mel-row__scroller .mel-event-card,
     .mel-row__scroller article[class*="card"],
     .mel-row__scroller article[class*="event"] {
-      min-width: 0 !important;
+      min-width: 0;
     }
   }
   
-  @media (min-width: 1024px) {
+  @media (width >= 1024px) {
     .mel-row__scroller {
-      overflow: visible !important;
-      grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
-      grid-auto-flow: initial !important;
-      grid-auto-columns: initial !important;
+      overflow: visible;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-auto-flow: initial;
+      grid-auto-columns: initial;
     }
     
     .mel-row__scroller > * {
-      min-width: 0 !important;
+      min-width: 0;
     }
     
     .mel-row__scroller .mel-card,
     .mel-row__scroller .mel-event-card,
     .mel-row__scroller article[class*="card"],
     .mel-row__scroller article[class*="event"] {
-      min-width: 0 !important;
+      min-width: 0;
     }
   }
   

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
@@ -101,7 +101,7 @@
   align-items: start;
   width: 100%;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     grid-template-columns: 1fr;
   }
 }
@@ -111,7 +111,7 @@
   top: 1rem;
   padding: mel.$mel-ds-space-md 0;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     display: none;
     position: static;
     padding: mel.$mel-ds-space-lg;
@@ -138,7 +138,7 @@
   margin-bottom: mel.$mel-ds-space-md;
   text-align: center;
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     display: inline-flex;
     justify-content: center;
   }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
@@ -416,7 +416,7 @@
 
 // Orange-forward styling for My Tickets page (#e67e22 = vivid orange)
 .mel-my-tickets .mel-page-title {
-  color: #e67e22 !important;
+  color: #e67e22;
 }
 
 .mel-my-tickets .mel-page-description {
@@ -425,7 +425,7 @@
 
 .mel-my-tickets .mel-section-title {
   color: colors.$mel-color-text;
-  border-bottom: 2px solid #e67e22 !important;
+  border-bottom: 2px solid #e67e22;
   padding-bottom: spacing.mel-space(2);
 }
 
@@ -452,7 +452,7 @@
 
 .mel-my-tickets .mel-event-title a,
 .mel-my-tickets .mel-link {
-  color: #e67e22 !important;
+  color: #e67e22;
   font-weight: typography.$mel-font-semibold;
   text-decoration: none;
 
@@ -478,7 +478,7 @@
 }
 
 .mel-my-tickets .mel-btn-primary {
-  background: #e67e22 !important;
+  background: #e67e22;
   color: #fff;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;
@@ -491,8 +491,8 @@
 
 .mel-my-tickets .mel-btn-secondary {
   background: transparent;
-  border: 2px solid #e67e22 !important;
-  color: #e67e22 !important;
+  border: 2px solid #e67e22;
+  color: #e67e22;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;
 
@@ -533,7 +533,7 @@
     display: inline-block;
     margin-right: spacing.mel-space(2);
     font-size: 0.7em;
-    color: #e67e22 !important;
+    color: #e67e22;
     transition: transform 0.2s ease;
   }
 
@@ -553,7 +553,7 @@
 }
 
 .mel-my-tickets .mel-empty-state .mel-btn-primary {
-  background: #e67e22 !important;
+  background: #e67e22;
   color: #fff;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;

--- a/web/themes/custom/myeventlane_theme/src/scss/tokens/_breakpoints.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/tokens/_breakpoints.scss
@@ -12,13 +12,13 @@ $mel-breakpoints: (
   $breakpoint: map.get($mel-breakpoints, $size);
   
   @if $direction == max {
-    // For max-width, subtract 1px to avoid overlap
-    $max-width: $breakpoint - 1px;
-    @media (max-width: $max-width) {
+    // Subtract 1px to avoid overlap.
+    $upper-bound: $breakpoint - 1px;
+    @media (width <= $upper-bound) {
       @content;
     }
   } @else {
-    @media (min-width: $breakpoint) {
+    @media (width >= $breakpoint) {
       @content;
     }
   }


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-ranging theme stylesheet refactor changes responsive `@media` conditions and removes many `!important` overrides, which could subtly alter cascade/specificity and break layouts at certain breakpoints.
> 
> **Overview**
> Standardizes responsive rules across the theme by migrating `@media (min|max-width: …)` to Media Queries Level 4 range syntax (`@media (width <= …)` / `@media (width >= …)`), including the shared `breakpoints.mel-break` mixin.
> 
> Removes `!important` from numerous declarations (e.g., checkout/payment visibility rules, mini-cart hiding on checkout, featured carousel overrides, event studio full-width overrides, and various utility/hidden states), relying on selector specificity instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2a7ecabe3f8d004caa4aaea73fb4bf87e295a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->