### PR TITLE
Cursor/2026 04 30 6g8i f0ae4

### DIFF
--- a/mel-routes.json
+++ b/mel-routes.json
@@ -1676,7 +1676,7 @@
     },
     "myeventlane_vendor.console.settings": {
         "path": "\/vendor\/settings",
-        "controller": "\\Drupal\\myeventlane_vendor_settings\\Form\\VendorSettingsForm",
+        "controller": null,
         "title": "Vendor settings"
     },
     "myeventlane_vendor.console.studio": {

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
@@ -16,9 +16,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
  *
  * Used for cart, checkout sidebar, confirmation, and email context. Does not
  * hardcode tax amounts; reads adjustments and Australian GST config.
- *
- * Order confirmation emails use buildForOrderConfirmationEmail() when only the
- * formatted total and GST note flag are required (no line-item breakdown).
  */
 final class OrderPricingBreakdownBuilder {
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
@@ -81,7 +81,7 @@ final class OrderConfirmationQueueBuilder {
       }
     }
 
-    $pricing = $this->orderPricingBreakdown->buildForOrderConfirmationEmail($order);
+    $pricing = $this->orderPricingBreakdown->build($order);
     $invoice = $this->taxInvoicePresentation->build($order);
 
     $context = [
@@ -93,6 +93,10 @@ final class OrderConfirmationQueueBuilder {
       'events' => $this->formatEventsForEmail($events),
       'ticket_items' => $this->formatTicketItemsForEmail($ticket_items),
       'donation_total' => $donation_total > 0 ? $this->formatPrice($donation_total) : NULL,
+      'order_subtotal_formatted' => $pricing['subtotal_formatted'],
+      'order_tax_rows' => $pricing['tax_rows'],
+      'order_fee_rows' => $pricing['fee_rows'],
+      'order_platform_fee_absorbed' => $pricing['platform_fee_absorbed'],
       'total_paid' => $pricing['total_formatted'] !== ''
         ? $pricing['total_formatted']
         : $this->formatPrice((float) $order->getTotalPrice()->getNumber()),

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorForm.php
@@ -25,8 +25,6 @@ class VendorForm extends ContentEntityForm {
    */
   protected VendorStoreSubscriber $vendorStoreSubscriber;
 
-  protected LoggerInterface $melDebugLogger;
-
   protected LoggerInterface $vendorLogger;
 
   /**
@@ -36,7 +34,6 @@ class VendorForm extends ContentEntityForm {
     /** @var static $instance */
     $instance = parent::create($container);
     $instance->vendorStoreSubscriber = $container->get('myeventlane_vendor.vendor_store_subscriber');
-    $instance->melDebugLogger = $container->get('logger.channel.mel_debug');
     $instance->vendorLogger = $container->get('logger.channel.myeventlane_vendor');
     $instance->setRequestStack($container->get('request_stack'));
     return $instance;
@@ -47,22 +44,6 @@ class VendorForm extends ContentEntityForm {
    */
   public function getFormId(): string {
     return 'organiser_profile_settings';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function buildForm(array $form, FormStateInterface $form_state): array {
-    $this->melDebugLogger->notice('ORGANISER FORM BUILD');
-    return parent::buildForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitForm(array &$form, FormStateInterface $form_state): void {
-    parent::submitForm($form, $form_state);
-    $this->melDebugLogger->notice('ORGANISER FORM SUBMIT');
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorSettingsForm.php
@@ -45,16 +45,7 @@ class VendorSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    \Drupal::logger('myeventlane_vendor')->notice('VALIDATE HIT');
-    parent::validateForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    \Drupal::logger('myeventlane_vendor')->notice('SUBMIT HIT');
     $this->configFactory->getEditable('myeventlane_vendor.settings')
       ->set('directory_title', $form_state->getValue('directory_title'))
       ->save();

--- a/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
@@ -308,6 +308,8 @@ class VendorSettingsForm extends FormBase {
     // Fallback when action still resolves to /vendor/form_action_* (pre_render strips /vendor/).
     $form['#pre_render'][] = [FormActionUrlFixer::class, 'fixFormActionUrl'];
 
+    $form['#attributes']['class'][] = 'mel-form';
+    $form['#attributes']['class'][] = 'mel-form--vendor-settings';
     $form['#attributes']['class'][] = 'vendor-settings-form';
     $form['#attributes']['class'][] = 'mel-settings-form';
     $form['#attributes']['class'][] = 'mel-protected-form';
@@ -319,16 +321,67 @@ class VendorSettingsForm extends FormBase {
     $form['#attached']['library'][] = 'myeventlane_vendor_theme/global-styling';
     $form['#attached']['library'][] = 'myeventlane_vendor_settings/settings_form';
 
-    // Profile Information Section.
-    $form['profile'] = [
-      '#type' => 'container',
-      '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
-    ];
-    $form['profile']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Profile Information') . '</h2>',
-      '#weight' => -10,
+    $this->buildProfileSection($form, $form_state, $vendor);
+    $this->buildVisualAssetsSection($form, $form_state, $vendor);
+    $this->buildContactSection($form, $form_state, $vendor);
+    $this->buildPublicSettingsSection($form, $form_state, $vendor);
+    $this->buildVenuesSection($form, $form_state, $vendor);
+    $this->buildCommerceSection($form, $form_state, $vendor);
+    $this->buildTeamSection($form, $form_state, $vendor);
+    $this->buildPreferencesSection($form, $form_state, $vendor);
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#weight' => 100,
+      '#attributes' => ['class' => ['mel-form__actions']],
     ];
 
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save changes'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+    ];
+
+    // Post-build #attached log (identifies AJAX library injectors; empty at buildForm() entry).
+    $this->logger->debug('MEL FORM ATTACHED: <pre>@data</pre>', [
+      '@data' => print_r($form['#attached'] ?? [], TRUE),
+    ]);
+
+    // Remove AJAX-related libraries ONLY.
+    if (!empty($form['#attached']['library'])) {
+      $form['#attached']['library'] = array_values(array_filter(
+        $form['#attached']['library'],
+        function ($lib) {
+          return !in_array($lib, [
+            'core/drupal.ajax',
+            'core/drupal.dialog.ajax',
+            'core/drupal.progress',
+          ], TRUE);
+        }
+      ));
+    }
+
+    if (isset($form['#attached']['drupalSettings']['ajax'])) {
+      unset($form['#attached']['drupalSettings']['ajax']);
+    }
+
+    $form['#attributes']['data-drupal-ajax'] = 'false';
+    $form['#attributes']['class'][] = 'mel-no-ajax';
+
+    return $form;
+  }
+
+  /**
+   * Builds the organiser profile fields.
+   */
+  private function buildProfileSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
+    $form['profile'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Profile Information'),
+      '#open' => TRUE,
+      '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
+    ];
     $form['profile']['name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Vendor Name'),
@@ -382,16 +435,17 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Visual Assets Section.
+  }
+
+  /**
+   * Builds image and visual branding fields.
+   */
+  private function buildVisualAssetsSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['visual_assets'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Visual Assets'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
     ];
-    $form['visual_assets']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Visual Assets') . '</h2>',
-      '#weight' => -10,
-    ];
-
     if ($vendor->hasField('field_vendor_logo') || $vendor->hasField('field_logo_image')) {
       $logo_field = $vendor->hasField('field_vendor_logo') ? 'field_vendor_logo' : 'field_logo_image';
       $logo_default = [];
@@ -433,16 +487,17 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Contact Information Section.
+  }
+
+  /**
+   * Builds public contact and social link fields.
+   */
+  private function buildContactSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['contact'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Contact Information'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
     ];
-    $form['contact']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Contact Information') . '</h2>',
-      '#weight' => -10,
-    ];
-
     if ($vendor->hasField('field_email')) {
       $form['contact']['email'] = [
         '#type' => 'email',
@@ -569,14 +624,16 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Public Page Settings Section.
+  }
+
+  /**
+   * Builds public profile visibility controls.
+   */
+  private function buildPublicSettingsSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['public_page'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Public Page Settings'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
-    ];
-    $form['public_page']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Public Page Settings') . '</h2>',
-      '#weight' => -10,
     ];
     $form['public_page']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings__card-description">' . $this->t('Control what information is displayed on your public vendor page.') . '</p>',
@@ -652,14 +709,16 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Recurring Venues Section.
+  }
+
+  /**
+   * Builds the recurring venues placeholder section.
+   */
+  private function buildVenuesSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['venues'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Recurring Venues'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
-    ];
-    $form['venues']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Recurring Venues') . '</h2>',
-      '#weight' => -10,
     ];
     $form['venues']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings__card-description">' . $this->t('Save frequently used venues to quickly add them to events.') . '</p>',
@@ -671,16 +730,17 @@ class VendorSettingsForm extends FormBase {
       '#markup' => '<p>' . $this->t('Venue management will be implemented here. For now, venues are managed per-event.') . '</p>',
     ];
 
-    // Payment & Store Settings Section.
+  }
+
+  /**
+   * Builds Commerce store, business, and payout readiness details.
+   */
+  private function buildCommerceSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['store'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Payment & Store Settings'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
     ];
-    $form['store']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Payment & Store Settings') . '</h2>',
-      '#weight' => -10,
-    ];
-
     // Business Information subsection.
     $form['store']['business'] = [
       '#type' => 'fieldset',
@@ -867,17 +927,19 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Team Members Section (AJAX wrapper id for add-member refresh only; must stay inside <form>).
+  }
+
+  /**
+   * Builds team membership controls.
+   */
+  private function buildTeamSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['team'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Team Members'),
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card'],
         'id' => 'mel-vendor-settings-team-ajax',
       ],
-    ];
-    $form['team']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Team Members') . '</h2>',
-      '#weight' => -10,
     ];
     $form['team']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings__card-description">' . $this->t('Manage users who have access to manage this vendor account.') . '</p>',
@@ -923,16 +985,17 @@ class VendorSettingsForm extends FormBase {
       ];
     }
 
-    // Preferences Section - now loads from/saves to vendor entity fields.
+  }
+
+  /**
+   * Builds notification and organiser preference controls.
+   */
+  private function buildPreferencesSection(array &$form, FormStateInterface $form_state, Vendor $vendor): void {
     $form['preferences'] = [
-      '#type' => 'container',
+      '#type' => 'details',
+      '#title' => $this->t('Preferences'),
       '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card']],
     ];
-    $form['preferences']['_title'] = [
-      '#markup' => '<h2 class="mel-vendor-settings__card-title">' . $this->t('Preferences') . '</h2>',
-      '#weight' => -10,
-    ];
-
     $form['preferences']['notifications'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Email Notifications'),
@@ -976,44 +1039,6 @@ class VendorSettingsForm extends FormBase {
       '#default_value' => $email_digest_default,
     ];
 
-    $form['actions'] = [
-      '#type' => 'actions',
-      '#weight' => 100,
-    ];
-
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save changes'),
-      '#button_type' => 'primary',
-    ];
-
-    // Post-build #attached log (identifies AJAX library injectors; empty at buildForm() entry).
-    $this->logger->debug('MEL FORM ATTACHED: <pre>@data</pre>', [
-      '@data' => print_r($form['#attached'] ?? [], TRUE),
-    ]);
-
-    // Remove AJAX-related libraries ONLY.
-    if (!empty($form['#attached']['library'])) {
-      $form['#attached']['library'] = array_values(array_filter(
-        $form['#attached']['library'],
-        function ($lib) {
-          return !in_array($lib, [
-            'core/drupal.ajax',
-            'core/drupal.dialog.ajax',
-            'core/drupal.progress',
-          ], TRUE);
-        }
-      ));
-    }
-
-    if (isset($form['#attached']['drupalSettings']['ajax'])) {
-      unset($form['#attached']['drupalSettings']['ajax']);
-    }
-
-    $form['#attributes']['data-drupal-ajax'] = 'false';
-    $form['#attributes']['class'][] = 'mel-no-ajax';
-
-    return $form;
   }
 
   /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_form.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_form.scss
@@ -1,0 +1,34 @@
+.mel-form {
+  max-width: 960px;
+  margin: 0 auto;
+
+  &--vendor-settings {
+    padding: 2rem;
+  }
+}
+
+.mel-card {
+  background: #fff;
+  border: 1px solid #eaeaea;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.mel-btn {
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+
+  &--primary {
+    background: #4f46e5;
+    color: #fff;
+  }
+}
+
+.mel-form__actions {
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  padding: 1rem;
+  border-top: 1px solid #eee;
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -35,6 +35,7 @@
   @include meta.load-css('components/tables');
   @include meta.load-css('components/tabs');
   @include meta.load-css('components/tooltips');
+  @include meta.load-css('components/form');
   @include meta.load-css('components/forms');
   @include meta.load-css('components/kpi-cards');
   @include meta.load-css('components/attendees-kpi-bar');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the vendor settings entry route and form build pipeline (including disabling AJAX libraries), and changes the data shape passed to order confirmation emails, which could break routing or templates if mismatched.
> 
> **Overview**
> Updates the order confirmation email context to use the full `OrderPricingBreakdownBuilder::build()` output (subtotal, tax/fee rows, and platform-fee-absorbed flag) instead of the minimal email-specific pricing helper.
> 
> Refactors the `/vendor/settings` organiser settings form (`myeventlane_vendor_settings` module) into section-builder helpers, converts sections to collapsible `details`, adds sticky “Save changes” actions styling hooks, and explicitly strips Drupal AJAX libraries/settings from the form. The vendor theme adds new SCSS for `.mel-form`/`.mel-card`/`.mel-btn` and includes it in `main.scss`, while removing temporary debug logging from vendor forms.
> 
> Also changes the `myeventlane_vendor.console.settings` route entry in `mel-routes.json` to have a `null` controller (previously pointed at `VendorSettingsForm`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7136b076405d67a4c5a96b3eec983ef59500d77a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->