### PR TITLE
feat(event-studio): refine MEL builder workspace UX

### DIFF
--- a/config/sync/field.storage.paragraph.field_highlight_icon.yml
+++ b/config/sync/field.storage.paragraph.field_highlight_icon.yml
@@ -13,34 +13,22 @@ settings:
   allowed_values:
     -
       value: music
-      label: '🎵 Music'
+      label: Music
+    -
+      value: star
+      label: Star
+    -
+      value: clock
+      label: Clock
     -
       value: food
-      label: '🍔 Food & drinks'
+      label: Food
     -
-      value: party
-      label: '🪩 Party / DJ'
+      value: info
+      label: Info
     -
-      value: network
-      label: '🤝 Networking'
-    -
-      value: art
-      label: '🎨 Arts'
-    -
-      value: outdoor
-      label: '🌿 Outdoor'
-    -
-      value: family
-      label: '👨‍👩‍👧 Family friendly'
-    -
-      value: lgbtq
-      label: '🏳️‍🌈 LGBTQ+'
-    -
-      value: wellness
-      label: '🧘 Wellness'
-    -
-      value: education
-      label: '📚 Workshop / learning'
+      value: access
+      label: Accessibility
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.info.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.info.yml
@@ -17,3 +17,4 @@ dependencies:
   - drupal:commerce_payment
   - drupal:commerce_price
   - drupal:node
+  - commerce_stripe:commerce_stripe

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
@@ -13,6 +13,7 @@
 
 declare(strict_types=1);
 
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
@@ -43,6 +44,219 @@ function myeventlane_checkout_flow_form_commerce_checkout_flow_mel_event_checkou
   /** @var \Drupal\myeventlane_checkout_flow\Service\CheckoutUxAttacher $attacher */
   $attacher = \Drupal::service('myeventlane_checkout_flow.checkout_ux_attacher');
   $attacher->attach($form);
+
+  myeventlane_checkout_flow_attach_fast_checkout($form, $form_state);
+}
+
+/**
+ * Adds the eligibility-gated fast checkout section to the checkout form.
+ */
+function myeventlane_checkout_flow_attach_fast_checkout(array &$form, FormStateInterface $form_state): void {
+  $order = myeventlane_checkout_flow_resolve_checkout_order();
+  if (!$order instanceof OrderInterface) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_checkout_flow\Service\FastCheckoutEligibility $eligibility */
+  $eligibility = \Drupal::service('myeventlane_checkout_flow.fast_checkout_eligibility');
+  $gateway = $eligibility->getStripeGateway($order);
+  if (!$gateway || !$eligibility->isFastCheckoutEligible($order, $gateway)) {
+    return;
+  }
+
+  $requires_minimal_data = $eligibility->requiresMinimalData($order);
+  $has_minimal_data = $eligibility->hasConfirmedMinimalData($order);
+
+  $form['mel_fast_checkout'] = [
+    '#type' => 'container',
+    '#weight' => -100,
+    '#attributes' => [
+      'class' => ['mel-fast-checkout'],
+      'aria-labelledby' => 'mel-fast-checkout-title',
+    ],
+    'header' => [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-fast-checkout__header']],
+      'title' => [
+        '#markup' => '<h2 id="mel-fast-checkout-title" class="mel-fast-checkout__title">' . t('Express checkout') . '</h2>',
+      ],
+      'intro' => [
+        '#markup' => '<p class="mel-fast-checkout__intro">' . t('Use Stripe Link, Apple Pay, or Google Pay when available for this device.') . '</p>',
+      ],
+    ],
+  ];
+
+  if ($requires_minimal_data && !$has_minimal_data) {
+    myeventlane_checkout_flow_add_fast_checkout_details_form($form, $order);
+    return;
+  }
+
+  /** @var \Drupal\commerce_stripe\ExpressCheckoutButtonsBuilderInterface $button_builder */
+  $button_builder = \Drupal::service('commerce_stripe.express_checkout_buttons_builder');
+  $buttons = $button_builder->build($order, $gateway);
+  myeventlane_checkout_flow_limit_express_payment_methods($buttons);
+
+  $form['mel_fast_checkout']['wallets'] = [
+    '#type' => 'container',
+    '#attributes' => ['class' => ['mel-fast-checkout__wallets']],
+    'buttons' => $buttons,
+  ];
+  $form['mel_fast_checkout']['fallback'] = [
+    '#markup' => '<p class="mel-fast-checkout__fallback">' . t('Or continue with details') . '</p>',
+  ];
+}
+
+/**
+ * Adds the lightweight details form needed before some express checkouts.
+ */
+function myeventlane_checkout_flow_add_fast_checkout_details_form(array &$form, OrderInterface $order): void {
+  $defaults = myeventlane_checkout_flow_get_fast_checkout_detail_defaults($order);
+
+  $form['mel_fast_checkout']['details'] = [
+    '#type' => 'container',
+    '#tree' => TRUE,
+    '#attributes' => ['class' => ['mel-fast-checkout__details']],
+    'help' => [
+      '#markup' => '<p class="mel-fast-checkout__details-help">' . t('This event only needs basic attendee details before express checkout.') . '</p>',
+    ],
+    'name' => [
+      '#type' => 'textfield',
+      '#title' => t('Name'),
+      '#required' => TRUE,
+      '#default_value' => $defaults['name'],
+      '#attributes' => [
+        'autocomplete' => 'name',
+        'class' => ['mel-fast-checkout__field'],
+      ],
+    ],
+    'email' => [
+      '#type' => 'email',
+      '#title' => t('Email'),
+      '#required' => TRUE,
+      '#default_value' => $defaults['email'],
+      '#attributes' => [
+        'autocomplete' => 'email',
+        'class' => ['mel-fast-checkout__field'],
+      ],
+    ],
+    'actions' => [
+      '#type' => 'actions',
+      'save' => [
+        '#type' => 'submit',
+        '#value' => t('Continue with express checkout'),
+        '#button_type' => 'primary',
+        '#limit_validation_errors' => [['mel_fast_checkout', 'details']],
+        '#validate' => ['myeventlane_checkout_flow_fast_checkout_details_validate'],
+        '#submit' => ['myeventlane_checkout_flow_fast_checkout_details_submit'],
+        '#attributes' => ['class' => ['mel-fast-checkout__details-submit']],
+      ],
+    ],
+  ];
+  $form['mel_fast_checkout']['fallback'] = [
+    '#markup' => '<p class="mel-fast-checkout__fallback">' . t('Or continue with details') . '</p>',
+  ];
+}
+
+/**
+ * Validates the lightweight fast checkout details form.
+ */
+function myeventlane_checkout_flow_fast_checkout_details_validate(array &$form, FormStateInterface $form_state): void {
+  $details = $form_state->getValue(['mel_fast_checkout', 'details']) ?? [];
+  $name = trim((string) ($details['name'] ?? ''));
+  $email = trim((string) ($details['email'] ?? ''));
+
+  if ($name === '') {
+    $form_state->setErrorByName('mel_fast_checkout][details][name', t('Name is required.'));
+  }
+  if ($email === '') {
+    $form_state->setErrorByName('mel_fast_checkout][details][email', t('Email is required.'));
+  }
+  elseif (!\Drupal::service('email.validator')->isValid($email)) {
+    $form_state->setErrorByName('mel_fast_checkout][details][email', t('Please enter a valid email address.'));
+  }
+}
+
+/**
+ * Saves lightweight fast checkout details and rebuilds the form.
+ */
+function myeventlane_checkout_flow_fast_checkout_details_submit(array &$form, FormStateInterface $form_state): void {
+  $order = myeventlane_checkout_flow_resolve_checkout_order();
+  if (!$order instanceof OrderInterface) {
+    \Drupal::logger('myeventlane_checkout_flow')->error('Fast checkout details could not be saved because the checkout order was missing.');
+    $form_state->setRebuild(TRUE);
+    return;
+  }
+
+  $details = $form_state->getValue(['mel_fast_checkout', 'details']) ?? [];
+  /** @var \Drupal\myeventlane_checkout_flow\Service\FastCheckoutEligibility $eligibility */
+  $eligibility = \Drupal::service('myeventlane_checkout_flow.fast_checkout_eligibility');
+  $eligibility->saveMinimalData(
+    $order,
+    (string) ($details['name'] ?? ''),
+    (string) ($details['email'] ?? '')
+  );
+
+  $form_state->setRebuild(TRUE);
+}
+
+/**
+ * Resolves the Commerce order from the checkout route.
+ */
+function myeventlane_checkout_flow_resolve_checkout_order(): ?OrderInterface {
+  $order = \Drupal::routeMatch()->getParameter('commerce_order');
+  if (is_numeric($order)) {
+    $loaded = \Drupal::entityTypeManager()->getStorage('commerce_order')->load((int) $order);
+    return $loaded instanceof OrderInterface ? $loaded : NULL;
+  }
+  return $order instanceof OrderInterface ? $order : NULL;
+}
+
+/**
+ * Gets default values for the lightweight details form.
+ *
+ * @return array{name: string, email: string}
+ *   Default name and email values.
+ */
+function myeventlane_checkout_flow_get_fast_checkout_detail_defaults(OrderInterface $order): array {
+  $email = trim((string) $order->getEmail());
+  $name = '';
+
+  $billing_profile = $order->getBillingProfile();
+  if ($billing_profile) {
+    $address = $billing_profile->get('address')->first();
+    if ($address) {
+      $parts = array_filter([
+        trim((string) $address->getGivenName()),
+        trim((string) $address->getFamilyName()),
+      ]);
+      $name = trim(implode(' ', $parts));
+    }
+  }
+
+  return [
+    'name' => $name,
+    'email' => $email,
+  ];
+}
+
+/**
+ * Limits the fast checkout surface to Stripe Link, Apple Pay, and Google Pay.
+ */
+function myeventlane_checkout_flow_limit_express_payment_methods(array &$buttons): void {
+  if (!isset($buttons['#attached']['drupalSettings']['commerceStripeExpressCheckoutElement'])) {
+    return;
+  }
+
+  $settings = &$buttons['#attached']['drupalSettings']['commerceStripeExpressCheckoutElement'];
+  $settings['expressCheckoutOptions']['paymentMethodOrder'] = ['link', 'applePay', 'googlePay'];
+  $settings['expressCheckoutOptions']['paymentMethods'] = [
+    'link' => 'auto',
+    'applePay' => 'auto',
+    'googlePay' => 'auto',
+    'paypal' => 'never',
+    'amazonPay' => 'never',
+    'klarna' => 'never',
+  ];
 }
 
 /**

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
@@ -45,6 +45,18 @@ services:
     class: Drupal\myeventlane_checkout_flow\Service\VendorOwnershipResolver
     arguments: ['@entity_type.manager']
 
+  myeventlane_checkout_flow.fast_checkout_eligibility:
+    class: Drupal\myeventlane_checkout_flow\Service\FastCheckoutEligibility
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.ticket_availability'
+      - '@logger.channel.myeventlane_checkout_flow'
+
+  myeventlane_checkout_flow.fast_checkout_access_check:
+    class: Drupal\myeventlane_checkout_flow\Access\FastCheckoutAccessCheck
+    arguments:
+      - '@myeventlane_checkout_flow.fast_checkout_eligibility'
+
   myeventlane_checkout_flow.my_tickets_order_access:
     class: Drupal\myeventlane_checkout_flow\Access\MyTicketsOrderAccess
     arguments: ['@entity_type.manager']
@@ -60,6 +72,11 @@ services:
       - '@config.factory'
       - '@current_route_match'
       - '@logger.channel.myeventlane_checkout_flow'
+    tags:
+      - { name: event_subscriber }
+
+  myeventlane_checkout_flow.fast_checkout_route_subscriber:
+    class: Drupal\myeventlane_checkout_flow\EventSubscriber\FastCheckoutRouteSubscriber
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Access/FastCheckoutAccessCheck.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Access/FastCheckoutAccessCheck.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_checkout_flow\Access;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\myeventlane_checkout_flow\Service\FastCheckoutEligibility;
+
+/**
+ * Protects Stripe express checkout confirmation for MEL ticket orders.
+ */
+final class FastCheckoutAccessCheck {
+
+  public function __construct(
+    private readonly FastCheckoutEligibility $eligibility,
+  ) {}
+
+  /**
+   * Checks access to the Commerce Stripe express confirmation route.
+   */
+  public function access(PaymentGatewayInterface $commerce_payment_gateway, OrderInterface $commerce_order): AccessResultInterface {
+    if (!$this->eligibility->hasTicketSelection($commerce_order)) {
+      return AccessResult::allowed()->addCacheableDependency($commerce_order);
+    }
+
+    $allowed = $this->eligibility->canConfirmFastCheckout($commerce_order, $commerce_payment_gateway);
+    return AccessResult::allowedIf($allowed)
+      ->addCacheableDependency($commerce_order)
+      ->addCacheableDependency($commerce_payment_gateway);
+  }
+
+}

--- a/web/modules/custom/myeventlane_checkout_flow/src/EventSubscriber/FastCheckoutRouteSubscriber.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/EventSubscriber/FastCheckoutRouteSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_checkout_flow\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Adds MEL fast checkout access checks to Stripe express confirmation.
+ */
+final class FastCheckoutRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    $route = $collection->get('commerce_stripe.express_checkout.payment_confirm');
+    if ($route === NULL) {
+      return;
+    }
+
+    $route->setRequirement('_custom_access', 'myeventlane_checkout_flow.fast_checkout_access_check::access');
+  }
+
+}

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/BuyerDetailsPane.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/BuyerDetailsPane.php
@@ -44,6 +44,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
   public function buildPaneForm(array $pane_form, FormStateInterface $form_state, array &$complete_form): array {
     $order = $this->order;
     $customer = $order->getCustomer();
+    $pane_form['#attributes']['class'][] = 'mel-contact-details-pane';
 
     // Load or create billing profile.
     $billing_profile = $order->getBillingProfile();
@@ -62,7 +63,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
       '#default_value' => $customer->getEmail() ?: $billing_profile->get('address')->first()?->get('email')?->value ?? '',
       '#attributes' => [
         'autocomplete' => 'email',
-        'class' => ['mel-buyer-email'],
+        'class' => ['mel-buyer-email', 'mel-contact-field'],
       ],
     ];
 
@@ -73,7 +74,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
       '#default_value' => $billing_profile->get('address')->first()?->get('given_name')?->value ?? '',
       '#attributes' => [
         'autocomplete' => 'given-name',
-        'class' => ['mel-buyer-first-name'],
+        'class' => ['mel-buyer-first-name', 'mel-contact-field'],
       ],
     ];
 
@@ -84,7 +85,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
       '#default_value' => $billing_profile->get('address')->first()?->get('family_name')?->value ?? '',
       '#attributes' => [
         'autocomplete' => 'family-name',
-        'class' => ['mel-buyer-last-name'],
+        'class' => ['mel-buyer-last-name', 'mel-contact-field'],
       ],
     ];
 
@@ -98,7 +99,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
       '#default_value' => $mobile_default,
       '#attributes' => [
         'autocomplete' => 'tel',
-        'class' => ['mel-buyer-mobile'],
+        'class' => ['mel-buyer-mobile', 'mel-contact-field'],
       ],
     ];
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/FastCheckoutEligibility.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/FastCheckoutEligibility.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_checkout_flow\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\StripePaymentElementInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\profile\Entity\ProfileInterface;
+
+/**
+ * Determines whether a MEL checkout order can use Stripe express checkout.
+ */
+final class FastCheckoutEligibility {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly TicketAvailabilityService $ticketAvailability,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Returns TRUE only when the order can use the fast checkout layer.
+   */
+  public function isFastCheckoutEligible(OrderInterface $order, ?PaymentGatewayInterface $gateway = NULL): bool {
+    if (!$this->hasTicketSelection($order)) {
+      return FALSE;
+    }
+
+    $total = $order->getTotalPrice();
+    if ($total === NULL || !$total->isPositive()) {
+      return FALSE;
+    }
+
+    if ($gateway !== NULL) {
+      if (!$this->isUsableStripeGateway($order, $gateway)) {
+        return FALSE;
+      }
+    }
+    elseif (!$this->getStripeGateway($order) instanceof PaymentGatewayInterface) {
+      return FALSE;
+    }
+
+    return $this->attendeeQuestionsAreFastCheckoutCompatible($order);
+  }
+
+  /**
+   * Returns TRUE when the order contains MEL ticket line items.
+   */
+  public function hasTicketSelection(OrderInterface $order): bool {
+    foreach ($order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item)) {
+        continue;
+      }
+      if ((int) $order_item->getQuantity() > 0) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Returns TRUE when basic name/email data must be confirmed before payment.
+   */
+  public function requiresMinimalData(OrderInterface $order): bool {
+    foreach ($this->getQuestionTemplates($order) as $question) {
+      if ($this->classifyBasicQuestion($question) !== NULL) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Returns TRUE when the lightweight details step has already populated data.
+   */
+  public function hasConfirmedMinimalData(OrderInterface $order): bool {
+    if (!$this->requiresMinimalData($order)) {
+      return TRUE;
+    }
+
+    return (bool) $order->getData('mel_fast_checkout_minimal_data_confirmed', FALSE)
+      && trim((string) $order->getEmail()) !== '';
+  }
+
+  /**
+   * Returns TRUE when the order may proceed through express confirmation.
+   */
+  public function canConfirmFastCheckout(OrderInterface $order, PaymentGatewayInterface $gateway): bool {
+    return $this->isFastCheckoutEligible($order, $gateway)
+      && $this->hasConfirmedMinimalData($order);
+  }
+
+  /**
+   * Finds the Stripe Payment Element gateway available for this order.
+   */
+  public function getStripeGateway(OrderInterface $order): ?PaymentGatewayInterface {
+    $storage = $this->entityTypeManager->getStorage('commerce_payment_gateway');
+    if (!method_exists($storage, 'loadMultipleForOrder')) {
+      $this->logger->error('Fast checkout could not load payment gateways for order @order_id because the gateway storage does not support loadMultipleForOrder().', [
+        '@order_id' => (string) $order->id(),
+      ]);
+      return NULL;
+    }
+
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface[] $gateways */
+    $gateways = $storage->loadMultipleForOrder($order);
+    foreach ($gateways as $gateway) {
+      if ($this->isUsableStripeGateway($order, $gateway)) {
+        return $gateway;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Saves lightweight name/email data for fast checkout.
+   */
+  public function saveMinimalData(OrderInterface $order, string $name, string $email): void {
+    $name = trim($name);
+    $email = trim($email);
+    [$first_name, $last_name] = $this->splitName($name);
+
+    $order->setEmail($email);
+    $this->saveBillingProfile($order, $first_name, $last_name);
+    $this->saveTicketHolderParagraphs($order, $name, $first_name, $last_name, $email);
+    $order->setData('mel_fast_checkout_minimal_data_confirmed', TRUE);
+    $order->save();
+  }
+
+  /**
+   * Checks whether this gateway can create Stripe Payment Element intents.
+   */
+  private function isUsableStripeGateway(OrderInterface $order, PaymentGatewayInterface $gateway): bool {
+    if (!$gateway->status()) {
+      return FALSE;
+    }
+    if (!$gateway->applies($order)) {
+      return FALSE;
+    }
+    return $gateway->getPlugin() instanceof StripePaymentElementInterface;
+  }
+
+  /**
+   * Ensures the order has no custom attendee questions beyond name/email.
+   */
+  private function attendeeQuestionsAreFastCheckoutCompatible(OrderInterface $order): bool {
+    foreach ($this->getQuestionTemplates($order) as $question) {
+      if ($this->classifyBasicQuestion($question) === NULL) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * Gets all merged question templates attached to the order's ticket items.
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   *   Attendee question template paragraphs.
+   */
+  private function getQuestionTemplates(OrderInterface $order): array {
+    $templates = [];
+    $seen = [];
+
+    foreach ($order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item)) {
+        continue;
+      }
+
+      foreach ($this->getQuestionTemplatesForOrderItem($order_item) as $template) {
+        $key = $this->questionTemplateDedupeKey($template);
+        if (isset($seen[$key])) {
+          continue;
+        }
+        $seen[$key] = TRUE;
+        $templates[] = $template;
+      }
+    }
+
+    return $templates;
+  }
+
+  /**
+   * Gets event and ticket-tier question templates for one order item.
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   *   Attendee question template paragraphs.
+   */
+  private function getQuestionTemplatesForOrderItem(OrderItemInterface $order_item): array {
+    $event = $this->resolveEventForOrderItem($order_item);
+    if (!$event instanceof FieldableEntityInterface) {
+      return [];
+    }
+
+    $event_templates = [];
+    if ($event->hasField('field_attendee_questions') && !$event->get('field_attendee_questions')->isEmpty()) {
+      $event_templates = $event->get('field_attendee_questions')->referencedEntities();
+    }
+
+    $tier_templates = [];
+    $variation = $order_item->getPurchasedEntity();
+    if ($variation instanceof ProductVariationInterface && $event instanceof NodeInterface) {
+      $tier = $this->ticketAvailability->resolveTierForVariation($event, $variation);
+      if ($tier !== NULL
+        && $tier->hasField('field_use_ticket_attendee_questions')
+        && $tier->get('field_use_ticket_attendee_questions')->value
+        && $tier->hasField('field_attendee_questions')
+        && !$tier->get('field_attendee_questions')->isEmpty()) {
+        $tier_templates = $tier->get('field_attendee_questions')->referencedEntities();
+      }
+    }
+
+    return $this->mergeQuestionTemplates($event_templates, $tier_templates);
+  }
+
+  /**
+   * Resolves the event node for a ticket order item.
+   */
+  private function resolveEventForOrderItem(OrderItemInterface $order_item): ?FieldableEntityInterface {
+    if ($order_item->hasField('field_target_event') && !$order_item->get('field_target_event')->isEmpty()) {
+      $event = $order_item->get('field_target_event')->entity;
+      if ($event instanceof FieldableEntityInterface) {
+        return $event;
+      }
+    }
+
+    $purchased_entity = $order_item->getPurchasedEntity();
+    if ($purchased_entity instanceof FieldableEntityInterface
+      && $purchased_entity->hasField('field_event')
+      && !$purchased_entity->get('field_event')->isEmpty()
+      && $purchased_entity->get('field_event')->entity instanceof FieldableEntityInterface) {
+      return $purchased_entity->get('field_event')->entity;
+    }
+
+    if ($purchased_entity !== NULL && method_exists($purchased_entity, 'getProduct')) {
+      $product = $purchased_entity->getProduct();
+      if ($product instanceof FieldableEntityInterface
+        && $product->hasField('field_event')
+        && !$product->get('field_event')->isEmpty()
+        && $product->get('field_event')->entity instanceof FieldableEntityInterface) {
+        return $product->get('field_event')->entity;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Merges question templates while preserving event-before-tier order.
+   *
+   * @param \Drupal\paragraphs\ParagraphInterface[] $event_templates
+   *   Event-level question templates.
+   * @param \Drupal\paragraphs\ParagraphInterface[] $tier_templates
+   *   Ticket-tier question templates.
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   *   Merged question templates.
+   */
+  private function mergeQuestionTemplates(array $event_templates, array $tier_templates): array {
+    $merged = [];
+    $seen = [];
+
+    foreach ([$event_templates, $tier_templates] as $batch) {
+      foreach ($batch as $template) {
+        if (!$template instanceof ParagraphInterface) {
+          continue;
+        }
+        $key = $this->questionTemplateDedupeKey($template);
+        if (isset($seen[$key])) {
+          continue;
+        }
+        $seen[$key] = TRUE;
+        $merged[] = $template;
+      }
+    }
+
+    return $merged;
+  }
+
+  /**
+   * Returns a stable key for attendee question template de-duplication.
+   */
+  private function questionTemplateDedupeKey(ParagraphInterface $paragraph): string {
+    if ($paragraph->hasField('field_question_machine_name') && !$paragraph->get('field_question_machine_name')->isEmpty()) {
+      $machine_name = trim((string) ($paragraph->get('field_question_machine_name')->value ?? ''));
+      if ($machine_name !== '') {
+        return 'machine:' . mb_strtolower($machine_name);
+      }
+    }
+    if ($paragraph->hasField('field_question_label') && !$paragraph->get('field_question_label')->isEmpty()) {
+      $label = trim((string) ($paragraph->get('field_question_label')->value ?? ''));
+      if ($label !== '') {
+        return 'label:' . mb_strtolower($label);
+      }
+    }
+    return $paragraph->id() !== NULL ? 'id:' . (string) $paragraph->id() : 'tmp:' . spl_object_id($paragraph);
+  }
+
+  /**
+   * Classifies name/email-only attendee question templates.
+   */
+  private function classifyBasicQuestion(ParagraphInterface $question): ?string {
+    $machine_name = $question->hasField('field_question_machine_name')
+      ? mb_strtolower(trim((string) ($question->get('field_question_machine_name')->value ?? '')))
+      : '';
+    $label = $question->hasField('field_question_label')
+      ? mb_strtolower(trim((string) ($question->get('field_question_label')->value ?? '')))
+      : '';
+    $type = $question->hasField('field_question_type')
+      ? mb_strtolower(trim((string) ($question->get('field_question_type')->value ?? 'textfield')))
+      : 'textfield';
+
+    $key = $machine_name !== '' ? $machine_name : $label;
+    $key = str_replace(['-', ' '], '_', $key);
+
+    if (in_array($key, ['name', 'full_name', 'attendee_name', 'ticket_holder_name'], TRUE)
+      && in_array($type, ['textfield', 'text'], TRUE)) {
+      return 'name';
+    }
+
+    if (in_array($key, ['first_name', 'firstname', 'given_name'], TRUE)
+      && in_array($type, ['textfield', 'text'], TRUE)) {
+      return 'first_name';
+    }
+
+    if (in_array($key, ['last_name', 'lastname', 'family_name', 'surname'], TRUE)
+      && in_array($type, ['textfield', 'text'], TRUE)) {
+      return 'last_name';
+    }
+
+    if (in_array($key, ['email', 'email_address', 'attendee_email'], TRUE)
+      && in_array($type, ['email', 'textfield', 'text'], TRUE)) {
+      return 'email';
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Determines whether an order item should collect ticket holders.
+   */
+  private function shouldCollectTicketHolders(OrderItemInterface $order_item): bool {
+    if (!$order_item->hasField('field_ticket_holder')) {
+      return FALSE;
+    }
+
+    return !$this->isProSubscriptionOrderItem($order_item);
+  }
+
+  /**
+   * Detects Pro subscription line items that should not be treated as tickets.
+   */
+  private function isProSubscriptionOrderItem(OrderItemInterface $order_item): bool {
+    $purchased_entity = $order_item->getPurchasedEntity();
+    if ($purchased_entity === NULL) {
+      return FALSE;
+    }
+
+    if (method_exists($purchased_entity, 'bundle') && $purchased_entity->bundle() === 'mel_pro_subscription_variation') {
+      return TRUE;
+    }
+
+    if (method_exists($purchased_entity, 'getSku')) {
+      $sku = mb_strtolower(trim((string) $purchased_entity->getSku()));
+      if ($sku !== '' && str_starts_with($sku, 'mel-pro')) {
+        return TRUE;
+      }
+    }
+
+    if (method_exists($purchased_entity, 'getProduct')) {
+      $product = $purchased_entity->getProduct();
+      if ($product !== NULL && method_exists($product, 'bundle') && $product->bundle() === 'mel_pro_subscription_product') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Saves buyer details to the order billing profile.
+   */
+  private function saveBillingProfile(OrderInterface $order, string $first_name, string $last_name): void {
+    $billing_profile = $order->getBillingProfile();
+    if (!$billing_profile instanceof ProfileInterface) {
+      $billing_profile = $this->entityTypeManager->getStorage('profile')->create([
+        'type' => 'customer',
+        'uid' => $order->getCustomerId(),
+      ]);
+    }
+
+    $address = $billing_profile->get('address')->first();
+    if ($address === NULL) {
+      $address = $billing_profile->get('address')->appendItem();
+    }
+    $address->set('given_name', $first_name);
+    $address->set('family_name', $last_name);
+
+    $billing_profile->save();
+    $order->setBillingProfile($billing_profile);
+  }
+
+  /**
+   * Saves lightweight attendee holder paragraphs for each ticket quantity.
+   */
+  private function saveTicketHolderParagraphs(OrderInterface $order, string $name, string $first_name, string $last_name, string $email): void {
+    foreach ($order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item)) {
+        continue;
+      }
+
+      $templates = $this->getQuestionTemplatesForOrderItem($order_item);
+      $holders = [];
+      $quantity = (int) $order_item->getQuantity();
+      for ($delta = 0; $delta < $quantity; $delta++) {
+        $holders[] = $this->createMinimalHolder($templates, $name, $first_name, $last_name, $email);
+      }
+      $order_item->set('field_ticket_holder', $holders);
+      $order_item->save();
+    }
+  }
+
+  /**
+   * Creates an attendee holder paragraph from lightweight details.
+   *
+   * @param \Drupal\paragraphs\ParagraphInterface[] $templates
+   *   Basic name/email question templates.
+   */
+  private function createMinimalHolder(array $templates, string $name, string $first_name, string $last_name, string $email): ParagraphInterface {
+    $holder = Paragraph::create(['type' => 'attendee_answer']);
+    $holder->set('field_first_name', $first_name);
+    $holder->set('field_last_name', $last_name);
+    $holder->set('field_email', $email);
+    if ($holder->hasField('field_phone')) {
+      $holder->set('field_phone', '');
+    }
+
+    $question_answers = [];
+    foreach ($templates as $template) {
+      if (!$template instanceof ParagraphInterface) {
+        continue;
+      }
+      $answer_type = $this->classifyBasicQuestion($template);
+      if ($answer_type === NULL) {
+        continue;
+      }
+      $clone = $template->createDuplicate();
+      if ($clone->hasField('field_attendee_extra_field')) {
+        $clone->set('field_attendee_extra_field', match ($answer_type) {
+          'name' => $name,
+          'first_name' => $first_name,
+          'last_name' => $last_name,
+          'email' => $email,
+          default => '',
+        });
+      }
+      $clone->save();
+      $question_answers[] = $clone;
+    }
+
+    if ($holder->hasField('field_attendee_questions') && $question_answers !== []) {
+      $holder->set('field_attendee_questions', $question_answers);
+    }
+
+    $holder->save();
+    return $holder;
+  }
+
+  /**
+   * Splits a display name into first and last name storage values.
+   *
+   * @return array{0: string, 1: string}
+   *   First name and last name.
+   */
+  private function splitName(string $name): array {
+    $parts = preg_split('/\s+/', trim($name)) ?: [];
+    $first_name = array_shift($parts) ?: $name;
+    $last_name = trim(implode(' ', $parts));
+
+    return [$first_name, $last_name !== '' ? $last_name : $first_name];
+  }
+
+}

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
@@ -96,6 +96,16 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       return $pane_form;
     }
 
+    if (!$this->hasAnyQuestionTemplates()) {
+      $pane_form['#attributes']['class'][] = 'mel-attendee-details-pane';
+      $pane_form['#attributes']['class'][] = 'mel-attendee-details-pane--empty';
+      $pane_form['no_attendee_questions'] = [
+        '#type' => 'hidden',
+        '#value' => '1',
+      ];
+      return $pane_form;
+    }
+
     $attendee_details_enabled = $this->attendeeDetailsEnabled($form_state);
     $attendee_toggle_selector = ':input[name="' . $this->getPluginId() . '[add_attendee_details]"]';
 
@@ -103,16 +113,16 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-intro']],
       'title' => [
-        '#markup' => '<h2>' . $this->t('Attendee details') . '</h2>',
+        '#markup' => '<h3>' . $this->t('Attendee questions') . '</h3>',
       ],
       'desc' => [
-        '#markup' => '<p>' . $this->t('Your buyer name and email are enough to continue. You can add per-ticket attendee details now if you have them.') . '</p>',
+        '#markup' => '<p>' . $this->t('Add per-ticket details and answer organiser questions now if you have them.') . '</p>',
       ],
     ];
 
     $pane_form['add_attendee_details'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Add attendee details'),
+      '#title' => $this->t('Add ticket holder details and attendee questions'),
       '#default_value' => $attendee_details_enabled ? 1 : 0,
       '#attributes' => [
         'class' => ['mel-attendee-details-toggle'],
@@ -166,6 +176,13 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       '#type' => 'details',
       '#title' => $this->t('Attendee @num', ['@num' => $delta + 1]),
       '#open' => TRUE,
+      '#attributes' => [
+        'class' => ['mel-attendee-card'],
+      ],
+    ];
+
+    $fieldset['identity_heading'] = [
+      '#markup' => '<h5 class="mel-attendee-card__heading">' . $this->t('Ticket holder') . '</h5>',
     ];
 
     // Required fields: first_name, last_name, email.
@@ -174,30 +191,47 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       '#title' => $this->t('First name'),
       '#default_value' => $holder?->get('field_first_name')->value ?? '',
       '#required' => $attendeeDetailsEnabled,
+      '#attributes' => [
+        'class' => ['mel-attendee-identity-field'],
+      ],
     ];
     $fieldset['field_last_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Last name'),
       '#default_value' => $holder?->get('field_last_name')->value ?? '',
       '#required' => $attendeeDetailsEnabled,
+      '#attributes' => [
+        'class' => ['mel-attendee-identity-field'],
+      ],
     ];
     $fieldset['field_email'] = [
       '#type' => 'email',
       '#title' => $this->t('Email'),
       '#default_value' => $holder?->get('field_email')->value ?? '',
       '#required' => $attendeeDetailsEnabled,
+      '#attributes' => [
+        'class' => ['mel-attendee-identity-field'],
+      ],
     ];
     $fieldset['field_phone'] = [
       '#type' => 'tel',
       '#title' => $this->t('Phone number'),
       '#default_value' => $holder && $holder->hasField('field_phone') ? ($holder->get('field_phone')->value ?? '') : '',
       '#required' => $attendeeDetailsEnabled,
+      '#attributes' => [
+        'class' => ['mel-attendee-identity-field'],
+      ],
     ];
 
     // Dynamic extra questions derived from templates (or existing children).
     $question_sources = ($holder && $holder->hasField('field_attendee_questions') && !$holder->get('field_attendee_questions')->isEmpty())
       ? $holder->get('field_attendee_questions')->referencedEntities()
       : $templates;
+    if ($question_sources !== []) {
+      $fieldset['questions_heading'] = [
+        '#markup' => '<h5 class="mel-attendee-card__heading mel-attendee-card__heading--questions">' . $this->t('Attendee questions') . '</h5>',
+      ];
+    }
     foreach ($question_sources as $q_index => $question) {
       $label = $question->hasField('field_question_label')
         ? (string) ($question->get('field_question_label')->value ?? '')
@@ -236,6 +270,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#options' => ['' => $this->t('- Select -')] + ($options ?: ['_' => $this->t('No options')]),
             '#default_value' => $default,
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
 
@@ -245,6 +282,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#default_value' => (bool) $default,
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
 
@@ -262,6 +302,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $decoded,
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
 
@@ -273,6 +316,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $default,
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
 
@@ -283,6 +329,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#rows' => 3,
             '#default_value' => $default,
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
 
@@ -292,6 +341,9 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#default_value' => is_scalar($default) || $default === NULL ? (string) ($default ?? '') : '',
             '#required' => $attendeeDetailsEnabled && $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+            ],
           ];
           break;
       }
@@ -316,6 +368,10 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function validatePaneForm(array &$pane_form, FormStateInterface $form_state, array &$complete_form): void {
+    if (!$this->hasAnyQuestionTemplates()) {
+      return;
+    }
+
     if (!$this->attendeeDetailsEnabled($form_state)) {
       return;
     }
@@ -358,6 +414,11 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
    * {@inheritdoc}
    */
   public function submitPaneForm(array &$pane_form, FormStateInterface $form_state, array &$complete_form): void {
+    if (!$this->hasAnyQuestionTemplates()) {
+      $this->saveMinimalTicketHoldersFromBuyerDetails($form_state);
+      return;
+    }
+
     if (!$this->attendeeDetailsEnabled($form_state)) {
       return;
     }
@@ -648,6 +709,89 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Detects whether any ticket item has organiser/ticket-level questions.
+   */
+  private function hasAnyQuestionTemplates(): bool {
+    foreach ($this->order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item)) {
+        continue;
+      }
+      if ($this->getExtraQuestionTemplates($order_item) !== []) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Creates hidden minimal holder paragraphs from the checkout contact pane.
+   */
+  private function saveMinimalTicketHoldersFromBuyerDetails(FormStateInterface $form_state): void {
+    $buyer_values = $form_state->getValue('mel_buyer_details') ?? [];
+    if (!is_array($buyer_values)) {
+      $buyer_values = [];
+    }
+
+    $email = trim((string) ($buyer_values['email'] ?? $this->order->getEmail()));
+    $first_name = trim((string) ($buyer_values['first_name'] ?? ''));
+    $last_name = trim((string) ($buyer_values['last_name'] ?? ''));
+    $phone = trim((string) ($buyer_values['mobile'] ?? ''));
+
+    if (($first_name === '' || $last_name === '') && $this->order->getBillingProfile()) {
+      $address = $this->order->getBillingProfile()->get('address')->first();
+      if ($address) {
+        $first_name = $first_name !== '' ? $first_name : trim((string) $address->getGivenName());
+        $last_name = $last_name !== '' ? $last_name : trim((string) $address->getFamilyName());
+      }
+    }
+
+    if ($email === '' || $first_name === '' || $last_name === '') {
+      $this->logger->error(
+        'Unable to create minimal ticket holder data for order @order because buyer details were incomplete.',
+        ['@order' => (string) $this->order->id()]
+      );
+      return;
+    }
+
+    foreach ($this->order->getItems() as $order_item) {
+      if (!$this->shouldCollectTicketHolders($order_item)) {
+        continue;
+      }
+
+      $quantity = (int) $order_item->getQuantity();
+      if ($quantity < 1) {
+        continue;
+      }
+
+      $holders = $order_item->get('field_ticket_holder')->referencedEntities();
+      $updated_holders = [];
+      for ($delta = 0; $delta < $quantity; $delta++) {
+        $holder = $holders[$delta] ?? NULL;
+        if (!$holder instanceof ParagraphInterface) {
+          $holder = Paragraph::create(['type' => 'attendee_answer']);
+        }
+
+        $holder->set('field_first_name', $first_name);
+        $holder->set('field_last_name', $last_name);
+        $holder->set('field_email', $email);
+        if ($holder->hasField('field_phone')) {
+          $holder->set('field_phone', $phone);
+        }
+        $holder->save();
+        $updated_holders[] = $holder;
+      }
+
+      $order_item->set('field_ticket_holder', $updated_holders);
+      $order_item->save();
+      $this->logger->info('Saved @count minimal ticket holder(s) for order item @id.', [
+        '@count' => count($updated_holders),
+        '@id' => $order_item->id(),
+      ]);
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -166,6 +166,7 @@ final class TicketSelectionForm extends FormBase {
     $published_variations = $this->ticketAvailability->filterPurchasableVariations($node, $product);
     $default_tier = $this->ticketTypeManager->getDefaultTicket($node);
     $default_variation_id = $this->resolveDefaultVariationId($default_tier);
+    $best_value_variation_id = $this->resolveBestValueVariationId($node);
     if ($default_variation_id !== NULL) {
       $published_variations = $this->sortVariationsDefaultFirst($published_variations, $default_variation_id);
     }
@@ -267,6 +268,9 @@ final class TicketSelectionForm extends FormBase {
         if ($default_variation_id !== NULL && (int) $variation_id === $default_variation_id) {
           $row_classes[] = 'mel-ticket-row--recommended';
         }
+        if ($best_value_variation_id !== NULL && (int) $variation_id === $best_value_variation_id) {
+          $row_classes[] = 'mel-ticket-row--best-value';
+        }
 
         $label_cell = [
           '#type' => 'container',
@@ -278,6 +282,15 @@ final class TicketSelectionForm extends FormBase {
             '#attributes' => ['class' => ['mel-ticket-label']],
           ],
         ];
+        if ($best_value_variation_id !== NULL && (int) $variation_id === $best_value_variation_id) {
+          $label_cell['best_value'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $this->t('Best value'),
+            '#attributes' => ['class' => ['mel-ticket-best-value-badge']],
+            '#weight' => 1,
+          ];
+        }
         if ($buyer_desc !== '') {
           $label_cell['description'] = [
             '#markup' => '<div class="mel-ticket-description mel-text--muted">' . nl2br(Html::escape($buyer_desc), FALSE) . '</div>',
@@ -306,6 +319,7 @@ final class TicketSelectionForm extends FormBase {
             'class' => $row_classes,
             'data-variation-id' => $variation_id,
             'data-mel-ticket-recommended' => ($default_variation_id !== NULL && (int) $variation_id === $default_variation_id) ? '1' : '0',
+            'data-mel-ticket-best-value' => ($best_value_variation_id !== NULL && (int) $variation_id === $best_value_variation_id) ? '1' : '0',
           ],
           'label_cell' => $label_cell,
           'price' => [
@@ -664,6 +678,28 @@ final class TicketSelectionForm extends FormBase {
     }
     $variation_id = (int) $tier->get('commerce_variation')->target_id;
     return $variation_id > 0 ? $variation_id : NULL;
+  }
+
+  private function resolveBestValueVariationId(NodeInterface $event): ?int {
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return NULL;
+    }
+
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $ticket) {
+      if (!$ticket instanceof TicketTypeInterface || $ticket->isArchived()) {
+        continue;
+      }
+      if (!$ticket->hasField('field_is_best_value') || !$ticket->isBestValueTicket()) {
+        continue;
+      }
+      if (!$ticket->hasField('commerce_variation') || $ticket->get('commerce_variation')->isEmpty()) {
+        continue;
+      }
+      $variation_id = (int) $ticket->get('commerce_variation')->target_id;
+      return $variation_id > 0 ? $variation_id : NULL;
+    }
+
+    return NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -22,6 +22,8 @@ final class TicketTierLifecycleService {
 
   public const CURRENCY_MISMATCH_MESSAGE = 'All tickets for an event must use the same currency.';
 
+  private const BEST_VALUE_REQUIRED_MESSAGE = 'Choose one Best value ticket when an event has more than one paid or RSVP ticket type.';
+
   private const SHORT_DESCRIPTION_MAX_LENGTH = 320;
 
   public function __construct(
@@ -427,6 +429,8 @@ final class TicketTierLifecycleService {
       ];
     }
 
+    $this->assertBestValueSelectionForNewTicket($event, $payload);
+
     return $payload;
   }
 
@@ -552,6 +556,8 @@ final class TicketTierLifecycleService {
       );
     }
 
+    $this->assertBestValueSelectionForTicketUpdate($event, $ticket, $payload);
+
     return $payload;
   }
 
@@ -620,7 +626,135 @@ final class TicketTierLifecycleService {
       $errors[] = self::CURRENCY_MISMATCH_MESSAGE;
     }
 
+    $bestValueError = $this->validateBestValueSelectionForRows($event, $account, $rows);
+    if ($bestValueError !== NULL) {
+      $errors[] = $bestValueError;
+    }
+
     return array_merge($errors, $this->validateRsvpCapacityAgainstEvent($event, $eventKind, $rsvpCapSum));
+  }
+
+  /**
+   * Enforces the MEL guided model for newly created joinable ticket types.
+   *
+   * @param array<string, mixed> $payload
+   */
+  private function assertBestValueSelectionForNewTicket(NodeInterface $event, array $payload): void {
+    $kind = (string) ($payload['ticket_kind'] ?? '');
+    if (!in_array($kind, ['paid', 'rsvp'], TRUE)) {
+      return;
+    }
+
+    $analysis = $this->analyzeBestValueTickets($event);
+    $joinableCount = $analysis['joinable_count'] + 1;
+    $hasBestValue = $analysis['has_best_value'] || !empty($payload['field_is_best_value']);
+    if ($joinableCount > 1 && !$hasBestValue) {
+      throw new InvalidArgumentException(self::BEST_VALUE_REQUIRED_MESSAGE);
+    }
+  }
+
+  /**
+   * Enforces the MEL guided model when editing an existing joinable ticket type.
+   *
+   * @param array<string, mixed> $payload
+   */
+  private function assertBestValueSelectionForTicketUpdate(NodeInterface $event, TicketTypeInterface $ticket, array $payload): void {
+    if (!$ticket->hasField('field_is_best_value') && !array_key_exists('field_is_best_value', $payload)) {
+      return;
+    }
+
+    $analysis = $this->analyzeBestValueTickets($event, $ticket, $payload);
+    if ($analysis['joinable_count'] > 1 && !$analysis['has_best_value']) {
+      throw new InvalidArgumentException(self::BEST_VALUE_REQUIRED_MESSAGE);
+    }
+  }
+
+  /**
+   * Validates a complete Event Studio ticket rows payload against existing tickets.
+   *
+   * @param list<array<string, mixed>> $rows
+   */
+  private function validateBestValueSelectionForRows(NodeInterface $event, AccountInterface $account, array $rows): ?string {
+    $tickets = $this->ticketTypeManager->loadEventTicketTypesForDisplay($event);
+    $joinableCount = 0;
+    $hasBestValue = FALSE;
+    $seenIds = [];
+
+    foreach ($rows as $row) {
+      $ticketId = (int) ($row['id'] ?? 0);
+      if ($ticketId > 0) {
+        $ticket = $this->loadWritableTicketForEvent($event, $ticketId, $account);
+        if (!$ticket instanceof TicketTypeInterface) {
+          continue;
+        }
+        $seenIds[$ticketId] = TRUE;
+        if (!$this->isJoinableTicketKind($ticket->getTicketKind())) {
+          continue;
+        }
+        $joinableCount++;
+        $hasBestValue = $hasBestValue || $this->ticketWillBeBestValue($ticket, $row);
+        continue;
+      }
+
+      $kind = $this->normalizeTicketKind($row['ticket_kind'] ?? 'paid');
+      if (!$this->isJoinableTicketKind($kind)) {
+        continue;
+      }
+      $joinableCount++;
+      $hasBestValue = $hasBestValue || !empty($row['field_is_best_value']);
+    }
+
+    foreach ($tickets as $ticketId => $ticket) {
+      if (isset($seenIds[(int) $ticketId]) || !$this->isJoinableTicketKind($ticket->getTicketKind())) {
+        continue;
+      }
+      $joinableCount++;
+      $hasBestValue = $hasBestValue || ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket());
+    }
+
+    return $joinableCount > 1 && !$hasBestValue ? self::BEST_VALUE_REQUIRED_MESSAGE : NULL;
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return array{joinable_count: int, has_best_value: bool}
+   */
+  private function analyzeBestValueTickets(NodeInterface $event, ?TicketTypeInterface $overrideTicket = NULL, array $payload = []): array {
+    $joinableCount = 0;
+    $hasBestValue = FALSE;
+    $overrideId = $overrideTicket instanceof TicketTypeInterface ? (int) $overrideTicket->id() : 0;
+
+    foreach ($this->ticketTypeManager->loadEventTicketTypesForDisplay($event) as $ticket) {
+      if (!$this->isJoinableTicketKind($ticket->getTicketKind())) {
+        continue;
+      }
+      $joinableCount++;
+      if ($overrideId > 0 && (int) $ticket->id() === $overrideId) {
+        $hasBestValue = $hasBestValue || $this->ticketWillBeBestValue($ticket, $payload);
+        continue;
+      }
+      $hasBestValue = $hasBestValue || ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket());
+    }
+
+    return [
+      'joinable_count' => $joinableCount,
+      'has_best_value' => $hasBestValue,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $values
+   */
+  private function ticketWillBeBestValue(TicketTypeInterface $ticket, array $values): bool {
+    if (array_key_exists('field_is_best_value', $values)) {
+      return !empty($values['field_is_best_value']);
+    }
+    return $ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket();
+  }
+
+  private function isJoinableTicketKind(string $kind): bool {
+    return in_array($kind, ['paid', 'rsvp'], TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -6,6 +6,8 @@
   'use strict';
 
   var HIGHLIGHT_MAX = 6;
+  var ATTENDEE_QUESTION_MAX = 5;
+  var TICKET_SOFT_MAX = 5;
 
   function melPrefersReducedMotion() {
     return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -1660,7 +1662,7 @@
     updateDraftEmptyState(form, tiers.length);
     syncPrimaryTicketClassInList(list);
     syncTicketTiersFromDomToHidden(form);
-    syncPaidTierWarning(form);
+    syncTicketModelWarnings(form);
   }
 
   function syncTicketTiersFromDomToHidden(form) {
@@ -1714,22 +1716,61 @@
     renderTicketBuilderRows(form, list, tiers);
   }
 
-  function syncPaidTierWarning(form) {
+  function countDraftJoinableTicketTiers(form) {
+    var list = getBuilderList(form);
+    if (!list) {
+      return 0;
+    }
+    var count = 0;
+    list.querySelectorAll('.mel-tier-row').forEach(function (card) {
+      if (['paid', 'rsvp'].indexOf(getDraftCardKind(card)) !== -1) {
+        count += 1;
+      }
+    });
+    return count;
+  }
+
+  function draftTicketsHaveBestValue(form) {
+    var list = getBuilderList(form);
+    if (!list) {
+      return false;
+    }
+    return !!list.querySelector('.mel-tier-row .mel-tier-best-value:checked');
+  }
+
+  function syncTicketModelWarnings(form) {
     var warn = document.getElementById('mel-ticket-tiers-warn');
-    if (!warn) {
-      return;
-    }
     var tt = valRadio(form, 'mel[field_event_type]');
-    if (tt !== 'paid') {
-      warn.setAttribute('hidden', 'hidden');
-      return;
-    }
     var list = getBuilderList(form);
     var n = list ? list.querySelectorAll('.mel-tier-row').length : 0;
-    if (n < 1) {
-      warn.removeAttribute('hidden');
-    } else {
-      warn.setAttribute('hidden', 'hidden');
+    if (warn) {
+      var warnText = warn.querySelector('.mel-ticket-tiers-warn__text');
+      var joinableCount = countDraftJoinableTicketTiers(form);
+      var needsBestValue = joinableCount > 1 && !draftTicketsHaveBestValue(form);
+      var needsPaidTicket = tt === 'paid' && n < 1;
+      if (needsBestValue) {
+        if (warnText) {
+          warnText.textContent = Drupal.t('Choose one Best value ticket when you offer more than one paid or RSVP ticket.');
+        }
+        warn.removeAttribute('hidden');
+      } else if (needsPaidTicket) {
+        if (warnText) {
+          warnText.textContent = Drupal.t('Add at least one ticket type.');
+        }
+        warn.removeAttribute('hidden');
+      } else {
+        warn.setAttribute('hidden', 'hidden');
+      }
+    }
+
+    var simplicityWarn = document.getElementById('mel-ticket-simplicity-warn');
+    if (simplicityWarn) {
+      var totalSignals = paidTicketTierSignalCount(form);
+      if (totalSignals > TICKET_SOFT_MAX) {
+        simplicityWarn.removeAttribute('hidden');
+      } else {
+        simplicityWarn.setAttribute('hidden', 'hidden');
+      }
     }
   }
 
@@ -1768,7 +1809,14 @@
         if (e.target.closest('#mel-add-ticket-tier')) {
           e.preventDefault();
           var tiersNow = collectTiersFromDom(form);
-          tiersNow.push(createDefaultTier(valRadio(form, 'mel[field_event_type]') || 'rsvp'));
+          var nextTier = createDefaultTier(valRadio(form, 'mel[field_event_type]') || 'rsvp');
+          var hasBestValue = tiersNow.some(function (tier) {
+            return ['paid', 'rsvp'].indexOf(normalizeTicketKind(tier.ticket_kind)) !== -1 && !!parseInt(tier.field_is_best_value || 0, 10);
+          });
+          if (tiersNow.length > 0 && !hasBestValue && ['paid', 'rsvp'].indexOf(normalizeTicketKind(nextTier.ticket_kind)) !== -1) {
+            nextTier.field_is_best_value = 1;
+          }
+          tiersNow.push(nextTier);
           renderTicketBuilderRows(form, list, tiersNow);
           var newCard = list.querySelector('.mel-tier-row:last-child .mel-tier-title');
           if (newCard && typeof newCard.focus === 'function') {
@@ -1845,7 +1893,7 @@
         }
         updateDraftTicketCardUi(card);
         syncTicketTiersFromDomToHidden(form);
-        syncPaidTierWarning(form);
+        syncTicketModelWarnings(form);
         setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
         refreshIntelligence(form);
       },
@@ -2511,6 +2559,13 @@
     }
     else if (stepEl && !stepEl.contains(activeCard) && !relaxStepContainment) {
       activeCard = null;
+    }
+
+    if (!activeCard && stepEl) {
+      activeCard = stepEl.querySelector('.mel-builder-card');
+      if (activeCard && activeCard.id) {
+        form.dataset.melBuilderActiveCardId = activeCard.id;
+      }
     }
 
     if (activeCard) {
@@ -4068,7 +4123,7 @@
     syncTicketProductPanel(form);
     syncTicketSummary(form, str);
     syncCoverPreview(form);
-    syncPaidTierWarning(form);
+    syncTicketModelWarnings(form);
 
     updateProgress(form);
     updateInsightsChecklist(form);
@@ -4119,6 +4174,7 @@
       h.value = '[]';
     }
     syncCollectHiddenFromAttendees(form);
+    syncAttendeeQuestionLimitWarning(form);
     var str = getSettings().strings || {};
     syncTicketSummary(form, str);
     melProgressiveRevealBuilder(form);
@@ -4139,6 +4195,46 @@
     }
     var n = parseAttendeeQuestionsState(form).length;
     sync.value = n > 0 ? '1' : '0';
+  }
+
+  function getAttendeeQuestionLimitWarning(form) {
+    return form.querySelector('#mel-attendee-questions-limit-warn');
+  }
+
+  function syncAttendeeQuestionLimitWarning(form) {
+    var warning = getAttendeeQuestionLimitWarning(form);
+    if (!warning) {
+      return;
+    }
+    var rows = parseAttendeeQuestionsState(form);
+    var show = rows.length > 0;
+    warning.hidden = !show;
+    warning.setAttribute('aria-hidden', show ? 'false' : 'true');
+
+    var addButton = form.querySelector('#mel-attendee-add-question');
+    var libraryButton = form.querySelector('[data-mel-attendee-library-add="1"]');
+    [addButton, libraryButton].forEach(function (button) {
+      if (!button) {
+        return;
+      }
+      button.disabled = rows.length >= ATTENDEE_QUESTION_MAX;
+      button.setAttribute('aria-disabled', rows.length >= ATTENDEE_QUESTION_MAX ? 'true' : 'false');
+    });
+  }
+
+  function canAddAttendeeQuestion(form) {
+    if (parseAttendeeQuestionsState(form).length < ATTENDEE_QUESTION_MAX) {
+      return true;
+    }
+    syncAttendeeQuestionLimitWarning(form);
+    var warning = getAttendeeQuestionLimitWarning(form);
+    if (warning && typeof warning.focus === 'function') {
+      if (!warning.hasAttribute('tabindex')) {
+        warning.setAttribute('tabindex', '-1');
+      }
+      warning.focus();
+    }
+    return false;
   }
 
   function melMaybeOpenAttendeeDetails(form, shouldOpen) {
@@ -4573,6 +4669,9 @@
   }
 
   function melAttendeeAddPreset(form, key) {
+    if (!canAddAttendeeQuestion(form)) {
+      return;
+    }
     var defs = attendeePresetDefinitions();
     var def = defs[key];
     if (!def) {
@@ -4607,6 +4706,9 @@
   }
 
   function melAttendeeAddFromLibrary(form) {
+    if (!canAddAttendeeQuestion(form)) {
+      return;
+    }
     var sel = form.querySelector('[data-mel-attendee-library-select="1"]');
     if (!sel || !sel.value) {
       return;
@@ -4629,6 +4731,7 @@
     }
     renderAttendeeQuestionRows(form);
     melMaybeOpenAttendeeDetails(form, parseAttendeeQuestionsState(form).length > 0);
+    syncAttendeeQuestionLimitWarning(form);
 
     if (!form.dataset.melAttendeeQuestionsBound) {
       form.dataset.melAttendeeQuestionsBound = '1';

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -36,6 +36,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 final class EventStudioForm extends FormBase {
 
+  private const ATTENDEE_QUESTION_LIMIT = 5;
+
   /**
    * Injected services must be protected (not private readonly) so FormBase
    * serialization can restore them from the container on cached form rebuilds.
@@ -880,7 +882,7 @@ final class EventStudioForm extends FormBase {
     $form['mel']['tickets_intro'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('Start with one ticket — you can add more later.'),
+      '#value' => $this->t('Simpler events get more bookings. Start with one ticket — you can add more later.'),
       '#attributes' => ['class' => ['mel-tickets-intro']],
     ];
 
@@ -908,6 +910,21 @@ final class EventStudioForm extends FormBase {
       '#attributes' => [
         'id' => 'mel-studio-ticket-tiers-json',
         'data-mel-studio-ticket-tiers' => '1',
+      ],
+    ];
+
+    $form['mel']['ticket_simplicity_warn'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'mel-ticket-simplicity-warn',
+        'class' => ['mel-ticket-simplicity-warn', 'messages', 'messages--warning'],
+        'hidden' => 'hidden',
+      ],
+      'inner' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Most events convert best with 3 to 5 ticket types. Keep the list simple unless attendees need more choices.'),
+        '#attributes' => ['class' => ['mel-ticket-simplicity-warn__text']],
       ],
     ];
 
@@ -1101,6 +1118,31 @@ final class EventStudioForm extends FormBase {
             'data-mel-attendee-library-add' => '1',
           ],
           '#access' => $has_vendor_question_library,
+        ],
+      ],
+      'guidance' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-attendee-questions-guidance', 'messages', 'messages--status']],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Default off. Simpler events get more bookings — only ask what you truly need.'),
+          '#attributes' => ['class' => ['mel-attendee-questions-guidance__text']],
+        ],
+      ],
+      'limit_warn' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'id' => 'mel-attendee-questions-limit-warn',
+          'class' => ['mel-attendee-questions-limit-warn', 'messages', 'messages--warning'],
+          'hidden' => 'hidden',
+          'data-mel-attendee-question-limit' => (string) self::ATTENDEE_QUESTION_LIMIT,
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('More questions may reduce bookings'),
+          '#attributes' => ['class' => ['mel-attendee-questions-limit-warn__text']],
         ],
       ],
       'add_menu' => [
@@ -1510,6 +1552,9 @@ final class EventStudioForm extends FormBase {
           $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
           if (!is_array($decoded)) {
             $form_state->setErrorByName('mel][attendee_questions_editor][items_state', $this->t('Attendee questions could not be read. Reset the list or reload the page.'));
+          }
+          elseif (count($decoded) > self::ATTENDEE_QUESTION_LIMIT) {
+            $form_state->setErrorByName('mel][attendee_questions_editor][items_state', $this->t('Add at most 5 attendee questions. More questions may reduce bookings.'));
           }
         }
         catch (\JsonException) {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -31,6 +31,8 @@ use Psr\Log\LoggerInterface;
  */
 final class EventStudioSaveService {
 
+  private const ATTENDEE_QUESTION_LIMIT = 5;
+
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly VenueManager $venueManager,
@@ -1004,6 +1006,9 @@ final class EventStudioSaveService {
     $items = $payload['attendee_questions'];
     if (!is_array($items)) {
       return ['Attendee questions data was invalid. Reload and try again.'];
+    }
+    if (count($items) > self::ATTENDEE_QUESTION_LIMIT) {
+      return ['Add at most 5 attendee questions. More questions may reduce bookings.'];
     }
 
     $field_map = $this->resolveAttendeeQuestionFieldMap();

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -222,6 +222,7 @@
               {% if element.mel.first_ticket_guidance is defined %}
                 {{ element.mel.first_ticket_guidance }}
               {% endif %}
+              {{ element.mel.tickets_intro }}
               {{ element.mel.field_event_type }}
               <div class="mel-tickets-product-region">
                 <div class="mel-tickets-section-divider" role="presentation">
@@ -230,6 +231,7 @@
                 <div class="mel-tickets-list-well">
                   <p class="mel-ticket-studio-autosave-hint" role="status">{{ 'Changes saved automatically'|t }}</p>
                   {{ element.mel.studio_ticket_tiers }}
+                  {{ element.mel.ticket_simplicity_warn }}
                   {% if element.mel.embedded_ticket_wizard is defined %}
                     {{ element.mel.embedded_ticket_wizard }}
                   {% endif %}

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
@@ -41,9 +41,7 @@ myeventlane_vendor.event_workspace.orders:
 myeventlane_vendor.event_workspace.attendees:
   title: 'Attendees'
   route_name: myeventlane_event_attendees.vendor_list
-  base_route: myeventlane_vendor.console.event_overview
-  route_parameters:
-    node: '{event}'
+  base_route: myeventlane_event_attendees.vendor_list
   weight: -8
 
 myeventlane_vendor.event_workspace.rsvps:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -282,7 +282,7 @@ services:
 
   myeventlane_vendor.controller.vendor_event_order_view:
     class: Drupal\myeventlane_vendor\Controller\VendorEventOrderViewController
-    arguments: ['@myeventlane_core.domain_detector', '@current_user', '@messenger', '@entity_type.manager', '@date.formatter', '@database', '@myeventlane_vendor.service.event_tabs', '@myeventlane_core.ticket_label_resolver', '@myeventlane_event_attendees.vendor_presentation', '@?myeventlane_refunds.processor']
+    arguments: ['@myeventlane_core.domain_detector', '@current_user', '@messenger', '@entity_type.manager', '@date.formatter', '@database', '@myeventlane_vendor.service.event_tabs', '@myeventlane_core.ticket_label_resolver', '@myeventlane_event_attendees.vendor_presentation', '@logger.channel.myeventlane_vendor', '@?myeventlane_refunds.processor']
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrderViewController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOrderViewController.php
@@ -20,6 +20,7 @@ use Drupal\node\NodeInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -46,6 +47,8 @@ final class VendorEventOrderViewController extends VendorConsoleBaseController {
    *   The date formatter.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection (for myeventlane_refund_log).
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The vendor logger.
    * @param \Drupal\myeventlane_refunds\Service\RefundProcessor|null $refundProcessor
    *   Refund processor (optional when refunds module is unavailable).
    */
@@ -59,6 +62,7 @@ final class VendorEventOrderViewController extends VendorConsoleBaseController {
     private readonly VendorEventTabsService $eventTabsService,
     private readonly TicketLabelResolver $ticketLabelResolver,
     private readonly VendorAttendeePresentationService $vendorPresentation,
+    private readonly LoggerInterface $logger,
     private readonly ?RefundProcessor $refundProcessor = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
@@ -439,7 +443,7 @@ final class VendorEventOrderViewController extends VendorConsoleBaseController {
         continue;
       }
 
-      $this->getLogger('myeventlane_vendor')->notice(
+      $this->logger->notice(
         'TEMP_DEBUG vendor_parity: order_detail fallback=holder_paragraphs order_item_id=@oi event_id=@eid',
         ['@oi' => (string) $oiid, '@eid' => (string) $eventId, 'order_item_id' => $oiid, 'event_id' => $eventId]
       );

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -37,6 +37,8 @@ final class VendorStudioController extends VendorConsoleBaseController implement
    */
   private const OVERVIEW_SAVE_TOKEN_ID = 'myeventlane_vendor_studio_overview_save';
 
+  private const ATTENDEE_QUESTION_LIMIT = 5;
+
   /**
    * Constructs the Studio controller.
    */
@@ -548,6 +550,13 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       return new JsonResponse([
         'success' => FALSE,
         'message' => 'Invalid attendee payload. Expected { "questions": [] }.',
+      ], 422);
+    }
+
+    if (count($payload['questions']) > self::ATTENDEE_QUESTION_LIMIT) {
+      return new JsonResponse([
+        'success' => FALSE,
+        'message' => 'Add at most 5 attendee questions. More questions may reduce bookings.',
       ], 422);
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Ticketing/EventTicketsBuilder.php
@@ -1435,7 +1435,7 @@ final class EventTicketsBuilder {
       '#parents' => array_merge($edit_path, ['hidden_label']),
     ];
 
-    $toggle_selector = ':input[name="' . Html::escape($this->formElementFullName($form_state, 'builder_shell', 'list', (string) $tid, 'edit', 'field_use_ticket_attendee_questions', '0', 'value')) . '"]';
+    $toggle_selector = ':input[name="' . Html::escape($this->formElementFullName($form_state, 'builder_shell', 'list', (string) $tid, 'edit', 'field_use_ticket_attendee_questions', 'value')) . '"]';
 
     $card['edit']['mel_ticket_questions_divider'] = [
       '#markup' => '<hr class="mel-ticket-questions__divider" aria-hidden="true" />',
@@ -1712,7 +1712,7 @@ final class EventTicketsBuilder {
         $this->removeTicketTypeAttendeeQuestionParagraphs($ticket);
       }
 
-      $ticket->save();
+      $this->lifecycle->updateTicketType($ticket, $event, []);
 
       $this->messenger->addStatus($this->t('Ticket updated.'));
       $success = TRUE;

--- a/web/themes/custom/myeventlane_theme/js/mel-checkout.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-checkout.js
@@ -1,0 +1,286 @@
+(function (Drupal, once) {
+  'use strict';
+
+  const IDENTITY_STORAGE_KEY = 'myeventlane.checkoutIdentity.v1';
+
+  Drupal.behaviors.melCheckout = {
+    attach(context) {
+      attachIdentityMemory(context);
+      attachContactCollapse(context);
+
+      const forms = once(
+        'mel-checkout-error-scroll',
+        '.mel-checkout-shell form, form.mel-checkout-single-page',
+        context
+      );
+
+      forms.forEach((form) => {
+        window.requestAnimationFrame(() => {
+          const errorTarget = findFirstError(form);
+
+          if (!errorTarget) {
+            return;
+          }
+
+          errorTarget.scrollIntoView({
+            behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+            block: 'center',
+          });
+
+          const focusTarget = findFocusableError(errorTarget);
+          if (focusTarget) {
+            focusTarget.focus({ preventScroll: true });
+          }
+        });
+      });
+    },
+  };
+
+  function attachIdentityMemory(context) {
+    const panes = once(
+      'mel-checkout-identity-memory',
+      '.mel-contact-details-pane',
+      context
+    );
+
+    panes.forEach((pane) => {
+      const form = pane.closest('form');
+      const fields = getIdentityFields(pane);
+
+      if (!form || !fields.email || !fields.firstName || !fields.lastName) {
+        return;
+      }
+
+      const stored = readStoredIdentity();
+      if (stored) {
+        prefillEmptyIdentityFields(fields, stored);
+        insertContinueAs(pane, fields, stored);
+      }
+
+      const persist = () => saveIdentityFromFields(fields);
+      form.addEventListener('submit', persist);
+      Object.values(fields).forEach((field) => {
+        if (field) {
+          field.addEventListener('change', persist);
+          field.addEventListener('blur', persist);
+        }
+      });
+    });
+  }
+
+  function attachContactCollapse(context) {
+    const panes = once(
+      'mel-checkout-contact-collapse',
+      '.mel-contact-details-pane',
+      context
+    );
+
+    panes.forEach((pane) => {
+      const fields = getIdentityFields(pane);
+
+      if (!hasRequiredIdentity(fields) || hasErrors(pane)) {
+        return;
+      }
+
+      pane.classList.add('mel-contact-details-pane--collapsed');
+      setIdentityFieldVisibility(pane, false);
+
+      insertContinueAs(pane, fields, { firstName: '', lastName: '', email: '' });
+      const summary = pane.querySelector('.mel-identity-memory');
+      if (summary) {
+        const edit = document.createElement('button');
+        edit.type = 'button';
+        edit.className = 'mel-identity-memory__edit';
+        edit.textContent = Drupal.t('Edit');
+        edit.addEventListener('click', () => {
+          pane.classList.remove('mel-contact-details-pane--collapsed');
+          setIdentityFieldVisibility(pane, true);
+          edit.remove();
+          const firstField = fields.email || fields.firstName;
+          if (firstField) {
+            firstField.focus();
+          }
+        });
+        summary.appendChild(edit);
+      }
+    });
+  }
+
+  function getIdentityFields(scope) {
+    return {
+      email: scope.querySelector('.mel-buyer-email'),
+      firstName: scope.querySelector('.mel-buyer-first-name'),
+      lastName: scope.querySelector('.mel-buyer-last-name'),
+      mobile: scope.querySelector('.mel-buyer-mobile'),
+    };
+  }
+
+  function prefillEmptyIdentityFields(fields, stored) {
+    if (fields.email && !fields.email.value && stored.email) {
+      fields.email.value = stored.email;
+    }
+    if (fields.firstName && !fields.firstName.value && stored.firstName) {
+      fields.firstName.value = stored.firstName;
+    }
+    if (fields.lastName && !fields.lastName.value && stored.lastName) {
+      fields.lastName.value = stored.lastName;
+    }
+  }
+
+  function insertContinueAs(pane, fields, stored) {
+    if (pane.querySelector('.mel-identity-memory')) {
+      return;
+    }
+
+    const name = formatName(fields, stored);
+    if (!name) {
+      return;
+    }
+
+    const summary = document.createElement('div');
+    summary.className = 'mel-identity-memory';
+    summary.setAttribute('role', 'status');
+
+    const label = document.createElement('span');
+    label.className = 'mel-identity-memory__label';
+    label.textContent = Drupal.t('Continue as @name', { '@name': name });
+    summary.appendChild(label);
+
+    pane.insertBefore(summary, pane.firstElementChild);
+  }
+
+  function setIdentityFieldVisibility(pane, visible) {
+    const selectors = [
+      '.mel-buyer-email',
+      '.mel-buyer-first-name',
+      '.mel-buyer-last-name',
+      '.mel-buyer-mobile',
+    ];
+
+    selectors.forEach((selector) => {
+      const field = pane.querySelector(selector);
+      const wrapper = field ? field.closest('.form-item') : null;
+      if (!wrapper) {
+        return;
+      }
+
+      if (!visible) {
+        wrapper.hidden = true;
+        return;
+      }
+
+      wrapper.hidden = !field.required && field.value.trim() === '';
+    });
+  }
+
+  function hasRequiredIdentity(fields) {
+    return Boolean(
+      fields.email && fields.email.value.trim() &&
+        fields.firstName && fields.firstName.value.trim() &&
+        fields.lastName && fields.lastName.value.trim()
+    );
+  }
+
+  function hasErrors(scope) {
+    return Boolean(
+      scope.querySelector('.form-item--error, [aria-invalid="true"], .messages--error')
+    );
+  }
+
+  function saveIdentityFromFields(fields) {
+    const storage = getLocalStorage();
+    if (!storage) {
+      return;
+    }
+
+    const email = fields.email ? fields.email.value.trim() : '';
+    const firstName = fields.firstName ? fields.firstName.value.trim() : '';
+    const lastName = fields.lastName ? fields.lastName.value.trim() : '';
+
+    if (!email || !firstName) {
+      return;
+    }
+
+    storage.setItem(
+      IDENTITY_STORAGE_KEY,
+      JSON.stringify({
+        email,
+        firstName,
+        lastName,
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  }
+
+  function readStoredIdentity() {
+    const storage = getLocalStorage();
+    if (!storage) {
+      return null;
+    }
+
+    try {
+      const raw = storage.getItem(IDENTITY_STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        return null;
+      }
+      return {
+        email: typeof parsed.email === 'string' ? parsed.email : '',
+        firstName: typeof parsed.firstName === 'string' ? parsed.firstName : '',
+        lastName: typeof parsed.lastName === 'string' ? parsed.lastName : '',
+      };
+    }
+    catch (e) {
+      return null;
+    }
+  }
+
+  function getLocalStorage() {
+    try {
+      return window.localStorage || null;
+    }
+    catch (e) {
+      return null;
+    }
+  }
+
+  function formatName(fields, stored) {
+    const firstName = fields.firstName && fields.firstName.value
+      ? fields.firstName.value.trim()
+      : stored.firstName;
+    const lastName = fields.lastName && fields.lastName.value
+      ? fields.lastName.value.trim()
+      : stored.lastName;
+
+    return [firstName, lastName].filter(Boolean).join(' ').trim();
+  }
+
+  function findFirstError(form) {
+    return form.querySelector(
+      '.form-item--error, [aria-invalid="true"], .messages--error'
+    );
+  }
+
+  function findFocusableError(errorTarget) {
+    if (isFocusable(errorTarget)) {
+      return errorTarget;
+    }
+
+    return errorTarget.querySelector(
+      'input:not([type="hidden"]), select, textarea, button, [tabindex]:not([tabindex="-1"])'
+    );
+  }
+
+  function isFocusable(element) {
+    return element.matches(
+      'input:not([type="hidden"]), select, textarea, button, [tabindex]:not([tabindex="-1"])'
+    );
+  }
+
+  function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -153,6 +153,14 @@ rsvp_sidebar:
     - core/drupal
     - core/once
 
+# Checkout form behaviour: first-error scroll/focus and structured layout hooks.
+mel_checkout:
+  js:
+    js/mel-checkout.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Contact /support entry (/contact). Styles are compiled into dist/main.css via
 # src/scss/pages/_contact.scss; this library ensures the bundle is referenced
 # when the contact form template attaches it.

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2710,6 +2710,10 @@ function myeventlane_theme_form_alter(array &$form, \Drupal\Core\Form\FormStateI
     return;
   }
 
+  if (str_starts_with($form_id, 'commerce_checkout_flow_')) {
+    $form['#attached']['library'][] = 'myeventlane_theme/mel_checkout';
+  }
+
   // Checkout: sidebar panes skip commerce_checkout_pane theme; add shell class
   // so governed SCSS applies (presentation only, no pane logic changes).
   if (str_starts_with($form_id, 'commerce_checkout_flow_') && isset($form['sidebar']) && is_array($form['sidebar'])) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -411,6 +411,136 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   border: 1px solid colors.$mel-color-border;
 }
 
+.mel-fast-checkout {
+  padding: spacing.mel-space(4);
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(colors.$mel-color-primary, 0.16);
+  border-radius: 18px;
+  box-shadow: 0 12px 34px rgba(44, 62, 80, 0.07);
+}
+
+.mel-fast-checkout__header {
+  margin-bottom: spacing.mel-space(3);
+}
+
+.mel-fast-checkout__title {
+  margin: 0;
+  color: colors.$mel-color-text;
+  font-size: typography.mel-font-size(xl);
+  font-weight: typography.$mel-font-bold;
+  letter-spacing: -0.02em;
+}
+
+.mel-fast-checkout__intro,
+.mel-fast-checkout__details-help,
+.mel-fast-checkout__fallback {
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+}
+
+.mel-fast-checkout__intro {
+  margin: spacing.mel-space(1) 0 0;
+}
+
+.mel-fast-checkout__details {
+  display: grid;
+  gap: spacing.mel-space(3);
+}
+
+.mel-fast-checkout__details .form-item {
+  margin: 0;
+}
+
+.mel-fast-checkout__details .form-actions {
+  margin: 0;
+}
+
+.mel-fast-checkout__details-submit,
+.mel-fast-checkout__details .button {
+  min-height: 48px;
+}
+
+.mel-fast-checkout__wallets,
+.mel-fast-checkout__wallets .stripe-express-checkout-element-form {
+  width: 100%;
+}
+
+.mel-fast-checkout__wallets [id^="stripe-express-checkout-element"] {
+  width: 100%;
+}
+
+.mel-fast-checkout__fallback {
+  display: flex;
+  align-items: center;
+  gap: spacing.mel-space(3);
+  margin: spacing.mel-space(3) 0 0;
+  text-align: center;
+}
+
+.mel-fast-checkout__fallback::before,
+.mel-fast-checkout__fallback::after {
+  content: '';
+  flex: 1 1 auto;
+  height: 1px;
+  background: colors.$mel-color-border;
+}
+
+.mel-identity-memory {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: spacing.mel-space(2);
+  margin-bottom: spacing.mel-space(3);
+  padding: spacing.mel-space(3);
+  border: 1px solid rgba(colors.$mel-color-primary, 0.18);
+  border-radius: radii.$mel-radius-lg;
+  background: rgba(colors.$mel-color-primary, 0.06);
+  color: colors.$mel-color-text;
+}
+
+.mel-identity-memory__label {
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-identity-memory__edit {
+  min-height: 44px;
+  padding: spacing.mel-space(1) spacing.mel-space(2);
+  border: 0;
+  background: transparent;
+  color: colors.$mel-color-primary;
+  font-weight: typography.$mel-font-semibold;
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid colors.$mel-color-primary;
+    outline-offset: 2px;
+    border-radius: radii.$mel-radius-sm;
+  }
+}
+
+.mel-ticket-row--best-value {
+  border-color: rgba(colors.$mel-color-primary, 0.42);
+  box-shadow: 0 10px 26px rgba(colors.$mel-color-primary, 0.1);
+}
+
+.mel-ticket-best-value-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 28px;
+  margin-top: spacing.mel-space(1);
+  padding: 0 spacing.mel-space(2);
+  border-radius: radii.$mel-radius-full;
+  background: rgba(colors.$mel-color-primary, 0.12);
+  color: colors.$mel-color-primary;
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-bold;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .mel-payment-methods {
   display: flex;
   flex-direction: column;
@@ -892,6 +1022,38 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   justify-content: center;
   gap: spacing.mel-space(3);
   flex-wrap: wrap;
+}
+
+.mel-confirmation--frictionless {
+  .mel-confirmation__main {
+    display: grid;
+    gap: spacing.mel-space(4);
+  }
+
+  .mel-confirmation-actions--frictionless {
+    align-items: center;
+    justify-content: flex-start;
+    padding: spacing.mel-space(4);
+    border: 1px solid colors.$mel-color-border;
+    border-radius: radii.$mel-radius-xl;
+    background: colors.$mel-color-surface;
+    box-shadow: $mel-checkout-shadow;
+  }
+
+  .mel-calendar-actions--frictionless {
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing.mel-space(2);
+  }
+
+  .mel-confirmation-actions__guest-note {
+    flex: 1 1 100%;
+    margin: 0;
+
+    p {
+      margin: 0 0 spacing.mel-space(1);
+    }
+  }
 }
 
 /* ==========================================================================
@@ -1530,6 +1692,19 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
     padding: 14px 16px;
   }
 
+  .mel-fast-checkout {
+    padding: spacing.mel-space(3);
+    border-radius: 16px;
+  }
+
+  .mel-fast-checkout__details-submit,
+  .mel-fast-checkout__details .button,
+  .mel-fast-checkout__wallets,
+  .mel-fast-checkout__wallets .stripe-express-checkout-element-form,
+  .mel-fast-checkout__wallets [id^="stripe-express-checkout-element"] {
+    width: 100%;
+  }
+
   .mel-checkout__actions,
   /* Sticky primary action: total + submit stay visible; summary is stacked above via order:-1 */
   .mel-checkout-section--cta {
@@ -1834,6 +2009,242 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 }
 
 // ---------------------------------------------------------------------------
+// MEL checkout — structured single-page layout
+// ---------------------------------------------------------------------------
+
+.mel-commerce-checkout .mel-checkout--structured,
+.mel-checkout--structured {
+  max-width: 1180px;
+  padding-inline: spacing.mel-space(3);
+
+  .mel-checkout__grid--sidebar-flow {
+    gap: spacing.mel-space(5);
+
+    @media (width >= 960px) {
+      grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+    }
+  }
+
+  .mel-checkout__main {
+    gap: spacing.mel-space(4);
+  }
+
+  .mel-checkout-section {
+    scroll-margin-top: 120px;
+  }
+
+  .mel-checkout-section--ticket-holders,
+  .mel-checkout-section--buyer,
+  .mel-checkout-section--donation,
+  .mel-checkout-section--legal,
+  .mel-checkout-section--payment,
+  .mel-checkout-section--cta {
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid rgba(colors.$mel-color-border, 0.9);
+    border-radius: 18px;
+    padding: spacing.mel-space(4);
+    box-shadow: 0 12px 34px rgba(44, 62, 80, 0.07);
+  }
+
+  .mel-checkout-section--legal {
+    padding-block: spacing.mel-space(3);
+    background: rgba(colors.$mel-color-bg, 0.76);
+    box-shadow: none;
+  }
+
+  .mel-checkout-section__header {
+    margin-bottom: spacing.mel-space(3);
+  }
+
+  .mel-checkout-section__eyebrow {
+    margin: 0 0 spacing.mel-space(1);
+    color: colors.$mel-color-text-muted;
+    font-size: typography.mel-font-size(xs);
+    font-weight: typography.$mel-font-bold;
+    letter-spacing: 0.08em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .mel-checkout-heading {
+    margin: 0;
+    font-size: typography.mel-font-size(xl);
+    font-weight: typography.$mel-font-bold;
+    letter-spacing: -0.02em;
+  }
+
+  .mel-checkout-section__intro {
+    max-width: 58ch;
+    margin: spacing.mel-space(1) 0 0;
+    color: colors.$mel-color-text-muted;
+    font-size: typography.mel-font-size(sm);
+    line-height: 1.5;
+  }
+
+  .mel-intro {
+    margin: spacing.mel-space(3) 0;
+    padding: spacing.mel-space(3);
+    border: 1px solid rgba(colors.$mel-color-border, 0.75);
+    border-radius: radii.$mel-radius-lg;
+    background: rgba(colors.$mel-color-primary, 0.045);
+
+    h2,
+    h3 {
+      margin: 0 0 spacing.mel-space(1);
+      font-size: typography.mel-font-size(base);
+      font-weight: typography.$mel-font-bold;
+    }
+
+    p {
+      margin: 0;
+      color: colors.$mel-color-text-muted;
+      font-size: typography.mel-font-size(sm);
+      line-height: 1.45;
+    }
+  }
+
+  .mel-attendee-details-toggle {
+    min-height: 44px;
+  }
+
+  .mel-checkout-ticket-group {
+    margin-top: spacing.mel-space(3);
+    padding: spacing.mel-space(3);
+    border: 1px solid rgba(colors.$mel-color-border, 0.72);
+    border-radius: radii.$mel-radius-lg;
+    background: rgba(colors.$mel-color-bg, 0.68);
+  }
+
+  .mel-checkout-ticket-type-title {
+    margin-bottom: spacing.mel-space(3);
+    padding-bottom: spacing.mel-space(2);
+    border-bottom: 1px solid rgba(colors.$mel-color-border, 0.6);
+  }
+
+  .mel-attendee-card {
+    margin-top: spacing.mel-space(3);
+    padding: spacing.mel-space(3);
+    border: 1px solid rgba(colors.$mel-color-border, 0.72);
+    border-radius: radii.$mel-radius-lg;
+    background: colors.$mel-color-surface;
+  }
+
+  .mel-attendee-card__heading {
+    margin: spacing.mel-space(2) 0 spacing.mel-space(2);
+    color: colors.$mel-color-text;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-bold;
+  }
+
+  .mel-attendee-card__heading--questions {
+    margin-top: spacing.mel-space(4);
+    padding-top: spacing.mel-space(3);
+    border-top: 1px solid rgba(colors.$mel-color-border, 0.6);
+  }
+
+  .mel-attendee-question-field {
+    background-color: rgba(colors.$mel-color-primary, 0.035);
+  }
+
+  .form-item--error-message,
+  .form-item__error-message {
+    display: block;
+    margin-top: spacing.mel-space(2);
+  }
+
+  [aria-invalid='true'],
+  .form-item--error input,
+  .form-item--error select,
+  .form-item--error textarea {
+    scroll-margin-top: 120px;
+  }
+
+  .mel-checkout__summary,
+  .mel-checkout-summary,
+  .mel-checkout__aside.mel-checkout__summary {
+    top: 88px;
+    max-height: calc(100vh - 112px);
+    overflow: auto;
+  }
+
+  .mel-checkout-summary__jump {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    margin-top: spacing.mel-space(2);
+    color: colors.$mel-color-primary;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-semibold;
+    text-decoration: underline;
+    text-underline-offset: 0.14em;
+
+    &:focus-visible {
+      outline: 2px solid colors.$mel-color-primary;
+      outline-offset: 3px;
+      border-radius: radii.$mel-radius-sm;
+    }
+  }
+
+  .mel-checkout-section--cta {
+    border-color: rgba(colors.$mel-color-primary, 0.18);
+  }
+}
+
+@media (width <= 768px) {
+  .mel-commerce-checkout .mel-checkout--structured,
+  .mel-checkout--structured {
+    padding-inline: spacing.mel-space(2);
+
+    .mel-checkout__grid--sidebar-flow {
+      gap: spacing.mel-space(3);
+    }
+
+    .mel-checkout__grid--sidebar-flow .mel-checkout__main {
+      padding-bottom: 120px;
+    }
+
+    .mel-checkout-section--ticket-holders,
+    .mel-checkout-section--buyer,
+    .mel-checkout-section--donation,
+    .mel-checkout-section--legal,
+    .mel-checkout-section--payment,
+    .mel-checkout-section--cta {
+      padding: spacing.mel-space(3);
+      border-radius: 16px;
+    }
+
+    .mel-checkout__summary,
+    .mel-checkout-summary,
+    .mel-checkout__aside.mel-checkout__summary {
+      max-height: none;
+      overflow: visible;
+    }
+
+    .mel-checkout-section--cta {
+      position: fixed;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 30;
+      margin: 0;
+      padding: spacing.mel-space(2) spacing.mel-space(3) calc(#{spacing.mel-space(2)} + env(safe-area-inset-bottom, 0px));
+      border-right: 0;
+      border-bottom: 0;
+      border-left: 0;
+      border-radius: 16px 16px 0 0;
+      background: rgba(colors.$mel-color-surface, 0.98);
+      box-shadow: 0 -10px 30px rgba(44, 62, 80, 0.14);
+    }
+
+    .mel-checkout-total-inline,
+    .mel-checkout-cta__total {
+      margin-bottom: spacing.mel-space(2);
+      padding: spacing.mel-space(2);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // MEL checkout — compact density (Twig: .mel-checkout--compact-flow; QA hook)
 // ---------------------------------------------------------------------------
 
@@ -2009,6 +2420,40 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
     .mel-checkout-section--cta {
       margin-top: spacing.mel-space(1);
       padding-top: spacing.mel-space(2);
+    }
+  }
+}
+
+.mel-commerce-checkout .mel-checkout--compact-flow.mel-checkout--structured {
+  .mel-checkout__grid--sidebar-flow {
+    @media (width >= 960px) {
+      grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+    }
+  }
+
+  .mel-checkout-section--ticket-holders,
+  .mel-checkout-section--buyer,
+  .mel-checkout-section--donation,
+  .mel-checkout-section--payment {
+    padding: spacing.mel-space(4);
+  }
+
+  .mel-checkout-section--cta {
+    padding: spacing.mel-space(4);
+  }
+}
+
+@media (width <= 768px) {
+  .mel-commerce-checkout .mel-checkout--compact-flow.mel-checkout--structured {
+    .mel-checkout-section--ticket-holders,
+    .mel-checkout-section--buyer,
+    .mel-checkout-section--donation,
+    .mel-checkout-section--payment {
+      padding: spacing.mel-space(3);
+    }
+
+    .mel-checkout-section--cta {
+      padding: spacing.mel-space(2) spacing.mel-space(3) calc(#{spacing.mel-space(2)} + env(safe-area-inset-bottom, 0px));
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -57,47 +57,25 @@
   {% endif %}
 {% endfor %}
 
-<div class="mel-confirmation">
+<div class="mel-confirmation mel-confirmation--frictionless">
   <header class="mel-confirmation__hero">
     <div class="mel-confirmation__hero-icon" aria-hidden="true">✓</div>
     <div class="mel-confirmation__hero-content">
-      {# Donation before tickets: mixed orders use donation-led hero copy only (same as original). #}
-      {% if mel_donation_total_formatted %}
+      {% if mel_donation_total_formatted and not mel_confirmation_has_tickets %}
         <h1 class="mel-confirmation__title">{{ 'Thank you'|t }}</h1>
       {% elseif mel_confirmation_has_tickets %}
-        <h1 class="mel-confirmation__title">{{ "You're in! 🎉"|t }}</h1>
+        <h1 class="mel-confirmation__title">{{ "You're in"|t }}</h1>
       {% else %}
-        <h1 class="mel-confirmation__title">{{ 'Order confirmed'|t }}</h1>
+        <h1 class="mel-confirmation__title">{{ 'Done'|t }}</h1>
       {% endif %}
-
-      {% if mel_donation_total_formatted %}
-        <p class="mel-confirmation__subtitle">
-          {{ 'We\'ve emailed your receipt to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
-        </p>
-      {% elseif mel_confirmation_has_tickets %}
-        {% if mel_confirm_paid %}
-          <p class="mel-confirmation__subtitle">
-            {{ 'Your booking is confirmed. We\'ve emailed your confirmation and tickets to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
-          </p>
-        {% else %}
-          <p class="mel-confirmation__subtitle">
-            {{ 'Your registration is confirmed. We\'ve emailed your confirmation to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
-          </p>
-        {% endif %}
-      {% else %}
-        <p class="mel-confirmation__subtitle">
-          {{ 'We\'ve emailed your confirmation to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
-        </p>
-      {% endif %}
+      <p class="mel-confirmation__subtitle">
+        {{ 'Confirmation sent to <strong>@email</strong>.'|t({'@email': order_entity.getEmail()})|raw }}
+      </p>
       <p class="mel-confirmation__reference">
         {{ 'Order'|t }} <strong>#{{ order_entity.getOrderNumber() }}</strong>
       </p>
     </div>
   </header>
-
-  {% if order_entity is defined %}
-    {% include '@myeventlane_theme/commerce/mel-tax-invoice-section.html.twig' %}
-  {% endif %}
 
   <div class="mel-confirmation__main">
     {% if events|length > 0 %}
@@ -111,19 +89,14 @@
           {% endif %}
           <div class="mel-confirmation-card__body">
             <p class="mel-confirmation-card__eyebrow">{{ 'Event summary'|t }}</p>
-            {% if event.hasField('field_event_start') and not event.get('field_event_start').isEmpty() %}
-              <span class="mel-confirmation-card__date-badge">{{ event.get('field_event_start').value|date('M j, Y') }}</span>
-            {% endif %}
             <h2 id="mel-confirmation-event-summary-{{ event.id() }}" class="mel-confirmation-card__title">{{ event.label() }}</h2>
             <div class="mel-confirmation-card__meta">
               {% if event.hasField('field_event_start') and not event.get('field_event_start').isEmpty() %}
-                <span class="mel-confirmation-card__date">
-                  {{ event.get('field_event_start').value|date('l, F j, Y') }}
-                </span>
+                <span class="mel-confirmation-card__date">{{ event.get('field_event_start').value|date('l, F j, Y') }}</span>
                 <span class="mel-confirmation-card__time">
                   {{ event.get('field_event_start').value|date('g:i A') }}
                   {% if event.hasField('field_event_end') and not event.get('field_event_end').isEmpty() %}
-                    – {{ event.get('field_event_end').value|date('g:i A') }}
+                    - {{ event.get('field_event_end').value|date('g:i A') }}
                   {% endif %}
                 </span>
               {% endif %}
@@ -164,50 +137,19 @@
                       {% set pe = item.getPurchasedEntity() %}
                       {{ pe ? pe.label() : item.getTitle() }}
                     </span>
-                    <span class="mel-confirmation-card__ticket-qty">× {{ item.getQuantity()|number_format(0) }}</span>
+                    <span class="mel-confirmation-card__ticket-qty">x {{ item.getQuantity()|number_format(0) }}</span>
                     <span class="mel-confirmation-card__ticket-price">{{ item.getTotalPrice()|commerce_price_format }}</span>
-                    {% set attendees = order_items_attendees[item.id()] ?? [] %}
-                    {% if attendees|length > 0 %}
-                      <ul class="mel-confirmation-card__attendees">
-                        {% for att in attendees %}
-                          <li>{{ att.first_name }} {{ att.last_name }}{% if att.email %} ({{ att.email }}){% endif %}</li>
-                        {% endfor %}
-                      </ul>
-                    {% endif %}
                   </div>
                 {% endif %}
               {% endfor %}
             </div>
-
-            <p class="mel-confirmation-card__reference">{{ 'Booking reference'|t }}: #{{ order_entity.getOrderNumber() }}</p>
           </div>
         </section>
       {% endfor %}
-      {% include '@myeventlane_theme/commerce/mel-confirmation-order-pricing.html.twig' %}
-      {% if not mel_confirm_paid %}
-        <div class="mel-confirmation-card mel-confirmation-card--total">
-          <div class="mel-confirmation-card__body">
-            <div class="mel-confirmation-card__total">
-              <span>{{ 'Order total'|t }}</span>
-              <strong>{{ 'Free'|t }}</strong>
-            </div>
-          </div>
-        </div>
-      {% elseif mel_order_pricing_breakdown is empty %}
-        <div class="mel-confirmation-card mel-confirmation-card--total">
-          <div class="mel-confirmation-card__body">
-            <div class="mel-confirmation-card__total">
-              <span>{{ 'Total paid'|t }}</span>
-              <strong>{{ order_entity.getTotalPrice()|commerce_price_format }}</strong>
-            </div>
-          </div>
-        </div>
-      {% endif %}
-    {% endif %}
-
-    {% if ticket_items|length > 0 and events|length == 0 %}
+    {% elseif ticket_items|length > 0 %}
       <section class="mel-confirmation-card mel-confirmation__summary">
         <div class="mel-confirmation-card__body">
+          <p class="mel-confirmation-card__eyebrow">{{ 'Event summary'|t }}</p>
           <h2 class="mel-confirmation-card__title">{{ 'Your tickets'|t }}</h2>
           <div class="mel-confirmation-card__tickets">
             {% for item in ticket_items %}
@@ -216,16 +158,8 @@
                   {% set pe = item.getPurchasedEntity() %}
                   {{ pe ? pe.label() : item.getTitle() }}
                 </span>
-                <span class="mel-confirmation-card__ticket-qty">× {{ item.getQuantity()|number_format(0) }}</span>
+                <span class="mel-confirmation-card__ticket-qty">x {{ item.getQuantity()|number_format(0) }}</span>
                 <span class="mel-confirmation-card__ticket-price">{{ item.getTotalPrice()|commerce_price_format }}</span>
-                {% set attendees = order_items_attendees[item.id()] ?? [] %}
-                {% if attendees|length > 0 %}
-                  <ul class="mel-confirmation-card__attendees">
-                    {% for att in attendees %}
-                      <li>{{ att.first_name }} {{ att.last_name }}{% if att.email %} ({{ att.email }}){% endif %}</li>
-                    {% endfor %}
-                  </ul>
-                {% endif %}
               </div>
             {% endfor %}
           </div>
@@ -233,185 +167,52 @@
       </section>
     {% endif %}
 
-    {% if events|length == 0 %}
-      {% include '@myeventlane_theme/commerce/mel-confirmation-order-pricing.html.twig' %}
-      {% if not mel_confirm_paid %}
-        <div class="mel-confirmation-card mel-confirmation-card--total">
-          <div class="mel-confirmation-card__body">
-            <div class="mel-confirmation-card__total">
-              <span>{{ 'Order total'|t }}</span>
-              <strong>{{ 'Free'|t }}</strong>
-            </div>
-          </div>
-        </div>
-      {% elseif mel_order_pricing_breakdown is empty %}
-        <div class="mel-confirmation-card mel-confirmation-card--total">
-          <div class="mel-confirmation-card__body">
-            <div class="mel-confirmation-card__total">
-              <span>{{ 'Total paid'|t }}</span>
-              <strong>{{ order_entity.getTotalPrice()|commerce_price_format }}</strong>
-            </div>
-          </div>
-        </div>
-      {% endif %}
-    {% endif %}
-
     {% if mel_donation_total_formatted %}
       <div class="mel-confirmation-card mel-confirmation-card--donation">
         <div class="mel-confirmation-card__body">
-          <h3 class="mel-confirmation-card__donation-title">{{ 'Your donation'|t }}</h3>
+          <h2 class="mel-confirmation-card__title">{{ 'Donation confirmed'|t }}</h2>
           <p class="mel-confirmation-card__donation-amount">{{ mel_donation_total_formatted|raw }}</p>
-          <p class="mel-confirmation-card__donation-note">
-            {{ 'Thank you — your contribution helps keep events running on MyEventLane.'|t }}
-          </p>
         </div>
       </div>
     {% endif %}
 
-    <div class="mel-confirmation-actions">
-      <div class="mel-confirmation-actions__primary">
-        {% if mel_confirmation_has_tickets %}
-          {% if order_entity.getCustomerId() %}
-            <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
-               class="mel-confirmation-button mel-confirmation-button--primary">
-              {{ 'View / download tickets'|t }}
-            </a>
-          {% else %}
-            <div class="mel-confirmation-actions__guest-note">
-              <p>{{ 'Your tickets and event details have been sent to your email.'|t }}</p>
-              <p>{{ 'Keep your order number handy: <strong>@order_number</strong>'|t({'@order_number': order_entity.getOrderNumber()})|raw }}</p>
-            </div>
-          {% endif %}
-        {% elseif order_entity.getCustomerId() %}
-          <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
-             class="mel-confirmation-button mel-confirmation-button--primary">
-            {{ 'View order details'|t }}
-          </a>
-        {% else %}
-          <div class="mel-confirmation-actions__guest-note">
-            <p>{{ 'We\'ve sent the details for this order to your email.'|t }}</p>
-            <p>{{ 'Keep your order number handy: <strong>@order_number</strong>'|t({'@order_number': order_entity.getOrderNumber()})|raw }}</p>
-          </div>
-        {% endif %}
-      </div>
-
-      <div class="mel-confirmation-access">
-        {# Donation before tickets: one access line for mixed orders (donation copy). #}
-        {% if mel_donation_total_formatted %}
-          <p>{{ 'Your receipt lists how your donation was processed.'|t }}</p>
-        {% elseif mel_confirmation_has_tickets %}
-          {% if mel_logged_in and order_entity.getCustomerId() %}
-            <p>{{ 'Your tickets are saved in your account.'|t }}</p>
-            <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-link">{{ 'View my tickets'|t }}</a>
-          {% else %}
-            <p>{{ 'Your tickets have been sent to your email.'|t }}</p>
-          {% endif %}
-        {% endif %}
-      </div>
+    <div class="mel-confirmation-actions mel-confirmation-actions--frictionless">
+      {% if mel_confirmation_has_tickets and order_entity.getCustomerId() %}
+        <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
+           class="mel-confirmation-button mel-confirmation-button--primary">
+          {{ 'View ticket'|t }}
+        </a>
+      {% elseif order_entity.getCustomerId() %}
+        <a href="{{ url('entity.commerce_order.user_view', {'user': order_entity.getCustomerId(), 'commerce_order': order_entity.id()}) }}"
+           class="mel-confirmation-button mel-confirmation-button--primary">
+          {{ 'View order'|t }}
+        </a>
+      {% else %}
+        <div class="mel-confirmation-actions__guest-note">
+          <p>{{ 'Your ticket link and order details have been sent to your email.'|t }}</p>
+          <p>{{ 'Order number: <strong>@order_number</strong>'|t({'@order_number': order_entity.getOrderNumber()})|raw }}</p>
+        </div>
+      {% endif %}
 
       {% if mel_calendar_links|length > 0 %}
-        <div class="mel-confirmation-calendar">
-          <h3 class="mel-confirmation-calendar__title">{{ 'Add to your calendar'|t }}</h3>
-          <p class="mel-calendar-prompt">{{ 'Don\'t forget to save the date'|t }}</p>
-          <div class="mel-calendar-actions">
-            {% if mel_calendar_links.apple is defined and mel_calendar_links.apple %}
-              <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn mel-calendar-btn--primary" target="_blank" rel="noopener noreferrer">{{ 'Add to calendar'|t }}</a>
-            {% endif %}
-            {% if mel_calendar_links.google is defined and mel_calendar_links.google %}
-              <a href="{{ mel_calendar_links.google }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Google Calendar'|t }}</a>
-            {% endif %}
-            {% if mel_calendar_links.outlook is defined and mel_calendar_links.outlook %}
-              <a href="{{ mel_calendar_links.outlook }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Outlook'|t }}</a>
-            {% endif %}
-          </div>
+        <div class="mel-calendar-actions mel-calendar-actions--frictionless">
+          {% if mel_calendar_links.apple is defined and mel_calendar_links.apple %}
+            <a href="{{ mel_calendar_links.apple }}" class="mel-calendar-btn mel-calendar-btn--primary" target="_blank" rel="noopener noreferrer">{{ 'Add to calendar'|t }}</a>
+          {% endif %}
+          {% if mel_calendar_links.google is defined and mel_calendar_links.google %}
+            <a href="{{ mel_calendar_links.google }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Google Calendar'|t }}</a>
+          {% endif %}
+          {% if mel_calendar_links.outlook is defined and mel_calendar_links.outlook %}
+            <a href="{{ mel_calendar_links.outlook }}" class="mel-calendar-btn" target="_blank" rel="noopener noreferrer">{{ 'Outlook'|t }}</a>
+          {% endif %}
         </div>
       {% endif %}
 
       {% if mel_event_url and events|length > 0 %}
-        <div class="mel-confirmation-actions__secondary">
-          <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
-            {{ 'View event page'|t }}
-          </a>
-        </div>
+        <a href="{{ mel_event_url }}" class="mel-confirmation-button mel-confirmation-button--secondary">
+          {{ 'View event'|t }}
+        </a>
       {% endif %}
-
-      {% if mel_event_url %}
-        {% set mel_share_title = events|length > 0 ? events[0].label() : 'MyEventLane event'|t %}
-        {% set mel_share_copy = 'I’m going to '|t ~ mel_share_title ~ ' on MyEventLane.'|t %}
-        <p class="mel-share-prompt">{{ 'Going with friends? Share this event'|t }}</p>
-        <section class="mel-confirmation-share">
-          <h3 class="mel-confirmation-share__title">{{ 'Share this event'|t }}</h3>
-          <div class="mel-share-actions">
-            <button type="button" class="mel-share-copy" data-url="{{ mel_event_url }}">{{ 'Copy event link'|t }}</button>
-            <button type="button" class="mel-share-native" data-url="{{ mel_event_url }}" data-title="{{ mel_share_title }}" data-text="{{ mel_share_copy }}">{{ 'Share'|t }}</button>
-            <a href="https://www.facebook.com/sharer/sharer.php?u={{ mel_event_url|url_encode }}" class="mel-share-link" target="_blank" rel="noopener noreferrer">{{ 'Facebook'|t }}</a>
-            <a href="https://twitter.com/intent/tweet?url={{ mel_event_url|url_encode }}&text={{ mel_share_copy|url_encode }}" class="mel-share-link" target="_blank" rel="noopener noreferrer">{{ 'X'|t }}</a>
-            <a href="mailto:?subject={{ mel_share_title|url_encode }}&body={{ mel_share_copy|url_encode }}%0A%0A{{ mel_event_url|url_encode }}" class="mel-share-link">{{ 'Email'|t }}</a>
-            <a href="{{ mel_event_url }}" class="mel-share-view">{{ 'View event page'|t }}</a>
-          </div>
-        </section>
-      {% endif %}
-
-      <div class="mel-confirmation-discover">
-        <h3>{{ 'Explore more events'|t }}</h3>
-        <p>{{ 'Discover what\'s happening near you.'|t }}</p>
-        <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-confirmation-button mel-confirmation-button--secondary">{{ 'Browse events'|t }}</a>
-      </div>
-
-      <section class="mel-confirmation-next">
-        <h2 class="mel-confirmation-next__title">{{ 'What happens next'|t }}</h2>
-        <ul class="mel-next-steps">
-          {% if mel_donation_total_formatted %}
-            <li>{{ '✔ Your donation is confirmed'|t }}</li>
-            <li>{{ '✔ We\'ve emailed your receipt'|t }}</li>
-            <li>{{ '✔ Keep your confirmation for your records'|t }}</li>
-          {% elseif mel_confirmation_has_tickets %}
-            <li>{{ '✔ Your tickets are ready'|t }}</li>
-            <li>{{ '✔ We\'ve emailed your confirmation'|t }}</li>
-            <li>{{ '✔ Add the event to your calendar'|t }}</li>
-          {% else %}
-            <li>{{ '✔ Your order is complete'|t }}</li>
-            <li>{{ '✔ We\'ve emailed your confirmation'|t }}</li>
-            <li>{{ '✔ Save your confirmation for your records'|t }}</li>
-          {% endif %}
-        </ul>
-      </section>
-    </div>
-
-    {% if mel_contextual_help_checkout_confirmation is defined and mel_contextual_help_checkout_confirmation %}
-      <div class="mel-confirmation-help mel-contextual-help mel-contextual-help--checkout-confirmation">
-        {{ mel_contextual_help_checkout_confirmation }}
-      </div>
-    {% endif %}
-
-    <nav class="mel-confirmation-trust-nav" aria-label="{{ 'Help and support'|t }}">
-      <a class="mel-confirmation-trust-nav__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a>
-      <span aria-hidden="true" class="mel-confirmation-trust-nav__sep">·</span>
-      <a class="mel-confirmation-trust-nav__link" href="{{ path('myeventlane_support.page') }}">{{ 'Support'|t }}</a>
-    </nav>
-
-    <footer class="mel-confirmation-support">
-      <div class="mel-confirmation-support__links">
-        {% set vendor_email = null %}
-        {% if events|length > 0 %}
-          {% for ev in events %}
-            {% if vendor_email == null and ev.hasField('field_event_vendor') and not ev.get('field_event_vendor').isEmpty() %}
-              {% set vendor = ev.get('field_event_vendor').entity %}
-              {% if vendor and vendor.hasField('field_email') and not vendor.get('field_email').isEmpty() and vendor.hasField('field_public_show_email') and vendor.get('field_public_show_email').value %}
-                {% set vendor_email = vendor.get('field_email').value %}
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-        {% if vendor_email %}
-          <a href="mailto:{{ vendor_email }}">{{ 'Contact organiser'|t }}</a>
-        {% endif %}
-      </div>
-      <p class="mel-confirmation-support__note">{{ 'Questions? We\'re here to help.'|t }}</p>
-    </footer>
-
-    <div class="mel-confirmation-close">
-      <p>{{ 'See you there'|t }}</p>
     </div>
   </div>
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -44,8 +44,8 @@
     <div class="visually-hidden">{{ form.mel_checkout_confidence }}</div>
   {% endif %}
 {% else %}
-  {# mel-checkout--compact-flow: QA hook + SCSS anchor for compact density (any Commerce flow). #}
-  <div class="mel-checkout mel-checkout--compact-flow">
+  {# mel-checkout--structured keeps the active Commerce step single-page while presenting guided sections. #}
+  <div class="mel-checkout mel-checkout--compact-flow mel-checkout--structured">
     {% if title %}
       <h1 class="mel-checkout__title">{{ title }}</h1>
     {% endif %}
@@ -57,8 +57,8 @@
     {% endif %}
 
     <div class="mel-checkout__intro">
-      <h2>{{ 'Secure checkout'|t }}</h2>
-      <p>{{ "You're almost done — review your details and complete your booking."|t }}</p>
+      <h2>{{ 'Complete your booking'|t }}</h2>
+      <p>{{ 'Add ticket holder details, answer attendee questions, then pay securely on this page.'|t }}</p>
     </div>
 
     <div class="mel-checkout-trust">
@@ -72,13 +72,17 @@
     </div>
 
     <div class="mel-checkout__helper">
-      {{ "We'll only use your details to send your ticket."|t }}
+      {{ 'Your order stays on one secure checkout page. Totals update when the checkout form refreshes.'|t }}
     </div>
 
     <div class="mel-checkout__layout mel-checkout__grid mel-checkout__grid--sidebar-flow">
       <div class="mel-checkout__main">
 
-        {{ form|without('progress', 'sidebar', 'actions', 'payment_information', 'mel_buyer_details', 'mel_donation', 'mel_legal_consent', 'ticket_holder_paragraph', 'mel_checkout_confidence') }}
+        {% if form.mel_fast_checkout is defined %}
+          {{ form.mel_fast_checkout }}
+        {% endif %}
+
+        {{ form|without('progress', 'sidebar', 'actions', 'payment_information', 'mel_buyer_details', 'mel_donation', 'mel_legal_consent', 'ticket_holder_paragraph', 'mel_checkout_confidence', 'mel_fast_checkout') }}
 
         {% if mel_contextual_help_checkout is not defined or not mel_contextual_help_checkout %}
           {% if mel_help_checkout_refund is defined and mel_help_checkout_refund %}
@@ -100,21 +104,34 @@
           </div>
         {% endif %}
 
-        {% if form.mel_buyer_details is defined %}
-          <div class="mel-checkout-section mel-checkout-section--buyer">
-            {{ form.mel_buyer_details }}
+        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
+          <div class="mel-checkout-section mel-checkout-section--attendees mel-checkout-section--ticket-holders">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Step 1'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Ticket holders'|t }}</h2>
+              <p class="mel-checkout-section__intro">{{ 'Grouped by ticket type. Add attendee questions here when the organiser asks for them.'|t }}</p>
+            </div>
+            {{ form.ticket_holder_paragraph }}
           </div>
         {% endif %}
 
-        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
-          <div class="mel-checkout-section mel-checkout-section--attendees">
-            <h3 class="mel-checkout-heading">{{ 'Attendee details'|t }}</h3>
-            {{ form.ticket_holder_paragraph }}
+        {% if form.mel_buyer_details is defined %}
+          <div class="mel-checkout-section mel-checkout-section--buyer">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Step 2'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Contact details'|t }}</h2>
+              <p class="mel-checkout-section__intro">{{ "We'll send tickets and booking updates to these details."|t }}</p>
+            </div>
+            {{ form.mel_buyer_details }}
           </div>
         {% endif %}
 
         {% if form.mel_donation is defined %}
           <div class="mel-checkout-section mel-checkout-section--donation">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Optional'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Optional donation'|t }}</h2>
+            </div>
             {{ form.mel_donation }}
           </div>
         {% endif %}
@@ -127,7 +144,10 @@
 
         {% if form.payment_information is defined %}
           <div class="mel-checkout-section mel-checkout-section--payment">
-            <h3 class="mel-checkout-heading">{{ 'Payment'|t }}</h3>
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Final step'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Payment'|t }}</h2>
+            </div>
             {{ form.payment_information }}
           </div>
         {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -49,8 +49,8 @@
     <div class="visually-hidden">{{ form.mel_checkout_confidence }}</div>
   {% endif %}
 {% else %}
-  {# mel-checkout--compact-flow: QA-visible hook + SCSS anchor for compact density (any Commerce flow). #}
-  <div class="mel-checkout mel-checkout--compact-flow">
+  {# mel-checkout--structured keeps the active Commerce step single-page while presenting guided sections. #}
+  <div class="mel-checkout mel-checkout--compact-flow mel-checkout--structured">
 
     {% if title %}
       <h1 class="mel-checkout__title">{{ title }}</h1>
@@ -63,8 +63,8 @@
     {% endif %}
 
     <div class="mel-checkout__intro">
-      <h2>{{ 'Secure checkout'|t }}</h2>
-      <p>{{ "You're almost done — review your details and complete your booking."|t }}</p>
+      <h2>{{ 'Complete your booking'|t }}</h2>
+      <p>{{ 'Add ticket holder details, answer attendee questions, then pay securely on this page.'|t }}</p>
     </div>
 
     <div class="mel-checkout-trust">
@@ -78,7 +78,7 @@
     </div>
 
     <div class="mel-checkout__helper">
-      {{ "We'll only use your details to send your ticket."|t }}
+      {{ 'Your order stays on one secure checkout page. Totals update when the checkout form refreshes.'|t }}
     </div>
 
     <div class="mel-checkout__layout mel-checkout__grid mel-checkout__grid--sidebar-flow">
@@ -90,7 +90,11 @@
           </div>
         {% endif %}
 
-        {{ form|without('progress', 'sidebar', 'actions', 'payment_information', 'mel_buyer_details', 'mel_donation', 'mel_legal_consent', 'ticket_holder_paragraph', 'mel_checkout_confidence') }}
+        {% if form.mel_fast_checkout is defined %}
+          {{ form.mel_fast_checkout }}
+        {% endif %}
+
+        {{ form|without('progress', 'sidebar', 'actions', 'payment_information', 'mel_buyer_details', 'mel_donation', 'mel_legal_consent', 'ticket_holder_paragraph', 'mel_checkout_confidence', 'mel_fast_checkout') }}
 
         {% if mel_contextual_help_checkout is not defined or not mel_contextual_help_checkout %}
           {% if mel_help_checkout_refund is defined and mel_help_checkout_refund %}
@@ -112,21 +116,34 @@
           </div>
         {% endif %}
 
-        {% if form.mel_buyer_details is defined %}
-          <div class="mel-checkout-section mel-checkout-section--buyer">
-            {{ form.mel_buyer_details }}
+        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
+          <div class="mel-checkout-section mel-checkout-section--attendees mel-checkout-section--ticket-holders">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Step 1'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Ticket holders'|t }}</h2>
+              <p class="mel-checkout-section__intro">{{ 'Grouped by ticket type. Add attendee questions here when the organiser asks for them.'|t }}</p>
+            </div>
+            {{ form.ticket_holder_paragraph }}
           </div>
         {% endif %}
 
-        {% if form.ticket_holder_paragraph is defined and form.ticket_holder_paragraph|render|striptags|trim is not empty %}
-          <div class="mel-checkout-section mel-checkout-section--attendees">
-            <h3 class="mel-checkout-heading">{{ 'Attendee details'|t }}</h3>
-            {{ form.ticket_holder_paragraph }}
+        {% if form.mel_buyer_details is defined %}
+          <div class="mel-checkout-section mel-checkout-section--buyer">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Step 2'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Contact details'|t }}</h2>
+              <p class="mel-checkout-section__intro">{{ "We'll send tickets and booking updates to these details."|t }}</p>
+            </div>
+            {{ form.mel_buyer_details }}
           </div>
         {% endif %}
 
         {% if form.mel_donation is defined %}
           <div class="mel-checkout-section mel-checkout-section--donation">
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Optional'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Optional donation'|t }}</h2>
+            </div>
             {{ form.mel_donation }}
           </div>
         {% endif %}
@@ -139,7 +156,10 @@
 
         {% if form.payment_information is defined %}
           <div class="mel-checkout-section mel-checkout-section--payment">
-            <h3 class="mel-checkout-heading">{{ 'Payment'|t }}</h3>
+            <div class="mel-checkout-section__header">
+              <p class="mel-checkout-section__eyebrow">{{ 'Final step'|t }}</p>
+              <h2 class="mel-checkout-heading">{{ 'Payment'|t }}</h2>
+            </div>
             {{ form.payment_information }}
           </div>
         {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
@@ -80,6 +80,6 @@
     <p class="mel-tax-note">{{ 'All prices include GST'|t }}</p>
   {% endif %}
 
-  <a class="mel-checkout-summary__cta" href="#mel-checkout-cta">{{ 'Continue to checkout'|t }}</a>
+  <a class="mel-checkout-summary__jump" href="#mel-checkout-cta">{{ 'Jump to payment'|t }}</a>
 </div>
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it adds Stripe express checkout UX plus custom access control on the Stripe confirmation route, and auto-writes order/billing/attendee paragraph data during checkout. It also changes ticket-tier validation rules and Event Studio client/server limits, which can block publishing/saving if misconfigured.
> 
> **Overview**
> Adds an **eligibility-gated Stripe Express checkout** block to the MEL checkout flow (Link/Apple Pay/Google Pay only), including a lightweight name/email capture step when required and a route-level `_custom_access` guard for `commerce_stripe.express_checkout.payment_confirm`.
> 
> Refactors attendee details handling so checkout can **auto-create minimal ticket-holder paragraphs** from buyer details when no organiser questions exist, and updates checkout theming/JS/CSS for a more structured single-page layout (error scroll/focus, remembered identity, revised confirmation page).
> 
> Updates Event Studio and ticketing to **enforce/communicate a “Best value” ticket** when multiple paid/RSVP tiers exist, adds UI badges, and introduces a **hard limit of 5 attendee questions** (client disable + server/form validation). Also simplifies highlight icon allowed values and tweaks vendor console wiring (attendees tab routing + controller logger injection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1cfa2d213621b837d717930762602946dbccbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->