### PR TITLE
fix(vendor-events): update cache max-age handling in bulk actions form

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -104,7 +104,10 @@ final class VendorEventsBulkActionsForm extends FormBase {
     $cache_metadata = $display->getCacheMetadata();
     $form['#cache']['tags'] = $cache_metadata->getCacheTags();
     $form['#cache']['contexts'] = $cache_metadata->getCacheContexts();
-    $form['#cache']['max-age'] = 0;
+    $max_age = $cache_metadata->getCacheMaxAge();
+    if ($max_age !== NULL) {
+      $form['#cache']['max-age'] = $max_age;
+    }
 
     if (empty($nodes)) {
       $form['empty_state'] = [


### PR DESCRIPTION
- Modified the cache max-age setting to dynamically retrieve the value from cache metadata instead of hardcoding it to 0, ensuring more efficient caching behavior for the form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes caching behavior for the vendor events bulk actions form, which could introduce stale UI if cache metadata is misconfigured. Scope is small and limited to cache max-age handling.
> 
> **Overview**
> Updates `VendorEventsBulkActionsForm` to stop hard-coding `#cache['max-age'] = 0` and instead apply the view display’s cache metadata `max-age` (when present), allowing the form to be cached according to the view’s settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7899f3fbd482788d40369144e8060632ecfc83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->