### PR TITLE
Fix/bugbot ics calendar ticket order update9011 studio collapse

### DIFF
--- a/web/modules/custom/mel_ticket/mel_ticket.info.yml
+++ b/web/modules/custom/mel_ticket/mel_ticket.info.yml
@@ -9,5 +9,7 @@ dependencies:
   - drupal:link
   - drupal:node
   - drupal:user
+  - drupal:entity_reference_revisions
   - commerce_price:commerce_price
   - commerce_product:commerce_product
+  - paragraphs:paragraphs

--- a/web/modules/custom/mel_ticket/mel_ticket.install
+++ b/web/modules/custom/mel_ticket/mel_ticket.install
@@ -372,6 +372,8 @@ function mel_ticket_update_9011(): string {
       'mel_ticket_update_9011 installFieldStorageDefinition: @message',
       ['@message' => $e->getMessage()]
     );
+
+    return 'field_is_default_ticket was not installed; see mel_ticket watchdog logs.';
   }
 
   return 'Installed mel_ticket_type.field_is_default_ticket for recommended tickets.';

--- a/web/modules/custom/mel_ticket/mel_ticket.install
+++ b/web/modules/custom/mel_ticket/mel_ticket.install
@@ -378,6 +378,97 @@ function mel_ticket_update_9011(): string {
 }
 
 /**
+ * Adds optional per-ticket attendee question paragraphs on ticket types.
+ */
+function mel_ticket_update_9012(): string {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('mel_ticket_type', FALSE);
+  if (!$entity_type) {
+    return 'mel_ticket_type entity type not found; rebuild caches and re-run updates.';
+  }
+  $fields = \Drupal\mel_ticket\Entity\TicketType::baseFieldDefinitions($entity_type);
+  $installed = [];
+  foreach (['field_use_ticket_attendee_questions', 'field_attendee_questions'] as $name) {
+    if (!isset($fields[$name])) {
+      continue;
+    }
+    try {
+      $update_manager->installFieldStorageDefinition(
+        $name,
+        'mel_ticket_type',
+        'mel_ticket',
+        $fields[$name]
+      );
+      $installed[] = $name;
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('mel_ticket')->warning(
+        'mel_ticket_update_9012 installFieldStorageDefinition @field: @message',
+        ['@field' => $name, '@message' => $e->getMessage()]
+      );
+    }
+  }
+  return $installed === []
+    ? 'No new mel_ticket_type attendee-question fields installed (may already exist).'
+    : 'Installed mel_ticket_type fields: ' . implode(', ', $installed);
+}
+
+/**
+ * Repairs missing attendee-question field tables per ticket type (9012 remediation).
+ *
+ * If deploy or schema sync skipped installFieldStorageDefinition, loading ticket
+ * types crashes with SQLSTATE Base table mel_ticket_type__field_attendee_questions
+ * not found. This update is idempotent.
+ */
+function mel_ticket_update_9013(): string {
+  $database_schema = \Drupal::database()->schema();
+  $table = 'mel_ticket_type__field_attendee_questions';
+  if ($database_schema->tableExists($table)) {
+    return 'mel_ticket_type attendee-question tables already exist; nothing to repair.';
+  }
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_type_manager->clearCachedDefinitions();
+  $entity_type = $entity_type_manager->getDefinition('mel_ticket_type', FALSE);
+  if (!$entity_type) {
+    return 'mel_ticket_type entity type not found; rebuild caches and re-run `drush updb`.';
+  }
+
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $fields = \Drupal\mel_ticket\Entity\TicketType::baseFieldDefinitions($entity_type);
+  $installed = [];
+  foreach (['field_use_ticket_attendee_questions', 'field_attendee_questions'] as $name) {
+    if (!isset($fields[$name])) {
+      continue;
+    }
+    try {
+      $update_manager->installFieldStorageDefinition(
+        $name,
+        'mel_ticket_type',
+        'mel_ticket',
+        $fields[$name]
+      );
+      $installed[] = $name;
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('mel_ticket')->error(
+        'mel_ticket_update_9013 installFieldStorageDefinition @field: @message',
+        ['@field' => $name, '@message' => $e->getMessage()]
+      );
+    }
+  }
+
+  $exists_after = $database_schema->tableExists($table);
+  return $exists_after
+    ? 'Repaired mel_ticket_type attendee question field storage (' . implode(', ', $installed) . ').'
+    : sprintf(
+      'Repair attempted for [%s]; table %s is still missing. Check logs.',
+      implode(', ', $installed),
+      $table
+    );
+}
+
+/**
  * Deletes ticket_type_config paragraph entities so config import can remove the type.
  *
  * Run `drush updb` then `drush cim`. Clears event field_ticket_types (if still

--- a/web/modules/custom/mel_ticket/src/Entity/TicketType.php
+++ b/web/modules/custom/mel_ticket/src/Entity/TicketType.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityPublishedTrait;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Entity\EntityStorageException;
 
 /**
@@ -245,6 +246,66 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
       ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', FALSE);
+
+    $fields['field_use_ticket_attendee_questions'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Add custom questions for this ticket'))
+      ->setDescription(t('Optional. Event-level attendee questions still apply; enable this only when this tier needs extra questions.'))
+      ->setDefaultValue(FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'weight' => 28,
+        'settings' => [
+          'display_label' => TRUE,
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $fields['field_attendee_questions'] = BaseFieldDefinition::create('entity_reference_revisions')
+      ->setLabel(t('Attendee questions for this ticket'))
+      ->setDescription(t('Paragraphs (attendee_extra_field) asked in addition to event-level questions for this tier.'))
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setSetting('target_type', 'paragraph')
+      ->setSetting('handler', 'default:paragraph')
+      ->setSetting('handler_settings', [
+        'target_bundles' => [
+          'attendee_extra_field' => 'attendee_extra_field',
+        ],
+        'negate' => 0,
+        'target_bundles_drag_drop' => [
+          'attendee_extra_field' => [
+            'enabled' => TRUE,
+            'weight' => 0,
+          ],
+        ],
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'paragraphs',
+        'weight' => 29,
+        'settings' => [
+          'title' => 'Question',
+          'title_plural' => 'Questions',
+          'edit_mode' => 'closed',
+          'closed_mode' => 'summary',
+          'autocollapse' => 'none',
+          'closed_mode_threshold' => 0,
+          'add_mode' => 'dropdown',
+          'form_display_mode' => 'default',
+          'default_paragraph_type' => 'attendee_extra_field',
+          'features' => [
+            'add_above' => '0',
+            'collapse_edit_all' => 'collapse_edit_all',
+            'duplicate' => 'duplicate',
+          ],
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'entity_reference_revisions_entity_view',
+        'weight' => 20,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
 
     $fields['vendor_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Vendor'))

--- a/web/modules/custom/myeventlane_checkout_paragraph/css/checkout-attendee-groups.css
+++ b/web/modules/custom/myeventlane_checkout_paragraph/css/checkout-attendee-groups.css
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * Checkout: ticket type heading + attendee grouping for holder pane.
+ */
+
+.mel-checkout-ticket-group {
+  margin-bottom: 1.75rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.mel-checkout-ticket-group:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.mel-checkout-ticket-type-title {
+  margin: 0 0 1rem;
+  font-size: 1.125rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  color: #1a1d26;
+}

--- a/web/modules/custom/myeventlane_checkout_paragraph/myeventlane_checkout_paragraph.libraries.yml
+++ b/web/modules/custom/myeventlane_checkout_paragraph/myeventlane_checkout_paragraph.libraries.yml
@@ -1,0 +1,5 @@
+checkout_attendee_groups:
+  version: 1.x
+  css:
+    theme:
+      css/checkout-attendee-groups.css: {}

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
@@ -7,11 +7,15 @@ namespace Drupal\myeventlane_checkout_paragraph\Plugin\Commerce\CheckoutPane;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\CheckoutPaneBase;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutFlow\CheckoutFlowInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Component\Utility\EmailValidatorInterface;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\myeventlane_core\Service\TicketLabelResolver;
+use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -53,6 +57,13 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
   private TicketLabelResolver $ticketLabelResolver;
 
   /**
+   * Paid tier resolver (variation → mel_ticket_type) for merged questions.
+   *
+   * @var \Drupal\myeventlane_commerce\Service\TicketAvailabilityService
+   */
+  private TicketAvailabilityService $ticketAvailability;
+
+  /**
    * {@inheritdoc}
    */
   public function getCacheContexts(): array {
@@ -70,6 +81,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
     $instance->logger = $container->get('logger.factory')->get('myeventlane_checkout_paragraph');
     $instance->emailValidator = $container->get('email.validator');
     $instance->ticketLabelResolver = $container->get('myeventlane_core.ticket_label_resolver');
+    $instance->ticketAvailability = $container->get('myeventlane_commerce.ticket_availability');
     return $instance;
   }
 
@@ -78,6 +90,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    */
   public function buildPaneForm(array $pane_form, FormStateInterface $form_state, array &$complete_form): array {
     $pane_form['#tree'] = TRUE;
+    $pane_form['#attached']['library'][] = 'myeventlane_checkout_paragraph/checkout_attendee_groups';
 
     if (!$this->isVisible()) {
       return $pane_form;
@@ -105,9 +118,12 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
 
       $ticket_label = $this->ticketLabelResolver->getTicketLabel($order_item);
       $pane_form['order_items'][$index] = [
-        '#type' => 'fieldset',
-        '#title' => $this->t('Ticket Holder Information for: @title', ['@title' => $ticket_label]),
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-checkout-ticket-group']],
         '#tree' => TRUE,
+        'ticket_title' => [
+          '#markup' => '<h4 class="mel-checkout-ticket-type-title">' . Html::escape($ticket_label) . '</h4>',
+        ],
       ];
 
       for ($delta = 0; $delta < $quantity; $delta++) {
@@ -125,7 +141,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
   private function buildTicketHolderForm(?ParagraphInterface $holder, array $templates, int $itemIndex, int $delta): array {
     $fieldset = [
       '#type' => 'details',
-      '#title' => $this->t('Ticket @num', ['@num' => $delta + 1]),
+      '#title' => $this->t('Attendee @num', ['@num' => $delta + 1]),
       '#open' => TRUE,
     ];
 
@@ -194,7 +210,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
           $fieldset[$field_name] = [
             '#type' => 'select',
             '#title' => $label,
-            '#options' => $options ?: ['_' => $this->t('No options')],
+            '#options' => ['' => $this->t('- Select -')] + ($options ?: ['_' => $this->t('No options')]),
             '#default_value' => $default,
             '#required' => $required,
           ];
@@ -205,6 +221,34 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#type' => 'checkbox',
             '#title' => $label,
             '#default_value' => (bool) $default,
+            '#required' => $required,
+          ];
+          break;
+
+        case 'checkboxes':
+          $decoded = [];
+          if ($default !== '' && $default !== NULL) {
+            $try = json_decode((string) $default, TRUE);
+            if (is_array($try)) {
+              $decoded = $try;
+            }
+          }
+          $fieldset[$field_name] = [
+            '#type' => 'checkboxes',
+            '#title' => $label,
+            '#options' => $options ?: ['_' => $this->t('Option')],
+            '#default_value' => $decoded,
+            '#required' => $required,
+          ];
+          break;
+
+        case 'radio':
+        case 'radios':
+          $fieldset[$field_name] = [
+            '#type' => 'radios',
+            '#title' => $label,
+            '#options' => $options ?: ['_' => $this->t('Option')],
+            '#default_value' => $default,
             '#required' => $required,
           ];
           break;
@@ -223,7 +267,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
           $fieldset[$field_name] = [
             '#type' => 'textfield',
             '#title' => $label,
-            '#default_value' => $default,
+            '#default_value' => is_scalar($default) || $default === NULL ? (string) ($default ?? '') : '',
             '#required' => $required,
           ];
           break;
@@ -256,7 +300,13 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
     }
 
     foreach ($order_items as $index => $tickets) {
+      if (!is_array($tickets)) {
+        continue;
+      }
       foreach ($tickets as $delta => $entry) {
+        if (!$this->isHolderFormDeltaKey($delta) || !is_array($entry)) {
+          continue;
+        }
         // Validate required fields.
         if (empty($entry['field_first_name'])) {
           $form_state->setErrorByName("{$this->getPluginId()}][order_items][$index][$delta][field_first_name", $this->t('First name is required.'));
@@ -324,6 +374,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
     }
 
     foreach ($holders as $delta => $paragraph) {
+      if (!$this->isHolderFormDeltaKey($delta)) {
+        continue;
+      }
       if (!$paragraph instanceof ParagraphInterface) {
         continue;
       }
@@ -509,23 +562,23 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
   }
 
   /**
-   * Pulls extra attendee question templates from the event, if present.
-   *
-   * @return \Drupal\paragraphs\ParagraphInterface[]
-   *   List of template paragraphs.
+   * Whether a form value key under order_items[*] is a numeric attendee delta.
    */
-  private function getExtraQuestionTemplates(OrderItemInterface $order_item): array {
-    $event = NULL;
+  private function isHolderFormDeltaKey(mixed $key): bool {
+    return is_int($key) || (is_string($key) && $key !== '' && ctype_digit($key));
+  }
 
-    // Preferred: order item points directly to the event.
-    // (MyEventLane uses field_target_event in many flows.)
+  /**
+   * Resolves the event node for an order item (event questions + tier lookup).
+   */
+  private function resolveEventForOrderItem(OrderItemInterface $order_item): ?FieldableEntityInterface {
+    $event = NULL;
     if ($order_item->hasField('field_target_event') && !$order_item->get('field_target_event')->isEmpty()) {
       $event = $order_item->get('field_target_event')->entity;
     }
 
     $purchased_entity = $order_item->getPurchasedEntity();
 
-    // Back-compat: some setups store field_event on the purchased entity itself.
     if (
       !$event
       && $purchased_entity instanceof FieldableEntityInterface
@@ -535,7 +588,6 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       $event = $purchased_entity->get('field_event')->entity;
     }
 
-    // Common: field_event is stored on the parent product, not on the variation.
     if (!$event && $purchased_entity && method_exists($purchased_entity, 'getProduct')) {
       $product = $purchased_entity->getProduct();
       if (
@@ -547,26 +599,91 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       }
     }
 
-    if (!$event) {
+    return $event instanceof FieldableEntityInterface ? $event : NULL;
+  }
+
+  /**
+   * Event-level questions followed by ticket-tier questions, deduped.
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   */
+  private function mergeQuestionTemplateParagraphs(array $event_templates, array $tier_templates): array {
+    $seen = [];
+    $out = [];
+    foreach ([$event_templates, $tier_templates] as $batch) {
+      foreach ($batch as $paragraph) {
+        if (!$paragraph instanceof ParagraphInterface) {
+          continue;
+        }
+        $key = $this->questionTemplateDedupeKey($paragraph);
+        if (isset($seen[$key])) {
+          continue;
+        }
+        $seen[$key] = TRUE;
+        $out[] = $paragraph;
+      }
+    }
+    return $out;
+  }
+
+  private function questionTemplateDedupeKey(ParagraphInterface $paragraph): string {
+    if ($paragraph->hasField('field_question_machine_name') && !$paragraph->get('field_question_machine_name')->isEmpty()) {
+      $machine = trim((string) ($paragraph->get('field_question_machine_name')->value ?? ''));
+      if ($machine !== '') {
+        return 'machine:' . mb_strtolower($machine);
+      }
+    }
+    if ($paragraph->hasField('field_question_label') && !$paragraph->get('field_question_label')->isEmpty()) {
+      $label = trim((string) ($paragraph->get('field_question_label')->value ?? ''));
+      if ($label !== '') {
+        return 'label:' . mb_strtolower($label);
+      }
+    }
+    if ($paragraph->id() !== NULL) {
+      return 'id:' . (string) $paragraph->id();
+    }
+    return 'tmp:' . spl_object_id($paragraph);
+  }
+
+  /**
+   * Loads merged attendee question templates (event + per-ticket type).
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   *   Template paragraphs in order: event first, then ticket-specific.
+   */
+  private function getExtraQuestionTemplates(OrderItemInterface $order_item): array {
+    $event = $this->resolveEventForOrderItem($order_item);
+    if (!$event instanceof FieldableEntityInterface) {
+      $purchased_entity = $order_item->getPurchasedEntity();
       $this->logger->warning(
         'Unable to resolve event for order item @id when building attendee questions. Purchased entity type: @type.',
         [
-          '@id' => $order_item->id(),
+          '@id' => (string) $order_item->id(),
           '@type' => $purchased_entity ? $purchased_entity->getEntityTypeId() : 'none',
         ]
       );
       return [];
     }
 
-    if (!$event instanceof FieldableEntityInterface || !$event->hasField('field_attendee_questions')) {
-      $this->logger->warning(
-        'Event entity for order item @id does not have field_attendee_questions; skipping extra questions.',
-        ['@id' => $order_item->id()]
-      );
-      return [];
+    $event_templates = [];
+    if ($event->hasField('field_attendee_questions') && !$event->get('field_attendee_questions')->isEmpty()) {
+      $event_templates = $event->get('field_attendee_questions')->referencedEntities();
     }
 
-    return $event->get('field_attendee_questions')->referencedEntities();
+    $tier_templates = [];
+    $variation = $order_item->getPurchasedEntity();
+    if ($variation instanceof ProductVariationInterface && $event instanceof NodeInterface) {
+      $tier = $this->ticketAvailability->resolveTierForVariation($event, $variation);
+      if ($tier !== NULL
+        && $tier->hasField('field_use_ticket_attendee_questions')
+        && $tier->get('field_use_ticket_attendee_questions')->value
+        && $tier->hasField('field_attendee_questions')
+        && !$tier->get('field_attendee_questions')->isEmpty()) {
+        $tier_templates = $tier->get('field_attendee_questions')->referencedEntities();
+      }
+    }
+
+    return $this->mergeQuestionTemplateParagraphs($event_templates, $tier_templates);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/EventIcalendarBuilder.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventIcalendarBuilder.php
@@ -62,7 +62,7 @@ final class EventIcalendarBuilder {
       'URL:' . $this->escapeStructuredValue($canonical),
     ];
 
-    $descPieces = trim($detail !== '' ? trim($detail) . '\n\n' . $canonical : $canonical, "\n\r\t ");
+    $descPieces = trim($detail !== '' ? trim($detail) . "\n\n" . $canonical : $canonical, "\n\r\t ");
     $lines[] = 'DESCRIPTION:' . $this->escapeTextValue($descPieces !== '' ? $descPieces : $canonical);
 
     if ($location !== '') {

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -135,6 +135,27 @@ final class TicketTierLifecycleService {
       $values['group_bundle_size'] = (int) $template->get('group_bundle_size')->value;
     }
 
+    if ($template->hasField('field_use_ticket_attendee_questions')) {
+      $values['field_use_ticket_attendee_questions'] = $template->get('field_use_ticket_attendee_questions')->value ? 1 : 0;
+    }
+    if ($template->hasField('field_attendee_questions') && !$template->get('field_attendee_questions')->isEmpty()) {
+      $refs = [];
+      foreach ($template->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+        if (!$paragraph instanceof \Drupal\paragraphs\ParagraphInterface) {
+          continue;
+        }
+        $dup = $paragraph->createDuplicate();
+        $dup->save();
+        $refs[] = [
+          'target_id' => (int) $dup->id(),
+          'target_revision_id' => (int) $dup->getRevisionId(),
+        ];
+      }
+      if ($refs !== []) {
+        $values['field_attendee_questions'] = $refs;
+      }
+    }
+
     $values['price'] = NULL;
     $values['commerce_variation'] = NULL;
     $values['template_source'] = ['target_id' => (int) $template->id()];
@@ -928,6 +949,12 @@ final class TicketTierLifecycleService {
     if (array_key_exists('group_bundle_size', $values) && $ticket->hasField('group_bundle_size')) {
       $value = $values['group_bundle_size'];
       $ticket->set('group_bundle_size', ($value === NULL || $value === '') ? NULL : (int) $value);
+    }
+    if (array_key_exists('field_use_ticket_attendee_questions', $values) && $ticket->hasField('field_use_ticket_attendee_questions')) {
+      $ticket->set('field_use_ticket_attendee_questions', (bool) $values['field_use_ticket_attendee_questions']);
+    }
+    if (array_key_exists('field_attendee_questions', $values) && $ticket->hasField('field_attendee_questions')) {
+      $ticket->set('field_attendee_questions', $values['field_attendee_questions']);
     }
   }
 

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -754,7 +754,16 @@ final class TicketTierLifecycleService {
    * @return \Drupal\mel_ticket\Entity\TicketTypeInterface[]
    */
   public function loadOrderedTicketsForEvent(NodeInterface $event): array {
-    return array_values($this->ticketTypeManager->loadEventTicketTypesDefaultFirst($event));
+    $out = [];
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return $out;
+    }
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $entity) {
+      if ($entity instanceof TicketTypeInterface && !$entity->isArchived()) {
+        $out[] = $entity;
+      }
+    }
+    return $out;
   }
 
   public function loadWritableTicketForEvent(NodeInterface $event, int $ticketId, AccountInterface $account): ?TicketTypeInterface {

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1065,9 +1065,9 @@ textarea.mel-input--body {
   }
 }
 
-/* Step nav lives in theme (left sidebar); keep scroll-margin for in-page jumps. */
+/* Step nav lives in theme (left sidebar); keep scroll-margin aligned with mel-event-studio.js MEL_SCROLL_OFFSET. */
 .mel-event-studio .mel-studio-section {
-  scroll-margin-top: 5.5rem;
+  scroll-margin-top: 120px;
 }
 
 .mel-ticket-wizard-embed {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -15,6 +15,23 @@
   var MEL_SCROLL_OFFSET = 120;
 
   /**
+   * While non-zero epoch ms, wizard IntersectionObserver must not overwrite nav/card state
+   * (smooth programmatic scroll crosses multiple steps briefly).
+   */
+  var melWizardIoNavSilentUntil = 0;
+
+  /**
+   * @param {number} [durationMs]
+   */
+  function melSuppressWizardIoNav(durationMs) {
+    var ms = typeof durationMs === 'number' ? durationMs : melPrefersReducedMotion() ? 120 : 750;
+    var until = Date.now() + ms;
+    if (until > melWizardIoNavSilentUntil) {
+      melWizardIoNavSilentUntil = until;
+    }
+  }
+
+  /**
    * Window scroll only — no nested scroll containers.
    *
    * @param {HTMLElement|null} target
@@ -23,6 +40,7 @@
     if (!target) {
       return;
     }
+    melSuppressWizardIoNav();
     var y = target.getBoundingClientRect().top + window.scrollY - MEL_SCROLL_OFFSET;
     window.scrollTo({
       top: Math.max(0, y),
@@ -160,44 +178,6 @@
     );
   }
 
-  /**
-   * Default expanded card: first incomplete card in the current wizard step, else last card in step.
-   *
-   * @param {HTMLFormElement} form
-   * @return {HTMLElement|null}
-   */
-  function melPickDefaultActiveBuilderCard(form) {
-    if (!form) {
-      return null;
-    }
-    var stepIdx = getWizardStepIndex(form);
-    var stepEl =
-      stepIdx >= 0 && stepIdx < MEL_STEPS.length
-        ? document.getElementById('mel-step-' + MEL_STEPS[stepIdx].id)
-        : null;
-    var cards = melOrderedVisibleBuilderCards(form);
-    if (stepEl) {
-      cards = cards.filter(function (c) {
-        return stepEl.contains(c);
-      });
-    }
-    var i;
-    for (i = 0; i < cards.length; i++) {
-      var c = cards[i];
-      if (c.id === 'mel-card-publish') {
-        continue;
-      }
-      if (!c.classList.contains('is-complete')) {
-        return cards[i];
-      }
-    }
-    for (i = cards.length - 1; i >= 0; i--) {
-      if (cards[i].id !== 'mel-card-publish') {
-        return cards[i];
-      }
-    }
-    return cards[0] || null;
-  }
 
   /**
    * @param {string|HTMLElement} sel
@@ -259,6 +239,10 @@
     }
     if (!el) {
       return;
+    }
+    var hostingCard = el.closest('.mel-builder-card');
+    if (hostingCard && form.contains(hostingCard) && hostingCard.id !== 'mel-card-publish') {
+      melSetActiveBuilderCard(form, hostingCard);
     }
     var progD = el.closest('details');
     while (progD && form.contains(progD)) {
@@ -2282,10 +2266,138 @@
       }
       return Drupal.t('No extra questions');
     }
+    if (cid === 'mel-card-preview') {
+      return Drupal.t('Preview card');
+    }
     if (cid === 'mel-card-publish') {
       return Drupal.t('Ready to publish');
     }
     return Drupal.t('Completed');
+  }
+
+  /**
+   * @param {Element|null} card
+   * @return {boolean}
+   */
+  function melIsPublishBuilderCard(card) {
+    return !!(card && card.id === 'mel-card-publish');
+  }
+
+  /** Collapses all accordion cards except publish (always expanded). */
+  function melCollapseAllBuilderCardsExceptPublish(form) {
+    if (!form) {
+      return;
+    }
+    delete form.dataset.melBuilderActiveCardId;
+
+    form.querySelectorAll('.mel-builder-card').forEach(function (card) {
+      var body = card.querySelector(':scope > .mel-builder-card__body');
+      var summary = card.querySelector(':scope > .mel-builder-card__summary');
+      if (!body || !summary) {
+        return;
+      }
+
+      if (melIsPublishBuilderCard(card)) {
+        body.style.display = '';
+        summary.hidden = true;
+        card.classList.add('mel-builder-card--body-expanded');
+        return;
+      }
+
+      card.classList.remove('mel-builder-card--expanded-edit');
+      card.classList.remove('mel-builder-card--body-expanded');
+      body.style.display = 'none';
+      summary.hidden = false;
+      var summaryContent = summary.querySelector('.mel-builder-card__summary-content');
+      if (summaryContent) {
+        summaryContent.textContent = melBuildCardSummary(card, form);
+      }
+    });
+
+    melUpdateBuilderCardCloseButtons(form);
+    melRequestBuilderCardActiveSync(form);
+  }
+
+  /**
+   * Ensures a footer row exists for in-card Continue + Close section controls.
+   *
+   * @param {HTMLElement} foot
+   * @return {HTMLElement}
+   */
+  function melBuilderCardEnsureFooterToolbar(foot) {
+    var toolbar = foot.querySelector('[data-mel-builder-footer-toolbar]');
+    if (!toolbar) {
+      toolbar = document.createElement('div');
+      toolbar.className = 'mel-builder-card__footer-toolbar';
+      toolbar.setAttribute('data-mel-builder-footer-toolbar', '1');
+      foot.appendChild(toolbar);
+    }
+    return toolbar;
+  }
+
+  /**
+   * Shows or hides footer "Close section" controls (complete + expanded only).
+   *
+   * @param {HTMLFormElement} form
+   */
+  function melUpdateBuilderCardCloseButtons(form) {
+    if (!form) {
+      return;
+    }
+    form.querySelectorAll('.mel-builder-card').forEach(function (card) {
+      if (melIsPublishBuilderCard(card)) {
+        return;
+      }
+      var btn = card.querySelector('[data-mel-builder-close-section]');
+      if (!btn) {
+        return;
+      }
+      var expanded = card.classList.contains('mel-builder-card--body-expanded');
+      var complete = card.classList.contains('is-complete');
+      var show = expanded && complete;
+      btn.hidden = !show;
+      btn.setAttribute('aria-hidden', show ? 'false' : 'true');
+    });
+  }
+
+  /**
+   * Ensures card footers have a toolbar row: Continue (next-step) + Close section.
+   *
+   * Safe to call repeatedly (e.g. after AJAX) — reconciles DOM order.
+   *
+   * @param {HTMLFormElement} form
+   */
+  function melEnsureCollapseDoneButtons(form) {
+    if (!form) {
+      return;
+    }
+    form.querySelectorAll('.mel-builder-card footer.mel-builder-card__footer').forEach(function (foot) {
+      var card = foot.closest('.mel-builder-card');
+      if (!card || melIsPublishBuilderCard(card)) {
+        return;
+      }
+      var toolbar = melBuilderCardEnsureFooterToolbar(foot);
+      var nextBlock = foot.querySelector(':scope > [data-mel-builder-next-step-block]');
+      if (nextBlock) {
+        toolbar.insertBefore(nextBlock, toolbar.firstChild);
+      }
+      if (!foot.querySelector('[data-mel-builder-close-section]')) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'mel-btn mel-btn--ghost mel-builder-card__close-section';
+        btn.setAttribute('data-mel-builder-close-section', '1');
+        btn.hidden = true;
+        btn.setAttribute('aria-hidden', 'true');
+        btn.textContent = Drupal.t('Close section');
+        toolbar.appendChild(btn);
+      }
+      else {
+        var existingClose = foot.querySelector('[data-mel-builder-close-section]');
+        if (existingClose && existingClose.parentNode !== toolbar) {
+          toolbar.appendChild(existingClose);
+        }
+      }
+    });
   }
 
   /**
@@ -2311,9 +2423,10 @@
         return;
       }
 
-      if (card.id === 'mel-card-publish') {
+      if (melIsPublishBuilderCard(card)) {
         body.style.display = '';
         summary.hidden = true;
+        card.classList.add('mel-builder-card--body-expanded');
         return;
       }
 
@@ -2323,8 +2436,10 @@
       if (isTarget) {
         body.style.display = '';
         summary.hidden = true;
+        card.classList.add('mel-builder-card--body-expanded');
       }
       else {
+        card.classList.remove('mel-builder-card--body-expanded');
         body.style.display = 'none';
         summary.hidden = false;
         var summaryContent = summary.querySelector('.mel-builder-card__summary-content');
@@ -2334,11 +2449,12 @@
       }
     });
 
+    melUpdateBuilderCardCloseButtons(form);
     melRequestBuilderCardActiveSync(form);
   }
 
   /**
-   * Apply single-active card UI; resolves active card from dataset or wizard-step default.
+   * Apply accordion state: expands only dataset.mel-builder-active-card, else collapses all.
    *
    * @param {HTMLFormElement} form
    */
@@ -2346,6 +2462,8 @@
     if (!form) {
       return;
     }
+    melEnsureCollapseDoneButtons(form);
+
     var activeId = form.dataset.melBuilderActiveCardId;
     var activeCard = activeId ? document.getElementById(activeId) : null;
     var stepIdx = getWizardStepIndex(form);
@@ -2356,12 +2474,19 @@
     if (
       !activeCard ||
       !form.contains(activeCard) ||
-      (stepEl && !stepEl.contains(activeCard))
+      !activeCard.closest ||
+      typeof activeCard.closest !== 'function' ||
+      !activeCard.closest('section.mel-step')
     ) {
-      activeCard = melPickDefaultActiveBuilderCard(form);
+      activeCard = null;
+    } else if (stepEl && !stepEl.contains(activeCard)) {
+      activeCard = null;
     }
+
     if (activeCard) {
       melSetActiveBuilderCard(form, activeCard);
+    } else {
+      melCollapseAllBuilderCardsExceptPublish(form);
     }
   }
 
@@ -2741,10 +2866,19 @@
       var activeLink = links[activeIndex];
       if (activeLink && activeLink.scrollIntoView) {
         window.setTimeout(function () {
+          try {
+            var navRect = nav.getBoundingClientRect();
+            var linkRect = activeLink.getBoundingClientRect();
+            var clipped =
+              linkRect.top < navRect.top + 2 || linkRect.bottom > navRect.bottom - 2;
+            if (!clipped) {
+              return;
+            }
+          } catch (eSidebarMeasure) {}
           activeLink.scrollIntoView({
             block: 'nearest',
             inline: 'nearest',
-            behavior: melPrefersReducedMotion() ? 'auto' : 'smooth',
+            behavior: 'auto',
           });
         }, 60);
       }
@@ -3184,7 +3318,16 @@
         btnEl.setAttribute('aria-describedby', hintId);
         nextBlock.appendChild(hintEl);
         nextBlock.appendChild(btnEl);
-        footer.appendChild(nextBlock);
+        var insertToolbar = melBuilderCardEnsureFooterToolbar(footer);
+        insertToolbar.insertBefore(nextBlock, insertToolbar.firstChild);
+      }
+
+      if (nextBlock && nextBlock.parentNode) {
+        var hostFooter = nextBlock.closest('.mel-builder-card__footer');
+        if (hostFooter && nextBlock.parentNode === hostFooter) {
+          var tBar = melBuilderCardEnsureFooterToolbar(hostFooter);
+          tBar.insertBefore(nextBlock, tBar.firstChild);
+        }
       }
 
       if (nextBlock) {
@@ -3203,7 +3346,6 @@
       if (!wasComplete && isComplete && nextStepHintKeys[key]) {
         var nextAfterComplete = melNextPrimaryFlowBuilderCard(form, card);
         if (nextAfterComplete) {
-          melSetActiveBuilderCard(form, nextAfterComplete);
           pendingCompletionScrollCard = nextAfterComplete;
         }
       }
@@ -3276,22 +3418,8 @@
       return;
     }
     var nextIdx = stepIdx + 1;
+    delete form.dataset.melBuilderActiveCardId;
     scrollToStudioSection(form, nextIdx);
-    var nextStepEl = document.getElementById('mel-step-' + MEL_STEPS[nextIdx].id);
-    var targetCard = null;
-    if (nextStepEl) {
-      var stepCards = nextStepEl.querySelectorAll('.mel-builder-card');
-      for (var ci = 0; ci < stepCards.length; ci++) {
-        if (melIsBuilderCardDomVisible(form, stepCards[ci])) {
-          targetCard = stepCards[ci];
-          break;
-        }
-      }
-    }
-    if (targetCard) {
-      melSetActiveBuilderCard(form, targetCard);
-      melScrollToBuilderCard(form, targetCard);
-    }
     melApplyBuilderCardCollapseState(form);
   }
 
@@ -3304,6 +3432,48 @@
     setWizardStepIndex(form, 0);
     setWizardNavActive(form, 0);
     updateProgress(form);
+
+    if (!form.dataset.melBuilderAccordionInteractionsBound) {
+      form.dataset.melBuilderAccordionInteractionsBound = '1';
+      melEnsureCollapseDoneButtons(form);
+
+      form.addEventListener(
+        'click',
+        function (e) {
+          var closeBtn = e.target.closest('[data-mel-builder-close-section]');
+          if (!closeBtn || !form.contains(closeBtn)) {
+            return;
+          }
+          e.preventDefault();
+          delete form.dataset.melBuilderActiveCardId;
+          melApplyBuilderCardCollapseState(form);
+        },
+        false,
+      );
+
+      form.addEventListener(
+        'click',
+        function (e) {
+          var hdr = e.target.closest('.mel-builder-card > .mel-builder-card__header');
+          if (!hdr || !form.contains(hdr)) {
+            return;
+          }
+          if (e.target.closest('button, a, input, select, textarea, label')) {
+            return;
+          }
+          var headerCard = hdr.closest('.mel-builder-card');
+          if (!headerCard || melIsPublishBuilderCard(headerCard)) {
+            return;
+          }
+          if (headerCard.classList.contains('mel-builder-card--body-expanded')) {
+            return;
+          }
+          e.preventDefault();
+          melSetActiveBuilderCard(form, headerCard);
+        },
+        false,
+      );
+    }
 
     form.querySelectorAll('a.mel-nav-link').forEach(function (link) {
       link.addEventListener('click', function (e) {
@@ -3390,6 +3560,9 @@
       var io = new IntersectionObserver(
         function (entries) {
           entries.forEach(function (entry) {
+            if (Date.now() < melWizardIoNavSilentUntil) {
+              return;
+            }
             if (!entry.isIntersecting) {
               return;
             }

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -2457,12 +2457,17 @@
    * Apply accordion state: expands only dataset.mel-builder-active-card, else collapses all.
    *
    * @param {HTMLFormElement} form
+   * @param {boolean} [allowActiveOutsideWizardStep=false] When true, keep active card ID even if
+   *   the card sits outside the wizard step indicated by data-mel-wizard-step (e.g. advancing
+   *   to next section's primary card immediately after marking the previous complete).
    */
-  function melApplyBuilderCardCollapseState(form) {
+  function melApplyBuilderCardCollapseState(form, allowActiveOutsideWizardStep) {
     if (!form) {
       return;
     }
     melEnsureCollapseDoneButtons(form);
+
+    var relaxStepContainment = !!allowActiveOutsideWizardStep;
 
     var activeId = form.dataset.melBuilderActiveCardId;
     var activeCard = activeId ? document.getElementById(activeId) : null;
@@ -2479,7 +2484,8 @@
       !activeCard.closest('section.mel-step')
     ) {
       activeCard = null;
-    } else if (stepEl && !stepEl.contains(activeCard)) {
+    }
+    else if (stepEl && !stepEl.contains(activeCard) && !relaxStepContainment) {
       activeCard = null;
     }
 
@@ -3364,7 +3370,10 @@
       }
     });
     melSyncPublishCardReadyState(form);
-    melApplyBuilderCardCollapseState(form);
+    if (pendingCompletionScrollCard) {
+      melSetActiveBuilderCard(form, pendingCompletionScrollCard);
+    }
+    melApplyBuilderCardCollapseState(form, !!pendingCompletionScrollCard);
     if (pendingCompletionScrollCard && form) {
       var scrollTargetCard = pendingCompletionScrollCard;
       window.setTimeout(function () {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -467,7 +467,7 @@
 
         <section id="mel-step-preview" class="mel-step mel-studio-section mel-studio-scroll-step" data-step="preview" role="tabpanel" aria-labelledby="mel-preview-section-heading">
           <div class="mel-builder-step-stack">
-            <section class="mel-builder-card" aria-labelledby="mel-preview-section-heading">
+            <section id="mel-card-preview" class="mel-builder-card" aria-labelledby="mel-preview-section-heading">
               <span class="mel-builder-card__done-badge" data-mel-builder-done-badge hidden>{{ '✓ Done'|t }}</span>
               <header class="mel-builder-card__header">
                 <h2 class="mel-builder-card__title" id="mel-preview-section-heading">{{ 'Preview'|t }}</h2>
@@ -506,6 +506,7 @@
               <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
                 {{ element.mel_mel_support }}
               </div>
+              <footer class="mel-builder-card__footer"></footer>
             </section>
             {% endif %}
 

--- a/web/modules/custom/myeventlane_vendor/css/ticket-cards.css
+++ b/web/modules/custom/myeventlane_vendor/css/ticket-cards.css
@@ -1062,3 +1062,27 @@
   max-width: 42ch;
   margin-inline: auto;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Per-ticket attendee questions (advanced)                                   */
+/* -------------------------------------------------------------------------- */
+
+.mel-ticket-questions__divider {
+  border: 0;
+  border-top: 1px solid #e2e4f0;
+  margin: 1.35rem 0 1rem;
+}
+
+.mel-ticket-questions h5 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 650;
+  color: #1f2430;
+}
+
+.mel-ticket-questions .description {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: #5c6370;
+}

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
@@ -21,6 +21,7 @@ dependencies:
   - drupal:views
   - drupal:field_ui
   - commerce:commerce_store
+  - paragraphs:paragraphs
   - myeventlane_vendor_analytics:myeventlane_vendor_analytics
 
 optional_dependencies:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
@@ -119,7 +119,7 @@ vendor_help_panel:
     - core/once
 
 ticket_cards:
-  version: 1.9
+  version: 1.10
   js:
     js/ticket-cards.js: {}
   css:
@@ -130,3 +130,4 @@ ticket_cards:
     - core/drupalSettings
     - core/drupal.ajax
     - core/once
+    - paragraphs/drupal.paragraphs.widget

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -6,7 +6,9 @@ namespace Drupal\myeventlane_vendor\Ticketing;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -23,6 +25,7 @@ use Drupal\myeventlane_commerce\Service\TicketTierAnalyticsService;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Shared ticket builder UI for wizard and workspace roots.
@@ -770,7 +773,7 @@ final class EventTicketsBuilder {
         $name === 'ticket_reorder' => $this->reorderTickets($form_state, $event),
         str_starts_with($name, 'edit_') => $this->beginInlineEdit($form_state, $name),
         str_starts_with($name, 'cancel_') => $this->cancelInlineEdit($form_state),
-        str_starts_with($name, 'save_') => $this->saveInlineEdit($form_state, $event, $name),
+        str_starts_with($name, 'save_') => $this->saveInlineEdit($form, $form_state, $event, $name),
         str_starts_with($name, 'ticket_remove_') => $this->removeTicket($event, $name),
         str_starts_with($name, 'ticket_duplicate_') => $this->duplicateTicket($event, $name),
         str_starts_with($name, 'ticket_archive_') => $this->archiveTicket($event, $name),
@@ -1399,6 +1402,54 @@ final class EventTicketsBuilder {
       '#parents' => array_merge($edit_path, ['hidden_label']),
     ];
 
+    $toggle_selector = ':input[name="' . Html::escape($this->formElementFullName($form_state, 'builder_shell', 'list', (string) $tid, 'edit', 'field_use_ticket_attendee_questions', 'value')) . '"]';
+
+    $card['edit']['mel_ticket_questions_divider'] = [
+      '#markup' => '<hr class="mel-ticket-questions__divider" aria-hidden="true" />',
+      '#weight' => 38,
+      '#states' => [
+        'visible' => [
+          $toggle_selector => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $questions_subform = ['#parents' => $edit_path];
+    $display = EntityFormDisplay::collectRenderDisplay($ticket, 'default');
+    if ($ticket->hasField('field_use_ticket_attendee_questions')
+      && ($w_toggle = $display->getRenderer('field_use_ticket_attendee_questions'))) {
+      $card['edit']['field_use_ticket_attendee_questions'] = $w_toggle->form(
+        $ticket->get('field_use_ticket_attendee_questions'),
+        $questions_subform,
+        $form_state
+      );
+      $card['edit']['field_use_ticket_attendee_questions']['#weight'] = 39;
+    }
+    if ($ticket->hasField('field_attendee_questions')
+      && ($w_questions = $display->getRenderer('field_attendee_questions'))) {
+      $card['edit']['mel_ticket_questions_intro'] = [
+        '#markup' => '<div class="mel-ticket-questions"><h5>' . Html::escape((string) $this->t('Attendee questions')) . '</h5>'
+          . '<p class="description">' . Html::escape((string) $this->t('Add questions specific to this ticket. Event-level questions always apply first.')) . '</p></div>',
+        '#weight' => 40,
+        '#states' => [
+          'visible' => [
+            $toggle_selector => ['checked' => TRUE],
+          ],
+        ],
+      ];
+      $card['edit']['field_attendee_questions'] = $w_questions->form(
+        $ticket->get('field_attendee_questions'),
+        $questions_subform,
+        $form_state
+      );
+      $card['edit']['field_attendee_questions']['#weight'] = 41;
+      $card['edit']['field_attendee_questions']['#states'] = [
+        'visible' => [
+          $toggle_selector => ['checked' => TRUE],
+        ],
+      ];
+    }
+
     $card['edit']['validation'] = [
       '#markup' => '<div class="mel-ticket-card__validation" data-mel-ticket-validation aria-live="polite"></div>',
     ];
@@ -1587,7 +1638,7 @@ final class EventTicketsBuilder {
     $this->messenger->addStatus($this->t('Tickets saved and synced.'));
   }
 
-  private function saveInlineEdit(FormStateInterface $form_state, NodeInterface $event, string $name): void {
+  private function saveInlineEdit(array &$form, FormStateInterface $form_state, NodeInterface $event, string $name): void {
     $tid = (int) str_replace('save_', '', $name);
     $card = $form_state->getValue($this->valuePath($form_state, 'builder_shell', 'list', (string) $tid, 'edit')) ?? [];
 
@@ -1600,8 +1651,36 @@ final class EventTicketsBuilder {
       }
 
       $payload = $this->lifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $card);
-    $payload = array_merge($payload, $this->buildSaleWindowFragmentForLifecycle($card));
-    $this->lifecycle->updateTicketType($ticket, $event, $payload);
+      $payload = array_merge($payload, $this->buildSaleWindowFragmentForLifecycle($card));
+      $this->lifecycle->updateTicketType($ticket, $event, $payload);
+
+      $ticket = $this->findEventTicket($event, $tid);
+      if (!$ticket) {
+        throw new \InvalidArgumentException('Ticket not found after save.');
+      }
+
+      $edit_path = $this->valuePath($form_state, 'builder_shell', 'list', (string) $tid, 'edit');
+      $branch = NestedArray::getValue($form, $edit_path);
+      $form_fragment = (is_array($branch) ? $branch : []) + ['#parents' => $edit_path];
+
+      $display = EntityFormDisplay::collectRenderDisplay($ticket, 'default');
+      foreach (['field_use_ticket_attendee_questions', 'field_attendee_questions'] as $field_name) {
+        if (!$ticket->hasField($field_name)) {
+          continue;
+        }
+        $renderer = $display->getRenderer($field_name);
+        if ($renderer) {
+          $renderer->extractFormValues($ticket->get($field_name), $form_fragment, $form_state);
+        }
+      }
+
+      if ($ticket->hasField('field_use_ticket_attendee_questions')
+        && !$ticket->get('field_use_ticket_attendee_questions')->value) {
+        $this->removeTicketTypeAttendeeQuestionParagraphs($ticket);
+      }
+
+      $this->lifecycle->updateTicketType($ticket, $event, []);
+
       $this->messenger->addStatus($this->t('Ticket updated.'));
       $success = TRUE;
     }
@@ -1628,6 +1707,22 @@ final class EventTicketsBuilder {
     }
     else {
       $form_state->set('editing_ticket_id', $tid);
+    }
+  }
+
+  /**
+   * Deletes per-ticket question paragraphs and clears the field reference.
+   */
+  private function removeTicketTypeAttendeeQuestionParagraphs(TicketTypeInterface $ticket): void {
+    if (!$ticket->hasField('field_attendee_questions')) {
+      return;
+    }
+    $refs = $ticket->get('field_attendee_questions')->referencedEntities();
+    $ticket->set('field_attendee_questions', []);
+    foreach ($refs as $entity) {
+      if ($entity instanceof ParagraphInterface) {
+        $entity->delete();
+      }
     }
   }
 
@@ -1716,6 +1811,27 @@ final class EventTicketsBuilder {
     }
     if ($ticket->hasField('group_bundle_size') && !$ticket->get('group_bundle_size')->isEmpty()) {
       $payload['group_bundle_size'] = (int) $ticket->get('group_bundle_size')->value;
+    }
+
+    if ($ticket->hasField('field_use_ticket_attendee_questions')) {
+      $payload['field_use_ticket_attendee_questions'] = $ticket->get('field_use_ticket_attendee_questions')->value ? 1 : 0;
+    }
+    if ($ticket->hasField('field_attendee_questions') && !$ticket->get('field_attendee_questions')->isEmpty()) {
+      $refs = [];
+      foreach ($ticket->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+        if (!$paragraph instanceof ParagraphInterface) {
+          continue;
+        }
+        $dup = $paragraph->createDuplicate();
+        $dup->save();
+        $refs[] = [
+          'target_id' => (int) $dup->id(),
+          'target_revision_id' => (int) $dup->getRevisionId(),
+        ];
+      }
+      if ($refs !== []) {
+        $payload['field_attendee_questions'] = $refs;
+      }
     }
 
     $this->lifecycle->createAttachAndSync($event, $payload);

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
@@ -325,6 +325,31 @@ $mel-builder-muted: $text-secondary;
   margin-top: 16px;
   padding-top: 16px;
   border-top: 1px solid $border-color-light;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+}
+
+.mel-event-studio .mel-builder-card__footer-toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: $spacing-3;
+  width: 100%;
+}
+
+.mel-event-studio .mel-builder-card__footer-toolbar .mel-builder-card__next-step {
+  margin-top: 0;
+}
+
+.mel-event-studio .mel-builder-card__footer-toolbar [data-mel-builder-close-section] {
+  margin-left: auto;
+}
+
+.mel-event-studio .mel-builder-card:not(.mel-builder-card--body-expanded) .mel-builder-card__footer-toolbar [data-mel-builder-close-section] {
+  display: none !important;
 }
 
 .mel-event-studio .mel-builder-card__complete {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new `mel_ticket_type` fields and update hooks plus new checkout/ticket-builder behavior, which can impact schema deployments and attendee data collection flows. Also modifies Event Studio accordion navigation logic, so regressions could affect the event creation UI.
> 
> **Overview**
> Adds **per-ticket attendee questions** on `mel_ticket_type` via new base fields (`field_use_ticket_attendee_questions`, `field_attendee_questions`) and update hooks (`9012`, plus an idempotent `9013` repair for missing field tables); also updates `9011` to return a clearer failure message. Ticket lifecycle operations now **clone and persist** these question paragraphs when duplicating/cloning tickets, and ticket ordering for an event is derived directly from `field_ticket_types` while filtering archived tiers.
> 
> Updates the vendor ticket builder to **edit these paragraph-based questions inline** (with new styling and required `paragraphs` dependencies) and ensures disabling the toggle cleans up the created paragraph entities. Checkout’s ticket-holder pane now **groups attendees by ticket type**, supports additional question input types (checkboxes/radios), and merges event-level + ticket-tier question templates with deduping.
> 
> Misc UX fixes: corrects newline handling in ICS `DESCRIPTION`, aligns Event Studio scroll offset to `120px`, and refactors Studio accordion behavior (footer toolbars, “Close section”, suppressed IntersectionObserver nav churn, and stable active-card syncing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756701cbc0df64ffd6747a0d220e1a7496f9a51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->