### PR TITLE
fix(pro): share abandoned cart terminal state resolution

### DIFF
--- a/web/modules/custom/myeventlane_pro/myeventlane_pro.services.yml
+++ b/web/modules/custom/myeventlane_pro/myeventlane_pro.services.yml
@@ -120,7 +120,14 @@ services:
       - '@logger.channel.myeventlane_pro'
       - '@myeventlane_pro.active_resolver'
       - '@state'
+      - '@myeventlane_pro.abandoned_cart_terminal_state_resolver'
+
+  myeventlane_pro.abandoned_cart_terminal_state_resolver:
+    class: Drupal\myeventlane_pro\Service\AbandonedCartTerminalStateResolver
+    arguments:
+      - '@entity_type.manager'
       - '@plugin.manager.workflow'
+      - '@logger.channel.myeventlane_pro'
 
   myeventlane_pro.recovery_analytics:
     class: Drupal\myeventlane_pro\Service\ProRecoveryAnalyticsService

--- a/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
+++ b/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
@@ -9,7 +9,6 @@ use Drupal\advancedqueue\Job;
 use Drupal\advancedqueue\JobResult;
 use Drupal\advancedqueue\Plugin\AdvancedQueue\JobType\JobTypeBase;
 use Drupal\commerce_order\Entity\OrderInterface;
-use Drupal\commerce_order\Entity\OrderTypeInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -20,8 +19,8 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
+use Drupal\myeventlane_pro\Service\AbandonedCartTerminalStateResolver;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
-use Drupal\state_machine\WorkflowManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -43,13 +42,6 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
   private const STATUS_FAILED = 'failed';
 
   /**
-   * Cached terminal states keyed by workflow id.
-   *
-   * @var array<string, array<string, bool>>
-   */
-  private array $terminalStatesByWorkflow = [];
-
-  /**
    * Constructs the job type.
    */
   public function __construct(
@@ -63,7 +55,7 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
     private readonly ProActiveResolver $proActiveResolver,
     private readonly ConfigFactoryInterface $configFactory,
     private readonly MailManagerInterface $mailManager,
-    private readonly WorkflowManagerInterface $workflowManager,
+    private readonly AbandonedCartTerminalStateResolver $terminalStateResolver,
     private readonly ?MessagingManager $messagingManager = NULL,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -84,7 +76,7 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
       $container->get('myeventlane_pro.active_resolver'),
       $container->get('config.factory'),
       $container->get('plugin.manager.mail'),
-      $container->get('plugin.manager.workflow'),
+      $container->get('myeventlane_pro.abandoned_cart_terminal_state_resolver'),
       $container->has('myeventlane_messaging.manager') ? $container->get('myeventlane_messaging.manager') : NULL,
     );
   }
@@ -159,7 +151,7 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
       return 'Order has no items.';
     }
 
-    if ($this->isTerminalState($order)) {
+    if ($this->terminalStateResolver->isTerminalState($order)) {
       return 'Order no longer abandoned.';
     }
 
@@ -348,65 +340,6 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
         '@message' => $exception->getMessage(),
       ]);
     }
-  }
-
-  /**
-   * Determines whether the order is currently in a terminal workflow state.
-   */
-  private function isTerminalState(OrderInterface $order): bool {
-    $orderType = $this->entityTypeManager
-      ->getStorage('commerce_order_type')
-      ->load($order->bundle());
-    if (!$orderType instanceof OrderTypeInterface) {
-      return FALSE;
-    }
-
-    $workflowId = $orderType->getWorkflowId();
-    if ($workflowId === '') {
-      return FALSE;
-    }
-
-    if (!isset($this->terminalStatesByWorkflow[$workflowId])) {
-      $this->terminalStatesByWorkflow[$workflowId] = $this->discoverTerminalStates($workflowId);
-    }
-
-    return isset($this->terminalStatesByWorkflow[$workflowId][$order->getState()->getId()]);
-  }
-
-  /**
-   * Discovers terminal states for a workflow id.
-   *
-   * @return array<string, bool>
-   *   Terminal state id lookup.
-   */
-  private function discoverTerminalStates(string $workflowId): array {
-    $terminalStates = [];
-
-    try {
-      $workflow = $this->workflowManager->createInstance($workflowId);
-      $states = $workflow->getStates();
-      $fromStates = [];
-
-      foreach ($workflow->getTransitions() as $transition) {
-        foreach ($transition->getFromStateIds() as $fromStateId) {
-          $fromStates[$fromStateId] = TRUE;
-        }
-      }
-
-      foreach (array_keys($states) as $stateId) {
-        if (!isset($fromStates[$stateId])) {
-          $terminalStates[$stateId] = TRUE;
-        }
-      }
-    }
-    catch (\Throwable $exception) {
-      $this->logger->error('Failed terminal-state discovery for workflow "@workflow": @message', [
-        '@workflow' => $workflowId,
-        '@message' => $exception->getMessage(),
-      ]);
-    }
-
-    return $terminalStates;
   }
 
 }

--- a/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartScheduler.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartScheduler.php
@@ -6,7 +6,6 @@ namespace Drupal\myeventlane_pro\Service;
 
 use Drupal\advancedqueue\Job;
 use Drupal\commerce_order\Entity\OrderInterface;
-use Drupal\commerce_order\Entity\OrderTypeInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
@@ -14,7 +13,6 @@ use Drupal\Core\Database\IntegrityConstraintViolationException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
-use Drupal\state_machine\WorkflowManagerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -36,13 +34,6 @@ final class AbandonedCartScheduler {
   private const STATUS_QUEUED = 'queued';
 
   /**
-   * Cached terminal states keyed by workflow id.
-   *
-   * @var array<string, array<string, bool>>
-   */
-  private array $terminalStatesByWorkflow = [];
-
-  /**
    * Ensures scheduler summary is only logged once per cron run.
    */
   private bool $summaryLogged = FALSE;
@@ -57,7 +48,7 @@ final class AbandonedCartScheduler {
     private readonly LoggerInterface $logger,
     private readonly ProActiveResolver $proActiveResolver,
     private readonly StateInterface $state,
-    private readonly WorkflowManagerInterface $workflowManager,
+    private readonly AbandonedCartTerminalStateResolver $terminalStateResolver,
   ) {}
 
   /**
@@ -315,7 +306,7 @@ final class AbandonedCartScheduler {
    * Determines whether the order is still an active cart.
    */
   private function isAbandonedState(OrderInterface $order): bool {
-    if ($this->isTerminalState($order)) {
+    if ($this->terminalStateResolver->isTerminalState($order)) {
       return FALSE;
     }
 
@@ -325,65 +316,6 @@ final class AbandonedCartScheduler {
     }
 
     return (bool) $order->get('cart')->value;
-  }
-
-  /**
-   * Determines whether the order is currently in a terminal workflow state.
-   */
-  private function isTerminalState(OrderInterface $order): bool {
-    $orderType = $this->entityTypeManager
-      ->getStorage('commerce_order_type')
-      ->load($order->bundle());
-    if (!$orderType instanceof OrderTypeInterface) {
-      return FALSE;
-    }
-
-    $workflowId = $orderType->getWorkflowId();
-    if ($workflowId === '') {
-      return FALSE;
-    }
-
-    if (!isset($this->terminalStatesByWorkflow[$workflowId])) {
-      $this->terminalStatesByWorkflow[$workflowId] = $this->discoverTerminalStates($workflowId);
-    }
-
-    return isset($this->terminalStatesByWorkflow[$workflowId][$order->getState()->getId()]);
-  }
-
-  /**
-   * Discovers terminal states for a workflow id.
-   *
-   * @return array<string, bool>
-   *   Terminal state id lookup.
-   */
-  private function discoverTerminalStates(string $workflowId): array {
-    $terminalStates = [];
-
-    try {
-      $workflow = $this->workflowManager->createInstance($workflowId);
-      $states = $workflow->getStates();
-      $fromStates = [];
-
-      foreach ($workflow->getTransitions() as $transition) {
-        foreach ($transition->getFromStateIds() as $fromStateId) {
-          $fromStates[$fromStateId] = TRUE;
-        }
-      }
-
-      foreach (array_keys($states) as $stateId) {
-        if (!isset($fromStates[$stateId])) {
-          $terminalStates[$stateId] = TRUE;
-        }
-      }
-    }
-    catch (\Throwable $exception) {
-      $this->logger->error('Failed terminal-state discovery for workflow "@workflow": @message', [
-        '@workflow' => $workflowId,
-        '@message' => $exception->getMessage(),
-      ]);
-    }
-
-    return $terminalStates;
   }
 
   /**

--- a/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartTerminalStateResolver.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/AbandonedCartTerminalStateResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_pro\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\state_machine\WorkflowManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves terminal workflow states for abandoned-cart order checks.
+ */
+final class AbandonedCartTerminalStateResolver {
+
+  /**
+   * Cached terminal states keyed by workflow id.
+   *
+   * @var array<string, array<string, bool>>
+   */
+  private array $terminalStatesByWorkflow = [];
+
+  /**
+   * Constructs the terminal state resolver.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly WorkflowManagerInterface $workflowManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Determines whether the order is currently in a terminal workflow state.
+   */
+  public function isTerminalState(OrderInterface $order): bool {
+    $orderType = $this->entityTypeManager
+      ->getStorage('commerce_order_type')
+      ->load($order->bundle());
+    if (!$orderType instanceof OrderTypeInterface) {
+      return FALSE;
+    }
+
+    $workflowId = $orderType->getWorkflowId();
+    if ($workflowId === '') {
+      return FALSE;
+    }
+
+    if (!isset($this->terminalStatesByWorkflow[$workflowId])) {
+      $this->terminalStatesByWorkflow[$workflowId] = $this->discoverTerminalStates($workflowId);
+    }
+
+    return isset($this->terminalStatesByWorkflow[$workflowId][$order->getState()->getId()]);
+  }
+
+  /**
+   * Discovers terminal states for a workflow id.
+   *
+   * @return array<string, bool>
+   *   Terminal state id lookup.
+   */
+  private function discoverTerminalStates(string $workflowId): array {
+    $terminalStates = [];
+
+    try {
+      $workflow = $this->workflowManager->createInstance($workflowId);
+      $states = $workflow->getStates();
+      $fromStates = [];
+
+      foreach ($workflow->getTransitions() as $transition) {
+        foreach ($transition->getFromStateIds() as $fromStateId) {
+          $fromStates[$fromStateId] = TRUE;
+        }
+      }
+
+      foreach (array_keys($states) as $stateId) {
+        if (!isset($fromStates[$stateId])) {
+          $terminalStates[$stateId] = TRUE;
+        }
+      }
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Failed terminal-state discovery for workflow "@workflow": @message', [
+        '@workflow' => $workflowId,
+        '@message' => $exception->getMessage(),
+      ]);
+    }
+
+    return $terminalStates;
+  }
+
+}

--- a/web/modules/custom/myeventlane_pro/tests/src/Kernel/AbandonedCartEngineKernelTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Kernel/AbandonedCartEngineKernelTest.php
@@ -303,10 +303,10 @@ final class AbandonedCartEngineKernelTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $this->container->get('datetime.time'),
       $this->container->get('logger.channel.myeventlane_pro'),
-      $this->container->get('myeventlane_pro.entitlement'),
+      $this->container->get('myeventlane_pro.active_resolver'),
       $this->container->get('config.factory'),
       $this->container->get('plugin.manager.mail'),
-      $this->container->get('plugin.manager.workflow'),
+      $this->container->get('myeventlane_pro.abandoned_cart_terminal_state_resolver'),
       $this->container->get('myeventlane_messaging.manager'),
     );
   }


### PR DESCRIPTION
Centralize workflow terminal-state discovery so scheduler and job processing use the same cached logic and do not drift when state-machine APIs change.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes dependency wiring and the terminal-state check used to decide whether abandoned-cart reminders are scheduled/sent; mistakes could cause reminders to be skipped or sent for completed orders.
> 
> **Overview**
> Refactors abandoned-cart reminder logic to **centralize workflow terminal-state detection** in a new `AbandonedCartTerminalStateResolver` service with per-workflow caching.
> 
> Updates both `AbandonedCartScheduler` and `ProAbandonedCartJob` to use this shared resolver (and updates DI/service definitions and the kernel test wiring), removing their duplicated inline terminal-state discovery code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a74c5fb0cc26df845a8c33c544c564aeb60392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->