### PR TITLE
Cursor/onboard storage fix 128b4

### DIFF
--- a/docs/audits/mel-event-studio-stripe-publish-gate.md
+++ b/docs/audits/mel-event-studio-stripe-publish-gate.md
@@ -1,0 +1,93 @@
+# Task 5B — Server-side Stripe charge-ready gate (Event Studio paid publish)
+
+**Date:** 2026-04-28
+
+## Root cause
+
+Task 5 found that Event Studio relied on **Twig/preprocess warnings** (`mel_publish_stripe_gate` / `mel_publish_blocked`) for paid events without a **canonical save-layer check**. Vendors could theoretically publish paid or hybrid (`both`) events while the Commerce store was not Stripe charge-ready if they bypassed UI hints.
+
+## Guard location
+
+| Layer | Behaviour |
+|-------|-----------|
+| **`PaidPublishStripeGate`** (`myeventlane_vendor`) | Single policy service: resolves vendor membership → Commerce store → validates `field_stripe_account_id` (non-empty `acct_*`) and `field_stripe_charges_enabled === TRUE`. No Stripe API calls. **Fail closed** if expected fields are missing on the store. |
+| **`EventStudioSaveService::save()`** | Before any node mutation, when `!$draft`, intended publish (`status`), and `field_event_type` ∈ `{paid, both}`, calls the gate; returns form errors instead of saving. |
+| **`EventStudioSaveService::setNodePublishedState()`** | Bulk/vendor list publish path: same rule when `$published === TRUE`; throws `InvalidArgumentException` with the user message so callers can handle it. |
+| **`VendorEventsBulkActionsForm`** | Catches `InvalidArgumentException` around bulk publish and surfaces the message (no white screen). |
+
+### Exact publish-intent rule (`save()`)
+
+- **Draft/autosave** (`$draft === TRUE`): gate **never** runs (vendors can keep editing unpaid Stripe setup).
+- **Non-draft** (`$draft === FALSE`): gate runs only if the save would **publish**:
+  - **New node:** `(bool) ($payload['status'] ?? FALSE)` — default unpublished; matches Event Studio “Published” checkbox default for new events.
+  - **Existing node:** `(bool) ($payload['status'] ?? TRUE)` — preserves prior behaviour when status omitted from payload.
+- **Event types:** `paid` and `both` only. `rsvp` and `external` unchanged.
+
+### Admin bypass
+
+Matches **`VendorConsoleBaseController::assertStripeConnected`**: user ID `1` or permission `administer site configuration` skips the gate.
+
+### Logging
+
+`logger.channel.myeventlane_vendor` receives **notice** lines with: `reason`, `uid`, `vendor_id`, `store_id`, `event_nid` — **no** secrets or Stripe keys.
+
+### User-facing message
+
+> Connect Stripe before publishing paid tickets. Stripe must be ready to accept charges before this event can go live.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php` | **New** — gate service |
+| `web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml` | Register `myeventlane_vendor.paid_publish_stripe_gate` |
+| `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml` | Inject gate into `myeventlane_event_studio.save` |
+| `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php` | Early validation in `save()`; validation in `setNodePublishedState()` |
+| `web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php` | `try/catch` on bulk publish |
+
+## Direct route `/vendor/events/create`
+
+**No route/controller change** in this task: vendors can still open Event Studio and **save unpublished** paid events (status unchecked / draft-capable flows). Only **publish intent** is blocked without charge-ready Stripe.
+
+**Follow-up (optional):** align `/vendor/events/add` redirect behaviour with `/vendor/events/create` for analytics/onboarding only — **not** required for server-side publish safety after this change.
+
+## Manual tests required (staging)
+
+| Case | Expected |
+|------|----------|
+| **A** Stripe charge-ready vendor publishes paid | Success |
+| **B** Vendor without charge-ready Stripe saves paid with **Published** unchecked | Success (draft/unpublished) |
+| **B2** Same vendor tries to publish paid (checkbox / publish step) | Blocked + message |
+| **C** RSVP-only publish | No Stripe gate |
+| **D** External-only publish | No Stripe gate |
+| **E** Admin / user 1 | Bypass (same as onboarding policy) |
+| **F** Bulk publish paid events from vendor list without Stripe | Error message per blocked row / attempt |
+
+## Verification commands / results
+
+Run locally after pull:
+
+```bash
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
+php -l web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+php -l web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+```
+
+Watchdog spot-check:
+
+```bash
+ddev drush ws --count=80 | grep -Ei "event_studio|stripe|charges|publish|error|exception" || true
+```
+
+*(Record actual command output in CI or staging when validating.)*
+
+## Remaining follow-ups
+
+- Optional: extend the same gate to **other** publish entrypoints (e.g. API or CLI) if they bypass `EventStudioSaveService`.
+- Task **6** intentionally **not** started here.
+
+## Ready to commit?
+
+Yes, after `composer validate`, `ddev drush cr`, `php -l` clean, and staging manual checks **A–F** documented above.

--- a/docs/audits/mel-event-studio-ticket-save-publish-check.md
+++ b/docs/audits/mel-event-studio-ticket-save-publish-check.md
@@ -1,0 +1,202 @@
+# Task 5 — Event Studio ticket save and publish (diagnostic audit)
+
+**Date:** 2026-04-28  
+**Environment:** Local `ddev` + codebase review (staging browser flows **not** executed in this session).  
+**Scope:** RSVP vs paid Event Studio paths, publish/save orchestration, booking entrypoints, Stripe readiness signals (no onboarding/gateway config edits).
+
+---
+
+## Plan (concise)
+
+1. Confirm routes and controllers for Event Studio, autosave, booking (`/event/{node}/book`), RSVP public routes.  
+2. Trace save chain: `EventStudioBaseForm` → `EventStudioMelPayloadService` → `EventStudioSaveService` → `MelTicketTypeManager`.  
+3. Compare legacy wizard validation (`EventWizardPublishValidator`) vs Event Studio publish (`EventStudioPublishForm`).  
+4. Check vendor entry (`VendorEventCreateController` vs direct Event Studio create).  
+5. Classify risks against P0/P1/P2; recommend Task 6 vs Task 5B.  
+
+---
+
+## Commands run
+
+| Command | Result |
+|--------|--------|
+| `git status --short` | Clean (no unstaged output) |
+| `git branch --show-current` | `cursor/onboard-storage-fix-128b4` |
+| `git log -1 --oneline` | `a15b2f5a Enhance StripeService to include additional gateway IDs for secret key retrieval` |
+| `composer validate` | `./composer.json is valid` |
+| `ddev drush cr` | Cache rebuild complete |
+| `ddev drush route \| grep -Ei "event_studio\|vendor/events\|event/.*/book\|rsvp\|checkout\|ticket"` | See **Routes checked** |
+| `grep -R "EventStudioTicketsForm\|…" web/modules/custom` | Broad match set (see **Files inspected**) |
+| `ddev drush ws --count=80 \| grep -Ei "event_studio\|ticket\|…"` | Sparse local hits (see **Watchdog**) |
+| `ddev drush php-eval` (latest 5 event nodes: type + published only) | Sample output only; no PII |
+
+**Config export/import:** not run (per instructions).  
+**Secrets:** not touched.
+
+---
+
+## Routes checked (`ddev drush route`)
+
+**Event Studio (representative)**
+
+| Route name | Path |
+|------------|------|
+| `myeventlane_event_studio.create` | `/vendor/events/create` |
+| `myeventlane_event_studio.edit_tickets` | `/vendor/events/{node}/edit/tickets` |
+| `myeventlane_event_studio.edit_publish` | `/vendor/events/{node}/edit/publish` |
+| `myeventlane_event_studio.autosave` | `/vendor/events/autosave` |
+| `myeventlane_vendor.console.studio.event_tickets_save` | `/vendor/studio/event/{event}/tickets` |
+
+**Booking / RSVP / checkout (representative)**
+
+| Route name | Path |
+|------------|------|
+| `myeventlane_commerce.event_book` | `/event/{node}/book` |
+| `myeventlane_rsvp.public_rsvp_form` | `/event/{event}/rsvp` |
+| `myeventlane_rsvp.form` | `/event/{node}/rsvp/form` |
+| `commerce_checkout.form` | `/checkout/{commerce_order}/{step}` |
+
+Legacy vendor build wizard routes (`/vendor/events/{event}/build/...`) remain registered but are outside Event Studio; redirects may apply via `VendorLegacyWizardRedirectSubscriber` (not expanded here).
+
+---
+
+## Files inspected
+
+**Event Studio**
+
+- `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml`
+- `src/Controller/EventStudioController.php`
+- `src/Controller/EventStudioAutosaveController.php` (partial)
+- `src/Form/EventStudioBaseForm.php`
+- `src/Form/EventStudioTicketsForm.php`
+- `src/Form/EventStudioPublishForm.php`
+- `src/Service/EventStudioSaveService.php`
+- `src/Service/EventStudioMelPayloadService.php`
+- `src/Service/MelTicketTypeManager.php` (partial + validation/sync sections)
+- `src/EventStudioPreprocess.php`
+- `templates/mel-event-studio.html.twig` (publish step)
+
+**Vendor / commerce / event**
+
+- `web/modules/custom/myeventlane_vendor/src/Controller/VendorEventCreateController.php`
+- `web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php` (`assertStripeConnected`)
+- `web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php` (partial)
+- `web/modules/custom/myeventlane_commerce/src/Controller/BookController.php`
+- `web/modules/custom/myeventlane_event/src/Service/EventCtaResolver.php` (partial)
+- `web/modules/custom/myeventlane_event/src/Form/EventWizardPublishForm.php` (legacy wizard publish)
+- `web/modules/custom/myeventlane_event/src/Service/EventWizardPublishValidator.php`
+- `web/modules/custom/myeventlane_event/src/Service/EventProductManager.php` (partial: `syncProducts`, RSVP product helper)
+
+---
+
+## Code-backed behaviour (save / publish)
+
+### Wizard save pipeline
+
+- Step forms extend `EventStudioBaseForm`; **Continue** calls `persistWizardMel()` → `EventStudioMelPayloadService::buildFromFormState()` → `EventStudioSaveService::save($payload, …, $draft)`.
+- **Tickets step** (`EventStudioTicketsForm`): `field_event_type` radios (`rsvp` | `paid` | `external`), embedded `EventTicketsBuilder`, hidden JSON `studio_ticket_tiers`, RSVP capacity maps to payload `capacity` via `rsvp_capacity` in the mel payload service (not `field_capacity` name in mel — normalized to `capacity` in payload).
+
+### Paid validation (non-draft)
+
+- `MelTicketTypeManager::validateStudioTicketDefinitions()` (non-draft): paid events require at least one tier **or** existing `field_ticket_types` refs, else: *“You must create at least one ticket type before saving a paid event.”*
+- `EventStudioSaveService::applyTicketPayload()` (non-draft): paid requires `field_product_target` **or** messaging references linking a product — error: *“Paid events need a ticket product…”* when empty.
+
+After node save, `MelTicketTypeManager::onEventStudioSaveComplete()` applies `studio_ticket_tiers` rows, merges `field_ticket_types`, then `syncCommerceAndPublishCatalogSignal()` runs paid tier sync via `TicketTierLifecycleService::syncPaidTiers()` for `paid`/`both`.
+
+### RSVP booking readiness (public `/event/{node}/book`)
+
+- `BookController` delegates RSVP branch to `RsvpPublicForm` only when `EventCtaResolver` yields RSVP **and** `melEventHasRsvp()` is true.
+- `melEventHasRsvp()` requires `field_ticket_types` referenced `mel_ticket_type` entities with `ticket_kind` **rsvp**. If there are no tiers / wrong kind, users see *“RSVP is not yet available for this event.”*
+
+RSVP **event-level** capacity uses `field_capacity` from payload `capacity` (from RSVP capacity field) in `applyTicketPayload`, separate from per-tier capacity in the ticket builder.
+
+### Publish step (Event Studio)
+
+- `EventStudioPublishForm` sets **draft save = false** so `status` / published flag applies; success redirects to canonical node view.
+- **No** call to `EventWizardPublishValidator` (that validator is for the legacy `/vendor/events/{event}/build/publish` wizard).
+- **No** Stripe / `charges_enabled` check inside `EventStudioSaveService` for paid publishes.
+
+### Stripe UX vs enforcement
+
+- `EventStudioPreprocess` sets `mel_publish_blocked` / `mel_publish_stripe_gate` when onboarding flags lack `stripe_connected` for **paid**/**both** events — used in `mel-event-studio.html.twig` as **warnings** beside `element.mel.status`; the publish checkbox remains in the form tree unless separately restricted (no matching server-side guard found in Event Studio save).
+- **Vendor entry:** `VendorEventCreateController::buildForm()` calls `assertStripeConnected()` before redirecting to Event Studio create — **blocks** `/vendor/events/add` when store not Stripe-connected (admin/user 1 bypass). Route `myeventlane_event_studio.create` itself does **not** invoke `assertStripeConnected()` in `EventStudioController::buildCreate()` (different entry path).
+
+### Legacy wizard-only RSVP rule
+
+- `EventWizardPublishValidator` may require `field_rsvp_target` when that field exists and join type is RSVP. Event Studio publish **does not** use this validator; public RSVP in `BookController` is driven by **mel_ticket_type** RSVP tiers, not `field_rsvp_target`.
+
+---
+
+## Manual / browser results (A–C)
+
+**Not performed** in this audit session (no authenticated vendor session on staging). Staging verification should confirm:
+
+- RSVP: ticket builder adds at least one **free RSVP** tier; publish; public CTA → `/event/{nid}/book` shows RSVP form; no card step for free RSVP.
+- Paid (Stripe ready): tiers + product sync; CTA → ticket selection → checkout → payment.
+- Paid (Stripe not ready): whether vendor can still submit publish via Event Studio footer (code suggests possible server-side gap); checkout behaviour.
+
+---
+
+## Database / read-only samples (`drush php-eval`)
+
+Safe aggregate only (latest five event nodes by changed date):
+
+```
+1577 type=paid published=no
+1563 type=paid published=no
+1380 type=paid published=yes
+1226 type=paid published=yes
+1093 type=paid published=yes
+```
+
+No attendee/order payloads printed.
+
+---
+
+## Watchdog (`ddev drush ws --count=80 | grep …`)
+
+Local sample filtered lines included `mel_debug` notices and unrelated errors (`cron` session, `myeventlane_pro` abandoned cart). **No** Event Studio save failures surfaced in this narrow window — not sufficient to prove staging health.
+
+---
+
+## Findings classification
+
+### P0 (blocking / safety — needs runtime proof)
+
+- **None proven** from code review alone. Critical scenarios (RSVP cannot save, paid sells without payment readiness, wrong vendor at checkout) must be confirmed on staging with manual flows + targeted logs.
+
+### P1
+
+1. **Paid publish vs charge-ready Stripe — UI-heavy gate:** Event Studio preprocess/template can warn when Stripe is not connected, but **`EventStudioSaveService` does not enforce `charges_enabled` / vendor Stripe readiness on publish** for paid events. If product requires “cannot publish paid listing until charge-ready,” this is a **server-side gap** relative to project **hard access control** expectations — **confirm with product** whether checkout/order pipelines already enforce enough.
+2. **Dual entry to Event Studio:** `/vendor/events/add` enforces Stripe redirect; **`/vendor/events/create` does not** call `assertStripeConnected()` — vendors might reach create via bookmark/direct URL depending on menu exposure (still subject to vendor console access).
+3. **RSVP requires MEL tiers:** Public book flow expects **at least one** `mel_ticket_type` with `ticket_kind = rsvp`. Saving RSVP mode **without** adding a tier in the builder can yield a published event whose book page shows RSVP unavailable — **validation gap or documentation/UX** (not necessarily P0 if intentional).
+
+### P2
+
+- `BookController::melEventHasRsvp()` uses `\Drupal::logger('mel_debug')` — service locator pattern and noisy tier-check logging (quality/maintainability).
+
+---
+
+## Smallest recommended fix (only if P1 #1 is confirmed)
+
+Add a **single server-side guard** in the paid publish path (e.g. validate store `field_stripe_charges_enabled` / platform rules inside `EventStudioSaveService` or a dedicated policy service injected into save) **after** product confirms the rule — **not implemented** in this diagnostic task.
+
+---
+
+## Recommended next task
+
+- If **staging manual checks** for A–C pass with **no** reproducible P0/P1 behaviour: **TASK 6 — Booking and checkout verification** (deeper Commerce checkout, order ownership, stock).
+- If **P1 #1** is confirmed (paid events publish while Stripe not charge-ready): **TASK 5B — Server-side Stripe charge-ready gate for Event Studio paid publish** (narrow scope; no unrelated refactors).
+
+---
+
+## Task 6 proceed?
+
+**Yes, recommend proceeding to TASK 6** once manual RSVP/paid/stripe-not-ready scenarios are executed on staging and this document is updated with results — **unless** manual testing confirms P1 #1 as a production blocker, in which case schedule **TASK 5B** first.
+
+---
+
+## Files changed in repo for this audit
+
+- **Added:** `docs/audits/mel-event-studio-ticket-save-publish-check.md`
+- **No** application code or config changed.

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -84,6 +84,7 @@ services:
       - '@logger.channel.myeventlane_event_studio'
       - '@myeventlane_event_studio.mel_ticket_type_manager'
       - '@myeventlane_event_studio.highlight_helper'
+      - '@myeventlane_vendor.paid_publish_stripe_gate'
 
   myeventlane_event_studio.autosave_controller:
     class: Drupal\myeventlane_event_studio\Controller\EventStudioAutosaveController

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -11,6 +11,7 @@ use Drupal\file\FileInterface;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_venue\Entity\Venue;
 use Drupal\myeventlane_venue\Service\VenueManager;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Psr\Log\LoggerInterface;
@@ -33,6 +34,7 @@ final class EventStudioSaveService {
     private readonly LoggerInterface $logger,
     private readonly MelTicketTypeManager $melTicketTypeManager,
     private readonly EventHighlightHelper $eventHighlightHelper,
+    private readonly PaidPublishStripeGate $paidPublishStripeGate,
   ) {}
 
   /**
@@ -44,6 +46,32 @@ final class EventStudioSaveService {
    * @return array{node: ?\Drupal\node\NodeInterface, errors: list<string>}
    */
   public function save(array $payload, ?NodeInterface $node, AccountInterface $account, bool $draft = FALSE): array {
+    $effectiveEventType = isset($payload['field_event_type'])
+      ? (string) $payload['field_event_type']
+      : ($node instanceof NodeInterface && $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()
+        ? (string) $node->get('field_event_type')->value
+        : 'rsvp');
+
+    $willPublish = FALSE;
+    if (!$draft) {
+      if ($node === NULL) {
+        $willPublish = (bool) ($payload['status'] ?? FALSE);
+      }
+      else {
+        $willPublish = (bool) ($payload['status'] ?? TRUE);
+      }
+    }
+
+    if (!$draft && $willPublish && in_array($effectiveEventType, ['paid', 'both'], TRUE)) {
+      $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed(
+        $account,
+        $node instanceof NodeInterface ? (int) $node->id() : NULL,
+      );
+      if ($stripeMsg !== NULL) {
+        return ['node' => NULL, 'errors' => [$stripeMsg]];
+      }
+    }
+
     $storage = $this->entityTypeManager->getStorage('node');
     if ($node === NULL) {
       $node = $storage->create([
@@ -336,6 +364,17 @@ final class EventStudioSaveService {
   public function setNodePublishedState(NodeInterface $node, AccountInterface $account, bool $published, string $revision_log = 'Vendor events list publish action.'): void {
     if ($node->bundle() !== 'event') {
       throw new \InvalidArgumentException('Expected event node.');
+    }
+    if ($published) {
+      $eventType = $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()
+        ? (string) $node->get('field_event_type')->value
+        : 'rsvp';
+      if (in_array($eventType, ['paid', 'both'], TRUE)) {
+        $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed($account, (int) $node->id());
+        if ($stripeMsg !== NULL) {
+          throw new \InvalidArgumentException($stripeMsg);
+        }
+      }
     }
     $node->setPublished($published);
     EventNodeRevisionSave::prepare($node, $revision_log);

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -40,6 +40,14 @@ services:
     arguments:
       - '@entity_type.manager'
 
+  myeventlane_vendor.paid_publish_stripe_gate:
+    class: Drupal\myeventlane_vendor\Service\PaidPublishStripeGate
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_vendor.user_vendor_membership_query'
+      - '@logger.channel.myeventlane_vendor'
+      - '@string_translation'
+
   myeventlane_vendor.vendor_theme_page_preprocess:
     class: Drupal\myeventlane_vendor\Service\VendorThemePagePreprocess
     arguments:

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -372,13 +372,18 @@ final class VendorEventsBulkActionsForm extends FormBase {
       if ($node instanceof NodeInterface
           && $node->bundle() === 'event'
           && (int) $node->getOwnerId() === $userId) {
-        $this->eventStudioSave->setNodePublishedState(
-          $node,
-          $this->currentUser,
-          $publish,
-          $publish ? 'Bulk publish from vendor events list.' : 'Bulk unpublish from vendor events list.',
-        );
-        $updatedCount++;
+        try {
+          $this->eventStudioSave->setNodePublishedState(
+            $node,
+            $this->currentUser,
+            $publish,
+            $publish ? 'Bulk publish from vendor events list.' : 'Bulk unpublish from vendor events list.',
+          );
+          $updatedCount++;
+        }
+        catch (\InvalidArgumentException $e) {
+          $this->messenger()->addError($e->getMessage());
+        }
       }
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Server-side guard: publishing paid/hybrid ticket events requires Stripe charge readiness.
+ *
+ * Uses Commerce store fields only (no live Stripe API calls). Aligns with
+ * VendorConsoleBaseController::assertStripeConnected store resolution.
+ */
+final class PaidPublishStripeGate {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly UserVendorMembershipQuery $membershipQuery,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Returns NULL when the account may publish paid/both events; else a translated message.
+   */
+  public function validatePaidPublishAllowed(AccountInterface $account, ?int $eventNodeId = NULL): ?string {
+    if ((int) $account->id() === 1 || $account->hasPermission('administer site configuration')) {
+      return NULL;
+    }
+
+    $vendorId = $this->resolveVendorIdForAccount($account);
+    $store = $this->resolveCommerceStoreForAccount($account);
+    $storeId = $store instanceof StoreInterface ? (int) $store->id() : NULL;
+
+    if (!$store instanceof StoreInterface) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'no_store');
+      return $this->blockedMessage();
+    }
+
+    if (!$store->hasField('field_stripe_account_id')) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'missing_account_id_field');
+      return $this->blockedMessage();
+    }
+    if ($store->get('field_stripe_account_id')->isEmpty()) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'empty_account_id');
+      return $this->blockedMessage();
+    }
+    $acct = trim((string) $store->get('field_stripe_account_id')->value);
+    if ($acct === '' || !str_starts_with($acct, 'acct_')) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'invalid_account_id');
+      return $this->blockedMessage();
+    }
+
+    if (!$store->hasField('field_stripe_charges_enabled')) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'missing_charges_field');
+      return $this->blockedMessage();
+    }
+    if ($store->get('field_stripe_charges_enabled')->isEmpty() || !(bool) $store->get('field_stripe_charges_enabled')->value) {
+      $this->logBlocked((int) $account->id(), $vendorId, $storeId, $eventNodeId, 'charges_not_enabled');
+      return $this->blockedMessage();
+    }
+
+    return NULL;
+  }
+
+  private function blockedMessage(): string {
+    return (string) $this->t('Connect Stripe before publishing paid tickets. Stripe must be ready to accept charges before this event can go live.');
+  }
+
+  /**
+   * @param int|null $vendorId
+   * @param int|null $storeId
+   */
+  private function logBlocked(int $uid, ?int $vendorId, ?int $storeId, ?int $eventNid, string $reason): void {
+    $this->logger->notice('Paid publish blocked (Stripe not charge-ready): reason=@reason uid=@uid vendor_id=@vid store_id=@sid event_nid=@nid', [
+      '@reason' => $reason,
+      '@uid' => (string) $uid,
+      '@vid' => $vendorId !== NULL ? (string) $vendorId : 'none',
+      '@sid' => $storeId !== NULL ? (string) $storeId : 'none',
+      '@nid' => $eventNid !== NULL ? (string) $eventNid : 'none',
+    ]);
+  }
+
+  private function resolveVendorIdForAccount(AccountInterface $account): ?int {
+    $ids = $this->membershipQuery->getVendorIdsForUser((int) $account->id());
+    if ($ids === []) {
+      return NULL;
+    }
+    return $ids[0];
+  }
+
+  private function resolveCommerceStoreForAccount(AccountInterface $account): ?StoreInterface {
+    $vid = $this->resolveVendorIdForAccount($account);
+    if ($vid !== NULL) {
+      $vendor = $this->entityTypeManager->getStorage('myeventlane_vendor')->load($vid);
+      if ($vendor instanceof Vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+        $cand = $vendor->get('field_vendor_store')->entity;
+        if ($cand instanceof StoreInterface) {
+          return $cand;
+        }
+      }
+    }
+
+    $uid = (int) $account->id();
+    $storeStorage = $this->entityTypeManager->getStorage('commerce_store');
+    $storeIds = $storeStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $uid)
+      ->range(0, 1)
+      ->execute();
+    if (!empty($storeIds)) {
+      $loaded = $storeStorage->load(reset($storeIds));
+      return $loaded instanceof StoreInterface ? $loaded : NULL;
+    }
+
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new server-side gate that can prevent paid/hybrid events from being published based on Commerce store Stripe readiness, which may change vendor workflows and bulk publish behavior. Risk is moderate because it touches publish/save paths but is narrow in scope and avoids external API calls.
> 
> **Overview**
> Adds a **server-side enforcement** that blocks publishing `paid`/`both` events unless the vendor’s Commerce store appears Stripe charge-ready (valid `field_stripe_account_id` and `field_stripe_charges_enabled`).
> 
> Event Studio’s save/publish flow now calls a new `PaidPublishStripeGate` before mutating nodes on publish-intent saves, and the vendor bulk publish action catches the resulting `InvalidArgumentException` to show a user-facing error instead of failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494c4597ad6cba1a6380e1895c6e297dcd381adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->