### PR TITLE
fix(theme): address Bugbot checkout and token issues

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/base/_tokens.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_tokens.scss
@@ -10,6 +10,7 @@
   --mel-color-accent-active: #555dd4;
   --mel-color-text: #24303a;
   --mel-color-text-secondary: #5b6670;
+  --mel-color-text-muted: #5b6670;
   --mel-color-border: #e9e3de;
   --mel-color-overlay: rgba(36, 48, 58, 0.38);
   --mel-color-on-primary: #fff;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -1338,50 +1338,6 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   margin-bottom: spacing.mel-space(3);
 }
 
-/* Trust list — above primary CTA (Phase 4) */
-.mel-checkout-trust {
-  margin: spacing.mel-space(3) 0 spacing.mel-space(2);
-  padding: spacing.mel-space(3) spacing.mel-space(3);
-  border-radius: radii.$mel-radius-lg;
-  border: $mel-checkout-border;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: $mel-checkout-shadow;
-}
-
-.mel-checkout-trust__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: spacing.mel-space(2);
-  font-size: typography.mel-font-size(sm);
-  color: colors.$mel-color-text-muted;
-  line-height: 1.45;
-
-  li {
-    margin: 0;
-    padding-left: 1.35rem;
-    position: relative;
-
-    &::before {
-      content: '✓';
-      position: absolute;
-      left: 0;
-      color: colors.$mel-color-success;
-      font-weight: typography.$mel-font-bold;
-    }
-  }
-}
-
-.mel-checkout-trust__list--compact {
-  gap: spacing.mel-space(1);
-
-  li {
-    padding-left: 1.25rem;
-  }
-}
-
 /* Single dominant primary CTA; back / secondary actions read as links */
 .mel-checkout-cta .form-actions,
 .mel-checkout-section--cta .form-actions {
@@ -1392,10 +1348,6 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   margin-top: 0;
   padding-top: 0;
   border-top: none;
-
-  .mel-checkout-next-steps {
-    display: none;
-  }
 
   .button--primary,
   [type='submit'].button--primary {
@@ -1512,37 +1464,6 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
   > div {
     margin: 0;
-  }
-}
-
-.mel-checkout-reassurance {
-  margin-top: spacing.mel-space(2);
-  font-size: typography.mel-font-size(sm);
-  color: colors.$mel-color-text-muted;
-  text-align: center;
-  line-height: 1.5;
-}
-
-.mel-checkout-next-steps {
-  margin-bottom: 8px;
-  font-size: 13px;
-
-  h4 {
-    font-weight: typography.$mel-font-semibold;
-    margin: 0 0 4px 0;
-  }
-
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  li {
-    margin-bottom: 4px;
-    min-height: 44px;
-    display: flex;
-    align-items: center;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -161,7 +161,7 @@
         {% if (mel_contextual_help_checkout is defined and mel_contextual_help_checkout) or (sidebar_content|striptags|trim is not empty) or (mel_support_panel is defined and mel_support_panel) %}
           <aside class="mel-checkout__summary" aria-label="{{ 'Order summary'|t }}">
             <div class="mel-checkout__summary-inner">
-              <h3 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h3>
+              <h2 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h2>
               {% if mel_contextual_help_checkout is defined and mel_contextual_help_checkout %}
                 <div class="mel-contextual-help mel-contextual-help--checkout mel-contextual-help--checkout-card mel-checkout__summary-region">
                   {{ mel_contextual_help_checkout }}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -173,7 +173,7 @@
         {% if (mel_contextual_help_checkout is defined and mel_contextual_help_checkout) or (sidebar_content|striptags|trim is not empty) or (mel_support_panel is defined and mel_support_panel) %}
           <aside class="mel-checkout__summary" aria-label="{{ 'Order summary'|t }}">
             <div class="mel-checkout__summary-inner">
-              <h3 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h3>
+              <h2 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h2>
               {% if mel_contextual_help_checkout is defined and mel_contextual_help_checkout %}
                 <div class="mel-contextual-help mel-contextual-help--checkout mel-contextual-help--checkout-card mel-checkout__summary-region">
                   {{ mel_contextual_help_checkout }}


### PR DESCRIPTION
- Add :root --mel-color-text-muted matching SCSS $mel-color-text-muted (#5b6670) so CSS variables stay aligned with tokens/_colors.scss.
- Use h2 for checkout sidebar "Your order" so grouped event titles (h3) nest correctly for assistive tech.
- Remove unused .mel-checkout-trust / next-steps / reassurance rules superseded by .mel-checkout__trust and updated checkout markup.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9e747f1d7b3f93f4d34f5fd8ca1e24773b483601. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->