### PR TITLE
fix(theme): cart and checkout visual trust polish

### DIFF
--- a/docs/audits/mel-cart-checkout-visual-trust-polish.md
+++ b/docs/audits/mel-cart-checkout-visual-trust-polish.md
@@ -1,0 +1,122 @@
+# Task 11 — Cart and checkout visual trust polish
+
+**Branch:** `cursor/onboard-storage-fix-128b4`  
+**Latest commit at run:** `9cd060d6` — `fix(theme): polish full event booking CTA layout` (Task 10)  
+**Working tree:** Clean after Task 11 commits (verify with `git status`).
+
+**Note:** Cursor Plan Mode was unavailable (rejected); work followed the phased diagnostic below in Agent mode.
+
+---
+
+## Phase 1 — Preflight
+
+| Command | Result |
+|--------|--------|
+| `git branch --show-current` | `cursor/onboard-storage-fix-128b4` |
+| `git status --short` | Clean (before committing Task 11) |
+| `git log -10 --oneline` | Task 10 present as tip before new commit |
+| `composer validate` | `./composer.json is valid` |
+| `ddev drush cr` | Success |
+| `npm run mel:lint` | Passed (hero check + scoped Stylelint) |
+| `npm run mel:build` | Passed (Vite + vendor theme) |
+
+---
+
+## Phase 2 — Template and SCSS map (answers)
+
+| # | Question | Answer |
+|---|----------|--------|
+| 1 | Cart Twig | `web/themes/custom/myeventlane_theme/templates/commerce/commerce-cart-form.html.twig` (full cart); empty state: `commerce-cart-empty-page.html.twig` |
+| 2 | Checkout form Twig | `commerce-checkout-form--with-sidebar.html.twig` (sidebar flows); `commerce-checkout-form.html.twig` (alternate / complete-with-sidebar cases) |
+| 3 | Checkout completion Twig | `commerce-checkout-completion.html.twig` (included from complete-step layouts in `commerce-checkout-form--complete.html.twig` / checkout form variants) |
+| 4 | Order summary Twig | Sidebar view: `views-view--commerce-checkout-order-summary.html.twig`, table variant `views-view-table--commerce-checkout-order-summary.html.twig`; grouped: `mel-checkout-order-summary-grouped.html.twig`; fallback `commerce-checkout-order-summary.html.twig` |
+| 5 | Cart layout SCSS | **`commerce/_commerce.scss`** (imported from `main.scss`) holds production cart rules. `components/_cart.scss` exists but is **not** `@use`’d in `main.scss` (legacy / duplicate risk). |
+| 6 | Checkout layout SCSS | `components/_checkout.scss` |
+| 7 | Checkout panes enabled | From `config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`: `mel_buyer_details`, `ticket_holder_paragraph`, `mel_donation`, `mel_legal_consent`, `payment_information`, sidebar `order_summary` (view `commerce_checkout_order_summary`) |
+| 8 | Buyer / ticket-holder labels | Pane `display_label` in YAML; Twig adds `mel-checkout-heading` for **Payment** and **Attendee details** where sections are wrapped |
+
+---
+
+## Phase 3 — Browser / manual audit
+
+**Status:** Not executed in this environment (no interactive browser session).  
+**Recommended checks:** `/cart`, `/event/1567/book`, checkout with one paid ticket, completion, `/my-tickets`; desktop + narrow viewport; keyboard tab order.
+
+---
+
+## Phase 4 — Issue classification (pre-fix)
+
+| Severity | Issues |
+|----------|--------|
+| **P0** | None identified from static review |
+| **P1** | Checkout pane **visual order** did not match Commerce pane weights (payment appeared before buyer and attendee panes). Repeated **trust bullets** on cart and checkout (three near-identical lines). Cart **event headings** implied grouping above a **single shared table**, which misled users about which rows belonged to which heading |
+| **P2** | Remove control affordance vs touch target; optional consolidation of duplicate `_cart.scss` vs `_commerce.scss` |
+
+---
+
+## Phase 5 — Implemented changes (visual / copy / SCSS only)
+
+**Constraints respected:** No Commerce order/payment logic, Stripe, ticket availability, Event Studio, vendor dashboard, Help routes, config export, or secrets.
+
+1. **Checkout pane order (Twig)**  
+   `commerce-checkout-form.html.twig` and `commerce-checkout-form--with-sidebar.html.twig`: render panes in flow order — buyer → attendee → donation → legal → payment → trust → CTA. Uses existing form elements only (reordering output).
+
+2. **Trust copy**  
+   Paid-path trust lists reduced to **two** concise strings (cart + checkout), class `mel-checkout-trust__list--compact` / `mel-cart-trust__list--compact`.
+
+3. **Cart event context**  
+   Replaced stacked `mel-cart-event-group` sections above one global table with **`mel-cart-event-overview`** chips (`mel-cart-event-chip`) plus an optional note when some items lack a single event (`items_without_event`).
+
+4. **Accessibility / touch**  
+   Cart remove controls: `min-height` / `min-width` 44px, `inline-flex`, `:focus-visible` ring (`commerce/_commerce.scss`).
+
+5. **Checkout SCSS**  
+   Transparent inner sections extended to `mel-checkout-section--buyer`, `--donation`, `--legal`; compact trust list spacing.
+
+---
+
+## Phase 6 — Verification
+
+| Command | Result |
+|--------|--------|
+| `composer validate` | OK |
+| `ddev drush cr` | OK |
+| `npm run mel:lint` | OK |
+| `npm run mel:build` | OK |
+| `ddev drush ws --count=100 \| grep -Ei "cart\|checkout\|..."` | No new theme/Twig fatals; routine cart/checkout info logs |
+
+**Browser / keyboard / mobile:** Pending human pass (see Phase 3).
+
+---
+
+## Files changed
+
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig`
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig`
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-cart-form.html.twig`
+- `web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss`
+- `web/themes/custom/myeventlane_theme/src/scss/commerce/_commerce.scss`
+- `docs/audits/mel-cart-checkout-visual-trust-polish.md`
+
+---
+
+## Before / after (summary)
+
+- **Before:** Payment block could appear before buyer and attendee fields; three repetitive trust bullets; cart showed multiple event headings above one table.  
+- **After:** Pane order matches checkout configuration; shorter trust copy; event context via overview chips; stronger remove-button targets and focus.
+
+---
+
+## Remaining P1 / P2
+
+- **P1:** None required for this task if browser QA confirms pane order and chips render correctly with real orders.  
+- **P2:** Consider importing or deleting duplicate `components/_cart.scss`; extend Stylelint scope to `commerce/_commerce.scss` / `_checkout.scss`; optional `aria-describedby` wiring if Drupal messages are not already linked to fields.
+
+---
+
+## Recommended next task
+
+No blocking P1 remains from this pass once manual QA is done.  
+**Recommend Task 12 — vendor dashboard access parity hardening or launch-readiness sweep.**
+
+If QA finds a single narrow follow-up (e.g. mobile summary + sticky CTA overlap), open **Task 11B — checkout sticky CTA vs order summary on small viewports** with screenshots.

--- a/web/themes/custom/myeventlane_theme/src/scss/commerce/_commerce.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/commerce/_commerce.scss
@@ -405,11 +405,16 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
     background: colors.$mel-color-surface;
   }
 
-  /* Remove should be quiet */
+  /* Remove — quiet but meets touch / focus targets */
   .delete-order-item,
   .remove-order-item,
   input.form-submit[value="Remove"],
   button[name*="remove"] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    min-width: 44px;
     background: transparent;
     border: 0;
     color: colors.$mel-color-text-muted;
@@ -417,6 +422,11 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
     padding: space-tokens.mel-space(2) space-tokens.mel-space(4);
     border-radius: radii.$mel-radius-pill;
     cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid colors.$mel-color-primary;
+      outline-offset: 2px;
+    }
   }
 
   .form-actions {
@@ -555,6 +565,58 @@ body.mel-commerce-checkout .mel-header-cart .mel-mini-cart {
     @include breakpoints.mel-break(md) {
       padding: space-tokens.mel-space(5);
     }
+  }
+
+  /* Events in cart — summary chips above the Commerce line-item table */
+  .mel-cart-event-overview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: space-tokens.mel-space(3);
+    margin-bottom: space-tokens.mel-space(4);
+    padding-bottom: space-tokens.mel-space(4);
+    border-bottom: 1px solid rgba(colors.$mel-color-border, 0.65);
+  }
+
+  .mel-cart-event-chip {
+    flex: 1 1 240px;
+    min-width: min(100%, 220px);
+    padding: space-tokens.mel-space(3) space-tokens.mel-space(4);
+    border-radius: radii.$mel-radius-lg;
+    border: 1px solid rgba(colors.$mel-color-border, 0.85);
+    background: rgba(colors.$mel-color-bg, 0.65);
+  }
+
+  .mel-cart-event-chip__title {
+    margin: 0 0 space-tokens.mel-space(2);
+    font-size: typography.mel-font-size(md);
+    font-weight: typography.$mel-font-semibold;
+    color: colors.$mel-color-text;
+    line-height: 1.25;
+  }
+
+  .mel-cart-event-chip__meta {
+    display: flex;
+    flex-direction: column;
+    gap: space-tokens.mel-space(1);
+    font-size: typography.mel-font-size(sm);
+    color: colors.$mel-color-text-muted;
+    line-height: 1.35;
+  }
+
+  .mel-cart-event-chip__date {
+    font-weight: typography.$mel-font-medium;
+    color: colors.$mel-color-text;
+  }
+
+  .mel-cart-event-overview__note {
+    margin: 0 0 space-tokens.mel-space(4);
+    font-size: typography.mel-font-size(sm);
+    color: colors.$mel-color-text-muted;
+    line-height: 1.45;
+  }
+
+  .mel-cart-trust__list--compact li {
+    padding-left: 1.25rem;
   }
 
   .mel-cart-summary {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -913,7 +913,10 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 }
 
 /* REMOVE OVER-STYLING FROM INNER SECTIONS */
+.mel-checkout-section--buyer,
 .mel-checkout-section--attendees,
+.mel-checkout-section--donation,
+.mel-checkout-section--legal,
 .mel-checkout-section--details {
   background: transparent;
   border: none;
@@ -1312,6 +1315,14 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
       color: colors.$mel-color-success;
       font-weight: typography.$mel-font-bold;
     }
+  }
+}
+
+.mel-checkout-trust__list--compact {
+  gap: spacing.mel-space(1);
+
+  li {
+    padding-left: 1.25rem;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-cart-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-cart-form.html.twig
@@ -23,39 +23,34 @@
     </div>
 
     {% if form['#order_items']|length > 0 %}
-      {# Group items by event for better UX and accessibility #}
+      {# Events summary: aligns with line items below without implying each heading owns only the rows beneath it. #}
       {% if grouped_items is defined and grouped_items|length > 0 %}
-        {% for event_id, group in grouped_items %}
-          <section class="mel-cart-event-group" data-event-id="{{ event_id }}">
-            <h2 class="mel-cart-event-title">
-              {{ group.event.label() }}
-            </h2>
-            {% if group.event.hasField('field_event_start') and not group.event.get('field_event_start').isEmpty() %}
-              <div class="mel-cart-event-meta">
-                <span class="mel-cart-event-date">
-                  {{ group.event.get('field_event_start').value|date('F j, Y') }}
-                </span>
-                {% if group.event.hasField('field_location') and not group.event.get('field_location').isEmpty() %}
-                  {% set loc = group.event.get('field_location')[0] %}
-                  {% if loc %}
-                    {% set loc_parts = [] %}
-                    {% if loc.address_line1 %}{% set loc_parts = loc_parts|merge([loc.address_line1]) %}{% endif %}
-                    {% if loc.locality %}{% set loc_parts = loc_parts|merge([loc.locality]) %}{% endif %}
-                    {% if loc.administrative_area %}{% set loc_parts = loc_parts|merge([loc.administrative_area]) %}{% endif %}
-                    <span class="mel-cart-event-location" aria-label="{{ 'Location'|t }}">{{ loc_parts|join(', ') }}</span>
+        <div class="mel-cart-event-overview" role="region" aria-label="{{ 'Events in your cart'|t }}">
+          {% for event_id, group in grouped_items %}
+            <article class="mel-cart-event-chip" data-event-id="{{ event_id }}">
+              <h2 class="mel-cart-event-chip__title">{{ group.event.label() }}</h2>
+              {% if group.event.hasField('field_event_start') and not group.event.get('field_event_start').isEmpty() %}
+                <div class="mel-cart-event-chip__meta">
+                  <span class="mel-cart-event-chip__date">{{ group.event.get('field_event_start').value|date('F j, Y') }}</span>
+                  {% if group.event.hasField('field_location') and not group.event.get('field_location').isEmpty() %}
+                    {% set loc = group.event.get('field_location')[0] %}
+                    {% if loc %}
+                      {% set loc_parts = [] %}
+                      {% if loc.address_line1 %}{% set loc_parts = loc_parts|merge([loc.address_line1]) %}{% endif %}
+                      {% if loc.locality %}{% set loc_parts = loc_parts|merge([loc.locality]) %}{% endif %}
+                      {% if loc.administrative_area %}{% set loc_parts = loc_parts|merge([loc.administrative_area]) %}{% endif %}
+                      {% if loc_parts|length > 0 %}
+                        <span class="mel-cart-event-chip__location">{{ loc_parts|join(', ') }}</span>
+                      {% endif %}
+                    {% endif %}
                   {% endif %}
-                {% endif %}
-              </div>
-            {% endif %}
-          </section>
-        {% endfor %}
-
+                </div>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
         {% if items_without_event is defined and items_without_event|length > 0 %}
-          <section class="mel-cart-event-group">
-            <h2 class="mel-cart-event-title">
-              {{ 'Other items'|t }}
-            </h2>
-          </section>
+          <p class="mel-cart-event-overview__note">{{ 'Some items are not linked to a single event — see the list below.'|t }}</p>
         {% endif %}
       {% endif %}
 
@@ -103,10 +98,9 @@
       </div>
 
       <div class="mel-cart-trust mel-cart-trust--inline" role="region" aria-label="{{ 'Secure checkout'|t }}">
-        <ul class="mel-cart-trust__list">
-          <li>{{ 'Secure checkout'|t }}</li>
-          <li>{{ 'Payment processed securely'|t }}</li>
-          <li>{{ 'Confirmation email sent'|t }}</li>
+        <ul class="mel-cart-trust__list mel-cart-trust__list--compact">
+          <li>{{ 'Encrypted checkout'|t }}</li>
+          <li>{{ 'Confirmation emailed after payment'|t }}</li>
         </ul>
       </div>
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -81,6 +81,31 @@
           </div>
         {% endif %}
 
+        {% if form.mel_buyer_details is defined %}
+          <div class="mel-checkout-section mel-checkout-section--buyer">
+            {{ form.mel_buyer_details }}
+          </div>
+        {% endif %}
+
+        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
+          <div class="mel-checkout-section mel-checkout-section--attendees">
+            <h3 class="mel-checkout-heading">{{ 'Attendee details'|t }}</h3>
+            {{ form.ticket_holder_paragraph }}
+          </div>
+        {% endif %}
+
+        {% if form.mel_donation is defined %}
+          <div class="mel-checkout-section mel-checkout-section--donation">
+            {{ form.mel_donation }}
+          </div>
+        {% endif %}
+
+        {% if form.mel_legal_consent is defined %}
+          <div class="mel-checkout-section mel-checkout-section--legal">
+            {{ form.mel_legal_consent }}
+          </div>
+        {% endif %}
+
         {% if form.payment_information is defined %}
           <div class="mel-checkout-section mel-checkout-section--payment">
             <h3 class="mel-checkout-heading">{{ 'Payment'|t }}</h3>
@@ -88,28 +113,11 @@
           </div>
         {% endif %}
 
-        {% if form.mel_buyer_details is defined or form.mel_donation is defined or form.mel_legal_consent is defined %}
-          <div class="mel-checkout-section mel-checkout-section--details">
-            <h3 class="mel-checkout-heading">{{ 'Your details'|t }}</h3>
-            {% if form.mel_buyer_details is defined %}{{ form.mel_buyer_details }}{% endif %}
-            {% if form.mel_donation is defined %}{{ form.mel_donation }}{% endif %}
-            {% if form.mel_legal_consent is defined %}{{ form.mel_legal_consent }}{% endif %}
-          </div>
-        {% endif %}
-
-        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
-          <div class="mel-checkout-section mel-checkout-section--attendees">
-            <h3 class="mel-checkout-heading">{{ 'Ticket holders'|t }}</h3>
-            {{ form.ticket_holder_paragraph }}
-          </div>
-        {% endif %}
-
         {% if form.payment_information is defined %}
           <div class="mel-checkout-trust mel-checkout-trust--paid" role="region" aria-label="{{ 'Secure checkout'|t }}">
-            <ul class="mel-checkout-trust__list">
-              <li>{{ 'Secure checkout'|t }}</li>
-              <li>{{ 'Payment processed securely'|t }}</li>
-              <li>{{ 'Confirmation email sent'|t }}</li>
+            <ul class="mel-checkout-trust__list mel-checkout-trust__list--compact">
+              <li>{{ 'Encrypted checkout'|t }}</li>
+              <li>{{ 'Confirmation emailed after payment'|t }}</li>
             </ul>
           </div>
         {% else %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -93,6 +93,31 @@
           </div>
         {% endif %}
 
+        {% if form.mel_buyer_details is defined %}
+          <div class="mel-checkout-section mel-checkout-section--buyer">
+            {{ form.mel_buyer_details }}
+          </div>
+        {% endif %}
+
+        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
+          <div class="mel-checkout-section mel-checkout-section--attendees">
+            <h3 class="mel-checkout-heading">{{ 'Attendee details'|t }}</h3>
+            {{ form.ticket_holder_paragraph }}
+          </div>
+        {% endif %}
+
+        {% if form.mel_donation is defined %}
+          <div class="mel-checkout-section mel-checkout-section--donation">
+            {{ form.mel_donation }}
+          </div>
+        {% endif %}
+
+        {% if form.mel_legal_consent is defined %}
+          <div class="mel-checkout-section mel-checkout-section--legal">
+            {{ form.mel_legal_consent }}
+          </div>
+        {% endif %}
+
         {% if form.payment_information is defined %}
           <div class="mel-checkout-section mel-checkout-section--payment">
             <h3 class="mel-checkout-heading">{{ 'Payment'|t }}</h3>
@@ -100,28 +125,11 @@
           </div>
         {% endif %}
 
-        {% if form.mel_buyer_details is defined or form.mel_donation is defined or form.mel_legal_consent is defined %}
-          <div class="mel-checkout-section mel-checkout-section--details">
-            <h3 class="mel-checkout-heading">{{ 'Your details'|t }}</h3>
-            {% if form.mel_buyer_details is defined %}{{ form.mel_buyer_details }}{% endif %}
-            {% if form.mel_donation is defined %}{{ form.mel_donation }}{% endif %}
-            {% if form.mel_legal_consent is defined %}{{ form.mel_legal_consent }}{% endif %}
-          </div>
-        {% endif %}
-
-        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
-          <div class="mel-checkout-section mel-checkout-section--attendees">
-            <h3 class="mel-checkout-heading">{{ 'Ticket holders'|t }}</h3>
-            {{ form.ticket_holder_paragraph }}
-          </div>
-        {% endif %}
-
         {% if form.payment_information is defined %}
           <div class="mel-checkout-trust mel-checkout-trust--paid" role="region" aria-label="{{ 'Secure checkout'|t }}">
-            <ul class="mel-checkout-trust__list">
-              <li>{{ 'Secure checkout'|t }}</li>
-              <li>{{ 'Payment processed securely'|t }}</li>
-              <li>{{ 'Confirmation email sent'|t }}</li>
+            <ul class="mel-checkout-trust__list mel-checkout-trust__list--compact">
+              <li>{{ 'Encrypted checkout'|t }}</li>
+              <li>{{ 'Confirmation emailed after payment'|t }}</li>
             </ul>
           </div>
         {% else %}


### PR DESCRIPTION
Reorder checkout panes to match mel_event_checkout weights (buyer, attendees, donation, legal, payment). Replace misleading cart event headings with overview chips; shorten repeated trust copy; improve remove-button touch targets and focus.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d2c66952c7e0f1bc9943bafee8223cbb7af9729d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->