### PR TITLE
fix(messaging): align order_confirmation non-invoice pricing with que…

### DIFF
--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -145,7 +145,31 @@ body_html: |
 
       {% if not (vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0) %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        <div style="display: flex; justify-content: space-between; align-items: center;">
+        {% if order_subtotal_formatted %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
+          </div>
+        {% endif %}
+        {% for row in order_tax_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% for row in order_fee_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% if order_platform_fee_absorbed %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
+            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
+          </div>
+        {% endif %}
+        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -145,7 +145,31 @@ body_html: |
 
       {% if not (vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0) %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        <div style="display: flex; justify-content: space-between; align-items: center;">
+        {% if order_subtotal_formatted %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
+          </div>
+        {% endif %}
+        {% for row in order_tax_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% for row in order_fee_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% if order_platform_fee_absorbed %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
+            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
+          </div>
+        {% endif %}
+        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>


### PR DESCRIPTION
…ue context

Bugbot reported config/install and config/sync drift for the simplified Total path (no tax invoice block). OrderConfirmationQueueBuilder already supplies order_subtotal_formatted, order_tax_rows, order_fee_rows, and order_platform_fee_absorbed; the templates now render that breakdown before Total paid and keep the GST disclaimer gated by show_includes_gst_note.

Keeps install defaults identical to exported sync so fresh module installs match production template behavior.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only changes affecting email rendering; no backend logic, auth, or data mutations are modified.
> 
> **Overview**
> Aligns the `order_confirmation` email’s *non-invoice* pricing block with the queue context by rendering `Subtotal`, iterating through `order_tax_rows` and `order_fee_rows`, and showing an “Organiser absorbs” platform-fee row before `Total paid`.
> 
> Applies the same template change to both `config/sync` and module `config/install` to eliminate drift and ensure fresh installs match exported/production behavior; the GST disclaimer remains gated by `show_includes_gst_note`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a5f45e2f028491ffb183be7887793b4ad5e905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->