### PR TITLE
Cursor/vendor form fix 06171

### DIFF
--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -10,9 +10,11 @@ dependencies:
     - field.field.user.user.field_mel_account_type
     - field.field.user.user.field_pro_subscription_managed
     - field.field.user.user.field_pronouns
+    - field.field.user.user.field_vendor_store
     - field.field.user.user.user_picture
     - image.style.thumbnail
   module:
+    - commerce_store
     - image
     - path
     - text
@@ -63,6 +65,16 @@ content:
     settings:
       size: 60
       placeholder: 'e.g. they/them, she/her, he/him'
+    third_party_settings: {  }
+  field_vendor_store:
+    type: entity_reference_autocomplete
+    weight: 50
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   language:
     weight: 0

--- a/config/sync/field.field.user.user.field_vendor_store.yml
+++ b/config/sync/field.field.user.user.field_vendor_store.yml
@@ -1,0 +1,29 @@
+uuid: b9e4d3c2-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_vendor_store
+  module:
+    - commerce_store
+    - user
+id: user.user.field_vendor_store
+field_name: field_vendor_store
+entity_type: user
+bundle: user
+label: 'Vendor Store'
+description: 'Commerce store linked to this vendor account (mirrors vendor profile store).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:commerce_store'
+  handler_settings:
+    target_bundles:
+      online: online
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/config/sync/field.storage.user.field_vendor_store.yml
+++ b/config/sync/field.storage.user.field_vendor_store.yml
@@ -1,0 +1,20 @@
+uuid: a8f3c2d1-4e5b-6a7c-8d9e-0f1a2b3c4d5e
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_store
+    - user
+id: user.field_vendor_store
+field_name: field_vendor_store
+entity_type: user
+type: entity_reference
+settings:
+  target_type: commerce_store
+module: core
+cardinality: 1
+translatable: false
+locked: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_vendor/config/install/field.field.user.user.field_vendor_store.yml
+++ b/web/modules/custom/myeventlane_vendor/config/install/field.field.user.user.field_vendor_store.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_vendor_store
+  module:
+    - commerce_store
+    - user
+id: user.user.field_vendor_store
+field_name: field_vendor_store
+entity_type: user
+bundle: user
+label: 'Vendor Store'
+description: 'Commerce store linked to this vendor account (mirrors vendor profile store).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:commerce_store'
+  handler_settings:
+    target_bundles:
+      online: online
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/web/modules/custom/myeventlane_vendor/config/install/field.storage.user.field_vendor_store.yml
+++ b/web/modules/custom/myeventlane_vendor/config/install/field.storage.user.field_vendor_store.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_store
+    - user
+id: user.field_vendor_store
+field_name: field_vendor_store
+entity_type: user
+type: entity_reference
+settings:
+  target_type: commerce_store
+module: core
+cardinality: 1
+translatable: false
+locked: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -1043,6 +1043,55 @@ function myeventlane_vendor_update_10020(): string {
 }
 
 /**
+ * Backfill AU GST tax registrations on Commerce stores (vendor stores had none).
+ *
+ * Without tax_registrations matching the GST zone (AU), Commerce Tax skips the
+ * entire tax type — orders show no "tax" adjustments.
+ */
+function myeventlane_vendor_update_10021(): string {
+  $module_handler = \Drupal::moduleHandler();
+  if (!$module_handler->moduleExists('commerce_store') || !$module_handler->moduleExists('commerce_tax')) {
+    return 'Skipped AU GST store backfill (commerce_store or commerce_tax not enabled).';
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('commerce_store');
+  $ids = $storage->getQuery()->accessCheck(FALSE)->execute();
+  if (!$ids) {
+    return 'No commerce stores found.';
+  }
+
+  $updated = 0;
+  foreach ($storage->loadMultiple($ids) as $store) {
+    $address = $store->getAddress();
+    if (!$address || $address->getCountryCode() !== 'AU') {
+      continue;
+    }
+    $existing = $store->get('tax_registrations')->getValue();
+    if ($existing !== []) {
+      continue;
+    }
+    $store->set('tax_registrations', ['AU']);
+    // Match Australian GST tax type (display inclusive) and catalog behaviour.
+    $store->set('prices_include_tax', TRUE);
+    try {
+      $store->save();
+      $updated++;
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_vendor')->error(
+        'Update 10021: failed to save store @id for AU GST: @message',
+        ['@id' => (string) $store->id(), '@message' => $e->getMessage()]
+      );
+    }
+  }
+
+  return sprintf(
+    'AU GST backfill: updated %d commerce store(s) with tax_registrations AU and prices_include_tax.',
+    $updated
+  );
+}
+
+/**
  * Implements hook_uninstall().
  */
 function myeventlane_vendor_uninstall(): void {

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -5,7 +5,9 @@
  * Install, update, and uninstall functions for myeventlane_vendor module.
  */
 
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_schema().
@@ -932,6 +934,112 @@ function myeventlane_vendor_update_10019(): string {
     }
   }
   return 'Access vendor dashboard is granted to vendor and staff when those roles exist. Administrator is unchanged (is_admin / all perms at runtime).';
+}
+
+/**
+ * Installs user.field_vendor_store, wires form display, and backfills vendor accounts.
+ */
+function myeventlane_vendor_update_10020(): string {
+  $messages = [];
+  $module_path = \Drupal::service('extension.list.module')->getPath('myeventlane_vendor');
+
+  $field_storage_config_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  $field_config_storage = \Drupal::entityTypeManager()->getStorage('field_config');
+
+  $storage_yaml_path = $module_path . '/config/install/field.storage.user.field_vendor_store.yml';
+  if (!file_exists($storage_yaml_path)) {
+    \Drupal::logger('myeventlane_vendor')->error('Update 10020: missing field storage YAML at @path', ['@path' => $storage_yaml_path]);
+    return 'Update 10020 failed: field.storage.user.field_vendor_store YAML not found.';
+  }
+
+  $storage_config = \Symfony\Component\Yaml\Yaml::parseFile($storage_yaml_path);
+  if (!$field_storage_config_storage->load('user.field_vendor_store')) {
+    try {
+      $field_storage_config_storage->create($storage_config)->save();
+      $messages[] = 'Installed field storage user.field_vendor_store.';
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('myeventlane_vendor')->error('Update 10020: field storage install failed: @message', ['@message' => $e->getMessage()]);
+      return 'Update 10020 failed creating field storage: ' . $e->getMessage();
+    }
+  }
+  else {
+    $messages[] = 'Field storage user.field_vendor_store already present.';
+  }
+
+  $field_yaml_path = $module_path . '/config/install/field.field.user.user.field_vendor_store.yml';
+  if (!file_exists($field_yaml_path)) {
+    \Drupal::logger('myeventlane_vendor')->error('Update 10020: missing field instance YAML at @path', ['@path' => $field_yaml_path]);
+    return 'Update 10020 failed: field.field.user.user.field_vendor_store YAML not found.';
+  }
+
+  $field_config_yaml = \Symfony\Component\Yaml\Yaml::parseFile($field_yaml_path);
+  if (!$field_config_storage->load('user.user.field_vendor_store')) {
+    try {
+      $field_config_storage->create($field_config_yaml)->save();
+      $messages[] = 'Installed field instance user.user.field_vendor_store.';
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('myeventlane_vendor')->error('Update 10020: field instance install failed: @message', ['@message' => $e->getMessage()]);
+      return 'Update 10020 failed creating field instance: ' . $e->getMessage();
+    }
+  }
+  else {
+    $messages[] = 'Field instance user.user.field_vendor_store already present.';
+  }
+
+  $form_display = EntityFormDisplay::load('user.user.default');
+  if ($form_display instanceof EntityFormDisplay && !$form_display->getComponent('field_vendor_store')) {
+    try {
+      $form_display->setComponent('field_vendor_store', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 50,
+        'region' => 'hidden',
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'match_limit' => 10,
+          'size' => 60,
+          'placeholder' => '',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $form_display->save();
+      $messages[] = 'Registered field_vendor_store on user form display (hidden).';
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('myeventlane_vendor')->error('Update 10020: form display update failed: @message', ['@message' => $e->getMessage()]);
+      return 'Update 10020 failed updating entity form display: ' . $e->getMessage();
+    }
+  }
+
+  \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+  \Drupal::entityTypeManager()->clearCachedDefinitions();
+
+  try {
+    $uids = \Drupal::entityQuery('user')
+      ->accessCheck(FALSE)
+      ->condition('roles', 'vendor')
+      ->execute();
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('myeventlane_vendor')->error('Update 10020: user query failed: @message', ['@message' => $e->getMessage()]);
+    return implode(' ', $messages) . ' Backfill skipped (query failed).';
+  }
+
+  /** @var \Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber $subscriber */
+  $subscriber = \Drupal::service('myeventlane_vendor.vendor_store_subscriber');
+  $count = 0;
+  foreach ($uids as $uid) {
+    $user = User::load($uid);
+    if ($user instanceof User) {
+      $subscriber->ensureLinkedStoreForVendorUser($user);
+      $count++;
+    }
+  }
+
+  $messages[] = sprintf('Ran store linkage for %d vendor-role account(s).', $count);
+
+  return implode(' ', $messages);
 }
 
 /**

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
@@ -19,6 +19,14 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_user_login().
+ */
+function myeventlane_vendor_user_login(UserInterface $account): void {
+  \Drupal::service('myeventlane_vendor.vendor_store_subscriber')->ensureLinkedStoreForVendorUser($account);
+}
 
 /**
  * Implements hook_theme().

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -76,6 +76,7 @@ services:
       - '@entity_type.manager'
       - '@logger.factory'
       - '@myeventlane_onboarding.manager'
+      - '@current_user'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Controller;
 
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Messenger\MessengerInterface;
@@ -120,47 +119,10 @@ final class VendorSettingsController extends VendorConsoleBaseController {
       ]);
     }
 
-    // Build the settings form - formBuilder handles both GET and POST.
-    $form_object_class = 'Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm';
-    $form = $this->formBuilder->getForm($form_object_class, $vendor);
-    \Drupal::logger('mel_debug')->notice('FORM CLASS: @class', ['@class' => $form_object_class]);
-
-    // If form was submitted and redirected, the form might be empty.
-    // Check if we have a redirect response.
-    if ($form instanceof RedirectResponse) {
-      return $form;
-    }
-
-    // Ensure form libraries are merged into the page.
-    $form_attached = [];
-    if (isset($form['#attached']['library'])) {
-      $form_attached = [
-        '#attached' => [
-          'library' => $form['#attached']['library'],
-        ],
-      ];
-      unset($form['#attached']);
-    }
-
-    // Build settings tabs for navigation.
-    $tabs = [
-      [
-        'label' => $this->t('Profile'),
-        'url' => Url::fromRoute('myeventlane_vendor.console.settings')->toString(),
-        'active' => TRUE,
-      ],
-      [
-        'label' => $this->t('Messaging Brand'),
-        'url' => Url::fromRoute('myeventlane_vendor.console.messaging_brand')->toString(),
-        'active' => FALSE,
-      ],
-    ];
-
-    return $this->buildVendorPage('myeventlane_vendor_console_page', [
-      'title' => 'Settings',
-      'tabs' => $tabs,
-      'body' => $form,
-    ] + $form_attached);
+    return $this->formBuilder->getForm(
+      \Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm::class,
+      $vendor
+    );
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
@@ -121,10 +121,9 @@ final class VendorSettingsController extends VendorConsoleBaseController {
     }
 
     // Build the settings form - formBuilder handles both GET and POST.
-    $form = $this->formBuilder->getForm(
-      'Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm',
-      $vendor
-    );
+    $form_object_class = 'Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm';
+    $form = $this->formBuilder->getForm($form_object_class, $vendor);
+    \Drupal::logger('mel_debug')->notice('FORM CLASS: @class', ['@class' => $form_object_class]);
 
     // If form was submitted and redirected, the form might be empty.
     // Check if we have a redirect response.

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -376,7 +376,7 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     $storage = $this->entityTypeManager->getStorage('myeventlane_vendor');
 
     $owner_ids = $storage->getQuery()
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->condition('uid', $uid)
       ->range(0, 1)
       ->execute();
@@ -389,7 +389,7 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     }
 
     $user_ids = $storage->getQuery()
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->condition('field_vendor_users', $uid)
       ->range(0, 1)
       ->execute();

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -8,12 +8,19 @@ use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\user\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Event subscriber to auto-create Commerce Store when Vendor is created.
+ *
+ * Also keeps the user account {@see field_vendor_store} in sync with the
+ * vendor profile store and ensures linkage on login and key vendor routes.
  */
 final class VendorStoreSubscriber implements EventSubscriberInterface {
 
@@ -37,11 +44,31 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   private OnboardingManager $onboardingManager;
 
   /**
+   * The current user (for request subscriber).
+   */
+  private AccountProxyInterface $currentUser;
+
+  /**
    * Track vendors being processed to prevent recursion.
    *
    * @var array
    */
   private static array $processing = [];
+
+  /**
+   * Prevent re-entry when syncing user store reference.
+   *
+   * @var array<int, bool>
+   */
+  private static array $ensureUserStoreRunning = [];
+
+  /**
+   * Routes that should trigger store linkage for vendor users.
+   */
+  private const VENDOR_STORE_ENSURE_ROUTES = [
+    'myeventlane_vendor.console.dashboard',
+    'myeventlane_vendor.console.settings',
+  ];
 
   /**
    * Constructs a VendorStoreSubscriber.
@@ -52,15 +79,19 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
    *   The logger factory.
    * @param \Drupal\myeventlane_core\Service\OnboardingManager $onboarding_manager
    *   Vendor onboarding.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user account proxy.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
     OnboardingManager $onboarding_manager,
+    AccountProxyInterface $current_user,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
     $this->onboardingManager = $onboarding_manager;
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -69,6 +100,7 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       'entity.myeventlane_vendor.insert' => 'onVendorInsert',
+      KernelEvents::REQUEST => ['onKernelRequest', 28],
     ];
   }
 
@@ -129,6 +161,27 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Ensures store linkage when vendors hit dashboard or account settings.
+   */
+  public function onKernelRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest() || \PHP_SAPI === 'cli') {
+      return;
+    }
+    $route = $event->getRequest()->attributes->get('_route');
+    if (!is_string($route) || !in_array($route, self::VENDOR_STORE_ENSURE_ROUTES, TRUE)) {
+      return;
+    }
+    $uid = (int) $this->currentUser->id();
+    if ($uid <= 0 || $this->currentUser->isAnonymous()) {
+      return;
+    }
+    $user = $this->entityTypeManager->getStorage('user')->load($uid);
+    if ($user instanceof UserInterface) {
+      $this->ensureLinkedStoreForVendorUser($user);
+    }
+  }
+
+  /**
    * Returns the vendor's store, or creates one when onboarding is complete.
    *
    * Used for Stripe Connect and other flows that require a store without
@@ -145,6 +198,10 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     if (!$vendor->get('field_vendor_store')->isEmpty()) {
       $entity = $vendor->get('field_vendor_store')->entity;
       if ($entity instanceof StoreInterface) {
+        $owner = $vendor->getOwner();
+        if ($owner instanceof UserInterface) {
+          $this->syncUserVendorStoreFromVendor($owner, $vendor);
+        }
         return $entity;
       }
     }
@@ -168,6 +225,39 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     }
 
     return $this->createAndPersistStoreForVendor($vendor);
+  }
+
+  /**
+   * Ensures the vendor role account has a Commerce store reference on the user.
+   *
+   * Relies on the vendor entity store field as the source of truth.
+   */
+  public function ensureLinkedStoreForVendorUser(UserInterface $user): void {
+    if (!$user->hasField('field_vendor_store')) {
+      return;
+    }
+    $uid = (int) $user->id();
+    if ($uid <= 0) {
+      return;
+    }
+    if (!in_array('vendor', $user->getRoles(), TRUE)) {
+      return;
+    }
+    if (isset(self::$ensureUserStoreRunning[$uid])) {
+      return;
+    }
+    self::$ensureUserStoreRunning[$uid] = TRUE;
+    try {
+      $vendor = $this->loadPrimaryVendorForUser($uid);
+      if ($vendor === NULL) {
+        return;
+      }
+      $this->ensureStoreForVendor($vendor);
+      $this->syncUserVendorStoreFromVendor($user, $vendor);
+    }
+    finally {
+      unset(self::$ensureUserStoreRunning[$uid]);
+    }
   }
 
   /**
@@ -210,6 +300,10 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
 
       unset(self::$processing[$vendor->id()]);
 
+      if ($owner instanceof UserInterface && $owner->hasField('field_vendor_store')) {
+        $this->syncUserVendorStoreFromVendor($owner, $vendor);
+      }
+
       return $store;
     }
     catch (EntityStorageException $e) {
@@ -224,6 +318,77 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
       );
       return NULL;
     }
+  }
+
+  /**
+   * Copies the vendor's store target to the user account field when present.
+   */
+  private function syncUserVendorStoreFromVendor(UserInterface $user, Vendor $vendor): void {
+    if (!$user->hasField('field_vendor_store')) {
+      return;
+    }
+    if (!$vendor->hasField('field_vendor_store') || $vendor->get('field_vendor_store')->isEmpty()) {
+      return;
+    }
+    $sid = $vendor->get('field_vendor_store')->target_id;
+    if ($sid === NULL) {
+      return;
+    }
+    $current = $user->get('field_vendor_store')->isEmpty()
+      ? NULL
+      : (int) $user->get('field_vendor_store')->target_id;
+    if ($current === (int) $sid) {
+      return;
+    }
+    try {
+      $user->set('field_vendor_store', $sid);
+      $user->save();
+    }
+    catch (EntityStorageException $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->error(
+        'Could not sync user @uid field_vendor_store from vendor @vid: @message',
+        [
+          '@uid' => (string) $user->id(),
+          '@vid' => (string) $vendor->id(),
+          '@message' => $e->getMessage(),
+        ]
+      );
+    }
+  }
+
+  /**
+   * Loads the primary vendor for an account (owner match preferred).
+   */
+  private function loadPrimaryVendorForUser(int $uid): ?Vendor {
+    $storage = $this->entityTypeManager->getStorage('myeventlane_vendor');
+
+    $owner_ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('uid', $uid)
+      ->range(0, 1)
+      ->execute();
+
+    if (!empty($owner_ids)) {
+      $vendor = $storage->load(reset($owner_ids));
+      if ($vendor instanceof Vendor) {
+        return $vendor;
+      }
+    }
+
+    $user_ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('field_vendor_users', $uid)
+      ->range(0, 1)
+      ->execute();
+
+    if (!empty($user_ids)) {
+      $vendor = $storage->load(reset($user_ids));
+      if ($vendor instanceof Vendor) {
+        return $vendor;
+      }
+    }
+
+    return NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -63,14 +63,6 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   private static array $ensureUserStoreRunning = [];
 
   /**
-   * Routes that should trigger store linkage for vendor users.
-   */
-  private const VENDOR_STORE_ENSURE_ROUTES = [
-    'myeventlane_vendor.console.dashboard',
-    'myeventlane_vendor.console.settings',
-  ];
-
-  /**
    * Constructs a VendorStoreSubscriber.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -100,7 +92,7 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       'entity.myeventlane_vendor.insert' => 'onVendorInsert',
-      KernelEvents::REQUEST => ['onKernelRequest', 28],
+      KernelEvents::REQUEST => ['onKernelRequest', 100],
     ];
   }
 
@@ -161,24 +153,40 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Ensures store linkage when vendors hit dashboard or account settings.
+   * Ensures vendor users have a linked store when the user store field is empty.
    */
   public function onKernelRequest(RequestEvent $event): void {
     if (!$event->isMainRequest() || \PHP_SAPI === 'cli') {
       return;
     }
-    $route = $event->getRequest()->attributes->get('_route');
-    if (!is_string($route) || !in_array($route, self::VENDOR_STORE_ENSURE_ROUTES, TRUE)) {
+
+    if (!$this->currentUser->isAuthenticated()) {
       return;
     }
+
     $uid = (int) $this->currentUser->id();
-    if ($uid <= 0 || $this->currentUser->isAnonymous()) {
+    if ($uid <= 0) {
       return;
     }
+
     $user = $this->entityTypeManager->getStorage('user')->load($uid);
-    if ($user instanceof UserInterface) {
-      $this->ensureLinkedStoreForVendorUser($user);
+    if (!$user instanceof UserInterface) {
+      return;
     }
+
+    if (!in_array('vendor', $user->getRoles(), TRUE)) {
+      return;
+    }
+
+    if (!$user->hasField('field_vendor_store')) {
+      return;
+    }
+
+    if (!$user->get('field_vendor_store')->isEmpty()) {
+      return;
+    }
+
+    $this->ensureLinkedStoreForVendorUser($user);
   }
 
   /**
@@ -288,6 +296,11 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
           'organization' => $vendor->getName(),
         ],
         'billing_countries' => ['AU'],
+        // Commerce Tax: Australian GST only applies when the store is registered
+        // to collect tax in AU (see LocalTaxTypeBase::matchesRegistrations()).
+        'tax_registrations' => ['AU'],
+        // Align with Australian GST config (display inclusive) and ticket face prices.
+        'prices_include_tax' => TRUE,
         'is_default' => FALSE,
         'status' => TRUE,
       ]);

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
@@ -11,7 +11,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
+use Drupal\user\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -42,6 +44,11 @@ class VendorProfileSettingsForm extends FormBase {
   protected ?CurrentVendorResolverInterface $vendorResolver = NULL;
 
   /**
+   * Ensures the vendor-linked Commerce store exists and stays in sync.
+   */
+  protected VendorStoreSubscriber $vendorStoreSubscriber;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
@@ -50,6 +57,7 @@ class VendorProfileSettingsForm extends FormBase {
     $instance->currentUser = $container->get('current_user');
     $instance->onboardingManager = $container->get('myeventlane_onboarding.manager');
     $instance->vendorResolver = $container->get('myeventlane_vendor.current_vendor_resolver');
+    $instance->vendorStoreSubscriber = $container->get('myeventlane_vendor.vendor_store_subscriber');
     $instance->setRequestStack($container->get('request_stack'));
     return $instance;
   }
@@ -164,8 +172,6 @@ class VendorProfileSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ?Vendor $vendor = NULL): array {
-    \Drupal::logger('mel_debug')->notice('FORM BUILD RUNNING');
-
     // Try to get vendor from form state first (for rebuilds).
     if (!$vendor) {
       $vendor = $form_state->get('vendor');
@@ -927,7 +933,7 @@ class VendorProfileSettingsForm extends FormBase {
 
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Save Settings'),
+      '#value' => $this->t('Save'),
       '#button_type' => 'primary',
     ];
 
@@ -1077,8 +1083,6 @@ class VendorProfileSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
-    \Drupal::logger('mel_debug')->notice('VALIDATE PHASE START');
-
     parent::validateForm($form, $form_state);
 
     // Validate website URL if provided.
@@ -1086,72 +1090,68 @@ class VendorProfileSettingsForm extends FormBase {
     if (!empty($website) && !filter_var($website, FILTER_VALIDATE_URL)) {
       $form_state->setError($form['contact']['website'], $this->t('Please enter a valid website URL.'));
     }
-
-    $errors = $form_state->getErrors();
-    if ($errors !== []) {
-      \Drupal::logger('mel_debug')->notice('VALIDATE HAS ERRORS: @keys', [
-        '@keys' => implode(', ', array_keys($errors)),
-      ]);
-    }
-    else {
-      \Drupal::logger('mel_debug')->notice('VALIDATE PHASE END — no errors');
-    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    \Drupal::logger('mel_debug')->notice('FORM SUBMIT RUNNING');
-
-    // Original debug keys (likely empty — real keys are under payment.business.*).
-    $abn = $form_state->getValue('field_abn');
-    $name = $form_state->getValue('field_business_name');
-
-    \Drupal::logger('mel_debug')->notice('ABN (root keys): ' . $abn);
-    \Drupal::logger('mel_debug')->notice('NAME (root keys): ' . $name);
-
-    $abn_nested = $form_state->getValue(['payment', 'business', 'abn']);
-    $name_nested = $form_state->getValue(['payment', 'business', 'business_name']);
-    \Drupal::logger('mel_debug')->notice('ABN nested payment.business.abn: ' . $abn_nested);
-    \Drupal::logger('mel_debug')->notice('NAME nested payment.business.business_name: ' . $name_nested);
-
-    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-    if ($user instanceof \Drupal\user\UserInterface
-      && $user->hasField('field_abn')
-      && $user->hasField('field_business_name')) {
-      $user->set('field_abn', $abn_nested ?? $abn);
-      $user->set('field_business_name', $name_nested ?? $name);
-      $user->save();
-      \Drupal::logger('mel_debug')->notice('USER SAVED');
-    }
-    else {
-      \Drupal::logger('mel_debug')->notice('USER SKIP — user entity has no field_abn / field_business_name');
-    }
-
-    $abn_for_store = $abn_nested ?? $abn;
-    $name_for_store = $name_nested ?? $name;
-
-    $store = \Drupal::entityTypeManager()
-      ->getStorage('commerce_store')
-      ->load(2); // TEMP — use known store ID
-
-    if ($store) {
-      if ($store->hasField('field_abn')) {
-        $store->set('field_abn', $abn_for_store);
-      }
-      $store->setName($name_for_store ?: 'Fallback Store Name');
-      $store->save();
-
-      \Drupal::logger('mel_debug')->notice('STORE SAVED');
-    }
-
     $vendor = $this->loadVendorFromFormState($form_state);
 
     if (!$vendor) {
       $this->messenger()->addError($this->t('Vendor not found. Unable to save settings. Please refresh the page and try again.'));
       $form_state->setRebuild();
       return;
+    }
+
+    // Nested keys are canonical; root keys may be unset on rebuilds.
+    $abn_nested = $form_state->getValue(['payment', 'business', 'abn']);
+    $name_nested = $form_state->getValue(['payment', 'business', 'business_name']);
+    $abn_root = $form_state->getValue('field_abn');
+    $name_root = $form_state->getValue('field_business_name');
+
+    $abn_raw = $abn_nested ?? $abn_root;
+    $name_raw = $name_nested ?? $name_root;
+    $abn_for_sync = trim((string) ($abn_raw ?? ''));
+    $abn_for_sync = $abn_for_sync !== '' ? (string) preg_replace('/\s+/', '', $abn_for_sync) : '';
+    $name_for_sync = trim((string) ($name_raw ?? ''));
+
+    $uid = (int) $this->getCurrentUser()->id();
+    if ($uid > 0) {
+      $user = User::load($uid);
+      if ($user instanceof \Drupal\user\UserInterface
+        && $user->hasField('field_abn')
+        && $user->hasField('field_business_name')) {
+        $user->set('field_abn', $abn_for_sync !== '' ? $abn_for_sync : NULL);
+        $user->set('field_business_name', $name_for_sync !== '' ? $name_for_sync : NULL);
+        try {
+          $user->save();
+        }
+        catch (\Throwable $e) {
+          \Drupal::logger('myeventlane_vendor')->error(
+            'Vendor settings: could not sync user business fields: @message',
+            ['@message' => $e->getMessage()]
+          );
+        }
+      }
+    }
+
+    $store = $this->vendorStoreSubscriber->ensureStoreForVendor($vendor);
+    if ($store !== NULL) {
+      if ($store->hasField('field_abn')) {
+        $store->set('field_abn', $abn_for_sync !== '' ? $abn_for_sync : NULL);
+      }
+      $store_label = $name_for_sync !== '' ? $name_for_sync : (string) $vendor->getName();
+      $store->setName($store_label);
+      try {
+        $store->save();
+      }
+      catch (\Throwable $e) {
+        \Drupal::logger('myeventlane_vendor')->error(
+          'Vendor settings: could not sync Commerce store: @message',
+          ['@message' => $e->getMessage()]
+        );
+      }
     }
 
     // Save profile information.

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
@@ -164,6 +164,8 @@ class VendorProfileSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ?Vendor $vendor = NULL): array {
+    \Drupal::logger('mel_debug')->notice('FORM BUILD RUNNING');
+
     // Try to get vendor from form state first (for rebuilds).
     if (!$vendor) {
       $vendor = $form_state->get('vendor');
@@ -1075,6 +1077,8 @@ class VendorProfileSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
+    \Drupal::logger('mel_debug')->notice('VALIDATE PHASE START');
+
     parent::validateForm($form, $form_state);
 
     // Validate website URL if provided.
@@ -1082,12 +1086,66 @@ class VendorProfileSettingsForm extends FormBase {
     if (!empty($website) && !filter_var($website, FILTER_VALIDATE_URL)) {
       $form_state->setError($form['contact']['website'], $this->t('Please enter a valid website URL.'));
     }
+
+    $errors = $form_state->getErrors();
+    if ($errors !== []) {
+      \Drupal::logger('mel_debug')->notice('VALIDATE HAS ERRORS: @keys', [
+        '@keys' => implode(', ', array_keys($errors)),
+      ]);
+    }
+    else {
+      \Drupal::logger('mel_debug')->notice('VALIDATE PHASE END — no errors');
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
+    \Drupal::logger('mel_debug')->notice('FORM SUBMIT RUNNING');
+
+    // Original debug keys (likely empty — real keys are under payment.business.*).
+    $abn = $form_state->getValue('field_abn');
+    $name = $form_state->getValue('field_business_name');
+
+    \Drupal::logger('mel_debug')->notice('ABN (root keys): ' . $abn);
+    \Drupal::logger('mel_debug')->notice('NAME (root keys): ' . $name);
+
+    $abn_nested = $form_state->getValue(['payment', 'business', 'abn']);
+    $name_nested = $form_state->getValue(['payment', 'business', 'business_name']);
+    \Drupal::logger('mel_debug')->notice('ABN nested payment.business.abn: ' . $abn_nested);
+    \Drupal::logger('mel_debug')->notice('NAME nested payment.business.business_name: ' . $name_nested);
+
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    if ($user instanceof \Drupal\user\UserInterface
+      && $user->hasField('field_abn')
+      && $user->hasField('field_business_name')) {
+      $user->set('field_abn', $abn_nested ?? $abn);
+      $user->set('field_business_name', $name_nested ?? $name);
+      $user->save();
+      \Drupal::logger('mel_debug')->notice('USER SAVED');
+    }
+    else {
+      \Drupal::logger('mel_debug')->notice('USER SKIP — user entity has no field_abn / field_business_name');
+    }
+
+    $abn_for_store = $abn_nested ?? $abn;
+    $name_for_store = $name_nested ?? $name;
+
+    $store = \Drupal::entityTypeManager()
+      ->getStorage('commerce_store')
+      ->load(2); // TEMP — use known store ID
+
+    if ($store) {
+      if ($store->hasField('field_abn')) {
+        $store->set('field_abn', $abn_for_store);
+      }
+      $store->setName($name_for_store ?: 'Fallback Store Name');
+      $store->save();
+
+      \Drupal::logger('mel_debug')->notice('STORE SAVED');
+    }
+
     $vendor = $this->loadVendorFromFormState($form_state);
 
     if (!$vendor) {

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
@@ -13,7 +13,6 @@ use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Comprehensive vendor profile settings form.
@@ -43,11 +42,6 @@ class VendorProfileSettingsForm extends FormBase {
   protected ?CurrentVendorResolverInterface $vendorResolver = NULL;
 
   /**
-   * The request stack.
-   */
-  protected RequestStack $requestStack;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
@@ -56,7 +50,7 @@ class VendorProfileSettingsForm extends FormBase {
     $instance->currentUser = $container->get('current_user');
     $instance->onboardingManager = $container->get('myeventlane_onboarding.manager');
     $instance->vendorResolver = $container->get('myeventlane_vendor.current_vendor_resolver');
-    $instance->requestStack = $container->get('request_stack');
+    $instance->setRequestStack($container->get('request_stack'));
     return $instance;
   }
 
@@ -290,7 +284,7 @@ class VendorProfileSettingsForm extends FormBase {
     }
 
     // Pin POST to this URI so Form API does not emit /vendor/form_action_* (404 on vendor host).
-    $request = $this->requestStack->getCurrentRequest();
+    $request = $this->getRequest();
     $form['#action'] = $request
       ? $request->getRequestUri()
       : Url::fromRoute('myeventlane_vendor.console.settings')->toString();

--- a/web/themes/custom/myeventlane_vendor_theme/templates/form/form.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/form/form.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Theme override for a 'form' element.
+ *
+ * Ensures Form API attributes (method, action, form_build_id, etc.) render on the form element.
+ */
+#}
+<form{{ attributes }}>
+  {{ children }}
+</form>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches vendor/store creation and sync logic plus mass update hooks that modify user and store entities (including tax settings), so misconfiguration could affect vendor linkage or tax behavior across existing stores.
> 
> **Overview**
> Adds a new `user.field_vendor_store` entity reference to `commerce_store`, registers it (hidden) on the user form display, and includes an update hook (`myeventlane_vendor_update_10020`) to install the field and backfill existing vendor-role accounts.
> 
> Extends `VendorStoreSubscriber` to keep the user’s store reference synchronized with the vendor profile store, ensure linkage on login and on main requests when missing, and sets new vendor stores to `tax_registrations: ['AU']` with `prices_include_tax = TRUE`.
> 
> Adds `myeventlane_vendor_update_10021` to backfill AU stores missing tax registrations, simplifies `VendorSettingsController` form rendering, updates `VendorProfileSettingsForm` to sync ABN/business name to the current user and vendor store on submit, and adds a `form.html.twig` override to ensure Form API attributes render on vendor theme forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ce1cc8b7502bddb773e6a8dbda89b73ef254a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->