### PR TITLE
Refactor vendor console path determination logic in VendorConsoleGate…

### DIFF
--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorConsoleGateRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/VendorConsoleGateRedirectSubscriber.php
@@ -138,7 +138,7 @@ final class VendorConsoleGateRedirectSubscriber implements EventSubscriberInterf
     if ($this->pathIsVendorSsoCallback($path)) {
       return FALSE;
     }
-    return str_starts_with($path, '/vendor');
+    return (bool) preg_match('#^/vendor(/|$)#', $path);
   }
 
   /**


### PR DESCRIPTION
…RedirectSubscriber. Updated the method to use a regular expression for improved accuracy in identifying vendor routes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change to vendor URL matching logic, but it can alter redirect behavior for edge-case paths that previously matched via prefix (e.g. `/vendorx`).
> 
> **Overview**
> Tightens vendor-console route detection in `VendorConsoleGateRedirectSubscriber::isVendorConsolePath()` by replacing a simple `str_starts_with('/vendor')` check with a regex that only matches `/vendor` at a path boundary.
> 
> This reduces false positives where non-vendor paths sharing the `/vendor` prefix could be treated as vendor console traffic and redirected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc9bd00874c841ac6b09e8b9ea6025a63ffac00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->