### PR TITLE
Cursor/myeventlane capacity b8aaf

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketTierAnalyticsService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketTierAnalyticsService.php
@@ -64,6 +64,9 @@ final class TicketTierAnalyticsService {
    * @return array{
    *   total_sold: int,
    *   total_remaining: int|null,
+   *   remaining_display: string,
+   *   has_finite_tier: bool,
+   *   has_unlimited_tier: bool,
    *   gross_revenue: array{number: string, currency_code: string}|null,
    *   active_tier_count: int,
    *   sold_out_tier_count: int,
@@ -76,6 +79,7 @@ final class TicketTierAnalyticsService {
     $totalRemaining = 0;
     $sumRemaining = FALSE;
     $hasUnlimitedTier = FALSE;
+    $hasFiniteTier = FALSE;
     $activeTierCount = 0;
     $soldOutTierCount = 0;
     $restrictedTierCount = 0;
@@ -109,6 +113,7 @@ final class TicketTierAnalyticsService {
         $hasUnlimitedTier = TRUE;
       }
       elseif ($metrics['remaining'] !== NULL) {
+        $hasFiniteTier = TRUE;
         $sumRemaining = TRUE;
         $totalRemaining += (int) $metrics['remaining'];
       }
@@ -141,9 +146,25 @@ final class TicketTierAnalyticsService {
       ];
     }
 
+    if ($hasUnlimitedTier && $hasFiniteTier) {
+      $remainingDisplay = 'Tickets available';
+    }
+    elseif ($hasUnlimitedTier) {
+      $remainingDisplay = 'No limit';
+    }
+    elseif ($sumRemaining) {
+      $remainingDisplay = (string) $totalRemaining;
+    }
+    else {
+      $remainingDisplay = '0';
+    }
+
     return [
       'total_sold' => $totalSold,
       'total_remaining' => !$hasUnlimitedTier && $sumRemaining ? $totalRemaining : NULL,
+      'remaining_display' => $remainingDisplay,
+      'has_finite_tier' => $hasFiniteTier,
+      'has_unlimited_tier' => $hasUnlimitedTier,
       'gross_revenue' => $grossRevenue,
       'active_tier_count' => $activeTierCount,
       'sold_out_tier_count' => $soldOutTierCount,

--- a/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
@@ -572,6 +572,7 @@ final class TicketSalesService {
       $variations = $product->getVariations();
       $total = 0;
       $hasUnlimited = FALSE;
+      $hasFinite = FALSE;
 
       foreach ($variations as $variation) {
         if ($variation->bundle() === 'boost_duration') {
@@ -579,6 +580,7 @@ final class TicketSalesService {
         }
 
         if ($variation->hasField('field_stock') && !$variation->get('field_stock')->isEmpty()) {
+          $hasFinite = TRUE;
           $total += (int) $variation->get('field_stock')->value;
         }
         else {
@@ -586,7 +588,13 @@ final class TicketSalesService {
         }
       }
 
-      return $hasUnlimited ? 'Unlimited' : $total;
+      if ($hasUnlimited && $hasFinite) {
+        return 'Tickets available';
+      }
+      if ($hasUnlimited) {
+        return 'No limit';
+      }
+      return $total;
     }
     catch (\Exception) {
       return 0;

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -1370,8 +1370,13 @@ final class EventTicketsBuilder {
     if (is_array($gross) && isset($gross['number'], $gross['currency_code'])) {
       $revDisplay = $gross['currency_code'] . ' ' . $this->formatPriceNumberForDisplay((string) $gross['number']);
     }
-    $remaining = $rollup['total_remaining'];
-    $remDisplay = $remaining === NULL ? (string) $this->t('Unlimited') : (string) $remaining;
+    $remDisplay = (string) ($rollup['remaining_display'] ?? '0');
+    if ($remDisplay === 'Tickets available') {
+      $remDisplay = (string) $this->t('Tickets available');
+    }
+    elseif ($remDisplay === 'No limit') {
+      $remDisplay = (string) $this->t('No limit');
+    }
 
     $note = (string) ($rollup['conversion_note'] ?? '');
     $html = '<div class="mel-ticket-analytics-strip" role="region" aria-label="' . Html::escape((string) $this->t('Ticket sales summary')) . '">';
@@ -1413,7 +1418,7 @@ final class EventTicketsBuilder {
     $isUnlimited = $capacity === NULL || $capacity < 1;
     $capDisplay = $isUnlimited ? (string) $this->t('Unlimited') : (string) $capacity;
     $remaining = $metrics['remaining'];
-    $remDisplay = $remaining === NULL ? (string) $this->t('Unlimited') : (string) $remaining;
+    $remDisplay = $remaining === NULL ? (string) $this->t('No limit') : (string) $remaining;
     $pct = $metrics['sell_through_percent'];
     $pctDisplay = $pct === NULL ? '—' : (string) $pct . '%';
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -65,9 +65,18 @@
             <p class="mel-kpi-card__label">{{ 'Tickets sold (tiers)'|t }}</p>
             <p class="mel-kpi-card__value">{{ ticket_tier_rollup.total_sold|default(0) }}</p>
           </div>
+          {% set remaining_display = ticket_tier_rollup.remaining_display|default('0') %}
           <div class="mel-kpi-card">
             <p class="mel-kpi-card__label">{{ 'Remaining'|t }}</p>
-            <p class="mel-kpi-card__value">{% if ticket_tier_rollup.total_remaining is null %}{{ 'Unlimited'|t }}{% else %}{{ ticket_tier_rollup.total_remaining }}{% endif %}</p>
+            <p class="mel-kpi-card__value">
+              {% if remaining_display == 'Tickets available' %}
+                {{ 'Tickets available'|t }}
+              {% elseif remaining_display == 'No limit' %}
+                {{ 'No limit'|t }}
+              {% else %}
+                {{ remaining_display }}
+              {% endif %}
+            </p>
           </div>
           <div class="mel-kpi-card">
             <p class="mel-kpi-card__label">{{ 'Gross revenue (tiers)'|t }}</p>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/tickets.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/tickets.html.twig
@@ -31,7 +31,15 @@
           </div>
           <div class="mel-stat">
             <div class="mel-stat__label">{{ 'Remaining'|t }}</div>
-            <div class="mel-stat__value">{{ sales.tickets_available|default(0) }}</div>
+            <div class="mel-stat__value">
+              {% if sales.tickets_available|default(0) == 'Tickets available' %}
+                {{ 'Tickets available'|t }}
+              {% elseif sales.tickets_available|default(0) == 'No limit' %}
+                {{ 'No limit'|t }}
+              {% else %}
+                {{ sales.tickets_available|default(0) }}
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes analytics/sales DTO shapes and the semantics of "remaining" (including new string states), which could affect any downstream consumers expecting numeric values.
> 
> **Overview**
> Updates ticket capacity/remaining rollups to distinguish **finite vs unlimited** tiers and provide a new `remaining_display` string (`Tickets available`, `No limit`, or a number) for events with mixed tier types.
> 
> Propagates the new display logic through the vendor ticket workspace and analytics UI (PHP builder + Twig templates), and standardizes per-tier remaining wording from `Unlimited` to `No limit` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26bdd3d316206a2af96247f66e793be1548ba6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->