### PR TITLE
Cursor/best value attendee a8276

### DIFF
--- a/web/modules/custom/mel_ticket/mel_ticket.install
+++ b/web/modules/custom/mel_ticket/mel_ticket.install
@@ -471,6 +471,40 @@ function mel_ticket_update_9013(): string {
 }
 
 /**
+ * Adds organiser-controlled best-value flag to ticket types.
+ */
+function mel_ticket_update_9014(): string {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('mel_ticket_type', FALSE);
+  if (!$entity_type) {
+    return 'mel_ticket_type entity type not found; rebuild caches and re-run updates.';
+  }
+  $fields = \Drupal\mel_ticket\Entity\TicketType::baseFieldDefinitions($entity_type);
+  if (!isset($fields['field_is_best_value'])) {
+    return 'field_is_best_value field definition missing; skipped.';
+  }
+
+  try {
+    $update_manager->installFieldStorageDefinition(
+      'field_is_best_value',
+      'mel_ticket_type',
+      'mel_ticket',
+      $fields['field_is_best_value']
+    );
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('mel_ticket')->error(
+      'mel_ticket_update_9014 installFieldStorageDefinition: @message',
+      ['@message' => $e->getMessage()]
+    );
+
+    return 'field_is_best_value was not installed; see mel_ticket watchdog logs.';
+  }
+
+  return 'Installed mel_ticket_type.field_is_best_value for best-value tickets.';
+}
+
+/**
  * Deletes ticket_type_config paragraph entities so config import can remove the type.
  *
  * Run `drush updb` then `drush cim`. Clears event field_ticket_types (if still

--- a/web/modules/custom/mel_ticket/src/Entity/TicketType.php
+++ b/web/modules/custom/mel_ticket/src/Entity/TicketType.php
@@ -136,6 +136,14 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
   /**
    * {@inheritdoc}
    */
+  public function isBestValueTicket(): bool {
+    return $this->hasField('field_is_best_value')
+      && (bool) $this->get('field_is_best_value')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
     $fields = parent::baseFieldDefinitions($entity_type);
 
@@ -243,6 +251,17 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'weight' => 4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $fields['field_is_best_value'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Mark as best value'))
+      ->setDescription(t('Shows a buyer-facing Best value badge. Only one ticket per event should be marked best value.'))
+      ->setDefaultValue(FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'weight' => 5,
       ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', FALSE);
@@ -548,6 +567,9 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
     }
     if ($this->isReusable() && $this->hasField('field_is_default_ticket')) {
       $this->set('field_is_default_ticket', FALSE);
+    }
+    if ($this->isReusable() && $this->hasField('field_is_best_value')) {
+      $this->set('field_is_best_value', FALSE);
     }
     parent::preSave($storage);
     $this->assertBusinessRules();

--- a/web/modules/custom/mel_ticket/src/Entity/TicketTypeInterface.php
+++ b/web/modules/custom/mel_ticket/src/Entity/TicketTypeInterface.php
@@ -56,4 +56,9 @@ interface TicketTypeInterface extends ContentEntityInterface {
    */
   public function isDefaultTicket(): bool;
 
+  /**
+   * Whether this ticket type is marked as the organiser-controlled best value.
+   */
+  public function isBestValueTicket(): bool;
+
 }

--- a/web/modules/custom/myeventlane_checkout_paragraph/css/checkout-attendee-groups.css
+++ b/web/modules/custom/myeventlane_checkout_paragraph/css/checkout-attendee-groups.css
@@ -22,3 +22,11 @@
   letter-spacing: -0.02em;
   color: #1a1d26;
 }
+
+.mel-attendee-details-toggle {
+  margin-top: 0.75rem;
+}
+
+.mel-attendee-details-groups {
+  margin-top: 1rem;
+}

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
@@ -96,14 +96,37 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       return $pane_form;
     }
 
+    $attendee_details_enabled = $this->attendeeDetailsEnabled($form_state);
+    $attendee_toggle_selector = ':input[name="' . $this->getPluginId() . '[add_attendee_details]"]';
+
     $pane_form['intro'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-intro']],
       'title' => [
-        '#markup' => '<h2>' . $this->t('Enter Your Details') . '</h2>',
+        '#markup' => '<h2>' . $this->t('Attendee details') . '</h2>',
       ],
       'desc' => [
-        '#markup' => '<p>' . $this->t('Please fill in your information below for each ticket.') . '</p>',
+        '#markup' => '<p>' . $this->t('Your buyer name and email are enough to continue. You can add per-ticket attendee details now if you have them.') . '</p>',
+      ],
+    ];
+
+    $pane_form['add_attendee_details'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Add attendee details'),
+      '#default_value' => $attendee_details_enabled ? 1 : 0,
+      '#attributes' => [
+        'class' => ['mel-attendee-details-toggle'],
+      ],
+    ];
+
+    $pane_form['order_items'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-attendee-details-groups']],
+      '#tree' => TRUE,
+      '#states' => [
+        'visible' => [
+          $attendee_toggle_selector => ['checked' => TRUE],
+        ],
       ],
     ];
 
@@ -128,7 +151,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
 
       for ($delta = 0; $delta < $quantity; $delta++) {
         $holder = $holders[$delta] ?? NULL;
-        $pane_form['order_items'][$index][$delta] = $this->buildTicketHolderForm($holder, $templates, $index, $delta);
+        $pane_form['order_items'][$index][$delta] = $this->buildTicketHolderForm($holder, $templates, $index, $delta, $attendee_details_enabled);
       }
     }
 
@@ -138,7 +161,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
   /**
    * Builds the form elements for a single ticket holder.
    */
-  private function buildTicketHolderForm(?ParagraphInterface $holder, array $templates, int $itemIndex, int $delta): array {
+  private function buildTicketHolderForm(?ParagraphInterface $holder, array $templates, int $itemIndex, int $delta, bool $attendeeDetailsEnabled): array {
     $fieldset = [
       '#type' => 'details',
       '#title' => $this->t('Attendee @num', ['@num' => $delta + 1]),
@@ -150,25 +173,25 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       '#type' => 'textfield',
       '#title' => $this->t('First name'),
       '#default_value' => $holder?->get('field_first_name')->value ?? '',
-      '#required' => TRUE,
+      '#required' => $attendeeDetailsEnabled,
     ];
     $fieldset['field_last_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Last name'),
       '#default_value' => $holder?->get('field_last_name')->value ?? '',
-      '#required' => TRUE,
+      '#required' => $attendeeDetailsEnabled,
     ];
     $fieldset['field_email'] = [
       '#type' => 'email',
       '#title' => $this->t('Email'),
       '#default_value' => $holder?->get('field_email')->value ?? '',
-      '#required' => TRUE,
+      '#required' => $attendeeDetailsEnabled,
     ];
     $fieldset['field_phone'] = [
       '#type' => 'tel',
       '#title' => $this->t('Phone number'),
       '#default_value' => $holder && $holder->hasField('field_phone') ? ($holder->get('field_phone')->value ?? '') : '',
-      '#required' => TRUE,
+      '#required' => $attendeeDetailsEnabled,
     ];
 
     // Dynamic extra questions derived from templates (or existing children).
@@ -212,7 +235,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => ['' => $this->t('- Select -')] + ($options ?: ['_' => $this->t('No options')]),
             '#default_value' => $default,
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
 
@@ -221,7 +244,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#type' => 'checkbox',
             '#title' => $label,
             '#default_value' => (bool) $default,
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
 
@@ -238,7 +261,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $decoded,
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
 
@@ -249,7 +272,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $default,
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
 
@@ -259,7 +282,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#rows' => 3,
             '#default_value' => $default,
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
 
@@ -268,7 +291,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#type' => 'textfield',
             '#title' => $label,
             '#default_value' => is_scalar($default) || $default === NULL ? (string) ($default ?? '') : '',
-            '#required' => $required,
+            '#required' => $attendeeDetailsEnabled && $required,
           ];
           break;
       }
@@ -293,6 +316,10 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function validatePaneForm(array &$pane_form, FormStateInterface $form_state, array &$complete_form): void {
+    if (!$this->attendeeDetailsEnabled($form_state)) {
+      return;
+    }
+
     $pane_values = $form_state->getValue($this->getPluginId()) ?? [];
     $order_items = $pane_values['order_items'] ?? [];
     if (!is_array($order_items)) {
@@ -331,6 +358,10 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function submitPaneForm(array &$pane_form, FormStateInterface $form_state, array &$complete_form): void {
+    if (!$this->attendeeDetailsEnabled($form_state)) {
+      return;
+    }
+
     $pane_values = $form_state->getValue($this->getPluginId()) ?? [];
     $order_items_values = $pane_values['order_items'] ?? NULL;
 
@@ -566,6 +597,57 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    */
   private function isHolderFormDeltaKey(mixed $key): bool {
     return is_int($key) || (is_string($key) && $key !== '' && ctype_digit($key));
+  }
+
+  /**
+   * Whether the buyer has chosen to reveal and submit attendee details.
+   */
+  private function attendeeDetailsEnabled(FormStateInterface $form_state): bool {
+    $pane_values = $form_state->getValue($this->getPluginId());
+    if (is_array($pane_values) && array_key_exists('add_attendee_details', $pane_values)) {
+      return !empty($pane_values['add_attendee_details']);
+    }
+
+    $user_input = $form_state->getUserInput();
+    if (isset($user_input[$this->getPluginId()]) && is_array($user_input[$this->getPluginId()])
+      && array_key_exists('add_attendee_details', $user_input[$this->getPluginId()])) {
+      return !empty($user_input[$this->getPluginId()]['add_attendee_details']);
+    }
+
+    return $this->hasExistingTicketHolderData();
+  }
+
+  /**
+   * Detects saved attendee data so existing details stay visible for editing.
+   */
+  private function hasExistingTicketHolderData(): bool {
+    foreach ($this->order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item) || $order_item->get('field_ticket_holder')->isEmpty()) {
+        continue;
+      }
+
+      foreach ($order_item->get('field_ticket_holder')->referencedEntities() as $holder) {
+        if (!$holder instanceof ParagraphInterface) {
+          continue;
+        }
+        foreach (['field_first_name', 'field_last_name', 'field_email', 'field_phone'] as $field_name) {
+          if ($holder->hasField($field_name) && !$holder->get($field_name)->isEmpty()) {
+            return TRUE;
+          }
+        }
+        if ($holder->hasField('field_attendee_questions')) {
+          foreach ($holder->get('field_attendee_questions')->referencedEntities() as $question) {
+            if ($question instanceof ParagraphInterface
+              && $question->hasField('field_attendee_extra_field')
+              && !$question->get('field_attendee_extra_field')->isEmpty()) {
+              return TRUE;
+            }
+          }
+        }
+      }
+    }
+
+    return FALSE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -799,10 +799,10 @@ final class TicketSelectionForm extends FormBase {
       return (string) $this->t('Limited availability');
     }
     if ($pool === 1) {
-      return (string) $this->t('1 ticket left');
+      return (string) $this->t('Only 1 left');
     }
     if ($pool <= 10) {
-      return (string) $this->t('@count tickets left', ['@count' => (string) $pool]);
+      return (string) $this->t('Only @count left', ['@count' => (string) $pool]);
     }
     return (string) $this->t('Available');
   }

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -48,6 +48,7 @@ final class TicketTierLifecycleService {
     $ticket->save();
     if ($sync && $event instanceof NodeInterface) {
       $this->ticketTypeManager->normalizeDefaultTicketSelection($event, $ticket);
+      $this->ticketTypeManager->normalizeBestValueTicketSelection($event, $ticket);
       $this->syncPaidTiers($event);
     }
     return $ticket;
@@ -170,6 +171,7 @@ final class TicketTierLifecycleService {
     $ticket = $this->persistNewTicketType($values, $event, FALSE);
     $this->appendTicketToEvent($event, (int) $ticket->id(), TRUE);
     $this->ticketTypeManager->normalizeDefaultTicketSelection($event, $ticket);
+    $this->ticketTypeManager->normalizeBestValueTicketSelection($event, $ticket);
     return $ticket;
   }
 
@@ -242,6 +244,7 @@ final class TicketTierLifecycleService {
         $event->save();
       }
       $this->ticketTypeManager->normalizeDefaultTicketSelection($event);
+      $this->ticketTypeManager->normalizeBestValueTicketSelection($event);
       $this->syncPaidTiers($event);
     }
 
@@ -281,6 +284,7 @@ final class TicketTierLifecycleService {
     EventNodeRevisionSave::prepare($event, 'Ticket order updated on event.');
     $event->save();
     $this->ticketTypeManager->normalizeDefaultTicketSelection($event);
+    $this->ticketTypeManager->normalizeBestValueTicketSelection($event);
     $this->syncPaidTiers($event);
   }
 
@@ -299,6 +303,10 @@ final class TicketTierLifecycleService {
     }
     if ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()) {
       $ticket->set('field_is_default_ticket', FALSE);
+      $changed = TRUE;
+    }
+    if ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket()) {
+      $ticket->set('field_is_best_value', FALSE);
       $changed = TRUE;
     }
     if ($changed) {
@@ -336,6 +344,7 @@ final class TicketTierLifecycleService {
     $ticket->save();
     if ($event instanceof NodeInterface) {
       $this->ticketTypeManager->normalizeDefaultTicketSelection($event, $ticket);
+      $this->ticketTypeManager->normalizeBestValueTicketSelection($event, $ticket);
       $this->syncPaidTiers($event);
     }
   }
@@ -383,6 +392,9 @@ final class TicketTierLifecycleService {
     }
     if (array_key_exists('field_is_default_ticket', $values)) {
       $payload['field_is_default_ticket'] = !empty($values['field_is_default_ticket']) ? 1 : 0;
+    }
+    if (array_key_exists('field_is_best_value', $values)) {
+      $payload['field_is_best_value'] = !empty($values['field_is_best_value']) ? 1 : 0;
     }
 
     if (in_array($kind, ['paid', 'rsvp'], TRUE)) {
@@ -498,6 +510,9 @@ final class TicketTierLifecycleService {
     }
     if (array_key_exists('field_is_default_ticket', $values)) {
       $payload['field_is_default_ticket'] = !empty($values['field_is_default_ticket']) ? 1 : 0;
+    }
+    if (array_key_exists('field_is_best_value', $values)) {
+      $payload['field_is_best_value'] = !empty($values['field_is_best_value']) ? 1 : 0;
     }
 
     if (array_key_exists('hidden_label', $values)) {
@@ -886,6 +901,9 @@ final class TicketTierLifecycleService {
     }
     if (array_key_exists('field_is_default_ticket', $values) && $ticket->hasField('field_is_default_ticket')) {
       $ticket->set('field_is_default_ticket', !empty($values['field_is_default_ticket']));
+    }
+    if (array_key_exists('field_is_best_value', $values) && $ticket->hasField('field_is_best_value')) {
+      $ticket->set('field_is_best_value', !empty($values['field_is_best_value']));
     }
     if (array_key_exists('lifecycle_status', $values)) {
       $ticket->set('lifecycle_status', (string) $values['lifecycle_status']);

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
@@ -408,6 +408,68 @@ final class TicketTypeManager {
   }
 
   /**
+   * Enforces one best-value ticket per event.
+   *
+   * When a specific ticket was just selected, it wins. Otherwise corrupted
+   * multi-best-value data is corrected deterministically to the first ticket in
+   * event display order, matching the public buyer fail-safe.
+   */
+  public function normalizeBestValueTicketSelection(NodeInterface $event, ?TicketTypeInterface $selectedTicket = NULL): void {
+    $tickets = $this->loadEventTicketTypesForDisplay($event);
+    if ($tickets === []) {
+      return;
+    }
+
+    $keepId = NULL;
+    if ($selectedTicket instanceof TicketTypeInterface
+      && !$selectedTicket->isArchived()
+      && $selectedTicket->hasField('field_is_best_value')
+      && $selectedTicket->isBestValueTicket()) {
+      $selectedId = (int) $selectedTicket->id();
+      if (isset($tickets[$selectedId])) {
+        $keepId = $selectedId;
+      }
+    }
+
+    $bestValueIds = [];
+    foreach ($tickets as $ticketId => $ticket) {
+      if ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket()) {
+        $bestValueIds[] = (int) $ticketId;
+      }
+    }
+
+    if ($keepId === NULL && $bestValueIds !== []) {
+      $keepId = $bestValueIds[0];
+    }
+
+    if ($keepId === NULL || $bestValueIds === [$keepId]) {
+      return;
+    }
+
+    if (count($bestValueIds) > 1) {
+      $this->loggerFactory->get('myeventlane_event')->warning(
+        'Multiple best-value tickets found for event @eid; keeping ticket @keep and clearing @ids.',
+        [
+          '@eid' => (string) $event->id(),
+          '@keep' => (string) $keepId,
+          '@ids' => implode(', ', array_map('strval', $bestValueIds)),
+        ]
+      );
+    }
+
+    foreach ($tickets as $ticketId => $ticket) {
+      if (!$ticket->hasField('field_is_best_value') || (int) $ticketId === $keepId) {
+        continue;
+      }
+      if (!$ticket->isBestValueTicket()) {
+        continue;
+      }
+      $ticket->set('field_is_best_value', FALSE);
+      $ticket->save();
+    }
+  }
+
+  /**
    * Checks loaded ticket types for mixed published paid currencies.
    *
    * @param \Drupal\mel_ticket\Entity\TicketTypeInterface[] $ticketTypes

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -919,6 +919,16 @@ textarea.mel-input--body {
   color: #b45309;
 }
 
+.mel-ticket-builder--draft .mel-ticket-card__field--title,
+.mel-ticket-builder--draft .mel-ticket-card__field--price {
+  grid-column: 1 / -1;
+}
+
+.mel-ticket-builder--draft .mel-ticket-card__field--title input,
+.mel-ticket-builder--draft .mel-ticket-card__field--price input {
+  width: 100%;
+}
+
 .mel-ticket-builder .mel-tier-remove {
   font-size: 0.8125rem;
   padding: 0.35rem 0.65rem;

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -1330,7 +1330,7 @@
 
   function createDefaultTier(kind) {
     kind = normalizeTicketKind(kind);
-    var row = { title: '', ticket_kind: kind, capacity: null };
+    var row = { title: '', ticket_kind: kind, capacity: null, field_is_best_value: 0 };
     if (kind === 'paid') {
       row.price_number = '';
       row.price_currency = getSettings().defaultCurrency || 'AUD';
@@ -1354,6 +1354,8 @@
       ticket_kind: kind,
       capacity: normalizeTierCapacity(capEl ? capEl.value : ''),
     };
+    var bestValueEl = card.querySelector('.mel-tier-best-value');
+    o.field_is_best_value = bestValueEl && bestValueEl.checked ? 1 : 0;
     if (id > 0) {
       o.id = id;
     }
@@ -1393,9 +1395,12 @@
     form.setAttribute('data-mel-last-ticket-type', normalizeTicketKind(kind));
   }
 
-  function fieldWrap(labelText, control, descriptionText) {
+  function fieldWrap(labelText, control, descriptionText, extraClass) {
     var wrap = document.createElement('label');
     wrap.className = 'mel-ticket-card__field';
+    if (extraClass) {
+      wrap.classList.add(extraClass);
+    }
     var label = document.createElement('span');
     label.className = 'mel-ticket-card__field-label';
     label.textContent = labelText;
@@ -1497,6 +1502,8 @@
     fields.appendChild(fieldWrap(
       Drupal.t('Title'),
       createTextInput('mel-tier-title', tier.title, Drupal.t('General Admission')),
+      null,
+      'mel-ticket-card__field--title',
     ));
 
     var price = document.createElement('input');
@@ -1506,7 +1513,7 @@
     price.min = '0';
     price.placeholder = '0.00';
     price.value = tier.price_number != null ? String(tier.price_number) : '';
-    fields.appendChild(fieldWrap(Drupal.t('Price'), price));
+    fields.appendChild(fieldWrap(Drupal.t('Price'), price, null, 'mel-ticket-card__field--price'));
 
     var ext = document.createElement('input');
     ext.type = 'url';
@@ -1523,6 +1530,16 @@
     cap.placeholder = Drupal.t('Leave empty for unlimited tickets');
     cap.value = tier.capacity != null && String(tier.capacity) !== '' ? String(tier.capacity) : '';
     fields.appendChild(fieldWrap(Drupal.t('Capacity'), cap, Drupal.t('Leave empty for unlimited tickets')));
+
+    var bestValue = document.createElement('input');
+    bestValue.type = 'checkbox';
+    bestValue.className = 'mel-tier-best-value';
+    bestValue.checked = !!parseInt(tier.field_is_best_value || 0, 10);
+    fields.appendChild(fieldWrap(
+      Drupal.t('Mark as best value'),
+      bestValue,
+      Drupal.t('Shows a Best value badge to buyers. Only one ticket per event can be marked best value.'),
+    ));
 
     card.appendChild(fields);
 
@@ -1818,6 +1835,13 @@
         }
         if (e.target.matches && e.target.matches('.mel-tier-kind')) {
           syncTicketKindToEventType(form, e.target.value);
+        }
+        if (e.target.matches && e.target.matches('.mel-tier-best-value') && e.target.checked) {
+          list.querySelectorAll('.mel-tier-best-value').forEach(function (input) {
+            if (input !== e.target) {
+              input.checked = false;
+            }
+          });
         }
         updateDraftTicketCardUi(card);
         syncTicketTiersFromDomToHidden(form);

--- a/web/modules/custom/myeventlane_vendor/css/ticket-cards.css
+++ b/web/modules/custom/myeventlane_vendor/css/ticket-cards.css
@@ -613,6 +613,13 @@
     grid-column: span 1;
   }
 
+  .mel-ticket-card__fields .mel-ticket-card__field--title,
+  .mel-ticket-card__fields .mel-ticket-card__field--price,
+  .mel-ticket-card__fields .form-item.mel-ticket-card__field--title,
+  .mel-ticket-card__fields .form-item.mel-ticket-card__field--price {
+    grid-column: 1 / -1;
+  }
+
   .mel-ticket-card__fields textarea,
   .mel-ticket-card__fields .form-type-textarea,
   .mel-ticket-card__field:has(textarea) {
@@ -625,6 +632,11 @@
   flex-direction: column;
   gap: 6px;
   min-width: 0;
+}
+
+.mel-ticket-card__field--title input,
+.mel-ticket-card__field--price input {
+  width: 100%;
 }
 
 .mel-ticket-card__field[hidden] {

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -824,6 +824,7 @@ final class EventTicketsBuilder {
     $visibility_default = (string) $this->newTicketDefault($form_state, 'visibility_mode', 'public');
     $status_default = (int) $this->newTicketDefault($form_state, 'status', 1);
     $recommended_default = (int) $this->newTicketDefault($form_state, 'field_is_default_ticket', 0);
+    $best_value_default = (int) $this->newTicketDefault($form_state, 'field_is_best_value', 0);
 
     $ticket_kind_input = ':input[name="' . $this->formElementFullName($form_state, 'builder_shell', 'list', 'new', 'fields', 'ticket_kind') . '"]';
 
@@ -864,6 +865,9 @@ final class EventTicketsBuilder {
             '#type' => 'textfield',
             '#title' => $this->t('Title'),
             '#default_value' => $title_default,
+            '#wrapper_attributes' => [
+              'class' => ['mel-ticket-card__field--title'],
+            ],
             '#attributes' => [
               'class' => ['js-mel-ticket-title'],
               'data-mel-ticket-required-message' => (string) $this->t('Title is required.'),
@@ -875,6 +879,9 @@ final class EventTicketsBuilder {
             '#step' => 0.01,
             '#min' => 0,
             '#default_value' => $price_default,
+            '#wrapper_attributes' => [
+              'class' => ['mel-ticket-card__field--price'],
+            ],
             '#attributes' => [
               'data-mel-ticket-preset-focus' => 'price',
               'class' => ['js-mel-ticket-price'],
@@ -952,6 +959,13 @@ final class EventTicketsBuilder {
           '#description' => $this->t('This ticket will be highlighted to buyers and selected by default.'),
           '#description_display' => 'after',
           '#default_value' => $recommended_default,
+        ],
+        'field_is_best_value' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Mark as best value'),
+          '#description' => $this->t('Shows a Best value badge to buyers. Only one ticket per event can be marked best value.'),
+          '#description_display' => 'after',
+          '#default_value' => $best_value_default,
         ],
         'sale_window_enabled' => [
           '#type' => 'checkbox',
@@ -1046,7 +1060,9 @@ final class EventTicketsBuilder {
     $badge_cluster = '<span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
       . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
         ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
-        : '')
+        : ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket()
+          ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->bestValueTicketBadgeLabel($ticket)) . '</span>'
+          : ''))
       . '<span class="mel-badge mel-badge--' . Html::escape($status_class) . '">' . Html::escape($status_label) . '</span>';
 
     $view['hero'] = [
@@ -1152,7 +1168,9 @@ final class EventTicketsBuilder {
     $badge_edit = '<span class="mel-ticket-card__state" data-mel-ticket-state aria-live="polite"></span>'
       . ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket()
         ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->recommendedTicketBadgeLabel($ticket)) . '</span>'
-        : '')
+        : ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket()
+          ? '<span class="mel-ticket-card__recommended-badge">' . Html::escape($this->bestValueTicketBadgeLabel($ticket)) . '</span>'
+          : ''))
       . '<span class="mel-badge mel-badge--' . Html::escape($edit_badge_class) . '">' . Html::escape($edit_status_label) . '</span>';
 
     $card['edit']['outcome_heading'] = [
@@ -1186,6 +1204,9 @@ final class EventTicketsBuilder {
       '#default_value' => (string) ($form_state->getValue(array_merge($edit_path, ['title'])) ?? $ticket->label()),
       '#required' => TRUE,
       '#parents' => array_merge($edit_path, ['title']),
+      '#wrapper_attributes' => [
+        'class' => ['mel-ticket-card__field--title'],
+      ],
       '#attributes' => [
         'class' => ['js-mel-ticket-title'],
         'data-mel-ticket-required-message' => (string) $this->t('Title is required.'),
@@ -1203,6 +1224,9 @@ final class EventTicketsBuilder {
         '#min' => 0.01,
         '#required' => TRUE,
         '#parents' => array_merge($edit_path, ['price']),
+        '#wrapper_attributes' => [
+          'class' => ['mel-ticket-card__field--price'],
+        ],
         '#attributes' => [
           'class' => ['js-mel-ticket-price'],
         ],
@@ -1302,6 +1326,15 @@ final class EventTicketsBuilder {
       '#default_value' => (int) ($form_state->getValue(array_merge($edit_path, ['field_is_default_ticket']))
         ?? ($ticket->hasField('field_is_default_ticket') && $ticket->isDefaultTicket() ? 1 : 0)),
       '#parents' => array_merge($edit_path, ['field_is_default_ticket']),
+    ];
+    $card['edit']['secondary']['field_is_best_value'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Mark as best value'),
+      '#description' => $this->t('Shows a Best value badge to buyers. Only one ticket per event can be marked best value.'),
+      '#description_display' => 'after',
+      '#default_value' => (int) ($form_state->getValue(array_merge($edit_path, ['field_is_best_value']))
+        ?? ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket() ? 1 : 0)),
+      '#parents' => array_merge($edit_path, ['field_is_best_value']),
     ];
 
     $vis_default = (string) ($form_state->getValue(array_merge($edit_path, ['visibility_mode']))
@@ -2044,6 +2077,13 @@ final class EventTicketsBuilder {
   private function recommendedTicketBadgeLabel(TicketTypeInterface $ticket): string {
     // Future labels can branch here on price rank or remaining inventory.
     return (string) $this->t('⭐ Most popular');
+  }
+
+  /**
+   * Buyer-facing best-value badge shown on organiser ticket cards.
+   */
+  private function bestValueTicketBadgeLabel(TicketTypeInterface $ticket): string {
+    return (string) $this->t('Best value');
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
@@ -268,6 +268,7 @@
         const selected = qty > 0;
         row.classList.toggle('has-quantity', selected);
         row.classList.toggle('mel-ticket-row--selected', selected);
+        row.classList.toggle('selected', selected);
         row.setAttribute('data-selected', selected ? 'true' : 'false');
         const badge = row.querySelector('[data-mel-ticket-selection-badge]');
         if (badge) {

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3491,14 +3491,9 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
  * Adds conversion-layer metadata (data attributes, BEM hooks) for
  * mel_booking_summary.js. Does not change submit handlers or quantities.
  *
- * Restructures rows for premium layout only: title_row + selection badge,
- * purchase_column (.mel-ticket-row__meta) wrapping price + quantity, group_hint
- * moved under the main column.
- *
- * Per-tier scarcity copy is not rendered here: computing “only X left” correctly
- * requires the same waitlist-offer and capacity branches as checkout validation.
- * The .mel-ticket-row__status container is nested under label_cell (left column)
- * and is output empty for future theming/hooks.
+ * Restructures rows for premium layout only: top title/price hierarchy,
+ * badge row + selection badge, purchase_column (.mel-ticket-row__meta)
+ * wrapping quantity, group_hint moved under the main column.
  */
 function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(array &$variables): void {
   $element = &$variables['element'];
@@ -3510,6 +3505,7 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
 
   $node = $element['#node'] ?? NULL;
   $tier_by_variation_id = [];
+  $best_value_ticket_ids = [];
   if ($node instanceof NodeInterface
     && $node->hasField('field_ticket_types')
     && !$node->get('field_ticket_types')->isEmpty()) {
@@ -3518,7 +3514,20 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
         continue;
       }
       $tier_by_variation_id[(int) $ticket->get('commerce_variation')->target_id] = $ticket;
+      if ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket()) {
+        $best_value_ticket_ids[] = (int) $ticket->id();
+      }
     }
+  }
+  $best_value_keep_id = $best_value_ticket_ids[0] ?? NULL;
+  if (count($best_value_ticket_ids) > 1 && $node instanceof NodeInterface) {
+    \Drupal::logger('myeventlane_theme')->warning(
+      'Multiple best-value tickets found while rendering ticket selection for event @eid; showing ticket @keep only.',
+      [
+        '@eid' => (string) $node->id(),
+        '@keep' => (string) $best_value_keep_id,
+      ]
+    );
   }
 
   $variation_storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
@@ -3623,11 +3632,26 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
       $row['#attributes']['class'][] = 'mel-ticket-row--recommended';
       $row['#attributes']['data-mel-ticket-recommended'] = '1';
     }
-    $recommended_badge_label = myeventlane_theme_recommended_ticket_badge_label($tier);
+    $is_best_value = !$is_recommended
+      && $tier instanceof TicketTypeInterface
+      && (int) $tier->id() === $best_value_keep_id
+      && $tier->hasField('field_is_best_value')
+      && $tier->isBestValueTicket();
+    if ($is_best_value) {
+      $row['#attributes']['class'][] = 'mel-ticket-row--best-value';
+    }
+    $buyer_badge_label = $is_recommended
+      ? myeventlane_theme_recommended_ticket_badge_label($tier)
+      : ($is_best_value ? myeventlane_theme_best_value_ticket_badge_label($tier) : '');
+    $buyer_badge_classes = ['mel-ticket-row__recommended-badge'];
+    if ($is_best_value) {
+      $buyer_badge_classes[] = 'mel-ticket-row__best-value-badge';
+    }
     $default_quantity = isset($row['quantity']['#default_value']) ? (int) $row['quantity']['#default_value'] : 0;
     $is_selected = $default_quantity > 0;
     if ($is_selected) {
       $row['#attributes']['class'][] = 'mel-ticket-row--selected';
+      $row['#attributes']['class'][] = 'selected';
       $row['#attributes']['data-selected'] = 'true';
     }
 
@@ -3643,7 +3667,7 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
       $row['label_cell']['group_hint']['#weight'] = 16;
     }
 
-    // Title row + "Selected" badge (visible on load for server-preselected tickets).
+    // Top title/price row + buyer and "Selected" badges.
     if (isset($row['label_cell']['label']) && is_array($row['label_cell']['label'])) {
       $label_el = $row['label_cell']['label'];
       unset($row['label_cell']['label']);
@@ -3653,21 +3677,37 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
       if (!in_array('mel-ticket-row__title', $label_el['#attributes']['class'], TRUE)) {
         $label_el['#attributes']['class'][] = 'mel-ticket-row__title';
       }
+      $label_el['#tag'] = 'h4';
       $label_el['#weight'] = 1;
       $row['label_cell']['title_row'] = [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-ticket-row__title-row']],
+        '#attributes' => ['class' => ['mel-ticket-row__top']],
         '#weight' => 2,
         'label' => $label_el,
+        'price' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => (string) ($row['price']['#value'] ?? ''),
+          '#attributes' => [
+            'class' => ['mel-ticket-row__top-price'],
+          ],
+          '#weight' => 2,
+          '#access' => isset($row['price']['#value']) && trim((string) $row['price']['#value']) !== '',
+        ],
+      ];
+      $row['label_cell']['badge_row'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-ticket-row__badge-row']],
+        '#weight' => 4,
         'recommended_badge' => [
           '#type' => 'html_tag',
           '#tag' => 'span',
-          '#value' => $recommended_badge_label,
+          '#value' => $buyer_badge_label,
           '#attributes' => [
-            'class' => ['mel-ticket-row__recommended-badge'],
+            'class' => $buyer_badge_classes,
           ],
-          '#access' => $is_recommended,
-          '#weight' => 2,
+          '#access' => $buyer_badge_label !== '',
+          '#weight' => 1,
         ],
         'selection_badge' => [
           '#type' => 'html_tag',
@@ -3677,11 +3717,11 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
             'class' => ['mel-ticket-row__selection-badge'],
             'data-mel-ticket-selection-badge' => '1',
           ],
-          '#weight' => 3,
+          '#weight' => 2,
         ],
       ];
       if (!$is_selected) {
-        $row['label_cell']['title_row']['selection_badge']['#attributes']['hidden'] = 'hidden';
+        $row['label_cell']['badge_row']['selection_badge']['#attributes']['hidden'] = 'hidden';
       }
     }
 
@@ -3704,17 +3744,9 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
       $row['label_cell']['#weight'] = 10;
     }
 
-    if (isset($row['price']) && is_array($row['price'])) {
-      if (isset($row['price']['#attributes']['class']) && is_array($row['price']['#attributes']['class'])) {
-        $row['price']['#attributes']['class'][] = 'mel-ticket-row__price';
-      }
-    }
-
-    if (isset($row['price']) && isset($row['quantity'])) {
-      $price_el = $row['price'];
+    if (isset($row['quantity'])) {
       $qty_el = $row['quantity'];
       unset($row['price'], $row['quantity']);
-      $price_el['#weight'] = 1;
       if (!isset($qty_el['#attributes']['class']) || !is_array($qty_el['#attributes']['class'])) {
         $qty_el['#attributes']['class'] = [];
       }
@@ -3726,7 +3758,6 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-ticket-row__meta']],
         '#weight' => 22,
-        'price' => $price_el,
         'quantity' => $qty_el,
       ];
     }
@@ -3751,6 +3782,13 @@ function myeventlane_theme_preprocess_form__myeventlane_ticket_selection_form(ar
 function myeventlane_theme_recommended_ticket_badge_label(?TicketTypeInterface $ticket): string {
   // Future labels can branch here on price rank or remaining inventory.
   return (string) t('⭐ Most popular');
+}
+
+/**
+ * Buyer-facing best-value badge shown on public ticket rows.
+ */
+function myeventlane_theme_best_value_ticket_badge_label(?TicketTypeInterface $ticket): string {
+  return (string) t('Best value');
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
@@ -590,14 +590,14 @@
     grid-template-areas: 'main meta';
     align-items: stretch;
     gap: spacing.mel-space(3) spacing.mel-space(4);
-    padding: spacing.mel-space(4) spacing.mel-space(4);
+    padding: 16px;
     background: linear-gradient(
       145deg,
       color.adjust(colors.$mel-color-surface, $lightness: 0%) 0%,
       color.adjust(colors.$mel-color-bg, $lightness: 1%) 100%
     );
     border: 1px solid color.adjust(colors.$mel-color-border, $lightness: 2%);
-    border-radius: radii.$mel-radius-lg + 2px;
+    border-radius: 12px;
     box-shadow: 0 4px 18px rgba(41, 50, 65, 0.05);
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease;
   }
@@ -608,7 +608,7 @@
   }
 
   .mel-ticket-row--recommended {
-    padding: spacing.mel-space(4) spacing.mel-space(5);
+    padding: 16px;
     border-width: 2px;
     border-color: colors.$mel-color-primary;
     background: linear-gradient(
@@ -627,17 +627,14 @@
   }
 
   .mel-ticket-row.mel-ticket-row--selected,
+  .mel-ticket-row.selected,
   .mel-ticket-row.has-quantity,
   .mel-ticket-row[data-selected='true'] {
     border-width: 2px;
-    border-color: color.adjust(colors.$mel-color-secondary, $lightness: -6%);
-    background: linear-gradient(
-      150deg,
-      color.adjust(colors.$mel-color-secondary, $lightness: 44%) 0%,
-      color.adjust(colors.$mel-color-surface, $lightness: 0%) 100%
-    );
+    border-color: colors.$mel-color-primary;
+    background: #fff7f5;
     box-shadow:
-      0 10px 32px rgba(108, 126, 242, 0.18),
+      0 10px 32px rgba(242, 109, 91, 0.16),
       0 1px 0 rgba(255, 255, 255, 0.5) inset;
   }
 
@@ -660,7 +657,17 @@
     justify-content: center;
   }
 
+  .mel-ticket-row__top,
   .mel-ticket-row__title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: spacing.mel-space(2);
+    min-width: 0;
+  }
+
+  .mel-ticket-row__badge-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -700,12 +707,18 @@
     line-height: 1.2;
   }
 
+  .mel-ticket-row__best-value-badge {
+    color: color.adjust(colors.$mel-color-secondary, $lightness: -32%);
+    border-color: rgba(colors.$mel-color-secondary, 0.4);
+  }
+
   .mel-ticket-label {
     font-size: typography.mel-font-size(md);
     font-weight: typography.$mel-font-bold;
     color: colors.$mel-color-text;
     min-width: 0;
     line-height: typography.$mel-leading-snug;
+    margin: 0;
   }
 
   .mel-ticket-description {
@@ -753,6 +766,17 @@
 
   .mel-ticket-price {
     margin: 0;
+    font-size: typography.mel-font-size(lg);
+    font-weight: typography.$mel-font-extrabold;
+    color: colors.$mel-color-primary;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: typography.$mel-tracking-tight;
+  }
+
+  .mel-ticket-row__top-price {
+    flex: 0 0 auto;
+    margin-left: auto;
     font-size: typography.mel-font-size(lg);
     font-weight: typography.$mel-font-extrabold;
     color: colors.$mel-color-primary;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persisted `mel_ticket_type.field_is_best_value` field with normalization logic to enforce a single best-value tier per event, plus changes checkout pane validation/submission based on a new attendee-details toggle. Risk is moderate due to schema updates and modifications to ticket lifecycle and checkout form behavior.
> 
> **Overview**
> Adds a new organiser-controlled `field_is_best_value` boolean on `mel_ticket_type` (including update hook `mel_ticket_update_9014`) and threads it through ticket creation/update/archive flows, enforcing **at most one** best-value tier per event via `TicketTypeManager::normalizeBestValueTicketSelection()`.
> 
> Updates organiser and buyer UIs to display a *Best value* badge (Event Studio draft cards, vendor ticket cards, and the public ticket selection preprocess), and includes a fail-safe when multiple tiers are marked.
> 
> Changes the checkout `TicketHolderParagraphPane` so attendee details are **optional by default**: a new “Add attendee details” checkbox gates visibility, required validation, and submission of per-ticket holder fields (with auto-enabled state when existing attendee data is present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d962db3d22361d93823282f1cc33d1f108d518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->