### PR TITLE
Cursor/upcoming query 9d703

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -40,6 +40,7 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@logger.channel.myeventlane_vendor'
+      - '@datetime.time'
 
   myeventlane_vendor.user_vendor_membership_query:
     class: Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery
@@ -189,6 +190,7 @@ services:
       - '@myeventlane_core.event_state_resolver'
       - '@state'
       - '@logger.channel.mel_debug'
+      - '@datetime.time'
       - '@?myeventlane_ai.usage_tracker'
       - '@config.factory'
       - '@?myeventlane_vendor.service.category_audience'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_vendor\Controller;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -18,6 +19,7 @@ use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\Service\OnboardingManager;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\myeventlane_growth\Service\GrowthInsightService;
@@ -146,6 +148,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
 
   protected LoggerInterface $melDebugLogger;
 
+  protected TimeInterface $time;
+
   /**
    * Route provider (detect optional myeventlane_boost routes; module may be on without routes).
    */
@@ -180,6 +184,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     EventStateResolver $event_domain_state_resolver,
     StateInterface $state,
     LoggerInterface $mel_debug_logger,
+    TimeInterface $time,
     ?AiUsageTracker $ai_usage_tracker = NULL,
     ?ConfigFactoryInterface $config_factory = NULL,
     ?CategoryAudienceService $category_audience_service = NULL,
@@ -205,6 +210,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $this->eventDomainStateResolver = $event_domain_state_resolver;
     $this->state = $state;
     $this->melDebugLogger = $mel_debug_logger;
+    $this->time = $time;
     $this->aiUsageTracker = $ai_usage_tracker;
     $this->configFactory = $config_factory;
     $this->categoryAudienceService = $category_audience_service;
@@ -238,6 +244,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $container->get('myeventlane_core.event_state_resolver'),
       $container->get('state'),
       $container->get('logger.channel.mel_debug'),
+      $container->get('datetime.time'),
       $container->has('myeventlane_ai.usage_tracker') ? $container->get('myeventlane_ai.usage_tracker') : NULL,
       $container->get('config.factory'),
       $container->has('myeventlane_vendor.service.category_audience') ? $container->get('myeventlane_vendor.service.category_audience') : NULL,
@@ -1010,9 +1017,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   }
 
   /**
-   * Get upcoming events count (published events with future start date).
+   * Get upcoming events count (published events that are future or ongoing).
    *
-   * Counts: Published events (status=1) with start date >= now.
+   * Counts: Published events (status=1) with start date or end date >= now.
    * Excludes: Draft events, past events.
    * Tables: node (event).
    *
@@ -1029,17 +1036,20 @@ final class VendorDashboardController extends VendorConsoleBaseController {
 
     try {
       $nodeStorage = $this->entityTypeManager->getStorage('node');
-      $now = date('Y-m-d\TH:i:s');
 
-      return (int) $nodeStorage->getQuery()
+      $query = $nodeStorage->getQuery()
         ->accessCheck(TRUE)
         ->condition('nid', $eventIds, 'IN')
-        ->condition('status', 1)
-        ->condition('field_event_start', $now, '>=')
+        ->condition('status', 1);
+      UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, (int) $this->time->getRequestTime());
+      return (int) $query
         ->count()
         ->execute();
     }
     catch (\Exception $e) {
+      $this->melDebugLogger->error('Unable to count upcoming dashboard events: @message', [
+        '@message' => $e->getMessage(),
+      ]);
       return 0;
     }
   }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\AnalyticsService;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
 use Drupal\myeventlane_core\Service\VendorFollowService;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\VendorCardBuilder;
@@ -207,14 +208,15 @@ final class VendorDetailController extends ControllerBase {
       return [];
     }
 
-    $event_ids = $this->entityTypeManagerService
+    $query = $this->entityTypeManagerService
       ->getStorage('node')
       ->getQuery()
       ->accessCheck(TRUE)
       ->condition('type', 'event')
       ->condition('field_event_vendor', (int) $vendor->id())
-      ->condition('field_event_start', date('Y-m-d\TH:i:s', $this->time->getRequestTime()), '>=')
-      ->condition('status', 1)
+      ->condition('status', 1);
+    UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, (int) $this->time->getRequestTime());
+    $event_ids = $query
       ->sort('field_event_start', 'ASC')
       ->range(0, 10)
       ->execute();

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Psr\Log\LoggerInterface;
 
@@ -21,6 +23,7 @@ final class VendorCardBuilder {
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly LoggerInterface $logger,
+    private readonly TimeInterface $time,
   ) {}
 
   /**
@@ -99,14 +102,15 @@ final class VendorCardBuilder {
    */
   public function countUpcomingEvents(Vendor $vendor): int {
     try {
-      return (int) $this->entityTypeManager
+      $query = $this->entityTypeManager
         ->getStorage('node')
         ->getQuery()
         ->accessCheck(TRUE)
         ->condition('type', 'event')
         ->condition('status', 1)
-        ->condition('field_event_vendor', (int) $vendor->id())
-        ->condition('field_event_start', date('Y-m-d\TH:i:s'), '>=')
+        ->condition('field_event_vendor', (int) $vendor->id());
+      UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, (int) $this->time->getRequestTime());
+      return (int) $query
         ->count()
         ->execute();
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk query logic change: expands “upcoming” event selection to include events whose end date is still in the future and standardizes time handling via `datetime.time` injection.
> 
> **Overview**
> Updates vendor “upcoming events” logic to include *ongoing* events by filtering on `field_event_start >= now OR field_event_end >= now` (via `UpcomingEventEntityQueryHelper`) instead of start-date-only checks.
> 
> This change is applied consistently across `VendorDashboardController`, `VendorDetailController`, and `VendorCardBuilder`, with `datetime.time` injected where needed for request-time-based comparisons; the dashboard count path also adds debug logging on query failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c1760c37190fb7b0bac02b45054d88612f773d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->