### PR TITLE
Fix/stripe connect

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/StripeService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/StripeService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_core\Service;
 
 use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\myeventlane_core\Security\SensitiveDataScrubber;
@@ -17,6 +19,7 @@ use Stripe\Exception\ApiErrorException;
 use Stripe\LoginLink;
 use Stripe\PaymentIntent;
 use Stripe\SetupIntent;
+use Stripe\Stripe;
 use Stripe\StripeClient;
 
 /**
@@ -65,6 +68,13 @@ final class StripeService {
   }
 
   /**
+   * Logs Stripe API failures to the dedicated production error channel.
+   */
+  private function logStripeApiError(ApiErrorException $e): void {
+    $this->loggerFactory->get('stripe_error')->error($e->getMessage());
+  }
+
+  /**
    * Gets the Stripe client for the platform account.
    *
    * @return \Stripe\StripeClient
@@ -79,7 +89,132 @@ final class StripeService {
       throw new \RuntimeException('Platform Stripe secret key is not configured.');
     }
 
+    Stripe::setApiKey($secretKey);
+    $this->loggerFactory->get('stripe_debug')->notice('Stripe key set');
+
     return new StripeClient($secretKey);
+  }
+
+  /**
+   * Gets or creates the vendor's Express Connect account.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $vendor
+   *   The MEL vendor entity.
+   * @param \Drupal\commerce_store\Entity\StoreInterface|null $store
+   *   The Commerce store already resolved by the caller, if available.
+   *
+   * @return string
+   *   The Stripe account ID.
+   */
+  public function getOrCreateAccount(ContentEntityInterface $vendor, ?StoreInterface $store = NULL): string {
+    $store ??= $this->resolveVendorStore($vendor);
+    if (!$store) {
+      $this->loggerFactory->get('stripe_debug')->error('No Commerce store found for vendor @vendor_id', [
+        '@vendor_id' => (string) $vendor->id(),
+      ]);
+      throw new \RuntimeException('No Commerce store found for vendor.');
+    }
+
+    if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
+      return trim((string) $store->get('field_stripe_account_id')->value);
+    }
+
+    $email = $this->resolveVendorOwnerEmail($vendor);
+    if ($email === '') {
+      $this->loggerFactory->get('stripe_debug')->error('No owner email found for vendor @vendor_id', [
+        '@vendor_id' => (string) $vendor->id(),
+      ]);
+      throw new \RuntimeException('Vendor owner email is required for Stripe onboarding.');
+    }
+
+    $account = $this->createConnectAccount($email, 'AU', 'express');
+    $accountId = (string) $account->id;
+    if ($accountId === '') {
+      $this->loggerFactory->get('stripe_debug')->error('Stripe account creation returned an empty account ID for vendor @vendor_id', [
+        '@vendor_id' => (string) $vendor->id(),
+      ]);
+      throw new \RuntimeException('Stripe account creation returned an empty account ID.');
+    }
+
+    if ($store->hasField('field_stripe_account_id')) {
+      $store->set('field_stripe_account_id', $accountId);
+    }
+    if ($store->hasField('field_stripe_status')) {
+      $store->set('field_stripe_status', 'pending');
+    }
+    if ($store->hasField('field_stripe_connected')) {
+      $store->set('field_stripe_connected', FALSE);
+    }
+    $store->save();
+
+    if ($vendor->hasField('field_stripe_account_id')) {
+      $vendor->set('field_stripe_account_id', $accountId);
+    }
+    if ($vendor->hasField('field_stripe_status')) {
+      $vendor->set('field_stripe_status', 'pending');
+    }
+    if ($vendor->hasField('field_stripe_connected')) {
+      $vendor->set('field_stripe_connected', FALSE);
+    }
+    if ($vendor->hasField('field_vendor_store')) {
+      $vendor->set('field_vendor_store', $store->id());
+    }
+    $vendor->save();
+
+    return $accountId;
+  }
+
+  /**
+   * Resolves the Commerce store attached to a vendor.
+   */
+  private function resolveVendorStore(ContentEntityInterface $vendor): ?StoreInterface {
+    if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+      $store = $vendor->get('field_vendor_store')->entity;
+      if ($store instanceof StoreInterface) {
+        return $store;
+      }
+    }
+
+    $ownerId = method_exists($vendor, 'getOwnerId') ? (int) $vendor->getOwnerId() : 0;
+    if ($ownerId <= 0) {
+      return NULL;
+    }
+
+    $storeStorage = $this->entityTypeManager->getStorage('commerce_store');
+    $storeIds = $storeStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $ownerId)
+      ->range(0, 1)
+      ->execute();
+
+    if ($storeIds === []) {
+      return NULL;
+    }
+
+    $store = $storeStorage->load(reset($storeIds));
+    return $store instanceof StoreInterface ? $store : NULL;
+  }
+
+  /**
+   * Resolves the vendor owner email address.
+   */
+  private function resolveVendorOwnerEmail(ContentEntityInterface $vendor): string {
+    if (method_exists($vendor, 'getOwner')) {
+      $owner = $vendor->getOwner();
+      if ($owner && method_exists($owner, 'getEmail')) {
+        return trim((string) $owner->getEmail());
+      }
+    }
+
+    $ownerId = method_exists($vendor, 'getOwnerId') ? (int) $vendor->getOwnerId() : 0;
+    if ($ownerId <= 0) {
+      return '';
+    }
+
+    $owner = $this->entityTypeManager->getStorage('user')->load($ownerId);
+    return $owner && method_exists($owner, 'getEmail')
+      ? trim((string) $owner->getEmail())
+      : '';
   }
 
   /**
@@ -165,7 +300,7 @@ final class StripeService {
    * @param string $country
    *   The country code (e.g., 'AU', 'US').
    * @param string $type
-   *   Account type: 'standard' (default) or 'express'.
+   *   Account type: 'express' (default) or another Stripe-supported type.
    *
    * @return \Stripe\Account
    *   The created Stripe account.
@@ -173,7 +308,7 @@ final class StripeService {
    * @throws \Stripe\Exception\ApiErrorException
    *   If account creation fails.
    */
-  public function createConnectAccount(string $email, string $country = 'AU', string $type = 'standard'): Account {
+  public function createConnectAccount(string $email, string $country = 'AU', string $type = 'express'): Account {
     $client = $this->getPlatformClient();
 
     try {
@@ -195,6 +330,7 @@ final class StripeService {
       return $account;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create Stripe Connect account: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -236,6 +372,7 @@ final class StripeService {
       return $link;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create AccountLink: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -268,6 +405,7 @@ final class StripeService {
       return $link;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create LoginLink: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -341,6 +479,7 @@ final class StripeService {
       ];
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       // Account retrieval failed - log error and return not eligible.
       $this->safeLog('error', 'Failed to retrieve Stripe account @id for eligibility check: @message', [
         '@id' => $accountId,
@@ -383,6 +522,7 @@ final class StripeService {
       return $this->createLoginLink($accountId);
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       throw $e;
     }
   }
@@ -405,12 +545,13 @@ final class StripeService {
     try {
       $account = $client->accounts->retrieve($accountId);
 
-      // Map Stripe account status to our status values.
+      // Map Stripe account status to MEL's seller-ready signal. Payouts can
+      // lag after onboarding, so they are tracked separately.
       $status = 'pending';
-      if ($account->details_submitted && $account->charges_enabled && $account->payouts_enabled) {
+      if ($account->details_submitted && $account->charges_enabled) {
         $status = 'complete';
       }
-      elseif ($account->charges_enabled === FALSE || $account->payouts_enabled === FALSE) {
+      elseif ($account->details_submitted === FALSE || $account->charges_enabled === FALSE) {
         $status = 'restricted';
       }
 
@@ -422,6 +563,7 @@ final class StripeService {
       ];
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to retrieve account status: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -482,6 +624,7 @@ final class StripeService {
       return $paymentIntent;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create PaymentIntent for ticket sale: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -530,6 +673,7 @@ final class StripeService {
       return $paymentIntent;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create PaymentIntent for Boost: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -589,6 +733,7 @@ final class StripeService {
       return $customer;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create Stripe Customer: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -631,6 +776,7 @@ final class StripeService {
       return $setupIntent;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Failed to create SetupIntent: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -691,6 +837,7 @@ final class StripeService {
       return $paymentIntent;
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('error', 'Off-session PaymentIntent failed: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -717,6 +864,7 @@ final class StripeService {
       }
     }
     catch (ApiErrorException $e) {
+      $this->logStripeApiError($e);
       $this->safeLog('warning', 'Could not retrieve PaymentMethod @id for last4: @message', [
         '@id' => $paymentMethodId,
         '@message' => $e->getMessage(),

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -103,19 +103,29 @@ myeventlane_vendor.stripe_connect:
     _controller: '\Drupal\myeventlane_vendor\Controller\StripeConnectController::connect'
     _title: 'Connect Stripe'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: '\Drupal\myeventlane_vendor\Access\StripeConnectAccess::access'
   options:
     _maintenance_access: FALSE
 
 # Stripe Connect callback.
 myeventlane_vendor.stripe_callback:
+  path: '/stripe/callback'
+  defaults:
+    _controller: '\Drupal\myeventlane_vendor\Controller\StripeConnectController::callback'
+    _title: 'Stripe Connect Callback'
+  requirements:
+    _access: 'TRUE'
+  options:
+    _maintenance_access: FALSE
+
+# Legacy Stripe Connect callback path retained for in-flight AccountLinks.
+myeventlane_vendor.stripe_callback_legacy:
   path: '/stripe/connect/callback'
   defaults:
     _controller: '\Drupal\myeventlane_vendor\Controller\StripeConnectController::callback'
     _title: 'Stripe Connect Callback'
   requirements:
-    _permission: 'access content'
-    _user_is_logged_in: 'TRUE'
+    _access: 'TRUE'
   options:
     _maintenance_access: FALSE
 
@@ -126,8 +136,7 @@ myeventlane_vendor.stripe_onboard_return:
     _controller: '\Drupal\myeventlane_vendor\Controller\StripeConnectController::callback'
     _title: 'Stripe Connect return'
   requirements:
-    _permission: 'access content'
-    _user_is_logged_in: 'TRUE'
+    _access: 'TRUE'
   options:
     _maintenance_access: FALSE
 
@@ -137,8 +146,7 @@ myeventlane_vendor.stripe_onboard_refresh:
     _controller: '\Drupal\myeventlane_vendor\Controller\StripeConnectController::connect'
     _title: 'Connect Stripe'
   requirements:
-    _permission: 'access content'
-    _user_is_logged_in: 'TRUE'
+    _custom_access: '\Drupal\myeventlane_vendor\Access\StripeConnectAccess::access'
   options:
     _maintenance_access: FALSE
 

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -64,7 +64,6 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@logger.factory'
-      - '@myeventlane_onboarding.manager'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_vendor/src/Access/StripeConnectAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/StripeConnectAccess.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access check for starting or resuming Stripe Connect onboarding.
+ */
+final class StripeConnectAccess {
+
+  /**
+   * Allows authenticated vendor-console users to start Stripe onboarding.
+   */
+  public function access(AccountInterface $account): AccessResult {
+    if ($account->isAnonymous()) {
+      return AccessResult::forbidden()
+        ->addCacheContexts(['user.roles']);
+    }
+
+    if ($account->hasPermission('access vendor console')) {
+      return AccessResult::allowed()
+        ->addCacheContexts(['user.permissions']);
+    }
+
+    return AccessResult::forbidden()
+      ->addCacheContexts(['user.permissions']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -317,6 +317,18 @@ final class StripeConnectController extends ControllerBase {
       $this->applyOffsiteStripeRedirectHeaders($response);
       return $response;
     }
+    catch (ApiErrorException $e) {
+      $this->loggerChannelFactory->get('stripe_error')->error('Stripe Connect API failure during onboarding for vendor @vendor_id uid @uid: @message', [
+        '@vendor_id' => (string) $vendor->id(),
+        '@uid' => (string) $currentUser->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $this->loggerChannelFactory->get('stripe_debug')->error('Stripe connect failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('Stripe onboarding is temporarily unavailable. The platform Connect profile needs to be reviewed before new vendor accounts can be created.'));
+      return $this->redirectToDashboard();
+    }
     catch (\Exception $e) {
       $this->loggerChannelFactory->get('stripe_debug')->error('Stripe connect failed: @message', [
         '@message' => $e->getMessage(),

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -6,14 +6,17 @@ namespace Drupal\myeventlane_vendor\Controller;
 
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\StripeService;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Stripe\Exception\ApiErrorException;
 
 /**
  * Controller for Stripe Connect onboarding and management.
@@ -26,13 +29,29 @@ final class StripeConnectController extends ControllerBase {
   private readonly StripeService $stripeService;
 
   /**
+   * The vendor store subscriber/service.
+   */
+  private readonly VendorStoreSubscriber $vendorStoreSubscriber;
+
+  /**
+   * The logger channel factory.
+   */
+  private readonly LoggerChannelFactoryInterface $loggerChannelFactory;
+
+  /**
    * Constructs a StripeConnectController.
    *
    * @param \Drupal\myeventlane_core\Service\StripeService $stripeService
    *   The Stripe service.
+   * @param \Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber $vendorStoreSubscriber
+   *   The vendor store subscriber/service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger channel factory.
    */
-  public function __construct(StripeService $stripeService) {
+  public function __construct(StripeService $stripeService, VendorStoreSubscriber $vendorStoreSubscriber, LoggerChannelFactoryInterface $loggerFactory) {
     $this->stripeService = $stripeService;
+    $this->vendorStoreSubscriber = $vendorStoreSubscriber;
+    $this->loggerChannelFactory = $loggerFactory;
   }
 
   /**
@@ -41,6 +60,8 @@ final class StripeConnectController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_core.stripe'),
+      $container->get('myeventlane_vendor.vendor_store_subscriber'),
+      $container->get('logger.factory'),
     );
   }
 
@@ -55,11 +76,8 @@ final class StripeConnectController extends ControllerBase {
    */
   private function getStoreForConnect(): ?StoreInterface {
     $vendor = $this->getCurrentUserVendor();
-    if ($vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
-      $store = $vendor->get('field_vendor_store')->entity;
-      if ($store instanceof StoreInterface) {
-        return $store;
-      }
+    if ($vendor) {
+      return $this->vendorStoreSubscriber->ensureStoreForVendor($vendor);
     }
     return $this->getCurrentUserStore();
   }
@@ -93,31 +111,48 @@ final class StripeConnectController extends ControllerBase {
       }
     }
 
-    // Fallback: try to find default store or any store.
-    // In a multi-vendor setup, this might not be ideal, but provides fallback.
-    $defaultStores = $storeStorage->loadByProperties(['is_default' => TRUE]);
-    if (!empty($defaultStores)) {
-      return reset($defaultStores);
+    return NULL;
+  }
+
+  /**
+   * Ensures the vendor points at the same Commerce store Stripe updates.
+   */
+  private function syncVendorStoreReference(Vendor $vendor, StoreInterface $store): void {
+    if (!$vendor->hasField('field_vendor_store')) {
+      return;
     }
 
-    return NULL;
+    $currentTargetId = !$vendor->get('field_vendor_store')->isEmpty()
+      ? (string) $vendor->get('field_vendor_store')->target_id
+      : '';
+    if ($currentTargetId === (string) $store->id()) {
+      return;
+    }
+
+    $vendor->set('field_vendor_store', $store->id());
+    $vendor->save();
   }
 
   /**
    * Builds absolute return and refresh URLs for Stripe AccountLink.
    *
-   * return_url: Stripe redirects here after onboarding. refresh_url: Stripe uses
-   * if the link expires. Both always carry the same `destination` query
-   * parameter (may be empty) for callback/refresh continuity.
+   * return_url: Stripe redirects here after onboarding. refresh_url points back
+   * to the connect route if the AccountLink expires. Both carry account_id so
+   * the callback can verify the exact Stripe account with the platform API.
    */
-  private function buildAccountLinkUrls(string $destination = ''): array {
-    $returnUrl = Url::fromRoute('myeventlane_vendor.stripe_onboard_return', [], [
+  private function buildAccountLinkUrls(string $accountId, string $destination = ''): array {
+    $query = ['account_id' => $accountId];
+    if ($destination !== '') {
+      $query['destination'] = $destination;
+    }
+
+    $returnUrl = Url::fromRoute('myeventlane_vendor.stripe_callback', [], [
       'absolute' => TRUE,
-      'query' => ['destination' => $destination],
+      'query' => $query,
     ])->toString();
-    $refreshUrl = Url::fromRoute('myeventlane_vendor.stripe_onboard_refresh', [], [
+    $refreshUrl = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
       'absolute' => TRUE,
-      'query' => ['destination' => $destination],
+      'query' => $query,
     ])->toString();
 
     return [$returnUrl, $refreshUrl];
@@ -138,11 +173,13 @@ final class StripeConnectController extends ControllerBase {
     }
 
     $vendorStorage = $this->entityTypeManager()->getStorage('myeventlane_vendor');
-    $vendorIds = $vendorStorage->getQuery()
+    $query = $vendorStorage->getQuery()
       ->accessCheck(FALSE)
+      ->range(0, 1);
+    $group = $query->orConditionGroup()
       ->condition('uid', $userId)
-      ->range(0, 1)
-      ->execute();
+      ->condition('field_vendor_users', $userId);
+    $vendorIds = $query->condition($group)->execute();
 
     if (!empty($vendorIds)) {
       $vendor = $vendorStorage->load(reset($vendorIds));
@@ -164,120 +201,114 @@ final class StripeConnectController extends ControllerBase {
   }
 
   /**
+   * Builds a redirect response back to the vendor dashboard.
+   */
+  private function redirectToDashboard(): RedirectResponse {
+    return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+  }
+
+  /**
    * Starts Stripe Connect onboarding.
    *
    * @return \Symfony\Component\HttpFoundation\RedirectResponse
    *   Redirect to Stripe onboarding or dashboard.
    */
-  public function connect(): RedirectResponse {
-    \Drupal::logger('mel_debug')->notice('STRIPE CONNECT HIT');
+  public function connect(Request $request): RedirectResponse {
+    $this->loggerChannelFactory->get('stripe_debug')->notice('Stripe connect route hit');
+    $this->loggerChannelFactory->get('mel_debug')->notice('STRIPE CONNECT HIT');
     $currentUser = $this->currentUser();
     if ($currentUser->isAnonymous()) {
       throw new AccessDeniedHttpException('You must be logged in to connect Stripe.');
     }
 
+    $vendor = $this->getCurrentUserVendor();
+    if (!$vendor) {
+      $this->loggerChannelFactory->get('stripe_debug')->error('Stripe connect failed: no vendor entity for uid @uid', [
+        '@uid' => (string) $currentUser->id(),
+      ]);
+      $this->messenger()->addError($this->t('No vendor profile found for your account. Please contact support.'));
+      return $this->redirectToDashboard();
+    }
+
     $store = $this->getStoreForConnect();
     if (!$store) {
+      $this->loggerChannelFactory->get('stripe_debug')->error('Stripe connect failed: no store for vendor @vendor_id uid @uid', [
+        '@vendor_id' => (string) $vendor->id(),
+        '@uid' => (string) $currentUser->id(),
+      ]);
       $this->messenger()->addError($this->t('No store found for your account. Please contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
     }
-
-    $accountId = NULL;
-    if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
-      $accountId = $store->get('field_stripe_account_id')->value;
-    }
-
-    // If account exists, refresh status from Stripe. Store may have account_id but
-    // missing field_stripe_charges_enabled (e.g. callback never ran). Event flow
-    // checks charges_enabled, so we must align.
-    if (!empty($accountId)) {
-      try {
-        $status = $this->stripeService->getAccountStatus($accountId);
-        if ($store->hasField('field_stripe_status')) {
-          $store->set('field_stripe_status', $status['status']);
-        }
-        if ($store->hasField('field_stripe_connected')) {
-          // Aligned with assertStripeConnected: seller-ready when charges are on.
-          $store->set('field_stripe_connected', (bool) $status['charges_enabled']);
-        }
-        if ($store->hasField('field_stripe_charges_enabled')) {
-          $store->set('field_stripe_charges_enabled', $status['charges_enabled']);
-        }
-        if ($store->hasField('field_stripe_payouts_enabled')) {
-          $store->set('field_stripe_payouts_enabled', $status['payouts_enabled']);
-        }
-        $store->save();
-
-        if ($status['charges_enabled']) {
-          $this->messenger()->addStatus($this->t('Stripe is already connected.'));
-          return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
-        }
-      }
-      catch (\Exception $e) {
-        $this->getLogger('myeventlane_vendor')->warning('Could not refresh Stripe status, will create AccountLink: @m', ['@m' => $e->getMessage()]);
-      }
-    }
+    $this->syncVendorStoreReference($vendor, $store);
 
     try {
-      $userEmail = $currentUser->getEmail();
-      if (empty($userEmail)) {
-        $this->messenger()->addError($this->t('Your account must have an email address to connect Stripe.'));
-        return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      $accountId = $this->stripeService->getOrCreateAccount($vendor, $store);
+      $this->loggerChannelFactory->get('stripe_debug')->notice('Account ID: @id', ['@id' => $accountId]);
+
+      if ($accountId === '') {
+        throw new \RuntimeException('Stripe account ID missing');
       }
 
-      if (empty($accountId)) {
-        // Create new Connect account.
-        $account = $this->stripeService->createConnectAccount($userEmail, 'AU', 'standard');
-        $accountId = $account->id;
-
-        // Save account ID to store.
-        if ($store->hasField('field_stripe_account_id')) {
-          $store->set('field_stripe_account_id', $accountId);
-          if ($store->hasField('field_stripe_status')) {
-            $store->set('field_stripe_status', 'pending');
-          }
-          if ($store->hasField('field_stripe_connected')) {
-            $store->set('field_stripe_connected', FALSE);
-          }
-          $store->save();
-        }
-
-        // Also save to vendor entity if it exists.
-        $vendor = $this->getCurrentUserVendor();
-        if ($vendor && $vendor->hasField('field_stripe_account_id')) {
-          $vendor->set('field_stripe_account_id', $accountId);
-          if ($vendor->hasField('field_stripe_status')) {
-            $vendor->set('field_stripe_status', 'pending');
-          }
-          $vendor->save();
-        }
+      try {
+        $status = $this->stripeService->getAccountStatus($accountId);
+      }
+      catch (ApiErrorException $e) {
+        $this->loggerChannelFactory->get('stripe_error')->error($e->getMessage());
+        throw $e;
       }
 
-      // Create AccountLink: return + refresh are absolute, with optional
-      // ?destination=… so the callback can redirect to /create-event, onboard, etc.
-      $reqQuery = \Drupal::request();
-      $destination = $reqQuery->query->get('destination');
+      if (empty($status)) {
+        $this->loggerChannelFactory->get('stripe_debug')->error('Missing account status');
+        return $this->redirectToDashboard();
+      }
+
+      $connected = (bool) ($status['details_submitted'] && $status['charges_enabled']);
+      if ($store->hasField('field_stripe_status')) {
+        $store->set('field_stripe_status', $status['status']);
+      }
+      if ($store->hasField('field_stripe_connected')) {
+        $store->set('field_stripe_connected', $connected);
+      }
+      if ($store->hasField('field_stripe_charges_enabled')) {
+        $store->set('field_stripe_charges_enabled', $status['charges_enabled']);
+      }
+      if ($store->hasField('field_stripe_payouts_enabled')) {
+        $store->set('field_stripe_payouts_enabled', $status['payouts_enabled']);
+      }
+      $store->save();
+
+      if ($connected) {
+        $this->messenger()->addStatus($this->t('Stripe is already connected.'));
+        return $this->redirectToDashboard();
+      }
+
+      // Create AccountLink: return + refresh are absolute and include account_id
+      // so the callback can verify the same Express account after Stripe returns.
+      $destination = $request->query->get('destination');
       $destStr = is_string($destination) ? $destination : '';
 
-      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($destStr);
-      $accountLink = $this->stripeService->createAccountLink($accountId, $returnUrl, $refreshUrl);
-      if ($accountLink === NULL || (is_object($accountLink) && empty($accountLink->url))) {
-        $this->getLogger('myeventlane_vendor')->error('Stripe connect failed: no account link returned for uid=@uid', [
-          '@uid' => (string) $this->currentUser()->id(),
+      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($accountId, $destStr);
+      try {
+        $accountLink = $this->stripeService->createAccountLink($accountId, $returnUrl, $refreshUrl);
+      }
+      catch (ApiErrorException $e) {
+        $this->loggerChannelFactory->get('stripe_error')->error($e->getMessage());
+        $this->loggerChannelFactory->get('stripe_debug')->error('Stripe error: @msg', [
+          '@msg' => $e->getMessage(),
         ]);
-        throw new \RuntimeException('Stripe onboarding could not be started. Account link missing.');
+        throw $e;
       }
-      $url = $accountLink->url;
-      if (!is_string($url) || $url === '') {
-        $this->getLogger('myeventlane_vendor')->error('Stripe connect failed: empty account link url for uid=@uid', [
-          '@uid' => (string) $this->currentUser()->id(),
-        ]);
-        throw new \RuntimeException('Stripe onboarding could not be started. Account link missing.');
+
+      $this->loggerChannelFactory->get('stripe_debug')->notice('AccountLink URL: @url', [
+        '@url' => $accountLink->url ?? 'NULL',
+      ]);
+
+      if (empty($accountLink->url)) {
+        throw new \Exception('Stripe AccountLink URL missing');
       }
-      if (!str_starts_with($url, 'https://connect.stripe.com')) {
-        throw new \RuntimeException('Invalid Stripe URL: ' . $url);
-      }
-      \Drupal::logger('mel_debug')->notice('Stripe redirecting to: @url', [
+
+      $url = (string) $accountLink->url;
+      $this->loggerChannelFactory->get('mel_debug')->notice('Stripe redirecting to: @url', [
         '@url' => $url,
       ]);
 
@@ -287,14 +318,13 @@ final class StripeConnectController extends ControllerBase {
       return $response;
     }
     catch (\Exception $e) {
-      if ($e instanceof \RuntimeException) {
-        throw $e;
-      }
-      $this->getLogger('myeventlane_vendor')->error('Stripe Connect onboarding failed: @message', [
+      $this->loggerChannelFactory->get('stripe_debug')->error('Stripe connect failed: @message', [
         '@message' => $e->getMessage(),
       ]);
-      $this->messenger()->addError($this->t('Failed to start Stripe onboarding. Please try again or contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      $this->loggerChannelFactory->get('myeventlane_vendor')->error('Stripe Connect onboarding failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      throw $e;
     }
   }
 
@@ -308,42 +338,55 @@ final class StripeConnectController extends ControllerBase {
    *   Redirect to vendor dashboard.
    */
   public function callback(Request $request): RedirectResponse {
-    \Drupal::logger('mel_debug')->notice('STRIPE CALLBACK HIT');
+    $this->loggerChannelFactory->get('mel_debug')->notice('STRIPE CALLBACK HIT');
     $currentUser = $this->currentUser();
     if ($currentUser->isAnonymous()) {
       throw new AccessDeniedHttpException('You must be logged in.');
     }
 
-    $destination = $request->query->get('destination');
-
     $store = $this->getStoreForConnect();
     if (!$store) {
       $this->messenger()->addError($this->t('No store found for your account.'));
-      // Redirect to destination if provided, otherwise dashboard.
-      if ($destination) {
-        return new RedirectResponse($destination);
-      }
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
+    }
+    $vendor = $this->getCurrentUserVendor();
+    if ($vendor) {
+      $this->syncVendorStoreReference($vendor, $store);
+    }
+
+    $queryAccountId = $request->query->get('account_id');
+    $accountId = is_string($queryAccountId) && str_starts_with($queryAccountId, 'acct_')
+      ? $queryAccountId
+      : NULL;
+    if ($accountId === NULL && $store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
+      $accountId = trim((string) $store->get('field_stripe_account_id')->value);
     }
 
     // Check if account ID exists.
-    if (!$store->hasField('field_stripe_account_id') || $store->get('field_stripe_account_id')->isEmpty()) {
+    if (empty($accountId)) {
+      $this->loggerChannelFactory->get('stripe_debug')->error('Stripe callback missing account_id');
       $this->messenger()->addWarning($this->t('Stripe account not found. Please start the connection process again.'));
       return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
     }
 
-    $accountId = $store->get('field_stripe_account_id')->value;
-
     try {
       // Get account status from Stripe.
       $status = $this->stripeService->getAccountStatus($accountId);
+      if (empty($status)) {
+        $this->loggerChannelFactory->get('stripe_debug')->error('Missing account status');
+        return $this->redirectToDashboard();
+      }
+      $connected = (bool) ($status['details_submitted'] && $status['charges_enabled']);
 
       // Update store with status.
+      if ($store->hasField('field_stripe_account_id')) {
+        $store->set('field_stripe_account_id', $accountId);
+      }
       if ($store->hasField('field_stripe_status')) {
         $store->set('field_stripe_status', $status['status']);
       }
       if ($store->hasField('field_stripe_connected')) {
-        $store->set('field_stripe_connected', (bool) $status['charges_enabled']);
+        $store->set('field_stripe_connected', $connected);
       }
       if ($store->hasField('field_stripe_charges_enabled')) {
         $store->set('field_stripe_charges_enabled', $status['charges_enabled']);
@@ -352,16 +395,17 @@ final class StripeConnectController extends ControllerBase {
         $store->set('field_stripe_payouts_enabled', $status['payouts_enabled']);
       }
       $store->save();
-      \Drupal::logger('mel_debug')->notice('STRIPE CALLBACK: store saved; field_stripe_connected=@c charges_enabled=@ch payouts=@p', [
+      $this->loggerChannelFactory->get('stripe_debug')->notice('Stripe saved to store @id', ['@id' => (string) $store->id()]);
+      $this->loggerChannelFactory->get('mel_debug')->notice('STRIPE CALLBACK: store saved; field_stripe_connected=@c charges_enabled=@ch details_submitted=@d payouts=@p', [
         '@c' => $store->hasField('field_stripe_connected') && !$store->get('field_stripe_connected')->isEmpty()
           ? (string) (int) (bool) $store->get('field_stripe_connected')->value
           : 'n/a',
         '@ch' => (string) (int) (bool) ($status['charges_enabled'] ?? FALSE),
+        '@d' => (string) (int) (bool) ($status['details_submitted'] ?? FALSE),
         '@p' => (string) (int) (bool) ($status['payouts_enabled'] ?? FALSE),
       ]);
 
       // Also update vendor entity if it exists.
-      $vendor = $this->getCurrentUserVendor();
       if ($vendor) {
         if ($vendor->hasField('field_stripe_account_id')) {
           $vendor->set('field_stripe_account_id', $accountId);
@@ -370,7 +414,7 @@ final class StripeConnectController extends ControllerBase {
           $vendor->set('field_stripe_status', $status['status']);
         }
         if ($vendor->hasField('field_stripe_connected')) {
-          $vendor->set('field_stripe_connected', (bool) $status['charges_enabled']);
+          $vendor->set('field_stripe_connected', $connected);
         }
         $vendor->save();
       }
@@ -387,18 +431,21 @@ final class StripeConnectController extends ControllerBase {
         ]));
       }
     }
+    catch (ApiErrorException $e) {
+      $this->loggerChannelFactory->get('stripe_error')->error($e->getMessage());
+      $this->loggerChannelFactory->get('myeventlane_vendor')->error('Stripe Connect callback failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
+    }
     catch (\Exception $e) {
-      $this->getLogger('myeventlane_vendor')->error('Stripe Connect callback failed: @message', [
+      $this->loggerChannelFactory->get('myeventlane_vendor')->error('Stripe Connect callback failed: @message', [
         '@message' => $e->getMessage(),
       ]);
       $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
     }
 
-    // Redirect to destination if provided (e.g., onboarding flow), otherwise dashboard.
-    if ($destination) {
-      return new RedirectResponse($destination);
-    }
-    return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+    return $this->redirectToDashboard();
   }
 
   /**
@@ -408,7 +455,7 @@ final class StripeConnectController extends ControllerBase {
    *   Redirect to Stripe dashboard or error.
    */
   public function manage(): RedirectResponse {
-    $logger = $this->getLogger('myeventlane_vendor');
+    $logger = $this->loggerChannelFactory->get('myeventlane_vendor');
     $currentUser = $this->currentUser();
 
     if ($currentUser->isAnonymous()) {
@@ -421,7 +468,7 @@ final class StripeConnectController extends ControllerBase {
         '@uid' => $currentUser->id(),
       ]);
       $this->messenger()->addError($this->t('No store found for your account.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
     }
 
     // VALIDATE STRIPE ACCOUNT ID: Check if account ID exists and is valid.
@@ -483,7 +530,7 @@ final class StripeConnectController extends ControllerBase {
           '@account_id' => $accountId,
         ]);
         $this->messenger()->addError($this->t('Failed to generate Stripe dashboard link. Please try again.'));
-        return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+        return $this->redirectToDashboard();
       }
 
       $logger->info('Stripe manage: Successfully created login link for account @account_id', [
@@ -504,7 +551,7 @@ final class StripeConnectController extends ControllerBase {
       ]);
 
       $this->messenger()->addError($this->t('Failed to open Stripe dashboard. Please try again or contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
     }
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
@@ -232,12 +232,31 @@ abstract class VendorConsoleBaseController {
       'query' => ['destination' => $destination],
     ]);
 
-    if (!$vendor || !$vendor->hasField('field_vendor_store') || $vendor->get('field_vendor_store')->isEmpty()) {
+    if (!$vendor) {
       $this->getMessenger()->addError($this->t('You must connect your Stripe account before setting up events.'));
       throw new EnforcedResponseException(new TrustedRedirectResponse($stripeConnectUrl->toString()));
     }
 
-    $store = $vendor->get('field_vendor_store')->entity;
+    $store = NULL;
+    if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+      $store = $vendor->get('field_vendor_store')->entity;
+    }
+    if (!$store) {
+      $entityTypeManager = $this->entityTypeManager ?? \Drupal::entityTypeManager();
+      $storeStorage = $entityTypeManager->getStorage('commerce_store');
+      $storeIds = $storeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('uid', (int) $this->currentUser->id())
+        ->range(0, 1)
+        ->execute();
+      if (!empty($storeIds)) {
+        $store = $storeStorage->load(reset($storeIds));
+        if ($store && $vendor->hasField('field_vendor_store')) {
+          $vendor->set('field_vendor_store', $store->id());
+          $vendor->save();
+        }
+      }
+    }
     if (!$store) {
       $this->getMessenger()->addError($this->t('You must connect your Stripe account before setting up events.'));
       throw new EnforcedResponseException(new TrustedRedirectResponse($stripeConnectUrl->toString()));

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -305,9 +305,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     // Format stripe status message for template (phase-driven copy in stripe-panel).
     $stripeStatusFormatted = $stripeStatus;
     $stripeStatusFormatted['status_message'] = match ($stripeStatus['stripe_phase'] ?? 'needs_connect') {
-      'payouts_ready' => $this->t('Payouts are enabled — you can receive funds from ticket sales.'),
-      'needs_completion' => $this->t('Finish setting up your Stripe account to enable payouts.'),
-      default => $this->t('Connect Stripe to receive payments from ticket sales and donations.'),
+      'payouts_ready' => $this->t('Stripe connected ✅'),
+      'needs_completion' => $this->t('Finish Stripe setup'),
+      default => $this->t('Connect Stripe'),
     };
 
     // STAGE A2: KPI strip. Resolve store from vendor; call VendorKpiService; omit if no store.
@@ -1632,18 +1632,18 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $status = [
       'connected' => FALSE,
       'status' => 'not_connected',
-      'status_label' => 'Not Connected',
+      'status_label' => (string) $this->t('Connect Stripe'),
       'account_id' => NULL,
       'next_payout_date' => NULL,
       'total_paid_out' => 0,
       'pending_balance' => 0,
       'stripe_dashboard_url' => NULL,
-      'connect_url' => '/vendor/stripe/connect',
+      'connect_url' => '/stripe/connect',
       'charges_enabled' => FALSE,
       'payouts_enabled' => FALSE,
       'is_onboarding_complete' => FALSE,
       'stripe_phase' => 'needs_connect',
-      'resume_url' => '/vendor/stripe/connect',
+      'resume_url' => '/stripe/connect',
     ];
 
     try {
@@ -1690,31 +1690,17 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         $status['charges_enabled'] = $charges_enabled;
         $status['payouts_enabled'] = $payouts_enabled;
 
-        if ($connected) {
-          $status['connected'] = TRUE;
-          $status['status'] = 'connected';
-          $status['status_label'] = 'Connected';
-        }
-
-        if ($payouts_enabled) {
+        if ($charges_enabled) {
           $status['stripe_phase'] = 'payouts_ready';
           $status['is_onboarding_complete'] = TRUE;
           $status['connected'] = TRUE;
           $status['status'] = 'connected';
-          $status['status_label'] = (string) $this->t('Payouts enabled');
-        }
-        elseif ($connected) {
-          // Charges enabled: same seller-ready signal as assertStripeConnected; do not require payouts.
-          $status['stripe_phase'] = 'payouts_ready';
-          $status['is_onboarding_complete'] = TRUE;
-          $status['connected'] = TRUE;
-          $status['status'] = 'connected';
-          $status['status_label'] = (string) $this->t('Connected');
+          $status['status_label'] = (string) $this->t('Stripe connected ✅');
         }
         elseif ($status['account_id']) {
           $status['stripe_phase'] = 'needs_completion';
           $status['status'] = 'pending';
-          $status['status_label'] = (string) $this->t('Action required');
+          $status['status_label'] = (string) $this->t('Finish Stripe setup');
           $status['is_onboarding_complete'] = FALSE;
         }
       }
@@ -1801,8 +1787,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     if (($stripeStatus['stripe_phase'] ?? '') !== 'payouts_ready') {
       $is_finish = ($stripeStatus['stripe_phase'] ?? '') === 'needs_completion';
       $stripe_url = $is_finish
-        ? ($stripeStatus['resume_url'] ?? $stripeStatus['connect_url'] ?? '/vendor/stripe/connect')
-        : ($stripeStatus['connect_url'] ?? '/vendor/stripe/connect');
+        ? ($stripeStatus['resume_url'] ?? $stripeStatus['connect_url'] ?? '/stripe/connect')
+        : ($stripeStatus['connect_url'] ?? '/stripe/connect');
       $notifications[] = [
         'type' => 'warning',
         'icon' => 'credit-card',

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\EventSubscriber;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * Event subscriber to auto-create Commerce Store when Vendor is created.
@@ -31,11 +31,6 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   private LoggerChannelFactoryInterface $loggerFactory;
 
   /**
-   * The onboarding state manager.
-   */
-  private OnboardingManager $onboardingManager;
-
-  /**
    * Track vendors being processed to prevent recursion.
    *
    * @var array
@@ -53,11 +48,9 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
-    OnboardingManager $onboarding_manager,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
-    $this->onboardingManager = $onboarding_manager;
   }
 
   /**
@@ -89,30 +82,48 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
    */
   public function onVendorInsertFromHook(Vendor $vendor): void {
     $logger = $this->loggerFactory->get('myeventlane_vendor');
-
     $logger->notice('Vendor insert hook fired for vendor @id', ['@id' => $vendor->id()]);
+    $this->ensureStoreForVendor($vendor);
+  }
 
-    $owner = $vendor->getOwner();
-    if ($owner !== NULL) {
-      $state = $this->onboardingManager->loadVendorStateByUid((int) $owner->id());
-      if ($state !== NULL && !$this->onboardingManager->isCompleted($state)) {
-        $logger->notice('Store creation skipped (onboarding incomplete) vendor=@id', [
-          '@id' => (string) $vendor->id(),
-        ]);
-        return;
-      }
+  /**
+   * Ensures a vendor has exactly one linked Commerce store.
+   */
+  public function ensureStoreForVendor(Vendor $vendor): ?StoreInterface {
+    $logger = $this->loggerFactory->get('myeventlane_vendor');
+
+    if (!$vendor->hasField('field_vendor_store')) {
+      $logger->error('Vendor @id is missing field_vendor_store.', [
+        '@id' => (string) $vendor->id(),
+      ]);
+      return NULL;
     }
 
     // Prevent recursion if we're already processing this vendor.
     if (isset(self::$processing[$vendor->id()])) {
       $logger->notice('Vendor @id already being processed, skipping', ['@id' => $vendor->id()]);
-      return;
+      return $this->getLinkedStore($vendor);
     }
 
-    // Only proceed if vendor doesn't already have a store.
+    // Only proceed if vendor doesn't already have a valid linked store.
     if (!$vendor->get('field_vendor_store')->isEmpty()) {
-      $logger->notice('Vendor @id already has a store, skipping', ['@id' => $vendor->id()]);
-      return;
+      $store = $vendor->get('field_vendor_store')->entity;
+      if ($store instanceof StoreInterface) {
+        $this->ensureStoreBackReference($store, $vendor);
+        $logger->notice('Vendor @id already has a store, skipping', ['@id' => $vendor->id()]);
+        return $store;
+      }
+    }
+
+    $existing_store = $this->loadExistingStoreForVendor($vendor);
+    if ($existing_store instanceof StoreInterface) {
+      $vendor->set('field_vendor_store', $existing_store->id());
+      $vendor->save();
+      $logger->notice('Linked existing store @store to vendor @vendor.', [
+        '@store' => (string) $existing_store->id(),
+        '@vendor' => (string) $vendor->id(),
+      ]);
+      return $existing_store;
     }
 
     $logger->notice('Proceeding to create store for vendor @id', ['@id' => $vendor->id()]);
@@ -123,12 +134,13 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     try {
       $store_storage = $this->entityTypeManager->getStorage('commerce_store');
       $owner = $vendor->getOwner();
+      $owner_id = $owner ? (int) $owner->id() : 1;
 
       // Create a new Commerce Store for this vendor.
       /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
       $store = $store_storage->create([
         'type' => 'online',
-        'uid' => $owner ? $owner->id() : 1,
+        'uid' => $owner_id,
         'name' => $vendor->getName() . ' Store',
         'mail' => $owner && $owner->getEmail() ? $owner->getEmail() : 'noreply@myeventlane.com',
         'default_currency' => 'AUD',
@@ -147,17 +159,19 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
       ]);
 
       // Link the store back to the vendor.
-      $store->set('field_vendor_reference', $vendor);
+      $this->ensureStoreBackReference($store, $vendor, FALSE);
       $store->save();
 
       // Link the vendor to the store.
-      $vendor->set('field_vendor_store', $store);
+      $vendor->set('field_vendor_store', $store->id());
       // Save the vendor again to persist the store reference.
       // This won't trigger insert again since the entity is no longer new.
       $vendor->save();
+      $this->loggerFactory->get('stripe_debug')->notice('Store created for user @uid', ['@uid' => (string) $owner_id]);
 
       // Unmark as processing.
       unset(self::$processing[$vendor->id()]);
+      return $store;
 
     }
     catch (EntityStorageException $e) {
@@ -171,6 +185,107 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
           '@message' => $e->getMessage(),
         ]
       );
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Gets the vendor's currently linked store, if it is valid.
+   */
+  private function getLinkedStore(Vendor $vendor): ?StoreInterface {
+    if (!$vendor->hasField('field_vendor_store') || $vendor->get('field_vendor_store')->isEmpty()) {
+      return NULL;
+    }
+
+    $store = $vendor->get('field_vendor_store')->entity;
+    return $store instanceof StoreInterface ? $store : NULL;
+  }
+
+  /**
+   * Loads an existing store before creating one.
+   */
+  private function loadExistingStoreForVendor(Vendor $vendor): ?StoreInterface {
+    $store_storage = $this->entityTypeManager->getStorage('commerce_store');
+
+    if ($vendor->id() !== NULL) {
+      try {
+        $store_ids = $store_storage->getQuery()
+          ->accessCheck(FALSE)
+          ->condition('field_vendor_reference', (int) $vendor->id())
+          ->range(0, 1)
+          ->execute();
+        if (!empty($store_ids)) {
+          $store = $store_storage->load(reset($store_ids));
+          if ($store instanceof StoreInterface) {
+            return $store;
+          }
+        }
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('myeventlane_vendor')->warning('Could not query stores by vendor reference for vendor @vendor: @message', [
+          '@vendor' => (string) $vendor->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    $owner = $vendor->getOwner();
+    $owner_id = $owner ? (int) $owner->id() : 0;
+    if ($owner_id <= 0) {
+      return NULL;
+    }
+
+    $store_ids = $store_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $owner_id)
+      ->execute();
+    if (empty($store_ids)) {
+      return NULL;
+    }
+
+    if (count($store_ids) > 1) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Multiple Commerce stores found for vendor owner uid @uid; linking the first store to vendor @vendor.', [
+        '@uid' => (string) $owner_id,
+        '@vendor' => (string) $vendor->id(),
+      ]);
+    }
+
+    $store = $store_storage->load(reset($store_ids));
+    if ($store instanceof StoreInterface) {
+      $this->ensureStoreBackReference($store, $vendor);
+    }
+
+    return $store instanceof StoreInterface ? $store : NULL;
+  }
+
+  /**
+   * Ensures the Commerce store can be discovered from the vendor side too.
+   */
+  private function ensureStoreBackReference(StoreInterface $store, Vendor $vendor, bool $save = TRUE): void {
+    if (!$store->hasField('field_vendor_reference')) {
+      return;
+    }
+
+    $current_target_id = !$store->get('field_vendor_reference')->isEmpty()
+      ? (string) $store->get('field_vendor_reference')->target_id
+      : '';
+    if ($current_target_id === (string) $vendor->id()) {
+      return;
+    }
+
+    if ($current_target_id !== '') {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Store @store is already linked to vendor @existing; not relinking it to vendor @vendor.', [
+        '@store' => (string) $store->id(),
+        '@existing' => $current_target_id,
+        '@vendor' => (string) $vendor->id(),
+      ]);
+      return;
+    }
+
+    $store->set('field_vendor_reference', $vendor->id());
+    if ($save) {
+      $store->save();
     }
   }
 

--- a/web/sites/default/mel.session.staging-au.yml
+++ b/web/sites/default/mel.session.staging-au.yml
@@ -1,5 +1,5 @@
-# Staging AU (*.myeventlane.com.au, including *.staging.myeventlane.com.au) —
-# shared session across apex / vendor / admin on the same registrable suffix.
+# Staging AU (*.staging.myeventlane.com.au) shared session across
+# staging / vendor.staging / admin.staging.
 # cookie_secure is applied at runtime by Drupal\Core\Session\SessionConfiguration
 # when the request is HTTPS (reverse_proxy + X-Forwarded-Proto must be correct).
 parameters:
@@ -11,4 +11,4 @@ parameters:
     cookie_samesite: Lax
     name_suffix: ''
     cookie_httponly: true
-    cookie_domain: '.myeventlane.com.au'
+    cookie_domain: '.staging.myeventlane.com.au'

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/stripe-panel.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/stripe-panel.html.twig
@@ -20,18 +20,18 @@
     <div class="mel-stripe-panel__status mel-stripe-panel__status--{{ phase }}">
       <span class="mel-stripe-panel__status-dot"></span>
       {% if phase == 'payouts_ready' %}
-        {{ 'Payouts enabled'|t }}
+        {{ 'Stripe connected ✅'|t }}
       {% elseif phase == 'needs_completion' %}
-        {{ 'Action required'|t }}
+        {{ 'Finish Stripe setup'|t }}
       {% else %}
-        {{ 'Not connected'|t }}
+        {{ 'Connect Stripe'|t }}
       {% endif %}
     </div>
   </div>
 
   <div class="mel-stripe-panel__body">
     {% if phase == 'payouts_ready' %}
-      <p class="mel-stripe-panel__lead mel-stripe-panel__lead--success">{{ 'Payouts enabled — funds from ticket sales can reach your bank.'|t }}</p>
+      <p class="mel-stripe-panel__lead mel-stripe-panel__lead--success">{{ 'Stripe connected ✅ Funds from ticket sales can reach your bank.'|t }}</p>
       {% if stripe.account_id %}
         <div class="mel-stripe-panel__account">
           <span class="mel-stripe-panel__account-label">{{ 'Account'|t }}</span>
@@ -48,7 +48,7 @@
     {% elseif phase == 'needs_completion' %}
       <p class="mel-stripe-panel__lead">{{ 'Finish setting up Stripe so payouts can reach your bank.'|t }}</p>
       <div class="mel-stripe-panel__actions">
-        <a href="{{ stripe.resume_url|default(stripe.connect_url)|default(path('myeventlane_vendor.stripe_connect', {}, {query: {destination: app.request.getPathInfo()}})) }}" class="mel-btn mel-btn--primary mel-button mel-button--primary mel-button--stripe">{{ 'Resume Stripe setup'|t }}</a>
+        <a href="{{ stripe.resume_url|default(stripe.connect_url)|default(path('myeventlane_vendor.stripe_connect', {}, {query: {destination: app.request.getPathInfo()}})) }}" class="mel-btn mel-btn--primary mel-button mel-button--primary mel-button--stripe">{{ 'Finish Stripe setup'|t }}</a>
       </div>
 
     {% else %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -342,7 +342,7 @@
             connected: false,
             status: 'not_connected',
             status_label: 'Not connected',
-            connect_url: '/vendor/stripe/connect'
+            connect_url: '/stripe/connect'
           })
         } only %}
       </section>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches Stripe payment/onboarding flows and vendor store linking, and the updated `VendorStoreSubscriber` appears to contain duplicate methods/undefined dependencies that could cause runtime fatals. Route/access changes and new public callback endpoint also increase the blast radius if misconfigured.
> 
> **Overview**
> Improves Stripe Connect onboarding reliability by adding `StripeService::getOrCreateAccount()` plus vendor/store resolution helpers, setting the Stripe API key globally, and routing all Stripe `ApiErrorException`s to a dedicated `stripe_error` channel.
> 
> Updates Connect onboarding behavior and URLs: introduces a new `/stripe/callback` route (keeping `/stripe/connect/callback` as legacy), switches `/stripe/connect` to a new `StripeConnectAccess` check, and updates dashboard/theme links and labels to use the new paths.
> 
> Adjusts vendor/store linking by removing onboarding-manager gating from `VendorStoreSubscriber`, attempting to link to an existing Commerce store by owner before creating one, and adding fallback store discovery when enforcing “Stripe must be connected” gating; also changes Connect “complete” status to depend on `details_submitted` + `charges_enabled` (not payouts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0e1ea20c6164dd804d28f779ce3d03cb145f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->