### PR TITLE
fix(theme): use Outlook web compose URL for event calendar tab

### DIFF
--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -732,8 +732,8 @@ function _myeventlane_theme_get_first_event_from_order($order) {
  * @param \Drupal\node\NodeInterface $event
  *   The event node.
  *
- * @return array{apple?: string, google?: string, outlook?: string}
- *   Calendar link URLs.
+ * @return array{ics?: string, apple?: string, google?: string, outlook?: string}
+ *   Calendar link URLs. Apple uses the ICS download route; Outlook uses a web compose deeplink.
  */
 function _myeventlane_theme_build_calendar_links(NodeInterface $event): array {
   $links = [];
@@ -3133,7 +3133,8 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
   if (($variables['view_mode'] ?? '') === 'full') {
     $cal_links = _myeventlane_theme_build_calendar_links($node);
     $variables['apple_ics_url'] = $cal_links['apple'] ?? $cal_links['ics'] ?? '';
-    $variables['outlook_ics_url'] = $cal_links['ics'] ?? '';
+    // Outlook tab: Outlook on the web compose URL — not the same ICS file as Apple.
+    $variables['outlook_ics_url'] = $cal_links['outlook'] ?? '';
     $variables['google_calendar_url'] = $cal_links['google'] ?? '';
   }
 }

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -696,7 +696,7 @@
                             <a href="{{ mel_apple_tab_href }}" class="mel-button mel-button--ghost">{{ 'Download for Apple Calendar'|t }}</a>
                           </div>
                           <div class="mel-calendar__pane" data-pane="outlook">
-                            <a href="{{ mel_outlook_tab_href }}" class="mel-button mel-button--ghost">{{ 'Download for Outlook'|t }}</a>
+                            <a href="{{ mel_outlook_tab_href }}" class="mel-button mel-button--ghost" target="_blank" rel="noopener noreferrer">{{ 'Add to Outlook'|t }}</a>
                           </div>
                           <div class="mel-calendar__pane" data-pane="google">
                             <a href="{{ mel_google_tab_href }}" class="mel-button mel-button--ghost" target="_blank" rel="noopener noreferrer">{{ 'Add to Google Calendar'|t }}</a>


### PR DESCRIPTION
Bugbot: apple_ics_url and outlook_ics_url both pointed at the ICS download. _myeventlane_theme_build_calendar_links already exposes outlook as an Outlook on the web deeplink; preprocess now assigns outlook_ics_url from that key.

- Document ics vs apple/outlook in calendar links helper return type
- Template: outlook opens in a new tab with clearer Add to Outlook label

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 58718e47bf4f82fd8e8c07b6bf440b58faaefe1b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->