### PR TITLE
feat(event-studio): refine MEL builder workspace UX

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
@@ -38,9 +38,21 @@ final class CheckoutGroupedSummaryBuilder {
    */
   public function build(OrderInterface $order): array {
     $line_buckets = [];
+    $donationTotals = [];
     $cacheTags = $order->getCacheTags();
 
     foreach ($order->getItems() as $item) {
+      if ($this->isDonationItem($item)) {
+        $donationPrice = $item->getTotalPrice();
+        if ($donationPrice instanceof Price && !$donationPrice->isZero()) {
+          $currencyCode = $donationPrice->getCurrencyCode();
+          $donationTotals[$currencyCode] = isset($donationTotals[$currencyCode])
+            ? $donationTotals[$currencyCode]->add($donationPrice)
+            : $donationPrice;
+        }
+        continue;
+      }
+
       $event_id = $this->resolveEventId($item);
       $purchased = $item->getPurchasedEntity();
       $line_key = $purchased ? 'p:' . $purchased->id() : 'i:' . $item->id();
@@ -65,6 +77,14 @@ final class CheckoutGroupedSummaryBuilder {
           ? $current->add($line_price)
           : $line_price;
       }
+    }
+
+    $donationFormatted = '';
+    if ($donationTotals !== []) {
+      $donationFormatted = implode(' + ', array_map(
+        fn (Price $price): string => $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode()),
+        array_values($donationTotals)
+      ));
     }
 
     $events_map = [];
@@ -137,12 +157,17 @@ final class CheckoutGroupedSummaryBuilder {
       'grouped_items' => $grouped_items,
       'order_total' => $order_total,
       'subtotal_formatted' => $breakdown['subtotal_formatted'],
+      'optional_donation_formatted' => $donationFormatted,
       'tax_rows' => $breakdown['tax_rows'],
       'fee_rows' => $breakdown['fee_rows'],
       'platform_fee_absorbed' => $breakdown['platform_fee_absorbed'],
       'show_includes_gst_note' => $breakdown['show_includes_gst_note'],
       'cache_tags' => $cacheTags,
     ];
+  }
+
+  private function isDonationItem(OrderItemInterface $item): bool {
+    return in_array($item->bundle(), ['checkout_donation', 'platform_donation', 'rsvp_donation'], TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutUxAttacher.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutUxAttacher.php
@@ -81,6 +81,7 @@ final class CheckoutUxAttacher {
       '#grouped_items' => $built['grouped_items'],
       '#order_total' => $built['order_total'],
       '#subtotal_formatted' => $built['subtotal_formatted'],
+      '#optional_donation_formatted' => $built['optional_donation_formatted'],
       '#tax_rows' => $built['tax_rows'],
       '#fee_rows' => $built['fee_rows'],
       '#platform_fee_absorbed' => $built['platform_fee_absorbed'],

--- a/web/themes/custom/myeventlane_theme/js/mel-confirmation-share.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-confirmation-share.js
@@ -21,6 +21,28 @@
           }
         });
       });
+
+      once('mel-share-native', '.mel-share-native', context).forEach((btn) => {
+        if (!navigator.share) {
+          btn.hidden = true;
+          return;
+        }
+
+        btn.addEventListener('click', () => {
+          const url = btn.dataset.url || '';
+          if (!url) {
+            return;
+          }
+
+          navigator.share({
+            title: btn.dataset.title || document.title,
+            text: btn.dataset.text || '',
+            url,
+          }).catch(() => {
+            // User cancelled or platform refused; visible fallback links remain.
+          });
+        });
+      });
     },
   };
 })(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -102,6 +102,7 @@ function myeventlane_theme_theme(array $existing, string $type, string $theme, s
         'grouped_items' => [],
         'order_total' => '',
         'subtotal_formatted' => '',
+        'optional_donation_formatted' => '',
         'tax_rows' => [],
         'fee_rows' => [],
         'platform_fee_absorbed' => FALSE,
@@ -592,14 +593,14 @@ function myeventlane_theme_preprocess_commerce_checkout_form(array &$variables):
       if (isset($form['actions']['next']) && $total_price !== NULL) {
         if ($total_price->isZero()) {
           if (_myeventlane_theme_order_is_natural_zero_price_rsvp($order_param)) {
-            $form['actions']['next']['#value'] = t('Confirm RSVP');
+            $form['actions']['next']['#value'] = t('Reserve your spot');
           }
           else {
-            $form['actions']['next']['#value'] = t('Complete order');
+            $form['actions']['next']['#value'] = t('Complete booking');
           }
         }
         else {
-          $form['actions']['next']['#value'] = t('Pay now');
+          $form['actions']['next']['#value'] = t('Complete booking');
         }
       }
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -1055,6 +1055,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
 /* SUMMARY PANEL — Premium companion card */
 .mel-checkout__summary,
+.mel-checkout-summary,
 .mel-checkout__aside.mel-checkout__summary {
   position: sticky;
   top: 100px;
@@ -1107,6 +1108,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: spacing.mel-space(2);
   font-size: typography.mel-font-size(sm);
   margin-bottom: spacing.mel-space(1);
   padding: spacing.mel-space(1) 0;
@@ -1114,6 +1116,29 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   &:last-child {
     margin-bottom: 0;
   }
+}
+
+.mel-summary-item__label {
+  display: inline-flex;
+  min-width: 0;
+  gap: spacing.mel-space(1);
+}
+
+.mel-summary-item__quantity {
+  flex: 0 0 auto;
+  color: colors.$mel-color-text-muted;
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-summary-item__ticket-type {
+  min-width: 0;
+  color: colors.$mel-color-text;
+}
+
+.mel-summary-item__price {
+  flex: 0 0 auto;
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text;
 }
 
 .mel-summary-breakdown {
@@ -1143,6 +1168,43 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .mel-summary-row__value {
   font-weight: typography.$mel-font-medium;
   color: colors.$mel-color-text;
+}
+
+.mel-summary-row--donation {
+  color: colors.$mel-color-text;
+
+  .mel-summary-row__label::before {
+    content: '+ ';
+  }
+}
+
+.mel-checkout-summary__cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  margin-top: spacing.mel-space(3);
+  padding: spacing.mel-space(2) spacing.mel-space(3);
+  border-radius: radii.$mel-radius-full;
+  background: colors.$mel-color-primary;
+  color: #fff;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-bold;
+  text-decoration: none;
+  box-shadow: 0 8px 18px rgba(colors.$mel-color-primary, 0.22);
+  transition: background $mel-checkout-transition, box-shadow $mel-checkout-transition, transform $mel-checkout-transition;
+
+  &:hover {
+    background: color.adjust(colors.$mel-color-primary, $lightness: -5%);
+    color: #fff;
+    box-shadow: 0 10px 22px rgba(colors.$mel-color-primary, 0.28);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(colors.$mel-color-primary, 0.28);
+    outline-offset: 3px;
+  }
 }
 
 .mel-summary-grouped .mel-tax-note {
@@ -1460,6 +1522,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   }
 
   .mel-checkout__summary,
+  .mel-checkout-summary,
   .mel-checkout__aside.mel-checkout__summary {
     position: static;
     margin-top: 0;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_confirmation.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_confirmation.scss
@@ -129,6 +129,15 @@
   padding: spacing.mel-space(5);
 }
 
+.mel-confirmation-card__eyebrow {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-bold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: colors.$mel-color-primary;
+}
+
 .mel-confirmation-card__title {
   font-size: typography.mel-font-size(xl);
   font-weight: typography.$mel-font-bold;
@@ -324,6 +333,16 @@
   &:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px colors.$mel-color-primary;
+  }
+}
+
+.mel-calendar-btn--primary {
+  color: #fff;
+  background: colors.$mel-color-primary;
+
+  &:hover {
+    background: color.adjust(colors.$mel-color-primary, $lightness: -6%);
+    color: #fff;
   }
 }
 
@@ -538,7 +557,9 @@
   gap: spacing.mel-space(2);
 }
 
-.mel-share-copy {
+.mel-share-copy,
+.mel-share-native,
+.mel-share-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -546,6 +567,7 @@
   min-height: 44px;
   font-size: typography.mel-font-size(sm);
   font-weight: typography.$mel-font-medium;
+  text-decoration: none;
   background: colors.$mel-color-surface;
   color: colors.$mel-color-text;
   border: 2px solid colors.$mel-color-border;
@@ -568,6 +590,21 @@
     opacity: 0.8;
     cursor: default;
   }
+}
+
+.mel-share-native {
+  color: #fff;
+  background: colors.$mel-color-primary;
+  border-color: colors.$mel-color-primary;
+
+  &:hover {
+    background: color.adjust(colors.$mel-color-primary, $lightness: -6%);
+    color: #fff;
+  }
+}
+
+.mel-share-native[hidden] {
+  display: none;
 }
 
 .mel-share-view {

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -65,11 +65,7 @@
       {% if mel_donation_total_formatted %}
         <h1 class="mel-confirmation__title">{{ 'Thank you'|t }}</h1>
       {% elseif mel_confirmation_has_tickets %}
-        {% if mel_confirm_paid %}
-          <h1 class="mel-confirmation__title">{{ "You're booked"|t }}</h1>
-        {% else %}
-          <h1 class="mel-confirmation__title">{{ "You're registered"|t }}</h1>
-        {% endif %}
+        <h1 class="mel-confirmation__title">{{ "You're in! 🎉"|t }}</h1>
       {% else %}
         <h1 class="mel-confirmation__title">{{ 'Order confirmed'|t }}</h1>
       {% endif %}
@@ -106,7 +102,7 @@
   <div class="mel-confirmation__main">
     {% if events|length > 0 %}
       {% for event in events %}
-        <section class="mel-confirmation-card mel-confirmation__summary">
+        <section class="mel-confirmation-card mel-confirmation-card--event-summary mel-confirmation__summary" aria-labelledby="mel-confirmation-event-summary-{{ event.id() }}">
           {% set event_image_url = mel_event_image_urls[event.id()] ?? null %}
           {% if event_image_url %}
             <div class="mel-confirmation-card__media">
@@ -114,10 +110,11 @@
             </div>
           {% endif %}
           <div class="mel-confirmation-card__body">
+            <p class="mel-confirmation-card__eyebrow">{{ 'Event summary'|t }}</p>
             {% if event.hasField('field_event_start') and not event.get('field_event_start').isEmpty() %}
               <span class="mel-confirmation-card__date-badge">{{ event.get('field_event_start').value|date('M j, Y') }}</span>
             {% endif %}
-            <h2 class="mel-confirmation-card__title">{{ event.label() }}</h2>
+            <h2 id="mel-confirmation-event-summary-{{ event.id() }}" class="mel-confirmation-card__title">{{ event.label() }}</h2>
             <div class="mel-confirmation-card__meta">
               {% if event.hasField('field_event_start') and not event.get('field_event_start').isEmpty() %}
                 <span class="mel-confirmation-card__date">
@@ -318,7 +315,7 @@
           <p class="mel-calendar-prompt">{{ 'Don\'t forget to save the date'|t }}</p>
           <div class="mel-calendar-actions">
             {% if mel_calendar_links.apple is defined and mel_calendar_links.apple %}
-              <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Apple Calendar'|t }}</a>
+              <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn mel-calendar-btn--primary" target="_blank" rel="noopener noreferrer">{{ 'Add to calendar'|t }}</a>
             {% endif %}
             {% if mel_calendar_links.google is defined and mel_calendar_links.google %}
               <a href="{{ mel_calendar_links.google }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Google Calendar'|t }}</a>
@@ -339,11 +336,17 @@
       {% endif %}
 
       {% if mel_event_url %}
+        {% set mel_share_title = events|length > 0 ? events[0].label() : 'MyEventLane event'|t %}
+        {% set mel_share_copy = 'I’m going to @event on MyEventLane.'|t({'@event': mel_share_title}) %}
         <p class="mel-share-prompt">{{ 'Going with friends? Share this event'|t }}</p>
         <section class="mel-confirmation-share">
           <h3 class="mel-confirmation-share__title">{{ 'Share this event'|t }}</h3>
           <div class="mel-share-actions">
             <button type="button" class="mel-share-copy" data-url="{{ mel_event_url }}">{{ 'Copy event link'|t }}</button>
+            <button type="button" class="mel-share-native" data-url="{{ mel_event_url }}" data-title="{{ mel_share_title }}" data-text="{{ mel_share_copy }}">{{ 'Share'|t }}</button>
+            <a href="https://www.facebook.com/sharer/sharer.php?u={{ mel_event_url|url_encode }}" class="mel-share-link" target="_blank" rel="noopener noreferrer">{{ 'Facebook'|t }}</a>
+            <a href="https://twitter.com/intent/tweet?url={{ mel_event_url|url_encode }}&text={{ mel_share_copy|url_encode }}" class="mel-share-link" target="_blank" rel="noopener noreferrer">{{ 'X'|t }}</a>
+            <a href="mailto:?subject={{ mel_share_title|url_encode }}&body={{ mel_share_copy|url_encode }}%0A%0A{{ mel_event_url|url_encode }}" class="mel-share-link">{{ 'Email'|t }}</a>
             <a href="{{ mel_event_url }}" class="mel-share-view">{{ 'View event page'|t }}</a>
           </div>
         </section>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -133,7 +133,7 @@
         {% endif %}
 
         {% if form.actions %}
-          <div class="mel-checkout-section mel-checkout-section--cta">
+          <div id="mel-checkout-cta" class="mel-checkout-section mel-checkout-section--cta">
             <div class="mel-checkout-cta">
               {# Total is form.actions.mel_cta_total (form_alter) so it rebuilds with AJAX next to submit. #}
               {{ form.actions }}
@@ -156,7 +156,7 @@
       {% if form.sidebar is defined %}
         {% set sidebar_content = form.sidebar|render %}
         {% if (mel_contextual_help_checkout is defined and mel_contextual_help_checkout) or (sidebar_content|striptags|trim is not empty) or (mel_support_panel is defined and mel_support_panel) %}
-          <aside class="mel-checkout__summary" aria-label="{{ 'Order summary'|t }}">
+          <aside class="mel-checkout__summary mel-checkout-summary" aria-label="{{ 'Order summary'|t }}">
             <div class="mel-checkout__summary-inner">
               <h2 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h2>
               {% if mel_contextual_help_checkout is defined and mel_contextual_help_checkout %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -145,7 +145,7 @@
         {% endif %}
 
         {% if form.actions %}
-          <div class="mel-checkout-section mel-checkout-section--cta">
+          <div id="mel-checkout-cta" class="mel-checkout-section mel-checkout-section--cta">
             <div class="mel-checkout-cta">
               {# Total is form.actions.mel_cta_total (form_alter) so it rebuilds with AJAX next to submit. #}
               {{ form.actions }}
@@ -168,7 +168,7 @@
       {% if form.sidebar is defined %}
         {% set sidebar_content = form.sidebar|render %}
         {% if (mel_contextual_help_checkout is defined and mel_contextual_help_checkout) or (sidebar_content|striptags|trim is not empty) or (mel_support_panel is defined and mel_support_panel) %}
-          <aside class="mel-checkout__summary" aria-label="{{ 'Order summary'|t }}">
+          <aside class="mel-checkout__summary mel-checkout-summary" aria-label="{{ 'Order summary'|t }}">
             <div class="mel-checkout__summary-inner">
               <h2 id="mel-checkout-summary-heading" class="mel-checkout__summary-title">{{ 'Your order'|t }}</h2>
               {% if mel_contextual_help_checkout is defined and mel_contextual_help_checkout %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
@@ -24,7 +24,10 @@
 
       {% for item in event.items %}
         <div class="mel-summary-item">
-          <span class="mel-summary-item__label">{{ item.quantity }} × {{ item.ticket_type }}</span>
+          <span class="mel-summary-item__label">
+            <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
+            <span class="mel-summary-item__ticket-type">{{ item.ticket_type }}</span>
+          </span>
           <span class="mel-summary-item__price">{{ item.total_price }}</span>
         </div>
       {% endfor %}
@@ -36,6 +39,13 @@
       <div class="mel-summary-row mel-summary-row--subtotal">
         <span class="mel-summary-row__label">{{ 'Subtotal'|t }}</span>
         <span class="mel-summary-row__value">{{ subtotal_formatted }}</span>
+      </div>
+    {% endif %}
+
+    {% if optional_donation_formatted|default('') %}
+      <div class="mel-summary-row mel-summary-row--donation">
+        <span class="mel-summary-row__label">{{ 'Optional donation'|t }}</span>
+        <span class="mel-summary-row__value">{{ optional_donation_formatted }}</span>
       </div>
     {% endif %}
 
@@ -69,5 +79,7 @@
   {% if show_includes_gst_note %}
     <p class="mel-tax-note">{{ 'All prices include GST'|t }}</p>
   {% endif %}
+
+  <a class="mel-checkout-summary__cta" href="#mel-checkout-cta">{{ 'Continue to checkout'|t }}</a>
 </div>
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches checkout/confirmation presentation and adds donation-specific aggregation logic, which could affect what totals/lines users see during purchase. No payment processing or persistence logic is changed, but regressions would impact conversion/clarity.
> 
> **Overview**
> Adds explicit handling for donation line items in the grouped checkout sidebar: donation order items are excluded from ticket grouping, summed per currency, and rendered as a new **“Optional donation”** row via `optional_donation_formatted` passed through the theme hook and attacher.
> 
> Updates checkout and confirmation UX copy and layout: checkout CTAs are renamed (e.g. “Complete booking”, “Reserve your spot”), the sidebar summary gains a sticky style tweak plus a “Continue to checkout” anchor link to the main CTA, and the confirmation page adds richer event/share UI (native share button with JS fallback + Facebook/X/Email links, plus minor calendar/heading styling/accessibility tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4350ae75c628ef4f96a112284e4907852a13834f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->