### PR TITLE
Fix RSVP booking flow ticket kind detection

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
+++ b/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
@@ -9,6 +9,7 @@ use Drupal\commerce_price\CurrencyFormatter;
 use Drupal\commerce_price\Price;
 use Drupal\Core\Url;
 use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
@@ -72,7 +73,7 @@ final class BookingFlowResolver {
       return self::MODE_EXTERNAL;
     }
 
-    if ($this->hasTicketTypes($event)) {
+    if ($this->hasPaidTicketTypes($event)) {
       return self::MODE_PAID;
     }
 
@@ -385,11 +386,20 @@ final class BookingFlowResolver {
   }
 
   /**
-   * Returns TRUE when the event has configured ticket type references.
+   * Returns TRUE when the event has configured paid ticket type references.
    */
-  private function hasTicketTypes(NodeInterface $event): bool {
-    return $event->hasField('field_ticket_types')
-      && !$event->get('field_ticket_types')->isEmpty();
+  private function hasPaidTicketTypes(NodeInterface $event): bool {
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return FALSE;
+    }
+
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $ticketType) {
+      if ($ticketType instanceof TicketTypeInterface && $ticketType->getTicketKind() === 'paid') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Only paid MEL ticket types should force the paid booking flow so RSVP events with RSVP ticket types continue to resolve through RSVP handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes booking mode resolution logic for events with `field_ticket_types`, which can alter which public forms/CTAs users see and how bookings proceed. Risk is moderate because it affects core event purchase/RSVP routing but is narrowly scoped to ticket-kind detection.
> 
> **Overview**
> Fixes booking flow detection so events only resolve to **paid** mode when `field_ticket_types` contains at least one `TicketTypeInterface` with `getTicketKind() === 'paid'`, rather than any ticket-type reference.
> 
> This updates `BookingFlowResolver::getBookingMode()` to call the new `hasPaidTicketTypes()` helper (and adds the `TicketTypeInterface` dependency), ensuring RSVP events with non-paid ticket types continue to use the RSVP flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5eb742eb0fcc92712f3624786d65b5b70ccf301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->