### PR TITLE
Cursor/form cache refunds 13c93

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -104,10 +104,7 @@ final class VendorEventsBulkActionsForm extends FormBase {
     $cache_metadata = $display->getCacheMetadata();
     $form['#cache']['tags'] = $cache_metadata->getCacheTags();
     $form['#cache']['contexts'] = $cache_metadata->getCacheContexts();
-    $max_age = $cache_metadata->getCacheMaxAge();
-    if ($max_age !== NULL) {
-      $form['#cache']['max-age'] = $max_age;
-    }
+    $form['#cache']['max-age'] = 0;
 
     if (empty($nodes)) {
       $form['empty_state'] = [

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -579,6 +579,12 @@ function myeventlane_theme_preprocess_commerce_checkout_form(array &$variables):
   if (($step_id ?? '') !== 'complete') {
     $order_param = _myeventlane_theme_commerce_order_from_route();
     if ($order_param instanceof OrderInterface) {
+      $event = _myeventlane_theme_get_first_event_from_order($order_param);
+      $variables['mel_checkout_refunds_available'] = _myeventlane_theme_event_has_refunds_available($event);
+      if ($event instanceof NodeInterface) {
+        $variables['#cache']['tags'][] = 'node:' . $event->id();
+      }
+
       $total_price = $order_param->getTotalPrice();
       // Primary CTA from order total + variation list prices (avoids stale labels when
       // payment pane is AJAX-hidden; RSVP label only for inherently free tickets).
@@ -783,6 +789,21 @@ function _myeventlane_theme_get_first_event_from_order($order) {
     }
   }
   return NULL;
+}
+
+/**
+ * Returns TRUE when an event policy indicates refunds may be available.
+ */
+function _myeventlane_theme_event_has_refunds_available(?NodeInterface $event): bool {
+  if (!$event instanceof NodeInterface || !$event->hasField('field_refund_policy') || $event->get('field_refund_policy')->isEmpty()) {
+    return FALSE;
+  }
+
+  return in_array((string) $event->get('field_refund_policy')->value, [
+    'refund_24h',
+    'refund_7d',
+    'case_by_case',
+  ], TRUE);
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -1344,6 +1344,27 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   }
 }
 
+.mel-checkout-trust {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: spacing.mel-space(2) spacing.mel-space(3);
+  padding: spacing.mel-space(3);
+  margin-bottom: 16px;
+  border: 1px solid rgba(colors.$mel-color-success, 0.18);
+  border-radius: radii.$mel-radius-lg;
+  background: rgba(colors.$mel-color-success, 0.07);
+  color: colors.$mel-color-text;
+  box-shadow: $mel-checkout-shadow;
+
+  p {
+    margin: 0;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-semibold;
+    line-height: 1.35;
+  }
+}
+
 .mel-checkout__summary-title {
   margin-bottom: 8px;
   margin-top: 0;

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -61,19 +61,15 @@
       <p>{{ "You're almost done — review your details and complete your booking."|t }}</p>
     </div>
 
-    {% if form.payment_information is defined %}
-      <div class="mel-checkout__trust">
-        <span>{{ '✔ Secure payment'|t }}</span>
-        <span>{{ '✔ No hidden fees'|t }}</span>
-        <span>{{ '✔ Instant confirmation'|t }}</span>
-      </div>
-    {% else %}
-      <div class="mel-checkout__trust mel-checkout__trust--free">
-        <span>{{ '✔ No payment required'|t }}</span>
-        <span>{{ '✔ No hidden fees'|t }}</span>
-        <span>{{ '✔ Instant confirmation'|t }}</span>
-      </div>
-    {% endif %}
+    <div class="mel-checkout-trust">
+      <p>{{ '✔ Secure checkout'|t }}</p>
+      <p>{{ '✔ Instant confirmation'|t }}</p>
+      {% if mel_checkout_refunds_available|default(false) %}
+        <p>{{ '✔ Refunds available'|t }}</p>
+      {% else %}
+        <p>{{ '✔ Easy refunds (if enabled)'|t }}</p>
+      {% endif %}
+    </div>
 
     <div class="mel-checkout__helper">
       {{ "We'll only use your details to send your ticket."|t }}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -67,19 +67,15 @@
       <p>{{ "You're almost done — review your details and complete your booking."|t }}</p>
     </div>
 
-    {% if form.payment_information is defined %}
-      <div class="mel-checkout__trust">
-        <span>{{ '✔ Secure payment'|t }}</span>
-        <span>{{ '✔ No hidden fees'|t }}</span>
-        <span>{{ '✔ Instant confirmation'|t }}</span>
-      </div>
-    {% else %}
-      <div class="mel-checkout__trust mel-checkout__trust--free">
-        <span>{{ '✔ No payment required'|t }}</span>
-        <span>{{ '✔ No hidden fees'|t }}</span>
-        <span>{{ '✔ Instant confirmation'|t }}</span>
-      </div>
-    {% endif %}
+    <div class="mel-checkout-trust">
+      <p>{{ '✔ Secure checkout'|t }}</p>
+      <p>{{ '✔ Instant confirmation'|t }}</p>
+      {% if mel_checkout_refunds_available|default(false) %}
+        <p>{{ '✔ Refunds available'|t }}</p>
+      {% else %}
+        <p>{{ '✔ Easy refunds (if enabled)'|t }}</p>
+      {% endif %}
+    </div>
 
     <div class="mel-checkout__helper">
       {{ "We'll only use your details to send your ticket."|t }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Drupal render caching (forces `max-age: 0` on vendor events view form and adds event cache tags to checkout preprocess), which can impact performance and cache invalidation behavior. Also changes checkout UX copy/styles based on event refund policy, so reviewers should sanity-check the policy mapping and caching.
> 
> **Overview**
> Updates checkout trust messaging to be **refund-policy aware**: `commerce_checkout_form` preprocess now derives the first event from the order, exposes `mel_checkout_refunds_available`, and adds the event’s `node:` cache tag; Twig templates render a unified trust block that toggles between “Refunds available” vs “Easy refunds (if enabled)”, with new `.mel-checkout-trust` styling.
> 
> Separately, the vendor events bulk actions form now **disables caching** by forcing `#cache['max-age'] = 0` instead of inheriting the view display max-age.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3d840e529282d73eb2e3eda3b2a22cd133e856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->