### PR TITLE
Cursor/form debug c78cb

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorSettingsController.php
@@ -8,7 +8,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -124,25 +123,9 @@ final class VendorSettingsController extends VendorConsoleBaseController {
       $vendor
     );
 
-    // Same tab navigation as VendorDashboardMessagingBrandController.
-    $tabs = [
-      [
-        'label' => $this->t('Profile'),
-        'url' => Url::fromRoute('myeventlane_vendor.console.settings')->toString(),
-        'active' => TRUE,
-      ],
-      [
-        'label' => $this->t('Messaging Brand'),
-        'url' => Url::fromRoute('myeventlane_vendor.console.messaging_brand')->toString(),
-        'active' => FALSE,
-      ],
-    ];
+    \Drupal::logger('mel_debug')->notice('FORM CLASS: ' . \Drupal\myeventlane_vendor\Form\VendorProfileSettingsForm::class);
 
-    return $this->buildVendorPage('myeventlane_vendor_console_page', [
-      'title' => $this->t('Settings'),
-      'tabs' => $tabs,
-      'body' => $form,
-    ]);
+    return $form;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorProfileSettingsForm.php
@@ -214,6 +214,8 @@ class VendorProfileSettingsForm extends FormBase {
     $form_state->set('vendor', $vendor);
     $form_state->set('vendor_id', $vendor->id());
 
+    \Drupal::logger('mel_debug')->notice('FORM BUILD RUNNING');
+
     // Store vendor ID in form for rebuilds and POST submissions.
     $form['vendor_id'] = [
       '#type' => 'value',
@@ -1096,6 +1098,8 @@ class VendorProfileSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
+    \Drupal::logger('mel_debug')->notice('FORM SUBMIT RUNNING');
+
     $vendor = $this->loadVendorFromFormState($form_state);
 
     if (!$vendor) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the rendered output of the vendor settings route (removing page wrapper/tabs), which may affect navigation and theming; logging-only additions are otherwise low risk.
> 
> **Overview**
> The vendor settings controller no longer builds the console page wrapper (including the Profile/Messaging Brand tab navigation) and now returns `VendorProfileSettingsForm` directly.
> 
> Adds temporary debug logging (`mel_debug`) in the settings controller and in `VendorProfileSettingsForm` during `buildForm` and `submitForm` to confirm the form lifecycle is running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512c2c9d33941e6c203fff67a2f696942679b6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->