### PR TITLE
feat(event-studio): refine MEL builder workspace UX

### DIFF
--- a/config/sync/field.storage.paragraph.field_highlight_icon.yml
+++ b/config/sync/field.storage.paragraph.field_highlight_icon.yml
@@ -13,22 +13,34 @@ settings:
   allowed_values:
     -
       value: music
-      label: Music
-    -
-      value: star
-      label: Star
-    -
-      value: clock
-      label: Clock
+      label: '🎵 Music'
     -
       value: food
-      label: Food
+      label: '🍔 Food & drinks'
     -
-      value: info
-      label: Info
+      value: party
+      label: '🪩 Party / DJ'
     -
-      value: access
-      label: Accessibility
+      value: network
+      label: '🤝 Networking'
+    -
+      value: art
+      label: '🎨 Arts'
+    -
+      value: outdoor
+      label: '🌿 Outdoor'
+    -
+      value: family
+      label: '👨‍👩‍👧 Family friendly'
+    -
+      value: lgbtq
+      label: '🏳️‍🌈 LGBTQ+'
+    -
+      value: wellness
+      label: '🧘 Wellness'
+    -
+      value: education
+      label: '📚 Workshop / learning'
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/modules/custom/myeventlane_commerce/src/Service/ParagraphQuestionMapper.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/ParagraphQuestionMapper.php
@@ -50,6 +50,18 @@ class ParagraphQuestionMapper {
           ];
           break;
 
+        case 'radios':
+          $options = $this->explodeOptions($para->get('field_question_options')->value ?? '');
+          $elements[$machine] = [
+            '#type' => 'radios',
+            '#title' => $title,
+            '#options' => $options !== [] ? $options : ['_' => 'Option'],
+            '#required' => $required,
+            '#default_value' => $defaults[$machine] ?? NULL,
+            '#description' => $help,
+          ];
+          break;
+
         case 'textarea':
           $elements[$machine] = [
             '#type' => 'textarea',

--- a/web/modules/custom/myeventlane_event/src/Service/MelPlatformSupportWizardFormHelper.php
+++ b/web/modules/custom/myeventlane_event/src/Service/MelPlatformSupportWizardFormHelper.php
@@ -35,6 +35,8 @@ final class MelPlatformSupportWizardFormHelper {
    *
    * @param bool $studio_presentation
    *   TRUE for Event Studio card copy/radio labels (“Support MyEventLane 💖”).
+   * @param bool $omit_heading_and_intro
+   *   TRUE when the Event Studio Twig card supplies its own title and lede.
    */
   public function buildSection(
     array &$form,
@@ -43,6 +45,7 @@ final class MelPlatformSupportWizardFormHelper {
     int $weight = 88,
     string $heading_id = 'mel-mel-support-heading',
     bool $studio_presentation = FALSE,
+    bool $omit_heading_and_intro = FALSE,
   ): void {
     if (!$this->moduleHandler->moduleExists('myeventlane_donations')) {
       return;
@@ -88,22 +91,24 @@ final class MelPlatformSupportWizardFormHelper {
       ],
     ];
 
-    $form['mel_mel_support']['_title'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'h3',
-      '#value' => $studio_presentation ? $this->t('Support MyEventLane 💖') : $this->t('Support MyEventLane'),
-      '#attributes' => [
-        'class' => ['mel-mel-support__title'],
-        'id' => $heading_id,
-      ],
-    ];
+    if (!$omit_heading_and_intro) {
+      $form['mel_mel_support']['_title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $studio_presentation ? $this->t('Support MyEventLane 💖') : $this->t('Support MyEventLane'),
+        '#attributes' => [
+          'class' => ['mel-mel-support__title'],
+          'id' => $heading_id,
+        ],
+      ];
 
-    $form['mel_mel_support']['_intro'] = [
-      '#type' => 'markup',
-      '#markup' => $studio_presentation
-        ? '<p class="mel-mel-support__intro">' . $this->t('<strong>This supports MyEventLane</strong>. It is <strong>not</strong> added to attendee ticket pricing or the ticket checkout total. One-time amounts are handled in a separate MEL step after you publish, when applicable.') . '</p>'
-        : '<p class="mel-mel-support__intro">' . $this->t('Optional: help us keep community event tools affordable. A one-time amount is paid on MyEventLane checkout <strong>after you publish</strong>—it is not mixed into the ticket cart or attendee purchases. Revenue % pledges are stored for future billing.') . '</p>',
-    ];
+      $form['mel_mel_support']['_intro'] = [
+        '#type' => 'markup',
+        '#markup' => $studio_presentation
+          ? '<p class="mel-mel-support__intro">' . $this->t('<strong>This supports MyEventLane</strong>. It is <strong>not</strong> added to attendee ticket pricing or the ticket checkout total. One-time amounts are handled in a separate MEL step after you publish, when applicable.') . '</p>'
+          : '<p class="mel-mel-support__intro">' . $this->t('Optional: help us keep community event tools affordable. A one-time amount is paid on MyEventLane checkout <strong>after you publish</strong>—it is not mixed into the ticket cart or attendee purchases. Revenue % pledges are stored for future billing.') . '</p>',
+      ];
+    }
 
     if ($studio_presentation) {
       $options = [
@@ -134,13 +139,29 @@ final class MelPlatformSupportWizardFormHelper {
       $effective_mode = 'none';
     }
 
-    $form['mel_mel_support']['mode'] = [
+    $mode_element = [
       '#type' => 'radios',
       '#title' => $this->t('Support MyEventLane'),
       '#options' => $options,
       '#default_value' => $effective_mode,
       '#required' => TRUE,
     ];
+
+    // Event Studio: card-style option selectors (vendor theme .mel-option-card).
+    if ($studio_presentation) {
+      $mode_element['#mel_option_cards'] = TRUE;
+      $mode_element['#mel_option_descriptions'] = [
+        'none' => $this->t('Skip optional platform support on this event.'),
+        'onetime' => $this->t('Handled in a separate MEL step after publish — never added to ticket checkout totals.'),
+      ];
+      if ($paid_like) {
+        $mode_element['#mel_option_descriptions']['percent'] = $this->t(
+          'Stores a pledge for future MEL vendor billing tools — nothing is charged immediately.'
+        );
+      }
+    }
+
+    $form['mel_mel_support']['mode'] = $mode_element;
 
     $form['mel_mel_support']['amount'] = [
       '#type' => 'number',

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -112,10 +112,18 @@
   margin-bottom: 0;
 }
 
-/* Stacks end with .mel-step-actions, so cards are never :last-child. Pure
-   section:last-of-type fails when a section is followed by details.mel-advanced. */
-.mel-event-studio .mel-es-stack:has(> .mel-step-actions:last-child) > :nth-last-child(2) {
+/* Stacks end with .mel-step-actions, so cards are never :last-child. */
+.mel-event-studio .mel-es-stack:has(> .mel-step-actions:last-child) > :nth-last-child(2),
+.mel-event-studio .mel-builder-step-stack:has(> .mel-step-actions:last-child) > :nth-last-child(2) {
   margin-bottom: 0;
+}
+
+/* Builder step column: spaced cards (replaces tight .mel-es-stack in wizard main). */
+.mel-event-studio .mel-builder-step-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
 }
 
 .mel-event-studio .mel-es-card__header {
@@ -348,38 +356,29 @@
 /* Tickets region (nested builder)                                              */
 /* -------------------------------------------------------------------------- */
 
-.mel-event-studio .mel-ticket-section {
-  margin-top: 0.5rem;
-  padding: 1rem 1.1rem 1.25rem;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-}
-
-.mel-event-studio .mel-ticket-section .mel-tickets-intro {
+.mel-event-studio .mel-builder-card--tickets .mel-tickets-intro {
   margin-top: 0;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-builder,
-.mel-event-studio .mel-ticket-section .mel-ticket-wizard-embed {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-builder,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-wizard-embed {
   background: #fff;
   border-color: #eee;
   box-shadow: none;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-controls {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-controls {
   margin-bottom: 12px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-controls--primary {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-controls--primary {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
 
-.mel-event-studio .mel-ticket-section .btn-primary,
-.mel-event-studio .mel-ticket-section .mel-ticket-controls__paid,
-.mel-event-studio .mel-ticket-section .mel-ticket-controls [name='ticket_save_sync'] {
+.mel-event-studio .mel-builder-card--tickets .btn-primary,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-controls__paid {
   background: #f26d5b !important;
   color: #fff !important;
   border-radius: 10px !important;
@@ -388,8 +387,8 @@
   border: none !important;
 }
 
-.mel-event-studio .mel-ticket-section .btn-secondary,
-.mel-event-studio .mel-ticket-section .mel-ticket-controls__rsvp {
+.mel-event-studio .mel-builder-card--tickets .btn-secondary,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-controls__rsvp {
   background: #eef2ff !important;
   color: #4f46e5 !important;
   border-radius: 10px !important;
@@ -398,8 +397,8 @@
   border: none !important;
 }
 
-.mel-event-studio .mel-ticket-section .btn-ghost,
-.mel-event-studio .mel-ticket-section .mel-ticket-controls__external {
+.mel-event-studio .mel-builder-card--tickets .btn-ghost,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-controls__external {
   background: transparent !important;
   border: 1px dashed #ddd !important;
   color: #666 !important;
@@ -408,7 +407,7 @@
   font-weight: 500 !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card {
   border-radius: 16px;
   border: 1px solid #eee;
   padding: 16px;
@@ -416,19 +415,19 @@
   background: #fff;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card:last-child {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card:last-child {
   margin-bottom: 0;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__title {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__title {
   font-weight: 600;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__price {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__price {
   color: #6e7ef2;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__meta {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
@@ -437,11 +436,11 @@
   margin-top: 8px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__meta li {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__meta li {
   margin: 0;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions {
   margin-top: 10px;
   display: flex;
   flex-wrap: wrap;
@@ -449,23 +448,23 @@
   align-items: flex-start;
 }
 
-.mel-event-studio .mel-ticket-section [data-mel-ticket-edit] {
+.mel-event-studio .mel-builder-card--tickets [data-mel-ticket-edit] {
   display: none;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card.is-editing [data-mel-ticket-view] {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.is-editing [data-mel-ticket-view] {
   display: none !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card.is-editing [data-mel-ticket-edit] {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.is-editing [data-mel-ticket-edit] {
   display: flex !important;
   flex-direction: column;
   gap: 14px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions .mel-btn,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions input.mel-btn,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions button.mel-btn {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions .mel-btn,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions input.mel-btn,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions button.mel-btn {
   width: auto !important;
   min-height: 34px;
   margin: 0 !important;
@@ -477,7 +476,7 @@
   box-shadow: none !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions [data-mel-ticket-edit-toggle] {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions [data-mel-ticket-edit-toggle] {
   appearance: none !important;
   border: 1px solid #dbe2ef !important;
   background: #f7f8ff !important;
@@ -486,62 +485,62 @@
   text-decoration: none !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions .mel-btn--ghost,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions button.mel-btn--ghost {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions .mel-btn--ghost,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions button.mel-btn--ghost {
   border: 1px solid #dbe2ef !important;
   background: #fff !important;
   color: #335cff !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions .mel-btn--secondary,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions input.mel-btn--secondary,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions button.mel-btn--secondary {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions .mel-btn--secondary,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions input.mel-btn--secondary,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions button.mel-btn--secondary {
   border: 1px solid #dbe2ef !important;
   background: #f7f8ff !important;
   color: #243b8f !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions .mel-btn--danger,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions input.mel-btn--danger,
-.mel-event-studio .mel-ticket-section .mel-ticket-card__actions button.mel-btn--danger {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions .mel-btn--danger,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions input.mel-btn--danger,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__actions button.mel-btn--danger {
   border: 1px solid #fed7d7 !important;
   background: #fff5f5 !important;
   color: #c53030 !important;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__header-actions {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__header-actions {
   display: inline-flex;
   align-items: center;
   gap: 8px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__meta-line {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__meta-line {
   margin-top: 10px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__visibility {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__visibility {
   margin-top: 8px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-edit {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-edit {
   margin-top: 12px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-edit__actions {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-edit__actions {
   align-items: center;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-edit__actions .js-mel-ticket-save,
-.mel-event-studio .mel-ticket-section .mel-ticket-edit__actions .js-mel-ticket-cancel {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-edit__actions .js-mel-ticket-save,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-edit__actions .js-mel-ticket-cancel {
   min-width: 128px;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card.is-editing .mel-ticket-drag-handle {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.is-editing .mel-ticket-drag-handle {
   top: 30px;
   transform: none;
 }
 
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow {
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow {
   position: relative;
   flex: 0 0 auto;
   margin-left: auto;
@@ -553,12 +552,12 @@
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
 }
 
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] {
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow[open] {
   padding: 8px;
   min-width: 11rem;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__overflow-trigger {
   list-style: none;
   cursor: pointer;
   width: 2.25rem;
@@ -577,25 +576,25 @@
   user-select: none;
 }
 
-.mel-event-studio .mel-ticket-section .mel-ticket-card__overflow-trigger::-webkit-details-marker {
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__overflow-trigger::-webkit-details-marker {
   display: none;
 }
 
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow[open] .mel-ticket-card__overflow-trigger {
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow[open] .mel-ticket-card__overflow-trigger {
   margin-bottom: 6px;
 }
 
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button,
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn,
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn {
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow .button,
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow input.mel-btn,
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow button.mel-btn {
   width: 100%;
   justify-content: center;
   margin-top: 4px;
 }
 
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow .button:first-of-type,
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow input.mel-btn:first-of-type,
-.mel-event-studio .mel-ticket-section details.mel-ticket-card__overflow button.mel-btn:first-of-type {
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow .button:first-of-type,
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow input.mel-btn:first-of-type,
+.mel-event-studio .mel-builder-card--tickets details.mel-ticket-card__overflow button.mel-btn:first-of-type {
   margin-top: 0;
 }
 
@@ -713,45 +712,20 @@
 /* MEL Builder canvas (main workspace)                                          */
 /* -------------------------------------------------------------------------- */
 
+/* Builder layout + card chrome: vendor theme components/_mel-builder.scss (.mel-vendor .mel-event-studio …). */
+
 .mel-event-studio .mel-studio-top.mel-studio-top--solo {
   margin-bottom: 20px;
 }
 
-.mel-event-studio .mel-builder {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 28px;
-  width: 100%;
+/* Preview docked below builder (was above workspace). */
+.mel-event-studio .mel-studio-preview-panel--bottom.mel-studio-top--solo {
+  margin-top: 20px;
+  margin-bottom: 0;
 }
 
-.mel-event-studio .mel-builder__main {
-  flex: 1 1 0;
-  min-width: 0;
-}
-
-.mel-event-studio .mel-builder__sidebar {
-  flex: 0 0 276px;
-  width: 276px;
-  max-width: 100%;
-}
-
-.mel-event-studio .mel-builder-sidebar__sticky {
-  position: sticky;
-  top: 88px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 16px 18px;
-  border-radius: 16px;
-  border: 1px solid #e8e8ef;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
-  background: #fff;
-  box-sizing: border-box;
-}
-
-.mel-event-studio .mel-builder-card {
-  scroll-margin-top: 112px;
+.mel-event-studio .mel-builder-card--publish .mel-publish-action-card {
+  margin-top: 4px;
 }
 
 .mel-event-studio .mel-builder .mel-step-actions {
@@ -789,6 +763,18 @@
   justify-content: center;
 }
 
+.mel-event-studio .mel-builder-sidebar__save {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.mel-event-studio .mel-builder-sidebar__save .mel-builder-save-sidebar {
+  width: 100%;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
 .mel-event-studio .mel-ai-controls--sidebar {
   padding-top: 6px;
   border-top: 1px dashed #e2e8f0;
@@ -815,30 +801,7 @@
   color: #475569;
 }
 
-@media (max-width: 959px) {
-  .mel-event-studio .mel-builder {
-    flex-direction: column-reverse;
-    gap: 18px;
-  }
-
-  .mel-event-studio .mel-builder__sidebar {
-    flex-basis: auto;
-    width: 100%;
-  }
-
-  .mel-event-studio .mel-builder-sidebar__sticky {
-    position: sticky;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
-    top: auto;
-    z-index: 12;
-    box-shadow: 0 -14px 32px rgba(15, 23, 42, 0.12);
-    border-radius: 16px;
-  }
-
-  .mel-event-studio .mel-studio-form-wrapper {
-    padding-bottom: 88px;
-  }
-}
+/* Builder responsive layout: vendor theme _mel-builder.scss */
 
 /* -------------------------------------------------------------------------- */
 /* Guided builder: progressive reveal, MEL contribution card, attendee editor  */
@@ -987,17 +950,13 @@
   border-bottom: 0;
 }
 
-.mel-event-studio .mel-attendee-row__grid {
+.mel-event-studio .mel-attendee-row__primary {
   margin-bottom: 8px;
 }
 
 /* -------------------------------------------------------------------------- */
 /* Task-based builder cards — spacing, hierarchy, MEL contribution            */
 /* -------------------------------------------------------------------------- */
-
-.mel-event-studio .mel-builder-task-card {
-  scroll-margin-top: 112px;
-}
 
 .mel-event-studio .mel-task-card__banner {
   margin: 0 0 22px;
@@ -1021,13 +980,72 @@
   color: #475569;
 }
 
-.mel-event-studio .mel-builder .mel-es-card {
-  margin-bottom: 24px;
-  padding: 26px 28px;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+.mel-event-studio .mel-stage-transition {
+  margin: 6px 0 24px;
+  padding: 20px 1.25rem 22px;
+  text-align: center;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.7);
 }
 
-.mel-event-studio .mel-builder .mel-es-stack > .mel-step-actions {
+.mel-event-studio .mel-stage-transition--tickets {
+  border-radius: 14px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  background: linear-gradient(180deg, rgba(240, 253, 250, 0.55) 0%, rgba(255, 255, 255, 0.35) 48%, rgba(255, 255, 255, 0.2) 100%);
+  box-shadow:
+    0 1px 0 0 rgba(255, 255, 255, 0.85),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.65);
+}
+
+.mel-event-studio .mel-stage-transition__progress {
+  height: 5px;
+  border-radius: 999px;
+  margin: 0 auto 14px;
+  max-width: 11rem;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.mel-event-studio .mel-stage-transition__progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  width: calc(100% * 2 / 6);
+  background: linear-gradient(90deg, #34d399 0%, #059669 100%);
+  transition: width 0.35s ease;
+}
+
+.mel-event-studio .mel-stage-transition__kicker {
+  margin: 0 auto 10px;
+  max-width: 36rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: #64748b;
+  line-height: 1.35;
+}
+
+.mel-event-studio .mel-stage-transition__title {
+  margin: 0 auto 10px;
+  max-width: 36rem;
+  font-size: 1.3125rem;
+  line-height: 1.35;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.mel-event-studio .mel-stage-transition__subtitle {
+  margin: 0 auto;
+  max-width: 36rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #64748b;
+}
+
+.mel-event-studio .mel-builder .mel-builder-step-stack > .mel-step-actions {
   margin-top: 8px;
 }
 
@@ -1103,11 +1121,6 @@
 
 .mel-event-studio .mel-btn.mel-btn--sidebar-secondary {
   min-height: 40px;
-}
-
-.mel-event-studio .mel-builder-card-group--post-ticket,
-.mel-event-studio .mel-builder-card-group--standout {
-  margin-bottom: 8px;
 }
 
 .mel-event-studio .mel-es-workspace__main .form-item,

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -144,49 +144,7 @@
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
 }
 
-.mel-radios .form-radios,
-.mel-radios--tickets .form-radios {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
 
-@media (min-width: 600px) {
-  .mel-radios--tickets .form-radios {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 0.65rem;
-  }
-}
-
-.mel-radios .form-type-radio {
-  margin: 0;
-}
-
-.mel-radios .form-type-radio label {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 500;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--mel-studio-border);
-  border-radius: var(--mel-studio-radius-sm);
-  background: var(--mel-studio-bg);
-  cursor: pointer;
-  margin: 0;
-}
-
-.mel-radios .form-type-radio input:checked + label,
-.mel-radios .form-type-radio label:has(input:checked) {
-  border-color: var(--mel-studio-accent);
-  background: var(--mel-studio-accent-soft);
-}
-
-/* Fallback when :has unsupported: rely on Drupal wrapping — use sibling if needed */
-.mel-radios .form-type-radio input:focus-visible + label {
-  outline: 2px solid var(--mel-studio-focus);
-  outline-offset: 2px;
-}
 
 .mel-panel--placeholder {
   background: var(--mel-studio-bg);
@@ -1058,6 +1016,26 @@ textarea.mel-input--body {
 
 .mel-highlights-builder .mel-highlight-remove {
   font-size: 0.8125rem;
+}
+
+/* Highlight icon — dropdown with emoji labels (field_highlight_icon). */
+.mel-event-studio .mel-highlights-builder-table .mel-highlight-icon-cell {
+  min-width: 11rem;
+  vertical-align: middle;
+}
+
+.mel-event-studio .mel-highlights-builder-table select.mel-highlight-icon {
+  width: 100%;
+  max-width: 100%;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-family:
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    'Noto Color Emoji',
+    system-ui,
+    sans-serif;
 }
 
 .mel-btn--touch {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -31,6 +31,175 @@
   }
 
   /**
+   * Scroll to a builder card and sync wizard nav to its step.
+   *
+   * @param {HTMLFormElement} form
+   * @param {HTMLElement|null} cardEl
+   */
+  function melScrollToBuilderCard(form, cardEl) {
+    if (!cardEl) {
+      return;
+    }
+    scrollToTarget(cardEl);
+    if (!form || !cardEl.closest) {
+      return;
+    }
+    var stepSection = cardEl.closest('section.mel-step[data-step]');
+    if (!stepSection) {
+      return;
+    }
+    var sid = stepSection.getAttribute('data-step');
+    for (var s = 0; s < MEL_STEPS.length; s++) {
+      if (MEL_STEPS[s].id === sid) {
+        setWizardNavActive(form, s);
+        setWizardStepIndex(form, s);
+        break;
+      }
+    }
+  }
+
+  /**
+   * True when the element is shown (within the studio form subtree).
+   *
+   * @param {HTMLFormElement} form
+   * @param {Element} el
+   * @return {boolean}
+   */
+  function melIsBuilderCardDomVisible(form, el) {
+    if (!form || !el || !form.contains(el)) {
+      return false;
+    }
+    var node = el;
+    while (node && node !== form && form.contains(node)) {
+      if (node.nodeType === 1) {
+        if (node.hidden || node.hasAttribute('hidden')) {
+          return false;
+        }
+        var st = window.getComputedStyle(node);
+        if (st.display === 'none' || st.visibility === 'hidden') {
+          return false;
+        }
+      }
+      node = node.parentElement;
+    }
+    return true;
+  }
+
+  /**
+   * Top-level studio cards in DOM order, excluding collapsed/hidden subtree.
+   *
+   * @param {HTMLFormElement} form
+   * @return {Element[]}
+   */
+  function melOrderedVisibleBuilderCards(form) {
+    if (!form) {
+      return [];
+    }
+    return Array.prototype.slice.call(form.querySelectorAll('.mel-builder-card')).filter(function (card) {
+      return melIsBuilderCardDomVisible(form, card);
+    });
+  }
+
+  /**
+   * Next visible builder card after the given one (DOM order inside the form).
+   *
+   * @param {HTMLFormElement} form
+   * @param {Element|null} currentCard
+   * @return {Element|null}
+   */
+  function melNextVisibleBuilderCard(form, currentCard) {
+    var cards = melOrderedVisibleBuilderCards(form);
+    if (!currentCard) {
+      return null;
+    }
+    var ix = cards.indexOf(currentCard);
+    if (ix < 0) {
+      return null;
+    }
+    return cards[ix + 1] || null;
+  }
+
+  /**
+   * Next card in primary flow — skips optional MEL support (still visible).
+   *
+   * @param {HTMLFormElement} form
+   * @param {Element|null} currentCard
+   * @return {Element|null}
+   */
+  function melNextPrimaryFlowBuilderCard(form, currentCard) {
+    var next = melNextVisibleBuilderCard(form, currentCard);
+    while (next && next.id === 'mel-card-support') {
+      next = melNextVisibleBuilderCard(form, next);
+    }
+    if (!next && currentCard && currentCard.id === 'mel-card-tickets') {
+      return document.getElementById('mel-card-standout');
+    }
+    return next;
+  }
+
+  /**
+   * @param {Element|null} card
+   * @return {Element|null}
+   */
+  function melBuilderCardHintHeading(card) {
+    if (!card) {
+      return null;
+    }
+    var mh = card.querySelector('#mel-description-heading');
+    if (mh) {
+      return mh;
+    }
+    var prog = card.querySelector('.mel-builder-progressive__title:not(.visually-hidden)');
+    if (prog) {
+      return prog;
+    }
+    return (
+      card.querySelector('.mel-builder-card__title:not(.visually-hidden)') ||
+      card.querySelector('h2:not(.visually-hidden), h3:not(.visually-hidden), h4:not(.visually-hidden)') ||
+      card.querySelector('h2, h3, h4')
+    );
+  }
+
+  /**
+   * Default expanded card: first incomplete card in the current wizard step, else last card in step.
+   *
+   * @param {HTMLFormElement} form
+   * @return {HTMLElement|null}
+   */
+  function melPickDefaultActiveBuilderCard(form) {
+    if (!form) {
+      return null;
+    }
+    var stepIdx = getWizardStepIndex(form);
+    var stepEl =
+      stepIdx >= 0 && stepIdx < MEL_STEPS.length
+        ? document.getElementById('mel-step-' + MEL_STEPS[stepIdx].id)
+        : null;
+    var cards = melOrderedVisibleBuilderCards(form);
+    if (stepEl) {
+      cards = cards.filter(function (c) {
+        return stepEl.contains(c);
+      });
+    }
+    var i;
+    for (i = 0; i < cards.length; i++) {
+      var c = cards[i];
+      if (c.id === 'mel-card-publish') {
+        continue;
+      }
+      if (!c.classList.contains('is-complete')) {
+        return cards[i];
+      }
+    }
+    for (i = cards.length - 1; i >= 0; i--) {
+      if (cards[i].id !== 'mel-card-publish') {
+        return cards[i];
+      }
+    }
+    return cards[0] || null;
+  }
+
+  /**
    * @param {string|HTMLElement} sel
    */
   function melScrollToSelector(sel) {
@@ -49,11 +218,14 @@
   var MEL_STEPS = [
     { id: 'identity', label: 'Event identity' },
     { id: 'tickets', label: 'How people join' },
-    { id: 'attendee', label: 'Attendee questions' },
     { id: 'standout', label: 'Stand out' },
+    { id: 'attendee', label: 'Attendee questions' },
     { id: 'preview', label: 'Preview' },
     { id: 'publish', label: 'Publish' },
   ];
+
+  /** @type {WeakMap<HTMLFormElement, number>} */
+  var melBuilderCardFocusRafIds = new WeakMap();
 
   function getSettings() {
     return (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudio) || {};
@@ -88,12 +260,16 @@
     if (!el) {
       return;
     }
-    var progHost = el.closest('[data-mel-reveal-section="mel-description"], [data-mel-reveal-section="mel-advanced"]');
-    if (progHost && progHost.classList.contains('mel-builder-reveal--hidden')) {
-      progHost.classList.remove('mel-builder-reveal--hidden');
-      progHost.setAttribute('aria-hidden', 'false');
+    var progD = el.closest('details');
+    while (progD && form.contains(progD)) {
+      progD.open = true;
+      var progP = progD.parentElement;
+      progD = progP ? progP.closest('details') : null;
     }
-    var scrollTarget = el.closest('.js-form-item, .form-item, .fieldset, .mel-step') || el;
+    var scrollTarget =
+      el.closest('.mel-builder-card') ||
+      el.closest('.js-form-item, .form-item, .fieldset, .mel-step') ||
+      el;
     scrollToTarget(scrollTarget);
     window.setTimeout(function () {
       try {
@@ -627,6 +803,28 @@
     return form.querySelector('[data-mel-ticket-card-list="draft"]');
   }
 
+  /**
+   * First direct child ticket card in a list is the “hero” tier (studio UX).
+   *
+   * @param {HTMLElement|null} list
+   */
+  function syncPrimaryTicketClassInList(list) {
+    if (!list || !list.children) {
+      return;
+    }
+    var cards = [];
+    var i;
+    for (i = 0; i < list.children.length; i++) {
+      var el = list.children[i];
+      if (el.classList && el.classList.contains('js-mel-ticket-card')) {
+        cards.push(el);
+      }
+    }
+    for (i = 0; i < cards.length; i++) {
+      cards[i].classList.toggle('mel-ticket--primary', i === 0);
+    }
+  }
+
   function getHighlightsTable(form) {
     return form.querySelector('table[data-mel-highlights-table]');
   }
@@ -726,6 +924,55 @@
     }
   }
 
+  function getHighlightIconPickerItems() {
+    var s = getSettings();
+    var raw = s.highlightIconPicker;
+    if (Array.isArray(raw)) {
+      return raw;
+    }
+    if (raw && typeof raw === 'object') {
+      return Object.keys(raw)
+        .filter(function (k) {
+          return /^\d+$/.test(k);
+        })
+        .sort(function (a, b) {
+          return Number(a) - Number(b);
+        })
+        .map(function (k) {
+          return raw[k];
+        });
+    }
+    return [];
+  }
+
+  /**
+   * Options for highlight icon <select>: value = storage key, label = visible text (emoji + words).
+   *
+   * @return {Array<{value: string, label: string}>}
+   */
+  function getHighlightIconSelectOptionPairs() {
+    var pairs = [{ value: '', label: Drupal.t('No icon') }];
+    var pickerItems = getHighlightIconPickerItems();
+    if (pickerItems.length > 0) {
+      var pi;
+      for (pi = 0; pi < pickerItems.length; pi++) {
+        var it = pickerItems[pi];
+        var key = it && it.value != null ? String(it.value) : '';
+        if (key === '') {
+          continue;
+        }
+        var lbl = it && it.label != null ? String(it.label) : key;
+        pairs.push({ value: key, label: lbl });
+      }
+      return pairs;
+    }
+    var icons = getHighlightIconOptions();
+    Object.keys(icons).forEach(function (k) {
+      pairs.push({ value: k, label: String(icons[k] || k) });
+    });
+    return pairs;
+  }
+
   function collectHighlightsFromDom(form) {
     var table = getHighlightsTable(form);
     if (!table) {
@@ -734,7 +981,7 @@
     var rows = table.querySelectorAll('tbody .mel-highlight-row');
     var out = [];
     rows.forEach(function (tr) {
-      var sel = tr.querySelector('.mel-highlight-icon');
+      var sel = tr.querySelector('select.mel-highlight-icon');
       var ta = tr.querySelector('.mel-highlight-text');
       var icon = sel ? String(sel.value || '').trim() : '';
       var text = ta ? String(ta.value || '').trim() : '';
@@ -747,24 +994,36 @@
     var tr = document.createElement('tr');
     tr.className = 'mel-highlight-row';
     tr.setAttribute('data-highlight-index', String(index));
-    var icons = getHighlightIconOptions();
+
     var tdIcon = document.createElement('td');
+    tdIcon.className = 'mel-highlight-icon-cell';
+
     var sel = document.createElement('select');
     sel.className = 'mel-input mel-highlight-icon';
     sel.setAttribute('aria-label', Drupal.t('Highlight icon'));
-    var optEmpty = document.createElement('option');
-    optEmpty.value = '';
-    optEmpty.textContent = Drupal.t('None');
-    sel.appendChild(optEmpty);
-    Object.keys(icons).forEach(function (k) {
-      var o = document.createElement('option');
-      o.value = k;
-      o.textContent = icons[k];
-      sel.appendChild(o);
-    });
-    if (row && row.icon) {
-      sel.value = row.icon;
+
+    var pairs = getHighlightIconSelectOptionPairs();
+    var rowIcon = row && row.icon != null ? String(row.icon).trim() : '';
+    var matched = false;
+    var i;
+    for (i = 0; i < pairs.length; i++) {
+      var opt = document.createElement('option');
+      opt.value = pairs[i].value;
+      opt.textContent = pairs[i].label;
+      if (pairs[i].value === rowIcon) {
+        opt.selected = true;
+        matched = true;
+      }
+      sel.appendChild(opt);
     }
+    if (!matched && rowIcon !== '') {
+      var legacy = document.createElement('option');
+      legacy.value = rowIcon;
+      legacy.textContent = rowIcon;
+      legacy.selected = true;
+      sel.insertBefore(legacy, sel.options[1] || null);
+    }
+
     tdIcon.appendChild(sel);
 
     var tdText = document.createElement('td');
@@ -1203,23 +1462,38 @@
     drag.setAttribute('draggable', 'true');
     card.appendChild(drag);
 
-    var header = document.createElement('div');
-    header.className = 'mel-ticket-card__header';
-    var titleGroup = document.createElement('div');
-    titleGroup.className = 'mel-ticket-card__title-group';
-    var title = document.createElement('div');
-    title.className = 'mel-ticket-card__title';
-    title.textContent = tier.title ? String(tier.title) : Drupal.t('Untitled ticket');
-    titleGroup.appendChild(title);
+    var display = document.createElement('div');
+    display.className = 'mel-ticket-card__display mel-ticket-card__display--draft';
+    display.setAttribute('data-mel-ticket-outcome-display', '1');
+    var displayTitle = document.createElement('h4');
+    displayTitle.className = 'mel-ticket-card__display-title';
+    displayTitle.textContent = tier.title ? String(tier.title) : Drupal.t('Untitled ticket');
+    var displayPrice = document.createElement('span');
+    displayPrice.className = 'mel-ticket-card__price';
+    displayPrice.setAttribute('data-mel-ticket-display-price', '');
+    displayPrice.textContent =
+      kind === 'paid'
+        ? tier.price_number && String(tier.price_number).trim() !== '' && parseFloat(String(tier.price_number)) > 0
+          ? String(tier.price_currency || 'AUD').toUpperCase().slice(0, 3) + ' ' + String(tier.price_number)
+          : '—'
+        : kind === 'rsvp'
+          ? Drupal.t('$0')
+          : Drupal.t('External');
+    display.appendChild(displayTitle);
+    display.appendChild(displayPrice);
+
     var state = document.createElement('span');
     state.className = 'mel-badge mel-badge--inactive';
     state.textContent = Drupal.t('Draft');
-    header.appendChild(titleGroup);
-    header.appendChild(state);
-    card.appendChild(header);
+
+    var headRow = document.createElement('div');
+    headRow.className = 'mel-ticket-card__header mel-ticket-card__header--outcome';
+    headRow.appendChild(display);
+    headRow.appendChild(state);
+    card.appendChild(headRow);
 
     var fields = document.createElement('div');
-    fields.className = 'mel-ticket-card__fields mel-ticket-card__fields--inline';
+    fields.className = 'mel-ticket-card__fields mel-ticket-card__fields--inline mel-ticket-card__edit-layer';
 
     var kindSelect = document.createElement('select');
     kindSelect.className = 'mel-input mel-tier-kind';
@@ -1319,10 +1593,28 @@
     var kind = getDraftCardKind(card);
     card.setAttribute('data-mel-ticket-kind', kind);
     var titleEl = card.querySelector('.mel-tier-title');
-    var title = card.querySelector('.mel-ticket-card__title');
+    var title = card.querySelector('.mel-ticket-card__display-title');
+    var priceLbl = card.querySelector('.mel-ticket-card__display--draft .mel-ticket-card__price, .mel-ticket-card__display .mel-ticket-card__price');
     if (title) {
       var label = titleEl ? String(titleEl.value || '').trim() : '';
       title.textContent = label || Drupal.t('Untitled ticket');
+    }
+    if (priceLbl) {
+      if (kind === 'paid') {
+        var priceInput = card.querySelector('.mel-tier-price');
+        var cur = card.getAttribute('data-tier-currency') || getSettings().defaultCurrency || 'AUD';
+        var amt = priceInput ? String(priceInput.value || '').trim() : '';
+        priceLbl.textContent =
+          amt !== '' && !isNaN(parseFloat(amt)) && parseFloat(amt) > 0
+            ? String(cur).toUpperCase().slice(0, 3) + ' ' + amt
+            : '\u2014';
+      }
+      else if (kind === 'rsvp') {
+        priceLbl.textContent = Drupal.t('$0');
+      }
+      else {
+        priceLbl.textContent = Drupal.t('External');
+      }
     }
     card.querySelectorAll('.mel-tier-price, .mel-tier-external, .mel-tier-capacity').forEach(function (el) {
       var field = el.closest('.mel-ticket-card__field');
@@ -1340,6 +1632,7 @@
       validation.textContent = errors.join(' ');
     }
     card.classList.toggle('is-invalid', errors.length > 0);
+    card.classList.toggle('mel-ticket--complete', errors.length === 0);
   }
 
   function updateDraftEmptyState(form, count) {
@@ -1364,6 +1657,7 @@
       list.appendChild(createDraftTicketCard(form, tier, index));
     });
     updateDraftEmptyState(form, tiers.length);
+    syncPrimaryTicketClassInList(list);
     syncTicketTiersFromDomToHidden(form);
     syncPaidTierWarning(form);
   }
@@ -1588,6 +1882,7 @@
     });
     list.addEventListener('drop', function (e) {
       e.preventDefault();
+      syncPrimaryTicketClassInList(list);
       syncTicketTiersFromDomToHidden(form);
       setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
       refreshIntelligence(form);
@@ -1936,6 +2231,140 @@
     return start || end;
   }
 
+  /**
+   * One-line summary for a collapsed completed builder card.
+   *
+   * @param {HTMLElement} card
+   * @param {HTMLFormElement} form
+   * @return {string}
+   */
+  function melBuildCardSummary(card, form) {
+    if (!card || !form) {
+      return '';
+    }
+    var cid = card.id || '';
+    if (cid === 'mel-card-identity') {
+      var titleRaw = val(form, 'mel[title]').trim();
+      return '\uD83C\uDF89 ' + (titleRaw ? titleRaw : Drupal.t('Untitled event'));
+    }
+    if (cid === 'mel-card-schedule') {
+      return scheduleSummary(form) + ' \u00b7 ' + venueSummaryLine(form);
+    }
+    if (cid === 'mel-card-tickets') {
+      var n = form.querySelectorAll('.js-mel-ticket-card').length;
+      return Drupal.formatPlural(n, '@count ticket type', '@count ticket types');
+    }
+    if (cid === 'mel-card-standout') {
+      var teaser = val(form, 'mel[summary]').trim();
+      if (teaser.length >= 10) {
+        return teaser.length > 72 ? teaser.slice(0, 72) + '\u2026' : teaser;
+      }
+      var about = val(form, 'mel[body]').trim();
+      if (about.length >= 40) {
+        return about.length > 72 ? about.slice(0, 72) + '\u2026' : about;
+      }
+      var intro = val(form, 'mel[field_event_intro]').trim();
+      if (intro.length >= 20) {
+        return intro.length > 72 ? intro.slice(0, 72) + '\u2026' : intro;
+      }
+      return Drupal.t('Listing details added');
+    }
+    if (cid === 'mel-card-attendee') {
+      var aq = 0;
+      try {
+        aq = parseAttendeeQuestionsState(form).length;
+      } catch (eAq) {
+        aq = 0;
+      }
+      if (aq > 0) {
+        var qlabel = aq === 1 ? Drupal.t('custom question') : Drupal.t('custom questions');
+        return String(aq) + ' ' + qlabel;
+      }
+      return Drupal.t('No extra questions');
+    }
+    if (cid === 'mel-card-publish') {
+      return Drupal.t('Ready to publish');
+    }
+    return Drupal.t('Completed');
+  }
+
+  /**
+   * Single active builder card: expand target, collapse others (publish card stays fully open).
+   *
+   * @param {HTMLFormElement} form
+   * @param {HTMLElement|null} targetCard
+   */
+  function melSetActiveBuilderCard(form, targetCard) {
+    if (!form || !targetCard) {
+      return;
+    }
+    if (targetCard.id) {
+      form.dataset.melBuilderActiveCardId = targetCard.id;
+    } else {
+      delete form.dataset.melBuilderActiveCardId;
+    }
+
+    form.querySelectorAll('.mel-builder-card').forEach(function (card) {
+      var body = card.querySelector(':scope > .mel-builder-card__body');
+      var summary = card.querySelector(':scope > .mel-builder-card__summary');
+      if (!body || !summary) {
+        return;
+      }
+
+      if (card.id === 'mel-card-publish') {
+        body.style.display = '';
+        summary.hidden = true;
+        return;
+      }
+
+      var isTarget = card === targetCard;
+      card.classList.remove('mel-builder-card--expanded-edit');
+
+      if (isTarget) {
+        body.style.display = '';
+        summary.hidden = true;
+      }
+      else {
+        body.style.display = 'none';
+        summary.hidden = false;
+        var summaryContent = summary.querySelector('.mel-builder-card__summary-content');
+        if (summaryContent) {
+          summaryContent.textContent = melBuildCardSummary(card, form);
+        }
+      }
+    });
+
+    melRequestBuilderCardActiveSync(form);
+  }
+
+  /**
+   * Apply single-active card UI; resolves active card from dataset or wizard-step default.
+   *
+   * @param {HTMLFormElement} form
+   */
+  function melApplyBuilderCardCollapseState(form) {
+    if (!form) {
+      return;
+    }
+    var activeId = form.dataset.melBuilderActiveCardId;
+    var activeCard = activeId ? document.getElementById(activeId) : null;
+    var stepIdx = getWizardStepIndex(form);
+    var stepEl =
+      stepIdx >= 0 && stepIdx < MEL_STEPS.length
+        ? document.getElementById('mel-step-' + MEL_STEPS[stepIdx].id)
+        : null;
+    if (
+      !activeCard ||
+      !form.contains(activeCard) ||
+      (stepEl && !stepEl.contains(activeCard))
+    ) {
+      activeCard = melPickDefaultActiveBuilderCard(form);
+    }
+    if (activeCard) {
+      melSetActiveBuilderCard(form, activeCard);
+    }
+  }
+
   function scheduleIsoHint(form) {
     var sd = form.querySelector('[name="mel[start_date][date]"]');
     var st = form.querySelector('[name="mel[start_date][time]"]');
@@ -2271,6 +2700,7 @@
     var submit = form.querySelector(
       '.mel-event-studio__footer-actions input[type="submit"], .mel-event-studio__footer-actions button[type="submit"]',
     );
+    var sidebarSave = document.getElementById('mel-builder-save-sidebar');
     if (!footer) {
       return;
     }
@@ -2282,39 +2712,44 @@
     } else {
       footer.classList.add('mel-footer--draft-focus');
     }
+    var publishReady = pub && score >= 70;
     if (submit) {
-      submit.classList.toggle('mel-btn--studio-publish', pub && score >= 70);
-      submit.classList.toggle('mel-btn--studio-draft', !(pub && score >= 70));
+      submit.classList.toggle('mel-btn--studio-publish', publishReady);
+      submit.classList.toggle('mel-btn--studio-draft', !publishReady);
+    }
+    if (sidebarSave && form.contains(sidebarSave)) {
+      sidebarSave.classList.toggle('mel-btn--studio-publish', publishReady);
+      sidebarSave.classList.toggle('mel-btn--studio-draft', !publishReady);
     }
   }
 
   function setWizardNavActive(form, activeIndex) {
     var nav = form.querySelector('#mel-wizard-nav');
-    if (!nav) {
-      return;
+    if (nav) {
+      var links = nav.querySelectorAll('a.mel-nav-link');
+      links.forEach(function (link) {
+        link.classList.remove('is-active');
+        link.classList.remove('active');
+      });
+      if (activeIndex >= 0 && activeIndex < links.length) {
+        links[activeIndex].classList.add('is-active');
+        links[activeIndex].classList.add('active');
+      }
+      links.forEach(function (link, i) {
+        link.setAttribute('aria-selected', i === activeIndex ? 'true' : 'false');
+      });
+      var activeLink = links[activeIndex];
+      if (activeLink && activeLink.scrollIntoView) {
+        window.setTimeout(function () {
+          activeLink.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+            behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+          });
+        }, 60);
+      }
     }
-    var links = nav.querySelectorAll('a.mel-nav-link');
-    links.forEach(function (link) {
-      link.classList.remove('is-active');
-      link.classList.remove('active');
-    });
-    if (activeIndex >= 0 && activeIndex < links.length) {
-      links[activeIndex].classList.add('is-active');
-      links[activeIndex].classList.add('active');
-    }
-    links.forEach(function (link, i) {
-      link.setAttribute('aria-selected', i === activeIndex ? 'true' : 'false');
-    });
-    var activeLink = links[activeIndex];
-    if (activeLink && activeLink.scrollIntoView) {
-      window.setTimeout(function () {
-        activeLink.scrollIntoView({
-          block: 'nearest',
-          inline: 'nearest',
-          behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
-        });
-      }, 60);
-    }
+    melSyncBuilderCardActiveState(form, activeIndex);
   }
 
   function isStepComplete(step, form) {
@@ -2359,6 +2794,443 @@
     }
   }
 
+  function titleCompleteForBuilderBadge(form) {
+    var titleVal = val(form, 'mel[title]').trim();
+    return titleVal !== '' && titleVal !== Drupal.t('Untitled event');
+  }
+
+  function scheduleCompleteForBuilderBadge(form) {
+    var sd = form.querySelector('[name="mel[start_date][date]"]');
+    if (!sd || !sd.value) {
+      return false;
+    }
+    var vm = valRadio(form, 'mel[venue_mode]');
+    if (vm === 'saved') {
+      return val(form, 'mel[venue_saved]') !== '';
+    }
+    if (vm === 'create') {
+      return val(form, 'mel[venue_create_name]') !== '' && parseHiddenLocation(form) !== '';
+    }
+    return parseHiddenLocation(form) !== '';
+  }
+
+  /**
+   * Stand out builder card: enough listing/description substance (matches progressive unlock signal).
+   *
+   * @param {HTMLFormElement} form
+   * @return {boolean}
+   */
+  function standoutCompleteForBuilderBadge(form) {
+    return melDescriptionSectorSatisfied(form);
+  }
+
+  /**
+   * Attendee questions card: settled — either collecting with ≥1 row, or not collecting extras.
+   *
+   * @param {HTMLFormElement} form
+   * @return {boolean}
+   */
+  function attendeeCompleteForBuilderBadge(form) {
+    var collectHidden = form.querySelector('[name="mel[collect_attendee_questions]"]');
+    var wantsCollect = !!(collectHidden && String(collectHidden.value || '') === '1');
+    var rowCount = 0;
+    try {
+      rowCount = parseAttendeeQuestionsState(form).length;
+    } catch (eRows) {
+      rowCount = 0;
+    }
+    if (rowCount > 0) {
+      return true;
+    }
+    return !wantsCollect;
+  }
+
+  /**
+   * True when standout description-like fields carry enough substance to unlock the attendee card.
+   *
+   * @param {HTMLFormElement} form
+   * @return {boolean}
+   */
+  function melDescriptionSectorSatisfied(form) {
+    if (val(form, 'mel[summary]').trim().length >= 10) {
+      return true;
+    }
+    if (val(form, 'mel[body]').trim().length >= 40) {
+      return true;
+    }
+    if (val(form, 'mel[field_event_intro]').trim().length >= 20) {
+      return true;
+    }
+    try {
+      var hlHidden = form.querySelector('input[data-mel-highlights-state]');
+      if (hlHidden && hlHidden.value) {
+        var rowsHl = JSON.parse(hlHidden.value);
+        if (
+          Array.isArray(rowsHl) &&
+          rowsHl.some(function (hr) {
+            return hr && String(hr.text || '').trim().length > 0;
+          })
+        ) {
+          return true;
+        }
+      }
+    } catch (eHlSat) {}
+    return false;
+  }
+
+  /** @param {HTMLFormElement} form */
+  function melAttendeeSectorBusy(form) {
+    try {
+      if (parseAttendeeQuestionsState(form).length > 0) {
+        return true;
+      }
+    } catch (eAtt) {}
+    var syncCollect = form.querySelector('[data-mel-collect-attendee-sync="1"]');
+    return !!(syncCollect && String(syncCollect.value || '') === '1');
+  }
+
+  /**
+   * One-time programmatic open per slot; resetting when prerequisites lapse (user edits back).
+   *
+   * @param {HTMLFormElement} form
+   * @param {HTMLDetailsElement|null} detailsEl
+   * @param {boolean} chainOk
+   * @param {boolean} intentOpen
+   */
+  function melProgressiveCollapseAutoOpen(form, detailsEl, chainOk, intentOpen) {
+    if (!form || !detailsEl || detailsEl.tagName !== 'DETAILS') {
+      return;
+    }
+    var mk = 'data-mel-progressive-chain-opened';
+    if (!chainOk) {
+      detailsEl.removeAttribute(mk);
+      return;
+    }
+    if (!intentOpen) {
+      return;
+    }
+    if (!detailsEl.getAttribute(mk)) {
+      detailsEl.open = true;
+      detailsEl.setAttribute(mk, '1');
+    }
+  }
+
+  /** @param {HTMLFormElement} form */
+  function melSyncProgressiveCollapseChain(form) {
+    var ticketOk = isStepComplete('tickets', form);
+    var descriptionOk = melDescriptionSectorSatisfied(form);
+    var attendeeBusy = melAttendeeSectorBusy(form);
+
+    var descSlot = form.querySelector('#mel-progressive-description');
+    var attSlot = form.querySelector('#mel-progressive-attendee');
+    var advSlot = form.querySelector('#mel-builder-more-options');
+
+    melProgressiveCollapseAutoOpen(form, descSlot, ticketOk, ticketOk);
+    melProgressiveCollapseAutoOpen(form, attSlot, ticketOk && descriptionOk, descriptionOk);
+    melProgressiveCollapseAutoOpen(
+      form,
+      advSlot,
+      ticketOk && descriptionOk && attendeeBusy,
+      attendeeBusy,
+    );
+  }
+
+  /**
+   * Builder root for focus-mode styling (toggle .mel-builder--focus-mode).
+   *
+   * @param {HTMLFormElement} form
+   * @return {HTMLElement|null}
+   */
+  function melGetBuilderShell(form) {
+    return form && form.querySelector ? form.querySelector('[data-mel-builder="1"]') : null;
+  }
+
+  /**
+   * Sections that act as stacked builder cards inside a wizard step.
+   *
+   * @param {HTMLElement} stepEl
+   * @return {HTMLElement[]}
+   */
+  function melCardsInWizardStep(stepEl) {
+    if (!stepEl || !stepEl.querySelectorAll) {
+      return [];
+    }
+    return Array.prototype.slice.call(stepEl.querySelectorAll('section.mel-builder-card'));
+  }
+
+  /**
+   * Prefer the card hosting the visible focus ring; fallback to viewport center.
+   *
+   * @param {HTMLElement} stepEl
+   * @param {HTMLFormElement} form
+   * @return {HTMLElement|null}
+   */
+  function melResolveFocusedBuilderCardInStep(stepEl, form) {
+    var candidates = melCardsInWizardStep(stepEl);
+    if (!candidates.length) {
+      return null;
+    }
+
+    try {
+      var ae = document.activeElement;
+      if (
+        ae &&
+        ae !== document.body &&
+        form.contains(ae) &&
+        typeof ae.closest === 'function'
+      ) {
+        var focusHost = ae.closest('section.mel-builder-card');
+        if (focusHost && stepEl.contains(focusHost)) {
+          return focusHost;
+        }
+      }
+    } catch (eFocus) {}
+
+    var centerY = typeof window.innerHeight === 'number' ? window.innerHeight * 0.5 : 0;
+    var best = candidates[0];
+    var bestDist = Infinity;
+    candidates.forEach(function (card) {
+      try {
+        var r = card.getBoundingClientRect();
+        var mid = (r.top + r.bottom) / 2;
+        var d = Math.abs(mid - centerY);
+        if (d < bestDist) {
+          bestDist = d;
+          best = card;
+        }
+      } catch (eGeom) {}
+    });
+    return best || null;
+  }
+
+  /** @param {HTMLFormElement} form */
+  function melRequestBuilderCardActiveSync(form) {
+    if (!form) {
+      return;
+    }
+    var pending = melBuilderCardFocusRafIds.get(form);
+    if (
+      pending !== undefined &&
+      typeof pending === 'number' &&
+      typeof window.cancelAnimationFrame === 'function'
+    ) {
+      window.cancelAnimationFrame(pending);
+    }
+    if (typeof window.requestAnimationFrame !== 'function') {
+      melSyncBuilderCardActiveState(form, getWizardStepIndex(form));
+      return;
+    }
+    var rid = window.requestAnimationFrame(function () {
+      melBuilderCardFocusRafIds.delete(form);
+      melSyncBuilderCardActiveState(form, getWizardStepIndex(form));
+    });
+    melBuilderCardFocusRafIds.set(form, rid);
+  }
+
+  /**
+   * Single focused builder card inside the wizard step (+ focus-mode on root shell).
+   *
+   * @param {HTMLFormElement} form
+   * @param {number} activeIndex
+   */
+  function melSyncBuilderCardActiveState(form, activeIndex) {
+    if (!form) {
+      return;
+    }
+    form.querySelectorAll('.mel-builder-card').forEach(function (card) {
+      card.classList.remove('is-active');
+    });
+
+    var root = melGetBuilderShell(form);
+    if (root) {
+      root.classList.remove('mel-builder--focus-mode');
+    }
+
+    if (activeIndex < 0 || activeIndex >= MEL_STEPS.length) {
+      return;
+    }
+
+    var stepEl = document.getElementById('mel-step-' + MEL_STEPS[activeIndex].id);
+    if (!stepEl) {
+      return;
+    }
+
+    var focused = melResolveFocusedBuilderCardInStep(stepEl, form);
+    if (focused && root) {
+      focused.classList.add('is-active');
+      root.classList.add('mel-builder--focus-mode');
+    }
+  }
+
+  /**
+   * All primary builder sections satisfied (published nodes excluded).
+   *
+   * @param {HTMLFormElement} form
+   * @return {boolean}
+   */
+  function melPublishCardSectionsAllReady(form) {
+    if (!form) {
+      return false;
+    }
+    var initialPub = getSettings().initial || {};
+    if (initialPub && initialPub.published) {
+      return false;
+    }
+    return (
+      titleCompleteForBuilderBadge(form) &&
+      scheduleCompleteForBuilderBadge(form) &&
+      isStepComplete('tickets', form) &&
+      standoutCompleteForBuilderBadge(form) &&
+      attendeeCompleteForBuilderBadge(form)
+    );
+  }
+
+  /** @param {HTMLFormElement} form */
+  function melSyncPublishCardReadyState(form) {
+    var pubCard = form.querySelector('#mel-card-publish');
+    if (!pubCard) {
+      return;
+    }
+    var celebrate = pubCard.querySelector('[data-mel-publish-ready-celebrate]');
+    var canPublishUi = !!form.querySelector('#mel-publish-now');
+    var ready = melPublishCardSectionsAllReady(form) && canPublishUi;
+    pubCard.classList.toggle('is-ready', ready);
+    if (celebrate) {
+      celebrate.hidden = !ready;
+    }
+  }
+
+  function melSyncBuilderCardCompletionBadges(form) {
+    if (!form) {
+      return;
+    }
+    var momentumByKey = {
+      'identity-title': Drupal.t('Nice — this looks great ✨'),
+      schedule: Drupal.t('Nice — this looks great ✨'),
+      tickets: Drupal.t('Awesome — people can now book your event 🎉'),
+      standout: Drupal.t('Your listing is starting to shine ✨'),
+      attendee: Drupal.t('Attendee checkout questions look good ✓'),
+      'pre-publish': Drupal.t("You're almost ready to go live 🚀"),
+    };
+    /** Keys that show the DOM-order "Continue" hint after the momentum message. */
+    var nextStepHintKeys = {
+      'identity-title': true,
+      schedule: true,
+      tickets: true,
+      standout: true,
+      attendee: true,
+    };
+    /** @type {HTMLElement|null} */
+    var pendingCompletionScrollCard = null;
+    form.querySelectorAll('[data-mel-track-complete]').forEach(function (card) {
+      var key = card.getAttribute('data-mel-track-complete');
+      var badge = card.querySelector('[data-mel-builder-complete-msg]');
+      var doneBadge = card.querySelector('[data-mel-builder-done-badge]');
+      if (!badge) {
+        return;
+      }
+      var done = false;
+      if (key === 'identity-title') {
+        done = titleCompleteForBuilderBadge(form);
+      } else if (key === 'schedule') {
+        done = scheduleCompleteForBuilderBadge(form);
+      } else if (key === 'tickets') {
+        done = isStepComplete('tickets', form);
+      } else if (key === 'standout') {
+        done = standoutCompleteForBuilderBadge(form);
+      } else if (key === 'attendee') {
+        done = attendeeCompleteForBuilderBadge(form);
+      } else if (key === 'pre-publish') {
+        var initialPub = getSettings().initial || {};
+        var alreadyLive = !!initialPub.published;
+        done =
+          !alreadyLive &&
+          isStepComplete('identity', form) &&
+          isStepComplete('tickets', form);
+      }
+      var momentumText = momentumByKey[key];
+      badge.textContent = done && momentumText ? momentumText : '';
+      badge.hidden = !(done && momentumText);
+
+      var footer = badge.closest('.mel-builder-card__footer');
+      var allowNextHint = !!nextStepHintKeys[key];
+      var nextCardEl = allowNextHint ? melNextPrimaryFlowBuilderCard(form, card) : null;
+      var heading = nextCardEl ? melBuilderCardHintHeading(nextCardEl) : null;
+      var hintLineText = '';
+      if (heading) {
+        var titleForHint = (heading.innerText || '').trim();
+        if (titleForHint) {
+          hintLineText = Drupal.t('Next: @title', {
+            '@title': titleForHint
+          });
+        }
+      }
+      var nextBlock = footer ? footer.querySelector('[data-mel-builder-next-step-block]') : null;
+      var showNext = !!(done && momentumText && footer && allowNextHint && nextCardEl && hintLineText);
+
+      if (footer && allowNextHint && !nextBlock) {
+        nextBlock = document.createElement('div');
+        nextBlock.className = 'mel-builder-card__next-step';
+        nextBlock.setAttribute('data-mel-builder-next-step-block', '');
+        nextBlock.hidden = true;
+        var hintEl = document.createElement('p');
+        hintEl.className = 'mel-builder-card__next-hint';
+        var hintId = 'mel-next-hint-' + String(key).replace(/[^a-z0-9-]+/gi, '-');
+        hintEl.id = hintId;
+        var btnEl = document.createElement('button');
+        btnEl.type = 'button';
+        btnEl.className = 'mel-next-step-btn';
+        btnEl.textContent = Drupal.t('Continue →');
+        btnEl.setAttribute('aria-describedby', hintId);
+        nextBlock.appendChild(hintEl);
+        nextBlock.appendChild(btnEl);
+        footer.appendChild(nextBlock);
+      }
+
+      if (nextBlock) {
+        var hintLine = nextBlock.querySelector('.mel-builder-card__next-hint');
+        var nextBtn = nextBlock.querySelector('.mel-next-step-btn');
+        if (showNext && hintLine && nextBtn) {
+          hintLine.textContent = hintLineText;
+          nextBlock.hidden = false;
+        } else {
+          nextBlock.hidden = true;
+        }
+      }
+
+      var wasComplete = card.dataset.wasComplete === 'true';
+      var isComplete = done;
+      if (!wasComplete && isComplete && nextStepHintKeys[key]) {
+        var nextAfterComplete = melNextPrimaryFlowBuilderCard(form, card);
+        if (nextAfterComplete) {
+          melSetActiveBuilderCard(form, nextAfterComplete);
+          pendingCompletionScrollCard = nextAfterComplete;
+        }
+      }
+      card.dataset.wasComplete = isComplete ? 'true' : 'false';
+
+      if (done) {
+        card.classList.add('is-complete');
+        if (doneBadge) {
+          doneBadge.hidden = key === 'pre-publish';
+        }
+      } else {
+        card.classList.remove('is-complete');
+        if (doneBadge) {
+          doneBadge.hidden = true;
+        }
+      }
+    });
+    melSyncPublishCardReadyState(form);
+    melApplyBuilderCardCollapseState(form);
+    if (pendingCompletionScrollCard && form) {
+      var scrollTargetCard = pendingCompletionScrollCard;
+      window.setTimeout(function () {
+        melScrollToBuilderCard(form, scrollTargetCard);
+      }, 0);
+    }
+  }
+
   function scrollToStudioSection(form, index) {
     if (index < 0 || index >= MEL_STEPS.length) {
       return;
@@ -2397,10 +3269,30 @@
       alert(Drupal.t('Complete required fields before continuing.'));
       return;
     }
+    form.querySelectorAll('.mel-builder-card--expanded-edit').forEach(function (node) {
+      node.classList.remove('mel-builder-card--expanded-edit');
+    });
     if (stepIdx >= MEL_STEPS.length - 1) {
       return;
     }
-    scrollToStudioSection(form, stepIdx + 1);
+    var nextIdx = stepIdx + 1;
+    scrollToStudioSection(form, nextIdx);
+    var nextStepEl = document.getElementById('mel-step-' + MEL_STEPS[nextIdx].id);
+    var targetCard = null;
+    if (nextStepEl) {
+      var stepCards = nextStepEl.querySelectorAll('.mel-builder-card');
+      for (var ci = 0; ci < stepCards.length; ci++) {
+        if (melIsBuilderCardDomVisible(form, stepCards[ci])) {
+          targetCard = stepCards[ci];
+          break;
+        }
+      }
+    }
+    if (targetCard) {
+      melSetActiveBuilderCard(form, targetCard);
+      melScrollToBuilderCard(form, targetCard);
+    }
+    melApplyBuilderCardCollapseState(form);
   }
 
   function initMelWizard(form) {
@@ -2431,6 +3323,7 @@
         if (idx >= 0) {
           setWizardNavActive(form, idx);
           setWizardStepIndex(form, idx);
+          melApplyBuilderCardCollapseState(form);
         }
       });
     });
@@ -2438,6 +3331,16 @@
     form.addEventListener(
       'click',
       function (e) {
+        var summaryStrip = e.target.closest('.mel-builder-card__summary');
+        if (summaryStrip && form.contains(summaryStrip)) {
+          var card = summaryStrip.closest('.mel-builder-card');
+          if (card && form.contains(card)) {
+            e.preventDefault();
+            melSetActiveBuilderCard(form, card);
+          }
+          return;
+        }
+
         var jumpPrev = e.target.closest('#mel-studio-jump-preview, #mel-jump-to-preview-card');
         if (jumpPrev && form.contains(jumpPrev)) {
           e.preventDefault();
@@ -2477,6 +3380,7 @@
         var stepIdx = getWizardStepIndex(form);
         if (stepIdx > 0) {
           scrollToStudioSection(form, stepIdx - 1);
+          melApplyBuilderCardCollapseState(form);
         }
       },
       false,
@@ -2498,8 +3402,12 @@
               }
             }
             if (idx >= 0 && entry.intersectionRatio >= 0.1) {
+              var prevStep = getWizardStepIndex(form);
               setWizardNavActive(form, idx);
               setWizardStepIndex(form, idx);
+              if (prevStep !== idx) {
+                melApplyBuilderCardCollapseState(form);
+              }
             }
           });
         },
@@ -2508,6 +3416,22 @@
       steps.forEach(function (s) {
         io.observe(s);
       });
+    }
+
+    if (!form.dataset.melBuilderFocusSyncUiBound) {
+      form.dataset.melBuilderFocusSyncUiBound = '1';
+      var syncCardsOnViewport = function () {
+        melRequestBuilderCardActiveSync(form);
+      };
+      window.addEventListener('scroll', syncCardsOnViewport, { passive: true, capture: true });
+      window.addEventListener('resize', syncCardsOnViewport, false);
+      form.addEventListener(
+        'focusin',
+        function () {
+          melSyncBuilderCardActiveState(form, getWizardStepIndex(form));
+        },
+        true,
+      );
     }
   }
 
@@ -2959,6 +3883,8 @@
 
     syncCollectHiddenFromAttendees(form);
     melProgressiveRevealBuilder(form);
+    melSyncProgressiveCollapseChain(form);
+    melSyncBuilderCardCompletionBadges(form);
 
     scheduleApplyLivePreview(form, debouncePreview);
   }
@@ -2990,10 +3916,11 @@
     var str = getSettings().strings || {};
     syncTicketSummary(form, str);
     melProgressiveRevealBuilder(form);
+    melMaybeOpenAttendeeDetails(form, rows.length > 0);
+    melSyncProgressiveCollapseChain(form);
     updateInsightsChecklist(form);
     melUpdateNextBest(form);
     updateFooterCtaState(form);
-    melMaybeOpenAttendeeDetails(form, rows.length > 0);
     if (rerender) {
       renderAttendeeQuestionRows(form);
     }
@@ -3009,54 +3936,237 @@
   }
 
   function melMaybeOpenAttendeeDetails(form, shouldOpen) {
+    if (!shouldOpen) {
+      return;
+    }
+    var shell = form.querySelector('#mel-progressive-attendee');
+    if (shell && shell.tagName === 'DETAILS') {
+      shell.open = true;
+    }
     var det = form.querySelector('#mel-attendee-questions-details');
     if (!det || det.tagName !== 'DETAILS') {
       return;
     }
-    if (shouldOpen) {
-      det.open = true;
+    det.open = true;
+  }
+
+  /** Legacy reveal class removal (progressive collapse uses <details> instead of display:none gates). */
+  function melProgressiveRevealBuilder(form) {
+    try {
+      form.querySelectorAll('.mel-builder-reveal--hidden').forEach(function (el) {
+        el.classList.remove('mel-builder-reveal--hidden');
+        el.removeAttribute('aria-hidden');
+      });
+    } catch (errReveal) {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn('MelEventStudio: progressive reveal cleanup fallback.', errReveal);
+      }
     }
   }
 
-  function melProgressiveRevealBuilder(form) {
-    var identityComplete = isStepComplete('identity', form);
+  function attendeeStudioTypeNeedsOptions(type) {
+    type = String(type || '').trim();
+    return type === 'select' || type === 'checkboxes' || type === 'radios';
+  }
 
-    var descEl = form.querySelector('[data-mel-reveal-section="mel-description"]');
-    var advEl = form.querySelector('[data-mel-reveal-section="mel-advanced"]');
-    var ticketsEl = form.querySelector('[data-mel-reveal-section="tickets"]');
-    var attendeeEl = form.querySelector('[data-mel-reveal-section="attendee"]');
+  function melAttendeeNormalizeType(type) {
+    type = String(type || '').trim();
+    var aliases = {
+      text: 'textfield',
+      checkbox: 'checkboxes',
+      radio: 'radios',
+    };
+    return aliases[type] || type || 'textfield';
+  }
 
-    function setRevealHidden(el, hide) {
-      if (!el) {
+  function collectAttendeeQuestionsFromDom(form) {
+    var host = form.querySelector('[data-mel-attendee-question-list="1"]');
+    if (!host) {
+      return [];
+    }
+    var prev = parseAttendeeQuestionsState(form);
+    var rows = [];
+    var pi = 0;
+    host.querySelectorAll(':scope > .mel-attendee-row').forEach(function (wrap) {
+      var old = prev[pi] || {};
+      pi += 1;
+      if (wrap.querySelector('.mel-attendee-row__lib')) {
+        var vid = parseInt(wrap.getAttribute('data-mel-attendee-vendor-qid') || '0', 10);
+        if (!isNaN(vid) && vid > 0) {
+          rows.push({ vendor_question_id: vid });
+        }
         return;
       }
-      el.classList.toggle('mel-builder-reveal--hidden', !!hide);
-      el.setAttribute('aria-hidden', hide ? 'true' : 'false');
-    }
-
-    var suppressProgressive = !identityComplete;
-    try {
-      setRevealHidden(descEl, suppressProgressive);
-      setRevealHidden(advEl, suppressProgressive);
-    } catch (errReveal) {
-      setRevealHidden(descEl, false);
-      setRevealHidden(advEl, false);
-      if (typeof console !== 'undefined' && console.warn) {
-        console.warn('MelEventStudio: progressive reveal fallback.', errReveal);
+      var labelInp = wrap.querySelector('.mel-attendee-label');
+      var typeSel = wrap.querySelector('.mel-attendee-type');
+      var req = wrap.querySelector('.mel-attendee-required');
+      var libSave = wrap.querySelector('.mel-attendee-save-lib');
+      var label = labelInp ? String(labelInp.value || '').trim() : '';
+      var type = typeSel ? melAttendeeNormalizeType(typeSel.value) : 'textfield';
+      var opts = [];
+      if (attendeeStudioTypeNeedsOptions(type)) {
+        wrap.querySelectorAll('.mel-attendee-option-input').forEach(function (inp) {
+          var t = String(inp.value || '').trim();
+          if (t !== '') {
+            opts.push(t);
+          }
+        });
       }
-    }
-
-    // Tickets, attendee questions, donations, and listing extras stay visible — no identity gate.
-    setRevealHidden(ticketsEl, false);
-    setRevealHidden(attendeeEl, false);
-
-    [ticketsEl, attendeeEl].forEach(function (el) {
-      if (!el || !el.classList.contains('mel-builder-reveal--hidden')) {
-        return;
+      var row = {
+        label: label,
+        type: type,
+        required: req ? !!req.checked : false,
+        save_to_library: libSave ? !!libSave.checked : false,
+      };
+      if (opts.length) {
+        row.options = opts;
       }
-      el.classList.remove('mel-builder-reveal--hidden');
-      el.setAttribute('aria-hidden', 'false');
+      if (old.machine_name) {
+        row.machine_name = old.machine_name;
+      }
+      rows.push(row);
     });
+    return rows;
+  }
+
+  function melAttendeePreviewHtml(label, type, options) {
+    var lab = String(label || '').trim();
+    var opts = Array.isArray(options)
+      ? options.filter(function (x) {
+          return String(x || '').trim() !== '';
+        })
+      : [];
+    var esc = Drupal.checkPlain;
+    if (!lab && opts.length === 0) {
+      return (
+        '<p class="mel-attendee-preview__empty">' +
+        esc(Drupal.t('Preview appears as you add details.')) +
+        '</p>'
+      );
+    }
+    var head = lab ? '<p class="mel-attendee-preview__label">' + esc(lab) + '</p>' : '';
+    type = melAttendeeNormalizeType(type);
+    if (type === 'checkboxes') {
+      var cb = opts
+        .map(function (o) {
+          return (
+            '<label class="mel-attendee-preview__pick"><input type="checkbox" disabled /> <span>' +
+            esc(o) +
+            '</span></label>'
+          );
+        })
+        .join('');
+      return '<div class="mel-attendee-preview mel-attendee-preview--checkboxes">' + head + cb + '</div>';
+    }
+    if (type === 'radios') {
+      var nm = 'mel-att-prev-' + String(Math.random()).slice(2);
+      var rd = opts
+        .map(function (o) {
+          return (
+            '<label class="mel-attendee-preview__pick"><input type="radio" disabled name="' +
+            nm +
+            '" /> <span>' +
+            esc(o) +
+            '</span></label>'
+          );
+        })
+        .join('');
+      return '<div class="mel-attendee-preview mel-attendee-preview--radios">' + head + rd + '</div>';
+    }
+    if (type === 'select') {
+      var inner = '<option value="">' + esc(Drupal.t('Choose…')) + '</option>';
+      opts.forEach(function (o) {
+        inner += '<option>' + esc(o) + '</option>';
+      });
+      return (
+        '<div class="mel-attendee-preview mel-attendee-preview--select">' +
+        head +
+        '<select class="mel-input" disabled="disabled">' +
+        inner +
+        '</select></div>'
+      );
+    }
+    if (type === 'textarea') {
+      return (
+        '<div class="mel-attendee-preview mel-attendee-preview--textarea">' +
+        head +
+        '<textarea class="mel-input" disabled rows="2" placeholder="' +
+        esc(Drupal.t('Long answer')) +
+        '"></textarea></div>'
+      );
+    }
+    return (
+      '<div class="mel-attendee-preview mel-attendee-preview--text">' +
+      head +
+      '<input type="text" class="mel-input" disabled placeholder="' +
+      esc(Drupal.t('Short answer')) +
+      '" /></div>'
+    );
+  }
+
+  function refreshAttendeeRowPreview(wrap) {
+    var box = wrap.querySelector('[data-mel-attendee-preview="1"]');
+    if (!box) {
+      return;
+    }
+    var labelInp = wrap.querySelector('.mel-attendee-label');
+    var typeSel = wrap.querySelector('.mel-attendee-type');
+    var label = labelInp ? String(labelInp.value || '').trim() : '';
+    var type = typeSel ? melAttendeeNormalizeType(typeSel.value) : 'textfield';
+    var opts = [];
+    if (attendeeStudioTypeNeedsOptions(type)) {
+      wrap.querySelectorAll('.mel-attendee-option-input').forEach(function (inp) {
+        var t = String(inp.value || '').trim();
+        if (t !== '') {
+          opts.push(t);
+        }
+      });
+    }
+    box.innerHTML = melAttendeePreviewHtml(label, type, opts);
+  }
+
+  function toggleAttendeeOptionsUi(wrap, typeRaw) {
+    var shell = wrap.querySelector('[data-mel-attendee-options-shell="1"]');
+    if (!shell) {
+      return;
+    }
+    var show = attendeeStudioTypeNeedsOptions(melAttendeeNormalizeType(typeRaw));
+    shell.hidden = !show;
+    shell.setAttribute('aria-hidden', show ? 'false' : 'true');
+  }
+
+  function melAttendeeTypeSelectOptions(selectedRaw) {
+    var selected = melAttendeeNormalizeType(selectedRaw);
+    var pairs = [
+      ['textfield', Drupal.t('Short answer')],
+      ['textarea', Drupal.t('Long answer')],
+      ['select', Drupal.t('Dropdown')],
+      ['checkboxes', Drupal.t('Checkboxes')],
+      ['radios', Drupal.t('Multiple choice')],
+      ['email', Drupal.t('Email')],
+      ['tel', Drupal.t('Phone number')],
+    ];
+    var html = '';
+    var i;
+    for (i = 0; i < pairs.length; i++) {
+      var v = pairs[i][0];
+      var sel = v === selected ? ' selected' : '';
+      html +=
+        '<option value="' +
+        Drupal.checkPlain(v) +
+        '"' +
+        sel +
+        '>' +
+        Drupal.checkPlain(pairs[i][1]) +
+        '</option>';
+    }
+    return html;
+  }
+
+  function patchAttendeeRowState(form, wrap) {
+    var rows = collectAttendeeQuestionsFromDom(form);
+    writeAttendeeQuestionsState(form, rows, false);
+    refreshAttendeeRowPreview(wrap);
   }
 
   function renderAttendeeQuestionRows(form) {
@@ -3073,6 +4183,7 @@
       wrap.setAttribute('data-mel-attendee-row-idx', String(idx));
 
       if (row.vendor_question_id) {
+        wrap.setAttribute('data-mel-attendee-vendor-qid', String(row.vendor_question_id));
         var lib = null;
         var libList = getSettings().vendorQuestionLibrary || [];
         for (var qi = 0; qi < libList.length; qi++) {
@@ -3089,40 +4200,153 @@
           '">' +
           Drupal.t('Remove') +
           '</button></p>';
-      } else {
-        var req = row.required ? ' checked' : '';
-        var libSave = row.save_to_library ? ' checked' : '';
-        wrap.innerHTML =
-          '<div class="mel-form-grid mel-attendee-row__grid">' +
-          '<label class="form-item"><span class="form-item__label">' +
-          Drupal.t('Question') +
-          '</span><input type="text" class="mel-input mel-attendee-label" data-idx="' +
-          String(idx) +
-          '" value="' +
-          Drupal.checkPlain(row.label || '') +
-          '" /></label>' +
-          '<label class="form-item"><span class="form-item__label">' +
-          Drupal.t('Save to library') +
-          '</span><input type="checkbox" class="mel-attendee-save-lib" data-idx="' +
-          String(idx) +
-          '"' +
-          libSave +
-          ' /></label>' +
-          '</div>' +
-          '<label class="form-item"><input type="checkbox" class="mel-attendee-required" data-idx="' +
-          String(idx) +
-          '"' +
-          req +
-          ' /> ' +
-          Drupal.t('Required') +
-          '</label>' +
-          '<button type="button" class="mel-btn mel-btn--ghost mel-attendee-remove" data-mel-attendee-remove="' +
-          String(idx) +
-          '">' +
-          Drupal.t('Remove') +
-          '</button>';
+        host.appendChild(wrap);
+        return;
       }
+
+      var qId = 'mel-attendee-q-' + String(idx);
+      var typeId = 'mel-attendee-type-' + String(idx);
+      var libId = 'mel-attendee-lib-' + String(idx);
+      var reqId = 'mel-attendee-req-' + String(idx);
+      var prevId = 'mel-attendee-preview-' + String(idx);
+
+      var primary = document.createElement('div');
+      primary.className = 'mel-attendee-row__primary';
+
+      var qWell = document.createElement('div');
+      qWell.className = 'js-form-item form-item mel-builder-field-well';
+      var qLab = document.createElement('label');
+      qLab.setAttribute('for', qId);
+      qLab.className = 'form-item__label';
+      qLab.textContent = Drupal.t('Question');
+      var qInp = document.createElement('input');
+      qInp.type = 'text';
+      qInp.id = qId;
+      qInp.className = 'mel-input mel-attendee-label';
+      qInp.setAttribute('data-idx', String(idx));
+      qInp.value = row.label || '';
+      qWell.appendChild(qLab);
+      qWell.appendChild(qInp);
+
+      var typeWell = document.createElement('div');
+      typeWell.className = 'js-form-item form-item mel-builder-field-well';
+      var typeLab = document.createElement('label');
+      typeLab.setAttribute('for', typeId);
+      typeLab.className = 'form-item__label';
+      typeLab.textContent = Drupal.t('Answer type');
+      var typeSel = document.createElement('select');
+      typeSel.id = typeId;
+      typeSel.className = 'mel-input mel-attendee-type';
+      typeSel.setAttribute('data-idx', String(idx));
+      typeSel.innerHTML = melAttendeeTypeSelectOptions(row.type || 'textfield');
+      typeWell.appendChild(typeLab);
+      typeWell.appendChild(typeSel);
+
+      var optShell = document.createElement('div');
+      optShell.className = 'mel-attendee-options-shell mel-builder-field-well';
+      optShell.setAttribute('data-mel-attendee-options-shell', '1');
+      var normType = melAttendeeNormalizeType(row.type || 'textfield');
+      var needsOpt = attendeeStudioTypeNeedsOptions(normType);
+      optShell.hidden = !needsOpt;
+      optShell.setAttribute('aria-hidden', needsOpt ? 'false' : 'true');
+
+      var optLab = document.createElement('label');
+      optLab.className = 'form-item__label';
+      optLab.textContent = Drupal.t('Choices');
+      optShell.appendChild(optLab);
+
+      var optList = document.createElement('div');
+      optList.className = 'mel-attendee-option-list';
+      optList.setAttribute('data-mel-attendee-option-list', '1');
+      var optLines = Array.isArray(row.options) && row.options.length ? row.options : [''];
+      optLines.forEach(function (lineText) {
+        var lineWrap = document.createElement('div');
+        lineWrap.className = 'mel-attendee-option-line';
+        var oi = document.createElement('input');
+        oi.type = 'text';
+        oi.className = 'mel-input mel-attendee-option-input';
+        oi.value = lineText;
+        lineWrap.appendChild(oi);
+        optList.appendChild(lineWrap);
+      });
+      optShell.appendChild(optList);
+
+      var addOptBtn = document.createElement('button');
+      addOptBtn.type = 'button';
+      addOptBtn.className = 'mel-btn mel-btn--secondary mel-attendee-add-option';
+      addOptBtn.textContent = Drupal.t('Add choice');
+      optShell.appendChild(addOptBtn);
+
+      var cards = document.createElement('div');
+      cards.className = 'mel-option-cards mel-option-cards--attendee-inline';
+      cards.innerHTML =
+        '<div class="mel-option-card">' +
+        '<input type="checkbox" id="' +
+        libId +
+        '" class="form-checkbox mel-attendee-save-lib" data-idx="' +
+        String(idx) +
+        '"' +
+        (row.save_to_library ? ' checked' : '') +
+        ' />' +
+        '<div class="mel-option-card__content">' +
+        '<label class="mel-option-card__label" for="' +
+        libId +
+        '"><strong>' +
+        Drupal.t('Save to library') +
+        '</strong></label>' +
+        '<p class="mel-option-card__desc">' +
+        Drupal.t('Keep this wording in your organizer library for reuse.') +
+        '</p>' +
+        '</div></div>' +
+        '<div class="mel-option-card">' +
+        '<input type="checkbox" id="' +
+        reqId +
+        '" class="form-checkbox mel-attendee-required" data-idx="' +
+        String(idx) +
+        '"' +
+        (row.required ? ' checked' : '') +
+        ' />' +
+        '<div class="mel-option-card__content">' +
+        '<label class="mel-option-card__label" for="' +
+        reqId +
+        '"><strong>' +
+        Drupal.t('Required') +
+        '</strong></label>' +
+        '<p class="mel-option-card__desc">' +
+        Drupal.t('Guests must answer before completing checkout or RSVP.') +
+        '</p>' +
+        '</div></div>';
+
+      var previewWell = document.createElement('div');
+      previewWell.className = 'mel-builder-field-well mel-attendee-preview-well';
+      var prevLab = document.createElement('label');
+      prevLab.className = 'form-item__label';
+      prevLab.setAttribute('for', prevId);
+      prevLab.textContent = Drupal.t('Guest preview');
+      var prevBox = document.createElement('div');
+      prevBox.id = prevId;
+      prevBox.className = 'mel-attendee-preview-host';
+      prevBox.setAttribute('data-mel-attendee-preview', '1');
+
+      previewWell.appendChild(prevLab);
+      previewWell.appendChild(prevBox);
+
+      primary.appendChild(qWell);
+      primary.appendChild(typeWell);
+      primary.appendChild(optShell);
+      primary.appendChild(cards);
+      primary.appendChild(previewWell);
+
+      var rm = document.createElement('button');
+      rm.type = 'button';
+      rm.className = 'mel-btn mel-btn--ghost mel-attendee-remove';
+      rm.setAttribute('data-mel-attendee-remove', String(idx));
+      rm.textContent = Drupal.t('Remove');
+
+      wrap.appendChild(primary);
+      wrap.appendChild(rm);
       host.appendChild(wrap);
+      refreshAttendeeRowPreview(wrap);
     });
   }
 
@@ -3235,6 +4459,28 @@
           melAttendeeAddFromLibrary(form);
           return;
         }
+        var addOpt = e.target.closest('.mel-attendee-add-option');
+        if (addOpt && form.contains(addOpt)) {
+          e.preventDefault();
+          var wrapOpt = addOpt.closest('.mel-attendee-row');
+          if (!wrapOpt) {
+            return;
+          }
+          var list = wrapOpt.querySelector('[data-mel-attendee-option-list="1"]');
+          if (!list) {
+            return;
+          }
+          var lineWrap = document.createElement('div');
+          lineWrap.className = 'mel-attendee-option-line';
+          var oi = document.createElement('input');
+          oi.type = 'text';
+          oi.className = 'mel-input mel-attendee-option-input';
+          lineWrap.appendChild(oi);
+          list.appendChild(lineWrap);
+          patchAttendeeRowState(form, wrapOpt);
+          oi.focus();
+          return;
+        }
         var rm = e.target.closest('[data-mel-attendee-remove]');
         if (rm && form.contains(rm)) {
           e.preventDefault();
@@ -3250,13 +4496,16 @@
       form.addEventListener(
         'input',
         function (e) {
-          if (e.target.classList && e.target.classList.contains('mel-attendee-label')) {
-            var idx = parseInt(e.target.getAttribute('data-idx'), 10);
-            var rows = parseAttendeeQuestionsState(form);
-            if (!isNaN(idx) && rows[idx]) {
-              rows[idx].label = e.target.value;
-              writeAttendeeQuestionsState(form, rows, false);
-            }
+          var wrapIn = e.target.closest('.mel-attendee-row');
+          if (!wrapIn || !form.contains(wrapIn) || wrapIn.querySelector('.mel-attendee-row__lib')) {
+            return;
+          }
+          if (
+            e.target.classList &&
+            (e.target.classList.contains('mel-attendee-label') ||
+              e.target.classList.contains('mel-attendee-option-input'))
+          ) {
+            patchAttendeeRowState(form, wrapIn);
           }
         },
         true,
@@ -3265,22 +4514,20 @@
       form.addEventListener(
         'change',
         function (e) {
-          var idx;
-          if (e.target.classList && e.target.classList.contains('mel-attendee-required')) {
-            idx = parseInt(e.target.getAttribute('data-idx'), 10);
-            var rows2 = parseAttendeeQuestionsState(form);
-            if (!isNaN(idx) && rows2[idx]) {
-              rows2[idx].required = !!e.target.checked;
-              writeAttendeeQuestionsState(form, rows2, false);
-            }
+          var wrapCh = e.target.closest('.mel-attendee-row');
+          if (!wrapCh || !form.contains(wrapCh) || wrapCh.querySelector('.mel-attendee-row__lib')) {
+            return;
           }
-          if (e.target.classList && e.target.classList.contains('mel-attendee-save-lib')) {
-            idx = parseInt(e.target.getAttribute('data-idx'), 10);
-            var rows3 = parseAttendeeQuestionsState(form);
-            if (!isNaN(idx) && rows3[idx]) {
-              rows3[idx].save_to_library = !!e.target.checked;
-              writeAttendeeQuestionsState(form, rows3, false);
-            }
+          if (e.target.classList && e.target.classList.contains('mel-attendee-type')) {
+            toggleAttendeeOptionsUi(wrapCh, e.target.value);
+          }
+          if (
+            e.target.classList &&
+            (e.target.classList.contains('mel-attendee-required') ||
+              e.target.classList.contains('mel-attendee-save-lib') ||
+              e.target.classList.contains('mel-attendee-type'))
+          ) {
+            patchAttendeeRowState(form, wrapCh);
           }
         },
         true,
@@ -3324,6 +4571,28 @@
         bindCoverFilePreview(form);
         initMelWizard(form);
         initPreviewDrawer(form);
+
+        if (!form.dataset.melNextStepBtnBound) {
+          form.dataset.melNextStepBtnBound = '1';
+          form.addEventListener(
+            'click',
+            function (e) {
+              var nextBtn = e.target.closest('.mel-next-step-btn');
+              if (!nextBtn || !form.contains(nextBtn)) {
+                return;
+              }
+              var currentCard = nextBtn.closest('.mel-builder-card');
+              var targetCard = melNextPrimaryFlowBuilderCard(form, currentCard);
+              if (!targetCard || !form.contains(targetCard)) {
+                return;
+              }
+              e.preventDefault();
+              melSetActiveBuilderCard(form, targetCard);
+              melScrollToBuilderCard(form, targetCard);
+            },
+            false,
+          );
+        }
 
         if (!form.dataset.melPublishCardBound) {
           form.dataset.melPublishCardBound = '1';
@@ -3389,6 +4658,62 @@
               }
             });
           }
+        }
+
+        if (!form.dataset.melBuilderValidationUiBound) {
+          form.dataset.melBuilderValidationUiBound = '1';
+          form.addEventListener(
+            'invalid',
+            function (e) {
+              var t = e.target;
+              if (!form.contains(t) || !t.closest) {
+                return;
+              }
+              var fi = t.closest('.form-item, .js-form-item');
+              if (fi) {
+                fi.classList.add('mel-builder-invalid');
+              }
+            },
+            true,
+          );
+          form.addEventListener(
+            'input',
+            function (e) {
+              var t = e.target;
+              if (!t.closest) {
+                return;
+              }
+              var fi = t.closest('.form-item.mel-builder-invalid, .js-form-item.mel-builder-invalid');
+              if (fi && form.contains(fi)) {
+                fi.classList.remove('mel-builder-invalid');
+              }
+            },
+            true,
+          );
+        }
+
+        var saveDraftBtn = document.getElementById('mel-save-draft-studio');
+        if (saveDraftBtn && !saveDraftBtn.dataset.melSaveDraftBound) {
+          saveDraftBtn.dataset.melSaveDraftBound = '1';
+          saveDraftBtn.addEventListener('click', function (e) {
+            e.preventDefault();
+            var sub = form.querySelector('.mel-builder-save-submit');
+            if (sub && typeof sub.click === 'function') {
+              sub.click();
+            }
+          });
+        }
+
+        var sidebarSaveBtn = document.getElementById('mel-builder-save-sidebar');
+        if (sidebarSaveBtn && form.contains(sidebarSaveBtn) && !sidebarSaveBtn.dataset.melSidebarSaveBound) {
+          sidebarSaveBtn.dataset.melSidebarSaveBound = '1';
+          sidebarSaveBtn.addEventListener('click', function (e) {
+            e.preventDefault();
+            var sub = form.querySelector('.mel-builder-save-submit');
+            if (sub && typeof sub.click === 'function') {
+              sub.click();
+            }
+          });
         }
 
         form.addEventListener(

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.3
+  version: 1.4
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
+use Drupal\myeventlane_event_studio\EventStudioMelOptionCards;
 
 /**
  * Implements hook_theme().
@@ -35,18 +36,82 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-wizard-preview',
     ],
+    'form_element__mel_option_card' => [
+      'base hook' => 'form_element',
+      'template' => 'form-element--mel-option-card',
+    ],
+    'form_element_label__mel_option_card' => [
+      'base hook' => 'form_element_label',
+      'template' => 'form-element-label--mel-option-card',
+    ],
   ];
 }
 
 /**
- * Implements hook_preprocess_html().
- *
- * Full-bleed Event Studio: body class scopes theme SCSS that relaxes global
- * layout containers (layout-container, Gin, off-canvas canvas, etc.).
+ * Implements hook_element_info_alter().
  */
-function myeventlane_event_studio_preprocess_html(array &$variables): void {
-  $route_name = \Drupal::routeMatch()->getRouteName();
-  $studio_routes = [
+function myeventlane_event_studio_element_info_alter(array &$info): void {
+  if (isset($info['radios']['#process'])) {
+    $info['radios']['#process'][] = [EventStudioMelOptionCards::class, 'processRadios'];
+  }
+  if (isset($info['checkbox']['#process'])) {
+    $info['checkbox']['#process'][] = [EventStudioMelOptionCards::class, 'processCheckbox'];
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for form_element.
+ */
+function myeventlane_event_studio_theme_suggestions_form_element_alter(array &$suggestions, array $variables): void {
+  if (!empty($variables['element']['#mel_option_card'])) {
+    $suggestions[] = 'form_element__mel_option_card';
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for form_element_label.
+ */
+function myeventlane_event_studio_theme_suggestions_form_element_label_alter(array &$suggestions, array $variables): void {
+  if (!empty($variables['element']['#mel_option_card_label'])) {
+    $suggestions[] = 'form_element_label__mel_option_card';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for form_element__mel_option_card.
+ */
+function myeventlane_event_studio_preprocess_form_element__mel_option_card(array &$variables): void {
+  if (isset($variables['label']) && is_array($variables['label'])) {
+    $variables['label']['#mel_option_card_label'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for radios.
+ */
+function myeventlane_event_studio_preprocess_radios(array &$variables): void {
+  $element = &$variables['element'];
+  if (empty($element['#mel_option_cards'])) {
+    return;
+  }
+  $attributes = &$variables['attributes'];
+  if (!$attributes instanceof Attribute) {
+    $variables['attributes'] = new Attribute((array) $attributes);
+    $attributes = &$variables['attributes'];
+  }
+  /** @var \Drupal\Core\Template\Attribute $attributes */
+  $attributes->addClass('mel-option-cards');
+  if (!empty($element['#mel_option_cards_tickets_layout'])) {
+    $attributes->addClass('mel-option-cards--tickets-row');
+  }
+}
+
+/**
+ * Returns TRUE when the HTTP route is an Event Studio create/edit/step screen.
+ */
+function _myeventlane_event_studio_is_event_studio_route(?string $route_name = NULL): bool {
+  $route_name ??= \Drupal::routeMatch()->getRouteName();
+  $routes = [
     'myeventlane_event_studio.create',
     'myeventlane_event_studio.edit',
     'myeventlane_event_studio.edit_basic',
@@ -56,7 +121,151 @@ function myeventlane_event_studio_preprocess_html(array &$variables): void {
     'myeventlane_event_studio.edit_preview',
     'myeventlane_event_studio.edit_publish',
   ];
-  if (!in_array($route_name, $studio_routes, TRUE)) {
+  return in_array($route_name, $routes, TRUE);
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for form_element.
+ */
+function myeventlane_event_studio_preprocess_form_element(array &$variables): void {
+  if (!_myeventlane_event_studio_is_event_studio_route()) {
+    return;
+  }
+  if (!isset($variables['attributes']) || !isset($variables['element'])) {
+    return;
+  }
+  /** @var array $element */
+  $element = $variables['element'];
+  $type = $element['#type'] ?? '';
+
+  // Opt-out escape hatch for edge widgets.
+  if (!empty($element['#mel_skip_builder_field_well'])) {
+    return;
+  }
+
+  if ($type === '') {
+    return;
+  }
+
+  $skip_types = [
+    'hidden',
+    'button',
+    'submit',
+    'image_button',
+    'label',
+    'item',
+    'markup',
+    'link',
+    'vertical_tabs',
+    'container',
+    'actions',
+    'details',
+    'fieldset',
+    'radio',
+    'processed_text',
+    'value',
+    'weight',
+    'table',
+    'view',
+    'token',
+    'machine_name_states',
+    'path',
+  ];
+  if (in_array($type, $skip_types, TRUE)) {
+    return;
+  }
+
+  if (!empty($element['#mel_option_card'])) {
+    return;
+  }
+
+  if ($type === 'checkbox' && empty($element['#mel_option_card'])) {
+    return;
+  }
+
+  /** @var list<string>|string|null $wrapper_classes */
+  $wrapper_attrs = $element['#wrapper_attributes'] ?? [];
+  $wrapper_classes = $wrapper_attrs['class'] ?? [];
+  if ($wrapper_classes && !is_array($wrapper_classes)) {
+    $wrapper_classes = [$wrapper_classes];
+  }
+  if (is_array($wrapper_classes) && in_array('mel-option-card', $wrapper_classes, TRUE)) {
+    return;
+  }
+
+  $includes_well = [
+    'textfield',
+    'tel',
+    'email',
+    'url',
+    'search',
+    'password',
+    'textarea',
+    'number',
+    'select',
+    'datetime',
+    'entity_autocomplete',
+    'managed_file',
+    'file',
+    'color',
+    'machine_name',
+  ];
+  if (!in_array($type, $includes_well, TRUE)) {
+    return;
+  }
+
+  if (!$variables['attributes'] instanceof Attribute) {
+    $variables['attributes'] = new Attribute((array) $variables['attributes']);
+  }
+  $variables['attributes']->addClass('mel-builder-field-well');
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for fieldset.
+ */
+function myeventlane_event_studio_preprocess_fieldset(array &$variables): void {
+  if (!_myeventlane_event_studio_is_event_studio_route()) {
+    return;
+  }
+  if (!isset($variables['attributes'], $variables['element'])) {
+    return;
+  }
+  $element = $variables['element'];
+  $attrs = $element['#attributes'] ?? [];
+  $classes = $attrs['class'] ?? [];
+  if ($classes && !is_array($classes)) {
+    $classes = [$classes];
+  }
+  $classes ??= [];
+
+  // Shell composite groups (radios legends, checkbox sets) without targeting admin vertical tabs shells.
+  if (!in_array('form-composite', $classes, TRUE) && !in_array('fieldgroup', $classes, TRUE)) {
+    return;
+  }
+  if (!empty($element['#mel_skip_builder_field_well'])) {
+    return;
+  }
+  foreach ($classes as $class) {
+    $slug = (string) $class;
+    if (strpos($slug, 'vertical-tabs') !== FALSE || strpos($slug, 'vertical_tabs') !== FALSE) {
+      return;
+    }
+  }
+
+  if (!$variables['attributes'] instanceof Attribute) {
+    $variables['attributes'] = new Attribute((array) $variables['attributes']);
+  }
+  $variables['attributes']->addClass('mel-builder-fieldset-well');
+}
+
+/**
+ * Implements hook_preprocess_html().
+ *
+ * Full-bleed Event Studio: body class scopes theme SCSS that relaxes global
+ * layout containers (layout-container, Gin, off-canvas canvas, etc.).
+ */
+function myeventlane_event_studio_preprocess_html(array &$variables): void {
+  if (!_myeventlane_event_studio_is_event_studio_route()) {
     return;
   }
   if (isset($variables['attributes']) && $variables['attributes'] instanceof Attribute) {

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioMelOptionCards.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioMelOptionCards.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Applies card-style wrappers to selected radios/checkboxes in Event Studio forms.
+ *
+ * Controlled per element via {@see \Drupal\Core\Render\Element\Radios} properties:
+ * - #mel_option_cards
+ * - #mel_option_descriptions (optional keyed by option value).
+ * - #mel_option_cards_tickets_layout (optional radios group horizontal layout marker).
+ *
+ * Checkboxes pass #mel_option_card.
+ */
+final class EventStudioMelOptionCards {
+
+  /**
+   * Augments radios children after core {@see Radios::processRadios()} has run.
+   */
+  public static function processRadios(array &$element, FormStateInterface $form_state, array &$complete_form): array {
+    if (empty($element['#mel_option_cards'])) {
+      return $element;
+    }
+
+    /** @var array<string, mixed> $descriptions */
+    $descriptions = $element['#mel_option_descriptions'] ?? [];
+
+    foreach (Element::children($element) as $key) {
+      if (($element[$key]['#type'] ?? '') !== 'radio') {
+        continue;
+      }
+
+      $element[$key]['#mel_option_card'] = TRUE;
+      $element[$key]['#wrapper_attributes'] ??= [];
+      $element[$key]['#wrapper_attributes'] += ['class' => []];
+      $element[$key]['#wrapper_attributes']['class'][] = 'mel-option-card';
+
+      if (array_key_exists($key, $descriptions) && $descriptions[$key] !== NULL && $descriptions[$key] !== '') {
+        $element[$key]['#description'] = $descriptions[$key];
+        $element[$key]['#description_display'] = 'after';
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * Adds a card wrapper class to checkboxes that opt in.
+   */
+  public static function processCheckbox(array &$element, FormStateInterface $form_state, array &$complete_form): array {
+    if (empty($element['#mel_option_card'])) {
+      return $element;
+    }
+
+    $element['#wrapper_attributes'] ??= [];
+    $element['#wrapper_attributes'] += ['class' => []];
+    $element['#wrapper_attributes']['class'][] = 'mel-option-card';
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
@@ -103,13 +103,18 @@ final class EventStudioDateForm extends EventStudioBaseForm {
     $form['mel']['venue_mode'] = [
       '#type' => 'radios',
       '#title' => $this->t('Location'),
+      '#mel_option_cards' => TRUE,
+      '#mel_option_descriptions' => [
+        'saved' => $this->t('Pick from venues under your organizer account.'),
+        'create' => $this->t('Save a reusable venue while you prepare this event.'),
+        'one_off' => $this->t('Use an address once without saving a venue profile.'),
+      ],
       '#options' => [
         'saved' => $this->t('Use saved venue'),
         'create' => $this->t('Create new venue'),
         'one_off' => $this->t('One-off address'),
       ],
       '#default_value' => $form_state->getValue(['mel', 'venue_mode'], $melDefaults['venue_mode'] ?? $venue_mode_default),
-      '#attributes' => ['class' => ['mel-radios']],
     ];
 
     $form['mel']['venue_saved'] = [

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -520,21 +520,8 @@ final class EventStudioForm extends FormBase {
       || $paid_no_mel_tickets
     );
 
-    $studio_tier_preview = [];
-    try {
-      $studio_tier_preview = json_decode($studio_tiers_json, TRUE, 512, JSON_THROW_ON_ERROR);
-    }
-    catch (\JsonException) {
-      $studio_tier_preview = [];
-    }
-    $has_ticket_refs = $event->hasField('field_ticket_types')
-      && !$event->get('field_ticket_types')->isEmpty();
-    $has_ticket_signal_for_mel = $has_ticket_refs
-      || ($type_default !== 'external' && $studio_tier_preview !== []);
-
-    // MEL contribution: require a ticket signal (draft tiers, saved types, or RSVP path)
-    // and hide for external events (no MEL ticket attach point in the same way).
-    $show_mel_contribution = $has_ticket_signal_for_mel && $type_default !== 'external';
+    // MEL contribution (donations / platform support): show for non-external events only.
+    $show_mel_contribution = $type_default !== 'external';
 
     $form['mel'] = [
       '#type' => 'container',
@@ -806,13 +793,18 @@ final class EventStudioForm extends FormBase {
     $form['mel']['venue_mode'] = [
       '#type' => 'radios',
       '#title' => $this->t('Location'),
+      '#mel_option_cards' => TRUE,
+      '#mel_option_descriptions' => [
+        'saved' => $this->t('Pick from venues under your organizer account.'),
+        'create' => $this->t('Save a reusable venue while you prepare this event.'),
+        'one_off' => $this->t('Use an address once without saving a venue profile.'),
+      ],
       '#options' => [
         'saved' => $this->t('Use saved venue'),
         'create' => $this->t('Create new venue'),
         'one_off' => $this->t('One-off address'),
       ],
       '#default_value' => $form_state->getValue(['mel', 'venue_mode'], $venue_mode_default),
-      '#attributes' => ['class' => ['mel-radios']],
     ];
 
     $form['mel']['venue_saved'] = [
@@ -888,20 +880,26 @@ final class EventStudioForm extends FormBase {
     $form['mel']['tickets_intro'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('Choose RSVP, paid tickets on MEL, or link to external checkout.'),
+      '#value' => $this->t('Start with one ticket — you can add more later.'),
       '#attributes' => ['class' => ['mel-tickets-intro']],
     ];
 
     $form['mel']['field_event_type'] = [
       '#type' => 'radios',
       '#title' => '',
+      '#mel_option_cards' => TRUE,
+      '#mel_option_cards_tickets_layout' => TRUE,
+      '#mel_option_descriptions' => [
+        'rsvp' => $this->t('Collect RSVPs without taking payment.'),
+        'paid' => $this->t('Sell tickets through MyEventLane.'),
+        'external' => $this->t('Send guests to Humanitix, Eventbrite, or your site.'),
+      ],
       '#options' => [
         'rsvp' => $this->t('RSVP (free)'),
         'paid' => $this->t('Paid tickets'),
         'external' => $this->t('External link'),
       ],
       '#default_value' => $type_default,
-      '#attributes' => ['class' => ['mel-radios', 'mel-radios--tickets']],
     ];
 
     $form['mel']['studio_ticket_tiers'] = [
@@ -970,12 +968,12 @@ final class EventStudioForm extends FormBase {
         ],
         'text' => [
           '#markup' => '<p class="mel-ticket-builder__empty-title">' . $this->t('No ticket cards yet') . '</p>'
-            . '<p class="mel-ticket-builder__empty-body">' . $this->t('Click Add ticket to create an editable draft card. Invalid drafts stay in the browser until you complete them.') . '</p>',
+            . '<p class="mel-ticket-builder__empty-body">' . $this->t('Use Add another ticket type to create an editable draft card. Invalid drafts stay in the browser until you complete them.') . '</p>',
         ],
       ],
       'add' => [
         '#type' => 'button',
-        '#value' => $this->t('Add ticket'),
+        '#value' => $this->t('Add another ticket type'),
         '#attributes' => [
           'class' => ['mel-btn', 'mel-btn--primary', 'button'],
           'type' => 'button',
@@ -1110,7 +1108,7 @@ final class EventStudioForm extends FormBase {
         '#attributes' => ['class' => ['mel-attendee-questions-add']],
         'add' => [
           '#type' => 'button',
-          '#value' => $this->t('+ Add question'),
+          '#value' => $this->t('Add question'),
           '#attributes' => [
             'type' => 'button',
             'id' => 'mel-attendee-add-question',
@@ -1340,7 +1338,8 @@ final class EventStudioForm extends FormBase {
       $form_state,
       $event,
       94,
-      'mel-studio-mel-support-heading',
+      'mel-mel-support-heading',
+      TRUE,
       TRUE,
     );
     if (isset($form['mel_mel_support'])) {
@@ -1383,6 +1382,7 @@ final class EventStudioForm extends FormBase {
         'venueMode' => $venue_mode_default,
       ],
       'highlightIconOptions' => $this->eventHighlightHelper->getIconOptionsForJs(),
+      'highlightIconPicker' => $this->eventHighlightHelper->getHighlightIconPickerItems(),
       'highlightErrors' => [
         'max' => (string) $this->t('You can add at most 6 highlights.'),
         'iconNoText' => (string) $this->t('Add text for each highlight that has an icon.'),
@@ -1399,7 +1399,6 @@ final class EventStudioForm extends FormBase {
         'typeExternal' => (string) $this->t('External link'),
       ],
       'defaultCurrency' => $this->resolveStudioDefaultCurrency($event),
-      'hasTicketSignalForMel' => $has_ticket_signal_for_mel,
       'showMelContribution' => $show_mel_contribution,
       'vendorQuestionLibrary' => $this->buildVendorQuestionLibraryPayload(),
       'urls' => [
@@ -1685,6 +1684,21 @@ final class EventStudioForm extends FormBase {
         'required' => $required,
         'save_to_library' => FALSE,
       ];
+      if ($paragraph->hasField('field_question_options') && !$paragraph->get('field_question_options')->isEmpty()) {
+        $opt_raw = trim((string) ($paragraph->get('field_question_options')->value ?? ''));
+        if ($opt_raw !== '') {
+          $opts = [];
+          foreach (preg_split('/\r?\n/', $opt_raw) as $line) {
+            $line = trim($line);
+            if ($line !== '') {
+              $opts[] = $line;
+            }
+          }
+          if ($opts !== []) {
+            $row['options'] = $opts;
+          }
+        }
+      }
       if ($paragraph->hasField('field_question_machine_name') && !$paragraph->get('field_question_machine_name')->isEmpty()) {
         $machine = trim((string) ($paragraph->get('field_question_machine_name')->value ?? ''));
         if ($machine !== '') {

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
@@ -70,13 +70,19 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
     $form['mel']['field_event_type'] = [
       '#type' => 'radios',
       '#title' => '',
+      '#mel_option_cards' => TRUE,
+      '#mel_option_cards_tickets_layout' => TRUE,
+      '#mel_option_descriptions' => [
+        'rsvp' => $this->t('Collect RSVPs without taking payment.'),
+        'paid' => $this->t('Sell tickets through MyEventLane.'),
+        'external' => $this->t('Send guests to Humanitix, Eventbrite, or your site.'),
+      ],
       '#options' => [
         'rsvp' => $this->t('Free RSVP'),
         'paid' => $this->t('Paid tickets'),
         'external' => $this->t('External link'),
       ],
       '#default_value' => $melDefaults['field_event_type'] ?? 'rsvp',
-      '#attributes' => ['class' => ['mel-radios', 'mel-radios--tickets']],
     ];
 
     $form['mel']['studio_ticket_tiers'] = [
@@ -141,7 +147,9 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
     $form['mel']['collect_attendee_questions'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Collect extra attendee details'),
+      '#description' => $this->t('Gather information per guest (beyond name and email).'),
       '#default_value' => !empty($melDefaults['collect_attendee_questions']),
+      '#mel_option_card' => TRUE,
     ];
 
     $form['#attached']['library'][] = 'myeventlane_vendor/ticket_cards';

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventHighlightHelper.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventHighlightHelper.php
@@ -28,19 +28,10 @@ final class EventHighlightHelper {
    *   Ordered allowed icon keys, or empty if storage is missing or invalid.
    */
   public function getAllowedIconKeys(): array {
-    $storage = $this->loadHighlightIconFieldStorage();
-    if ($storage === NULL) {
-      return [];
-    }
-    $raw = $storage->getSetting('allowed_values');
-    if (!is_array($raw)) {
-      return [];
-    }
+    $pairs = $this->getHighlightIconAllowedPairs();
     $keys = [];
-    foreach ($raw as $item) {
-      if (is_array($item) && isset($item['value'])) {
-        $keys[] = (string) $item['value'];
-      }
+    foreach ($pairs as $pair) {
+      $keys[] = $pair['value'];
     }
     return $keys;
   }
@@ -52,21 +43,101 @@ final class EventHighlightHelper {
    *   Keys are allowed values; values are human-readable labels.
    */
   public function getIconOptionsForJs(): array {
+    $out = [];
+    foreach ($this->getHighlightIconAllowedPairs() as $pair) {
+      $out[$pair['value']] = $pair['label'];
+    }
+    return $out;
+  }
+
+  /**
+   * Icon picker rows for Event Studio (emoji button + storage value + label).
+   *
+   * @return list<array{value: string, emoji: string, label: string}>
+   */
+  public function getHighlightIconPickerItems(): array {
+    $out = [];
+    foreach ($this->getHighlightIconAllowedPairs() as $pair) {
+      $value = $pair['value'];
+      $label = trim($pair['label']);
+      $emoji = $this->extractLeadingEmoji($label);
+      $out[] = [
+        'value' => $value,
+        'emoji' => $emoji,
+        'label' => $label,
+      ];
+    }
+    return $out;
+  }
+
+  /**
+   * Normalizes field_storage allowed_values for list_string option fields.
+   *
+   * Supports:
+   * - Export shape: list of rows `[ ['value' => …, 'label' => …], … ]`
+   * - Flat map: `[ machine_key => human_label, … ]`
+   *
+   * @return list<array{value: string, label: string}>
+   */
+  private function getHighlightIconAllowedPairs(): array {
     $storage = $this->loadHighlightIconFieldStorage();
     if ($storage === NULL) {
       return [];
     }
     $raw = $storage->getSetting('allowed_values');
-    if (!is_array($raw)) {
+    if (!is_array($raw) || $raw === []) {
       return [];
     }
-    $out = [];
+
+    $hasStructured = FALSE;
     foreach ($raw as $item) {
-      if (is_array($item) && isset($item['value'], $item['label'])) {
-        $out[(string) $item['value']] = (string) $item['label'];
+      if (is_array($item) && array_key_exists('value', $item)) {
+        $hasStructured = TRUE;
+        break;
       }
     }
-    return $out;
+
+    if ($hasStructured) {
+      $out = [];
+      foreach ($raw as $item) {
+        if (!is_array($item) || !array_key_exists('value', $item)) {
+          continue;
+        }
+        $out[] = [
+          'value' => (string) $item['value'],
+          'label' => array_key_exists('label', $item) ? (string) $item['label'] : (string) $item['value'],
+        ];
+      }
+      return $out;
+    }
+
+    $flat = [];
+    foreach ($raw as $value => $label) {
+      if (!is_string($value) && !is_int($value)) {
+        continue;
+      }
+      if (!is_scalar($label)) {
+        continue;
+      }
+      $flat[] = [
+        'value' => (string) $value,
+        'label' => (string) $label,
+      ];
+    }
+    return $flat;
+  }
+
+  /**
+   * First Unicode extended grapheme cluster in a string (emoji-safe lead character).
+   */
+  private function extractLeadingEmoji(string $label): string {
+    if ($label === '') {
+      return '';
+    }
+    if (preg_match('/^(\X)/u', $label, $m) === 1) {
+      return (string) ($m[1] ?? '');
+    }
+    return '';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -358,6 +358,18 @@ final class EventStudioMelPayloadService {
       if ($machine !== '') {
         $item['machine_name'] = $machine;
       }
+      $option_lines = [];
+      if (isset($row['options']) && is_array($row['options'])) {
+        foreach ($row['options'] as $opt) {
+          $t = trim((string) $opt);
+          if ($t !== '') {
+            $option_lines[] = $t;
+          }
+        }
+      }
+      if ($option_lines !== []) {
+        $item['options'] = $option_lines;
+      }
       $out[] = $item;
     }
     return $out;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1062,6 +1062,29 @@ final class EventStudioSaveService {
         $paragraph->set($field_map['type'], $this->normalizeAttendeeQuestionTypeValue($type));
         $paragraph->set($field_map['required'], $required ? 1 : 0);
 
+        $normalized_type = $this->normalizeAttendeeQuestionTypeValue($type);
+        if ($paragraph->hasField('field_question_options')) {
+          $needs_opts = in_array($normalized_type, ['select', 'checkboxes', 'radios'], TRUE);
+          if ($needs_opts) {
+            $lines = [];
+            if (isset($question['options']) && is_array($question['options'])) {
+              foreach ($question['options'] as $opt_line) {
+                $t = trim((string) $opt_line);
+                if ($t !== '') {
+                  $lines[] = $t;
+                }
+              }
+            }
+            if ($lines === []) {
+              return [sprintf('Add at least one choice for question %d.', (int) $index + 1)];
+            }
+            $paragraph->set('field_question_options', ['value' => implode("\n", $lines)]);
+          }
+          else {
+            $paragraph->set('field_question_options', NULL);
+          }
+        }
+
         if ($paragraph->hasField('field_question_machine_name')) {
           $machine = trim((string) ($question['machine_name'] ?? ''));
           if ($machine === '') {
@@ -1143,9 +1166,18 @@ final class EventStudioSaveService {
   }
 
   private function normalizeAttendeeQuestionTypeValue(string $type): string {
+    $type = trim($type);
     return match ($type) {
-      'text' => 'textfield',
-      default => $type,
+      'text', 'textfield' => 'textfield',
+      'textarea' => 'textarea',
+      'select' => 'select',
+      'checkbox' => 'checkboxes',
+      'checkboxes' => 'checkboxes',
+      'radio' => 'radios',
+      'radios' => 'radios',
+      'email' => 'email',
+      'tel' => 'tel',
+      default => 'textfield',
     };
   }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/form-element--mel-option-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/form-element--mel-option-card.html.twig
@@ -1,0 +1,73 @@
+{#
+/**
+ * @file
+ * Event Studio — card-style radio/checkbox wrapper (mel-option-card).
+ *
+ * Same contract as system form-element; description for label "after" is
+ * rendered inside .mel-option-card__content (no duplicate trailing block).
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'form-type-' ~ type|clean_class,
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set desc_trailing_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+{%
+  set desc_card_classes = [
+    'mel-option-card__desc',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if label_display in ['before', 'invisible'] %}
+    {{ label }}
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes.addClass(desc_trailing_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    <div class="mel-option-card__content">
+      {{ label }}
+      {% if description_display in ['after', 'invisible'] and description.content %}
+        <p{{ description.attributes.addClass(desc_card_classes) }}>
+          {{ description.content }}
+        </p>
+      {% endif %}
+    </div>
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if label_display != 'after' and description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(desc_trailing_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/form-element-label--mel-option-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/form-element-label--mel-option-card.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Event Studio — option card label: bold title line for mel-option-card radios/checkboxes.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+    'mel-option-card__label',
+  ]
+%}
+{% if title is not empty or required -%}
+  <label{{ attributes.addClass(classes) }}>{%- if title is not empty -%}<strong>{{ title }}</strong>{%- endif -%}</label>
+{%- endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-nav.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-nav.html.twig
@@ -16,10 +16,10 @@
       <a href="#mel-step-tickets" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="tickets" role="tab" aria-selected="false">{{ 'How people join'|t }}</a>
     </li>
     <li>
-      <a href="#mel-step-attendee" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="attendee" role="tab" aria-selected="false">{{ 'Attendee questions'|t }}</a>
+      <a href="#mel-step-standout" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="standout" role="tab" aria-selected="false">{{ 'Stand out'|t }}</a>
     </li>
     <li>
-      <a href="#mel-step-standout" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="standout" role="tab" aria-selected="false">{{ 'Stand out'|t }}</a>
+      <a href="#mel-step-attendee" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="attendee" role="tab" aria-selected="false">{{ 'Attendee questions'|t }}</a>
     </li>
     <li>
       <a href="#mel-step-preview" class="mel-nav-item mel-nav-link mel-event-studio-nav__item" data-step="preview" role="tab" aria-selected="false">{{ 'Preview'|t }}</a>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-nav.html.twig
@@ -11,8 +11,8 @@
   <nav class="mel-nav mel-wizard-nav mel-event-studio-wizard-nav" aria-label="{{ 'Event steps'|t }}">
     <a href="{{ studio_base }}#mel-step-identity" class="mel-nav__link{% if current_step in ['basic', 'datetime'] %} is-active{% endif %}">{{ 'Event identity'|t }}</a>
     <a href="{{ studio_base }}#mel-step-tickets" class="mel-nav__link{% if current_step == 'tickets' %} is-active{% endif %}">{{ 'Tickets'|t }}</a>
-    <a href="{{ studio_base }}#mel-step-attendee" class="mel-nav__link">{{ 'Attendee questions'|t }}</a>
     <a href="{{ studio_base }}#mel-step-standout" class="mel-nav__link{% if current_step == 'description' %} is-active{% endif %}">{{ 'Stand out'|t }}</a>
+    <a href="{{ studio_base }}#mel-step-attendee" class="mel-nav__link">{{ 'Attendee questions'|t }}</a>
     <a href="{{ studio_base }}#mel-step-preview" class="mel-nav__link{% if current_step == 'preview' %} is-active{% endif %}">{{ 'Preview'|t }}</a>
     <a href="{{ studio_base }}#mel-step-publish" class="mel-nav__link{% if current_step == 'publish' %} is-active{% endif %}">{{ 'Publish'|t }}</a>
   </nav>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Event Studio — task-based builder: identity → join → attendee needs → stand out (+ preview / publish).
+ * Event Studio — task-based builder: identity → join → stand out → attendee questions (+ preview / publish).
  *
  * Theme hook is applied to the form root (render element = element) so this
  * template includes a real <form> and Drupal hidden fields (build ID, token).
@@ -12,7 +12,7 @@
     {{ element.mel_contextual_help_card }}
   {% endif %}
 
-  <div class="mel-event-studio mel-event-studio--{{ mode|default('create') }}" data-mel-studio-shell="1">
+  <div class="mel-event-studio mel-event-studio--builder-inline-validation mel-event-studio--{{ mode|default('create') }}" data-mel-studio-shell="1">
     {{ element.mel.ai_settings }}
     <h1 class="mel-event-studio__page-title visually-hidden">
       {% if mode == 'create' %}
@@ -80,71 +80,6 @@
       </div>
     {% endif %}
 
-    {# TOP ZONE — live preview (aside + mobile drawer) #}
-    <div class="mel-studio-top mel-studio-top--solo" id="mel-studio-preview-panel">
-      <div class="mel-studio-top__preview mel-studio-top__preview--wide">
-        <div class="mel-event-studio__top">
-          <aside
-            class="mel-preview"
-            id="mel-live-preview"
-            data-mel-live-preview="1"
-            aria-label="{{ 'Live preview'|t }}"
-          >
-            <button
-              type="button"
-              class="mel-preview__drawer-toggle"
-              id="mel-preview-drawer-toggle"
-              aria-expanded="false"
-              aria-controls="mel-preview-drawer-panel"
-            >
-              <span class="mel-preview__drawer-toggle-label">{{ 'Preview'|t }}</span>
-              <span class="mel-preview__drawer-hint" aria-hidden="true">{{ 'Tap to expand'|t }}</span>
-            </button>
-            <div class="mel-preview__panel" id="mel-preview-drawer-panel">
-              <div class="mel-event-studio__preview">
-                <div id="mel-preview-card" data-mel-studio-preview-anchor="1">
-                  <article class="mel-preview-card">
-                    <div class="mel-preview-card__media" id="mel-preview-card-media">
-                      <img class="mel-preview-card__img" id="mel-preview-card-img" src="" alt="" width="640" height="336" loading="lazy" hidden />
-                      <div class="mel-preview-card__media-placeholder" id="mel-preview-card-placeholder">
-                        <span aria-hidden="true"></span>
-                      </div>
-                    </div>
-                    <div class="mel-preview-card__body">
-                      <h3 class="mel-preview-card__title" id="mel-preview-title">—</h3>
-                      <p class="mel-preview-card__meta">
-                        <time class="mel-preview-card__time" id="mel-preview-schedule" datetime="">—</time>
-                      </p>
-                      <p class="mel-preview-card__location" id="mel-preview-location">—</p>
-                      <p class="mel-preview-card__badge" id="mel-preview-booking-mode">—</p>
-                      <p class="mel-preview-card__pricing" id="mel-preview-pricing">—</p>
-                      <p class="mel-preview-card__status" id="mel-preview-status">—</p>
-                      <div class="mel-preview-card__cta">
-                        <a href="#" class="mel-btn mel-btn--primary mel-preview__cta" id="mel-preview-cta">{{ 'RSVP free'|t }}</a>
-                      </div>
-                    </div>
-                  </article>
-                </div>
-                <div class="mel-preview-hints" id="mel-preview-hints" aria-live="polite"></div>
-              </div>
-
-              <div class="mel-event-actions">
-                {% if mel_event_actions.view %}
-                  <a href="{{ mel_event_actions.view }}" class="mel-btn mel-btn--ghost" target="_blank" rel="noopener noreferrer">{{ 'View page'|t }}</a>
-                {% endif %}
-                {% if mel_event_actions.booking %}
-                  <a href="{{ mel_event_actions.booking }}" class="mel-btn mel-btn--secondary" target="_blank" rel="noopener noreferrer">{{ 'Booking page'|t }}</a>
-                {% endif %}
-                {% if mel_event_actions.scan %}
-                  <a href="{{ mel_event_actions.scan }}" class="mel-btn mel-btn--accent">{{ 'Scan tickets'|t }}</a>
-                {% endif %}
-              </div>
-            </div>
-          </aside>
-        </div>
-      </div>
-    </div>
-
     <div class="mel-es-workspace{% if show_onboarding_sidebar %} mel-es-workspace--has-onboarding{% endif %}">
       {% if show_onboarding_sidebar %}
         <aside class="mel-es-workspace__sidebar mel-es-workspace__sidebar--onboarding" aria-label="{{ 'Organiser setup'|t }}">
@@ -157,117 +92,154 @@
       <main class="mel-es-workspace__main">
 
     <div class="mel-studio-form-wrapper mel-event-studio__form-full mel-studio-main-full">
+
       <div class="mel-builder" data-mel-builder="1">
         <div class="mel-builder__main">
       <div class="mel-wizard">
 
-        {# —— 1. Event identity (title + schedule + venue) —— #}
-        <div id="mel-card-identity" class="mel-builder-card mel-builder-task-card mel-builder-card--identity" data-mel-builder-card="identity">
+        {# —— 1. Identity + schedule (single step, stacked cards) —— #}
         <section id="mel-step-identity" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="identity" role="tabpanel" aria-labelledby="mel-task-identity-heading">
-          <div class="mel-es-stack">
+          <div class="mel-builder-step-stack">
+            {% if element.mel.guidance_title is defined %}
+              {{ element.mel.guidance_title }}
+            {% endif %}
             <header class="mel-task-card__banner" id="mel-task-identity-heading">
-              <h2 class="mel-task-card__title">{{ 'Event identity'|t }}</h2>
-              <p class="mel-task-card__lede">{{ 'Name it, schedule it, and pin where it happens — guests need all three to trust the listing.'|t }}</p>
+              <h2 class="mel-task-card__title">{{ 'Basics'|t }}</h2>
+              <p class="mel-task-card__lede">{{ 'Lock in the essentials — guests see these first.'|t }}</p>
             </header>
 
-            <section class="mel-es-card mel-section mel-section--builder mel-section--basic" aria-labelledby="mel-basic-heading">
-              <header class="mel-section__header">
-                <h3 class="mel-section__title" id="mel-basic-heading">{{ 'Title'|t }}</h3>
-                <p class="mel-section__hint">{{ 'Use a clear, specific name — you can refine discovery details after tickets are set up.'|t }}</p>
+            <section id="mel-card-identity" class="mel-builder-card mel-builder-card--identity" data-mel-builder-card="identity" data-mel-track-complete="identity-title" aria-labelledby="mel-basic-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h3 class="mel-builder-card__title" id="mel-basic-heading">{{ 'Give your event a name'|t }}</h3>
+                <p class="mel-builder-card__hint">{{ 'This is how it will appear to guests — make it clear and exciting.'|t }}</p>
               </header>
-
-              <div class="mel-basic-section">
-                <div class="mel-basic-title-with-ai">
-                  {{ element.mel.title }}
-                  <div class="mel-ai-autofill">
-                    <button
-                      type="button"
-                      id="mel-ai-generate"
-                      class="mel-btn mel-btn--secondary"
-                      data-mel-ai-default-label="{{ '✨ Generate with AI'|t }}"
-                    >
-                      {{ '✨ Generate with AI'|t }}
-                    </button>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body">
+                <div class="mel-basic-section">
+                  <div class="mel-basic-title-with-ai">
+                    {{ element.mel.title }}
+                    <div class="mel-ai-autofill">
+                      <button
+                        type="button"
+                        id="mel-ai-generate"
+                        class="mel-btn mel-btn--secondary"
+                        data-mel-ai-default-label="{{ 'Generate with AI'|t }}"
+                      >
+                        {{ 'Generate with AI'|t }}
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
             </section>
 
-            <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--details" aria-labelledby="mel-details-heading">
-              <header class="mel-section__header">
-                <h3 class="mel-section__title" id="mel-details-heading">{{ 'Date & time'|t }}</h3>
-                <p class="mel-section__hint">{{ 'When your event runs — used in search, reminders, and calendars.'|t }}</p>
+            <section id="mel-card-schedule" class="mel-builder-card mel-builder-card--schedule" data-mel-track-complete="schedule" aria-labelledby="mel-schedule-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h3 class="mel-builder-card__title" id="mel-schedule-heading">{{ 'When and where is it happening?'|t }}</h3>
+                <p class="mel-builder-card__hint">{{ 'Used for discovery, reminders, and calendars.'|t }}</p>
               </header>
-
-              <div class="mel-form-grid">
-                {{ element.mel.start_date }}
-                {{ element.mel.end_date }}
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
               </div>
-            </section>
-
-            <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--location" aria-labelledby="mel-location-heading">
-              <header class="mel-section__header">
-                <h3 class="mel-section__title" id="mel-location-heading">{{ 'Location'|t }}</h3>
-                <p class="mel-section__hint">{{ 'Helps attendees plan with confidence.'|t }}</p>
-              </header>
-
-              {{ element.mel.venue_mode }}
-              {{ element.mel.venue_saved }}
-              {{ element.mel.venue_create_name }}
-              {{ element.mel.location_search }}
-
-              <div class="mel-location-display" id="mel-location-display" role="status" aria-live="polite">
-                <p class="mel-location-display__label">{{ 'Selected address'|t }}</p>
-                <p class="mel-location-display__value" id="mel-location-display-value">{{ 'Nothing selected yet — search or pick a venue above.'|t }}</p>
+              <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--schedule">
+                <div class="mel-builder-fields__col mel-builder-fields mel-builder-fields--stack">
+                  {{ element.mel.start_date }}
+                  {{ element.mel.end_date }}
+                </div>
+                <div class="mel-builder-fields__col mel-builder-fields mel-builder-fields--stack">
+                  {{ element.mel.venue_mode }}
+                  {{ element.mel.venue_saved }}
+                  {{ element.mel.venue_create_name }}
+                  {{ element.mel.location_search }}
+                  <div class="mel-location-display" id="mel-location-display" role="status" aria-live="polite">
+                    <p class="mel-location-display__label">{{ 'Selected address'|t }}</p>
+                    <p class="mel-location-display__value" id="mel-location-display-value">{{ 'Nothing selected yet — search or pick a venue above.'|t }}</p>
+                  </div>
+                  <div class="mel-location-map-placeholder" id="mel-location-map-placeholder" aria-hidden="true">
+                    <span class="mel-location-map-placeholder__pin" aria-hidden="true"></span>
+                    <span class="mel-location-map-placeholder__caption">{{ 'Map preview'|t }}</span>
+                  </div>
+                  <div class="mel-location-technical">
+                    {{ element.mel.field_location }}
+                    {{ element.mel.field_location_latitude }}
+                    {{ element.mel.field_location_longitude }}
+                  </div>
+                </div>
               </div>
-
-              <div class="mel-location-map-placeholder" id="mel-location-map-placeholder" aria-hidden="true">
-                <span class="mel-location-map-placeholder__pin" aria-hidden="true"></span>
-                <span class="mel-location-map-placeholder__caption">{{ 'Map preview'|t }}</span>
-              </div>
-
-              <div class="mel-location-technical">
-                {{ element.mel.field_location }}
-                {{ element.mel.field_location_latitude }}
-                {{ element.mel.field_location_longitude }}
-              </div>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
             </section>
 
             <div class="mel-step-actions">
               <button type="button" class="mel-btn mel-prev" disabled>{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue →'|t }}</button>
             </div>
           </div>
         </section>
-        </div>{# /.mel-builder-card--identity #}
 
-        {# —— 2. How people join —— #}
-        <div id="mel-card-tickets" class="mel-builder-card mel-builder-task-card mel-builder-card--tickets" data-mel-builder-card="tickets" data-mel-reveal-section="tickets">
+        {# —— 2. Tickets + optional RSVP donations + platform support —— #}
         <section id="mel-step-tickets" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="tickets" role="tabpanel" aria-labelledby="mel-task-tickets-heading">
-          <div class="mel-es-stack">
+          <div class="mel-builder-step-stack">
             <header class="mel-task-card__banner" id="mel-task-tickets-heading">
-              <h2 class="mel-task-card__title">{{ 'How people join'|t }}</h2>
-              <p class="mel-task-card__lede">{{ 'Choose RSVP, paid tickets, or an external link — then configure cards and when sales run.'|t }}</p>
+              <h2 class="mel-task-card__title">{{ 'Tickets'|t }}</h2>
+              <p class="mel-task-card__lede">{{ 'Set how people join and optionally add extras.'|t }}</p>
             </header>
 
-            <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--tickets" aria-labelledby="mel-tickets-type-heading">
-              <header class="mel-section__header">
-                <h3 class="mel-section__title" id="mel-tickets-type-heading">{{ 'Ticket type'|t }}</h3>
-                <p class="mel-section__hint">{{ 'RSVP, paid on MEL, or link out to your own checkout.'|t }}</p>
-              </header>
+            <div class="mel-stage-transition mel-stage-transition--tickets" role="region" aria-labelledby="mel-stage-transition-tickets-title">
+              <div class="mel-stage-transition__progress" role="progressbar" aria-valuemin="1" aria-valuenow="2" aria-valuemax="6" aria-label="{{ 'Event Studio checklist progress'|t }}">
+                <span class="mel-stage-transition__progress-fill"></span>
+              </div>
+              <p class="mel-stage-transition__kicker">{{ 'Step 2 of 6 · How people join'|t }}</p>
+              <p class="mel-stage-transition__title" id="mel-stage-transition-tickets-title">
+                {{ '🎟 You\'re ready — now let\'s set up how people book your event'|t }}
+              </p>
+              <p class="mel-stage-transition__subtitle">
+                {{ 'Start with one ticket — you can add more anytime'|t }}
+              </p>
+            </div>
 
-              <div class="mel-ticket-section">
-              {{ element.mel.tickets_intro }}
-              {{ element.mel.field_event_type }}
-              {{ element.mel.studio_ticket_tiers }}
-              {% if element.mel.embedded_ticket_wizard is defined %}
-                {{ element.mel.embedded_ticket_wizard }}
+            <section id="mel-card-tickets" class="mel-builder-card mel-builder-card--tickets" data-mel-builder-card="tickets" data-mel-reveal-section="tickets" data-mel-track-complete="tickets" aria-labelledby="mel-tickets-type-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h3 class="mel-builder-card__title" id="mel-tickets-type-heading">{{ 'How will people join?'|t }}</h3>
+                <p class="mel-builder-card__hint">{{ 'Start with one ticket — you can add more later.'|t }}</p>
+              </header>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
+              {% if element.mel.first_ticket_guidance is defined %}
+                {{ element.mel.first_ticket_guidance }}
               {% endif %}
-              {{ element.mel.studio_ticket_builder }}
+              {{ element.mel.field_event_type }}
+              <div class="mel-tickets-product-region">
+                <div class="mel-tickets-section-divider" role="presentation">
+                  <span class="mel-tickets-section-divider__label">{{ 'Your tickets'|t }}</span>
+                </div>
+                <div class="mel-tickets-list-well">
+                  <p class="mel-ticket-studio-autosave-hint" role="status">{{ 'Changes saved automatically'|t }}</p>
+                  {{ element.mel.studio_ticket_tiers }}
+                  {% if element.mel.embedded_ticket_wizard is defined %}
+                    {{ element.mel.embedded_ticket_wizard }}
+                  {% endif %}
+                  {{ element.mel.studio_ticket_builder }}
+                </div>
+              </div>
               {{ element.mel.rsvp_capacity }}
 
               <div class="mel-ticket-paid-shell" id="mel-ticket-paid-shell" hidden>
-                <div class="mel-ticket-fields-deck mel-form-grid">
+                <div class="mel-builder-fields mel-builder-fields--2col">
                   {{ element.mel.field_product_target }}
                   {{ element.mel.field_ticket_types }}
                 </div>
@@ -275,221 +247,279 @@
 
               {{ element.mel.paid_ticket_panel }}
               {{ element.mel.external_url }}
-              {{ element.mel.enable_donations }}
-              {{ element.mel.donation_amount }}
-              {{ element.mel.donation_options }}
-              {{ element.mel.donation_label }}
               {{ element.mel.ticket_summary }}
 
-              <div class="mel-ticket-sale-windows mel-es-subsection" aria-labelledby="mel-ticket-sale-windows-heading">
-                <header class="mel-section__header mel-section__header--compact">
-                  <h3 class="mel-section__title" id="mel-ticket-sale-windows-heading">{{ 'Sale windows'|t }}</h3>
-                  <p class="mel-section__hint">{{ 'Optional listing-wide limits. Use per-ticket windows on each card for finer control.'|t }}</p>
+              <div class="mel-builder-card__subsection" aria-labelledby="mel-rsvp-donations-heading">
+                <header class="mel-builder-card__header mel-builder-card__header--compact">
+                  <h4 class="mel-builder-card__title" id="mel-rsvp-donations-heading">{{ 'Optional donations at RSVP'|t }}</h4>
+                  <p class="mel-builder-card__hint">{{ 'Tip jars and suggested amounts alongside free RSVP.'|t }}</p>
                 </header>
-                <div class="mel-form-grid">
+                <div class="mel-builder-fields mel-builder-fields--stack">
+                  {{ element.mel.enable_donations }}
+                  {{ element.mel.donation_amount }}
+                  {{ element.mel.donation_options }}
+                  {{ element.mel.donation_label }}
+                </div>
+              </div>
+
+              <div class="mel-builder-card__subsection" aria-labelledby="mel-ticket-sale-windows-heading">
+                <header class="mel-builder-card__header mel-builder-card__header--compact">
+                  <h4 class="mel-builder-card__title" id="mel-ticket-sale-windows-heading">{{ 'Sale windows'|t }}</h4>
+                  <p class="mel-builder-card__hint">{{ 'Optional listing-wide limits. Use per-ticket windows on each card for finer control.'|t }}</p>
+                </header>
+                <div class="mel-builder-fields mel-builder-fields--2col">
                   {{ element.mel.field_sales_start }}
                   {{ element.mel.field_sales_end }}
                 </div>
               </div>
 
               </div>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
             </section>
 
             <div class="mel-step-actions">
               <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue →'|t }}</button>
             </div>
           </div>
         </section>
-        </div>{# /.mel-builder-card--tickets #}
 
-        {# —— 3. Attendee questions — always mounted; questionnaire UI in native <details> (collapsed default) —— #}
-        <div id="mel-card-attendee" class="mel-builder-card mel-builder-task-card mel-builder-card--attendee" data-mel-builder-card="attendee" data-mel-reveal-section="attendee">
-          <section id="mel-step-attendee" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="attendee" role="tabpanel" aria-labelledby="mel-task-attendee-heading">
-            <div class="mel-es-stack">
-              <header class="mel-task-card__banner" id="mel-task-attendee-heading">
-                <h2 class="mel-task-card__title">{{ 'What do you need from attendees?'|t }}</h2>
-                <p class="mel-task-card__lede">{{ 'Ask only what you need at checkout or RSVP — questions show clearly below as you add them.'|t }}</p>
+        {# —— 3. Stand out — listing + collapsed more options —— #}
+        <section id="mel-step-standout" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="standout" role="tabpanel" aria-labelledby="mel-task-standout-heading">
+          <div class="mel-builder-step-stack">
+            <header class="mel-task-card__banner" id="mel-task-standout-heading">
+              <h2 class="mel-task-card__title">{{ 'Stand out'|t }}</h2>
+              <p class="mel-task-card__lede">{{ 'Polish your listing so the right people notice.'|t }}</p>
+            </header>
+
+            <section id="mel-card-standout" class="mel-builder-card mel-builder-card--advanced" data-mel-builder-card="standout" data-mel-track-complete="standout" aria-labelledby="mel-advanced-card-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h3 class="mel-builder-card__title visually-hidden" id="mel-advanced-card-heading">{{ 'Listing details'|t }}</h3>
               </header>
-
-              <details id="mel-attendee-questions-details" class="mel-attendee-questions-details">
-                <summary class="mel-attendee-questions-details__summary">
-                  <span class="mel-attendee-questions-details__summary-text">{{ 'Checkout questions'|t }}</span>
-                  <span class="mel-attendee-questions-details__summary-hint">{{ 'Optional — expand to add dietary, accessibility, or custom fields.'|t }}</span>
-                </summary>
-
-                <div class="mel-attendee-questions-details__body">
-                  <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-attendee-questions-panel" aria-labelledby="mel-attendee-panel-heading">
-                    <header class="mel-section__header">
-                      <h3 class="mel-section__title visually-hidden" id="mel-attendee-panel-heading">{{ 'Attendee questions'|t }}</h3>
-                    </header>
-                    {{ element.mel.collect_attendee_questions }}
-                    {{ element.mel.attendee_questions_editor }}
-                  </section>
-                </div>
-              </details>
-
-              <div class="mel-step-actions">
-                <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-                <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue'|t }}</button>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
               </div>
-            </div>
-          </section>
-        </div>{# /.mel-builder-card--attendee #}
+              <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
 
-        {# —— 4. Stand out — description & advanced listing options progressively revealed after identity complete —— #}
-        <div class="mel-builder-card-group mel-builder-card-group--post-ticket mel-builder-card-group--standout">
-          <div id="mel-card-standout" class="mel-builder-card mel-builder-task-card mel-builder-card--standout" data-mel-builder-card="standout">
-          <section id="mel-step-standout" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="standout" role="tabpanel" aria-labelledby="mel-task-standout-heading">
-            <div class="mel-es-stack">
-              <header class="mel-task-card__banner" id="mel-task-standout-heading">
-                <h2 class="mel-task-card__title">{{ 'Make your event stand out'|t }}</h2>
-                <p class="mel-task-card__lede">{{ 'Strong copy, imagery, and categories improve discovery — finish these while the event is fresh in your mind.'|t }}</p>
-              </header>
-
-              <section class="mel-es-card mel-section mel-section--card mel-section--builder" aria-labelledby="mel-description-heading" data-mel-reveal-section="mel-description">
-                <header class="mel-section__header">
-                  <h3 class="mel-section__title" id="mel-description-heading">{{ 'Description'|t }}</h3>
-                  <p class="mel-section__hint">{{ 'This content appears on your public event page.'|t }}</p>
-                </header>
-
-                <div class="mel-section">
-                  <h4 class="mel-subsection__title">{{ 'About the event'|t }}</h4>
-                  {{ element.mel.body }}
-                  <div class="mel-ai-rewrite-actions">
-                    <button type="button" id="mel-ai-rewrite-about" class="mel-btn mel-btn--secondary">{{ 'Rewrite About'|t }}</button>
-                  </div>
-                </div>
-
-                <div class="mel-section">
-                  <h4 class="mel-subsection__title">{{ 'Highlights'|t }}</h4>
-                  {{ element.mel.event_highlights }}
-                </div>
-
-                <div class="mel-section">
-                  <h4 class="mel-subsection__title">{{ 'What to expect'|t }}</h4>
-                  {{ element.mel.field_event_intro }}
-                  <div class="mel-ai-rewrite-actions">
-                    <button type="button" id="mel-ai-rewrite-expect" class="mel-btn mel-btn--secondary">{{ 'Rewrite What to Expect'|t }}</button>
-                  </div>
-                </div>
-              </section>
-
-              <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--listing-extras" aria-labelledby="mel-listing-extras-heading">
-                <header class="mel-section__header">
-                  <h3 class="mel-section__title" id="mel-listing-extras-heading">{{ 'Cover image & categories'|t }}</h3>
-                  <p class="mel-section__hint">{{ 'Visuals and taxonomy help the right people discover your event.'|t }}</p>
-                </header>
-                {{ element.mel.summary }}
-                <div class="mel-form-group">
-                  {{ element.mel.field_category }}
-                </div>
-                <div class="mel-category-chips" id="mel-category-chips" aria-live="polite"></div>
-                <div class="mel-identity-media mel-identity-media--compact">
-                  <div class="mel-cover-preview" id="mel-cover-preview" data-mel-cover-preview>
-                    <img class="mel-cover-preview__img" id="mel-cover-preview-img" src="" alt="" width="1200" height="630" loading="lazy" hidden />
-                    <div class="mel-cover-preview__empty" id="mel-cover-preview-empty">
-                      <span class="mel-cover-preview__empty-icon" aria-hidden="true"></span>
-                      <span class="mel-cover-preview__empty-text">{{ 'No cover yet — events with images get better placement in discovery.'|t }}</span>
+                <details id="mel-progressive-description" class="mel-builder-progressive mel-builder-progressive--description-card" data-mel-reveal-section="mel-description" data-mel-progressive-slot="description">
+                  <summary class="mel-builder-progressive__summary">
+                    <span class="mel-builder-progressive__summary-text">
+                      <span class="mel-builder-progressive__title" id="mel-description-heading">{{ 'Description'|t }}</span>
+                      <span class="mel-builder-progressive__hint">{{ 'This content appears on your public event page.'|t }}</span>
+                    </span>
+                    <span class="mel-builder-progressive__chev" aria-hidden="true"></span>
+                  </summary>
+                  <div class="mel-builder-progressive__panel">
+                    <div class="mel-builder-card__subsection">
+                      <h5 class="mel-builder-card__subtitle">{{ 'About the event'|t }}</h5>
+                      {{ element.mel.body }}
+                      <div class="mel-ai-rewrite-actions">
+                        <button type="button" id="mel-ai-rewrite-about" class="mel-btn mel-btn--secondary">{{ 'Rewrite About'|t }}</button>
+                      </div>
+                    </div>
+                    <div class="mel-builder-card__subsection">
+                      <h5 class="mel-builder-card__subtitle">{{ 'Highlights'|t }}</h5>
+                      {{ element.mel.event_highlights }}
+                    </div>
+                    <div class="mel-builder-card__subsection">
+                      <h5 class="mel-builder-card__subtitle">{{ 'What to expect'|t }}</h5>
+                      {{ element.mel.field_event_intro }}
+                      <div class="mel-ai-rewrite-actions">
+                        <button type="button" id="mel-ai-rewrite-expect" class="mel-btn mel-btn--secondary">{{ 'Rewrite What to Expect'|t }}</button>
+                      </div>
                     </div>
                   </div>
-                  <div class="mel-identity-media__fields mel-form-grid">
-                    {{ element.mel.field_event_image }}
-                    {{ element.mel.field_event_image_alt }}
+                </details>
+
+                <div class="mel-builder-card__subsection" aria-labelledby="mel-listing-extras-heading">
+                  <header class="mel-builder-card__header mel-builder-card__header--compact">
+                    <h4 class="mel-builder-card__title" id="mel-listing-extras-heading">{{ 'Cover image & categories'|t }}</h4>
+                    <p class="mel-builder-card__hint">{{ 'Visuals and taxonomy help the right people discover your event.'|t }}</p>
+                  </header>
+                  {{ element.mel.summary }}
+                  <div class="mel-builder-fields mel-builder-fields--stack">
+                    {{ element.mel.field_category }}
+                  </div>
+                  <div class="mel-category-chips" id="mel-category-chips" aria-live="polite"></div>
+                  <div class="mel-identity-media mel-identity-media--compact">
+                    <div class="mel-cover-preview" id="mel-cover-preview" data-mel-cover-preview>
+                      <img class="mel-cover-preview__img" id="mel-cover-preview-img" src="" alt="" width="1200" height="630" loading="lazy" hidden />
+                      <div class="mel-cover-preview__empty" id="mel-cover-preview-empty">
+                        <span class="mel-cover-preview__empty-icon" aria-hidden="true"></span>
+                        <span class="mel-cover-preview__empty-text">{{ 'No cover yet — events with images get better placement in discovery.'|t }}</span>
+                      </div>
+                    </div>
+                    <div class="mel-identity-media__fields mel-builder-fields mel-builder-fields--2col">
+                      {{ element.mel.field_event_image }}
+                      {{ element.mel.field_event_image_alt }}
+                    </div>
                   </div>
                 </div>
-              </section>
 
-              {% if element.mel_mel_support is defined %}
-              <div class="mel-mel-contribution-packaging mel-mel-support-section-wrap">
-                <p class="mel-mel-contribution-kicker">{{ 'Optional — helps keep MyEventLane sustainable'|t }}</p>
-                <p class="mel-mel-contribution-headline">{{ 'Say thanks with a small platform contribution'|t }}</p>
-                {{ element.mel_mel_support }}
+                <div data-mel-reveal-section="mel-advanced">
+                  <details id="mel-builder-more-options" class="mel-builder-more-options mel-builder-progressive mel-builder-progressive--advanced-slot" data-mel-progressive-slot="advanced">
+                    <summary class="mel-builder-more-options__summary">{{ 'More options'|t }}</summary>
+                    <div class="mel-builder-more-options__body mel-builder-fields mel-builder-fields--stack">
+                      <div class="mel-builder-card__subsection" aria-labelledby="mel-more-tags-heading">
+                        <header class="mel-builder-card__header mel-builder-card__header--compact">
+                          <h4 class="mel-builder-card__title" id="mel-more-tags-heading">{{ 'Tags'|t }}</h4>
+                          <p class="mel-builder-card__hint">{{ 'Help people discover your event.'|t }}</p>
+                        </header>
+                        {{ element.mel.field_tags }}
+                      </div>
+                      <div class="mel-builder-card__subsection" aria-labelledby="mel-more-contact-heading">
+                        <header class="mel-builder-card__header mel-builder-card__header--compact">
+                          <h4 class="mel-builder-card__title" id="mel-more-contact-heading">{{ 'Organizer contact'|t }}</h4>
+                        </header>
+                        <div class="mel-builder-fields mel-builder-fields--2col">
+                          {{ element.mel.field_contact_email }}
+                          {{ element.mel.field_contact_phone }}
+                        </div>
+                      </div>
+                      <div class="mel-builder-card__subsection" aria-labelledby="mel-more-age-heading">
+                        <header class="mel-builder-card__header mel-builder-card__header--compact">
+                          <h4 class="mel-builder-card__title" id="mel-more-age-heading">{{ 'Age restriction'|t }}</h4>
+                        </header>
+                        <div class="mel-builder-fields mel-builder-fields--2col">
+                          {{ element.mel.field_age_policy }}
+                          {{ element.mel.field_age_policy_note }}
+                        </div>
+                        {{ element.mel.field_age_restriction }}
+                      </div>
+                      <div class="mel-builder-card__subsection" aria-labelledby="mel-more-refund-heading">
+                        <header class="mel-builder-card__header mel-builder-card__header--compact">
+                          <h4 class="mel-builder-card__title" id="mel-more-refund-heading">{{ 'Refund policy'|t }}</h4>
+                        </header>
+                        {{ element.mel.field_refund_policy }}
+                      </div>
+                      <div class="mel-builder-card__subsection" aria-labelledby="mel-more-a11y-heading">
+                        <header class="mel-builder-card__header mel-builder-card__header--compact">
+                          <h4 class="mel-builder-card__title" id="mel-more-a11y-heading">{{ 'Accessibility'|t }}</h4>
+                          <p class="mel-builder-card__hint">{{ 'Features and practical details for attendees with access needs.'|t }}</p>
+                        </header>
+                        {{ element.mel.field_accessibility }}
+                        {{ element.mel.field_accessibility_contact }}
+                        {{ element.mel.field_accessibility_directions }}
+                        {{ element.mel.field_accessibility_entry }}
+                        {{ element.mel.field_accessibility_parking }}
+                      </div>
+                    </div>
+                  </details>
+                </div>
+
               </div>
-              {% endif %}
-
-              <details class="mel-advanced mel-more-organizer" data-mel-reveal-section="mel-advanced">
-                <summary>{{ 'Additional listing and organiser options — tags, policies, accessibility, contact'|t }}</summary>
-                <p class="mel-section__hint mel-more-organizer__hint">{{ 'Fine-tune discovery tags, audience policies, and how attendees can reach you.'|t }}</p>
-
-                <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--discovery" aria-labelledby="mel-discovery-heading">
-                  <header class="mel-section__header">
-                    <h3 class="mel-section__title" id="mel-discovery-heading">{{ 'Discovery'|t }}</h3>
-                    <p class="mel-section__hint">{{ 'Tags help people find your event.'|t }}</p>
-                  </header>
-                  {{ element.mel.field_tags }}
-                </section>
-
-                <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--contact" aria-labelledby="mel-contact-heading">
-                  <header class="mel-section__header">
-                    <h3 class="mel-section__title" id="mel-contact-heading">{{ 'Organizer contact'|t }}</h3>
-                  </header>
-                  <div class="mel-form-grid">
-                    {{ element.mel.field_contact_email }}
-                    {{ element.mel.field_contact_phone }}
-                  </div>
-                </section>
-
-                <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--policies" aria-labelledby="mel-policies-heading">
-                  <header class="mel-section__header">
-                    <h3 class="mel-section__title" id="mel-policies-heading">{{ 'Policies & audience'|t }}</h3>
-                  </header>
-                  <div class="mel-form-grid">
-                    {{ element.mel.field_age_policy }}
-                    {{ element.mel.field_age_policy_note }}
-                  </div>
-                  {{ element.mel.field_age_restriction }}
-                  {{ element.mel.field_refund_policy }}
-                </section>
-
-                <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--accessibility" aria-labelledby="mel-a11y-heading">
-                  <header class="mel-section__header">
-                    <h3 class="mel-section__title" id="mel-a11y-heading">{{ 'Accessibility'|t }}</h3>
-                    <p class="mel-section__hint">{{ 'Features and practical details for attendees with access needs.'|t }}</p>
-                  </header>
-                  {{ element.mel.field_accessibility }}
-                  {{ element.mel.field_accessibility_contact }}
-                  {{ element.mel.field_accessibility_directions }}
-                  {{ element.mel.field_accessibility_entry }}
-                  {{ element.mel.field_accessibility_parking }}
-                </section>
-              </details>
-
-              <div class="mel-step-actions">
-                <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-                <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue'|t }}</button>
-              </div>
-            </div>
-          </section>
-          </div>{# /.mel-builder-card--standout #}
-
-        </div>{# /.mel-builder-card-group--standout #}
-
-        <section id="mel-step-preview" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="preview" role="tabpanel">
-          <div class="mel-es-stack">
-            <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--preview" aria-labelledby="mel-preview-section-heading">
-              <header class="mel-section__header">
-                <h2 class="mel-section__title" id="mel-preview-section-heading">{{ 'Preview'|t }}</h2>
-                <p class="mel-section__hint">{{ 'Your live card at the top updates as you work through each task.'|t }}</p>
-              </header>
-              <p class="mel-preview-section__text">{{ 'Jump up anytime to check title, schedule, location, and ticket mode.'|t }}</p>
-              <button type="button" class="mel-btn mel-btn--secondary" id="mel-jump-to-preview-card">{{ 'Show live preview'|t }}</button>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
             </section>
 
             <div class="mel-step-actions">
               <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue →'|t }}</button>
             </div>
           </div>
         </section>
 
-        <section id="mel-step-publish" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="publish" role="tabpanel">
-          <div class="mel-es-stack">
-            <section class="mel-es-card mel-section mel-section--card mel-section--builder mel-section--publish" aria-labelledby="mel-publish-heading">
-              <header class="mel-section__header">
-                <h2 class="mel-section__title" id="mel-publish-heading">{{ 'Publish'|t }}</h2>
-                <p class="mel-section__hint">{{ 'When you are ready, go live from the card below. You can return here anytime.'|t }}</p>
+        {# —— 4. Attendee questions —— #}
+        <section id="mel-step-attendee" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="attendee" role="tabpanel" aria-labelledby="mel-task-attendee-heading">
+          <div class="mel-builder-step-stack">
+            <header class="mel-task-card__banner" id="mel-task-attendee-heading">
+              <h2 class="mel-task-card__title">{{ 'Attendee questions'|t }}</h2>
+              <p class="mel-task-card__lede">{{ 'Optional — add only what you truly need at checkout.'|t }}</p>
+            </header>
+
+            <section id="mel-card-attendee" class="mel-builder-card mel-builder-card--attendees" data-mel-builder-card="attendee" data-mel-reveal-section="attendee" data-mel-track-complete="attendee" aria-labelledby="mel-attendee-panel-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body mel-builder-card__body--attendee-progressive">
+                <details id="mel-progressive-attendee" class="mel-builder-progressive mel-builder-progressive--attendee-card" data-mel-progressive-slot="attendee">
+                  <summary class="mel-builder-progressive__summary">
+                    <span class="mel-builder-progressive__summary-text">
+                      <span class="mel-builder-progressive__title" id="mel-attendee-panel-heading">{{ 'What do you need from attendees?'|t }}</span>
+                      <span class="mel-builder-progressive__hint">{{ 'Collect useful info like dietary needs or contact details.'|t }}</span>
+                    </span>
+                    <span class="mel-builder-progressive__chev" aria-hidden="true"></span>
+                  </summary>
+                  <div class="mel-builder-progressive__panel mel-builder-fields mel-builder-fields--stack">
+                    {{ element.mel.collect_attendee_questions }}
+                    {{ element.mel.attendee_questions_editor }}
+                  </div>
+                </details>
+              </div>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
+            </section>
+
+            <div class="mel-step-actions">
+              <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue →'|t }}</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="mel-step-preview" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="preview" role="tabpanel" aria-labelledby="mel-preview-section-heading">
+          <div class="mel-builder-step-stack">
+            <section class="mel-builder-card" aria-labelledby="mel-preview-section-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h2 class="mel-builder-card__title" id="mel-preview-section-heading">{{ 'Preview'|t }}</h2>
+                <p class="mel-builder-card__hint">{{ 'Your live card below the builder updates as you work through each task.'|t }}</p>
               </header>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body">
+                <p class="mel-preview-section__text">{{ 'Scroll down anytime to check title, schedule, location, and ticket mode.'|t }}</p>
+                <button type="button" class="mel-btn mel-btn--secondary" id="mel-jump-to-preview-card">{{ 'Show live preview'|t }}</button>
+              </div>
+            </section>
+
+            <div class="mel-step-actions">
+              <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
+              <button type="button" class="mel-btn mel-continue-button mel-next">{{ 'Continue →'|t }}</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="mel-step-publish" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="publish" role="tabpanel" aria-labelledby="mel-publish-heading">
+          <div class="mel-builder-step-stack">
+            {% if element.mel_mel_support is defined %}
+            <section id="mel-card-support" class="mel-builder-card mel-builder-card--mel-support mel-builder-card--secondary" aria-labelledby="mel-mel-support-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h3 class="mel-builder-card__title" id="mel-mel-support-heading">{{ 'Support MyEventLane 💖 (optional)'|t }}</h3>
+                <p class="mel-builder-card__hint">{{ 'Keep events like yours free and accessible'|t }}</p>
+              </header>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
+                {{ element.mel_mel_support }}
+              </div>
+            </section>
+            {% endif %}
+
+            <section id="mel-card-publish" class="mel-card-publish mel-builder-card mel-builder-card--publish" data-mel-track-complete="pre-publish" aria-labelledby="mel-publish-heading">
+              <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
+              <header class="mel-builder-card__header">
+                <h2 class="mel-builder-card__title" id="mel-publish-heading">{{ 'Ready to go live?'|t }}</h2>
+                <p class="mel-builder-card__hint">{{ 'Your event is ready — publish now and start getting attendees.'|t }}</p>
+              </header>
+              <div class="mel-builder-card__summary" hidden>
+                <div class="mel-builder-card__summary-content"></div>
+                <button type="button" class="mel-builder-card__edit-btn">{{ 'Edit'|t }}</button>
+              </div>
+              <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
               {% if mel_publish_blocked %}
                 {% if mel_publish_stripe_gate %}
                   <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Connect payments to publish'|t }}">
@@ -516,10 +546,14 @@
               <div class="mel-publish-action-card" role="region" aria-labelledby="mel-publish-action-title" data-mel-publish-card="1">
                 <div class="mel-publish-action-card__panel mel-publish-action-card__draft" data-mel-publish-panel="draft"{% if mel_event_is_published %} hidden{% endif %}>
                   <h3 id="mel-publish-action-title" class="mel-publish-action-card__title">{{ 'Publish event'|t }}</h3>
-                  <p class="mel-publish-action-card__desc">{{ 'Make your event live and visible'|t }}</p>
-                  {% if not mel_publish_blocked %}
-                    <button type="button" class="mel-btn mel-btn--primary" id="mel-publish-now">{{ 'Publish now'|t }}</button>
-                  {% endif %}
+                  <p class="mel-publish-action-card__desc">{{ 'Your event is ready — publish now and start getting attendees.'|t }}</p>
+                  <p class="mel-card-publish__ready-celebrate" data-mel-publish-ready-celebrate hidden>{{ "You're ready to go live 🎉"|t }}</p>
+                  <div class="mel-builder-publish-actions">
+                    {% if not mel_publish_blocked %}
+                      <button type="button" class="mel-btn mel-btn--primary" id="mel-publish-now">{{ 'Publish event'|t }}</button>
+                    {% endif %}
+                    <button type="button" class="mel-btn mel-btn--ghost" id="mel-save-draft-studio">{{ 'Save draft'|t }}</button>
+                  </div>
                 </div>
                 <div class="mel-publish-action-card__panel mel-publish-action-card__live" data-mel-publish-panel="live"{% if not mel_event_is_published %} hidden{% endif %}>
                   <h3 class="mel-publish-action-card__title">{{ 'Your event is live'|t }}</h3>
@@ -528,11 +562,15 @@
                 </div>
                 {{ element.mel.status }}
               </div>
+              </div>
+              <footer class="mel-builder-card__footer">
+                <p class="mel-builder-card__complete mel-builder-card__momentum" data-mel-builder-complete-msg hidden aria-live="polite"></p>
+              </footer>
             </section>
 
             <div class="mel-step-actions">
               <button type="button" class="mel-btn mel-prev">{{ 'Back'|t }}</button>
-              <button type="button" class="mel-btn mel-next" hidden aria-hidden="true">{{ 'Continue'|t }}</button>
+              <button type="button" class="mel-btn mel-next" hidden aria-hidden="true">{{ 'Continue →'|t }}</button>
             </div>
           </div>
         </section>
@@ -595,11 +633,82 @@
             <div id="mel-publish-readiness" class="mel-publish-readiness-body"></div>
           </div>
 
+          <div class="mel-builder-sidebar__save">
+            <button type="button" class="mel-btn mel-btn--primary mel-builder-save-sidebar" id="mel-builder-save-sidebar" aria-label="{{ 'Save event'|t }}">
+              {{ 'Save'|t }}
+            </button>
+          </div>
+
           <p class="mel-aside-footnote" id="mel-studio-form-state" role="status"></p>
         </div>
       </aside>
 
       </div>{# /.mel-builder #}
+
+      {# Live preview — below builder grid (drawer behaviour unchanged on small viewports) #}
+      <div class="mel-studio-top mel-studio-top--solo mel-studio-preview-panel--bottom" id="mel-studio-preview-panel">
+        <div class="mel-studio-top__preview mel-studio-top__preview--wide">
+          <div class="mel-event-studio__top">
+            <aside
+              class="mel-preview"
+              id="mel-live-preview"
+              data-mel-live-preview="1"
+              aria-label="{{ 'Live preview'|t }}"
+            >
+              <button
+                type="button"
+                class="mel-preview__drawer-toggle"
+                id="mel-preview-drawer-toggle"
+                aria-expanded="false"
+                aria-controls="mel-preview-drawer-panel"
+              >
+                <span class="mel-preview__drawer-toggle-label">{{ 'Preview'|t }}</span>
+                <span class="mel-preview__drawer-hint" aria-hidden="true">{{ 'Tap to expand'|t }}</span>
+              </button>
+              <div class="mel-preview__panel" id="mel-preview-drawer-panel">
+                <div class="mel-event-studio__preview">
+                  <div id="mel-preview-card" data-mel-studio-preview-anchor="1">
+                    <article class="mel-preview-card">
+                      <div class="mel-preview-card__media" id="mel-preview-card-media">
+                        <img class="mel-preview-card__img" id="mel-preview-card-img" src="" alt="" width="640" height="336" loading="lazy" hidden />
+                        <div class="mel-preview-card__media-placeholder" id="mel-preview-card-placeholder">
+                          <span aria-hidden="true"></span>
+                        </div>
+                      </div>
+                      <div class="mel-preview-card__body">
+                        <h3 class="mel-preview-card__title" id="mel-preview-title">—</h3>
+                        <p class="mel-preview-card__meta">
+                          <time class="mel-preview-card__time" id="mel-preview-schedule" datetime="">—</time>
+                        </p>
+                        <p class="mel-preview-card__location" id="mel-preview-location">—</p>
+                        <p class="mel-preview-card__badge" id="mel-preview-booking-mode">—</p>
+                        <p class="mel-preview-card__pricing" id="mel-preview-pricing">—</p>
+                        <p class="mel-preview-card__status" id="mel-preview-status">—</p>
+                        <div class="mel-preview-card__cta">
+                          <a href="#" class="mel-btn mel-btn--primary mel-preview__cta" id="mel-preview-cta">{{ 'RSVP free'|t }}</a>
+                        </div>
+                      </div>
+                    </article>
+                  </div>
+                  <div class="mel-preview-hints" id="mel-preview-hints" aria-live="polite"></div>
+                </div>
+
+                <div class="mel-event-actions">
+                  {% if mel_event_actions.view %}
+                    <a href="{{ mel_event_actions.view }}" class="mel-btn mel-btn--ghost" target="_blank" rel="noopener noreferrer">{{ 'View page'|t }}</a>
+                  {% endif %}
+                  {% if mel_event_actions.booking %}
+                    <a href="{{ mel_event_actions.booking }}" class="mel-btn mel-btn--secondary" target="_blank" rel="noopener noreferrer">{{ 'Booking page'|t }}</a>
+                  {% endif %}
+                  {% if mel_event_actions.scan %}
+                    <a href="{{ mel_event_actions.scan }}" class="mel-btn mel-btn--accent">{{ 'Scan tickets'|t }}</a>
+                  {% endif %}
+                </div>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </div>
 
       {{ element.nid }}
 

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_highlight_icon.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_highlight_icon.yml
@@ -10,13 +10,16 @@ entity_type: paragraph
 type: list_string
 settings:
   allowed_values:
-    - { value: star, label: star }
-    - { value: music, label: music }
-    - { value: food, label: food }
-    - { value: community, label: community }
-    - { value: workshop, label: workshop }
-    - { value: accessibility, label: accessibility }
-    - { value: warning, label: warning }
+    - { value: music, label: '🎵 Music' }
+    - { value: food, label: '🍔 Food & drinks' }
+    - { value: party, label: '🪩 Party / DJ' }
+    - { value: network, label: '🤝 Networking' }
+    - { value: art, label: '🎨 Arts' }
+    - { value: outdoor, label: '🌿 Outdoor' }
+    - { value: family, label: '👨‍👩‍👧 Family friendly' }
+    - { value: lgbtq, label: '🏳️‍🌈 LGBTQ+' }
+    - { value: wellness, label: '🧘 Wellness' }
+    - { value: education, label: '📚 Workshop / learning' }
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/modules/custom/myeventlane_vendor/js/ticket-cards.js
+++ b/web/modules/custom/myeventlane_vendor/js/ticket-cards.js
@@ -105,6 +105,27 @@
   }
 
   /**
+   * Marks the first ticket card in list DOM order (Event Studio hero tier).
+   *
+   * @param {HTMLElement|null} list
+   */
+  function syncPrimaryTicketClassInList(list) {
+    if (!list || !list.children) {
+      return;
+    }
+    const cards = [];
+    for (let i = 0; i < list.children.length; i++) {
+      const el = list.children[i];
+      if (el.classList && el.classList.contains('js-mel-ticket-card')) {
+        cards.push(el);
+      }
+    }
+    cards.forEach((card, i) => {
+      card.classList.toggle('mel-ticket--primary', i === 0);
+    });
+  }
+
+  /**
    * @param {HTMLElement} list
    */
   function clearDropTargets(list) {
@@ -316,6 +337,89 @@
     return valid;
   }
 
+  /** @param {HTMLElement} card */
+  function silentTicketOutcomeValid(card) {
+    let valid = true;
+    editableFields(card).forEach((field) => {
+      if (
+        field.matches('[required], [aria-required="true"], .js-mel-ticket-title') &&
+        String(field.value || '').trim() === ''
+      ) {
+        valid = false;
+      }
+    });
+    const kindField = card.querySelector('select[name$="[ticket_kind]"]');
+    const ticketKind = kindField ? kindField.value : card.getAttribute('data-mel-ticket-kind');
+    if (ticketKind === 'paid') {
+      const priceField = card.querySelector(
+        'input.js-mel-ticket-price, input[name$="[price_amount]"], input[name$="[price_number]"], input[name$="[price]"]',
+      );
+      const price = priceField ? parseFloat(String(priceField.value || '')) : 0;
+      if (!priceField || Number.isNaN(price) || price <= 0) {
+        valid = false;
+      }
+    }
+    if (ticketKind === 'external') {
+      const ext = card.querySelector('input[name$="[external_uri]"], input[type="url"][name*="external_uri"]');
+      if (!ext && card.getAttribute('data-ticket-id')) {
+        // Persisted tiers may omit URI from this inline subtree.
+      }
+      else if (ext) {
+        const uri = String(ext.value || '').trim().toLowerCase();
+        if (uri.indexOf('https://') !== 0) {
+          valid = false;
+        }
+      }
+      else {
+        valid = false;
+      }
+    }
+    return valid;
+  }
+
+  /** Updates outcome header (PHP-rendered preview) while editing — Event Studio UX. */
+  function syncOutcomeDisplay(card) {
+    const displayRoot = card.querySelector('[data-mel-ticket-outcome-display="1"], [data-mel-ticket-outcome-display]');
+    if (!displayRoot) {
+      return;
+    }
+    const titleSlot = displayRoot.querySelector('.mel-ticket-card__display-title');
+    const priceSlot = displayRoot.querySelector('[data-mel-ticket-display-price]');
+    const kindField = card.querySelector('select[name$="[ticket_kind]"]');
+    let ticketKind = kindField ? kindField.value : card.getAttribute('data-mel-ticket-kind');
+
+    const titleEl = card.querySelector('.js-mel-ticket-title');
+    const titleTxt = titleEl ? String(titleEl.value || '').trim() : '';
+    if (titleSlot) {
+      titleSlot.textContent = titleTxt || Drupal.t('New ticket');
+    }
+
+    let priceTxt = Drupal.t('—');
+    if (ticketKind === 'paid') {
+      const priceField = card.querySelector(
+        'input.js-mel-ticket-price, input[name$="[price_amount]"], input[name$="[price_number]"], input[name$="[price]"]',
+      );
+      const currField = card.querySelector('input[name$="[price_currency]"], input[name$="price_currency"]');
+      const amt = priceField ? String(priceField.value || '').trim() : '';
+      const code = currField ? String(currField.value || '').trim().toUpperCase().slice(0, 3) : '';
+      if (amt !== '' && !Number.isNaN(parseFloat(amt)) && parseFloat(amt) > 0) {
+        priceTxt = `${code ? code + ' ' : ''}${amt}`;
+      }
+    }
+    else if (ticketKind === 'rsvp') {
+      priceTxt = Drupal.t('$0');
+    }
+    else if (ticketKind === 'external') {
+      priceTxt = Drupal.t('External');
+    }
+
+    if (priceSlot) {
+      priceSlot.textContent = priceTxt;
+    }
+
+    card.classList.toggle('mel-ticket--complete', silentTicketOutcomeValid(card));
+  }
+
   function updateEditState(card) {
     const validation = card.querySelector('[data-mel-ticket-validation]');
     const initial = card.getAttribute('data-mel-ticket-initial') || '';
@@ -334,6 +438,7 @@
     if (card.getAttribute('data-mel-ticket-state-value') !== 'saving') {
       setCardState(card, fieldSignature(card) === initial ? '' : 'dirty');
     }
+    syncOutcomeDisplay(card);
   }
 
   function initInlineEditCard(card) {
@@ -691,6 +796,7 @@
         list.insertBefore(active, after);
       }
       persistOrder(list);
+      syncPrimaryTicketClassInList(list);
     });
 
     wrapper.querySelectorAll('.js-mel-ticket-drag-handle').forEach((handle) => {
@@ -713,6 +819,7 @@
           const list = wrapper.querySelector('.js-mel-ticket-sortable');
           if (list) {
             initSortable(list, wrapper);
+            syncPrimaryTicketClassInList(list);
           }
         },
     );
@@ -720,8 +827,42 @@
     once('mel-ticket-card-delegated', elementsFromContext('#mel-ticket-builder-ajax-wrapper', context)).forEach(
         (wrapper) => {
           wrapper.addEventListener('click', (e) => handleDelegatedClick(e, wrapper), true);
+          wrapper.addEventListener(
+            'input',
+            (e) => {
+              const t = e.target && e.target.nodeType === Node.ELEMENT_NODE ? e.target : null;
+              if (!t || !wrapper.contains(t)) {
+                return;
+              }
+              const card = t.closest('.js-mel-ticket-card.mel-ticket-card--new, .mel-ticket-card--new');
+              if (card && wrapper.contains(card)) {
+                syncOutcomeDisplay(card);
+              }
+            },
+            true,
+          );
+          wrapper.addEventListener(
+            'change',
+            (e) => {
+              const t = e.target && e.target.nodeType === Node.ELEMENT_NODE ? e.target : null;
+              if (!t || !wrapper.contains(t)) {
+                return;
+              }
+              const card = t.closest('.js-mel-ticket-card.mel-ticket-card--new');
+              if (card && wrapper.contains(card)) {
+                syncOutcomeDisplay(card);
+              const kindEl = card.querySelector('select[name$="[ticket_kind]"]');
+              const kv = kindEl ? kindEl.value : '';
+              if (kv) {
+                card.setAttribute('data-mel-ticket-kind', kv);
+              }
+              }
+            },
+            true,
+          );
           consumePendingSaves(wrapper);
           focusNewPresetCard(wrapper);
+          wrapper.querySelectorAll('.mel-ticket-card--new').forEach((c) => syncOutcomeDisplay(c));
         },
     );
 
@@ -736,6 +877,7 @@
     once('mel-ticket-inline-edit', elementsFromContext('.js-mel-ticket-card[data-ticket-id]', context)).forEach(
         (card) => {
           initInlineEditCard(card);
+          syncOutcomeDisplay(card);
           const shouldEdit = card.classList.contains('is-editing') || shouldRestoreEdit(card);
           setEditMode(card, shouldEdit, shouldEdit);
         },

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -299,7 +299,7 @@ final class EventTicketsBuilder {
     $form['builder_shell']['controls']['open_presets'] = [
       '#type' => 'html_tag',
       '#tag' => 'button',
-      '#value' => $this->t('Add ticket'),
+      '#value' => $this->t('Add another ticket type'),
       '#attributes' => [
         'type' => 'button',
         'class' => ['mel-btn', 'mel-btn--primary', 'mel-ticket-controls__add'],
@@ -347,22 +347,6 @@ final class EventTicketsBuilder {
       '#access' => FALSE,
     ];
 
-    $form['builder_shell']['controls']['save_sync'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save & sync'),
-      '#name' => 'ticket_save_sync',
-      '#submit' => ['::handleAction'],
-      '#ajax' => [
-        'callback' => '::ajaxRebuildTicketBuilder',
-        'wrapper' => EventTicketsBuilder::BUILDER_WRAPPER_ID,
-      ],
-      '#limit_validation_errors' => [],
-      '#attributes' => [
-        'class' => ['mel-btn', 'mel-btn--secondary'],
-        'formnovalidate' => 'formnovalidate',
-      ],
-    ];
-
     $form['builder_shell']['order'] = [
       '#type' => 'hidden',
       '#default_value' => Json::encode($ordered_ids),
@@ -399,7 +383,15 @@ final class EventTicketsBuilder {
 
     if ($adding_new) {
       $form['builder_shell']['list']['new'] = $this->buildNewTicketCard($event, $form_state);
+      // Hero styling: first row when this is the only ticket surface (preset flow).
+      if ($tickets === []) {
+        $form['builder_shell']['list']['new']['#attributes']['class'][] = 'mel-ticket--primary';
+      }
     }
+
+    // First saved ticket is "primary" when it leads the list (or follows the inline
+    // "new" card — match client-side reorder highlighting in ticket-cards.js).
+    $assign_primary_saved = !$adding_new || $tickets !== [];
 
     foreach ($tickets as $ticket) {
       $tid = (int) $ticket->id();
@@ -415,6 +407,13 @@ final class EventTicketsBuilder {
         'js-mel-ticket-card',
         $is_editing ? 'is-editing' : 'is-view',
       ];
+      if (!$read_only_card && $this->ticketCardIsOutcomeComplete($ticket)) {
+        $card_classes[] = 'mel-ticket--complete';
+      }
+      if ($assign_primary_saved) {
+        $card_classes[] = 'mel-ticket--primary';
+        $assign_primary_saved = FALSE;
+      }
       if ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()) {
         $card_classes[] = 'mel-ticket-card--recommended';
       }
@@ -825,6 +824,10 @@ final class EventTicketsBuilder {
 
     $ticket_kind_input = ':input[name="' . $this->formElementFullName($form_state, 'builder_shell', 'list', 'new', 'fields', 'ticket_kind') . '"]';
 
+    $preview_title = trim((string) $title_default);
+    $display_heading = $preview_title !== '' ? $preview_title : (string) $this->t('New ticket');
+    $price_caption_default = $this->newTicketOutcomePriceCaption((string) $kind_default, (string) $price_default, (string) $currency);
+
     return [
       '#type' => 'container',
       '#attributes' => [
@@ -832,28 +835,15 @@ final class EventTicketsBuilder {
         'data-mel-ticket-kind' => $kind_default,
         'data-mel-ticket-selected-preset' => $preset_key,
       ],
-      'header' => [
-        '#type' => 'html_tag',
-        '#tag' => 'h4',
-        '#value' => $this->t('New ticket'),
-        '#attributes' => ['class' => ['mel-ticket-card__title', 'mel-ticket-card__title--form']],
+      'display_preview' => [
+        '#markup' => '<div class="mel-ticket-card__display mel-ticket-card__display--new" data-mel-ticket-outcome-display="1">'
+          . '<h4 class="mel-ticket-card__display-title" data-mel-ticket-display-title>' . Html::escape($display_heading) . '</h4>'
+          . '<span class="mel-ticket-card__price" data-mel-ticket-display-price>' . Html::escape($price_caption_default) . '</span>'
+          . '</div>',
       ],
       'fields' => [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-ticket-card__fields']],
-        'title' => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Title'),
-          '#default_value' => $title_default,
-        ],
-        'short_description' => [
-          '#type' => 'textarea',
-          '#title' => $this->t('Short description (buyers)'),
-          '#description' => $this->t('Optional. About two lines — shown on the public ticket picker.'),
-          '#rows' => 2,
-          '#maxlength' => self::SHORT_DESCRIPTION_MAX_LENGTH,
-          '#default_value' => (string) ($form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields', 'short_description')) ?? ''),
-        ],
+        '#attributes' => ['class' => ['mel-ticket-card__fields', 'mel-ticket-card__edit-layer']],
         'ticket_kind' => [
           '#type' => 'select',
           '#title' => $this->t('Type'),
@@ -864,18 +854,32 @@ final class EventTicketsBuilder {
           ],
           '#default_value' => $kind_default,
         ],
-        'price_amount' => [
-          '#type' => 'number',
-          '#title' => $this->t('Price'),
-          '#step' => 0.01,
-          '#min' => 0,
-          '#default_value' => $price_default,
-          '#attributes' => [
-            'data-mel-ticket-preset-focus' => 'price',
+        'row_title_price' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-ticket-card__fields-inline-2']],
+          'title' => [
+            '#type' => 'textfield',
+            '#title' => $this->t('Title'),
+            '#default_value' => $title_default,
+            '#attributes' => [
+              'class' => ['js-mel-ticket-title'],
+              'data-mel-ticket-required-message' => (string) $this->t('Title is required.'),
+            ],
           ],
-          '#states' => [
-            'visible' => [
-              $ticket_kind_input => ['value' => 'paid'],
+          'price_amount' => [
+            '#type' => 'number',
+            '#title' => $this->t('Price'),
+            '#step' => 0.01,
+            '#min' => 0,
+            '#default_value' => $price_default,
+            '#attributes' => [
+              'data-mel-ticket-preset-focus' => 'price',
+              'class' => ['js-mel-ticket-price'],
+            ],
+            '#states' => [
+              'visible' => [
+                $ticket_kind_input => ['value' => 'paid'],
+              ],
             ],
           ],
         ],
@@ -890,6 +894,14 @@ final class EventTicketsBuilder {
               $ticket_kind_input => ['value' => 'paid'],
             ],
           ],
+        ],
+        'short_description' => [
+          '#type' => 'textarea',
+          '#title' => $this->t('Short description (buyers)'),
+          '#description' => $this->t('Optional. About two lines — shown on the public ticket picker.'),
+          '#rows' => 2,
+          '#maxlength' => self::SHORT_DESCRIPTION_MAX_LENGTH,
+          '#default_value' => (string) ($form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', 'new', 'fields', 'short_description')) ?? ''),
         ],
         'capacity' => [
           '#type' => 'number',
@@ -1016,7 +1028,7 @@ final class EventTicketsBuilder {
     $ticket_status = $this->ticketStatus->getStatus($ticket);
     $status_label = $this->ticketCardStatusLabel($ticket_status);
     $status_class = $this->ticketCardStatusClassSuffix($ticket_status);
-    $meta_line = $this->buildCardPriceCapacityLine($ticket);
+    $capacity_line = $this->formatCapacityText($ticket);
     $visibility_label = $this->ticketVisibilityLabel($ticket);
 
     $card['view'] = [
@@ -1028,27 +1040,24 @@ final class EventTicketsBuilder {
     ];
     $view = &$card['view'];
 
-    $view['header'] = [
-      '#type' => 'container',
-      '#attributes' => ['class' => ['mel-ticket-card__header']],
-      'title_group' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-ticket-card__title-group']],
-        'title' => [
-          '#markup' => '<div class="mel-ticket-card__title">' . Html::escape($ticket->label()) . '</div>',
-        ],
-      ],
-      'status' => [
-        '#markup' => '<span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
-          . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
-            ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
-            : '')
-          . '<span class="mel-badge mel-badge--' . Html::escape($status_class) . '">' . Html::escape($status_label) . '</span>',
-      ],
+    $badge_cluster = '<span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
+      . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
+        ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
+        : '')
+      . '<span class="mel-badge mel-badge--' . Html::escape($status_class) . '">' . Html::escape($status_label) . '</span>';
+
+    $view['hero'] = [
+      '#markup' => '<div class="mel-ticket-card__header mel-ticket-card__header--outcome">'
+        . '<div class="mel-ticket-card__display">'
+        . '<h4 class="mel-ticket-card__display-title">' . Html::escape($ticket->label()) . '</h4>'
+        . '<span class="mel-ticket-card__price">' . Html::escape($this->formatPriceText($ticket)) . '</span>'
+        . '</div>'
+        . '<div class="mel-ticket-card__header-actions">' . $badge_cluster . '</div>'
+        . '</div>',
     ];
 
     $view['meta'] = [
-      '#markup' => '<div class="' . Html::escape('mel-ticket-card__meta-line') . '">' . Html::escape($meta_line) . '</div>',
+      '#markup' => '<div class="' . Html::escape('mel-ticket-card__meta-line') . '">' . Html::escape($capacity_line) . '</div>',
     ];
 
     $view['visibility'] = [
@@ -1137,22 +1146,38 @@ final class EventTicketsBuilder {
       ],
     ];
 
-    $card['edit']['status'] = [
-      '#markup' => '<div class="mel-ticket-card__header"><div class="mel-ticket-card__title-group"><div class="mel-ticket-card__title">' . Html::escape($ticket->label()) . '</div><div class="mel-ticket-card__description">' . Html::escape(ucfirst($ticket->getTicketKind())) . '</div></div><div class="mel-ticket-card__header-actions"><span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
-        . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
-          ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
-          : '')
-        . '<span class="mel-badge mel-badge--' . Html::escape($edit_badge_class) . '">' . Html::escape($edit_status_label) . '</span></div></div>',
-      '#weight' => -20,
+    $badge_edit = '<span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
+      . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
+        ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
+        : '')
+      . '<span class="mel-badge mel-badge--' . Html::escape($edit_badge_class) . '">' . Html::escape($edit_status_label) . '</span>';
+
+    $card['edit']['outcome_heading'] = [
+      '#markup' => '<div class="mel-ticket-card__header mel-ticket-card__header--outcome mel-ticket-card__header--editable">'
+        . '<div class="mel-ticket-card__display" data-mel-ticket-outcome-display="1">'
+        . '<h4 class="mel-ticket-card__display-title">' . Html::escape($ticket->label()) . '</h4>'
+        . '<span class="mel-ticket-card__price" data-mel-ticket-display-price>' . Html::escape($this->formatPriceText($ticket)) . '</span>'
+        . '</div>'
+        . '<p class="mel-ticket-card__kind-hint">' . Html::escape(ucfirst($ticket->getTicketKind())) . '</p>'
+        . '<div class="mel-ticket-card__header-actions">' . $badge_edit . '</div>'
+        . '</div>',
+      '#weight' => -30,
     ];
 
     $card['edit']['primary'] = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-ticket-card__fields', 'mel-ticket-card__fields--primary']],
+      '#attributes' => [
+        'class' => ['mel-ticket-card__fields', 'mel-ticket-card__fields--primary', 'mel-ticket-card__edit-layer'],
+      ],
       '#weight' => -10,
     ];
 
-    $card['edit']['primary']['title'] = [
+    $card['edit']['primary']['pair'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-ticket-card__fields-inline-2']],
+    ];
+
+    $card['edit']['primary']['pair']['title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Title'),
       '#default_value' => (string) ($form_state->getValue(array_merge($edit_path, ['title'])) ?? $ticket->label()),
@@ -1167,7 +1192,7 @@ final class EventTicketsBuilder {
     if ($ticket->getTicketKind() === 'paid') {
       $price = $ticket->toPriceValue();
 
-      $card['edit']['primary']['price'] = [
+      $card['edit']['primary']['pair']['price'] = [
         '#type' => 'number',
         '#title' => $this->t('Price'),
         '#default_value' => $price ? $price->getNumber() : 0,
@@ -1175,6 +1200,9 @@ final class EventTicketsBuilder {
         '#min' => 0.01,
         '#required' => TRUE,
         '#parents' => array_merge($edit_path, ['price']),
+        '#attributes' => [
+          'class' => ['js-mel-ticket-price'],
+        ],
       ];
     }
 
@@ -1532,7 +1560,7 @@ final class EventTicketsBuilder {
   /**
    * Syncs Commerce for paid tiers; if a new-tier form is open with a title, saves it first.
    *
-   * Vendors often click "Save & sync" instead of "Create ticket"; without this, nothing persists.
+   * Vendors historically used this path as a shorthand for create + commerce sync.
    */
   private function performSaveAndSync(FormStateInterface $form_state, NodeInterface $event): void {
     if ($form_state->get('mel_ticket_adding_new')) {
@@ -1553,7 +1581,7 @@ final class EventTicketsBuilder {
         }
         return;
       }
-      $this->messenger->addWarning($this->t('Enter a ticket title and price or capacity as needed, then use Save & sync again — or use Create ticket.'));
+      $this->messenger->addWarning($this->t('Enter a ticket title and a valid price or capacity as needed, then use Create ticket.'));
     }
     $this->lifecycle->syncPaidTiers($event);
     $this->messenger->addStatus($this->t('Tickets saved and synced.'));
@@ -1804,6 +1832,45 @@ final class EventTicketsBuilder {
   }
 
   /**
+   * Whether the ticket has the minimum viable info for buyer-facing tiers.
+   */
+  private function ticketCardIsOutcomeComplete(TicketTypeInterface $ticket): bool {
+    $title = trim((string) $ticket->label());
+    if ($title === '') {
+      return FALSE;
+    }
+
+    return match ($ticket->getTicketKind()) {
+      'paid' => (function () use ($ticket): bool {
+          $price = $ticket->toPriceValue();
+          return $price !== NULL && is_numeric($price->getNumber()) && (float) $price->getNumber() > 0;
+        })(),
+      'external' => (function () use ($ticket): bool {
+          $uri = $ticket->getExternalUrlString();
+          if ($uri === NULL || trim($uri) === '') {
+            return FALSE;
+          }
+          return str_starts_with(mb_strtolower(trim($uri)), 'https://');
+        })(),
+      default => TRUE,
+    };
+  }
+
+  /**
+   * Default outcome price line for new-ticket display before inline JS updates it.
+   */
+  private function newTicketOutcomePriceCaption(string $ticket_kind, string $price_amount_raw, string $currency_code): string {
+    return match ($ticket_kind) {
+      'paid' => ''
+        !== trim($price_amount_raw) && is_numeric($price_amount_raw) && (float) $price_amount_raw > 0
+        ? $currency_code . ' ' . $this->formatPriceNumberForDisplay(trim($price_amount_raw))
+          : (string) $this->t('—'),
+      'rsvp' => (string) $this->t('$0'),
+      default => (string) $this->t('External'),
+    };
+  }
+
+  /**
    * Human-readable price line for card header (escaped HTML string).
    */
   private function formatPrice(TicketTypeInterface $ticket): string {
@@ -1826,13 +1893,6 @@ final class EventTicketsBuilder {
       return (string) $this->t('$0');
     }
     return (string) $this->t('External');
-  }
-
-  /**
-   * Compact price/capacity line for the view card.
-   */
-  private function buildCardPriceCapacityLine(TicketTypeInterface $ticket): string {
-    return $this->formatPriceText($ticket) . ' • ' . $this->formatCapacityText($ticket);
   }
 
   /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
@@ -1,0 +1,1214 @@
+/**
+ * @file
+ * Event Studio — MEL Builder layout & card system (vendor console).
+ *
+ * Loaded via meta.load-css inside main.scss `.mel-vendor { }` — do not prefix
+ * selectors with `.mel-vendor` here (that would double-nest in compiled CSS).
+ * Module CSS may load earlier;
+ * grid/layout rules use specificity so theme wins for studio pages.
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/typography' as *;
+@use '../tokens/breakpoints' as *;
+@use '../tokens/spacing' as *;
+
+@use 'sass:color' as sass-color;
+
+// Semantic aliases (design brief)
+$mel-builder-bg-page: $bg-secondary;
+$mel-builder-muted: $text-secondary;
+
+.mel-event-studio .mel-builder {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 32px;
+  padding: 32px;
+  max-width: 1200px;
+  margin-inline: auto;
+  background: $mel-builder-bg-page;
+  border-radius: $mel-radius-md;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+@media (min-width: 1200px) {
+  .mel-event-studio .mel-builder {
+    grid-template-columns: 1fr 260px;
+  }
+}
+
+.mel-event-studio .mel-builder__main {
+  max-width: none;
+  margin: 0;
+  width: 100%;
+  min-width: 0;
+  padding-right: 24px;
+  box-sizing: border-box;
+}
+
+/* Builder step stacks: gutter between cards only (avoid margin + gap doubling). */
+.mel-event-studio .mel-builder-step-stack {
+  gap: $spacing-8;
+}
+
+.mel-event-studio .mel-builder-step-stack > .mel-builder-card {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-builder__sidebar {
+  position: sticky;
+  top: 24px;
+  height: fit-content;
+  align-self: start;
+}
+
+.mel-event-studio .mel-builder-sidebar__sticky {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: $mel-radius-md;
+  border: 1px solid $border-color-light;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  background: $bg-primary;
+  box-sizing: border-box;
+}
+
+/* Highlight icon — pulldown (emoji + label visible in list & closed state where supported). */
+.mel-event-studio .mel-highlights-builder-table .mel-highlight-icon-cell {
+  min-width: 11rem;
+  vertical-align: middle;
+}
+
+.mel-event-studio .mel-highlights-builder-table select.mel-highlight-icon {
+  width: 100%;
+  max-width: 100%;
+  font-size: $font-size-body;
+  line-height: 1.35;
+  font-family:
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    'Noto Color Emoji',
+    system-ui,
+    sans-serif;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Card system                                                                */
+/* -------------------------------------------------------------------------- */
+
+@keyframes mel-builder-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.mel-event-studio .mel-builder-card {
+  position: relative;
+  background: $bg-primary;
+  border-radius: $mel-radius-md;
+  padding: 28px;
+  margin-bottom: 28px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+  border: 1px solid $border-color-light;
+  box-sizing: border-box;
+  scroll-margin-top: 112px;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      border-color 0.28s ease,
+      border-width 0.28s ease,
+      box-shadow 0.28s ease,
+      transform 0.28s ease,
+      background-color 0.28s ease,
+      opacity 0.28s ease,
+      filter 0.28s ease;
+    animation: mel-builder-card-enter 0.45s ease-out backwards;
+  }
+
+  @media (hover: hover) {
+    &:hover:not(.is-active) {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+    }
+
+    &.is-active:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow:
+        0 12px 32px rgba(0, 0, 0, 0.08),
+        0 0 0 4px rgba(242, 109, 91, 0.12);
+    }
+  }
+}
+
+/* Completion + active step affordances */
+.mel-event-studio .mel-builder-card.is-complete {
+  border-left: 4px solid #2ecc71;
+}
+
+.mel-event-studio .mel-builder-card.is-complete > .mel-builder-card__header:first-of-type {
+  padding-right: 6.5rem;
+}
+
+.mel-event-studio .mel-builder-card.is-active {
+  opacity: 1;
+  background: #fffdf8;
+  border: 2px solid $mel-ws-coral;
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.08),
+    0 0 0 4px rgba(242, 109, 91, 0.12);
+
+  @media (prefers-reduced-motion: no-preference) {
+    transform: scale(1.02);
+  }
+}
+
+/**
+ * Dim sibling cards — one viewport/focus-aligned card carries .is-active (see mel-event-studio.js).
+ */
+.mel-event-studio .mel-builder--focus-mode .mel-builder-card:not(.is-active) {
+  opacity: 0.78;
+  filter: saturate(0.9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+
+  @media (prefers-reduced-motion: no-preference) {
+    transform: scale(0.99);
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      box-shadow: 0 8px 22px rgba(0, 0, 0, 0.06);
+
+      @media (prefers-reduced-motion: no-preference) {
+        transform: translateY(-2px) scale(0.99);
+      }
+    }
+  }
+}
+
+.mel-event-studio .mel-builder-card__done-badge {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 1;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  color: $success;
+  line-height: 1.2;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.mel-event-studio .mel-builder-card__done-badge[hidden] {
+  display: none !important;
+}
+
+.mel-event-studio .mel-builder-card__summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  cursor: pointer;
+  box-sizing: border-box;
+  margin-bottom: 0;
+
+  &::after {
+    content: '\203a';
+    font-size: 18px;
+    line-height: 1;
+    opacity: 0.4;
+    flex-shrink: 0;
+    pointer-events: none;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      background-color 0.2s ease;
+  }
+}
+
+.mel-event-studio .mel-builder-card__summary[hidden] {
+  display: none !important;
+}
+
+@media (hover: hover) {
+  .mel-event-studio .mel-builder-card__summary:hover {
+    background: #f1f5f9;
+
+    @media (prefers-reduced-motion: no-preference) {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
+    }
+  }
+}
+
+.mel-event-studio .mel-builder-card__summary-content {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  color: #1e293b;
+  line-height: 1.35;
+}
+
+.mel-event-studio .mel-builder-card__edit-btn {
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: $spacing-2 $spacing-5;
+  margin: 0;
+  margin-left: $spacing-2;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  line-height: 1.15;
+  color: sass-color.adjust($mel-ws-coral, $lightness: -10%);
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+  background: rgba($mel-ws-coral, 0.09);
+  border: 1px solid rgba($mel-ws-coral, 0.42);
+  border-radius: $mel-radius-pill;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    background: rgba($mel-ws-coral, 0.16);
+    border-color: rgba($mel-ws-coral, 0.66);
+    color: sass-color.adjust($mel-ws-coral, $lightness: -14%);
+    text-decoration: none;
+    box-shadow:
+      0 2px 6px rgba(242, 109, 91, 0.14),
+      0 1px 2px rgba(15, 23, 42, 0.05);
+
+    @media (prefers-reduced-motion: no-preference) {
+      transform: translateY(-1px);
+    }
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $mel-ws-coral;
+    outline-offset: 2px;
+    border-radius: $mel-radius-pill;
+    box-shadow: 0 0 0 3px rgba(242, 109, 91, 0.22);
+  }
+}
+
+.mel-event-studio .mel-builder-card__footer {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid $border-color-light;
+}
+
+.mel-event-studio .mel-builder-card__complete {
+  margin: 0;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  color: $success;
+}
+
+.mel-event-studio .mel-builder-card__momentum {
+  color: $text-primary;
+  font-weight: $font-weight-semibold;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio .mel-builder-card__complete[hidden] {
+  display: none !important;
+}
+
+.mel-event-studio .mel-builder-card__next-step {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.mel-event-studio .mel-builder-card__next-step[hidden] {
+  display: none !important;
+}
+
+.mel-event-studio .mel-builder-card__next-hint {
+  margin: 0;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  color: $mel-builder-muted;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio .mel-next-step-btn {
+  appearance: none;
+  margin: 0;
+  cursor: pointer;
+  min-height: 44px;
+  padding: 10px 18px;
+  border-radius: $radius-button;
+  font-size: $font-size-body;
+  font-weight: $font-weight-semibold;
+  line-height: 1.2;
+  border: 1px solid $border-color-light;
+  background: $bg-primary;
+  color: $text-primary;
+  box-sizing: border-box;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &:hover {
+    border-color: $ml-slate-300;
+    background: $ml-slate-50;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $ml-color-accent;
+    outline-offset: 2px;
+  }
+}
+
+/* Soft highlight — optional MEL contribution (secondary visual system) */
+.mel-event-studio .mel-builder-card--mel-support {
+  background: transparent;
+  border-color: transparent;
+}
+
+.mel-event-studio .mel-builder-card--secondary.mel-builder-card--mel-support {
+  margin-top: 8px;
+  background: #fff8f5;
+  border: 1px dashed #f26d5b;
+  border-radius: $mel-radius-md;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 248, 245, 0.08);
+    border-color: rgba(242, 109, 91, 0.55);
+  }
+}
+
+/* Headings inside cards (Twig uses mel-builder-card__title on section headers) */
+.mel-event-studio .mel-builder-card > .mel-builder-card__header .mel-builder-card__title {
+  font-size: $font-size-section-title;
+  font-weight: $font-weight-bold;
+  margin: 0 0 8px;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-card > .mel-builder-card__header .mel-builder-card__hint {
+  color: $mel-builder-muted;
+  margin: 0 0 16px;
+  font-size: $font-size-sm;
+  line-height: $line-height-normal;
+}
+
+/* Legacy: direct h2/p inside cards */
+.mel-event-studio .mel-builder-card > h2:first-child {
+  font-size: $font-size-section-title;
+  font-weight: $font-weight-bold;
+  margin: 0 0 8px;
+}
+
+.mel-event-studio .mel-builder-card > p:not([class]) {
+  color: $mel-builder-muted;
+  margin-bottom: 16px;
+}
+
+/* Schedule: date + location columns */
+.mel-event-studio .mel-builder-fields--schedule {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+
+  @media (min-width: $breakpoint-md) {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+
+.mel-event-studio .mel-builder-fields--schedule > .mel-builder-fields__col {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+}
+
+/* Inputs inside builder cards */
+.mel-event-studio .mel-builder-card input:not([type='checkbox']):not([type='radio']):not([type='file']):not([type='hidden']),
+.mel-event-studio .mel-builder-card textarea,
+.mel-event-studio .mel-builder-card select {
+  border-radius: $radius-input;
+  padding: 12px;
+  border: 1px solid $border-color-light;
+  font-size: $font-size-body;
+  box-sizing: border-box;
+}
+
+/* Tickets step: product prominence (not “just another setting”) */
+.mel-event-studio .mel-builder-card--tickets {
+  padding: 28px 28px 32px;
+  margin-bottom: 28px;
+}
+
+.mel-event-studio .mel-builder-card--tickets > .mel-builder-card__body.mel-builder-fields--stack {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.mel-event-studio .mel-tickets-product-region {
+  margin-top: 2px;
+}
+
+.mel-event-studio .mel-tickets-section-divider {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 4px 0 16px;
+}
+
+.mel-event-studio .mel-tickets-section-divider::before,
+.mel-event-studio .mel-tickets-section-divider::after {
+  content: '';
+  flex: 1;
+  min-width: 12px;
+  height: 1px;
+  background: $border-color-light;
+}
+
+.mel-event-studio .mel-tickets-section-divider__label {
+  font-size: $font-size-xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: $mel-builder-muted;
+  white-space: nowrap;
+}
+
+.mel-event-studio .mel-tickets-list-well {
+  padding: 20px 20px 22px;
+  border-radius: $mel-radius-md;
+  position: relative;
+  background: linear-gradient(
+    165deg,
+    rgba(242, 109, 91, 0.07) 0%,
+    rgba(110, 126, 242, 0.05) 48%,
+    rgba(15, 23, 42, 0.02) 100%
+  );
+  border: 1px solid rgba(15, 23, 42, 0.07);
+  box-sizing: border-box;
+}
+
+.mel-event-studio .mel-ticket-studio-autosave-hint {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  margin: 0 0 12px;
+  padding: 10px 14px;
+  font-size: $font-size-sm;
+  color: $mel-builder-muted;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: $mel-radius-sm;
+  box-shadow: 0 -4px 14px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket--complete {
+  border: 2px solid #2ecc71;
+  background: #f9fffb;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(46, 204, 113, 0.12);
+    border-color: rgba(46, 204, 113, 0.75);
+  }
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__display {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px 14px;
+  margin-bottom: 10px;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__display-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: $font-weight-bold;
+  line-height: 1.25;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__price {
+  font-size: 1.0625rem;
+  font-weight: $font-weight-semibold;
+  color: $text-primary;
+  white-space: nowrap;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__header--outcome {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+
+  .mel-ticket-card__display {
+    flex: 1 1 220px;
+    margin-bottom: 0;
+  }
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__kind-hint {
+  margin: -4px 0 12px;
+  font-size: $font-size-xs;
+  color: $mel-builder-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card__fields-inline-2 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0 16px;
+
+  @media (min-width: $breakpoint-md) {
+    grid-template-columns: minmax(0, 2fr) minmax(140px, 1fr);
+  }
+
+  &:has(select[name*="[ticket_kind]"]) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card .mel-ticket-card__edit-layer .form-item,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket-card--new .mel-ticket-card__fields .form-item {
+  margin-bottom: 12px !important;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card .mel-ticket-card__edit-layer label,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket-card--new .mel-ticket-card__fields label {
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card .mel-ticket-card__edit-layer input:not([type='checkbox']):not([type='radio']):not([type='file']):not([type='hidden']),
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card .mel-ticket-card__edit-layer textarea,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card .mel-ticket-card__edit-layer select,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket-card--new .mel-ticket-card__fields input:not([type='checkbox']):not([type='radio']):not([type='file']):not([type='hidden']),
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket-card--new .mel-ticket-card__fields textarea,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket-card--new .mel-ticket-card__fields select {
+  border-radius: 10px;
+  padding: 10px !important;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-tickets-list-well .mel-ticket-builder,
+.mel-event-studio .mel-builder-card--tickets .mel-tickets-list-well .mel-ticket-wizard-embed {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card {
+  padding: 18px 20px;
+  margin-bottom: 18px;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card:last-child {
+  margin-bottom: 0;
+}
+
+/* First / lead ticket — slight lift */
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket--primary {
+  border-color: rgba(242, 109, 91, 0.35);
+  background: $bg-primary;
+  box-shadow:
+    0 12px 32px rgba(15, 23, 42, 0.12),
+    0 0 0 1px rgba(255, 255, 255, 0.75) inset;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transform: scale(1.018);
+    transition:
+      transform 0.22s ease,
+      box-shadow 0.22s ease,
+      border-color 0.22s ease;
+  }
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-card.mel-ticket--primary.is-dragging {
+  transform: none;
+}
+
+/* Tickets: emphasize add-tier CTA */
+.mel-event-studio .mel-builder-card--tickets #mel-add-ticket-tier {
+  font-weight: $font-weight-semibold;
+}
+
+/* Attendee: primary Add question */
+.mel-event-studio .mel-builder-card--attendees #mel-attendee-add-question {
+  border-radius: $radius-button;
+  padding: 12px 18px;
+  font-weight: $font-weight-semibold;
+}
+
+/* Question rows as mini-cards */
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-row {
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  border: 1px solid $border-color-light;
+  border-radius: $mel-radius-sm;
+  border-bottom: 1px solid $border-color-light;
+  background: $ml-slate-50;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-row:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-row__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-option-cards.mel-option-cards--attendee-inline {
+  gap: 10px;
+
+  @media (min-width: $breakpoint-md) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-option-cards--attendee-inline > .mel-option-card {
+  flex: 1 1 220px;
+  min-width: min(220px, 100%);
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-row .mel-builder-field-well .form-item__label {
+  display: block;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-sm;
+  margin-bottom: 6px;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-options-shell {
+  margin-top: 4px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-option-line {
+  margin-bottom: 8px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-add-option {
+  margin-top: 4px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-preview-well {
+  margin-top: 12px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-preview__label {
+  margin: 0;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-sm;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-preview__pick {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: $font-size-sm;
+  margin: 0;
+  color: $text-secondary;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-preview__empty {
+  margin: 0;
+  font-size: $font-size-sm;
+  color: $mel-builder-muted;
+}
+
+.mel-event-studio .mel-builder-card--attendees .mel-attendee-row .mel-option-card input.form-checkbox {
+  margin-block-start: 4px;
+}
+
+/* Progressive collapse (<details>): default collapsed; Identity / Schedule / Tickets stay expanded (no wrappers). */
+.mel-event-studio .mel-builder-progressive {
+  margin: 0;
+  padding: 0;
+  border-radius: $mel-radius-md;
+  border: 1px solid $border-color-light;
+  background: $bg-primary;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.05);
+}
+
+.mel-event-studio .mel-builder-card > .mel-builder-card__body > .mel-builder-progressive.mel-builder-progressive--attendee-card {
+  margin: -24px -24px 0;
+}
+
+.mel-event-studio .mel-builder-progressive + .mel-builder-card__subsection,
+.mel-event-studio .mel-builder-card__subsection + .mel-builder-progressive {
+  margin-top: 28px;
+}
+
+.mel-event-studio .mel-builder-progressive__summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  font: inherit;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-progressive__summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio .mel-builder-progressive__summary-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.mel-event-studio .mel-builder-progressive__title {
+  display: block;
+  font-weight: $font-weight-bold;
+  font-size: $font-size-section-title;
+  line-height: $line-height-normal;
+  margin: 0;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-progressive--description-card .mel-builder-progressive__title {
+  font-size: $font-size-lg;
+}
+
+.mel-event-studio .mel-builder-progressive__hint {
+  display: block;
+  margin: 0;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-normal;
+  color: $mel-builder-muted;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio .mel-builder-progressive__chev {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  margin-top: 2px;
+  border-radius: 8px;
+  border: 1px solid $border-color-light;
+  background: $ml-slate-50;
+  position: relative;
+  transition: transform 0.22s ease, background-color 0.15s ease;
+}
+
+.mel-event-studio .mel-builder-progressive__chev::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid $ml-slate-600;
+  border-bottom: 2px solid $ml-slate-600;
+  transform: translate(-52%, -64%) rotate(45deg);
+  transition: transform 0.22s ease;
+}
+
+.mel-event-studio .mel-builder-progressive[open] > .mel-builder-progressive__summary .mel-builder-progressive__chev {
+  transform: rotate(180deg);
+  background: $bg-primary;
+}
+
+.mel-event-studio .mel-builder-progressive__panel {
+  padding: 0 22px 22px;
+  border-top: 1px solid $border-color-light;
+}
+
+/* More options (collapsed) */
+.mel-event-studio .mel-builder-more-options {
+  margin-bottom: 24px;
+  border-radius: $mel-radius-md;
+  border: 1px solid $border-color-light;
+  background: $bg-primary;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.05);
+  padding: 0;
+}
+
+.mel-event-studio .mel-builder-more-options__summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 18px 22px;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-lg;
+  color: $text-primary;
+}
+
+.mel-event-studio .mel-builder-more-options__summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio .mel-builder-more-options__body {
+  padding: 0 22px 22px;
+  border-top: 1px solid $border-color-light;
+}
+
+/* Publish card — destination state when builder is fully ready */
+.mel-event-studio .mel-card-publish.mel-builder-card.is-ready {
+  border: 2px solid #2ecc71;
+  box-shadow: 0 0 0 4px rgba(46, 204, 113, 0.1);
+}
+
+.mel-event-studio .mel-card-publish__ready-celebrate {
+  margin: 12px 0 12px;
+  font-size: $font-size-body;
+  font-weight: $font-weight-semibold;
+  color: $text-primary;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio .mel-card-publish__ready-celebrate[hidden] {
+  display: none !important;
+}
+
+/* Publish CTAs */
+.mel-event-studio .mel-builder-card--publish .mel-publish-action-card__draft .mel-btn--primary#mel-publish-now {
+  font-weight: $font-weight-bold;
+}
+
+.mel-event-studio .mel-builder-publish-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+/* Strip tabular chrome inside ticket builder where not tabledrag */
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-list table:not(.tabledrag),
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-builder table:not(.tabledrag) {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-list table:not(.tabledrag) th,
+.mel-event-studio .mel-builder-card--tickets .mel-ticket-list table:not(.tabledrag) td {
+  border: 0;
+  padding: 8px 0;
+  vertical-align: top;
+}
+
+/* Fieldsets: no admin chrome */
+.mel-event-studio .mel-builder__main fieldset.fieldset,
+.mel-event-studio .mel-builder__main .fieldset {
+  border: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  padding: 0 !important;
+  margin: 0 0 1rem !important;
+  min-width: 0;
+}
+
+.mel-event-studio .mel-builder__main fieldset.fieldset .fieldset__wrapper,
+.mel-event-studio .mel-builder__main .fieldset .fieldset__wrapper {
+  padding: 0 !important;
+}
+
+/* Inline validation affordance */
+.mel-event-studio--builder-inline-validation .form-item.mel-builder-invalid .mel-input,
+.mel-event-studio--builder-inline-validation .form-item.mel-builder-invalid input:not([type='hidden']),
+.mel-event-studio--builder-inline-validation .form-item.mel-builder-invalid textarea,
+.mel-event-studio--builder-inline-validation .form-item.mel-builder-invalid select {
+  border-color: $danger !important;
+  box-shadow: 0 0 0 2px $danger-light;
+}
+
+/* Suppress duplicate top-of-form error banner when inline hints exist */
+.mel-event-studio--builder-inline-validation .mel-studio-form-wrapper > .messages.messages--error {
+  display: none !important;
+}
+
+@media (max-width: #{$breakpoint-md - 1px}) {
+  .mel-event-studio .mel-builder {
+    grid-template-columns: 1fr;
+    padding: 20px 16px;
+    gap: 24px;
+  }
+
+  .mel-event-studio .mel-builder__sidebar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: auto;
+    z-index: 20;
+    padding: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+    background: $bg-primary;
+    box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.1);
+    border-radius: $mel-radius-md $mel-radius-md 0 0;
+    max-height: 45vh;
+    overflow-y: auto;
+  }
+
+  .mel-event-studio .mel-builder-sidebar__sticky {
+    position: static;
+    box-shadow: none;
+    border: 0;
+    padding: 0;
+    max-height: none;
+  }
+
+  .mel-event-studio .mel-studio-form-wrapper {
+    padding-bottom: 120px;
+  }
+}
+
+/* ========================================================================== */
+/* Option cards — radio / checkbox selectors (mel-option-cards)                */
+/* ========================================================================== */
+
+.mel-event-studio .mel-option-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &.mel-option-cards--tickets-row {
+    @media (min-width: $breakpoint-md) {
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+  }
+}
+
+// Brief alias aligned with vendor form tokens ($primary maps to interactive blue).
+$color-primary: $primary;
+
+.mel-event-studio .mel-option-cards .mel-option-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid $border-color-light;
+  background: $bg-primary;
+  cursor: pointer;
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  min-width: min(260px, 100%);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  @media (hover: hover) {
+    &:hover {
+      border-color: $color-primary;
+    }
+  }
+
+  &.form-disabled {
+    cursor: default;
+    opacity: 0.72;
+
+    &:hover {
+      border-color: $border-color-light;
+    }
+  }
+}
+
+.mel-event-studio .mel-option-cards--tickets-row .mel-option-card {
+  @media (min-width: $breakpoint-md) {
+    min-width: 200px;
+  }
+}
+
+.mel-event-studio .mel-option-card input.form-radio,
+.mel-event-studio .mel-option-card input.form-checkbox {
+  flex-shrink: 0;
+  margin-block-start: 4px;
+  width: auto;
+  max-width: none;
+  cursor: pointer;
+}
+
+.mel-event-studio .mel-option-card__content {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 4px;
+  border-inline-start: 3px solid transparent;
+  margin-inline-start: 0;
+  transition: border-color 0.15s ease;
+}
+
+.mel-event-studio .mel-option-card input:checked + .mel-option-card__content {
+  border-inline-start-color: $color-primary;
+}
+
+.mel-event-studio .mel-option-card .mel-option-card__label {
+  display: block;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  font-weight: $font-weight-normal;
+}
+
+.mel-event-studio .mel-option-card .mel-option-card__label strong {
+  display: block;
+  font-weight: $font-weight-bold;
+  font-size: $font-size-body;
+  color: $text-primary;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio .mel-option-card .mel-option-card__desc {
+  margin: 6px 0 0;
+  padding: 0;
+  font-size: $font-size-sm;
+  line-height: $line-height-normal;
+  color: $text-secondary;
+
+  &.visually-hidden {
+    margin: 0;
+  }
+}
+
+.mel-event-studio .mel-option-card:focus-within {
+  outline: 2px solid $ml-color-accent;
+  outline-offset: 2px;
+}
+
+/* ========================================================================== */
+/* Field wells — text, select, datetime, file, etc. (.mel-builder-field-well)   */
+/* ========================================================================== */
+
+.mel-event-studio .mel-builder .mel-builder-field-well.form-item {
+  margin-block-start: 0;
+  margin-block-end: 12px;
+
+  &:last-child {
+    margin-block-end: 0;
+  }
+}
+
+.mel-event-studio .mel-builder .mel-builder-field-well {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid $border-color-light;
+  background: $ml-slate-50;
+  box-sizing: border-box;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &.form-item--error {
+    border-color: $danger;
+    box-shadow: 0 0 0 2px $danger-light;
+  }
+
+  &:focus-within {
+    outline: none;
+    border-color: $primary;
+  }
+
+  &:focus-within:not(:has(table)) {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  }
+}
+
+.mel-event-studio .mel-builder table .mel-builder-field-well {
+  margin: 0 !important;
+  padding: 4px 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.mel-event-studio .mel-builder table .mel-builder-field-well:focus-within {
+  box-shadow: none !important;
+}
+
+/* Legend + radios groups: restore visible shell (fieldsets are stripped above). */
+.mel-event-studio .mel-builder__main fieldset.fieldset.mel-builder-fieldset-well.form-composite,
+.mel-event-studio .mel-builder__main fieldset.fieldset.mel-builder-fieldset-well.fieldgroup {
+  border: 1px solid $border-color-light !important;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.05) !important;
+  background: $ml-slate-50 !important;
+  padding: 12px 14px !important;
+  margin: 0 0 12px !important;
+  border-radius: 12px !important;
+}
+
+.mel-event-studio .mel-builder__main fieldset.fieldset.mel-builder-fieldset-well > .fieldset-wrapper {
+  padding: 0 !important;
+}
+
+.mel-event-studio .mel-ai-controls .mel-ai-controls__group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid $border-color-light;
+  background: $ml-slate-50;
+  box-sizing: border-box;
+}
+
+.mel-event-studio .mel-ai-controls .mel-ai-controls__group > span:first-child {
+  font-size: $font-size-xs;
+  font-weight: $font-weight-semibold;
+  color: $text-secondary;
+}
+
+.mel-event-studio .mel-ai-controls .mel-ai-controls__group select.mel-input {
+  width: 100%;
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -49,6 +49,7 @@
   @include meta.load-css('components/empty-states');
   @include meta.load-css('components/console');
   @include meta.load-css('components/workspace');
+  @include meta.load-css('components/mel-builder');
   @include meta.load-css('components/boost-insights');
   @include meta.load-css('components/mel-workspace-percent');
   @include meta.load-css('components/event-form');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Event Studio form rendering/theming and large client-side wizard logic changes, which could affect navigation, validation, and saving behavior across multiple steps. Backend changes add new attendee-question types/options and highlight-icon value updates that require careful compatibility with existing stored data.
> 
> **Overview**
> Refactors the Event Studio builder UI to a more guided, card-based workflow: step order changes to *identity → tickets → stand out → attendee → preview → publish*, cards now collapse/expand with summaries, and the live preview panel moves below the workspace with an added sidebar Save button.
> 
> Introduces a reusable **option-card** presentation for radios/checkboxes (new `EventStudioMelOptionCards` + Twig templates + theme hooks) and adopts it for ticket type selection, venue mode, platform support mode, and “collect attendee details”.
> 
> Expands the attendee questions feature to support `radios` (plus better type normalization) and persists per-question choice options end-to-end (JS editor UI + payload normalization + paragraph save mapping). Highlight icons are updated to emoji-labeled values, with a new picker payload and select rendering that preserves legacy values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2a4ee94874eb57ed52d7701cf1d97c417f4048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->