### PR TITLE
fix(event-studio): update event status logic to handle publish condit…

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -78,7 +78,7 @@ final class EventStudioSaveService {
         'type' => 'event',
         'title' => trim((string) ($payload['title'] ?? 'Untitled event')),
         'uid' => (int) $account->id(),
-        'status' => $draft ? 0 : 1,
+        'status' => $draft ? 0 : ($willPublish ? 1 : 0),
       ]);
     }
     else {


### PR DESCRIPTION
…ions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default publish state for newly created Event Studio events, which can affect content visibility and workflows if any clients relied on implicit publishing.
> 
> **Overview**
> Newly created Event Studio `event` nodes no longer default to published on non-draft saves. Creation now sets `status` based on the computed `willPublish` flag (derived from the incoming `status` payload), so missing/false publish intent keeps the new node unpublished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59106d29e5abd8b4be4c4a871f1ce3845053589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->