### PR TITLE
Cursor/fix bugbot csrf analytics 0501

### DIFF
--- a/web/modules/custom/myeventlane_core/js/vendor-public.js
+++ b/web/modules/custom/myeventlane_core/js/vendor-public.js
@@ -1,16 +1,34 @@
 (function (Drupal, once, drupalSettings) {
+  const vendorPublicSettings = drupalSettings.melVendorPublic || {};
+  let csrfToken = vendorPublicSettings.csrfToken || null;
   let csrfTokenPromise = null;
 
   const getCsrfToken = () => {
+    if (csrfToken) {
+      return Promise.resolve(csrfToken);
+    }
+
     if (!csrfTokenPromise) {
       csrfTokenPromise = fetch(Drupal.url('session/token'), {
         credentials: 'same-origin',
-      }).then((response) => {
-        if (!response.ok) {
-          throw new Error(Drupal.t('Unable to get a security token.'));
-        }
-        return response.text();
-      });
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(Drupal.t('Unable to get a security token.'));
+          }
+          return response.text();
+        })
+        .then((token) => {
+          csrfToken = (token || '').trim();
+          if (!csrfToken) {
+            throw new Error(Drupal.t('Unable to get a security token.'));
+          }
+          return csrfToken;
+        })
+        .catch((error) => {
+          csrfTokenPromise = null;
+          throw error;
+        });
     }
 
     return csrfTokenPromise;
@@ -69,32 +87,27 @@
       });
 
       once('mel-event-click-analytics', '[data-mel-track-event-click]', context).forEach((link) => {
-        link.addEventListener('click', async () => {
+        link.addEventListener('click', () => {
           const settings = drupalSettings.melPublicAnalytics || {};
           const eventId = link.getAttribute('data-event-id');
-          if (!settings.eventClickUrl || !eventId) {
+          const eventClickToken = settings.csrfToken || csrfToken;
+          if (!settings.eventClickUrl || !eventId || !eventClickToken) {
             return;
           }
 
           const payload = new FormData();
           payload.append('event_id', eventId);
 
-          try {
-            const csrfToken = await getCsrfToken();
-            fetch(settings.eventClickUrl, {
-              method: 'POST',
-              credentials: 'same-origin',
-              body: payload,
-              keepalive: true,
-              headers: {
-                'X-CSRF-Token': csrfToken,
-                'X-Requested-With': 'XMLHttpRequest',
-              },
-            }).catch((error) => console.error(error));
-          }
-          catch (error) {
-            console.error(error);
-          }
+          fetch(settings.eventClickUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: payload,
+            keepalive: true,
+            headers: {
+              'X-CSRF-Token': eventClickToken,
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+          }).catch((error) => console.error(error));
         });
       });
     },

--- a/web/modules/custom/myeventlane_core/js/vendor-public.js
+++ b/web/modules/custom/myeventlane_core/js/vendor-public.js
@@ -1,4 +1,21 @@
 (function (Drupal, once, drupalSettings) {
+  let csrfTokenPromise = null;
+
+  const getCsrfToken = () => {
+    if (!csrfTokenPromise) {
+      csrfTokenPromise = fetch(Drupal.url('session/token'), {
+        credentials: 'same-origin',
+      }).then((response) => {
+        if (!response.ok) {
+          throw new Error(Drupal.t('Unable to get a security token.'));
+        }
+        return response.text();
+      });
+    }
+
+    return csrfTokenPromise;
+  };
+
   Drupal.behaviors.melVendorPublic = {
     attach(context) {
       once('mel-vendor-follow', '.mel-follow-button[data-follow-url]', context).forEach((button) => {
@@ -12,15 +29,18 @@
 
           button.disabled = true;
           try {
+            const csrfToken = await getCsrfToken();
             const response = await fetch(followUrl, {
               method: 'POST',
               credentials: 'same-origin',
               headers: {
                 'Accept': 'application/json',
+                'X-CSRF-Token': csrfToken,
                 'X-Requested-With': 'XMLHttpRequest',
               },
             });
-            const data = await response.json();
+            const contentType = response.headers.get('content-type') || '';
+            const data = contentType.includes('application/json') ? await response.json() : {};
             if (!response.ok || data.status !== 'ok') {
               throw new Error(data.message || Drupal.t('Unable to update follow state.'));
             }
@@ -49,7 +69,7 @@
       });
 
       once('mel-event-click-analytics', '[data-mel-track-event-click]', context).forEach((link) => {
-        link.addEventListener('click', () => {
+        link.addEventListener('click', async () => {
           const settings = drupalSettings.melPublicAnalytics || {};
           const eventId = link.getAttribute('data-event-id');
           if (!settings.eventClickUrl || !eventId) {
@@ -58,17 +78,23 @@
 
           const payload = new FormData();
           payload.append('event_id', eventId);
-          if (navigator.sendBeacon) {
-            navigator.sendBeacon(settings.eventClickUrl, payload);
-            return;
-          }
 
-          fetch(settings.eventClickUrl, {
-            method: 'POST',
-            credentials: 'same-origin',
-            body: payload,
-            keepalive: true,
-          }).catch((error) => console.error(error));
+          try {
+            const csrfToken = await getCsrfToken();
+            fetch(settings.eventClickUrl, {
+              method: 'POST',
+              credentials: 'same-origin',
+              body: payload,
+              keepalive: true,
+              headers: {
+                'X-CSRF-Token': csrfToken,
+                'X-Requested-With': 'XMLHttpRequest',
+              },
+            }).catch((error) => console.error(error));
+          }
+          catch (error) {
+            console.error(error);
+          }
         });
       });
     },

--- a/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.routing.yml
@@ -135,7 +135,7 @@ myeventlane_core.vendor_follow_toggle:
   requirements:
     _entity_access: 'myeventlane_vendor.view'
     _user_is_logged_in: 'TRUE'
-    _csrf_token: 'TRUE'
+    _csrf_request_header_token: 'TRUE'
   options:
     parameters:
       myeventlane_vendor:
@@ -148,5 +148,5 @@ myeventlane_core.analytics_event_click:
     _controller: '\Drupal\myeventlane_core\Controller\PublicAnalyticsController::eventClick'
   requirements:
     _permission: 'access content'
-    _csrf_token: 'TRUE'
+    _csrf_request_header_token: 'TRUE'
   methods: [POST]

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -88,10 +88,6 @@ final class VendorDetailController extends ControllerBase {
       '#follower_count' => $this->vendorFollowService->countFollowers($myeventlane_vendor),
       '#follow_url' => $is_authenticated ? Url::fromRoute('myeventlane_core.vendor_follow_toggle', [
         'myeventlane_vendor' => $myeventlane_vendor->id(),
-      ], [
-        'query' => [
-          'token' => $this->csrfToken('vendor/{myeventlane_vendor}/follow'),
-        ],
       ])->toString() : Url::fromRoute('user.login', [], [
         'query' => [
           'destination' => Url::fromRoute('entity.myeventlane_vendor.canonical', [
@@ -105,11 +101,7 @@ final class VendorDetailController extends ControllerBase {
         'library' => ['myeventlane_core/vendor_public'],
         'drupalSettings' => [
           'melPublicAnalytics' => [
-            'eventClickUrl' => Url::fromRoute('myeventlane_core.analytics_event_click', [], [
-              'query' => [
-                'token' => $this->csrfToken('mel/analytics/event-click'),
-              ],
-            ])->toString(),
+            'eventClickUrl' => Url::fromRoute('myeventlane_core.analytics_event_click')->toString(),
           ],
         ],
       ],
@@ -120,7 +112,7 @@ final class VendorDetailController extends ControllerBase {
         ))),
         'contexts' => array_values(array_unique(array_merge(
           $myeventlane_vendor->getCacheContexts(),
-          ['user', 'user.permissions']
+          ['session', 'user', 'user.permissions']
         ))),
         'max-age' => $myeventlane_vendor->getCacheMaxAge(),
       ],

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -69,6 +69,7 @@ final class VendorDetailController extends ControllerBase {
     $content = $this->buildVisibleContent($myeventlane_vendor);
     $events = $this->buildUpcomingEventCards($myeventlane_vendor);
     $is_authenticated = (int) $this->account->id() > 0;
+    $csrf_token = $this->csrfToken->get('');
 
     $build = [
       '#theme' => 'entity__myeventlane_vendor__full',
@@ -100,8 +101,12 @@ final class VendorDetailController extends ControllerBase {
       '#attached' => [
         'library' => ['myeventlane_core/vendor_public'],
         'drupalSettings' => [
+          'melVendorPublic' => [
+            'csrfToken' => $csrf_token,
+          ],
           'melPublicAnalytics' => [
             'eventClickUrl' => Url::fromRoute('myeventlane_core.analytics_event_click')->toString(),
+            'csrfToken' => $csrf_token,
           ],
         ],
       ],
@@ -257,13 +262,6 @@ final class VendorDetailController extends ControllerBase {
         'image_link' => '',
       ],
     ]);
-  }
-
-  /**
-   * Builds a CSRF token for a route path.
-   */
-  private function csrfToken(string $path): string {
-    return $this->csrfToken->get($path);
   }
 
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_vendor.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_vendor.scss
@@ -2,7 +2,7 @@
 
 .mel-vendor-directory,
 .mel-vendor {
-  width: min(1120px, calc(100% - 32px));
+  width: min(1040px, calc(100% - 40px));
   margin: 0 auto;
 }
 
@@ -36,20 +36,20 @@
 }
 
 .mel-vendor {
-  padding: 32px 0 80px;
+  padding: 28px 0 88px;
 }
 
 .mel-vendor__hero {
   overflow: hidden;
-  max-height: 340px;
-  margin-bottom: -48px;
+  max-height: 300px;
+  margin-bottom: -56px;
   border-radius: mel.$mel-ds-radius-lg;
   background: color-mix(in srgb, mel.$mel-ds-color-text 6%, transparent);
 
   img {
     display: block;
     width: 100%;
-    height: min(340px, 34vw);
+    height: min(300px, 30vw);
     min-height: 180px;
     object-fit: cover;
   }
@@ -58,11 +58,12 @@
 .mel-vendor__header {
   position: relative;
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 20px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 22px;
   align-items: center;
-  margin-bottom: 40px;
-  padding: 24px;
+  max-width: 860px;
+  margin: 0 auto 42px;
+  padding: 22px 28px;
   background: mel.$mel-ds-color-surface;
   border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
   border-radius: mel.$mel-ds-radius-lg;
@@ -77,11 +78,17 @@
   border-radius: mel.$mel-ds-radius-md;
 }
 
+.mel-vendor__title {
+  min-width: 0;
+}
+
 .mel-vendor__name {
   margin: 0;
   color: mel.$mel-ds-color-text;
-  font-size: clamp(2rem, 4vw, 3rem);
-  line-height: 1.05;
+  font-size: clamp(2rem, 3.6vw, 2.75rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
 }
 
 .mel-vendor__tagline,
@@ -89,9 +96,20 @@
   margin: 8px 0 0;
 }
 
+.mel-vendor__tagline {
+  display: -webkit-box;
+  max-width: 62ch;
+  overflow: hidden;
+  color: mel.$mel-ds-color-muted;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .mel-vendor__followers {
   color: mel.$mel-ds-color-muted;
-  font-size: 0.95rem;
+  font-size: 0.875rem;
 }
 
 .mel-follow-button {
@@ -107,6 +125,18 @@
   border: 0;
   border-radius: 999px;
   cursor: pointer;
+  box-shadow: 0 8px 18px color-mix(in srgb, mel.$mel-ds-color-accent 22%, transparent);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: mel.$mel-ds-color-surface;
+    text-decoration: none;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px color-mix(in srgb, mel.$mel-ds-color-accent 28%, transparent);
+  }
 
   &.is-following {
     color: mel.$mel-ds-color-text;
@@ -122,31 +152,76 @@
 .mel-vendor__bio,
 .mel-vendor__contact,
 .mel-vendor__events {
-  margin-top: 40px;
+  margin-top: 36px;
 }
 
 .mel-vendor__bio {
-  max-width: 760px;
+  max-width: 780px;
+  margin-right: auto;
+  margin-left: auto;
   color: mel.$mel-ds-color-text;
   font-size: 1.075rem;
   line-height: 1.75;
+  overflow-wrap: anywhere;
 }
 
 .mel-vendor__contact {
-  padding: 24px;
-  background: color-mix(in srgb, mel.$mel-ds-color-text 4%, transparent);
-  border-radius: mel.$mel-ds-radius-md;
+  max-width: 780px;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 24px 28px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, mel.$mel-ds-color-surface 92%, transparent), color-mix(in srgb, mel.$mel-ds-color-bg 72%, transparent));
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 6%, transparent);
+  border-radius: mel.$mel-ds-radius-lg;
+
+  h2 {
+    margin: 0 0 16px;
+    color: mel.$mel-ds-color-text;
+    font-size: 1.35rem;
+    line-height: 1.2;
+  }
 }
 
 .mel-vendor__contact-grid {
   display: grid;
-  gap: 16px;
+  gap: 12px;
+}
+
+.mel-vendor__contact-item {
+  color: mel.$mel-ds-color-text;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+
+  a {
+    color: mel.$mel-ds-color-accent;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+}
+
+.mel-vendor__events {
+  max-width: 780px;
+  margin-right: auto;
+  margin-left: auto;
+
+  h2 {
+    margin: 0 0 22px;
+    color: mel.$mel-ds-color-text;
+    font-size: 1.65rem;
+    line-height: 1.2;
+  }
 }
 
 .mel-vendor__event-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 340px));
   gap: 24px;
+  align-items: stretch;
+}
+
+.mel-vendor__event-grid .mel-event-card {
+  max-width: 340px;
 }
 
 .mel-vendor__empty-events {
@@ -154,12 +229,26 @@
 }
 
 @media (max-width: 720px) {
+  .mel-vendor-directory,
+  .mel-vendor {
+    width: min(100% - 28px, 1040px);
+  }
+
+  .mel-vendor__hero {
+    margin-bottom: -36px;
+  }
+
   .mel-vendor__header {
     grid-template-columns: 1fr;
+    padding: 20px;
   }
 
   .mel-vendor__logo img {
     width: 84px;
     height: 84px;
+  }
+
+  .mel-follow-button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates CSRF enforcement for public POST endpoints and changes the client-side token plumbing; mismatches could break follow/analytics requests for some sessions. Styling/layout changes to the vendor page are low risk but broad UI-affecting.
> 
> **Overview**
> Switches the vendor follow toggle and public event-click analytics POST routes to require header-based CSRF validation (`_csrf_request_header_token`) instead of query-string tokens.
> 
> Updates `vendor-public.js` to obtain/reuse a CSRF token (from `drupalSettings` or `GET /session/token`) and send it via `X-CSRF-Token` for follow and analytics requests, with safer response parsing.
> 
> Adjusts `VendorDetailController` to stop appending `?token=` to URLs, inject a CSRF token into `drupalSettings`, and add `session` to cache contexts. Also refines vendor page SCSS for updated layout/typography and button interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a34c03f4280caf9c41b8db99c5efddb82e3cdbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->