### PR TITLE
Feature/mel v2 task based completion audit

### DIFF
--- a/docs/audits/mel-stripe-connect-audit.md
+++ b/docs/audits/mel-stripe-connect-audit.md
@@ -1,0 +1,282 @@
+# MEL — Full Stripe Connect audit
+
+**Date:** 2026-04-27  
+**Branch under audit:** `feature/mel-v2-task-based-completion-audit` (HEAD `bd2e5209` at run time)  
+**Read-only task:** this file only; no code, config, DB updates, or merges.  
+**Comparison branch (evidence only, not merged):** `fix/stripe-connect`
+
+---
+
+## 1. Current Stripe package / config
+
+### Composer (output of `composer show | grep -Ei "stripe|commerce"`)
+
+- `drupal/commerce` 3.3.5 (and commerce_order, commerce_payment, commerce_store, commerce_price, etc.)  
+- `drupal/commerce_stripe` 2.2.1  
+- `drupal/commerce_paypal` 2.1.2 (non-Stripe)  
+- `stripe/stripe-php` 15.10.0  
+
+### Drupal modules (enabled)
+
+- **Commerce + Commerce Stripe** (contrib) for Payment Element / gateway stack.  
+- **Custom:** `myeventlane_core` (Stripe service), `myeventlane_commerce` (Connect gateway plugin + payment service), `myeventlane_vendor` (onboarding UI/controllers), `myeventlane_admin_dashboard` (payout webhooks), `myeventlane_webhooks` (MEL’s **outgoing** webhooks to subscribers — not Stripe’s inbound API), `myeventlane_pro` (subscription webhook), etc.
+
+### Where platform keys are read (code)
+
+- `Drupal\myeventlane_core\Service\StripeService::getPlatformSecretKey()` loads **`commerce_payment_gateway` entities** `mel_stripe` (preferred) then `stripe`, then optional `myeventlane_core.stripe_settings: platform_secret_key`.  
+- `config/sync/commerce_payment.commerce_payment_gateway.stripe.yml` has **`publishable_key: ''` and `secret_key: ''`** in sync (no secrets committed in active sync for that file).  
+- A gateway definition file exists for `mel_stripe_cc` (manual / test) in sync — do not confuse with live Connect.  
+- The custom plugin class **`StripeConnect`** lives under `myeventlane_commerce`; an **export** in `config/sync` for `plugin: stripe_connect` was **not found** in this audit pass — the **live checkout gateway** configuration may be **DB-only, overridden, or under a name not in sync**. That is a **documentation / ops** gap (P2), not proof of misconfiguration.
+
+### Secret scan (grep for key patterns, excluding `vendor` / `node_modules` / `.git`)
+
+- **Hits included:**  
+  - `_INVALID_config_backup_2026-01-02/.../commerce_payment.commerce_payment_gateway.stripe.yml` — contains **`pk_test_…` and `sk_test_…` literals**.  
+  - `_myeventlane_audit/config-sync/.../commerce_payment.commerce_payment_gateway.stripe.yml` — same.  
+  - Documentation references in `SECRETS_PROTECTION_GUIDE.md` / `docs/…` (pattern examples, not live keys in body beyond descriptions).  
+- **Full values** are not reproduced here. **Classification:** if those backup paths are tracked in the repository, that is a **P0** hygiene issue (test keys in tree); treat as **rotate** if the keys were ever real and reuse is possible.  
+- **Active** `config/sync` gateway for `stripe` uses **empty** keys in YAML as checked above.
+
+---
+
+## 2. Current Stripe **account** model (this branch, from code)
+
+### Account creation (onboarding)
+
+- `StripeConnectController::connect()` (current branch) calls  
+  `StripeService::createConnectAccount($userEmail, 'AU', '**standard**')` when no `field_stripe_account_id` on the store — see `web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php` (~line 230).  
+- `StripeService::createConnectAccount()` uses Stripe API: `'type' => $type` (default `standard` in docblock), with **`capabilities`**: `card_payments` and `transfers` both **requested: true** — `web/modules/custom/myeventlane_core/src/Service/StripeService.php`.  
+- **AccountLink** is created with `'type' => 'account_onboarding'`. No OAuth `authorize_url` path was found in MEL for Connect; flow is **Account Links** to hosted onboarding.
+
+### `fix/stripe-connect` divergence (evidence, not merged)
+
+- `git log feature/mel-v2-task-based-completion-audit..fix/stripe-connect` shows three commits; **`StripeService` on that branch** adds `getOrCreateAccount()` which calls `createConnectAccount($email, 'AU', '**express**')` (Express, not Standard).  
+- **Conclusion for product:** this audit branch and `fix/stripe-connect` are **not aligned** on **account type (Standard vs Express)**. Resolving that is a **P1** product/compliance decision, not a guess.
+
+---
+
+## 3. Current **charge** model (from code; no guesswork beyond this)
+
+### Primary pattern: **destination charges** on the **platform** account
+
+- `StripeService::createPaymentIntentForTicketSale()` builds a `PaymentIntent` with:  
+  - `application_fee_amount`  
+  - `transfer_data['destination']` = vendor Connect account ID `acct_…`  
+- `StripeConnectPaymentService::getConnectPaymentIntentParams()` merges into Commerce PaymentIntents:  
+  - `application_fee_amount` (from ticket revenue only)  
+  - `transfer_data` with **`destination`** and explicit **`amount`** = ticket revenue in cents; donations excluded from that amount per comments.  
+- The **custom** Commerce gateway `Drupal\myeventlane_commerce\Plugin\Commerce\PaymentGateway\StripeConnect` **extends** `commerce_stripe` `StripePaymentElement` and overrides `createPaymentIntent()` to inject those params.
+
+### Merchant of record (from design comments only)
+
+- `StripeConnectPaymentService` file-level doc and `getConnectPaymentIntentParams` comments state: total charged includes tickets + donations; **application fee and transfer math** are described as platform fee on tickets + **donations stay with platform** — **vendor receives ticket net of fee** via `transfer_data`.  
+- Exact Stripe MoR for Standard vs Connect fee liability is a **Stripe account + settings** question; the code **does** implement **application fees + transfer to connected account** (not “direct charge on connected only” in this path).
+
+### `on_behalf_of` / `Stripe-Account` header in custom PI helper
+
+- The reviewed `createPaymentIntentForTicketSale` snippet **does not** set `on_behalf_of` in the array shown. Whether `commerce_stripe` adds options elsewhere was **not** fully traced in this task.  
+- **Grep** across `web/modules/custom` + `config/sync` for those strings is part of the required audit list; MEL’s **explicit** Connect ticket logic uses **`application_fee_amount` + `transfer_data`**.
+
+### Checkout gating of “not ready” vendor
+
+- `StripeConnectPaymentService::validateOrderForConnect()` requires a **store** and **`field_stripe_account_id` on the store** for paid line items, or returns invalid with a user-oriented message.  
+- `StripeConnectValidationSubscriber` on **checkout completion** only **logs a warning** if validation fails — it does **not** block completion. **P1:** risk that misconfiguration is caught **late**; rely on **earlier** validation in checkout/payment (Commerce + gateway) in normal operation.  
+- Vendor booking forms (`RsvpBookingForm::isVendorStripeConnected`) use **`field_stripe_charges_enabled`**, then `field_stripe_connected` on the store.
+
+### Commerce Stripe (contrib) routes (Drush `route` sample)
+
+- Includes `/admin/commerce/.../connect` OAuth, `/stripe-connect/oauth/return/...`, Express Checkout, etc. MEL’s primary vendor path is **custom** (`/stripe/connect`).
+
+**Required `ddev drush route | grep`:** exit **141** when piped/limited (not a Drush error); a prefix of routes was captured, including `myeventlane_admin_dashboard.stripe_payout_webhook: /stripe/webhook/payout` and MEL vendor routes.
+
+---
+
+## 4. Vendor / store / account relationship
+
+### Storage (config entity fields in sync)
+
+- `commerce_store` bundle `online` has: `field_stripe_account_id`, `field_stripe_connected`, `field_stripe_charges_enabled`, `field_stripe_payouts_enabled`, `field_stripe_onboard_url`, `field_stripe_dashboard_url` (and related storage YAML under `config/sync/field.…`).  
+- `myeventlane_vendor` entity: vendor links to a single store via `field_vendor_store` (as used in `StripeConnectController::getStoreForConnect()`).
+
+### Onboarding code behaviour (this branch)
+
+- Resolves **store** via vendor’s `field_vendor_store`, else “first store by uid” query, else **default store** (`getCurrentUserStore()` can return default store) — see `StripeConnectController`.  
+- New Connect account ID is written to **store** and optionally **vendor** `field_stripe_account_id`.  
+- **Overwriting** risk: recreating a new account for the same store when `accountId` is empty could orphan old `acct_` in Stripe; no merge analysis performed here. **P2** to review with Stripe Dashboard ops.
+
+### Drush `php-eval` (read-only) — store `field_stripe_connected` snapshot (local DDEV)
+
+Command ran successfully. Output was one line per store id with `0` or `1` (boolean stored). A few stores showed `1`; most `0` — **environment-specific**, not a pass/fail.
+
+---
+
+## 5. Onboarding flow (this branch, sequence)
+
+1. **Vendor** hits **`GET /stripe/connect`** → route `myeventlane_vendor.stripe_connect` → `StripeConnectController::connect()`.  
+2. **Anonymous** → access denied.  
+3. **Store** resolved; if **none** → error message, redirect to **vendor dashboard**.  
+4. If **existing `field_stripe_account_id`:** call **`getAccountStatus`**, update store flags; if **`charges_enabled`**, early exit “already connected” to dashboard.  
+5. If **no account id:** `createConnectAccount(…, '**standard**')` → save `acct_` on store + vendor fields → **`createAccountLink`**.  
+6. **Return/refresh URLs** from `buildAccountLinkUrls` → `myeventlane_vendor.stripe_onboard_return` and `myeventlane_vendor.stripe_onboard_refresh` (see `StripeConnectController`).  
+7. **Redirect** to `https://connect.stripe.com/...` (validated prefix).  
+8. **Callback** `StripeConnectController::callback` → reads account id from **store**, refreshes `getAccountStatus`, updates store/vendor, messages, **redirect to destination** if query param, else **dashboard**.  
+9. **Manage** (`::manage`) → `createLoginLinkIfEligible` path (uses eligibility including `details_submitted`, `charges_enabled`).
+
+**`fix/stripe-connect` (diff only):** reworks store resolution through `VendorStoreSubscriber::ensureStoreForVendor`, **removes** default-store fallback, changes **return/refresh** to pass **`account_id` in query** and different routes, uses **`getOrCreateAccount`**, **Express** type, and adds **`ApiErrorException`** user messaging and logging; **connect method signature** becomes `connect(Request $request)`.
+
+### Watchdog evidence (onboarding / loop)
+
+- `ddev drush ws` filtered output showed many repeated lines in the same second: **STRIPE CONNECT HIT**, **Created AccountLink for account acct_…**, and **`mel_debug` logging “Stripe redirecting to: @url”** with a **connect.stripe.com** URL.  
+- **P1 (logging safety):** **Full AccountLink URLs** (or long redirect URLs) are written to `mel_debug` / `myeventlane_core` at **notice/info** in ways that can expose **sensitive, single-use** onboarding URLs in logs. **P2 (ops):** repeated hits suggest **retry** or **double navigation**; confirm monitoring.
+
+**Required `drush route | grep`:** see section 1 (exit 141 when truncated).
+
+---
+
+## 6. The “managing **losses** / responsibilities” error
+
+### In-repo string search
+
+- Grep in `web/modules/custom` for that phrase: **no matches** (error is not MEL’s own string). It is consistent with a **Stripe API** or **Stripe-hosted** onboarding error when the **Connect platform** or **account type** (e.g. **Standard** + platform liability) does not match the platform’s **Connect profile** or **loss liability** configuration.
+
+### Likely locus (inference limited to public Stripe behaviour + MEL’s Standard path)
+
+- On this branch, **account type is `standard`**. If the **Stripe Dashboard / Connect** settings for the platform are incomplete or conflict with **Standard** + requested capabilities, Stripe may reject **account** creation or **AccountLink** creation with a **platform-level** or **onboarding** error. MEL’s **`fix/stripe-connect`** branch adds a **user-visible** message (on `ApiErrorException`) that references the **platform Connect profile** needing **review** — that points to the **same class of failure** (operator-facing), but **does not by itself** change the **root** Stripe **account type** in `createConnectAccount` on **this** branch; the **separate** diff moves creation toward **Express** in `getOrCreateAccount`.
+
+**Conclusion for Task 3:** document **P1: operator must** inspect **Stripe Connect settings**, **Connect application**, and **account type (Standard vs Express)** with Stripe. Do **not** treat this file as a Stripe support diagnosis.
+
+**Required watchdog grep:** no line contained the literal “losses” in the last 100 entries shown; the sample was dominated by connect redirects and “Created AccountLink”.
+
+---
+
+## 7. Account readiness checks (code)
+
+`StripeService::getAccountStatus()` maps:
+
+- `details_submitted` + `charges_enabled` + `payouts_enabled` all true → `status` **complete**; else if charges or payouts false → **restricted**; else **pending** (simplified; see method).  
+- Returns `charges_enabled`, `payouts_enabled`, `details_submitted` booleans.  
+- **Not** used in the audited snippet: `requirements.currently_due`, `past_due`, `disabled_reason`, or **capability** objects beyond the **initial** `createConnectAccount` capability request.  
+- **P2:** for **payouts held** with **charges live**, gating on **`charges_enabled` alone** in places may be **incomplete** (depends on product — some flows intentionally ignore payouts, see in-code comment on onboard controller).
+
+`validateAccountDashboardEligibility()` **does** require `details_submitted` and `charges_enabled` (and not deleted) before **LoginLink**.
+
+**Paid sales blocking:** see §3 (validation service + form checks). **P1** remains: completion subscriber is **log-only**.
+
+---
+
+## 8. Webhooks (summary)
+
+| Area | Findings (from code grep + sample files) |
+|------|------------------------------------------|
+| **MEL payout** | `web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php` — **`Webhook::constructEvent($payload, $sigHeader, $webhookSecret)`**; secret from **config** key `…->get('stripe_webhook_secret')` (schema documents `whsec_` pattern). Fails closed if **empty** (rejects with 500 in snippet). **Idempotence** for `transfer.paid` via ledger/transfer id checks in same file (partial read / grep). |
+| **MEL Pro subscription** | `ProSubscriptionWebhookController` — `constructEvent` (same pattern). |
+| **Commerce Stripe (contrib)** | Inbound payment webhooks are **Commerce Stripe** / queue; **not** re-audited line-by-line in this task. |
+| **myeventlane_webhooks** | **Outbound** HMAC to subscribers; **not** Stripe inbound signature verification. |
+
+**Logging safety:** `StripeService::safeLog` uses `SensitiveDataScrubber` for service logs; `StripeConnectController` still uses direct `\Drupal::logger('mel_debug')->notice('Stripe redirecting to: @url',…)` for **full URL** (see §5).
+
+### Required `grep` for webhook / PaymentIntent (high level)
+
+- `constructEvent` only in `myeventlane_admin_dashboard` and `myeventlane_pro` in the `grep` head for custom code.  
+- `application_fee_amount`, `transfer_data`, `PaymentIntent` in `StripeService` and `StripeConnectPaymentService` as above.
+
+---
+
+## 9. Vendor UX (condensed)
+
+- **Dashboard / vendor console** uses `VendorDashboardController::getStripeConnectStatus()` and CTA/JS `stripe-connect-cta.js` (file names only in grep).  
+- **assertStripeConnected()** in `VendorConsoleBaseController` checks **`field_stripe_connected` or `field_stripe_charges_enabled`**, and redirects to **`/stripe/connect?destination=…`**. **Admins and uid 1** bypass.  
+- **“One primary action”** for connection is the **connect route**; exact Twig/theme review was **out of scope** for this doc.
+
+---
+
+## 10. Admin UX (condensed)
+
+- **Routes** exist for **payouts**, **vendors list**, and **staged financial tools** under `myeventlane_admin_dashboard` (e.g. `/admin/myeventlane/payouts`, …).  
+- This audit **does not** confirm each field visible on the admin **vendor** edit form; **no bank/KYC** fields should be added in MEL; **P2** to verify only **safe** Stripe ids/status are shown in UI.
+
+---
+
+## 11. Risk summary
+
+### P0 (launch / security)
+
+1. **Test Stripe secret/publishable keys** present in **repository copy paths** (`_INVALID_config_backup*`, `_myeventlane_audit*`) — treat as **committed secret material** until removed or gitignored; **rotate** if ever valid.  
+2. **(Conditional P0)** If production ever relied on the same test keys, **fraud and leakage** — **out of code scope**; ops must confirm.  
+3. **No** evidence in this pass that **vendor A** can read **vendor B** Stripe fields via **MEL** code (would need targeted access review) — **not** listed as P0.
+
+### P1 (important)
+
+1. **Branch drift:** `fix/stripe-connect` changes **Connect account type** to **Express** in new helper vs **Standard** in current `connect()` — **product alignment** required before any merge.  
+2. **Onboarding / API errors:** `fix/stripe-connect` adds **ApiErrorException** handling and user messaging; **this branch** has **generic** catch in `::connect` (and does **not** list the **“platform profile”** string).  
+3. **Checkout completion** only **logs** failed Connect validation — **safety** depends on **earlier** steps.  
+4. **Watchdog** may contain **sensitive** redirect URLs; **scrub** or downgrade log level.  
+5. **“Managing losses”** — **operator** must reconcile **Connect app**, **account type**, and **Stripe** dashboard with Stripe docs; MEL has **no** local string match.
+
+### P2 (polish / ops)
+
+1. **Gateway export:** `plugin: stripe_connect` **not in** `config/sync` grep; document **where** the active gateway is stored in each env.  
+2. **Status fields** do not map **all** Stripe **requirements** arrays in `getAccountStatus` return.  
+3. **Onboarding** retry noise in logs.
+
+### P3 (later)
+
+- npm / Stripe-PHP version drift — routine dependency hygiene.
+
+**Required `git` / shell commands:** see **Appendix** (all were run; **failed** only where noted: `ddev drush route` with pipe exit 141, not a business failure).
+
+---
+
+## Current Stripe model (concise)
+
+- **Connect** with **Account** creation ( **`standard` on this branch** ), **Account Links** to **Stripe-hosted** onboarding, and **Connect destination-style** `PaymentIntents` with **`application_fee_amount`** and **`transfer_data[destination]`** to the **connected account id** stored on the **Commerce store**. **Platform** Stripe secret comes from **Commerce payment gateway** (or `myeventlane_core` settings) via **`StripeService`**. **Commerce Stripe** and **MEL** custom gateway work together; exact **active** gateway id in each env may be **outside** sync. **Payout** reconciliation uses a **dedicated** `StripeWebhookController` with **signature verification** when the secret is configured.
+
+---
+
+## Vendor responsibility alignment (concise)
+
+- Code and service comments state **tickets** pay out to vendor **net of application fee**; **donations** and **certain** line types are modelled as **platform**-retained. Vendors’ **obligations** (tax, disputes, **their** Dashboard) are **in line with** Stripe’s **Connect** model, but **Standard vs Express** and **liability** must match **product** and **Stripe** setup — **diverging branches** (Express vs Standard) need **resolution** before claiming alignment.
+
+---
+
+## Confirmed risks (short list)
+
+- **Test keys in backup/audit tree paths** in the repo.  
+- **Log exposure** of full **onboarding** redirect URLs.  
+- **Standard vs Express** + **`fix/stripe-connect`** not merged — **inconsistent** Connect behaviour until unified.  
+- **Checkout** completion Connect validation is **log-only** at the last subscriber.
+
+---
+
+## Recommended next task
+
+**TASK 4 — Fix Stripe onboarding / account-creation path only (single coherent implementation, including merge or supersede of `fix/stripe-connect` with explicit product sign-off on account type, store resolution, and logging safety)** — *without* in this turn changing unrelated checkout or global charge model unless Task 4 scope is written to include them.
+
+---
+
+## Appendix: commands run and outcomes
+
+| Command | Outcome |
+|---------|---------|
+| `git status --short` | **empty** (clean) |
+| `git branch --show-current` | `feature/mel-v2-task-based-completion-audit` |
+| `git log -1 --oneline` | `bd2e5209 docs(audit): add MEL v2 current build audit` |
+| `composer show \| grep -Ei "stripe\|commerce"` | See §1 |
+| `ddev drush route \| grep -Ei "stripe\|connect\|payout\|vendor"` | **Exit 141** (broken pipe to pager); first lines included Commerce Stripe + MEL admin payout webhook, vendor routes |
+| `ddev drush ws --count=100 \| grep -Ei "stripe\|…"` | Matched many Stripe/AccountLink/redirect lines; no “losses” in sample |
+| `grep -R "sk_test\|…" -n . --exclude-dir=vendor --exclude-dir=node_modules --exclude-dir=.git` | See §1; **backup/audit yml** hits |
+| `ddev drush php-eval '…'` (stores / `field_stripe_connected`) | **OK**; per-store 0/1 output |
+| `git log --oneline feature/…audit..fix/stripe-connect` | 3 commits listed |
+| `git diff feature/…audit..fix/stripe-connect -- …StripeConnectController.php` | Large diff: Express, `getOrCreateAccount`, URLs, `ApiErrorException`, etc. |
+| `git diff feature/…audit..fix/stripe-connect -- myeventlane_stripe` | **empty** (no change under that path) |
+| `git diff` … `StripeService.php` (manual) | **Non-empty**; adds `getOrCreateAccount`, Express, etc. |
+| Grep groups from prompt (`StripeConnect`, `Account::create`, `PaymentIntent`, `webhook`, etc.) | Summarized in report; full outputs not pasted |
+
+### Failed / noisy commands
+
+- **None** in the “command not found / exception” sense for Drush, except **`drush route` exit 141** when used with a **pipe** (expected).  
+- **`grep` for `myeventlane_stripe` diff** returned **no** diff; actual Stripe service changes on `fix/stripe-connect` are under **`myeventlane_core`**, not **`myeventlane_stripe`**.
+
+---
+
+**END — Task 3 (audit file only).**

--- a/docs/audits/mel-stripe-connect-task-4-summary.md
+++ b/docs/audits/mel-stripe-connect-task-4-summary.md
@@ -1,0 +1,115 @@
+# Task 4 — Stripe Connect onboarding (MEL) — summary
+
+**Branch:** `feature/mel-v2-task-based-completion-audit`  
+**Product decision:** Stripe Connect **Express** for vendor onboarding (Stripe-hosted onboarding, vendor responsibility, no custom KYC in MEL).
+
+---
+
+## Account type implemented
+
+- New Connect accounts are created as **Express** via `StripeService::createConnectAccount(..., 'express')` (default parameter is Express).
+- `ensureConnectAccountIdForStore()` **reuses** existing `field_stripe_account_id` when set; it only creates an account when the field is empty.
+- Method names and docblocks describe Express as the MEL default; `standard` is documented as legacy-only in the account-creation API.
+
+---
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `web/modules/custom/myeventlane_core/src/Service/StripeService.php` | Express default; `maskAccountId()`; `ensureConnectAccountIdForStore()`; `applyConnectStatusToCommerceStore()`; safe logging (masked account ids in info logs; no full URLs in new code paths). |
+| `web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php` | Account link flow, query `account_id` validation, callback, `manage()`; `ApiErrorException` handling with `logConnectApiError()` on manage; no full Account Link / login URLs in logs. |
+| `web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php` | `ensureStoreForVendor()` + `createAndPersistStoreForVendor()` — store from vendor relationship only (onboarding guard preserved). |
+| `web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php` | `getStripeConnectStatus()`: **removed** `commerce_store` lookup by `uid`; store only from `field_vendor_store`; `account_id` on connect/resume URLs; `mel_stripe_state` + `primary_action` + `action_url`; dashboard copy and alerts/notifications aligned. |
+
+---
+
+## Cherry-picks from `fix/stripe-connect`
+
+- **No bulk merge** and **no cherry-pick commits** from that branch. Implementation was aligned manually with the same goals (Express, membership-based vendor, store subscriber, safe logging).
+
+---
+
+## How existing connected vendors are protected
+
+- If `field_stripe_account_id` is **non-empty**, `ensureConnectAccountIdForStore()` returns it and **does not** create another Stripe account.
+- New-account creation only initializes `field_stripe_*` flags when a **new** account is created (empty id).
+- Callback and connect “resume” paths call `getAccountStatus()` and `applyConnectStatusToCommerceStore()` to **refresh** flags from Stripe (authoritative for charges/payouts).
+
+---
+
+## Store resolution
+
+- **No** default platform store and **no** “first store by user uid” fallback on the dashboard.
+- Store is resolved via the **vendor** → `field_vendor_store` relationship (and `VendorStoreSubscriber::ensureStoreForVendor()` when a store must be created after onboarding is complete).
+
+---
+
+## Account links
+
+- Each onboarding attempt builds a **new** Account Link via `createAccountLink()` after `ensureConnectAccountIdForStore()`.
+- `return_url` → `myeventlane_vendor.stripe_callback` and `refresh_url` → `myeventlane_vendor.stripe_connect`, both with `account_id` (+ optional `destination`) for validation.
+- Redirect host must be `https://connect.stripe.com` for onboarding links.
+- Logs: **no** full redirect URLs; structured notice with vendor id, store id, **masked** account id.
+
+---
+
+## Logging removed or masked
+
+- `StripeService` info logs for Connect account / Account Link / Login Link / ticket PaymentIntent destination use **masked** account ids where applicable.
+- Controllers use masked account ids in structured error/notice messages; `logConnectApiError()` includes vendor id, user id, store id, masked account id, Stripe error type/code, and message (API message only — not raw response bodies).
+
+---
+
+## Verification commands and results (2026-04-27)
+
+| Command | Result |
+|---------|--------|
+| `composer validate` | `./composer.json is valid` |
+| `ddev drush cr` | Success (cache rebuild) |
+| `ddev drush route \| grep -Ei "myeventlane_vendor\.stripe"` | Listed `/stripe/connect`, `/stripe/connect/callback`, `/stripe/manage`, onboard refresh/return aliases |
+| `grep -R "Stripe redirecting to:\|connect.stripe.com" -n web/modules/custom` | Only host validation in `StripeConnectController` (no full URL logging) |
+| `grep -R "createConnectAccount" -n web/modules/custom` | `StripeService` only (Express) |
+| `grep -R "type.*standard\|type.*express" -n web/modules/custom` | Connect `type` is `express` in `createConnectAccount`; other matches are unrelated Views “standard” sort ids |
+
+**Not run in this pass (no SCSS/twig changes in Task 4):** `npm run mel:lint` / `npm run mel:build`.
+
+**Optional:** `ddev drush ws --count=100 | grep -Ei "stripe|connect|..."` — run after manual tests in a real environment.
+
+---
+
+## Manual tests still required
+
+1. Vendor with existing `field_stripe_account_id`: Connect does not create a duplicate; flags refresh from Stripe.
+2. Vendor with store, no account: Express account created; id saved; redirect to Stripe onboarding; return/callback updates store.
+3. Vendor without store (onboarding complete): store created via subscriber; Stripe attaches to that store only.
+4. Expired Account Link: hit `refresh_url`; new link generated; no loop.
+5. `return_url` with `destination` and `account_id`: relationship validated; status updated.
+6. Induce Stripe `ApiErrorException`: user sees generic message; logs are safe.
+7. **Paid selling:** ticket/event flows using `assertStripeConnected()` — confirm behaviour matches policy (charges/connected flags). Broader “publish paid event” gating may live outside this task; see follow-up.
+
+---
+
+## Follow-up tasks
+
+1. **Under review / disabled:** `getAccountStatus()` does not expose `requirements` arrays; dashboard states are derived from **stored** fields only. To show “Under review” or “Disabled/rejected” accurately, either extend stored metadata (if product agrees) or a controlled background refresh (watch performance).
+2. **Repository secret hygiene:** rotate/remove `_INVALID_config_backup*`, `_myeventlane_audit*` key material (not in Task 4 scope).
+3. **Publish path for paid events:** if anything allows publishing a paid-ticket event without `charges_enabled`, add a follow-up ticket; vendor console already uses `assertStripeConnected()` on key routes.
+
+---
+
+## Root cause (brief)
+
+Prior work mixed **Standard/Express** assumptions, **uid-based** store fallbacks, and **unsafe or overly verbose** logging. Task 4 converges on **Express**, **vendor-bound store** resolution, and **safe** operator logs while preserving existing Connect account ids.
+
+---
+
+## Ready to commit?
+
+**Yes, pending your review and the manual checks above.** Working tree: modified custom modules and this summary (new file); commit when satisfied.
+
+---
+
+## STOP
+
+Task 4 implementation and documentation are complete; no further scope unless Anna extends the task.

--- a/docs/audits/mel-v2-current-build-audit.md
+++ b/docs/audits/mel-v2-current-build-audit.md
@@ -1,0 +1,224 @@
+# MEL v2 — current build read-only audit
+
+**Date:** 2026-04-27  
+**Branch:** `feature/mel-v2-task-based-completion-audit` (at time of audit)  
+**Method:** read-only: Drush, repo inspection, one runtime route match in DDEV, no `cex`, no fixes, no merges.  
+**Scope note:** This documents **what the codebase and environment report**. Functional QA (browsers, payments, real Stripe) was **not** performed.
+
+---
+
+## 1. Git and environment
+
+| Check | Result |
+|--------|--------|
+| current branch | `feature/mel-v2-task-based-completion-audit` |
+| latest commit | `477d9a4d Merge pull request #203 from anna-pye/stripe-intent-type` |
+| working tree | **clean** (`git status --short` empty) |
+| `composer validate` | **pass** — `./composer.json is valid` |
+| `ddev drush status` | **pass** — Drupal **11.3.8**, DB connected, bootstrap successful |
+| default theme | `myeventlane_theme` |
+| admin theme | `gin` |
+| `ddev drush theme:status` | **failed** — *Command "theme:status" is not defined* (suggested: `config:status`, `theme:enable`, etc.) |
+
+**Enabled MEL custom modules (representative, from `ddev drush pm:list … \| grep -E "myeventlane\|mel_"`)** include the full MEL set: e.g. `myeventlane_core` … `myeventlane_webhooks`, `mel_admin_dashboard` / `mel_ticket` as shown in Drush output; **no attempt** to list every sub-module name token that wrapped on one line. Key commerce/help/event modules: `myeventlane_commerce`, `myeventlane_rsvp`, `myeventlane_checkout_flow`, `myeventlane_checkout_paragraph`, `myeventlane_event_studio`, `myeventlane_vendor`, `myeventlane_stripe`, `myeventlane_help_assistant`, `myeventlane_help_centre*`, `myeventlane_staff_playbooks*`, etc.
+
+**Prioritised findings (§1):**
+
+- **P2:** `ddev drush theme:status` is not available on this Drush; use `drush config:get system.theme` or UI if theme status is needed.  
+- **P3:** Local `npm` warnings re `devdir` during `mel:lint` / `mel:build` (no task fix).
+
+---
+
+## 2. Routes (names + file locations or config source)
+
+Sources: `ddev drush route \| grep …` (sample), `myeventlane_*.routing.yml` files, `config/sync/views.*.yml` for Views pages, and **runtime** route match in DDEV for `/home` and a few paths.
+
+| Area | Route name(s) | Path / note | File / config |
+|------|---------------|-------------|---------------|
+| **Homepage / discovery** | `view.frontpage.page_1` | **`/home`** (Views) | `system.site` front = `/home`; `config/sync/system.site.yml`; View `frontpage` display `page_1` |
+| **/events** | `view.upcoming_events.page_events` | **`/events`** | `config/sync/views.view.upcoming_events.yml` (display `page_events`, `path: events`); view description: canonical public discovery |
+| **Category** | `view.upcoming_events.page_category` (and block displays) | **`/events/category/%** (taxonomy in path)** | same view file; `path: events/category/%` |
+| **Event full** | `entity.node.canonical` | Resolves to node path (often pathauto) — e.g. `/node/{id}` or alias; not hard-coded in one custom `routing.yml` for all | Core + Pathauto; bundle `event` |
+| **Event booking (unified)** | `myeventlane_commerce.event_book` | **`/event/{node}/book`** | `web/modules/custom/myeventlane_commerce/myeventlane_commerce.routing.yml` |
+| **RSVP → book redirect** | `myeventlane_rsvp.public_rsvp_form` | **`/event/{event}/rsvp`** | `web/modules/custom/myeventlane_rsvp/myeventlane_rsvp.routing.yml` **→ `RsvpRedirectController::redirectToBooking`** |
+| **RSVP form / thank you** | `myeventlane_rsvp.form`, `myeventlane_rsvp.thankyou` | `/event/{node}/rsvp/form`, `/event/{event}/rsvp/thank-you` | same file |
+| **Paid ticket (Commerce)** | `commerce_checkout.*`, `commerce_checkout.form` | **`/checkout`**, **`/checkout/{commerce_order}/{step}`** | Contrib; step includes payment and completion |
+| **Confirmation** | `commerce_checkout.form` (step) | part of **checkout** flow — e.g. complete step on order | See checkout flow `mel_event_checkout` in config (below) |
+| **Vendor dashboard** | `myeventlane_vendor.console.dashboard` (matched) | **`/vendor/dashboard`** | `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml` — route key near `path: '/vendor/dashboard'` |
+| **Event Studio create** | `myeventlane_event_studio.create` | **`/vendor/events/create`** | `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml` |
+| **Event Studio edit (wizard)** | `myeventlane_event_studio.edit`, `…edit_basic`, `…tickets`, etc. | `/vendor/events/{node}/edit`, sub-steps | same |
+| **Stripe Connect onboarding** | `myeventlane_vendor.stripe_connect` | **`/stripe/connect`** | `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml` — `StripeConnectController::connect` |
+| **Stripe callback** | `myeventlane_vendor.stripe_callback` | **`/stripe/connect/callback`** | same, `::callback` |
+| **(Additional)** | `myeventlane_vendor.*` | `/vendor/onboard/stripe-return`, `/vendor/onboard/stripe-refresh` | same file (onboarding return URLs) |
+| **Help centre** | `myeventlane_help_centre.home` etc. | `/help`, `/help/index`, `/help/vendors`, etc. | `web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml` |
+| **Help assistant** | `myeventlane_help_assistant.page` / `ask` | **`/help/assistant`** (GET + POST) | `web/modules/custom/myeventlane_help_assistant/myeventlane_help_assistant.routing.yml` |
+| **Staff playbooks (example)** | `myeventlane_staff_playbooks.governance_dashboard` | **`/admin/myeventlane/governance`** (permission: `administer escalations`) | `web/modules/custom/myeventlane_staff_playbooks/myeventlane_staff_playbooks.routing.yml` — **not** exhaustive of all staff routes |
+
+**Runtime checks (DDEV, router):**
+
+- `/home` → `view.frontpage.page_1` (Views `ViewPageController`).  
+- `/events` → `view.upcoming_events.page_events`.  
+- `/checkout` → `commerce_checkout.checkout`.  
+- `/vendor/dashboard` → `myeventlane_vendor.console.dashboard`.  
+
+`ddev drush route` is **huge**; the pipeline returned exit **141** (pipe closed / `head`).
+
+---
+
+## 3. Event Studio (audit)
+
+| Topic | Notes |
+|-------|--------|
+| **Create** | `myeventlane_event_studio.create` → `EventStudioController::buildCreate` at `/vendor/events/create` |
+| **Edit** | `myeventlane_event_studio.edit` + sub-routes (basic, datetime, tickets, description, preview, publish) under `/vendor/events/{node}/edit/...` |
+| **Access** | Create: `myeventlane_vendor.access.vendor_console:access` (routing); steps: `node:update` |
+| **Ticket builder** | `EventStudioTicketsForm` at `…/edit/tickets` |
+| **RSVP / paid save paths** | **RSVP** uses redirect to **unified book** `web/modules/custom/myeventlane_rsvp/myeventlane_rsvp.routing.yml` — paid flows go through **Commerce** cart and **mel_event_checkout** (separate from Studio save in normal checkout). **Studio** saves tickets through domain forms; exact sync to Commerce product/variation is in **form/service** code (not re-read in full in this pass). **No code edits** in this task. |
+| **Commerce product/variation sync** | Pushed to `myeventlane_tickets` / `myeventlane_commerce` (see project `project-rules.md` references); full trace = Task later if needed. |
+| **AJAX** | `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml` — `autosave` POST, AI POST, ticket suggestions POST with CSRF header requirements. |
+| **Libraries** | `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml` — `mel_event_studio` (CSS+JS+location autocomplete); shell-only variant. |
+| **Active theme on vendor** | `myeventlane_vendor_theme` (watchdog sample: *Vendor isolation active on /vendor/dashboard with theme myeventlane_vendor_theme*) |
+
+**Prioritised (§3):**
+
+- **P2:** **Two** vendor event editing surfaces in routing exist — **Event Studio** (`/vendor/events/.../edit/...`) and **legacy** `/vendor/events/{event}/build/...` wizard in `web/modules/custom/myeventlane_event/myeventlane_event.routing.yml` — risk of **operator confusion** if not documented.  
+- **P2:** Parallel **old** editor paths like `/vendor/event/{event}/...` in same vendor file — product should confirm canonical UX.
+
+---
+
+## 4. Booking and checkout
+
+| Topic | Notes |
+|-------|--------|
+| **Free RSVP path** | `myeventlane_rsvp` routes + redirect to `myeventlane_commerce.event_book` (unify with paid booking surface). |
+| **Paid** | `BookController` + `commerce_checkout` + flow **`mel_event_checkout`**. |
+| **Checkout flow plugin** | `config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml` — `plugin: mel_event_checkout`, panes: `mel_buyer_details`, `ticket_holder_paragraph`, `mel_donation`, `mel_legal_consent`, `payment_information` (…), order summary in sidebar, several panes disabled. |
+| **Payment / summary** | `payment_information` step `checkout` weight 4; `order_summary` in `_sidebar` with `commerce_checkout_order_summary` view. |
+| **Ticket holder** | `ticket_holder_paragraph` (Commerce checkout pane) — dedicated attendee handling also exists at `myeventlane_commerce` routes like `/cart/attendee-info/{order_item}`. |
+| **Confirmation** | **Commerce** checkout `complete` (or custom completion) is **on the `commerce_checkout.form` step**; exact template/pane = theme + flow config. |
+| **Email / tickets** | Not fully traced (queues, rules, `myeventlane_tickets`); would need Task focused on comms. |
+
+**Prioritised (§4):**
+
+- **P1:** `payment_information` in sync config has `require_payment_method: false` — may be **intentional** for $0, but **validates in staging** for mixed paid/RSVP.  
+- **P2:** Several panes on `_disabled` — **matches** a deliberate layout; do not "fix" without product sign-off.  
+- **P3:** Guest flags `guest_new_account: true` — confirm with privacy/help copy.
+
+---
+
+## 5. Vendor dashboard
+
+| Topic | Notes |
+|-------|--------|
+| **Entry** | `/vendor/dashboard` — `myeventlane_vendor` console. |
+| **Attendees (global)** | `myeventlane_checkout_flow.vendor_attendees` — `/vendor/attendees` (controller access check). |
+| **Menu / link** | Not re-audited menu YAML in this pass; `myeventlane_vendor` defines many **vendor** and **/dashboard** fallbacks. |
+| **Attendee data / CSV** | `web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.routing.yml` — `/vendor/events/{node}/attendees/export` etc.; `myeventlane_views` has `AttendeeCsvController` with access notes in class docblock. |
+| **Admin/staff** | MEL **admin** dashboard: `myeventlane_admin_dashboard` routes (orders, financials, payouts, `admin/myeventlane`, webhooks) — see Drush `route` output prefix `myeventlane_admin_dashboard.`. |
+| **Analytics** | `myeventlane_analytics.dashboard` — `/vendor/analytics`, per-event under `/vendor/analytics/event/{node}`. |
+
+**Prioritised (§5):**
+
+- **P2:** Multiple overlapping routes for vendor event management (Studio vs “studio” API vs “event” path) — **governance/UX** risk.  
+- **P1:** Payout/stripe **admin** paths and `/stripe/webhook/payout` exist — **operational** security and signing must be part of **Task 3**.
+
+---
+
+## 6. Stripe Connect (recon only — not full audit)
+
+| Topic | Notes |
+|-------|--------|
+| **Controllers** | `web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php` — `connect`, `callback`, plus return routes in `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml` |
+| **Service layer** | `myeventlane_stripe` (and `StripeService` as referenced in branch log messages on `fix/stripe-connect` — not diffed in this worktree) |
+| **Store relationship** | Vendor ↔ Commerce store mapping lives in MEL custom modules; exact field names: **out of scope** for this pass (no schema edits). |
+| **connect account storage** | Typically on vendor/connector entity/fields — **confirm in Task 3** with `services.yml` + install entity definitions. |
+| **Onboarding loop** | `fix/stripe-connect` branch log mentions **onboarding** improvements and `ApiErrorException` handling; **this audit branch** does not include the latest 3 commits from `fix/stripe-connect` (see below). |
+| **fix/stripe-connect vs this branch** | `git log feature/mel-v2-task-based-completion-audit..fix/stripe-connect` shows: `e0653f59` (connect API failure handling in controller), `37851723` (StripeService / express / logging), `af70f4c0` (integration + user feedback) — **not in** current feature branch. |
+| **Dedicated full audit** | **Yes, recommended** — current pass is only mapping and divergence note. |
+
+**Prioritised (§6):**
+
+- **P1 (merge/product):** `feature/mel-v2-task-based-completion-audit` is **behind** `fix/stripe-connect` by **3** commits; Stripe behaviour and operator messaging **differ** until integrated.  
+- **P0:** None proven without runtime Stripe tests — do **not** list as launch blocker on evidence above alone.
+
+---
+
+## 7. Help and AI support
+
+| Topic | Evidence |
+|--------|------------|
+| **help_article** | `node.type` + fields in `config/sync`; `field.storage.node.field_audience` and usage on `help_article` and landing types (grep on sync). |
+| **field_audience** | In Search API: `config/sync/search_api.index.mel_content.yml` — indexed as `field_audience` (help audience canonical). |
+| **staff_playbook** | Content type `config/sync/node.type.staff_playbook.yml` + `field_internal_only` and related fields; **not** listed in `mel_content` content bundle grep as `staff_playbook` in the same index snippet. |
+| **Help Assistant** | `web/modules/custom/myeventlane_help_assistant/src/Service/HelpRetriever.php` — `type = help_article` only; `field_audience` filtered to public/vendor; **rejects** `staff`; requires `field_help_ai_allowed` and status checks. |
+| **Search API** | Index id **`mel_content`**; query restricts by type and audience. |
+| **Staff leak** | **Code path** in HelpRetriever explicitly **excludes** staff-tagged and non-public/vendor content for assistant retrieval; **separate** risk: Views/routes to staff playbooks must stay permission-gated (not fully audited here). |
+
+**Prioritised (§7):**
+
+- **P1:** Re-verify any **View** or **search** display that might expose `help_article` with staff audience to the wrong role (theme-only hiding is not enough) — **spot-check** in Task follow-up, not in this file’s scope.  
+- **P2:** `mel_debug` and similar **verbose** log entries in watchdog (not help-specific but noisy).
+
+---
+
+## 8. Theme and frontend (recon)
+
+| Area | Notes |
+|------|--------|
+| **Event cards / full / home** | Large SCSS/twig in `web/themes/custom/myeventlane_theme` (e.g. `components/_event-*.scss`, `node--event--full.html.twig`) — **no line-by-line** review. |
+| **Discovery / filters** | `web/modules/custom/myeventlane_core/myeventlane_core.routing.yml` — `/mel/filter-events` (AJAX fragment) + Views `config/sync/views.view.upcoming_events.yml` for `/events`, `events/today`, `events/free`, etc. |
+| **Category** | `/events/category/...` from same view. |
+| **Checkout** | Default Commerce checkout theme behaviour + MEL panes; vendor checkout questions under vendor routes. |
+| **Vendor / Studio** | `myeventlane_vendor_theme` (Vite in `package.json`); **Event Studio** CSS/JS in module + vendor theme. |
+| **Break / duplicate styles** | Public theme main bundle ~**567 kB** gzip ~85 kB (build output) — **performance** and cascade risks worth profiling later. |
+| **Accessibility** | Not **audited** with tools in this pass — **P2** to run axe/keyboard in a dedicated a11y task. |
+
+**Prioritised (§8):**
+
+- **P2:** CSS bundle size and two-theme split (public vs vendor) — follow performance budget.  
+- **P2:** `mel:lint` covers a **fixed** list of SCSS files; new partials not in the list are **unlinted** (known pattern).
+
+---
+
+## Commands run (required + supporting)
+
+- `git status --short` — **clean**  
+- `git branch --show-current`  
+- `git log -1 --oneline`  
+- `composer validate` — **ok**  
+- `ddev drush status` — **ok**  
+- `ddev drush theme:status \|\| true` — **failed** (see §1)  
+- `ddev drush pm:list --type=module --status=enabled \| grep -E "myeventlane\|mel_"`
+- `ddev drush route \| grep -Ei "…" \| head -200` — **exit 141** (truncation/pipe)  
+- `npm run mel:lint \|\| true` — **pass** (Stylelint; npm `devdir` notice)  
+- `npm run mel:build \|\| true` — **pass**  
+- `ddev drush ws --count=50` — **pass** (recent notices)  
+- Supporting: `ddev drush ev` for route match on `/home`, `/events`, `/vendor/dashboard`, and `git log feature/…..fix/stripe-connect`
+
+**Failed (recorded, not “fixed”):** `ddev drush theme:status` — *Command "theme:status" is not defined.*
+
+**Watchdog (sample, last 50):** Mostly `mel_debug` (BOOST CANDIDATE) and `mel_admin_access_debug` / `mel_theme_debug` (vendor dashboard). **P2:** reduce debug noise in production configs.
+
+---
+
+## Global prioritised summary
+
+| ID | Level | Item |
+|----|-------|------|
+| 1 | **P1** | `fix/stripe-connect` has **3 commits** not on this audit branch — Stripe/onboarding and `StripeService` work **diverge**; needs merge decision + **Task 3** full audit. |
+| 2 | **P1** | `mel_event_checkout` has `require_payment_method: false` on payment pane — **verify** for paid events before launch. |
+| 3 | **P2** | Overlapping vendor event routes (Event Studio, wizard, legacy “event/…”) — document canonical paths. |
+| 4 | **P2** | Drush 13 has no `theme:status` — use alternate commands. |
+| 5 | **P2** | Noisy `mel_debug` in watchdog. |
+| 6 | **P2** | Large public CSS output + SCSS lint allowlist. |
+| 7 | **P3** | npm audit **moderate** in theme deps. |
+
+**P0 (launch blocker) from this read-only pass:** **None established** (no production smoke, no failed core bootstrap, no payment E2E).
+
+---
+
+## Recommended next task
+
+**TASK 3 — Full Stripe Connect audit only** (controllers, `StripeService`, store/account linkage, webhooks, `charges_enabled` / `requirements` gates, `fix/stripe-connect` diff vs this branch, and a written test matrix; **no** implementation in Task 3 unless the audit explicitly defers to a “fix” task).
+
+STOP — Task 2 only.

--- a/web/modules/custom/myeventlane_core/src/Service/StripeService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/StripeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_core\Service;
 
 use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -158,14 +159,94 @@ final class StripeService {
   }
 
   /**
+   * Masks a Stripe Connect account id for safe logs (e.g. acct_1Ab…YZ).
+   */
+  public static function maskAccountId(string $accountId): string {
+    $accountId = trim($accountId);
+    if ($accountId === '' || !str_starts_with($accountId, 'acct_')) {
+      return '(invalid)';
+    }
+    if (strlen($accountId) <= 12) {
+      return $accountId[0] . $accountId[1] . $accountId[2] . $accountId[3] . '…';
+    }
+    return substr($accountId, 0, 8) . '…' . substr($accountId, -4);
+  }
+
+  /**
+   * Returns existing Connect account id on the store, or creates an Express account.
+   *
+   * Never overwrites a non-empty field_stripe_account_id (connected vendors
+   * keep their account; new Express accounts are only created when the id is
+   * empty).
+   *
+   * @return string
+   *   Stripe account id (acct_…).
+   */
+  public function ensureConnectAccountIdForStore(StoreInterface $store, string $email, string $country = 'AU'): string {
+    if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
+      $existing = trim((string) $store->get('field_stripe_account_id')->value);
+      if ($existing !== '') {
+        return $existing;
+      }
+    }
+
+    if (trim($email) === '') {
+      throw new \InvalidArgumentException('Email is required to create a Connect account.');
+    }
+
+    $account = $this->createConnectAccount($email, $country, 'express');
+    $accountId = (string) $account->id;
+
+    if ($store->hasField('field_stripe_account_id')) {
+      $store->set('field_stripe_account_id', $accountId);
+    }
+    if ($store->hasField('field_stripe_status')) {
+      $store->set('field_stripe_status', 'pending');
+    }
+    if ($store->hasField('field_stripe_connected')) {
+      $store->set('field_stripe_connected', FALSE);
+    }
+    if ($store->hasField('field_stripe_charges_enabled')) {
+      $store->set('field_stripe_charges_enabled', FALSE);
+    }
+    if ($store->hasField('field_stripe_payouts_enabled')) {
+      $store->set('field_stripe_payouts_enabled', FALSE);
+    }
+    $store->save();
+
+    return $accountId;
+  }
+
+  /**
+   * Persists common Connect flags from a getAccountStatus() result on the store.
+   */
+  public function applyConnectStatusToCommerceStore(StoreInterface $store, array $status): void {
+    if ($store->hasField('field_stripe_status')) {
+      $store->set('field_stripe_status', $status['status'] ?? 'pending');
+    }
+    if ($store->hasField('field_stripe_connected')) {
+      $store->set('field_stripe_connected', (bool) ($status['charges_enabled'] ?? FALSE));
+    }
+    if ($store->hasField('field_stripe_charges_enabled')) {
+      $store->set('field_stripe_charges_enabled', (bool) ($status['charges_enabled'] ?? FALSE));
+    }
+    if ($store->hasField('field_stripe_payouts_enabled')) {
+      $store->set('field_stripe_payouts_enabled', (bool) ($status['payouts_enabled'] ?? FALSE));
+    }
+    $store->save();
+  }
+
+  /**
    * Creates a Stripe Connect account.
+   *
+   * MEL uses Connect Express for vendor-hosted onboarding and responsibilities.
    *
    * @param string $email
    *   The vendor email address.
    * @param string $country
    *   The country code (e.g., 'AU', 'US').
    * @param string $type
-   *   Account type: 'standard' (default) or 'express'.
+   *   Connect account type: 'express' (MEL default) or 'standard' (legacy only).
    *
    * @return \Stripe\Account
    *   The created Stripe account.
@@ -173,7 +254,7 @@ final class StripeService {
    * @throws \Stripe\Exception\ApiErrorException
    *   If account creation fails.
    */
-  public function createConnectAccount(string $email, string $country = 'AU', string $type = 'standard'): Account {
+  public function createConnectAccount(string $email, string $country = 'AU', string $type = 'express'): Account {
     $client = $this->getPlatformClient();
 
     try {
@@ -188,7 +269,7 @@ final class StripeService {
       ]);
 
       $this->safeLog('info', 'Created Stripe Connect account @id for @email', [
-        '@id' => $account->id,
+        '@id' => self::maskAccountId((string) $account->id),
         '@email' => $email,
       ]);
 
@@ -230,7 +311,7 @@ final class StripeService {
       ]);
 
       $this->safeLog('info', 'Created AccountLink for account @id', [
-        '@id' => $accountId,
+        '@id' => self::maskAccountId($accountId),
       ]);
 
       return $link;
@@ -262,7 +343,7 @@ final class StripeService {
       $link = $client->accounts->createLoginLink($accountId);
 
       $this->safeLog('info', 'Created LoginLink for account @id', [
-        '@id' => $accountId,
+        '@id' => self::maskAccountId($accountId),
       ]);
 
       return $link;
@@ -475,7 +556,7 @@ final class StripeService {
         '@id' => $paymentIntent->id,
         '@amount' => $amount,
         '@currency' => $currency,
-        '@account' => $stripeAccountId,
+        '@account' => self::maskAccountId($stripeAccountId),
         '@fee' => $applicationFeeAmount,
       ]);
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -6,34 +6,30 @@ namespace Drupal\myeventlane_vendor\Controller;
 
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\StripeService;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
+use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Stripe\Exception\ApiErrorException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
- * Controller for Stripe Connect onboarding and management.
+ * Controller for Stripe Connect Express onboarding and management.
  */
 final class StripeConnectController extends ControllerBase {
 
-  /**
-   * The Stripe service.
-   */
-  private readonly StripeService $stripeService;
-
-  /**
-   * Constructs a StripeConnectController.
-   *
-   * @param \Drupal\myeventlane_core\Service\StripeService $stripeService
-   *   The Stripe service.
-   */
-  public function __construct(StripeService $stripeService) {
-    $this->stripeService = $stripeService;
-  }
+  public function __construct(
+    private readonly StripeService $stripeService,
+    private readonly LoggerChannelFactoryInterface $loggerChannelFactory,
+    private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
+    private readonly VendorStoreSubscriber $vendorStoreSubscriber,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -41,244 +37,250 @@ final class StripeConnectController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_core.stripe'),
+      $container->get('logger.factory'),
+      $container->get('myeventlane_vendor.user_vendor_membership_query'),
+      $container->get('myeventlane_vendor.vendor_store_subscriber'),
     );
   }
 
   /**
-   * Gets the store to use for Stripe Connect.
-   *
-   * Prefers the vendor's field_vendor_store (same store assertStripeConnected
-   * uses) so connect and event flow stay aligned.
-   *
-   * @return \Drupal\commerce_store\Entity\StoreInterface|null
-   *   The store entity, or NULL if not found.
+   * Resolves a vendor for the current user (owner or field_vendor_users).
    */
-  private function getStoreForConnect(): ?StoreInterface {
-    $vendor = $this->getCurrentUserVendor();
-    if ($vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
-      $store = $vendor->get('field_vendor_store')->entity;
-      if ($store instanceof StoreInterface) {
-        return $store;
-      }
-    }
-    return $this->getCurrentUserStore();
-  }
-
-  /**
-   * Gets the store for the current user (by uid).
-   *
-   * @return \Drupal\commerce_store\Entity\StoreInterface|null
-   *   The store entity, or NULL if not found.
-   */
-  private function getCurrentUserStore(): ?StoreInterface {
-    $currentUser = $this->currentUser();
-    $userId = (int) $currentUser->id();
-
+  private function getCurrentUserVendor(): ?Vendor {
+    $userId = (int) $this->currentUser()->id();
     if ($userId === 0) {
       return NULL;
     }
 
-    // Try to find a store owned by this user.
-    $storeStorage = $this->entityTypeManager()->getStorage('commerce_store');
-    $storeIds = $storeStorage->getQuery()
-      ->accessCheck(FALSE)
-      ->condition('uid', $userId)
-      ->range(0, 1)
-      ->execute();
+    $ids = $this->userVendorMembershipQuery->getVendorIdsForUser($userId);
+    if ($ids === []) {
+      return NULL;
+    }
 
-    if (!empty($storeIds)) {
-      $store = $storeStorage->load(reset($storeIds));
-      if ($store instanceof StoreInterface) {
-        return $store;
+    $storage = $this->entityTypeManager()->getStorage('myeventlane_vendor');
+    $vendors = $storage->loadMultiple($ids);
+    $fallback = NULL;
+    foreach ($vendors as $vendor) {
+      if ($vendor instanceof Vendor) {
+        if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+          return $vendor;
+        }
+        $fallback = $vendor;
       }
     }
 
-    // Fallback: try to find default store or any store.
-    // In a multi-vendor setup, this might not be ideal, but provides fallback.
-    $defaultStores = $storeStorage->loadByProperties(['is_default' => TRUE]);
-    if (!empty($defaultStores)) {
-      return reset($defaultStores);
-    }
-
-    return NULL;
+    return $fallback instanceof Vendor ? $fallback : NULL;
   }
 
   /**
-   * Builds absolute return and refresh URLs for Stripe AccountLink.
-   *
-   * return_url: Stripe redirects here after onboarding. refresh_url: Stripe uses
-   * if the link expires. Both always carry the same `destination` query
-   * parameter (may be empty) for callback/refresh continuity.
+   * Resolves the vendor’s Commerce store without platform default store fallback.
    */
-  private function buildAccountLinkUrls(string $destination = ''): array {
-    $returnUrl = Url::fromRoute('myeventlane_vendor.stripe_onboard_return', [], [
+  private function getStoreForConnect(?Vendor $vendor): ?StoreInterface {
+    if (!$vendor) {
+      return NULL;
+    }
+    return $this->vendorStoreSubscriber->ensureStoreForVendor($vendor);
+  }
+
+  /**
+   * Ensures the vendor entity references the same store Stripe updates.
+   */
+  private function syncVendorStoreReference(Vendor $vendor, StoreInterface $store): void {
+    if (!$vendor->hasField('field_vendor_store')) {
+      return;
+    }
+    $current = !$vendor->get('field_vendor_store')->isEmpty()
+      ? (string) $vendor->get('field_vendor_store')->target_id
+      : '';
+    if ($current === (string) $store->id()) {
+      return;
+    }
+    $vendor->set('field_vendor_store', $store->id());
+    $vendor->save();
+  }
+
+  /**
+   * Copies Stripe id/status fields from the store to the vendor when present.
+   */
+  private function syncStripeAccountFieldsToVendor(StoreInterface $store, Vendor $vendor): void {
+    if (!$store->hasField('field_stripe_account_id') || $store->get('field_stripe_account_id')->isEmpty()) {
+      return;
+    }
+    $id = trim((string) $store->get('field_stripe_account_id')->value);
+    if ($id === '' || !str_starts_with($id, 'acct_')) {
+      return;
+    }
+    if ($vendor->hasField('field_stripe_account_id')) {
+      $vendor->set('field_stripe_account_id', $id);
+    }
+    if ($vendor->hasField('field_stripe_status') && $store->hasField('field_stripe_status') && !$store->get('field_stripe_status')->isEmpty()) {
+      $vendor->set('field_stripe_status', (string) $store->get('field_stripe_status')->value);
+    }
+    if ($vendor->hasField('field_stripe_connected') && $store->hasField('field_stripe_connected') && !$store->get('field_stripe_connected')->isEmpty()) {
+      $vendor->set('field_stripe_connected', (bool) $store->get('field_stripe_connected')->value);
+    }
+    $vendor->save();
+  }
+
+  /**
+   * Builds return and refresh URLs for Account Links; includes account_id for callback validation.
+   */
+  private function buildAccountLinkUrls(string $accountId, string $destination = ''): array {
+    $query = [
+      'account_id' => $accountId,
+    ];
+    if ($destination !== '') {
+      $query['destination'] = $destination;
+    }
+    $returnUrl = Url::fromRoute('myeventlane_vendor.stripe_callback', [], [
       'absolute' => TRUE,
-      'query' => ['destination' => $destination],
+      'query' => $query,
     ])->toString();
-    $refreshUrl = Url::fromRoute('myeventlane_vendor.stripe_onboard_refresh', [], [
+    $refreshUrl = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
       'absolute' => TRUE,
-      'query' => ['destination' => $destination],
+      'query' => $query,
     ])->toString();
 
     return [$returnUrl, $refreshUrl];
   }
 
-  /**
-   * Gets the vendor entity for the current user.
-   *
-   * @return \Drupal\myeventlane_vendor\Entity\Vendor|null
-   *   The vendor entity, or NULL if not found.
-   */
-  private function getCurrentUserVendor(): ?Vendor {
-    $currentUser = $this->currentUser();
-    $userId = (int) $currentUser->id();
-
-    if ($userId === 0) {
-      return NULL;
-    }
-
-    $vendorStorage = $this->entityTypeManager()->getStorage('myeventlane_vendor');
-    $vendorIds = $vendorStorage->getQuery()
-      ->accessCheck(FALSE)
-      ->condition('uid', $userId)
-      ->range(0, 1)
-      ->execute();
-
-    if (!empty($vendorIds)) {
-      $vendor = $vendorStorage->load(reset($vendorIds));
-      if ($vendor instanceof Vendor) {
-        return $vendor;
-      }
-    }
-
-    return NULL;
-  }
-
-  /**
-   * Disables edge caching of off-site Stripe redirect responses.
-   */
   private function applyOffsiteStripeRedirectHeaders(TrustedRedirectResponse $response): TrustedRedirectResponse {
     $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
     $response->headers->set('Pragma', 'no-cache');
     return $response;
   }
 
+  private function redirectToDashboard(): RedirectResponse {
+    return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+  }
+
   /**
-   * Starts Stripe Connect onboarding.
-   *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Redirect to Stripe onboarding or dashboard.
+   * Validates query account_id against the store’s Connect account; returns usable id.
    */
-  public function connect(): RedirectResponse {
-    \Drupal::logger('mel_debug')->notice('STRIPE CONNECT HIT');
+  private function resolveValidatedAccountId(?string $queryAccountId, StoreInterface $store): ?string {
+    $fromStore = $store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()
+      ? trim((string) $store->get('field_stripe_account_id')->value)
+      : '';
+
+    if (is_string($queryAccountId) && str_starts_with($queryAccountId, 'acct_')) {
+      if ($fromStore !== '' && $fromStore !== $queryAccountId) {
+        $this->loggerChannelFactory->get('myeventlane_vendor')->error(
+          'Stripe connect: account_id query @q does not match store @sid account @s',
+          [
+            '@q' => StripeService::maskAccountId($queryAccountId),
+            '@sid' => (string) $store->id(),
+            '@s' => StripeService::maskAccountId($fromStore),
+          ]
+        );
+        return NULL;
+      }
+      return $queryAccountId;
+    }
+
+    return $fromStore !== '' ? $fromStore : NULL;
+  }
+
+  /**
+   * Starts or resumes Stripe Connect Express onboarding (Account Links).
+   */
+  public function connect(Request $request): RedirectResponse {
+    $log = $this->loggerChannelFactory->get('myeventlane_vendor');
     $currentUser = $this->currentUser();
     if ($currentUser->isAnonymous()) {
       throw new AccessDeniedHttpException('You must be logged in to connect Stripe.');
     }
 
-    $store = $this->getStoreForConnect();
+    $vendor = $this->getCurrentUserVendor();
+    if (!$vendor) {
+      $log->error('Stripe connect: no vendor profile for user @uid', [
+        '@uid' => (string) $currentUser->id(),
+      ]);
+      $this->messenger()->addError($this->t('No vendor profile found for your account. Please contact support.'));
+      return $this->redirectToDashboard();
+    }
+
+    $store = $this->getStoreForConnect($vendor);
     if (!$store) {
-      $this->messenger()->addError($this->t('No store found for your account. Please contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      $log->error('Stripe connect: no store for vendor @vid uid @uid', [
+        '@vid' => (string) $vendor->id(),
+        '@uid' => (string) $currentUser->id(),
+      ]);
+      $this->messenger()->addError($this->t('Your vendor store is not ready yet. Complete vendor onboarding, then return to connect Stripe.'));
+      return $this->redirectToDashboard();
+    }
+    $this->syncVendorStoreReference($vendor, $store);
+
+    $destination = $request->query->get('destination');
+    $destStr = is_string($destination) ? $destination : '';
+    $queryAccount = $request->query->get('account_id');
+    $queryAccountStr = is_string($queryAccount) ? $queryAccount : '';
+
+    $accountId = $this->resolveValidatedAccountId(
+      $queryAccountStr !== '' ? $queryAccountStr : NULL,
+      $store
+    );
+    if ($queryAccountStr !== '' && $accountId === NULL) {
+      $this->messenger()->addError($this->t('Stripe account mismatch. Please start Connect again or contact support.'));
+      return $this->redirectToDashboard();
     }
 
-    $accountId = NULL;
-    if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
-      $accountId = $store->get('field_stripe_account_id')->value;
-    }
-
-    // If account exists, refresh status from Stripe. Store may have account_id but
-    // missing field_stripe_charges_enabled (e.g. callback never ran). Event flow
-    // checks charges_enabled, so we must align.
     if (!empty($accountId)) {
       try {
         $status = $this->stripeService->getAccountStatus($accountId);
-        if ($store->hasField('field_stripe_status')) {
-          $store->set('field_stripe_status', $status['status']);
-        }
-        if ($store->hasField('field_stripe_connected')) {
-          // Aligned with assertStripeConnected: seller-ready when charges are on.
-          $store->set('field_stripe_connected', (bool) $status['charges_enabled']);
-        }
-        if ($store->hasField('field_stripe_charges_enabled')) {
-          $store->set('field_stripe_charges_enabled', $status['charges_enabled']);
-        }
-        if ($store->hasField('field_stripe_payouts_enabled')) {
-          $store->set('field_stripe_payouts_enabled', $status['payouts_enabled']);
-        }
-        $store->save();
+        $this->stripeService->applyConnectStatusToCommerceStore($store, $status);
+        $this->syncStripeAccountFieldsToVendor($store, $vendor);
 
-        if ($status['charges_enabled']) {
-          $this->messenger()->addStatus($this->t('Stripe is already connected.'));
-          return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+        if (!empty($status['charges_enabled'])) {
+          $this->messenger()->addStatus($this->t('Stripe is already connected and ready to accept card payments.'));
+          return $this->redirectToDashboard();
         }
       }
       catch (\Exception $e) {
-        $this->getLogger('myeventlane_vendor')->warning('Could not refresh Stripe status, will create AccountLink: @m', ['@m' => $e->getMessage()]);
+        if ($e instanceof ApiErrorException) {
+          $this->logConnectApiError($e, $vendor, $store, (string) $accountId);
+          $this->messenger()->addError($this->t('We could not refresh your Stripe status. Please try again in a few minutes or contact support.'));
+          return $this->redirectToDashboard();
+        }
+        $log->warning('Stripe connect: refresh status for resume link: @m', [
+          '@m' => $e->getMessage(),
+        ]);
       }
     }
 
+    $userEmail = (string) $currentUser->getEmail();
+    if (trim($userEmail) === '') {
+      $this->messenger()->addError($this->t('Your account must have an email address to connect Stripe.'));
+      return $this->redirectToDashboard();
+    }
+
     try {
-      $userEmail = $currentUser->getEmail();
-      if (empty($userEmail)) {
-        $this->messenger()->addError($this->t('Your account must have an email address to connect Stripe.'));
-        return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
-      }
-
       if (empty($accountId)) {
-        // Create new Connect account.
-        $account = $this->stripeService->createConnectAccount($userEmail, 'AU', 'standard');
-        $accountId = $account->id;
-
-        // Save account ID to store.
-        if ($store->hasField('field_stripe_account_id')) {
-          $store->set('field_stripe_account_id', $accountId);
-          if ($store->hasField('field_stripe_status')) {
-            $store->set('field_stripe_status', 'pending');
-          }
-          if ($store->hasField('field_stripe_connected')) {
-            $store->set('field_stripe_connected', FALSE);
-          }
-          $store->save();
-        }
-
-        // Also save to vendor entity if it exists.
-        $vendor = $this->getCurrentUserVendor();
-        if ($vendor && $vendor->hasField('field_stripe_account_id')) {
-          $vendor->set('field_stripe_account_id', $accountId);
-          if ($vendor->hasField('field_stripe_status')) {
-            $vendor->set('field_stripe_status', 'pending');
-          }
-          $vendor->save();
-        }
+        $accountId = $this->stripeService->ensureConnectAccountIdForStore($store, $userEmail, 'AU');
+        $this->syncStripeAccountFieldsToVendor($store, $vendor);
+      }
+      if ($accountId === '') {
+        throw new \RuntimeException('Stripe account id missing after ensure.');
       }
 
-      // Create AccountLink: return + refresh are absolute, with optional
-      // ?destination=… so the callback can redirect to /create-event, onboard, etc.
-      $reqQuery = \Drupal::request();
-      $destination = $reqQuery->query->get('destination');
-      $destStr = is_string($destination) ? $destination : '';
-
-      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($destStr);
+      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($accountId, $destStr);
       $accountLink = $this->stripeService->createAccountLink($accountId, $returnUrl, $refreshUrl);
-      if ($accountLink === NULL || (is_object($accountLink) && empty($accountLink->url))) {
-        $this->getLogger('myeventlane_vendor')->error('Stripe connect failed: no account link returned for uid=@uid', [
-          '@uid' => (string) $this->currentUser()->id(),
+      if (empty($accountLink->url) || !is_string($accountLink->url) || $accountLink->url === '') {
+        $log->error('Stripe connect: empty AccountLink for vendor @vid store @sid', [
+          '@vid' => (string) $vendor->id(),
+          '@sid' => (string) $store->id(),
         ]);
-        throw new \RuntimeException('Stripe onboarding could not be started. Account link missing.');
+        throw new \RuntimeException('Stripe onboarding could not be started (no link).');
       }
       $url = $accountLink->url;
-      if (!is_string($url) || $url === '') {
-        $this->getLogger('myeventlane_vendor')->error('Stripe connect failed: empty account link url for uid=@uid', [
-          '@uid' => (string) $this->currentUser()->id(),
-        ]);
-        throw new \RuntimeException('Stripe onboarding could not be started. Account link missing.');
-      }
       if (!str_starts_with($url, 'https://connect.stripe.com')) {
-        throw new \RuntimeException('Invalid Stripe URL: ' . $url);
+        $log->error('Stripe connect: unexpected redirect host for vendor @vid', ['@vid' => (string) $vendor->id()]);
+        throw new \RuntimeException('Invalid Stripe URL.');
       }
-      \Drupal::logger('mel_debug')->notice('Stripe redirecting to: @url', [
-        '@url' => $url,
+
+      $log->notice('Stripe Account Link created: vendor @vid, store @sid, account @acct', [
+        '@vid' => (string) $vendor->id(),
+        '@sid' => (string) $store->id(),
+        '@acct' => StripeService::maskAccountId($accountId),
       ]);
 
       $response = new TrustedRedirectResponse($url);
@@ -286,126 +288,139 @@ final class StripeConnectController extends ControllerBase {
       $this->applyOffsiteStripeRedirectHeaders($response);
       return $response;
     }
+    catch (ApiErrorException $e) {
+      $this->logConnectApiError($e, $vendor, $store, (string) ($accountId ?? ''));
+      $this->messenger()->addError($this->t('We could not start Stripe onboarding. If this continues, the platform may need a Stripe review for Connect, or you can try again later.'));
+      return $this->redirectToDashboard();
+    }
     catch (\Exception $e) {
       if ($e instanceof \RuntimeException) {
         throw $e;
       }
-      $this->getLogger('myeventlane_vendor')->error('Stripe Connect onboarding failed: @message', [
-        '@message' => $e->getMessage(),
+      $this->getLogger('myeventlane_vendor')->error('Stripe connect: @m', [
+        '@m' => $e->getMessage(),
       ]);
       $this->messenger()->addError($this->t('Failed to start Stripe onboarding. Please try again or contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
     }
   }
 
+  private function logConnectApiError(ApiErrorException $e, Vendor $vendor, StoreInterface $store, string $accountId): void {
+    $stripe = $e->getStripeCode() ?? $e->getCode();
+    $this->loggerChannelFactory->get('myeventlane_vendor')->error(
+      'Stripe API error: vendor @vid, uid @uid, store @sid, account @acct, type @type, @message',
+      [
+        '@vid' => (string) $vendor->id(),
+        '@uid' => (string) $this->currentUser()->id(),
+        '@sid' => (string) $store->id(),
+        '@acct' => $accountId !== '' ? StripeService::maskAccountId($accountId) : 'n/a',
+        '@type' => is_string($stripe) || is_int($stripe) || is_float($stripe) ? (string) $stripe : 'unknown',
+        '@message' => $e->getMessage(),
+      ]
+    );
+  }
+
   /**
-   * Handles Stripe Connect callback after onboarding.
-   *
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The request.
-   *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Redirect to vendor dashboard.
+   * Handles Stripe return after Connect onboarding (callback route).
    */
   public function callback(Request $request): RedirectResponse {
-    \Drupal::logger('mel_debug')->notice('STRIPE CALLBACK HIT');
+    $log = $this->loggerChannelFactory->get('myeventlane_vendor');
     $currentUser = $this->currentUser();
     if ($currentUser->isAnonymous()) {
       throw new AccessDeniedHttpException('You must be logged in.');
     }
 
     $destination = $request->query->get('destination');
+    $dest = is_string($destination) ? $destination : '';
+    if ($dest !== '' && !str_starts_with($dest, '/')) {
+      $dest = '';
+    }
 
-    $store = $this->getStoreForConnect();
+    $vendor = $this->getCurrentUserVendor();
+    if (!$vendor) {
+      $this->messenger()->addError($this->t('No vendor profile found for your account.'));
+      return $this->redirectToDashboard();
+    }
+
+    $store = $this->getStoreForConnect($vendor);
     if (!$store) {
       $this->messenger()->addError($this->t('No store found for your account.'));
-      // Redirect to destination if provided, otherwise dashboard.
-      if ($destination) {
-        return new RedirectResponse($destination);
-      }
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
     }
+    $this->syncVendorStoreReference($vendor, $store);
 
-    // Check if account ID exists.
-    if (!$store->hasField('field_stripe_account_id') || $store->get('field_stripe_account_id')->isEmpty()) {
-      $this->messenger()->addWarning($this->t('Stripe account not found. Please start the connection process again.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
-    }
-
-    $accountId = $store->get('field_stripe_account_id')->value;
-
-    try {
-      // Get account status from Stripe.
-      $status = $this->stripeService->getAccountStatus($accountId);
-
-      // Update store with status.
-      if ($store->hasField('field_stripe_status')) {
-        $store->set('field_stripe_status', $status['status']);
-      }
-      if ($store->hasField('field_stripe_connected')) {
-        $store->set('field_stripe_connected', (bool) $status['charges_enabled']);
-      }
-      if ($store->hasField('field_stripe_charges_enabled')) {
-        $store->set('field_stripe_charges_enabled', $status['charges_enabled']);
-      }
-      if ($store->hasField('field_stripe_payouts_enabled')) {
-        $store->set('field_stripe_payouts_enabled', $status['payouts_enabled']);
-      }
-      $store->save();
-      \Drupal::logger('mel_debug')->notice('STRIPE CALLBACK: store saved; field_stripe_connected=@c charges_enabled=@ch payouts=@p', [
-        '@c' => $store->hasField('field_stripe_connected') && !$store->get('field_stripe_connected')->isEmpty()
-          ? (string) (int) (bool) $store->get('field_stripe_connected')->value
-          : 'n/a',
-        '@ch' => (string) (int) (bool) ($status['charges_enabled'] ?? FALSE),
-        '@p' => (string) (int) (bool) ($status['payouts_enabled'] ?? FALSE),
-      ]);
-
-      // Also update vendor entity if it exists.
-      $vendor = $this->getCurrentUserVendor();
-      if ($vendor) {
-        if ($vendor->hasField('field_stripe_account_id')) {
-          $vendor->set('field_stripe_account_id', $accountId);
-        }
-        if ($vendor->hasField('field_stripe_status')) {
-          $vendor->set('field_stripe_status', $status['status']);
-        }
-        if ($vendor->hasField('field_stripe_connected')) {
-          $vendor->set('field_stripe_connected', (bool) $status['charges_enabled']);
-        }
-        $vendor->save();
-      }
-
-      if ($status['status'] === 'complete') {
-        $this->messenger()->addStatus($this->t('Stripe account connected successfully! You can now accept payments.'));
-      }
-      elseif ($status['status'] === 'pending') {
-        $this->messenger()->addWarning($this->t('Stripe account is pending. Please complete the onboarding process.'));
+    $qid = $request->query->get('account_id');
+    $qidStr = is_string($qid) ? $qid : '';
+    $accountId = $this->resolveValidatedAccountId($qidStr !== '' ? $qidStr : NULL, $store);
+    if ($accountId === NULL) {
+      if ($qidStr !== '') {
+        $this->messenger()->addError($this->t('Stripe account mismatch. Please use Connect from your dashboard again.'));
       }
       else {
-        $this->messenger()->addWarning($this->t('Stripe account status: @status. Some features may be limited.', [
-          '@status' => $status['status'],
-        ]));
+        $this->messenger()->addWarning($this->t('Stripe account not found. Please start the connection process again.'));
       }
-    }
-    catch (\Exception $e) {
-      $this->getLogger('myeventlane_vendor')->error('Stripe Connect callback failed: @message', [
-        '@message' => $e->getMessage(),
-      ]);
-      $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
+      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
+        'query' => $dest ? ['destination' => $dest] : [],
+      ])->setAbsolute()->toString());
     }
 
-    // Redirect to destination if provided (e.g., onboarding flow), otherwise dashboard.
-    if ($destination) {
-      return new RedirectResponse($destination);
+    try {
+      $status = $this->stripeService->getAccountStatus($accountId);
     }
-    return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+    catch (ApiErrorException $e) {
+      $this->logConnectApiError($e, $vendor, $store, $accountId);
+      $this->messenger()->addError($this->t('We could not verify your Stripe account. Please try again.'));
+      if ($dest !== '') {
+        return new RedirectResponse($dest);
+      }
+      return $this->redirectToDashboard();
+    }
+    catch (\Exception $e) {
+      $log->error('Stripe callback: @m', ['@m' => $e->getMessage()]);
+      $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
+      if ($dest !== '') {
+        return new RedirectResponse($dest);
+      }
+      return $this->redirectToDashboard();
+    }
+
+    if ($store->hasField('field_stripe_account_id')) {
+      $store->set('field_stripe_account_id', $accountId);
+    }
+    $this->stripeService->applyConnectStatusToCommerceStore($store, $status);
+    $this->syncStripeAccountFieldsToVendor($store, $vendor);
+
+    $log->notice('Stripe callback saved: store @sid, account @acct, charges @ch, payouts @p, details @d', [
+      '@sid' => (string) $store->id(),
+      '@acct' => StripeService::maskAccountId($accountId),
+      '@ch' => !empty($status['charges_enabled']) ? '1' : '0',
+      '@p' => !empty($status['payouts_enabled']) ? '1' : '0',
+      '@d' => !empty($status['details_submitted']) ? '1' : '0',
+    ]);
+
+    if (($status['status'] ?? '') === 'complete') {
+      $this->messenger()->addStatus($this->t('Stripe account connected. You can accept card payments when charges are active.'));
+    }
+    elseif (!empty($status['charges_enabled'])) {
+      $this->messenger()->addStatus($this->t('Stripe can process charges. Check your Stripe Dashboard for any remaining items.'));
+    }
+    elseif (($status['status'] ?? '') === 'pending' || !empty($status['details_submitted']) === FALSE) {
+      $this->messenger()->addWarning($this->t('Please complete the remaining steps in your Stripe account setup.'));
+    }
+    else {
+      $this->messenger()->addWarning($this->t('Stripe account status: @status.', [
+        '@status' => (string) ($status['status'] ?? 'unknown'),
+      ]));
+    }
+
+    if ($dest !== '') {
+      return new RedirectResponse($dest);
+    }
+    return $this->redirectToDashboard();
   }
 
   /**
-   * Creates a login link to Stripe dashboard for the vendor.
-   *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Redirect to Stripe dashboard or error.
+   * Login link to the vendor’s Express Stripe Dashboard.
    */
   public function manage(): RedirectResponse {
     $logger = $this->getLogger('myeventlane_vendor');
@@ -415,96 +430,79 @@ final class StripeConnectController extends ControllerBase {
       throw new AccessDeniedHttpException('You must be logged in to manage Stripe.');
     }
 
-    $store = $this->getStoreForConnect();
+    $vendor = $this->getCurrentUserVendor();
+    $store = $this->getStoreForConnect($vendor);
     if (!$store) {
-      $logger->warning('Stripe manage: No store found for user @uid', [
-        '@uid' => $currentUser->id(),
+      $logger->warning('Stripe manage: no store for user @uid', [
+        '@uid' => (string) $currentUser->id(),
       ]);
       $this->messenger()->addError($this->t('No store found for your account.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      return $this->redirectToDashboard();
+    }
+    if ($vendor) {
+      $this->syncVendorStoreReference($vendor, $store);
     }
 
-    // VALIDATE STRIPE ACCOUNT ID: Check if account ID exists and is valid.
-    $accountId = NULL;
-    if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
-      $accountId = trim($store->get('field_stripe_account_id')->value);
-    }
+    $accountId = $store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()
+      ? trim((string) $store->get('field_stripe_account_id')->value)
+      : '';
 
-    // If account ID is missing or empty, do NOT attempt link creation.
-    if (empty($accountId)) {
-      $logger->warning('Stripe manage: Missing or empty account ID for user @uid, store @store_id', [
-        '@uid' => $currentUser->id(),
-        '@store_id' => $store->id(),
-      ]);
+    if ($accountId === '' || !str_starts_with($accountId, 'acct_')) {
       $this->messenger()->addWarning($this->t('Stripe is not connected. Please connect your Stripe account first.'));
       return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
     }
 
-    // Validate account ID format (should start with 'acct_').
-    if (!str_starts_with($accountId, 'acct_')) {
-      $logger->error('Stripe manage: Invalid account ID format for user @uid, account_id: @account_id', [
-        '@uid' => $currentUser->id(),
-        '@account_id' => $accountId,
-      ]);
-      $this->messenger()->addError($this->t('Invalid Stripe account ID. Please reconnect your Stripe account.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
-    }
-
-    // Attempt to create login link only if account is eligible.
-    // This method validates eligibility BEFORE calling Stripe API to prevent errors.
     try {
-      $logger->info('Stripe manage: Checking eligibility and creating login link for account @account_id, user @uid', [
-        '@account_id' => $accountId,
-        '@uid' => $currentUser->id(),
-      ]);
-
       $loginLink = $this->stripeService->createLoginLinkIfEligible($accountId);
-
-      // If login link is NULL, account is not eligible.
       if ($loginLink === NULL) {
-        // Get eligibility details for logging.
         $eligibility = $this->stripeService->validateAccountDashboardEligibility($accountId);
-        $reason = $eligibility['reason'] ?? 'Unknown reason';
-
-        // Log at NOTICE level (eligibility failures are expected for incomplete accounts).
-        $logger->notice('Stripe manage: Account @account_id is not eligible for dashboard login link. Reason: @reason', [
-          '@account_id' => $accountId,
+        $reason = (string) ($eligibility['reason'] ?? 'Unknown');
+        $logger->notice('Stripe manage: ineligible for login link, account @acct, reason @reason', [
+          '@acct' => StripeService::maskAccountId($accountId),
           '@reason' => $reason,
         ]);
-
-        // Show clear UI message about incomplete onboarding.
-        $this->messenger()->addWarning($this->t('Stripe onboarding incomplete. Your account is not yet ready for dashboard access. Please complete the Stripe onboarding process.'));
+        $this->messenger()->addWarning($this->t('Stripe onboarding is not complete enough to open the dashboard yet. Continue setup in Connect.'));
         return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
       }
 
       if (empty($loginLink->url)) {
-        // This is an unexpected error (link created but URL missing).
-        $logger->error('Stripe manage: Login link created but URL is empty for account @account_id', [
-          '@account_id' => $accountId,
-        ]);
-        $this->messenger()->addError($this->t('Failed to generate Stripe dashboard link. Please try again.'));
-        return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+        $this->messenger()->addError($this->t('Failed to generate a Stripe link. Please try again.'));
+        return $this->redirectToDashboard();
       }
 
-      $logger->info('Stripe manage: Successfully created login link for account @account_id', [
-        '@account_id' => $accountId,
-      ]);
+      $url = (string) $loginLink->url;
+      if (!str_starts_with($url, 'https://connect.stripe.com') && !str_starts_with($url, 'https://dashboard.stripe.com')) {
+        $logger->error('Stripe manage: unexpected host for login link, account @acct', [
+          '@acct' => StripeService::maskAccountId($accountId),
+        ]);
+        $this->messenger()->addError($this->t('Invalid Stripe link. Please try again or contact support.'));
+        return $this->redirectToDashboard();
+      }
 
-      $response = new TrustedRedirectResponse($loginLink->url);
-      $response->setTrustedTargetUrl($loginLink->url);
+      $response = new TrustedRedirectResponse($url);
+      $response->setTrustedTargetUrl($url);
       $this->applyOffsiteStripeRedirectHeaders($response);
       return $response;
     }
+    catch (ApiErrorException $e) {
+      if ($vendor instanceof Vendor) {
+        $this->logConnectApiError($e, $vendor, $store, $accountId);
+      }
+      else {
+        $logger->error('Stripe manage API: uid @uid, type @t', [
+          '@uid' => (string) $currentUser->id(),
+          '@t' => (string) ($e->getStripeCode() ?? $e->getCode()),
+        ]);
+      }
+      $this->messenger()->addError($this->t('We could not open your Stripe account. Try again in a few minutes, or open Stripe from the Connect link if setup is still in progress.'));
+      return $this->redirectToDashboard();
+    }
     catch (\Exception $e) {
-      // Unexpected failures during API calls - log as ERROR.
-      $error_message = $e->getMessage();
-      $logger->error('Stripe manage: Unexpected error creating login link for account @account_id: @message', [
-        '@account_id' => $accountId,
-        '@message' => $error_message,
+      $logger->error('Stripe manage: @m', [
+        '@m' => $e->getMessage(),
       ]);
-
-      $this->messenger()->addError($this->t('Failed to open Stripe dashboard. Please try again or contact support.'));
-      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
+      $this->messenger()->addError($this->t('Failed to open Stripe. Please try again or contact support.'));
+      return $this->redirectToDashboard();
     }
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_vendor\Controller;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -304,9 +305,17 @@ final class VendorDashboardController extends VendorConsoleBaseController {
 
     // Format stripe status message for template (phase-driven copy in stripe-panel).
     $stripeStatusFormatted = $stripeStatus;
-    $stripeStatusFormatted['status_message'] = match ($stripeStatus['stripe_phase'] ?? 'needs_connect') {
-      'payouts_ready' => $this->t('Payouts are enabled — you can receive funds from ticket sales.'),
-      'needs_completion' => $this->t('Finish setting up your Stripe account to enable payouts.'),
+    $melState = (string) ($stripeStatus['mel_stripe_state'] ?? 'not_connected');
+    $stripeStatusFormatted['status_message'] = match ($melState) {
+      'not_connected' => $this->t('Connect Stripe to receive card payments and payouts for your events.'),
+      'continue_setup' => $this->t('Finish setting up your Stripe account to go live with ticket sales.'),
+      'under_review' => $this->t('Stripe is reviewing your information. This can take a short time — check back soon.'),
+      'action_required' => $this->t('Action is required in Stripe to keep accepting charges or receiving payouts. Review your Stripe account.'),
+      'payouts_restricted' => $this->t('You can sell tickets, but bank payouts are still restricted. Complete your payout details in Stripe.'),
+      'ready_to_sell' => (bool) ($stripeStatus['payouts_enabled'] ?? FALSE)
+        ? $this->t('Stripe is ready: you can sell tickets and receive payouts.')
+        : $this->t('Stripe is ready to process charges. Complete any remaining payout or bank details in your Stripe account.'),
+      'disabled' => $this->t('This Stripe account cannot be used. Contact support or review messages in your Stripe account.'),
       default => $this->t('Connect Stripe to receive payments from ticket sales and donations.'),
     };
 
@@ -1632,7 +1641,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $status = [
       'connected' => FALSE,
       'status' => 'not_connected',
-      'status_label' => 'Not Connected',
+      'status_label' => (string) $this->t('Not connected'),
       'account_id' => NULL,
       'next_payout_date' => NULL,
       'total_paid_out' => 0,
@@ -1643,84 +1652,150 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       'payouts_enabled' => FALSE,
       'is_onboarding_complete' => FALSE,
       'stripe_phase' => 'needs_connect',
+      'mel_stripe_state' => 'not_connected',
+      'primary_action' => 'connect',
+      'action_url' => NULL,
+      'manage_stripe_url' => NULL,
+      'payouts_restricted' => FALSE,
       'resume_url' => '/vendor/stripe/connect',
     ];
 
+    $accountIdForQuery = NULL;
+
     try {
+      $qDash = [
+        'destination' => '/vendor/dashboard',
+      ];
+      $qOnboard = [
+        'destination' => '/vendor/onboard/stripe',
+      ];
       $status['connect_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
-        'query' => ['destination' => '/vendor/dashboard'],
+        'query' => $qDash,
       ])->toString();
       $status['resume_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
-        'query' => ['destination' => '/vendor/onboard/stripe'],
+        'query' => $qOnboard,
       ])->toString();
     }
     catch (\Throwable) {
-      // Route optional in some builds.
+    }
+
+    try {
+      $status['manage_stripe_url'] = Url::fromRoute('myeventlane_vendor.stripe_manage')->toString();
+    }
+    catch (\Throwable) {
     }
 
     try {
       $store = NULL;
       if ($vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
-        $store = $vendor->get('field_vendor_store')->entity;
+        $cand = $vendor->get('field_vendor_store')->entity;
+        if ($cand instanceof StoreInterface) {
+          $store = $cand;
+        }
       }
       if (!$store) {
-        $stores = $this->entityTypeManager->getStorage('commerce_store')
-          ->loadByProperties(['uid' => $userId]);
-        $store = !empty($stores) ? reset($stores) : NULL;
+        $status['action_url'] = $status['connect_url'];
+        return $status;
       }
 
-      if ($store && $store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
-        $status['account_id'] = $store->get('field_stripe_account_id')->value;
-        $status['stripe_dashboard_url'] = 'https://dashboard.stripe.com';
-
-        $connected = FALSE;
-        if ($store->hasField('field_stripe_connected') && !$store->get('field_stripe_connected')->isEmpty()) {
-          $connected = (bool) $store->get('field_stripe_connected')->value;
-        }
-        if (!$connected && $store->hasField('field_stripe_charges_enabled') && !$store->get('field_stripe_charges_enabled')->isEmpty()) {
-          $connected = (bool) $store->get('field_stripe_charges_enabled')->value;
-        }
-        $charges_enabled = $store->hasField('field_stripe_charges_enabled') && !$store->get('field_stripe_charges_enabled')->isEmpty()
-          ? (bool) $store->get('field_stripe_charges_enabled')->value
-          : FALSE;
-        $payouts_enabled = $store->hasField('field_stripe_payouts_enabled') && !$store->get('field_stripe_payouts_enabled')->isEmpty()
-          ? (bool) $store->get('field_stripe_payouts_enabled')->value
-          : FALSE;
-
-        $status['charges_enabled'] = $charges_enabled;
-        $status['payouts_enabled'] = $payouts_enabled;
-
-        if ($connected) {
-          $status['connected'] = TRUE;
-          $status['status'] = 'connected';
-          $status['status_label'] = 'Connected';
-        }
-
-        if ($payouts_enabled) {
-          $status['stripe_phase'] = 'payouts_ready';
-          $status['is_onboarding_complete'] = TRUE;
-          $status['connected'] = TRUE;
-          $status['status'] = 'connected';
-          $status['status_label'] = (string) $this->t('Payouts enabled');
-        }
-        elseif ($connected) {
-          // Charges enabled: same seller-ready signal as assertStripeConnected; do not require payouts.
-          $status['stripe_phase'] = 'payouts_ready';
-          $status['is_onboarding_complete'] = TRUE;
-          $status['connected'] = TRUE;
-          $status['status'] = 'connected';
-          $status['status_label'] = (string) $this->t('Connected');
-        }
-        elseif ($status['account_id']) {
-          $status['stripe_phase'] = 'needs_completion';
-          $status['status'] = 'pending';
-          $status['status_label'] = (string) $this->t('Action required');
-          $status['is_onboarding_complete'] = FALSE;
+      if ($store->hasField('field_stripe_account_id') && !$store->get('field_stripe_account_id')->isEmpty()) {
+        $id = trim((string) $store->get('field_stripe_account_id')->value);
+        if ($id !== '' && str_starts_with($id, 'acct_')) {
+          $status['account_id'] = $id;
+          $accountIdForQuery = $id;
         }
       }
+      if ($accountIdForQuery) {
+        $qDashA = [
+          'destination' => '/vendor/dashboard',
+          'account_id' => $accountIdForQuery,
+        ];
+        $qOnboardA = [
+          'destination' => '/vendor/onboard/stripe',
+          'account_id' => $accountIdForQuery,
+        ];
+        $status['connect_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
+          'query' => $qDashA,
+        ])->toString();
+        $status['resume_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
+          'query' => $qOnboardA,
+        ])->toString();
+      }
+      $status['stripe_dashboard_url'] = 'https://dashboard.stripe.com';
+
+      $raw_flags = 'pending';
+      if ($store->hasField('field_stripe_status') && !$store->get('field_stripe_status')->isEmpty()) {
+        $raw_flags = (string) $store->get('field_stripe_status')->value;
+      }
+
+      $charges_enabled = $store->hasField('field_stripe_charges_enabled') && !$store->get('field_stripe_charges_enabled')->isEmpty()
+        ? (bool) $store->get('field_stripe_charges_enabled')->value
+        : FALSE;
+      $payouts_enabled = $store->hasField('field_stripe_payouts_enabled') && !$store->get('field_stripe_payouts_enabled')->isEmpty()
+        ? (bool) $store->get('field_stripe_payouts_enabled')->value
+        : FALSE;
+
+      $status['charges_enabled'] = $charges_enabled;
+      $status['payouts_enabled'] = $payouts_enabled;
+      $status['payouts_restricted'] = $charges_enabled && !$payouts_enabled;
+
+      if (empty($status['account_id'])) {
+        $status['mel_stripe_state'] = 'not_connected';
+        $status['primary_action'] = 'connect';
+        $status['action_url'] = $status['connect_url'];
+        $status['status_label'] = (string) $this->t('Not connected');
+        $status['stripe_phase'] = 'needs_connect';
+        return $status;
+      }
+
+      if ($charges_enabled && $payouts_enabled) {
+        $status['connected'] = TRUE;
+        $status['status'] = 'connected';
+        $status['status_label'] = (string) $this->t('Payouts enabled');
+        $status['mel_stripe_state'] = 'ready_to_sell';
+        $status['primary_action'] = 'open_dashboard';
+        $status['action_url'] = $status['manage_stripe_url'] ?? $status['connect_url'];
+        $status['stripe_phase'] = 'payouts_ready';
+        $status['is_onboarding_complete'] = TRUE;
+        return $status;
+      }
+
+      if ($charges_enabled && !$payouts_enabled) {
+        $status['connected'] = TRUE;
+        $status['status'] = 'connected';
+        $status['status_label'] = (string) $this->t('Payouts restricted');
+        $status['mel_stripe_state'] = 'payouts_restricted';
+        $status['primary_action'] = 'open_dashboard';
+        $status['action_url'] = $status['manage_stripe_url'] ?? $status['connect_url'];
+        $status['stripe_phase'] = 'payouts_ready';
+        $status['is_onboarding_complete'] = TRUE;
+        return $status;
+      }
+
+      if ($raw_flags === 'restricted') {
+        $status['status'] = 'pending';
+        $status['status_label'] = (string) $this->t('Action required');
+        $status['mel_stripe_state'] = 'action_required';
+        $status['primary_action'] = 'review_requirements';
+        $status['action_url'] = $status['resume_url'];
+        $status['stripe_phase'] = 'needs_completion';
+        $status['is_onboarding_complete'] = FALSE;
+        return $status;
+      }
+
+      $status['status'] = 'pending';
+      $status['status_label'] = (string) $this->t('Continue setup');
+      $status['mel_stripe_state'] = 'continue_setup';
+      $status['primary_action'] = 'continue';
+      $status['action_url'] = $status['resume_url'];
+      $status['stripe_phase'] = 'needs_completion';
+      $status['is_onboarding_complete'] = FALSE;
     }
-    catch (\Exception $e) {
-      // Stripe Connect may not be configured.
+    catch (\Exception) {
+    }
+
+    if ($status['action_url'] === NULL) {
+      $status['action_url'] = $status['connect_url'];
     }
 
     return $status;
@@ -1798,17 +1873,32 @@ final class VendorDashboardController extends VendorConsoleBaseController {
 
     // Check Stripe status.
     $stripeStatus = $this->getStripeConnectStatus($userId, $vendor);
+    $mel = (string) ($stripeStatus['mel_stripe_state'] ?? 'not_connected');
+    if ($mel === 'payouts_restricted') {
+      $notifications[] = [
+        'type' => 'info',
+        'icon' => 'credit-card',
+        'message' => t('Add or verify your bank in Stripe to receive ticket payouts'),
+        'url' => $stripeStatus['action_url'] ?? $stripeStatus['connect_url'] ?? '/vendor/stripe/connect',
+      ];
+    }
     if (($stripeStatus['stripe_phase'] ?? '') !== 'payouts_ready') {
       $is_finish = ($stripeStatus['stripe_phase'] ?? '') === 'needs_completion';
-      $stripe_url = $is_finish
+      $is_action = $mel === 'action_required';
+      $stripe_url = $is_finish || $is_action
         ? ($stripeStatus['resume_url'] ?? $stripeStatus['connect_url'] ?? '/vendor/stripe/connect')
         : ($stripeStatus['connect_url'] ?? '/vendor/stripe/connect');
+      $msg = t('Connect Stripe to receive payments');
+      if ($is_action) {
+        $msg = t('Stripe needs more information. Review requirements in Connect.');
+      }
+      elseif ($is_finish) {
+        $msg = t('Finish Stripe setup to enable payouts');
+      }
       $notifications[] = [
         'type' => 'warning',
         'icon' => 'credit-card',
-        'message' => $is_finish
-          ? t('Finish Stripe setup to enable payouts')
-          : t('Connect Stripe to receive payments'),
+        'message' => $msg,
         'url' => $stripe_url,
       ];
     }
@@ -2190,23 +2280,41 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   private function buildDashboardAlerts(array $stripe, array $eventNodes): array {
     $alerts = [];
 
+    $actionUrl = $stripe['action_url'] ?? $stripe['connect_url'] ?? $this->safeRouteUrl('myeventlane_vendor.stripe_connect');
+    $mel = (string) ($stripe['mel_stripe_state'] ?? 'not_connected');
+    if ($mel === 'payouts_restricted') {
+      $alerts[] = [
+        'type' => 'info',
+        'title' => (string) $this->t('Finish payout setup'),
+        'message' => (string) $this->t('You can take card payments. Complete bank and verification in Stripe to receive your transfers.'),
+        'url' => $actionUrl,
+        'link_label' => (string) $this->t('Open Stripe Dashboard'),
+      ];
+    }
     $stripe_phase = $stripe['stripe_phase'] ?? (empty($stripe['connected']) ? 'needs_connect' : 'needs_completion');
     if ($stripe_phase !== 'payouts_ready') {
       $is_finish = $stripe_phase === 'needs_completion';
+      $is_action = $mel === 'action_required';
       $alerts[] = [
-        'type' => $is_finish ? 'warning' : 'info',
-        'title' => $is_finish
-          ? (string) $this->t('Finish setting up Stripe')
-          : (string) $this->t('Connect Stripe to receive payments'),
-        'message' => $is_finish
-          ? (string) $this->t('Complete your Stripe account so payouts can reach your bank.')
-          : (string) $this->t('Connect Stripe so ticket sales can pay out automatically.'),
-        'url' => $is_finish
+        'type' => $is_action ? 'warning' : ($is_finish ? 'warning' : 'info'),
+        'title' => $is_action
+          ? (string) $this->t('Stripe: action required')
+          : ($is_finish
+            ? (string) $this->t('Finish setting up Stripe')
+            : (string) $this->t('Connect Stripe to receive payments')),
+        'message' => $is_action
+          ? (string) $this->t('Log in to Stripe to resolve outstanding requirements, or continue the Connect flow.')
+          : ($is_finish
+            ? (string) $this->t('Complete your Stripe account so you can get paid for ticket sales.')
+            : (string) $this->t('Connect Stripe so ticket sales can pay out automatically.')),
+        'url' => $is_finish || $is_action
           ? ($stripe['resume_url'] ?? $stripe['connect_url'] ?? $this->safeRouteUrl('myeventlane_vendor.stripe_connect'))
           : ($stripe['connect_url'] ?? $this->safeRouteUrl('myeventlane_vendor.stripe_connect')),
-        'link_label' => $is_finish
-          ? (string) $this->t('Resume Stripe setup')
-          : (string) $this->t('Connect Stripe'),
+        'link_label' => $is_action
+          ? (string) $this->t('Review Stripe requirements')
+          : ($is_finish
+            ? (string) $this->t('Continue Stripe setup')
+            : (string) $this->t('Connect Stripe')),
       ];
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\EventSubscriber;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
@@ -117,14 +118,55 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
 
     $logger->notice('Proceeding to create store for vendor @id', ['@id' => $vendor->id()]);
 
-    // Mark as processing.
-    self::$processing[$vendor->id()] = TRUE;
+    $this->createAndPersistStoreForVendor($vendor);
+  }
 
+  /**
+   * Returns the vendor's store, or creates one when onboarding is complete.
+   *
+   * Used for Stripe Connect and other flows that require a store without
+   * falling back to the platform default or another user's store.
+   */
+  public function ensureStoreForVendor(Vendor $vendor): ?StoreInterface {
+    if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+      $entity = $vendor->get('field_vendor_store')->entity;
+      if ($entity instanceof StoreInterface) {
+        return $entity;
+      }
+    }
+
+    $owner = $vendor->getOwner();
+    if ($owner !== NULL) {
+      $state = $this->onboardingManager->loadVendorStateByUid((int) $owner->id());
+      if ($state !== NULL && !$this->onboardingManager->isCompleted($state)) {
+        $this->loggerFactory->get('myeventlane_vendor')->notice('Store ensure: onboarding incomplete, vendor @id', [
+          '@id' => (string) $vendor->id(),
+        ]);
+        return NULL;
+      }
+    }
+
+    if (isset(self::$processing[$vendor->id()])) {
+      $this->loggerFactory->get('myeventlane_vendor')->notice('Store ensure: vendor @id already in progress', [
+        '@id' => (string) $vendor->id(),
+      ]);
+      return NULL;
+    }
+
+    return $this->createAndPersistStoreForVendor($vendor);
+  }
+
+  /**
+   * Creates and saves a Commerce store for a vendor, linking both entities.
+   */
+  private function createAndPersistStoreForVendor(Vendor $vendor): ?StoreInterface {
+    self::$processing[$vendor->id()] = TRUE;
+    $logger = $this->loggerFactory->get('myeventlane_vendor');
+    $store = NULL;
     try {
       $store_storage = $this->entityTypeManager->getStorage('commerce_store');
       $owner = $vendor->getOwner();
 
-      // Create a new Commerce Store for this vendor.
       /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
       $store = $store_storage->create([
         'type' => 'online',
@@ -146,25 +188,20 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
         'status' => TRUE,
       ]);
 
-      // Link the store back to the vendor.
       $store->set('field_vendor_reference', $vendor);
       $store->save();
 
-      // Link the vendor to the store.
       $vendor->set('field_vendor_store', $store);
-      // Save the vendor again to persist the store reference.
-      // This won't trigger insert again since the entity is no longer new.
       $vendor->save();
 
-      // Unmark as processing.
       unset(self::$processing[$vendor->id()]);
 
+      return $store;
     }
     catch (EntityStorageException $e) {
-      // Unmark as processing on error.
       unset(self::$processing[$vendor->id()]);
 
-      $this->loggerFactory->get('myeventlane_vendor')->error(
+      $logger->error(
         'Failed to create store for vendor @vendor: @message',
         [
           '@vendor' => $vendor->id(),
@@ -172,6 +209,8 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
         ]
       );
     }
+
+    return $store;
   }
 
 }


### PR DESCRIPTION
Stripe QA still required before merge:

1. Existing connected vendor reuses existing acct_ and does not create a duplicate.
2. New vendor with store creates Express account, saves acct_ to the store, and redirects to Stripe-hosted onboarding.
3. Vendor without store creates/links a store through canonical vendor store logic only.
4. Expired/reused Account Link generates a fresh link and does not loop.
5. Callback validates account_id against current vendor/store and updates local status fields.
6. Stripe API errors show safe vendor-facing copy and safe logs only.
7. Paid selling is blocked unless vendor is charge-ready.

Log check from DDEV showed masked account ids and no full Stripe Account Link URL in the sampled logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Stripe Connect onboarding/account-creation flow and vendor dashboard state logic, which can affect who can take payments and how vendors are routed through onboarding; requires Stripe QA in a real environment. Risk is mitigated by preserving existing `acct_` ids and adding validation/safer logging, but mis-routing or status gating regressions are still possible.
> 
> **Overview**
> Converges vendor Stripe Connect onboarding on **Connect Express**: `StripeService::createConnectAccount()` now defaults to `express`, with new helpers to **reuse existing** `field_stripe_account_id`, persist initial Connect flags, and apply refreshed status back onto the Commerce store.
> 
> Refactors `StripeConnectController` to resolve the vendor via membership, resolve the store via `VendorStoreSubscriber::ensureStoreForVendor()` (removing uid/default-store fallbacks), include and validate `account_id` in return/refresh URLs, add explicit `ApiErrorException` handling, and remove unsafe logging of full Stripe redirect URLs (masking account ids instead).
> 
> Updates vendor dashboard Stripe panel logic to derive a clearer `mel_stripe_state` (incl. payouts-restricted/action-required) and drive CTA/alerts/notifications from the vendor-bound store only. Adds audit/task documentation under `docs/audits/` describing the Stripe Connect model, risks, and the Task 4 implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01980368ceed3f6a193b27f2fe5c1ebacd0082bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->