### PR TITLE
Chore/scss lint cleanup

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -301,8 +301,6 @@ final class EventRecommendationService {
       if ($this->eventStateResolver->isEventBoosted($event)) {
         $score += 15;
       }
-      $click_score = $this->getClickScore((int) $event->id());
-      $score += min($click_score * 5, 50);
 
       $current = $node;
       if ($this->sharesCategory($event, $current)) {
@@ -342,7 +340,7 @@ final class EventRecommendationService {
           $score += 25;
         }
       }
-      $score = max(1, min($score, 100));
+      $score = max(1, min($score, 200));
 
       $context = $this->getRecommendationContext(
         $event,
@@ -449,13 +447,6 @@ final class EventRecommendationService {
     $factor = exp(-0.08 * ($days_until - 7));
 
     return max(1, (int) round($score * $factor));
-  }
-
-  /**
-   * Click proxy: reuses the same stored engagement metric as list views.
-   */
-  private function getClickScore(int $nid): int {
-    return $this->getViewerCountCached($nid);
   }
 
   private function getPrimaryCategory(NodeInterface $event): ?int {

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1138,6 +1138,14 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       }
     }
   }
+  if ($variables['mel_tonight_urgency_label'] !== NULL && isset($variables['elements']) && is_array($variables['elements'])) {
+    $variables['elements']['#cache']['max-age'] = 60;
+    $contexts = $variables['elements']['#cache']['contexts'] ?? [];
+    if (!in_array('timezone', $contexts, TRUE)) {
+      $contexts[] = 'timezone';
+    }
+    $variables['elements']['#cache']['contexts'] = $contexts;
+  }
   $event_cta = is_array($variables['event_cta'] ?? NULL) ? $variables['event_cta'] : [];
   // Semantic CTA and badges: always set for the event bundle (all view modes: full,
   // teaser, event_card, etc.); do not scope to a single view mode here.

--- a/web/modules/custom/myeventlane_pro/src/Service/ProSubscriptionLifecycleScheduler.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProSubscriptionLifecycleScheduler.php
@@ -249,12 +249,15 @@ final class ProSubscriptionLifecycleScheduler {
 
     $sent = 0;
     $storage = $this->entityTypeManager->getStorage('commerce_subscription');
-    $subscriptionIds = array_map(static fn(array $row): int => (int) $row['subscription_id'], $rows);
+    $subscriptionIds = array_values(array_filter(array_map(static function (object $row): int {
+      return isset($row->subscription_id) ? (int) $row->subscription_id : 0;
+    }, $rows)));
     /** @var \Drupal\commerce_recurring\Entity\SubscriptionInterface[] $subscriptions */
     $subscriptions = $storage->loadMultiple($subscriptionIds);
 
     foreach ($rows as $id => $row) {
-      $subscription = $subscriptions[(int) $row['subscription_id']] ?? NULL;
+      $subscriptionId = isset($row->subscription_id) ? (int) $row->subscription_id : 0;
+      $subscription = $subscriptions[$subscriptionId] ?? NULL;
       if (!$subscription instanceof SubscriptionInterface) {
         $this->markRenewalNotification((int) $id, self::STATUS_FAILED);
         continue;
@@ -312,12 +315,15 @@ final class ProSubscriptionLifecycleScheduler {
 
     $sent = 0;
     $storage = $this->entityTypeManager->getStorage('commerce_subscription');
-    $subscriptionIds = array_map(static fn(array $row): int => (int) $row['subscription_id'], $rows);
+    $subscriptionIds = array_values(array_filter(array_map(static function (object $row): int {
+      return isset($row->subscription_id) ? (int) $row->subscription_id : 0;
+    }, $rows)));
     /** @var \Drupal\commerce_recurring\Entity\SubscriptionInterface[] $subscriptions */
     $subscriptions = $storage->loadMultiple($subscriptionIds);
 
     foreach ($rows as $id => $row) {
-      $subscription = $subscriptions[(int) $row['subscription_id']] ?? NULL;
+      $subscriptionId = isset($row->subscription_id) ? (int) $row->subscription_id : 0;
+      $subscription = $subscriptions[$subscriptionId] ?? NULL;
       if (!$subscription instanceof SubscriptionInterface) {
         $this->markFailedSequence((int) $id, self::STATUS_FAILED);
         continue;
@@ -339,7 +345,8 @@ final class ProSubscriptionLifecycleScheduler {
         continue;
       }
 
-      $template = match ((int) $row['step']) {
+      $step = isset($row->step) ? (int) $row->step : -1;
+      $template = match ($step) {
         0 => 'pro_subscription_payment_failed_day_0',
         3 => 'pro_subscription_payment_failed_day_3',
         6 => 'pro_subscription_payment_failed_day_6',
@@ -354,7 +361,7 @@ final class ProSubscriptionLifecycleScheduler {
       $messageId = $this->messagingManager->queue($template, $recipient, [
         'first_name' => $this->resolveCustomerFirstName($subscription),
         'subscription_id' => (int) $subscription->id(),
-        'step' => (int) $row['step'],
+        'step' => $step,
       ]);
 
       if ($messageId === NULL) {

--- a/web/themes/custom/myeventlane_theme/js/mel-filters.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-filters.js
@@ -182,16 +182,9 @@
       return;
     }
     const startId = 'start_filter';
-    const allReset = filter === 'all' || !filter;
-    if (allReset) {
-      clearStartRange(form, startId);
-      clearRsvpType(form);
-      clearTrending(form);
-    } else {
-      clearStartRange(form, startId);
-      clearRsvpType(form);
-      clearTrending(form);
-    }
+    clearStartRange(form, startId);
+    clearRsvpType(form);
+    clearTrending(form);
 
     const todayStart = startOfLocalDay(new Date());
     const nextDay = startOfNextLocalDay(todayStart);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1501,7 +1501,9 @@ function _myeventlane_theme_event_event_save_flag_link($node): ?array {
         'default',
       ],
     ],
-    '#create_placeholder' => FALSE,
+    // Keep placeholder rendering enabled so Flag builds per-request state/tokens
+    // safely instead of risking cached stale action links.
+    '#create_placeholder' => TRUE,
   ];
   return $build;
 }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2183,9 +2183,12 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
     $variables['directory'] = base_path() . $theme_path;
   }
 
-  if ($view->id() === 'upcoming_events' && $view->current_display === 'page_category') {
+  if (
+    $view->id() === 'upcoming_events'
+    && in_array($view->current_display, ['page_category', 'page_today', 'page_this_weekend', 'page_free'], TRUE)
+  ) {
     $args = $view->args ?? [];
-    if (!empty($args[0])) {
+    if ($view->current_display === 'page_category' && !empty($args[0])) {
       $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($args[0]);
       if ($term instanceof TermInterface) {
         $variables['mel_browse_category_name'] = $term->label();

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1850,9 +1850,9 @@
   border-bottom: none;
 }
 
-.mel-filter-chip a:hover,
-.mel-filter-chip a:focus,
-.mel-filter-chip a:focus-visible {
+.mel-event--v2 .mel-filter-chip a:hover,
+.mel-event--v2 .mel-filter-chip a:focus,
+.mel-event--v2 .mel-filter-chip a:focus-visible {
   text-decoration: none;
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
@@ -5,20 +5,35 @@
  * (displays without a more specific template).
  */
 #}
-{{ attach_library('myeventlane_theme/mel-events-discovery') }}
-
-{% include '@myeventlane_theme/views/includes/mel-events-discovery-filters.html.twig' %}
-
-{{ exposed }}
-
-{% if rows %}
-  <div class="view-content">
-    {{ rows }}
-  </div>
-{% elseif empty %}
-  <div class="view-empty">
-    {{ empty }}
-  </div>
+{% if not mel_chip_listing_fragment|default(false) %}
+  {{ attach_library('myeventlane_theme/mel-events-discovery') }}
+  {% include '@myeventlane_theme/views/includes/mel-events-discovery-filters.html.twig' %}
+  {{ exposed }}
 {% endif %}
 
-{{ pager }}
+{% if mel_chip_listing_fragment|default(false) %}
+  <div data-mel-filter-results>
+    {% if rows %}
+      <div class="view-content" data-mel-chip-listing>
+        {{ rows }}
+      </div>
+    {% elseif empty %}
+      <div class="view-empty" data-mel-chip-listing>
+        {{ empty }}
+      </div>
+    {% endif %}
+    {{ pager }}
+  </div>
+{% else %}
+  {% if rows %}
+    <div class="view-content">
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    <div class="view-empty">
+      {{ empty }}
+    </div>
+  {% endif %}
+
+  {{ pager }}
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ranking logic, render caching, and subscription email dispatch paths; regressions could affect event ordering, stale UI state, or missed/extra lifecycle emails.
> 
> **Overview**
> Adjusts event recommendation scoring by **removing the click/viewer proxy contribution** and **raising the score cap to 200**, changing how related events are ranked.
> 
> Improves time-sensitive UI caching: the Tonight urgency label now varies by `timezone` with a short `max-age`, and the event save Flag link is rendered via placeholders to avoid cached stale state/tokens.
> 
> Hardens Pro subscription lifecycle dispatch by treating DB result rows as objects (with null-safe `subscription_id`/`step` handling) to prevent mis-addressed or failed renewal/dunning sends.
> 
> Updates discovery chip/listing UX by simplifying filter reset logic, scoping filter-chip hover styles to `.mel-event--v2`, and enabling a `mel_chip_listing_fragment` mode in the `upcoming_events` view template/preprocess to return results/pager without re-rendering filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4046e7571851d3b2af1ad99f3a3cf3e1acc900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->