### PR TITLE
fix(messaging): conditional GST note, templates sync, invoice subscri…

### DIFF
--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -145,35 +145,13 @@ body_html: |
 
       {% if not (vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0) %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        {% if order_subtotal_formatted %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
-          </div>
-        {% endif %}
-        {% for row in order_tax_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% for row in order_fee_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% if order_platform_fee_absorbed %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
-            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
-          </div>
-        {% endif %}
-        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
+        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+        {% endif %}
       </div>
       {% endif %}
 

--- a/config/sync/myeventlane_messaging.template.order_receipt.yml
+++ b/config/sync/myeventlane_messaging.template.order_receipt.yml
@@ -135,35 +135,13 @@ body_html: |
         </div>
       {% else %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        {% if order_subtotal_formatted %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
-          </div>
-        {% endif %}
-        {% for row in order_tax_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% for row in order_fee_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% if order_platform_fee_absorbed %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
-            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
-          </div>
-        {% endif %}
-        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total Paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
+        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Controller/OrderTaxInvoicePdfController.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Controller/OrderTaxInvoicePdfController.php
@@ -86,8 +86,10 @@ final class OrderTaxInvoicePdfController extends ControllerBase {
     $dompdf->setPaper('A4', 'portrait');
     $dompdf->render();
 
-    $safe_number = preg_replace('/[^a-zA-Z0-9_-]/', '-', $commerce_order->getOrderNumber());
-    $filename = 'tax-invoice-' . ($safe_number !== '' ? $safe_number : (string) $commerce_order->id()) . '.pdf';
+    $order_number_raw = $commerce_order->getOrderNumber();
+    $sanitized = preg_replace('/[^a-zA-Z0-9_-]/', '-', (string) ($order_number_raw ?? ''));
+    $safe_slug = (is_string($sanitized) && $sanitized !== '') ? $sanitized : (string) $commerce_order->id();
+    $filename = 'tax-invoice-' . $safe_slug . '.pdf';
 
     return new Response($dompdf->output(), 200, [
       'Content-Type' => 'application/pdf',

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -149,6 +149,9 @@ body_html: |
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
+        {% if show_includes_gst_note|default(false) %}
+        <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
@@ -135,35 +135,13 @@ body_html: |
         </div>
       {% else %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        {% if order_subtotal_formatted %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
-          </div>
-        {% endif %}
-        {% for row in order_tax_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% for row in order_fee_rows %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
-            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
-          </div>
-        {% endfor %}
-        {% if order_platform_fee_absorbed %}
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
-            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
-          </div>
-        {% endif %}
-        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total Paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
+        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.info.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.info.yml
@@ -6,7 +6,6 @@ core_version_requirement: ^11
 lifecycle: stable
 
 dependencies:
-  - myeventlane_checkout_flow:myeventlane_checkout_flow
   - myeventlane_core:myeventlane_core
   - myeventlane_event:myeventlane_event
   - myeventlane_event_attendees:myeventlane_event_attendees

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -153,6 +153,7 @@ services:
       $dateFormatter: '@date.formatter'
       $time: '@datetime.time'
       $entityTypeManager: '@entity_type.manager'
+      $orderPricingBreakdown: '@myeventlane_checkout_flow.order_pricing_breakdown'
       $taxInvoicePresentation: '@myeventlane_checkout_flow.tax_invoice_presentation'
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/myeventlane_messaging/src/Controller/TemplatePreviewController.php
+++ b/web/modules/custom/myeventlane_messaging/src/Controller/TemplatePreviewController.php
@@ -200,6 +200,7 @@ final class TemplatePreviewController extends ControllerBase {
         'tax_lines' => [
           ['label' => 'GST', 'amount' => '$9.00'],
         ],
+        'show_includes_gst_note' => TRUE,
       ],
       'order_invoice' => [
         'invoice_date' => 'April 9, 2026',

--- a/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
+++ b/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
@@ -10,6 +10,7 @@ use Drupal\commerce_order\Event\OrderEvents;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder;
 use Drupal\myeventlane_checkout_flow\Service\TaxInvoicePresentationBuilder;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
 use Drupal\node\NodeInterface;
@@ -30,6 +31,7 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
     private readonly DateFormatterInterface $dateFormatter,
     private readonly TimeInterface $time,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OrderPricingBreakdownBuilder $orderPricingBreakdown,
     private readonly TaxInvoicePresentationBuilder $taxInvoicePresentation,
   ) {}
 
@@ -120,20 +122,13 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
     $events = $this->extractEventNodes($order);
     $primaryEventId = !empty($events) ? (int) reset($events)->id() : NULL;
 
+    $breakdown = $this->orderPricingBreakdown->build($order);
     $invoice = $this->taxInvoicePresentation->build($order);
 
     $placed = $order->getPlacedTime();
     $invoice_timestamp = $placed ?: $this->time->getRequestTime();
 
-    $line_items = [];
-    foreach ($invoice['invoice_lines'] as $row) {
-      $line_items[] = [
-        'title' => $row['title'],
-        'quantity' => $row['quantity'],
-        'unit_price' => $row['unit_price'],
-        'line_total' => $row['line_total'],
-      ];
-    }
+    $line_items = $invoice['invoice_lines'];
 
     $context = [
       'first_name' => $first_name,
@@ -153,6 +148,7 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
       'invoice_fee_lines' => $invoice['fee_lines'],
       'tax_lines' => $invoice['tax_lines'],
       'invoice_tax_lines' => $invoice['tax_lines'],
+      'show_includes_gst_note' => $breakdown['show_includes_gst_note'],
       'events' => $this->formatEventsBrief($events),
       'event_name' => !empty($events) ? reset($events)->label() : 'your event',
     ];

--- a/web/modules/custom/myeventlane_messaging/src/Form/TemplateTestForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/TemplateTestForm.php
@@ -201,6 +201,7 @@ final class TemplateTestForm extends FormBase {
         'tax_lines' => [
           ['label' => 'GST', 'amount' => '$9.00'],
         ],
+        'show_includes_gst_note' => TRUE,
       ],
       'order_invoice' => [
         'invoice_date' => 'April 9, 2026',

--- a/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
@@ -83,15 +83,6 @@ final class OrderConfirmationQueueBuilder {
 
     $breakdown = $this->orderPricingBreakdown->build($order);
     $invoice = $this->taxInvoicePresentation->build($order);
-    $invoice_lines = [];
-    foreach ($invoice['invoice_lines'] as $row) {
-      $invoice_lines[] = [
-        'title' => $row['title'],
-        'quantity' => $row['quantity'],
-        'unit_price' => $row['unit_price'],
-        'line_total' => $row['line_total'],
-      ];
-    }
 
     $context = [
       'first_name' => $first_name,
@@ -109,11 +100,12 @@ final class OrderConfirmationQueueBuilder {
       'order_tax_rows' => $breakdown['tax_rows'],
       'order_fee_rows' => $breakdown['fee_rows'],
       'order_platform_fee_absorbed' => $breakdown['platform_fee_absorbed'],
+      'show_includes_gst_note' => $breakdown['show_includes_gst_note'],
       'vendor_name' => $invoice['vendor_name'],
       'vendor_abn' => $invoice['vendor_abn'],
       'order_total_gst' => $invoice['order_total_gst'],
       'order_total' => $invoice['order_total'],
-      'invoice_lines' => $invoice_lines,
+      'invoice_lines' => $invoice['invoice_lines'],
       'invoice_tax_lines' => $invoice['tax_lines'],
       'invoice_fee_lines' => $invoice['fee_lines'],
       'tax_lines' => $invoice['tax_lines'],


### PR DESCRIPTION
…bers

- Pass show_includes_gst_note from OrderPricingBreakdownBuilder into order confirmation and paid invoice email contexts; templates show the GST disclaimer only when the flag is true (Twig default false for legacy sends).
- Align order_confirmation and order_receipt fallback blocks in config/sync and module install YAML with simplified total-only layout (fixes stale variables vs OrderConfirmationQueueBuilder).
- Remove duplicate myeventlane_checkout_flow dependency from messaging info.yml.
- OrderPaidInvoiceSubscriber: inject OrderPricingBreakdownBuilder for GST flag; use invoice invoice_lines directly instead of redundant copy loop.
- OrderConfirmationQueueBuilder: use TaxInvoicePresentation invoice_lines as-is.
- OrderTaxInvoicePdfController: coerce nullable order number before preg_replace and avoid empty PDF filename slug when order number is absent.
- Template preview/test sample context: include show_includes_gst_note for QA.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect customer-facing transactional email rendering and invoice PDF download headers; mistakes could cause incorrect pricing disclosure or malformed filenames, but logic changes are small and mostly additive/defensive.
> 
> **Overview**
> Order confirmation/receipt templates (both `config/sync` and module install configs) now simplify the non-invoice fallback block to *total-only* and render the “All prices include GST…” disclaimer only when `show_includes_gst_note` is true (defaults to false for legacy contexts).
> 
> `OrderConfirmationQueueBuilder` and `OrderPaidInvoiceSubscriber` now pass `show_includes_gst_note` from `OrderPricingBreakdownBuilder` into email contexts and stop re-mapping `invoice_lines` (use `TaxInvoicePresentationBuilder` output directly). The messaging module also removes a duplicate `myeventlane_checkout_flow` dependency, and `OrderTaxInvoicePdfController` now safely handles nullable/empty order numbers when building the PDF download filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a50625924d151728b6f29d2a69dbd909b3309b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->