### PR TITLE
fix(vendor): restore single ensureStoreForVendor; fix connect() brace…

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -64,6 +64,7 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@logger.factory'
+      - '@myeventlane_onboarding.manager'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Stripe\Exception\ApiErrorException;
 
 /**
  * Controller for Stripe Connect Express onboarding and management.
@@ -246,6 +245,7 @@ final class StripeConnectController extends ControllerBase {
           '@m' => $e->getMessage(),
         ]);
       }
+    }
 
     $userEmail = (string) $currentUser->getEmail();
     if (trim($userEmail) === '') {

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -8,6 +8,7 @@ use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -31,6 +32,11 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   private LoggerChannelFactoryInterface $loggerFactory;
 
   /**
+   * The onboarding state manager.
+   */
+  private OnboardingManager $onboardingManager;
+
+  /**
    * Track vendors being processed to prevent recursion.
    *
    * @var array
@@ -44,13 +50,17 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
    *   The entity type manager.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
+   * @param \Drupal\myeventlane_core\Service\OnboardingManager $onboarding_manager
+   *   Vendor onboarding.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
+    OnboardingManager $onboarding_manager,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
+    $this->onboardingManager = $onboarding_manager;
   }
 
   /**
@@ -82,48 +92,35 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
    */
   public function onVendorInsertFromHook(Vendor $vendor): void {
     $logger = $this->loggerFactory->get('myeventlane_vendor');
+
     $logger->notice('Vendor insert hook fired for vendor @id', ['@id' => $vendor->id()]);
-    $this->ensureStoreForVendor($vendor);
-  }
 
-  /**
-   * Ensures a vendor has exactly one linked Commerce store.
-   */
-  public function ensureStoreForVendor(Vendor $vendor): ?StoreInterface {
-    $logger = $this->loggerFactory->get('myeventlane_vendor');
-
-    if (!$vendor->hasField('field_vendor_store')) {
-      $logger->error('Vendor @id is missing field_vendor_store.', [
-        '@id' => (string) $vendor->id(),
-      ]);
-      return NULL;
+    $owner = $vendor->getOwner();
+    if ($owner !== NULL) {
+      $state = $this->onboardingManager->loadVendorStateByUid((int) $owner->id());
+      if ($state !== NULL && !$this->onboardingManager->isCompleted($state)) {
+        $logger->notice('Store creation skipped (onboarding incomplete) vendor=@id', [
+          '@id' => (string) $vendor->id(),
+        ]);
+        return;
+      }
     }
 
     // Prevent recursion if we're already processing this vendor.
     if (isset(self::$processing[$vendor->id()])) {
       $logger->notice('Vendor @id already being processed, skipping', ['@id' => $vendor->id()]);
-      return $this->getLinkedStore($vendor);
+      return;
     }
 
-    // Only proceed if vendor doesn't already have a valid linked store.
-    if (!$vendor->get('field_vendor_store')->isEmpty()) {
-      $store = $vendor->get('field_vendor_store')->entity;
-      if ($store instanceof StoreInterface) {
-        $this->ensureStoreBackReference($store, $vendor);
-        $logger->notice('Vendor @id already has a store, skipping', ['@id' => $vendor->id()]);
-        return $store;
-      }
-    }
-
-    $existing_store = $this->loadExistingStoreForVendor($vendor);
-    if ($existing_store instanceof StoreInterface) {
-      $vendor->set('field_vendor_store', $existing_store->id());
-      $vendor->save();
-      $logger->notice('Linked existing store @store to vendor @vendor.', [
-        '@store' => (string) $existing_store->id(),
-        '@vendor' => (string) $vendor->id(),
+    if (!$vendor->hasField('field_vendor_store')) {
+      $logger->error('Vendor @id is missing field_vendor_store.', [
+        '@id' => (string) $vendor->id(),
       ]);
-      return $existing_store;
+      return;
+    }
+    if (!$vendor->get('field_vendor_store')->isEmpty()) {
+      $logger->notice('Vendor @id already has a store, skipping', ['@id' => $vendor->id()]);
+      return;
     }
 
     $logger->notice('Proceeding to create store for vendor @id', ['@id' => $vendor->id()]);
@@ -138,7 +135,14 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
    * falling back to the platform default or another user's store.
    */
   public function ensureStoreForVendor(Vendor $vendor): ?StoreInterface {
-    if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+    if (!$vendor->hasField('field_vendor_store')) {
+      $this->loggerFactory->get('myeventlane_vendor')->error('Vendor @id is missing field_vendor_store.', [
+        '@id' => (string) $vendor->id(),
+      ]);
+      return NULL;
+    }
+
+    if (!$vendor->get('field_vendor_store')->isEmpty()) {
       $entity = $vendor->get('field_vendor_store')->entity;
       if ($entity instanceof StoreInterface) {
         return $entity;
@@ -176,12 +180,11 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     try {
       $store_storage = $this->entityTypeManager->getStorage('commerce_store');
       $owner = $vendor->getOwner();
-      $owner_id = $owner ? (int) $owner->id() : 1;
 
       /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
       $store = $store_storage->create([
         'type' => 'online',
-        'uid' => $owner_id,
+        'uid' => $owner ? $owner->id() : 1,
         'name' => $vendor->getName() . ' Store',
         'mail' => $owner && $owner->getEmail() ? $owner->getEmail() : 'noreply@myeventlane.com',
         'default_currency' => 'AUD',
@@ -204,10 +207,8 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
 
       $vendor->set('field_vendor_store', $store);
       $vendor->save();
-      $this->loggerFactory->get('stripe_debug')->notice('Store created for user @uid', ['@uid' => (string) $owner_id]);
 
       unset(self::$processing[$vendor->id()]);
-      return $store;
 
       return $store;
     }


### PR DESCRIPTION
…; reinject OnboardingManager

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vendor store provisioning and Stripe Connect resume logic; mistakes could block store creation or mis-handle Connect redirects for vendors mid-onboarding.
> 
> **Overview**
> Adjusts vendor store provisioning to be **onboarding-aware**: `VendorStoreSubscriber` now injects `OnboardingManager` and skips auto-creating a Commerce store on vendor insert until vendor onboarding is completed, while keeping `ensureStoreForVendor()` as the single entry point for on-demand creation.
> 
> Also fixes a Stripe Connect controller issue by correcting the control-flow/bracing around the “resume link” status refresh so the rest of the Connect onboarding flow executes only after the refresh attempt completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9e836e936064c60c06ef567c747b92c99b6e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->