### PR TITLE
Fix Bugbot form styling and pricing cleanup

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
@@ -116,46 +116,6 @@ final class OrderPricingBreakdownBuilder {
     ];
   }
 
-  /**
-   * Minimal pricing context for order confirmation email (no row breakdown).
-   *
-   * Skips subtotal, per-adjustment row formatting, fee aggregation, and
-   * platform-fee-absorbed detection when templates only need total + GST note.
-   *
-   * @return array{
-   *   total_formatted: string,
-   *   show_includes_gst_note: bool,
-   * }
-   */
-  public function buildForOrderConfirmationEmail(OrderInterface $order): array {
-    $has_gst = FALSE;
-    foreach ($order->getAdjustments() as $adjustment) {
-      if ($adjustment->getType() !== 'tax') {
-        continue;
-      }
-      $amount = $adjustment->getAmount();
-      if ($amount instanceof Price && !$amount->isZero()) {
-        $has_gst = TRUE;
-        break;
-      }
-    }
-
-    $store = $order->getStore();
-    $prices_include_tax = $this->storePricesIncludeTax($store);
-    $au_store = $this->storeIsAustralia($store);
-    $gst_type_active = $this->australianGstTaxTypeIsActive();
-
-    $show_includes_gst_note = $prices_include_tax && $au_store && $gst_type_active && $has_gst;
-
-    $total = $order->getTotalPrice();
-    $total_formatted = $total ? $this->formatPrice($total) : '';
-
-    return [
-      'total_formatted' => $total_formatted,
-      'show_includes_gst_note' => $show_includes_gst_note,
-    ];
-  }
-
   private function storePricesIncludeTax(?StoreInterface $store): bool {
     if (!$store || !$store->hasField('prices_include_tax') || $store->get('prices_include_tax')->isEmpty()) {
       return FALSE;

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_form.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_form.scss
@@ -1,34 +1,24 @@
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+
 .mel-form {
   max-width: 960px;
   margin: 0 auto;
 
   &--vendor-settings {
-    padding: 2rem;
+    padding: $spacing-8;
   }
-}
 
-.mel-card {
-  background: #fff;
-  border: 1px solid #eaeaea;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.mel-btn {
-  border-radius: 8px;
-  padding: 0.75rem 1.5rem;
-
-  &--primary {
-    background: #4f46e5;
-    color: #fff;
+  .mel-vendor-settings__card {
+    padding: $card-padding;
+    margin-bottom: $card-gap;
   }
 }
 
 .mel-form__actions {
   position: sticky;
   bottom: 0;
-  background: #fff;
-  padding: 1rem;
-  border-top: 1px solid #eee;
+  background: $bg-primary;
+  padding: $spacing-4;
+  border-top: 1px solid $border-color-light;
 }


### PR DESCRIPTION
Scope vendor settings form styles to avoid overriding shared card and button components, and remove the unused order confirmation pricing helper after email context moved to the full pricing breakdown.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an apparently unused helper method and tightens SCSS selectors; main risk is unintended styling changes on vendor settings pages if selectors/tokens don’t match existing markup.
> 
> **Overview**
> Removes the specialized `buildForOrderConfirmationEmail()` path from `OrderPricingBreakdownBuilder`, consolidating email pricing context onto the main `build()` breakdown logic.
> 
> Updates vendor theme form SCSS to stop globally overriding shared `mel-card`/`mel-btn` styles by scoping vendor-settings card spacing under `.mel-form` and switching hardcoded values to design tokens (including the sticky actions bar background/padding/border).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9dbee64631b2c599429013928e994006317c19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->