### PR TITLE
Fix/bugbot vendor console messaging gst

### DIFF
--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -145,7 +145,31 @@ body_html: |
 
       {% if not (vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0) %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        <div style="display: flex; justify-content: space-between; align-items: center;">
+        {% if order_subtotal_formatted %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
+          </div>
+        {% endif %}
+        {% for row in order_tax_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% for row in order_fee_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% if order_platform_fee_absorbed %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
+            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
+          </div>
+        {% endif %}
+        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>

--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -140,6 +140,9 @@ body_html: |
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
           <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if show_includes_gst_note|default(false) %}
+          <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+          {% endif %}
         </div>
       {% endif %}
 
@@ -173,9 +176,7 @@ body_html: |
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
-        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
-        {% endif %}
       </div>
       {% endif %}
 

--- a/config/sync/myeventlane_messaging.template.order_receipt.yml
+++ b/config/sync/myeventlane_messaging.template.order_receipt.yml
@@ -132,6 +132,9 @@ body_html: |
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
           <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if show_includes_gst_note|default(false) %}
+          <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+          {% endif %}
         </div>
       {% else %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
@@ -139,9 +142,7 @@ body_html: |
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total Paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
-        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
-        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -145,7 +145,31 @@ body_html: |
 
       {% if not (vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0) %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
-        <div style="display: flex; justify-content: space-between; align-items: center;">
+        {% if order_subtotal_formatted %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Subtotal</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ order_subtotal_formatted }}</span>
+          </div>
+        {% endif %}
+        {% for row in order_tax_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% for row in order_fee_rows %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">{{ row.label }}</span>
+            <span style="color: #2c3e50; font-size: 15px;">{{ row.amount_formatted }}</span>
+          </div>
+        {% endfor %}
+        {% if order_platform_fee_absorbed %}
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <span style="color: #34495e; font-size: 15px;">Platform fee</span>
+            <span style="color: #2c3e50; font-size: 15px;">Organiser absorbs</span>
+          </div>
+        {% endif %}
+        <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 8px; border-top: 1px solid #e0e0e0;">
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -140,6 +140,9 @@ body_html: |
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
           <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if show_includes_gst_note|default(false) %}
+          <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+          {% endif %}
         </div>
       {% endif %}
 
@@ -173,9 +176,7 @@ body_html: |
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
-        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
-        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
@@ -132,6 +132,9 @@ body_html: |
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
           <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if show_includes_gst_note|default(false) %}
+          <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
+          {% endif %}
         </div>
       {% else %}
       <div style="margin: 30px 0; padding: 20px; background-color: #f9f9f9; border-radius: 6px;">
@@ -139,9 +142,7 @@ body_html: |
           <span style="font-weight: 600; color: #2c3e50; font-size: 18px;">Total Paid</span>
           <span style="font-weight: 700; color: #2c3e50; font-size: 20px;">{{ total_paid }}</span>
         </div>
-        {% if show_includes_gst_note|default(false) %}
         <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
-        {% endif %}
       </div>
       {% endif %}
 

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -153,7 +153,6 @@ services:
       $dateFormatter: '@date.formatter'
       $time: '@datetime.time'
       $entityTypeManager: '@entity_type.manager'
-      $orderPricingBreakdown: '@myeventlane_checkout_flow.order_pricing_breakdown'
       $taxInvoicePresentation: '@myeventlane_checkout_flow.tax_invoice_presentation'
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
+++ b/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
@@ -10,7 +10,6 @@ use Drupal\commerce_order\Event\OrderEvents;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder;
 use Drupal\myeventlane_checkout_flow\Service\TaxInvoicePresentationBuilder;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
 use Drupal\node\NodeInterface;
@@ -31,7 +30,6 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
     private readonly DateFormatterInterface $dateFormatter,
     private readonly TimeInterface $time,
     private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly OrderPricingBreakdownBuilder $orderPricingBreakdown,
     private readonly TaxInvoicePresentationBuilder $taxInvoicePresentation,
   ) {}
 
@@ -122,7 +120,6 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
     $events = $this->extractEventNodes($order);
     $primaryEventId = !empty($events) ? (int) reset($events)->id() : NULL;
 
-    $breakdown = $this->orderPricingBreakdown->build($order);
     $invoice = $this->taxInvoicePresentation->build($order);
 
     $placed = $order->getPlacedTime();
@@ -148,7 +145,6 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
       'invoice_fee_lines' => $invoice['fee_lines'],
       'tax_lines' => $invoice['tax_lines'],
       'invoice_tax_lines' => $invoice['tax_lines'],
-      'show_includes_gst_note' => $breakdown['show_includes_gst_note'],
       'events' => $this->formatEventsBrief($events),
       'event_name' => !empty($events) ? reset($events)->label() : 'your event',
     ];

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
@@ -119,10 +119,30 @@ final class VendorSettingsController extends VendorConsoleBaseController {
       ]);
     }
 
-    return $this->formBuilder->getForm(
+    $form = $this->formBuilder->getForm(
       \Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm::class,
       $vendor
     );
+
+    // Same tab navigation as VendorDashboardMessagingBrandController.
+    $tabs = [
+      [
+        'label' => $this->t('Profile'),
+        'url' => Url::fromRoute('myeventlane_vendor.console.settings')->toString(),
+        'active' => TRUE,
+      ],
+      [
+        'label' => $this->t('Messaging Brand'),
+        'url' => Url::fromRoute('myeventlane_vendor.console.messaging_brand')->toString(),
+        'active' => FALSE,
+      ],
+    ];
+
+    return $this->buildVendorPage('myeventlane_vendor_console_page', [
+      'title' => $this->t('Settings'),
+      'tabs' => $tabs,
+      'body' => $form,
+    ]);
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -169,12 +169,12 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $user = $this->entityTypeManager->getStorage('user')->load($uid);
-    if (!$user instanceof UserInterface) {
+    if (!in_array('vendor', $this->currentUser->getRoles(), TRUE)) {
       return;
     }
 
-    if (!in_array('vendor', $user->getRoles(), TRUE)) {
+    $user = $this->entityTypeManager->getStorage('user')->load($uid);
+    if (!$user instanceof UserInterface) {
       return;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly template/UX changes plus small service wiring and role-check refactor; main risk is unintended email rendering differences if expected template variables are missing.
> 
> **Overview**
> Adjusts `order_confirmation`/`order_receipt` email templates to better surface pricing details: adds a subtotal/tax/fee breakdown (including platform-fee-absorbed messaging) for non-invoice orders and ensures the "includes GST" note is displayed consistently (and conditionally in the tax-invoice block).
> 
> Simplifies invoice email queuing by removing the `order_pricing_breakdown` dependency from `OrderPaidInvoiceSubscriber` and dropping `show_includes_gst_note` from the invoice template context.
> 
> Updates the vendor console settings page to use the standard tabbed navigation (Profile/Messaging Brand), and tightens `VendorStoreSubscriber` to short-circuit earlier for non-vendor users by checking roles on the current account before loading the user entity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c2a746c2a46dd66846904befaec4e5dc59f6f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->