### PR TITLE
fix(vendor-events): improve bulk delete handling with error logging

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Form;
 
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -103,10 +104,7 @@ final class VendorEventsBulkActionsForm extends FormBase {
     $cache_metadata = $display->getCacheMetadata();
     $form['#cache']['tags'] = $cache_metadata->getCacheTags();
     $form['#cache']['contexts'] = $cache_metadata->getCacheContexts();
-    $max_age = $cache_metadata->getCacheMaxAge();
-    if ($max_age !== NULL) {
-      $form['#cache']['max-age'] = $max_age;
-    }
+    $form['#cache']['max-age'] = 0;
 
     if (empty($nodes)) {
       $form['empty_state'] = [
@@ -335,6 +333,7 @@ final class VendorEventsBulkActionsForm extends FormBase {
    */
   private function handleDelete(array $selectedEvents, int $userId, $nodeStorage): void {
     $deletedCount = 0;
+    $failedCount = 0;
 
     foreach (array_keys($selectedEvents) as $nodeId) {
       $nodeId = (int) $nodeId;
@@ -343,8 +342,18 @@ final class VendorEventsBulkActionsForm extends FormBase {
       if ($node instanceof NodeInterface
           && $node->bundle() === 'event'
           && (int) $node->getOwnerId() === $userId) {
-        $node->delete();
-        $deletedCount++;
+        try {
+          $node->delete();
+          $deletedCount++;
+        }
+        catch (EntityStorageException $e) {
+          $failedCount++;
+          $this->logger->error('Vendor events bulk delete failed for event @nid by user @uid: @message', [
+            '@nid' => (string) $nodeId,
+            '@uid' => (string) $userId,
+            '@message' => $e->getMessage(),
+          ]);
+        }
       }
     }
 
@@ -355,6 +364,12 @@ final class VendorEventsBulkActionsForm extends FormBase {
     }
     else {
       $this->messenger()->addWarning($this->t('No events were deleted.'));
+    }
+
+    if ($failedCount > 0) {
+      $this->messenger()->addError($this->t('@count event(s) could not be deleted. Please try again or contact support.', [
+        '@count' => $failedCount,
+      ]));
     }
   }
 


### PR DESCRIPTION
- Added error handling for failed deletions in the bulk delete process, logging specific errors encountered during the operation.
- Updated cache max-age setting to 0 for the form to ensure it is always fresh.
- Introduced user feedback for cases where events could not be deleted, enhancing user experience and support communication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event deletion flow and forces the vendor events bulk-actions form to be uncached (`max-age: 0`), which could impact performance and user-facing behavior if misconfigured.
> 
> **Overview**
> Improves vendor event bulk delete robustness by wrapping `Node::delete()` in a `try/catch`, logging `EntityStorageException` failures, and showing an additional error message when some deletions fail.
> 
> Forces the vendor events bulk actions form to always be fresh by setting `#cache['max-age'] = 0` instead of inheriting the view display’s cache max-age.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a9391fd1ea5a6c2c13f33fb8396637171d7a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->