### PR TITLE
Cursor/public vendor logic f8f77

### DIFF
--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorDomainSubscriber.php
@@ -92,8 +92,13 @@ final class VendorDomainSubscriber implements EventSubscriberInterface {
     $is_vendor_domain = $this->domainDetector->isVendorDomain();
 
     $is_vendor_path_prefix = self::isVendorPathPrefix($path);
-    $is_vendor_route = str_starts_with($route_name, 'myeventlane_vendor.')
-      || $is_vendor_path_prefix;
+    $is_public_vendor_route = in_array($route_name, [
+      'myeventlane_vendor.public_list',
+      'myeventlane_vendor.organisers',
+    ], TRUE);
+    $is_vendor_route = !$is_public_vendor_route
+      && (str_starts_with($route_name, 'myeventlane_vendor.')
+        || $is_vendor_path_prefix);
 
     // Prevent redirect loops on vendor domain
     if ($is_vendor_domain && $is_vendor_path_prefix) {

--- a/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
@@ -69,14 +69,18 @@ final class DomainDetector {
   /**
    * Determines whether the current request is on the vendor domain.
    *
-   * If vendor_domain is misconfigured to the same host as public_domain, the
-   * apex must be treated as public only; otherwise vendor-only subscribers
-   * (e.g. console gate) run on the main site and fight with public routing.
+   * If vendor_domain is misconfigured to the same host as public_domain, that
+   * shared host must be treated as public only; otherwise vendor-only
+   * subscribers (e.g. console gate) run on the main site and fight with public
+   * routing.
    */
   public function isVendorDomain(): bool {
-    if ($this->hostnameMatchesConfiguredPublicHost()) {
+    $public = $this->getConfiguredDomainHost('public_domain');
+    $vendor = $this->getConfiguredDomainHost('vendor_domain');
+    if ($public !== NULL && $vendor !== NULL && $public === $vendor) {
       return FALSE;
     }
+
     return $this->isMatchingConfiguredDomain('vendor_domain', 'vendor.');
   }
 
@@ -142,22 +146,6 @@ final class DomainDetector {
     $path = '/' . ltrim($path, '/');
 
     return $base_url . $path;
-  }
-
-  /**
-   * TRUE when any request hostname candidate matches configured public_domain.
-   */
-  private function hostnameMatchesConfiguredPublicHost(): bool {
-    $public = $this->getConfiguredDomainHost('public_domain');
-    if ($public === NULL || $public === '') {
-      return FALSE;
-    }
-    foreach ($this->hostnameCandidatesForMatching() as $hostname) {
-      if ($hostname === $public) {
-        return TRUE;
-      }
-    }
-    return FALSE;
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes vendor/public domain detection and redirect routing, which can affect request handling and potentially introduce misdirects or redirect loops if edge cases/configurations differ from expectations.
> 
> **Overview**
> Adjusts vendor-domain redirect logic to **exclude specific vendor routes** (`myeventlane_vendor.public_list`, `myeventlane_vendor.organisers`) from being treated as vendor-only, so they won’t trigger vendor-domain redirects.
> 
> Updates `DomainDetector::isVendorDomain()` to explicitly return public when `public_domain` and `vendor_domain` are configured to the same host, removing the prior public-host matching helper and preventing vendor-only behavior from activating on a shared host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3195298534109a3571049e4c7a7e527098590b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->