### PR TITLE
Cursor/ticket unlimited fef25

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketTierAnalyticsService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketTierAnalyticsService.php
@@ -146,7 +146,10 @@ final class TicketTierAnalyticsService {
       ];
     }
 
-    if ($hasUnlimitedTier && $hasFiniteTier) {
+    if ($activeTierCount === 0) {
+      $remainingDisplay = 'Unlimited';
+    }
+    elseif ($hasUnlimitedTier && $hasFiniteTier) {
       $remainingDisplay = 'Tickets available';
     }
     elseif ($hasUnlimitedTier) {

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -1377,6 +1377,9 @@ final class EventTicketsBuilder {
     elseif ($remDisplay === 'No limit') {
       $remDisplay = (string) $this->t('No limit');
     }
+    elseif ($remDisplay === 'Unlimited') {
+      $remDisplay = (string) $this->t('Unlimited');
+    }
 
     $note = (string) ($rollup['conversion_note'] ?? '');
     $html = '<div class="mel-ticket-analytics-strip" role="region" aria-label="' . Html::escape((string) $this->t('Ticket sales summary')) . '">';

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -73,6 +73,8 @@
                 {{ 'Tickets available'|t }}
               {% elseif remaining_display == 'No limit' %}
                 {{ 'No limit'|t }}
+              {% elseif remaining_display == 'Unlimited' %}
+                {{ 'Unlimited'|t }}
               {% else %}
                 {{ remaining_display }}
               {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts rollup display logic for remaining tickets and adds corresponding translation handling in the vendor UI, without changing order/revenue calculations.
> 
> **Overview**
> When an event has **no active (published) ticket tiers**, the tier rollup `remaining_display` now returns `Unlimited` instead of falling through to `0`/other states.
> 
> The vendor-facing analytics strip (`EventTicketsBuilder`) and analytics dashboard template now translate and render this new `Unlimited` remaining state consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8ddefbbad5709e043bbca41a5f37561b04dc14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->