### PR TITLE
Cursor/onboard storage fix 128b4

### DIFF
--- a/docs/audits/mel-stripe-staging-env-key-check.md
+++ b/docs/audits/mel-stripe-staging-env-key-check.md
@@ -1,0 +1,118 @@
+# MEL Staging — Stripe `settings.php` gateway override (TASK 4I)
+
+**Date:** 2026-04-28  
+**Problem:** Staging could not start Stripe vendor onboarding because the platform secret appeared missing.
+
+**Security:** No full `sk_`, `pk_`, or `whsec_` values appear here. Treat any keys previously pasted into terminals or chat as **exposed** and **rotate** test secrets and webhook signing material in the Stripe Dashboard after staging is stable; update env or Commerce UI only—never tickets or Git.
+
+---
+
+## Root cause
+
+Load order in [`web/sites/default/settings.php`](../../web/sites/default/settings.php):
+
+1. [`settings.mel_shared_session.php`](../../web/sites/default/settings.mel_shared_session.php) is required **first** and merges `MEL_STRIPE_SECRET_KEY` / `MEL_STRIPE_PUBLISHABLE_KEY` into Commerce gateway `$config` when those env vars are non-empty.
+
+2. A **later** block used to assign:
+
+   - `getenv('STRIPE_PK') ?: ''` and `getenv('STRIPE_SK') ?: ''` directly into `commerce_payment.commerce_payment_gateway.stripe` and `stripe_pe_recurring` `publishable_key` / `secret_key`.
+
+When `STRIPE_PK` / `STRIPE_SK` were **unset**, those expressions became **empty strings** and **overwrote** the effective gateway overrides, erasing MEL- or DB-backed keys for the web runtime. [`StripeService`](../../web/modules/custom/myeventlane_core/src/Service/StripeService.php) then saw no platform secret.
+
+---
+
+## Safe override pattern (current `settings.php` logic)
+
+Only override when the corresponding env var is **non-empty**. **Never** assign empty strings into gateway config from this block.
+
+```php
+$stripe_pk = getenv('STRIPE_PK') ?: '';
+$stripe_sk = getenv('STRIPE_SK') ?: '';
+
+if ($stripe_pk !== '') {
+  $config['commerce_payment.commerce_payment_gateway.stripe']['configuration']['publishable_key'] = $stripe_pk;
+  $config['commerce_payment.commerce_payment_gateway.stripe_pe_recurring']['configuration']['publishable_key'] = $stripe_pk;
+}
+
+if ($stripe_sk !== '') {
+  $config['commerce_payment.commerce_payment_gateway.stripe']['configuration']['secret_key'] = $stripe_sk;
+  $config['commerce_payment.commerce_payment_gateway.stripe_pe_recurring']['configuration']['secret_key'] = $stripe_sk;
+}
+```
+
+**`MEL_STRIPE_SECRET_KEY`:** Unchanged. It continues to be applied in `settings.mel_shared_session.php` **before** this block; this block no longer clears those merges when `STRIPE_*` is unset.
+
+---
+
+## Git and deployment
+
+- **[`.gitignore`](../../.gitignore)** ignores `web/sites/*/*settings*.php`, so **`web/sites/default/settings.php` is not tracked** unless you use `git add -f`. **Do not force-add** unless Anna explicitly approves.
+- **Staging:** Apply the same logic **manually** on the server or through your approved deployment process for `settings.php`.
+
+---
+
+## Local verification (DDEV)
+
+Commands run after the fix:
+
+- `php -l web/sites/default/settings.php` — **OK** (no syntax errors).
+- `ddev drush cr` — **OK**.
+- Reflection on `StripeService::getPlatformSecretKey()` (private method): **platform secret present: yes**; **prefix** `sk_test_...` (first eight characters only; do not log full keys).
+
+---
+
+## Staging operator procedure (exact steps)
+
+1. **SSH** to staging.
+
+2. Go to the Drupal root (adjust path if your host differs):
+
+   ```bash
+   cd ~/staging/current
+   ```
+
+3. **Patch** `web/sites/default/settings.php`: replace any block that assigns `getenv('STRIPE_PK') ?: ''` / `getenv('STRIPE_SK') ?: ''` **unconditionally** into Commerce Stripe gateway config with the **safe pattern** in § “Safe override pattern” above (preserve surrounding code; do not add secrets to the file).
+
+4. **Clear cache:**
+
+   ```bash
+   ./vendor/bin/drush cr
+   ```
+
+5. **Verify** Stripe can resolve a platform secret **without printing it:**
+
+   ```bash
+   ./vendor/bin/drush php-eval '$service = \Drupal::service("myeventlane_core.stripe"); $ref = new ReflectionClass($service); $m = $ref->getMethod("getPlatformSecretKey"); $m->setAccessible(TRUE); try { $key = $m->invoke($service); echo "StripeService platform secret present: " . (!empty($key) ? "yes" : "no") . PHP_EOL; echo "Prefix: " . (!empty($key) ? substr($key, 0, 8) . "..." : "none") . PHP_EOL; } catch (\Throwable $e) { echo "StripeService error: " . $e->getMessage() . PHP_EOL; }'
+   ```
+
+6. If the result is **no**:
+
+   - add the matching test **secret** (and publishable if needed) via **Drupal admin** → Commerce → **Payment gateways** → `stripe` (test mode), **or**
+   - set **`MEL_STRIPE_SECRET_KEY`** in the **web** PHP process (PHP-FPM pool / host env), restart PHP or the web server, then run `drush cr` again.
+
+7. Click **Connect Stripe** once on staging.
+
+8. **Logs:**
+
+   ```bash
+   ./vendor/bin/drush ws --count=80 | grep -A4 -B2 -Ei "Stripe is not configured|MEL_STRIPE_SECRET_KEY|Stripe API error|Failed to create Stripe Connect account|Stripe Account Link created|Created AccountLink|managing losses"
+   ```
+
+**Expected when healthy:**
+
+- No “platform secret key is missing” / “Stripe is not configured” for that reason.
+- No **managing losses** message if the Connect **Platform Profile** is complete for the same Stripe test platform account.
+- **Stripe Account Link created** / masked `acct_…` in logs where applicable.
+- **No** full secret keys, **no** full `connect.stripe.com` Account Link URLs in logs.
+
+---
+
+## Related audits
+
+- Earlier notes: [mel-stripe-staging-key-check.md](mel-stripe-staging-key-check.md) (gateway snapshot / UI-first fix context).
+
+---
+
+## Task 5
+
+Do **not** start Task 5 from this document.

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -280,3 +280,4 @@ services:
       - '@lock'
       - '@current_user'
       - '@datetime.time'
+      - '@?workspaces.manager'

--- a/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
+++ b/web/modules/custom/myeventlane_core/src/Service/OnboardingManager.php
@@ -15,6 +15,7 @@ use Drupal\myeventlane_core\Entity\OnboardingStateInterface;
 use Drupal\myeventlane_core\OnboardingStateStorage;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\user\UserInterface;
+use Drupal\workspaces\WorkspaceManagerInterface;
 
 /**
  * Onboarding state manager.
@@ -59,6 +60,13 @@ final class OnboardingManager {
   private LockBackendInterface $lock;
 
   /**
+   * Present when Workspaces module is enabled; used to save onboarding state in Live.
+   *
+   * @var \Drupal\workspaces\WorkspaceManagerInterface|null
+   */
+  private ?WorkspaceManagerInterface $workspaceManager;
+
+  /**
    * Whether we have already logged duplicate state this request.
    *
    * @var array<string, true>
@@ -74,12 +82,14 @@ final class OnboardingManager {
     LockBackendInterface $lock,
     ?AccountProxyInterface $current_user = NULL,
     ?TimeInterface $time = NULL,
+    ?WorkspaceManagerInterface $workspace_manager = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
     $this->currentUser = $current_user;
     $this->time = $time;
     $this->lock = $lock;
+    $this->workspaceManager = $workspace_manager;
   }
 
   /**
@@ -115,7 +125,7 @@ final class OnboardingManager {
       'has_account' => TRUE,
       'has_orders' => $this->customerHasOrders($uid),
     ]);
-    $state->save();
+    $this->saveOnboardingState($state);
     return $state;
   }
 
@@ -268,7 +278,7 @@ final class OnboardingManager {
       ]);
       $state->setOwnerId($uid);
       $state->setFlags([]);
-      $state->save();
+      $this->saveOnboardingState($state);
       return $state;
     }
     finally {
@@ -305,7 +315,7 @@ final class OnboardingManager {
         $by_uid->setStoreId($store_id);
       }
       $by_uid->setFlags(array_merge($by_uid->getFlags(), $this->computeVendorFlags($vendor)));
-      $by_uid->save();
+      $this->saveOnboardingState($by_uid);
       return $by_uid;
     }
 
@@ -335,7 +345,7 @@ final class OnboardingManager {
     $state->setVendorId($vid);
     $state->setStoreId($store_id);
     $state->setFlags($this->computeVendorFlags($vendor));
-    $state->save();
+    $this->saveOnboardingState($state);
     return $state;
   }
 
@@ -506,7 +516,7 @@ final class OnboardingManager {
     $mel[$milestone] = TRUE;
     $flags['mel_create_event_gateway'] = $mel;
     $state->setFlags($flags);
-    $state->save();
+    $this->saveOnboardingState($state);
   }
 
   /**
@@ -542,7 +552,7 @@ final class OnboardingManager {
         ]));
       }
     }
-    $state->save();
+    $this->saveOnboardingState($state);
     return $state;
   }
 
@@ -565,7 +575,7 @@ final class OnboardingManager {
       return $state;
     }
     $state->setStage($stage);
-    $state->save();
+    $this->saveOnboardingState($state);
     return $state;
   }
 
@@ -634,7 +644,7 @@ final class OnboardingManager {
     }
     $this->advanceStage($state, 'complete');
     $state->setCompleted(TRUE);
-    $state->save();
+    $this->saveOnboardingState($state);
   }
 
   /**
@@ -793,7 +803,7 @@ final class OnboardingManager {
       }
       $id = (int) $state->id();
       try {
-        $state->delete();
+        $this->deleteOnboardingState($state);
         $this->logger()->warning('Removed duplicate vendor-track onboarding state id=@id (@track @key); kept=@keep.', [
           '@id' => (string) $id,
           '@track' => $log_track,
@@ -808,6 +818,51 @@ final class OnboardingManager {
         ]);
       }
     }
+  }
+
+  /**
+   * Persists onboarding state while Workspaces “Live” is active if needed.
+   *
+   * Unsupported entity types cannot be saved inside a non-default workspace.
+   *
+   * @see \Drupal\workspaces\WorkspaceManagerInterface::executeOutsideWorkspace()
+   */
+  private function saveOnboardingState(OnboardingStateInterface $state): void {
+    $this->runOnboardingStateInLive(function () use ($state): void {
+      $state->save();
+    });
+  }
+
+  /**
+   * Deletes onboarding state while Workspaces “Live” is active if needed.
+   */
+  private function deleteOnboardingState(OnboardingStateInterface $state): void {
+    $this->runOnboardingStateInLive(function () use ($state): void {
+      $state->delete();
+    });
+  }
+
+  /**
+   * @template T
+   *
+   * @param callable(): T $callback
+   *
+   * @return T
+   */
+  private function runOnboardingStateInLive(callable $callback): mixed {
+    if ($this->workspaceManager !== NULL) {
+      return $this->workspaceManager->executeOutsideWorkspace($callback);
+    }
+    return $callback();
+  }
+
+  /**
+   * Persists onboarding state when Workspaces may be active (forms/controllers).
+   *
+   * Prefer over calling save() directly on onboarding state entities.
+   */
+  public function persistOnboardingState(OnboardingStateInterface $state): void {
+    $this->saveOnboardingState($state);
   }
 
   /**

--- a/web/modules/custom/myeventlane_legal/src/Form/VendorTermsForm.php
+++ b/web/modules/custom/myeventlane_legal/src/Form/VendorTermsForm.php
@@ -173,7 +173,7 @@ final class VendorTermsForm extends FormBase {
       }
     }
     $state->setFlags($flags);
-    $state->save();
+    $this->onboardingManager->persistOnboardingState($state);
 
     $vendor = $this->onboardingManager->ensureVendorExists($this->currentUser);
     $this->onboardingManager->applyVendorLegalFieldsFromStateFlags($vendor, $flags);

--- a/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
@@ -181,7 +181,7 @@ class CreateEventGatewayController extends ControllerBase {
 
     if ($state->getVendorId() !== (int) $vendor->id()) {
       $state->setVendorId((int) $vendor->id());
-      $state->save();
+      $this->onboardingManager->persistOnboardingState($state);
     }
 
     try {

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardCompleteController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardCompleteController.php
@@ -96,7 +96,7 @@ final class VendorOnboardCompleteController extends ControllerBase {
 
     $state->setStage('complete');
     $state->setCompleted(TRUE);
-    $state->save();
+    $this->onboardingManager->persistOnboardingState($state);
 
     $this->vendorStoreSubscriber->onVendorInsertFromHook($vendor);
 

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -208,7 +208,7 @@ final class VendorOnboardProfileForm extends FormBase {
     }
 
     $state->setFlags($flags);
-    $state->save();
+    $this->onboardingManager->persistOnboardingState($state);
 
     $this->getLogger('myeventlane_vendor')->notice(
       'MEL: terms checkbox saved uid=@uid value=@value',
@@ -239,7 +239,7 @@ final class VendorOnboardProfileForm extends FormBase {
     $this->onboardingManager->ensureVendorAccess($account);
     if ((int) ($state->getVendorId() ?? 0) !== (int) $vendor->id()) {
       $state->setVendorId((int) $vendor->id());
-      $state->save();
+      $this->onboardingManager->persistOnboardingState($state);
     }
 
     // Mark onboarding complete (profile + terms) once vendor is linked. Must run
@@ -248,7 +248,7 @@ final class VendorOnboardProfileForm extends FormBase {
     if (!empty($flags['terms_accepted']) && $name !== '' && (int) ($state->getVendorId() ?? 0) > 0) {
       $state->setStage('complete');
       $state->setCompleted(TRUE);
-      $state->save();
+      $this->onboardingManager->persistOnboardingState($state);
       $this->getLogger('myeventlane_vendor')->notice(
         'MEL: onboarding marked complete from profile uid=@uid',
         ['@uid' => (string) $this->currentUser->id()],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches onboarding persistence paths by routing all `myeventlane_onboarding_state` saves/deletes through Workspaces-aware wrappers, which could affect vendor onboarding progression and data writes when Workspaces is enabled. Behavior should remain the same when Workspaces is disabled, but misconfiguration could still cause unexpected state not being persisted.
> 
> **Overview**
> **Onboarding state persistence is now Workspaces-aware.** `OnboardingManager` optionally injects `workspaces.manager` and wraps onboarding state `save()`/`delete()` calls in `executeOutsideWorkspace()` so unsupported onboarding state entities are persisted in *Live* even when a non-default workspace is active.
> 
> All direct `OnboardingStateInterface::save()` call sites touched in vendor onboarding flows (terms/profile forms, gateway controller, completion controller, and internal manager logic) are replaced with `OnboardingManager::persistOnboardingState()`/internal wrappers.
> 
> Adds an audit doc (`docs/audits/mel-stripe-staging-env-key-check.md`) describing a staging issue where empty `STRIPE_*` env overrides in `settings.php` could wipe Commerce Stripe gateway keys, and provides a safe override pattern and operator steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0448b1bfc08f74e2bd4700898b6e940152fa7de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->