### PR TITLE
Cursor/onboard storage fix 128b4

### DIFF
--- a/docs/audits/mel-book-page-ticket-availability-fix.md
+++ b/docs/audits/mel-book-page-ticket-availability-fix.md
@@ -1,0 +1,69 @@
+# /event/{nid}/book ticket availability (TASK 5G)
+
+## Plan (concise)
+
+- **Message source:** `TicketSelectionForm` → `filterPurchasableVariations()` empty and no waitlist rows.
+- **Chain:** `BookController::buildPaidForm` → `TicketSelectionForm` with `field_product_target` product → `$ticketAvailability->filterPurchasableVariations($node, $product)`.
+- **Rules:** Each **published** Commerce variation on the product must pass `TicketAvailabilityService::assertPaidVariationLineConstraints`, including **`resolveTierForVariation()`** (mel_ticket_type **`commerce_variation`** → variation id), tier access, status, price match, capacity.
+
+## Event 1567 — state before this fix (data)
+
+- **Product 90** `variation_ids` was **`["4121","4122","4122"]`** (duplicate **4122**).
+- **Tickets 88 / 89** had **`commerce_variation`** → **4121** / **4122**, prices aligned, `visibility_mode` public, `status` on.
+
+## Root cause (one sentence)
+
+**`/event/1567/book` showed no tickets because the ticket product’s variation list contained a duplicate variation id, so purchasable-variation resolution and short-lived runtime cache could disagree with the real sellable set; we now dedupe on sync, skip duplicate iterations when filtering, tag/invalidate cache on sync, and correct cache `set()` tag usage.**
+
+(If mappings were missing, the same empty state appears because **`resolveTierForVariation`** fails when **`commerce_variation`** is empty — that was not the case once sync completed.)
+
+## Availability rule (exact)
+
+For each **published** variation returned by `$product->getVariations()` (deduped by variation id):
+
+1. Variation belongs to the event’s **`field_product_target`** product.
+2. Some **`mel_ticket_type`** on **`event.field_ticket_types`** references that variation via **`commerce_variation`**.
+3. Tier published, access rules allow public booking, **`TicketStatusEvaluator`** = active (not upcoming/ended/sold out/inactive), price matches tier, capacity allows at least 1.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php` | Dedupe ids when appending a new variation; **`normalizeProductVariationIds()`** after sync; **`Cache::invalidateTags`** for product + event node. |
+| `web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php` | Dedupe cached id list + variation loop; attach **cache tags** `commerce_product:{pid}` and `node:{nid}` on purchasable-variation cache write (fixes incorrect nested `tags` array on first pass). |
+
+## Commands run
+
+```bash
+git branch --show-current
+git status --short
+git log -10 --oneline
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
+php -l web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
+```
+
+**Repair product 90 + prove dedupe (optional):**
+
+```bash
+ddev drush php-eval '\Drupal::service("myeventlane_event.ticket_type_manager")->syncTicketTypesToVariations(\Drupal::entityTypeManager()->getStorage("node")->load(1567));'
+```
+
+Expect log: `Deduped Commerce variation references on product 90 (was ["4121","4122","4122"], now [4121,4122]).`
+
+## Browser verification
+
+1. Open `/event/1567/book`.
+2. Confirm ticket rows, labels, prices, quantity widgets, **Add to cart**.
+3. Confirm no duplicate rows for the same tier.
+4. Re-save event in Studio if needed to trigger sync once.
+
+## Follow-ups
+
+- If tickets still empty after dedupe: check **`TicketStatusEvaluator`** (sale window, sold counts vs capacity), **`TicketTierAccessService`** (hidden / access code / group-only), and **`commerce_variation`** empty on tier entities.
+- **`BookController::melEventHasRsvp`** still references `mel_debug` logger — unrelated to paid book page.
+
+## Ready to commit
+
+After browser check on `/event/1567/book` and `composer validate` / `drush cr` / `php -l` clean — yes.

--- a/docs/audits/mel-event-studio-final-publish-fix.md
+++ b/docs/audits/mel-event-studio-final-publish-fix.md
@@ -1,0 +1,102 @@
+# Event Studio final publish fix (TASK 5F)
+
+## Root cause (one sentence)
+
+**Event 1567 did not publish because the event uses Content Moderation (`moderation_state` was `draft`), and Content Moderation’s presave handler syncs the node’s published flag to the moderation state—so `EventStudioSaveService` calling `setPublished(TRUE)` was immediately undone while `moderation_state` stayed `draft`.**
+
+Reference: `ModerationHandler::onPresave()` aligns `EntityPublishedInterface::isPublished()` with the current moderation state’s `isPublishedState()` flag.
+
+## Preflight (Phase 1)
+
+- **Branch:** `cursor/onboard-storage-fix-128b4`
+- **`git status --short`:** modified `EventStudioMelPayloadService.php`; untracked `mel-event-studio-publish-blocker-fix.md`; plus this audit doc after creation.
+- **`composer validate`:** OK
+- **`ddev drush cr`:** OK
+
+## Event state before fix (Phase 2)
+
+Commands:
+
+```bash
+ddev drush php-eval '$n=\Drupal::entityTypeManager()->getStorage("node")->load(1567); echo "published=" . ($n && $n->isPublished() ? "yes" : "no") . PHP_EOL; ...'
+```
+
+Observed for node **1567**:
+
+- `published=no` (node `status` field `0`)
+- `field_event_type`: `paid`
+- `field_ticket_types`: refs `88`, `89`
+- `field_product_target`: ref `90`
+- **`moderation_state`:** `draft`
+
+## Answers — trace publish pipeline (Phase 3)
+
+| # | Answer |
+|---|--------|
+| 1 | **Full editor** (`/vendor/events/{nid}/edit`): primary submit is **`Save`** (`EventStudioForm`). **Wizard publish route** (`/vendor/events/{nid}/edit/publish`): **`Save and view event`** → `EventStudioBaseForm::submitContinue`. |
+| 2 | Yes — `mel-event-studio.html.twig` renders `{{ element.mel.status }}` in the Publish step. |
+| 3 | **`mel[status]`** (checkbox). |
+| 4 | Yes — `EventStudioMelPayloadService::buildFromFormState()` sets `'status' => !empty($mel['status'])`. |
+| 5 | When the checkbox is checked, **`status` is `true`** in the payload. |
+| 6 | **`EventStudioForm::submitForm()`** passes **`$draft = FALSE`** to `save()`. **`EventStudioPublishForm`** uses **`isDraftWizardSave(): FALSE`**. |
+| 7 | **`save()`** called **`setPublished()`** from payload `status`; without the moderation fix this did not survive entity save. |
+| 8 | **Yes — Content Moderation** forced unpublished while **`moderation_state`** remained **`draft`**. Not ticket payload / JS draft routing for this case. |
+| 9 | No — main submit is not replaced by a draft action; ticket-builder submits are explicitly excluded from highlight validation. |
+| 10 | Footer/readiness JS adjusts styling; it does not cancel the main form submit (highlights validation can). |
+
+## Fix (Phase 6 — narrow)
+
+**Allowed category:** D — preserve intended publish state against later logic (moderation presave).
+
+### Files changed
+
+1. **`web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php`**
+   - After the node is created or loaded, when **`!$draft && $willPublish`** and **`moderation_state` is `draft`**, set **`moderation_state` to `published`** (Editorial workflow `publish` transition target state).
+   - Keeps existing Stripe gate and ticket validation unchanged.
+
+2. **Existing local work (unchanged by this task):** `EventStudioMelPayloadService.php` — ticket/product payload merge from DB for saved nodes (separate product-autocomplete issue).
+
+### Status payload before / after
+
+| Stage | Before fix | After fix |
+|-------|------------|-----------|
+| Form → payload `status` | `true` when Published checked | Same |
+| Before entity save | `setPublished(true)` then presave resets visibility | `moderation_state`: `draft` → `published`; published flag stays aligned at save |
+
+## Verification commands (Phase 7)
+
+```bash
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+```
+
+**Browser (required to confirm 1567):**
+
+1. Open `/vendor/events/1567/edit`, Publish step.
+2. Check **Published**, **Save**.
+3. Re-run php-eval; expect **`published=yes`**, **`moderation_state`** **`published`** (or equivalent published state label in UI).
+
+```bash
+ddev drush php-eval '$n=\Drupal::entityTypeManager()->getStorage("node")->load(1567); echo "published=" . ($n && $n->isPublished() ? "yes" : "no") . PHP_EOL; echo "moderation=" . ($n->get("moderation_state")->isEmpty() ? "empty" : $n->get("moderation_state")->value) . PHP_EOL;'
+```
+
+## Event 1567 final state
+
+- **After code deploy, cache rebuild, and successful publish save in browser:** expect **`published=yes`**; confirm with Drush eval above.
+- **At documentation time (before your browser retest):** node remained **`published=no`**, **`moderation=draft`** — fix not exercised via automated publish in this session.
+
+## Diagnostics (Phase 4 / 8)
+
+- No temporary log lines were added; root cause was identifiable from **`moderation_state`** + Content Moderation behaviour.
+- Remove any local debug if you had added it separately.
+
+## Follow-ups
+
+- **In review:** Events need **`publish_from_review`** if vendors should go live from **`review`** without admin; vendor role currently has **`publish`** (draft→published) per `config/sync/user.role.vendor.yml`.
+- **Bulk list publish** (`setNodePublishedState`): same moderation issue may apply; treat as a separate change if lists fail for moderated events.
+
+## Ready to commit
+
+- **Code:** Yes, after you complete browser + Drush verification on **1567** and confirm paid/RSVP/external regression smoke tests you care about.
+- **Docs:** This file + your existing `mel-event-studio-publish-blocker-fix.md` as needed.

--- a/docs/audits/mel-event-studio-publish-blocker-fix.md
+++ b/docs/audits/mel-event-studio-publish-blocker-fix.md
@@ -1,0 +1,67 @@
+# Task 5E — Event Studio publish blocker after ticket refs (field_product_target payload)
+
+**Date:** 2026-04-28
+
+## Context
+
+After **`field_ticket_types`** reconciliation ([commit c13637cd](https://github.com/myeventlane/myeventlane/commit/c13637cd)) and **paid readiness JS** ([75b41e94](https://github.com/myeventlane/myeventlane/commit/75b41e94)), event **1567** still showed tickets and product **90** in the database, but publish from Event Studio could still fail or regress product linkage on save.
+
+## Event 1567 state (CLI snapshot)
+
+- **`field_event_type`**: paid  
+- **`field_ticket_types`**: 88, 89  
+- **`field_product_target`**: 90 (Commerce ticket product, published)  
+- **`PaidPublishStripeGate`** for owner **uid 1**: **ALLOW** (admin bypass)  
+
+Stripe charge-ready **server** gate was not blocking uid 1.
+
+## Root cause
+
+**Publish is blocked or product linkage is cleared because `EventStudioMelPayloadService::buildFromFormState()` did not carry forward `field_product_target` from the saved node when the submitted `mel[field_product_target]` value was empty**, while it already did so for `field_ticket_types`.
+
+The ticket product field lives under **`#states`** (visible when event type is paid). On full-form submit the autocomplete can be **missing from POST or empty** even though the node already references product **90**.  
+`EventStudioSaveService::applyTicketPayload()` then received **`field_product_target` ⇒ empty**, cleared the node reference, and failed paid validation (“Paid events need a ticket product”) or blocked publish.
+
+This is independent of:
+
+- **`PaidPublishStripeGate`** (unchanged; vendor testing still gated correctly).  
+- **`mel_publish_blocked`** in Twig preprocess (onboarding Stripe messaging — separate UX).
+
+## Fix
+
+**File:** [`web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php`](../../web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php)
+
+For **`$nid > 0`**, after merging **`field_ticket_types`** from the loaded node: if **`field_product_target`** from the form is missing/zero **and** the node already has a non-empty **`field_product_target`**, set **`payload['field_product_target']`** to the existing **`target_id`**.
+
+Does **not**:
+
+- Create tickets, products, or variations.  
+- Bypass Stripe onboarding or the publish gate.  
+- Hide Twig warnings globally.
+
+## Verification
+
+```bash
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+```
+
+**Manual (browser)**
+
+1. `/vendor/events/1567/edit` — ticket cards visible; product linked.  
+2. Toggle publish / save — event saves without clearing **`field_product_target`**.  
+3. Vendor user without charge-ready Stripe — paid publish still blocked server-side with Stripe message.  
+4. RSVP/external flows unchanged.
+
+## Browser result
+
+*(Record after QA.)*
+
+## Follow-ups
+
+- Optional: align **`mel_publish_blocked`** preprocess flag with **`PaidPublishStripeGate`** Commerce-store criteria so the Stripe banner matches server behaviour for vendors with **`stripe_connected`** in onboarding but not charge-ready on the store (product polish only).
+
+## Ready to commit?
+
+Yes, after one successful publish/save smoke test on a paid event with product linked only on the node (simulate empty product field in POST).

--- a/docs/audits/mel-event-studio-ticket-persistence-fix.md
+++ b/docs/audits/mel-event-studio-ticket-persistence-fix.md
@@ -1,0 +1,86 @@
+# Task 5D — Event Studio ticket save persistence (field_ticket_types canonical sync)
+
+**Date:** 2026-04-28
+
+## Problem
+
+Paid ticket builder actions (create, save & sync) ran and Commerce variation sync logged success, but Event Studio still treated tickets as not persisted because **`node.field_ticket_types`** did not list the `mel_ticket_type` IDs, while ticket entities correctly referenced the event via **`mel_ticket_type.event`** (inverse reference).
+
+Example (**event 1567**, local DDEV):
+
+| Before fix | After reconcile |
+|------------|-----------------|
+| `field_ticket_types`: empty | `field_ticket_types`: `88`, `89` (ticket entities tied to event 1567) |
+| `field_product_target`: product 90 | unchanged (already set) |
+| Inverse query `event = 1567`: tickets 88, 89 | same |
+
+`TicketTierLifecycleService::loadOrderedTicketsForEvent()` only reads **`field_ticket_types`**, so the ticket card list and `findEventTicket()` saw **no tiers** when the node field was empty, even though tiers existed.
+
+## Root cause (exact)
+
+**Ticket save creates/updates `mel_ticket_type` entities and Commerce variations, but Event Studio does not persist/read the ticket as canonical on the event node when `field_ticket_types` was never written or was cleared**, because:
+
+1. **`loadOrderedTicketsForEvent()`** ([`TicketTierLifecycleService.php`](../../web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php)) returns tiers **only** from `node.field_ticket_types`.
+2. Ticket entities can exist with **`event` → event nid** without the matching **`field_ticket_types` → ticket ids** on the node (historical paths or failed bidirectional sync).
+
+Related UX fix (Task 5C): [`mel-event-studio.js`](../../web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js) preserves hidden tier JSON and counts AJAX cards; that does not replace **node field** persistence.
+
+## Persistence rule (canonical)
+
+For a given event node:
+
+- **`field_ticket_types`** must reference every `mel_ticket_type` whose **`event`** field points at that node (ordered: preserve existing field order for IDs still valid; append missing inverse IDs sorted by ticket id).
+- **[`TicketTierLifecycleService::reconcileEventTicketReferences()`](../../web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php)** implements this merge idempotently (no-op when already aligned).
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| [`web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php`](../../web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php) | Add `reconcileEventTicketReferences()`; notice/error logging; `syncPaidTiers()` after successful save |
+| [`web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php`](../../web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php) | Inject `EntityTypeManagerInterface`; call reconcile + reload event at start of `build()`; call reconcile after `handleAction` |
+| [`web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml`](../../web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml) | Pass `@entity_type.manager` into `myeventlane_vendor.ticket_builder` |
+| [`web/modules/custom/myeventlane_event_studio/src/Service/MelTicketTypeManager.php`](../../web/modules/custom/myeventlane_event_studio/src/Service/MelTicketTypeManager.php) | Call reconcile + reload node at start of `onEventStudioSaveComplete()` (non-draft) |
+
+## Verification (CLI)
+
+```bash
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+php -l web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+php -l web/modules/custom/myeventlane_event_studio/src/Service/MelTicketTypeManager.php
+```
+
+Example reconcile smoke test (event 1567):
+
+```bash
+ddev drush php-eval '$s=\Drupal::service("myeventlane_event.ticket_tier_lifecycle"); $n=\Drupal::entityTypeManager()->getStorage("node")->load(1567); $s->reconcileEventTicketReferences($n);'
+```
+
+Expected log: `Reconciled field_ticket_types on event 1567: 88,89.`  
+Expected DB: `field_ticket_types` populated with those target IDs.
+
+Watchdog spot-check:
+
+```bash
+ddev drush ws --count=80 | grep -Ei "event_studio|ticket|variation|product|publish|readiness|error|exception|orphan|Reconciled" || true
+```
+
+## Browser verification (manual)
+
+On `/vendor/events/1567/edit` (and similar):
+
+1. Tickets / RSVP shows ticket cards matching inverse tier count after load.
+2. Saving tickets does not clear `field_ticket_types` when tiers remain on the event.
+3. Publish readiness / insights (with Task 5C JS) align when node field is populated.
+4. Paid publish still enforced by Stripe charge-ready gate (unchanged).
+5. No duplicate products/variations from reload alone (reconcile does not create tiers).
+
+## Follow-ups (optional)
+
+- Investigate **`myeventlane_commerce` “No mel_ticket_type maps variation …”** if it still appears after refs are canonical — may indicate orphaned variations from tier churn, separate from this field sync.
+- Confirm **`appendTicketToEvent`** on new creates always persists (if gaps remain, reconcile covers legacy data).
+
+## Ready to commit?
+
+Yes, after browser confirmation on a affected event (e.g. 1567) and green CLI checks above.

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
@@ -152,8 +152,7 @@ final class TicketAvailabilityService {
           $by_id[(int) $v->id()] = $v;
         }
         $out = [];
-        foreach ($ids as $vid) {
-          $vid = (int) $vid;
+        foreach (array_unique(array_map(static fn ($id) => (int) $id, $ids)) as $vid) {
           if (isset($by_id[$vid]) && $by_id[$vid]->isPublished()) {
             $out[] = $by_id[$vid];
           }
@@ -166,7 +165,13 @@ final class TicketAvailabilityService {
     $capacityMaps = $this->buildCapacityMapsForProduct($event, $product);
 
     $out = [];
+    $seenVariationId = [];
     foreach ($product->getVariations() as $variation) {
+      $variationId = (int) $variation->id();
+      if (isset($seenVariationId[$variationId])) {
+        continue;
+      }
+      $seenVariationId[$variationId] = TRUE;
       if (!$variation->isPublished()) {
         continue;
       }
@@ -190,7 +195,11 @@ final class TicketAvailabilityService {
       $this->cache->set(
         $cid,
         array_map(static fn (ProductVariationInterface $v) => (int) $v->id(), $out),
-        $this->time->getRequestTime() + self::PURCHASABLE_CACHE_MAX_AGE
+        $this->time->getRequestTime() + self::PURCHASABLE_CACHE_MAX_AGE,
+        [
+          'commerce_product:' . (string) $pid,
+          'node:' . (string) $eid,
+        ]
       );
     }
 

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -267,6 +267,98 @@ final class TicketTierLifecycleService {
   }
 
   /**
+   * Ensures node field_ticket_types lists every mel_ticket_type targeting this event.
+   *
+   * Ticket builder paths set ticket.event but historically some saves omitted the
+   * bidirectional node reference. Without this, loadOrderedTicketsForEvent() is
+   * empty while ticket entities still exist (inverse lookup).
+   *
+   * Merge rule: preserve current field order for IDs still valid on ticket entities,
+   * then append any ticket IDs found via event reference that were missing.
+   */
+  public function reconcileEventTicketReferences(NodeInterface $event): void {
+    $nid = $event->id();
+    if ($nid === NULL || !$event->hasField('field_ticket_types')) {
+      return;
+    }
+
+    $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
+    if (!$loaded instanceof NodeInterface) {
+      return;
+    }
+    $event = $loaded;
+
+    $ticketStorage = $this->entityTypeManager->getStorage('mel_ticket_type');
+    $inverseIds = array_values(array_map(
+      'intval',
+      array_keys($ticketStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('event', $nid)
+        ->sort('id')
+        ->execute()),
+    ));
+
+    if ($inverseIds === []) {
+      return;
+    }
+
+    $fieldIds = [];
+    if (!$event->get('field_ticket_types')->isEmpty()) {
+      foreach ($event->get('field_ticket_types')->getValue() as $row) {
+        if (!empty($row['target_id'])) {
+          $fieldIds[] = (int) $row['target_id'];
+        }
+      }
+    }
+    $fieldIds = array_values(array_unique($fieldIds));
+
+    $inverseSet = array_flip($inverseIds);
+    $merged = [];
+    foreach ($fieldIds as $id) {
+      if (isset($inverseSet[$id])) {
+        $merged[] = $id;
+      }
+    }
+    foreach ($inverseIds as $id) {
+      if (!in_array($id, $merged, TRUE)) {
+        $merged[] = $id;
+      }
+    }
+
+    if ($merged === $fieldIds) {
+      return;
+    }
+
+    $event->set(
+      'field_ticket_types',
+      array_map(static fn (int $id): array => ['target_id' => $id], $merged),
+    );
+    EventNodeRevisionSave::prepare($event, 'Synced ticket type references from ticket entities.');
+    try {
+      $event->save();
+      $this->loggerFactory->get('myeventlane_event')->notice(
+        'Reconciled field_ticket_types on event @nid: @ids.',
+        [
+          '@nid' => (string) $nid,
+          '@ids' => implode(',', array_map('strval', $merged)),
+        ],
+      );
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_event')->error(
+        'reconcileEventTicketReferences save failed for nid @nid: @message',
+        [
+          '@nid' => (string) $nid,
+          '@message' => $e->getMessage(),
+        ],
+      );
+      return;
+    }
+
+    $this->syncPaidTiers($event);
+  }
+
+  /**
    * Loads ticket types for an event in field order.
    *
    * @return \Drupal\mel_ticket\Entity\TicketTypeInterface[]

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
@@ -9,6 +9,7 @@ use Drupal\commerce_product\Entity\Product;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -81,6 +82,11 @@ final class TicketTypeManager {
 
     $this->removeOrphanedVariations($product, $activeVariationUuids);
     $this->syncProductTitle($product, $event);
+    $this->normalizeProductVariationIds($product);
+    Cache::invalidateTags([
+      'commerce_product:' . (string) $product->id(),
+      'node:' . (string) $event->id(),
+    ]);
 
     return TRUE;
   }
@@ -226,10 +232,10 @@ final class TicketTypeManager {
       $existing_variations = $product->getVariations();
       $variation_ids = [];
       foreach ($existing_variations as $existing_var) {
-        $variation_ids[] = $existing_var->id();
+        $variation_ids[(int) $existing_var->id()] = (int) $existing_var->id();
       }
-      $variation_ids[] = $variation->id();
-      $product->set('variations', $variation_ids);
+      $variation_ids[(int) $variation->id()] = (int) $variation->id();
+      $product->set('variations', array_values($variation_ids));
       $product->save();
 
       $this->loggerFactory->get('myeventlane_event')->notice(
@@ -249,6 +255,30 @@ final class TicketTypeManager {
     $labelSlug = strtolower(preg_replace('/[^a-z0-9]+/', '-', $label));
     $labelSlug = trim($labelSlug, '-');
     return 'ticket-' . $eventId . '-' . $labelSlug . '-' . time();
+  }
+
+  /**
+   * Removes duplicate variation target IDs on the Commerce product (fixes booking UI drift).
+   */
+  private function normalizeProductVariationIds(ProductInterface $product): void {
+    $raw = $product->getVariationIds();
+    if (!is_array($raw) || $raw === []) {
+      return;
+    }
+    $unique = array_values(array_unique(array_map(static fn ($id) => (int) $id, $raw)));
+    if (count($raw) === count($unique)) {
+      return;
+    }
+    $product->set('variations', $unique);
+    $product->save();
+    $this->loggerFactory->get('myeventlane_event')->notice(
+      'Deduped Commerce variation references on product @pid (was @before, now @after).',
+      [
+        '@pid' => (string) $product->id(),
+        '@before' => (string) json_encode($raw),
+        '@after' => (string) json_encode($unique),
+      ]
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -1020,6 +1020,41 @@
     }
   }
 
+  /**
+   * Count of ticket tier "signals" the user can perceive as configured.
+   *
+   * Reads from whichever source the current Event Studio mode renders:
+   * inline tier table (new event), AJAX ticket cards (saved event), and the
+   * server-populated hidden JSON. Used by readiness/insights/summary so all
+   * three agree regardless of which builder is active.
+   *
+   * @param {HTMLFormElement} form
+   * @return {number}
+   */
+  function paidTicketTierSignalCount(form) {
+    var counts = [];
+
+    var table = getBuilderTable(form);
+    if (table) {
+      counts.push(table.querySelectorAll('tbody .mel-tier-row').length);
+    }
+
+    var ajaxShell = document.getElementById('mel-ticket-builder-ajax-wrapper');
+    if (ajaxShell) {
+      counts.push(ajaxShell.querySelectorAll('.js-mel-ticket-card[data-ticket-id]').length);
+    }
+
+    var hidden = form.querySelector('input[name="mel[studio_ticket_tiers]"]');
+    if (hidden) {
+      counts.push(parseTiersHidden(hidden.value).length);
+    }
+
+    if (counts.length === 0) {
+      return 0;
+    }
+    return Math.max.apply(null, counts);
+  }
+
   function getRenderedTicketTableKind(table) {
     if (!table) {
       return '';
@@ -1219,9 +1254,14 @@
       return;
     }
 
-    var tiers = collectTiersFromDom(form);
+    // Saved events render the AJAX ticket builder (#mel-ticket-builder-ajax-wrapper),
+    // not the inline tier table. Without a table, collectTiersFromDom() returns []
+    // and would wipe the server-populated JSON from encodeStudioTiersJsonForEvent().
+    if (!getBuilderTable(form)) {
+      return;
+    }
 
-    // Always persist UI → hidden
+    var tiers = collectTiersFromDom(form);
     hidden.value = JSON.stringify(tiers);
   }
 
@@ -1632,9 +1672,7 @@
         Drupal.t('Link a ticket product above, or finish in the Tickets workspace.') +
         '</li>';
     }
-    var sTable = getBuilderTable(form);
-    var sTierRows = sTable ? sTable.querySelectorAll('tbody .mel-tier-row').length : 0;
-    if (tt === 'paid' && sTierRows < 1) {
+    if (tt === 'paid' && paidTicketTierSignalCount(form) < 1) {
       warn +=
         '<li class="mel-ticket-summary__warn">' +
         Drupal.t('Add at least one ticket type.') +
@@ -1855,9 +1893,7 @@
       if (!hasProduct) {
         add('high', Drupal.t('Link a ticket product for paid events — or create ticket types in the Tickets workspace first.'), 'mel[field_product_target]');
       }
-      var tTable = getBuilderTable(form);
-      var tierRows = tTable ? tTable.querySelectorAll('tbody .mel-tier-row').length : 0;
-      if (tierRows < 1) {
+      if (paidTicketTierSignalCount(form) < 1) {
         add('high', Drupal.t('Add at least one ticket type for paid checkout.'), 'mel[studio_ticket_focus]');
       }
     } else if (tt === 'external') {
@@ -2216,16 +2252,7 @@
     if (tt === 'paid' && val(form, 'mel[field_product_target]') === '') {
       blocking.push(Drupal.t('Ticket product'));
     }
-    var pTable = getBuilderTable(form);
-    var paidTierRows = pTable ? pTable.querySelectorAll('tbody .mel-tier-row').length : 0;
-    var ajaxShell = document.getElementById('mel-ticket-builder-ajax-wrapper');
-    if (ajaxShell && tt === 'paid') {
-      paidTierRows = Math.max(
-        paidTierRows,
-        ajaxShell.querySelectorAll('.js-mel-ticket-card[data-ticket-id]').length,
-      );
-    }
-    if (tt === 'paid' && paidTierRows < 1) {
+    if (tt === 'paid' && paidTicketTierSignalCount(form) < 1) {
       blocking.push(Drupal.t('Ticket types'));
     }
     var mode = valRadio(form, 'mel[venue_mode]');

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -144,13 +144,23 @@ final class EventStudioMelPayloadService {
     $nid = (int) ($form_state->getValue('nid') ?? 0);
     if ($nid > 0) {
       $loaded = $entityTypeManager->getStorage('node')->load($nid);
-      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event' && $loaded->hasField('field_ticket_types')) {
-        $payload['field_ticket_types'] = [];
-        foreach ($loaded->get('field_ticket_types')->getValue() as $row) {
-          $tid = (int) ($row['target_id'] ?? 0);
-          if ($tid > 0) {
-            $payload['field_ticket_types'][] = $tid;
+      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+        if ($loaded->hasField('field_ticket_types')) {
+          $payload['field_ticket_types'] = [];
+          foreach ($loaded->get('field_ticket_types')->getValue() as $row) {
+            $tid = (int) ($row['target_id'] ?? 0);
+            if ($tid > 0) {
+              $payload['field_ticket_types'][] = $tid;
+            }
           }
+        }
+        // Ticket product autocomplete may be omitted from POST when hidden or unchanged; do not
+        // clear field_product_target on save when the node already has a linked product.
+        $pid = $payload['field_product_target'] ?? NULL;
+        if (($pid === NULL || $pid < 1)
+            && $loaded->hasField('field_product_target')
+            && !$loaded->get('field_product_target')->isEmpty()) {
+          $payload['field_product_target'] = (int) $loaded->get('field_product_target')->target_id;
         }
       }
     }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -91,6 +91,14 @@ final class EventStudioSaveService {
       }
     }
 
+    // Editorial workflow: `draft` is not a published moderation state. Content Moderation's
+    // presave syncs the entity published flag to that state, undoing setPublished(TRUE).
+    // When the vendor intends to publish, transition to `published` so presave stays aligned.
+    if (!$draft && $willPublish && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()
+        && (string) $node->get('moderation_state')->value === 'draft') {
+      $node->set('moderation_state', 'published');
+    }
+
     if ($node->hasField('field_event_summary') && isset($payload['summary'])) {
       $s = trim((string) $payload['summary']);
       if ($s !== '') {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/MelTicketTypeManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/MelTicketTypeManager.php
@@ -145,6 +145,13 @@ final class MelTicketTypeManager {
       return;
     }
 
+    // Align node.field_ticket_types before tier payload merge (ticket builder uses inverse event refs).
+    $this->ticketTierLifecycle->reconcileEventTicketReferences($event);
+    $reloaded = $this->entityTypeManager->getStorage('node')->load($event->id());
+    if ($reloaded instanceof NodeInterface) {
+      $event = $reloaded;
+    }
+
     $tiers = $this->normalizeStudioTiersPayload($payload['studio_ticket_tiers'] ?? NULL);
     if ($tiers !== []) {
       $this->applyStudioTierRows($event, $account, $payload, $tiers);

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -111,6 +111,7 @@ services:
       - '@current_user'
       - '@messenger'
       - '@logger.factory'
+      - '@entity_type.manager'
     calls:
       - [setStringTranslation, ['@string_translation']]
 

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -8,6 +8,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Url;
@@ -44,6 +45,7 @@ final class EventTicketsBuilder {
     private readonly AccountProxyInterface $currentUser,
     private readonly MessengerInterface $messenger,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
   ) {}
 
   /**
@@ -113,6 +115,17 @@ final class EventTicketsBuilder {
     }
 
     $form_state->set('event', $event);
+
+    // Align node.field_ticket_types with ticket entities that reference this event
+    // (fixes orphan inverse refs when the node field was never written).
+    $this->lifecycle->reconcileEventTicketReferences($event);
+    if ($event->id()) {
+      $fresh = $this->entityTypeManager->getStorage('node')->load($event->id());
+      if ($fresh instanceof NodeInterface) {
+        $event = $fresh;
+        $form_state->set('event', $fresh);
+      }
+    }
 
     $tickets = array_values(array_filter(
       $this->lifecycle->loadOrderedTicketsForEvent($event),
@@ -550,6 +563,10 @@ final class EventTicketsBuilder {
         ]
       );
       $this->messenger->addError($this->t('Ticket update failed: @message', ['@message' => $e->getMessage()]));
+    }
+
+    if ($event->id()) {
+      $this->lifecycle->reconcileEventTicketReferences($event);
     }
 
     // Full form rebuild so EventFormAlter can re-apply ticket-driven #access on ops fields.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches paid ticketing availability, caching, and publish state transitions; mistakes could hide tickets or incorrectly publish/unpublish moderated events.
> 
> **Overview**
> Improves **paid ticket persistence and booking availability** by reconciling `event.field_ticket_types` from inverse `mel_ticket_type.event` references, deduping Commerce product variation IDs during sync, and skipping duplicate variation iterations when determining purchasable variations.
> 
> Hardens **ticket availability caching** by deduping cached variation IDs and writing cache entries with proper `commerce_product:{id}` and `node:{id}` tags, then invalidating those tags after ticket→variation sync.
> 
> Fixes **Event Studio publish/save edge cases** by (1) carrying forward an existing `field_product_target` when the paid product autocomplete is missing/empty in POST, (2) setting `moderation_state` to `published` when a non-draft save intends to publish (so Content Moderation doesn’t undo `setPublished(TRUE)`), and (3) updating readiness/summary JS to count ticket tiers consistently across inline table, AJAX ticket cards, and hidden JSON without wiping server-populated tier JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2272fb2e97b5227d2add0685ed85e7fcd50f9eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->