### PR TITLE
Stripe intent type

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
+++ b/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
@@ -62,8 +62,8 @@ class StripeConnect extends StripePaymentElement implements SupportsStoredPaymen
       // contrib modules (e.g. payment_intent_id added by commerce_stripe).
       if (isset($connectParams['metadata']) && isset($intent_attributes['metadata'])) {
         $connectParams['metadata'] = array_merge(
-          (array) $intent_attributes['metadata'],
           $connectParams['metadata'],
+          (array) $intent_attributes['metadata'],
         );
       }
       $intent_attributes = array_merge($intent_attributes, $connectParams);

--- a/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
+++ b/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
@@ -9,6 +9,7 @@ use Drupal\commerce_payment\Entity\PaymentInterface;
 use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\SupportsStoredPaymentMethodsInterface;
 use Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\StripePaymentElement;
 use Drupal\myeventlane_commerce\Service\StripeConnectPaymentService;
+use Stripe\PaymentIntent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -52,7 +53,7 @@ class StripeConnect extends StripePaymentElement implements SupportsStoredPaymen
   /**
    * {@inheritdoc}
    */
-  public function createPaymentIntent(OrderInterface $order, $intent_attributes = [], ?PaymentInterface $payment = NULL) {
+  public function createPaymentIntent(OrderInterface $order, $intent_attributes = [], ?PaymentInterface $payment = NULL): PaymentIntent {
     /** @var array $intent_attributes */
     $connectParams = $this->stripeConnectPayment->getConnectPaymentIntentParams($order);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches payment intent creation for Stripe Connect; changes return typing and flips metadata merge precedence, which could affect downstream Stripe metadata and order/vendor payout reconciliation.
> 
> **Overview**
> Updates the `StripeConnect::createPaymentIntent()` override to explicitly return a `Stripe\PaymentIntent` (and imports the class) to match the underlying Stripe SDK behavior.
> 
> Adjusts the metadata deep-merge when applying Connect intent parameters so that existing `intent_attributes['metadata']` values take precedence over Connect-provided metadata, avoiding overwriting keys set by Commerce/contrib during intent creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfd924899e6f920ae67eeb207d9b99eb4a49ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->