### PR TITLE
Cursor/onboard storage fix 128b4

### DIFF
--- a/docs/audits/mel-final-launch-readiness-audit.md
+++ b/docs/audits/mel-final-launch-readiness-audit.md
@@ -1,0 +1,248 @@
+# Task 13 — Final launch-readiness and deployment audit
+
+**Branch:** `cursor/onboard-storage-fix-128b4`  
+**HEAD:** `3ebf4e16` — fix(vendor): align dashboard analytics and attendee export access  
+**Upstream:** `origin/cursor/onboard-storage-fix-128b4` (tracking)  
+**Date:** 2026-04-29  
+**Scope:** Diagnostic audit before merge/deploy. No Stripe configuration changes, no config export, no secrets touched during this run.
+
+---
+
+## A. Git / branch / PR readiness
+
+| Check | Result |
+|-------|--------|
+| Current branch | `cursor/onboard-storage-fix-128b4` |
+| Working tree | **Clean** (`git status --short` empty) |
+| Pushed | Yes — upstream `origin/cursor/onboard-storage-fix-128b4` |
+| Task 12 on branch | Yes — tip commit is vendor analytics/export parity; history includes Event Studio, theme, docs audits |
+| PR diff vs `origin/main` | See below — **narrow**; Tasks 4–11 work appears **already on `main`** relative to this comparison |
+
+**Latest 20 commits (excerpt):** vendor parity (tip), theme cart/checkout polish, event booking CTA, discovery chips, docs (help, vendor dashboard), Event Studio ticket/publish fixes, Stripe gateway lookup docs, onboarding persistence refactors, shared session Stripe retrieval improvements.
+
+**Ignored secrets/settings accidentally committed:** **No** new secrets in *this branch’s diff vs main*. **However**, a targeted scan found **full Stripe test secret keys in other tracked paths** (see Section F and P0). That is a repository hygiene issue predating or outside the branch diff.
+
+---
+
+## B. Diff against `origin/main`
+
+Commands: `git fetch origin`, `git diff --stat origin/main...HEAD`, `git diff --name-only origin/main...HEAD`.
+
+**Stat:** 10 files, +359 / −26 lines.
+
+**Files:**
+
+| Area | Files |
+|------|--------|
+| **docs/audits** | `mel-vendor-access-parity-launch-readiness.md` |
+| **Vendor / checkout / analytics** | `EventVendorAccessChecker.php` (new), `MetricsAggregator.php`, `RsvpStatsService.php`, `AnalyticsDashboardController.php`, `AttendeeExportController.php`, `VendorOrderController.php`, `myeventlane_vendor.services.yml`, `myeventlane_analytics.info.yml`, `myeventlane_checkout_paragraph.info.yml` |
+
+**Unexpected vs broad “Tasks 4–12” narrative:** The PR-shaped delta vs `main` is **only Task 12 vendor access parity + audit doc**. Stripe/theme/Event Studio/help changes from earlier tasks are **not** in this diff — they are presumably **already merged into `main`**.
+
+**Merge:** Not performed (audit only).
+
+---
+
+## C. Build / dependency readiness
+
+| Step | Result |
+|------|--------|
+| `composer validate` | `./composer.json` **valid** |
+| `composer audit` | **No security vulnerability advisories found** |
+| `ddev drush status` | Drupal **11.3.8**, bootstrap successful, DB connected, config `config/sync` |
+| `ddev drush cr` | **Success** |
+| `npm run mel:lint` | **Exit 0** (hero check + stylelint on scoped SCSS) |
+| `npm run mel:build` | **Exit 0** (Vite builds for `myeventlane_theme` and `myeventlane_vendor_theme`; npm reported moderate severity advisories in theme deps — informational) |
+| `git status` after build | **Clean** — no tracked file changes from build |
+
+**Lockfile drift:** Not indicated by this run; branch diff vs `main` does not include `composer.lock` / root lock changes.
+
+**Config export drift:** Not created; no `cex` run.
+
+---
+
+## D. Drupal runtime readiness
+
+**Drush status summary:** Site URI `https://myeventlane.ddev.site`, PHP 8.3, Drush 13.7, profile `standard`, public files under `sites/default/files`.
+
+**Enabled modules (grep sample):** Core Search/Views; Commerce suite + Commerce Stripe + webhook events; Search API + DB; Paragraphs; Flag; all **myeventlane_*** custom modules relevant to launch (vendor, event_studio, commerce, checkout_flow, checkout_paragraph, cart, help_centre, help_assistant, rsvp, stripe, analytics, etc.) — **present and enabled** in the listing captured during audit.
+
+**Routes:** Grepped `drush route` for vendor dashboard, events, book, cart, checkout, help, assistant, analytics, export, rsvp, my-tickets, stripe, connect — **expected routes registered** (including `/vendor/dashboard`, `/event/{node}/book`, `/cart`, `/checkout`, `/help`, `/help/assistant`, `/vendor/help`, Stripe Connect/OAuth/admin paths, exports, RSVP paths).
+
+**`drush config:status`:** Differences reported (typical local DDEV vs `config/sync`): Stripe gateway entities, Stripe webhook settings, `core.extension`, and Flag “following” **only in DB**. **No export performed** — document for operators; staging should follow normal import procedures.
+
+**Search API:** Indexes `mel_categories`, `mel_content`, `mel_vendors` enabled. **`mel_content`: 100% complete**, 76 / 76 indexed.
+
+**Cron / queues:** Not deeply exercised; watchdog shows occasional “cron already running” warnings (see P2).
+
+---
+
+## E. Watchdog / runtime errors
+
+**Filtered grep** (`ws --count=200` + keyword pattern): Mostly matched benign substrings (e.g. “vendor” in paths). **Not relied on** for severity.
+
+**`drush ws --severity=Error --count=200` (representative issues):**
+
+| Theme | Examples | Classification |
+|-------|----------|----------------|
+| **Abandoned cart / Pro** | `Order::isEmpty()` undefined on commerce order — abandoned cart scheduler fails on cron | **P1** — recurring cron error, abandoned-cart behaviour at risk |
+| **Auth / onboarding** | `OnboardingState::getOwnerId()` return type (`?int` vs string) — customer order onboarding progression failed | **P1** — type bug affecting onboarding flow |
+| **Commerce / tickets** | No `mel_ticket_type` maps variation for event 1547; blocking purchase; ticket issuance “no attendee records” for some orders | **P1/P2** — may be test-data or mapping gaps; verify per environment |
+| **Stripe Connect UI** | Cannot create Express Dashboard edit link for account (restrictions) | **P1/P2** — account-state / Stripe side; not branch-diff specific |
+| **Cron** | Session “headers already sent” during cron | **P1** — noisy cron failures |
+
+**Recent 50 (`ws --count=50`):** Mostly **Notice** — `mel_theme_debug`, `mel_admin_access_debug`, `mel_debug` (BOOST CANDIDATES), `TEMP_DEBUG vendor_parity`, domain projection debug. **P2** noise unless debug logging is disabled for production.
+
+**Warnings sample:** Pro subscription state fallback for store 38; attendee_answer paragraph integrity warnings; **404** warnings for `/event/1540` and `/event/1567` at one timestamp — **path alias / request context** worth confirming in smoke tests (canonical paths may differ).
+
+---
+
+## F. Secrets and privacy scan
+
+**Recursive grep** (patterns per Task 13; exclusions per spec): Thousands of hits in **`web/core` tests** from `password` token — **ignored as core noise**.
+
+**Targeted follow-up:** Search for Stripe secret patterns in non-core YAML:
+
+- **`_INVALID_config_backup_2026-01-02/sync/commerce_payment.commerce_payment_gateway.stripe.yml`** — contains a **full `sk_test_…` secret key** string.
+- **`_myeventlane_audit/config-sync/commerce_payment.commerce_payment_gateway.stripe.yml`** — **same class of material**.
+
+Both paths are **tracked by git** (`git ls-files` includes under `_INVALID_config_backup_*` and `_myeventlane_audit/`).
+
+**Verdict:** **P0 — real Stripe secret material in the repository tree.** Redacted prefix for documentation: `sk_test_51…` (full value not repeated here).
+
+**Other `git ls-files` matches:** `docs/SECRETS_PROTECTION_GUIDE.md`, field machine names `field_help_seed_key`, `private/` docs (internal specs), `_myeventlane_audit/sites-default/settings.php` (template-style audit copy — review separately), not evaluated as live production secrets in this pass.
+
+---
+
+## G. Test entities (no PII)
+
+**Nodes (php-eval):**
+
+| NID | Title | Published | Type | Notes |
+|-----|-------|-----------|------|--------|
+| 1567 | Experience Anna Live | yes | paid | `field_ticket_types` count 2, product **90** |
+| 1540 | New RSVP Test | yes | rsvp | tickets count 1 |
+
+**Paid product 90:** Published; **2** variations (**4121** ~49.88 AUD, **4122** ~50.00 AUD), both published.
+
+**RSVP SQL:** `1540` — `confirmed` = **8** rows. `1567` — no rows (expected for paid).
+
+**Last 10 orders (aggregates only):** Mix of `draft` / `completed`; line items reference events **1567**, **1547**, **1538** with variation IDs — useful for smoke routing; **no attendee names/emails** logged in this doc.
+
+---
+
+## H. Manual browser smoke (DDEV / staging)
+
+All items **pending** in this automated audit session (no browser executed here). Track as owner QA before production.
+
+**Public:** `/`, `/events`, category page, `/event/1567`, `/event/1540`, `/event/1567/book`, `/event/1540/book`, `/cart`, checkout one paid ticket, completion/payment step.
+
+**Vendor:** `/vendor/dashboard`, `/vendor/events/1567/edit`, create RSVP draft, create paid draft, publish paid when Stripe ready, blocked when not, attendee export owner/team, analytics owner/team.
+
+**Help:** `/help`, `/help/assistant`, `/vendor/help`, staff playbook routes **admin/staff only**.
+
+**Security:** anonymous vendor route probe, other-vendor deep link, `/my-tickets` isolation.
+
+---
+
+## I. Staging / deployment readiness
+
+| Topic | Notes |
+|-------|--------|
+| **Deploy workflow** | [`.github/workflows/deploy-staging.yml`](../../.github/workflows/deploy-staging.yml) — deploy on **push to `main`**, uses reusable build artifact, `environment: staging`. |
+| **CI** | [`.github/workflows/php-composer.yml`](../../.github/workflows/php-composer.yml), [`.github/workflows/reusable-build.yml`](../../.github/workflows/reusable-build.yml). |
+| **Staging settings in repo** | Live secrets belong in env / server — **not** committed; audit copies under `_myeventlane_audit/` / backups must not hold live keys. |
+| **Staging Stripe** | Documented in [docs/audits/mel-stripe-staging-env-key-check.md](mel-stripe-staging-env-key-check.md) (gateway IDs, `StripeService` lookup). |
+| **Config sync** | `sites/default` → `config/sync` per Drush status (verify server `settings.php` on staging). |
+| **Health** | Help docs health route exists (`/admin/myeventlane/docs/health`); full staging smoke should follow Task 13 manual list. |
+| **Artifact** | Staging workflow downloads `artifact.tar.gz` from build job — see workflow steps. |
+
+---
+
+## J. Classification
+
+### P0
+
+1. **Stripe secret key material committed** in tracked files under `_INVALID_config_backup_2026-01-02/sync/` and `_myeventlane_audit/config-sync/` (gateway YAML with full `sk_test_…`). **Blocks** responsible merge until removed/scrubbed, `.gitignore` updated if appropriate, and **key rotation** considered if exposure scope warrants it.
+
+### P1
+
+1. **Abandoned cart scheduler:** `Call to undefined method Drupal\commerce_order\Entity\Order::isEmpty()` — recurring cron **Error**.
+2. **OnboardingState::getOwnerId()** type mismatch — customer order onboarding progression **Error** (uids 1, 72 observed).
+3. **Ticket / commerce mapping** errors for specific events/variations (e.g. 1547 / 2110) — verify data and maps on staging.
+4. **Vendor Stripe “Express Dashboard” edit link** errors for some accounts — environment/account configuration.
+5. **Cron session / headers** errors — investigate cron bootstrap context.
+6. **404** on `/event/1567` and `/event/1540` in one warning pair — confirm canonical URLs vs aliases in QA.
+7. **Manual** vendor team access matrix for analytics/export — **not executed** in this session (Tasks 7–12 addressed in code; still verify manually).
+
+### P2
+
+1. High volume of **Notice** logs (`mel_debug`, BOOST candidates, `mel_theme_debug`, `TEMP_DEBUG`).
+2. **Projection miss** debug messages for domain events.
+3. **Integrity warnings** on attendee_answer paragraphs.
+4. **npm audit** moderate advisories inside theme packages (review on upgrade cadence).
+
+---
+
+## K. Launch recommendation
+
+**Verdict: Blocked by P0** (committed Stripe secret material in backup/audit config paths).
+
+**After P0 remediation (narrow Task 13B suggested):**
+
+1. Remove or redact secret-bearing YAML from tracked paths; ensure backups are not committed or contain placeholders only.
+2. Rotate the exposed Stripe **test** secret if policy requires (still credential hygiene).
+3. Re-run secret grep on `main` candidate.
+4. Address **P1** abandoned-cart `Order::isEmpty()` and onboarding type bug before relying on those flows in production.
+
+Then: **Open PR** for the Task 12 vendor parity changes (already clean vs `main`) **and** complete **manual smoke** (Section H) on staging.
+
+---
+
+## L. Commands run (audit session)
+
+```text
+git branch --show-current
+git status --short
+git log -20 --oneline
+git remote -v
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+git status -sb
+git fetch origin
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+composer validate
+composer audit
+ddev drush status
+ddev drush cr
+npm run mel:lint
+npm run mel:build
+git status --short
+ddev drush pm:list --type=module --status=enabled | grep -Ei "myeventlane|commerce|stripe|search|views|flag|paragraph"
+ddev drush route | grep -Ei "vendor/dashboard|vendor/events|event/.*/book|checkout|cart|help|assistant|analytics|export|rsvp|my-tickets|stripe|connect"
+ddev drush config:status
+ddev drush search-api:list
+ddev drush search-api:status mel_content
+ddev drush ws --count=200 | grep -Ei "emergency|alert|critical|error|..."
+ddev drush ws --count=50
+ddev drush ws --count=200 --severity=Error
+ddev drush ws --count=50 --severity=Warning
+grep -R "sk_test_|sk_live_|..." (with exclusions per Task 13)
+git ls-files | grep -Ei "settings.php|settings.local.php|\\.env|private|secret|key"
+ddev drush php-eval '...' (nodes 1567, 1540; product 1567; orders)
+ddev drush sqlq "SELECT ... rsvp_submission ..."
+```
+
+---
+
+## M. Files changed by this audit
+
+- **Added:** `docs/audits/mel-final-launch-readiness-audit.md` (this file).
+
+No application code, Stripe config, or config export was modified during Task 13.
+
+---
+
+## Ready to commit/push this audit?
+
+**Yes** — committing **only** this audit document is appropriate and does not resolve **P0** secret exposure elsewhere; recommend fixing or ticketing P0 before relying on repo cleanliness for compliance.

--- a/docs/audits/mel-vendor-access-parity-launch-readiness.md
+++ b/docs/audits/mel-vendor-access-parity-launch-readiness.md
@@ -1,0 +1,171 @@
+# Task 12 — Vendor access parity hardening and launch-readiness sweep
+
+**Branch:** `cursor/onboard-storage-fix-128b4`  
+**Date:** 2026-04-29  
+**Scope:** Access parity for vendor analytics, checkout-paragraph exports, order attendee views, and RSVP vendor aggregates. No Stripe, checkout payment logic, Event Studio, public theme, Help, config export, or secrets changes.
+
+---
+
+## Plan (before implementation)
+
+- Introduce a single service matching `VendorConsoleBaseController::assertEventOwnership` for **node author + `field_event_vendor` → `field_vendor_users`**, with **fail closed**; callers add **admin/staff** and **route permission** rules.
+- Reuse that service in Pro analytics per-event access, attendee CSV export access, and `VendorOrderController` (access + row filtering for mixed-owner orders).
+- Add **team-aware** published-event RSVP aggregation for vendor KPIs; keep legacy `getVendorRsvpCount` for author-UID semantics.
+- Verify with Drush `php-eval` (no PII in doc), `composer validate`, `drush cr`, `php -l`, secret grep (custom + docs: labels/redacted examples only), watchdog sample.
+
+---
+
+## Task 7 P1 findings addressed
+
+| P1 (Task 7) | Resolution |
+|-------------|------------|
+| **1. `AnalyticsDashboardController::accessEvent` owner-only gap** | Per-event access now allows users with `access analytics dashboard` who pass **`EventVendorAccessChecker::accountHasWorkspaceParityForEvent`** (owner or vendor team). **`administer event attendees`** unchanged as staff bypass. |
+| **2. `AttendeeExportController::access` owner-only gap** | Same parity checker; **`administer nodes`** unchanged. |
+| **3. `VendorOrderController` mixed-owner order risk** | **`access()`** uses parity on events resolved per line item (**`field_target_event` preferred, else variation `field_event`**). **`collectRows()`** outputs holders only for lines the user may manage; non-admin rows without a resolvable event are skipped. Admins still see full order context. |
+| **4. `RsvpStatsService::getVendorRsvpCount` author-only aggregate** | **`getVendorRsvpCount(int)`** kept with documented legacy semantics. **`getManagedPublishedEventsRsvpCount(int)`** added: published events owned by UID **or** linked to vendors from **`UserVendorMembershipQuery::getVendorIdsForUser`**. **`MetricsAggregator::getVendorKpis`** now uses the managed-events total for the RSVP KPI. |
+
+---
+
+## Routes / controllers / services changed
+
+| Area | Change |
+|------|--------|
+| **Service** `myeventlane_vendor.event_access_checker` | New `EventVendorAccessChecker`. |
+| **`AnalyticsDashboardController::accessEvent`** | Uses parity checker after permission gates. |
+| **`AttendeeExportController::access`** | Uses parity checker; DI wired in `create()`. |
+| **`VendorOrderController`** | Injects checker; `collectRows(Order, AccountInterface)` filters lines; `resolveEventFromOrderItem()` prefers `field_target_event`. |
+| **`RsvpStatsService`** | Injects `UserVendorMembershipQuery`; new `getManagedPublishedEventsRsvpCount`. |
+| **`MetricsAggregator`** | RSVP KPI calls `getManagedPublishedEventsRsvpCount`. |
+| **`myeventlane_analytics.info.yml`** | Depends on `myeventlane_vendor`. |
+| **`myeventlane_checkout_paragraph.info.yml`** | Depends on `myeventlane_vendor`. |
+
+---
+
+## Access rule summary
+
+### Analytics (`accessEvent`)
+
+**Before:** `administer event attendees` **or** (event **owner** and `access analytics dashboard`).  
+**After:** Same staff bypass; **`access analytics dashboard`** plus **workspace parity** (owner **or** vendor team on `field_event_vendor`), aligned with `assertEventOwnership` membership checks.
+
+### Attendee CSV export (`AttendeeExportController::access`)
+
+**Before:** `administer nodes` **or** node owner.  
+**After:** `administer nodes` **or** workspace parity.
+
+### Order attendees (`VendorOrderController`)
+
+**Before:** Access if **any** line’s variation `field_event` owner matched account; **`collectRows`** returned **all** holders.  
+**After:** Access if admin **or** any line’s resolved event passes parity; **`collectRows`** only includes holders for lines that pass parity (or admin for full visibility). Internal route comment/docblock describes mixed-owner protection.
+
+### RSVP vendor KPI aggregate
+
+**Before:** KPI RSVP total used author-scoped `getVendorRsvpCount`.  
+**After:** KPI uses **`getManagedPublishedEventsRsvpCount`** (owner + team-linked published events). **`getVendorRsvpCount`** retained unchanged for callers that need strict author-only totals.
+
+---
+
+## Mixed-owner order protection
+
+- Each order item resolves an event node when possible; holder rows are emitted only when the account may manage that event (or user has `administer nodes`).
+- Recent orders sampled via Drush showed **single event per line** in the spot check; no mixed-owner order reproduced locally. Behaviour is safe if multiple events appear on one order.
+
+---
+
+## Commands run
+
+```bash
+git branch --show-current
+git status --short
+git log -12 --oneline
+composer validate
+ddev drush cr
+php -l web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
+php -l web/modules/custom/myeventlane_vendor/src/Service/RsvpStatsService.php
+php -l web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+php -l web/modules/custom/myeventlane_checkout_paragraph/src/Controller/AttendeeExportController.php
+php -l web/modules/custom/myeventlane_checkout_paragraph/src/Controller/VendorOrderController.php
+ddev drush php-eval "echo \Drupal::service('myeventlane_vendor.event_access_checker') instanceof \Drupal\myeventlane_vendor\Service\EventVendorAccessChecker ? 'ok' : 'fail';"
+```
+
+Drush event/order **`php-eval`** snippets from the task (nid/owner/vendor refs and order/item/event IDs only) were executed for local verification.
+
+```bash
+grep -R "sk_test_\|sk_live_\|whsec_\|rk_live_\|pk_live_" -n web/modules/custom docs --exclude-dir=vendor  # labels/redacted docs only
+ddev drush ws --count=120 | grep -Ei "error|exception|fatal|access denied|forbidden" || true
+```
+
+**PHPUnit:** Direct `ddev exec ./vendor/bin/phpunit …` failed (`Drupal\KernelTests\KernelTestBase` not found — project expects bootstrap/configured runner). No new automated tests added (narrow scope; existing kernel suite needs standard runner).
+
+---
+
+## Manual / browser checks
+
+**Pending** (recommended):
+
+1. Vendor owner: `/vendor/dashboard`, `/vendor/analytics/event/{nid}`, `/vendor/export-attendees/{nid}/download`.
+2. Vendor team user listed on `field_vendor_users`: same routes for their vendor’s events.
+3. Another vendor: denied or empty safe state on deep links.
+4. Staff with `administer event attendees` / `administer nodes`: oversight as intended.
+5. Anonymous: vendor routes blocked as before.
+6. Mixed-owner order (if reproducible): only accessible events’ rows visible.
+
+---
+
+## Launch-readiness sweep (post-change)
+
+| Check | Result |
+|-------|--------|
+| Working tree | Modified files listed below only (before commit). |
+| Secrets in repo (custom + docs) | No live keys; schema/UI strings reference `whsec_…` patterns only. |
+| Full Stripe keys in docs | Audit docs describe prefixes/redaction only. |
+| Config export | Not run for this task. |
+| PHP syntax | All changed PHP files pass `php -l`. |
+| Cache rebuild | `ddev drush cr` success. |
+| Test NIDs | Paid **1567**, RSVP **1540** remain referenced in prior audits (not altered here). |
+| Watchdog (sample) | Informational/errors unrelated to this change set (commerce/ticket map noise). |
+
+---
+
+## Remaining risk classification
+
+| Severity | Items |
+|----------|--------|
+| **P0** | None identified in this pass. |
+| **P1** | Browser matrix above **pending**; broader route audit (`AttendeeCsvController`, check-in) remains out of scope unless escalated. |
+| **P2** | Task 7 dual RSVP URLs; CSV Views performance; copy/UI polish. |
+
+---
+
+## Recommended next task
+
+- Execute the **manual/browser matrix** above and optionally add `_custom_access` on checkout_paragraph routes mirroring controller checks for defense-in-depth.
+- **Task 13** — not started per brief.
+
+---
+
+## Files touched
+
+**Added**
+
+- `web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php`
+- `docs/audits/mel-vendor-access-parity-launch-readiness.md`
+
+**Modified**
+
+- `web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml`
+- `web/modules/custom/myeventlane_vendor/src/Service/RsvpStatsService.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php`
+- `web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml`
+- `web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php`
+- `web/modules/custom/myeventlane_checkout_paragraph/myeventlane_checkout_paragraph.info.yml`
+- `web/modules/custom/myeventlane_checkout_paragraph/src/Controller/AttendeeExportController.php`
+- `web/modules/custom/myeventlane_checkout_paragraph/src/Controller/VendorOrderController.php`
+
+---
+
+## Suggested commit message
+
+```
+fix(vendor): align dashboard analytics and attendee export access
+```

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
@@ -7,6 +7,7 @@ lifecycle: stable
 
 dependencies:
   - myeventlane_core:myeventlane_core
+  - myeventlane_vendor:myeventlane_vendor
   - myeventlane_dashboard:myeventlane_dashboard
   - myeventlane_commerce:myeventlane_commerce
   - drupal:node

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
@@ -17,6 +17,7 @@ use Drupal\myeventlane_analytics\Service\ConversionAnalyticsService;
 use Drupal\myeventlane_analytics\Service\ReportGeneratorService;
 use Drupal\myeventlane_dashboard\Service\DashboardEventLoader;
 use Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\node\NodeInterface;
@@ -43,6 +44,7 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     private readonly ConversionAnalyticsService $conversionService,
     private readonly ReportGeneratorService $reportService,
     private readonly DashboardEventLoader $eventLoader,
+    private readonly EventVendorAccessChecker $eventAccessChecker,
   ) {
     parent::__construct($domainDetector, $currentUser, $messenger);
   }
@@ -60,6 +62,7 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
       $container->get('myeventlane_analytics.conversion'),
       $container->get('myeventlane_analytics.report'),
       $container->get('myeventlane_dashboard.event_loader'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -257,15 +260,17 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
       return AccessResult::forbidden('Not an event.');
     }
 
-    // Admin can access all.
     if ($account->hasPermission('administer event attendees')) {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    // Check if user is the event author.
-    $isOwner = (int) $node->getOwnerId() === (int) $account->id();
+    if (!$account->hasPermission('access analytics dashboard')) {
+      return AccessResult::forbidden('Missing analytics permission.')
+        ->cachePerPermissions()
+        ->addCacheableDependency($node);
+    }
 
-    if ($isOwner && $account->hasPermission('access analytics dashboard')) {
+    if ($this->eventAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
       return AccessResult::allowed()
         ->cachePerUser()
         ->addCacheableDependency($node);

--- a/web/modules/custom/myeventlane_checkout_paragraph/myeventlane_checkout_paragraph.info.yml
+++ b/web/modules/custom/myeventlane_checkout_paragraph/myeventlane_checkout_paragraph.info.yml
@@ -7,6 +7,7 @@ lifecycle: stable
 
 dependencies:
   - myeventlane_commerce:myeventlane_commerce
+  - myeventlane_vendor:myeventlane_vendor
   - myeventlane_event_attendees:myeventlane_event_attendees
   - drupal:commerce_checkout
   - drupal:commerce

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Controller/AttendeeExportController.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Controller/AttendeeExportController.php
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_event_attendees\Service\AttendanceManagerInterface;
 use Drupal\myeventlane_event_attendees\Service\VendorAttendeePresentationService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -32,6 +33,7 @@ final class AttendeeExportController extends ControllerBase implements Container
     private readonly AttendanceManagerInterface $attendanceManager,
     private readonly VendorAttendeePresentationService $vendorPresentation,
     private readonly MessengerInterface $messengerService,
+    private readonly EventVendorAccessChecker $eventAccessChecker,
   ) {}
 
   /**
@@ -42,20 +44,23 @@ final class AttendeeExportController extends ControllerBase implements Container
       $container->get('myeventlane_event_attendees.manager'),
       $container->get('myeventlane_event_attendees.vendor_presentation'),
       $container->get('messenger'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
   /**
-   * Access check: vendor owner or admin.
+   * Access check: event workspace parity (owner or vendor team) or admin.
    */
   public function access(NodeInterface $event, AccountInterface $account): AccessResult {
     if ($account->hasPermission('administer nodes')) {
       return AccessResult::allowed()->cachePerPermissions();
     }
-    $is_owner = (int) $event->getOwnerId() === (int) $account->id();
-    return $is_owner
-      ? AccessResult::allowed()->cachePerUser()->addCacheableDependency($event)
-      : AccessResult::forbidden('Not the event owner.')->addCacheableDependency($event);
+
+    if ($this->eventAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return AccessResult::allowed()->cachePerUser()->addCacheableDependency($event);
+    }
+
+    return AccessResult::forbidden('Not authorized for this event.')->addCacheableDependency($event);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Controller/VendorOrderController.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Controller/VendorOrderController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_checkout_paragraph\Controller;
 
 use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -12,12 +13,19 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\TicketLabelResolver;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Vendor controller to show attendee details for an order.
+ *
+ * Mixed-owner orders: access requires at least one line item whose event passes
+ * workspace parity for the account; rendered rows are limited to those events
+ * (plus full rows for admins). Prevents listing holders for another organiser's
+ * event in the same Commerce order.
  */
 final class VendorOrderController extends ControllerBase implements ContainerInjectionInterface {
 
@@ -27,6 +35,7 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
   public function __construct(
     private readonly MessengerInterface $messengerService,
     private readonly TicketLabelResolver $ticketLabelResolver,
+    private readonly EventVendorAccessChecker $eventAccessChecker,
   ) {}
 
   /**
@@ -36,6 +45,7 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
     return new static(
       $container->get('messenger'),
       $container->get('myeventlane_core.ticket_label_resolver'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -48,12 +58,13 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
     }
 
     foreach ($commerce_order->getItems() as $item) {
-      $variation = $item->getPurchasedEntity();
-      if ($variation && $variation->hasField('field_event') && !$variation->get('field_event')->isEmpty()) {
-        $event = $variation->get('field_event')->entity;
-        if ($event && (int) $event->getOwnerId() === (int) $account->id()) {
-          return AccessResult::allowed()->cachePerUser()->addCacheableDependency($event);
-        }
+      $event = $this->resolveEventFromOrderItem($item);
+      if ($event instanceof NodeInterface
+        && $this->eventAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+        return AccessResult::allowed()
+          ->cachePerUser()
+          ->addCacheableDependency($event)
+          ->addCacheableDependency($commerce_order);
       }
     }
 
@@ -70,7 +81,8 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
       return $this->redirect('<front>');
     }
 
-    $rows = $this->collectRows($commerce_order);
+    $account = $this->currentUser();
+    $rows = $this->collectRows($commerce_order, $account);
     $grouped = $this->groupRowsByEvent($rows);
 
     $build = [
@@ -114,20 +126,29 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
   }
 
   /**
-   * Collects row data per ticket holder.
+   * Collects row data per ticket holder; skips lines for events the user cannot manage.
    */
-  private function collectRows(Order $commerce_order): array {
+  private function collectRows(Order $commerce_order, AccountInterface $account): array {
+    $is_admin = $account->hasPermission('administer nodes');
     $rows = [];
     foreach ($commerce_order->getItems() as $item) {
-      $variation = $item->getPurchasedEntity();
+      $event = $this->resolveEventFromOrderItem($item);
+      $can_show_line = $is_admin
+        || ($event instanceof NodeInterface
+          && $this->eventAccessChecker->accountHasWorkspaceParityForEvent($event, $account));
+      if (!$can_show_line) {
+        continue;
+      }
+
       $event_title = $this->t('Unlinked Event');
       $event_id = NULL;
-      if ($variation && $variation->hasField('field_event') && !$variation->get('field_event')->isEmpty()) {
-        $event = $variation->get('field_event')->entity;
-        if ($event) {
-          $event_title = $event->label();
-          $event_id = $event->id();
-        }
+      if ($event instanceof NodeInterface) {
+        $event_title = $event->label();
+        $event_id = $event->id();
+      }
+      elseif (!$is_admin) {
+        // Without a resolvable event, only admins may see holder rows (mixed-owner protection).
+        continue;
       }
 
       if ($item->hasField('field_ticket_holder')) {
@@ -149,6 +170,28 @@ final class VendorOrderController extends ControllerBase implements ContainerInj
       }
     }
     return $rows;
+  }
+
+  /**
+   * Prefers order item field_target_event; falls back to variation field_event.
+   */
+  private function resolveEventFromOrderItem(OrderItemInterface $item): ?NodeInterface {
+    if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+      $entity = $item->get('field_target_event')->entity;
+      if ($entity instanceof NodeInterface && $entity->bundle() === 'event') {
+        return $entity;
+      }
+    }
+
+    $variation = $item->getPurchasedEntity();
+    if ($variation && $variation->hasField('field_event') && !$variation->get('field_event')->isEmpty()) {
+      $entity = $variation->get('field_event')->entity;
+      if ($entity instanceof NodeInterface && $entity->bundle() === 'event') {
+        return $entity;
+      }
+    }
+
+    return NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -40,6 +40,9 @@ services:
     arguments:
       - '@entity_type.manager'
 
+  myeventlane_vendor.event_access_checker:
+    class: Drupal\myeventlane_vendor\Service\EventVendorAccessChecker
+
   myeventlane_vendor.paid_publish_stripe_gate:
     class: Drupal\myeventlane_vendor\Service\PaidPublishStripeGate
     arguments:
@@ -138,6 +141,7 @@ services:
       - '@database'
       - '@datetime.time'
       - '@entity_type.manager'
+      - '@myeventlane_vendor.user_vendor_membership_query'
 
   myeventlane_vendor.service.category_audience:
     class: Drupal\myeventlane_vendor\Service\CategoryAudienceService

--- a/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Event access aligned with VendorConsoleBaseController::assertEventOwnership.
+ *
+ * Use for route access and API checks so vendor team members (field_event_vendor
+ * → field_vendor_users) have the same event reach as the node author.
+ *
+ * This does not assert vendor domain or global vendor console permissions; those
+ * belong on routes or calling code. Admin/staff bypasses are left to callers.
+ */
+final class EventVendorAccessChecker {
+
+  /**
+   * TRUE when the account is the event author or listed on the linked vendor.
+   */
+  public function accountHasWorkspaceParityForEvent(NodeInterface $event, AccountInterface $account): bool {
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+
+    if ((int) $event->getOwnerId() === (int) $account->id()) {
+      return TRUE;
+    }
+
+    if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
+      $vendor = $event->get('field_event_vendor')->entity;
+      if ($vendor && $vendor->hasField('field_vendor_users')) {
+        foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
+          if (isset($item['target_id']) && (int) $item['target_id'] === (int) $account->id()) {
+            return TRUE;
+          }
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
@@ -64,7 +64,7 @@ final class MetricsAggregator {
     // Get revenue data from TicketSalesService (includes published events filter).
     $revenue = $this->ticketSalesService->getVendorRevenue($userId);
     // Get RSVP count from RsvpStatsService (includes published events filter).
-    $rsvpCount = $this->rsvpStatsService->getVendorRsvpCount($userId);
+    $rsvpCount = $this->rsvpStatsService->getManagedPublishedEventsRsvpCount($userId);
 
     return [
       [

--- a/web/modules/custom/myeventlane_vendor/src/Service/RsvpStatsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/RsvpStatsService.php
@@ -19,6 +19,7 @@ final class RsvpStatsService {
     private readonly Connection $database,
     private readonly TimeInterface $time,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
   ) {}
 
   /**
@@ -27,6 +28,10 @@ final class RsvpStatsService {
    * Counts: Confirmed RSVPs only (status='confirmed' or 'active').
    * Excludes: Draft events, cancelled/pending RSVPs.
    * Tables: rsvp_submission entity or legacy myeventlane_rsvp table.
+   *
+   * Legacy semantics: published events owned by this UID only (node author).
+   * Prefer getManagedPublishedEventsRsvpCount() for dashboard KPI parity with
+   * vendor team membership, unless you explicitly need author-scoped totals.
    *
    * @param int $vendor_uid
    *   The vendor user ID.
@@ -65,6 +70,57 @@ final class RsvpStatsService {
     catch (\Exception $e) {
       return 0;
     }
+  }
+
+  /**
+   * Confirmed RSVPs for every published event the user manages (author or team).
+   *
+   * Includes events owned by the account and events linked to vendor entities
+   * where the user is owner or in field_vendor_users. Aligns with vendor
+   * workspace / assertEventOwnership coverage.
+   */
+  public function getManagedPublishedEventsRsvpCount(int $uid): int {
+    if ($uid <= 0) {
+      return 0;
+    }
+
+    try {
+      $eventIds = $this->getManagedPublishedEventNids($uid);
+      if ($eventIds === []) {
+        return 0;
+      }
+      $total = 0;
+      foreach ($eventIds as $eventId) {
+        $total += $this->getEventRsvpCount($eventId);
+      }
+      return $total;
+    }
+    catch (\Exception $e) {
+      return 0;
+    }
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function getManagedPublishedEventNids(int $uid): array {
+    $vendorIds = $this->userVendorMembershipQuery->getVendorIdsForUser($uid);
+    $storage = $this->entityTypeManager->getStorage('node');
+    $query = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->condition('status', 1);
+    $or = $query->orConditionGroup();
+    $or->condition('uid', $uid);
+    if ($vendorIds !== []) {
+      $or->condition('field_event_vendor', $vendorIds, 'IN');
+    }
+    $query->condition($or);
+    $ids = $query->execute();
+    if (empty($ids)) {
+      return [];
+    }
+    return array_map('intval', array_values($ids));
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect authorization checks and attendee data visibility in vendor-facing routes; mistakes could lead to overexposure or unintended access regressions, especially for mixed-owner orders and team membership edge cases.
> 
> **Overview**
> **Vendor access parity hardening:** introduces `EventVendorAccessChecker` and wires it into analytics per-event access and attendee CSV export so vendor *team members* (via `field_event_vendor` → `field_vendor_users`) can access the same events as the node author, while preserving admin/staff bypass permissions.
> 
> **Mixed-owner order safety + KPI parity:** updates `VendorOrderController` to resolve an event per line item and only render attendee rows for events the viewer can manage (preventing leakage in mixed-owner orders), and updates RSVP dashboard KPIs to count published events managed by the user (owner or team) via a new `getManagedPublishedEventsRsvpCount`.
> 
> Adds module dependency links (`myeventlane_analytics`/`myeventlane_checkout_paragraph` → `myeventlane_vendor`) and includes two new audit documents covering vendor parity and a launch-readiness sweep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03f2b553ed2290c6eee6a76ca564eae8c2774fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->