### PR TITLE
Refactor StripeConnectController and VendorDashboardController to imp…

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -123,12 +123,14 @@ final class StripeConnectController extends ControllerBase {
   }
 
   /**
-   * Builds return and refresh URLs for Account Links; includes account_id for callback validation.
+   * Builds return and refresh URLs for Account Links.
+   *
+   * The store’s field_stripe_account_id is set before the redirect; the
+   * callback resolves the account from the store so the ID is not placed in
+   * query strings (logs, referrers, history).
    */
-  private function buildAccountLinkUrls(string $accountId, string $destination = ''): array {
-    $query = [
-      'account_id' => $accountId,
-    ];
+  private function buildAccountLinkUrls(string $destination = ''): array {
+    $query = [];
     if ($destination !== '') {
       $query['destination'] = $destination;
     }
@@ -262,7 +264,7 @@ final class StripeConnectController extends ControllerBase {
         throw new \RuntimeException('Stripe account id missing after ensure.');
       }
 
-      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($accountId, $destStr);
+      [$returnUrl, $refreshUrl] = $this->buildAccountLinkUrls($destStr);
       $accountLink = $this->stripeService->createAccountLink($accountId, $returnUrl, $refreshUrl);
       if (empty($accountLink->url) || !is_string($accountLink->url) || $accountLink->url === '') {
         $log->error('Stripe connect: empty AccountLink for vendor @vid store @sid', [
@@ -294,9 +296,6 @@ final class StripeConnectController extends ControllerBase {
       return $this->redirectToDashboard();
     }
     catch (\Exception $e) {
-      if ($e instanceof \RuntimeException) {
-        throw $e;
-      }
       $this->getLogger('myeventlane_vendor')->error('Stripe connect: @m', [
         '@m' => $e->getMessage(),
       ]);
@@ -368,19 +367,13 @@ final class StripeConnectController extends ControllerBase {
       $status = $this->stripeService->getAccountStatus($accountId);
     }
     catch (ApiErrorException $e) {
+      $this->loggerChannelFactory->get('stripe_error')->error($e->getMessage());
       $this->logConnectApiError($e, $vendor, $store, $accountId);
       $this->messenger()->addError($this->t('We could not verify your Stripe account. Please try again.'));
       if ($dest !== '') {
         return new RedirectResponse($dest);
       }
       return $this->redirectToDashboard();
-    }
-    catch (ApiErrorException $e) {
-      $this->loggerChannelFactory->get('stripe_error')->error($e->getMessage());
-      $this->loggerChannelFactory->get('myeventlane_vendor')->error('Stripe Connect callback failed: @message', [
-        '@message' => $e->getMessage(),
-      ]);
-      $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
     }
     catch (\Exception $e) {
       $log->error('Stripe callback: @m', ['@m' => $e->getMessage()]);
@@ -411,7 +404,7 @@ final class StripeConnectController extends ControllerBase {
     elseif (!empty($status['charges_enabled'])) {
       $this->messenger()->addStatus($this->t('Stripe can process charges. Check your Stripe Dashboard for any remaining items.'));
     }
-    elseif (($status['status'] ?? '') === 'pending' || !empty($status['details_submitted']) === FALSE) {
+    elseif (($status['status'] ?? '') === 'pending' || empty($status['details_submitted'] ?? NULL)) {
       $this->messenger()->addWarning($this->t('Please complete the remaining steps in your Stripe account setup.'));
     }
     else {

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -1660,8 +1660,6 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       'resume_url' => '/vendor/stripe/connect',
     ];
 
-    $accountIdForQuery = NULL;
-
     try {
       $qDash = [
         'destination' => '/vendor/dashboard',
@@ -1702,24 +1700,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         $id = trim((string) $store->get('field_stripe_account_id')->value);
         if ($id !== '' && str_starts_with($id, 'acct_')) {
           $status['account_id'] = $id;
-          $accountIdForQuery = $id;
         }
-      }
-      if ($accountIdForQuery) {
-        $qDashA = [
-          'destination' => '/vendor/dashboard',
-          'account_id' => $accountIdForQuery,
-        ];
-        $qOnboardA = [
-          'destination' => '/vendor/onboard/stripe',
-          'account_id' => $accountIdForQuery,
-        ];
-        $status['connect_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
-          'query' => $qDashA,
-        ])->toString();
-        $status['resume_url'] = Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
-          'query' => $qOnboardA,
-        ])->toString();
       }
       $status['stripe_dashboard_url'] = 'https://dashboard.stripe.com';
 

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -222,9 +222,8 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
           '@message' => $e->getMessage(),
         ]
       );
+      return NULL;
     }
-
-    return $store;
   }
 
 }


### PR DESCRIPTION
…rove URL handling and error logging. Removed unnecessary account ID query parameters and streamlined callback error handling. Updated VendorStoreSubscriber to ensure consistent return values on error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe Connect onboarding and callback flows, so mistakes could block vendor payouts/onboarding. Changes are mostly URL/query handling and error/log paths, limiting blast radius but still payment-adjacent.
> 
> **Overview**
> **Stripe Connect onboarding no longer puts `account_id` in return/refresh URLs or dashboard-generated connect/resume links**, relying on the store’s saved `field_stripe_account_id` instead to avoid leaking IDs via query strings.
> 
> **Error handling and logging were streamlined** in `StripeConnectController` (simplified exception handling, adds `stripe_error` logging on callback API errors) and the callback’s “pending/incomplete” detection was tightened.
> 
> `VendorStoreSubscriber` now returns `NULL` on store-creation failures to make the error path’s return value explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e882bd6bfa7d76b332bb474d7e8891105c603c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->