### PR TITLE
refactor(workflow): update state retrieval logic in AbandonedCartSche…

### DIFF
--- a/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
+++ b/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
@@ -384,11 +384,13 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
 
     try {
       $workflow = $this->workflowManager->createInstance($workflowId);
-      $states = $workflow->getGroup()->getStates();
+      $states = $workflow->getStates();
       $fromStates = [];
 
       foreach ($workflow->getTransitions() as $transition) {
-        $fromStates[$transition->getFromStateId()] = TRUE;
+        foreach ($transition->getFromStateIds() as $fromStateId) {
+          $fromStates[$fromStateId] = TRUE;
+        }
       }
 
       foreach (array_keys($states) as $stateId) {

--- a/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartScheduler.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartScheduler.php
@@ -361,11 +361,13 @@ final class AbandonedCartScheduler {
 
     try {
       $workflow = $this->workflowManager->createInstance($workflowId);
-      $states = $workflow->getGroup()->getStates();
+      $states = $workflow->getStates();
       $fromStates = [];
 
       foreach ($workflow->getTransitions() as $transition) {
-        $fromStates[$transition->getFromStateId()] = TRUE;
+        foreach ($transition->getFromStateIds() as $fromStateId) {
+          $fromStates[$fromStateId] = TRUE;
+        }
       }
 
       foreach (array_keys($states) as $stateId) {


### PR DESCRIPTION
…duler and ProAbandonedCartJob to handle multiple from state IDs, improving transition management

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal-state discovery used to decide whether abandoned-cart reminders should send; incorrect state detection could cause reminders to be sent or skipped unexpectedly. The change is localized but touches workflow transition logic in both the scheduler and the queue job.
> 
> **Overview**
> Updates terminal workflow-state discovery in both `AbandonedCartScheduler` and `ProAbandonedCartJob`.
> 
> The logic now pulls states via `Workflow::getStates()` (instead of `getGroup()->getStates()`) and builds the non-terminal set by iterating `Transition::getFromStateIds()` to support transitions with *multiple* "from" states when determining which states are terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20722e875d53475ee84af2667e096e54d9388774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->