### PR TITLE
fix(theme): restore link hover color and image-wrap reduced-motion

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/base/_base.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_base.scss
@@ -128,7 +128,7 @@ a {
   transition: color melmotion.$mel-transition-fast;
 
   &:hover {
-    color: var(--mel-primary);
+    color: var(--mel-color-primary-hover);
   }
 
   &:focus-visible {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -120,6 +120,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .mel-event-card:hover .mel-event-card__image-wrap img,
   .mel-event-card:hover .mel-event-card__image img,
   .mel-event-card:hover .mel-event-card__image .mel-event-card__image-element {
     transform: none;


### PR DESCRIPTION
- Use --mel-color-primary-hover for global link :hover so hover differs from default (Bugbot: --mel-primary matched default).
- Include .mel-event-card__image-wrap img in prefers-reduced-motion transform reset alongside other card image selectors.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f51429a6e2149e43f5c006c1fd553c4c98d61898. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->