### PR TITLE
fix(checkout): restore fast-checkout question keys and dedupe donatio…

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
@@ -81,16 +81,19 @@ final class CheckoutGroupedSummaryBuilder {
       }
     }
 
-    foreach ($order->getAdjustments() as $adjustment) {
-      if ((string) $adjustment->getLabel() !== 'Contribution') {
-        continue;
-      }
-      $donationPrice = $adjustment->getAmount();
-      if ($donationPrice instanceof Price && !$donationPrice->isZero()) {
-        $currencyCode = $donationPrice->getCurrencyCode();
-        $donationTotals[$currencyCode] = isset($donationTotals[$currencyCode])
-          ? $donationTotals[$currencyCode]->add($donationPrice)
-          : $donationPrice;
+    // Skip adjustments when donation line items already contributed (migration overlap).
+    if ($donationTotals === []) {
+      foreach ($order->getAdjustments() as $adjustment) {
+        if ((string) $adjustment->getLabel() !== 'Contribution') {
+          continue;
+        }
+        $donationPrice = $adjustment->getAmount();
+        if ($donationPrice instanceof Price && !$donationPrice->isZero()) {
+          $currencyCode = $donationPrice->getCurrencyCode();
+          $donationTotals[$currencyCode] = isset($donationTotals[$currencyCode])
+            ? $donationTotals[$currencyCode]->add($donationPrice)
+            : $donationPrice;
+        }
       }
     }
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/FastCheckoutEligibility.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/FastCheckoutEligibility.php
@@ -347,11 +347,25 @@ final class FastCheckoutEligibility {
     $key = $machine_name !== '' ? $machine_name : $label;
     $key = str_replace(['-', ' '], '_', $key);
 
-    if ($key === 'name' && $type === 'textfield') {
+    $textTypes = ['textfield', 'text'];
+
+    if (in_array($key, ['name', 'full_name', 'attendee_name'], TRUE)
+      && in_array($type, $textTypes, TRUE)) {
       return 'name';
     }
 
-    if ($key === 'email' && in_array($type, ['email', 'textfield'], TRUE)) {
+    if (in_array($key, ['first_name', 'firstname', 'given_name'], TRUE)
+      && in_array($type, $textTypes, TRUE)) {
+      return 'first_name';
+    }
+
+    if (in_array($key, ['last_name', 'lastname', 'family_name', 'surname'], TRUE)
+      && in_array($type, $textTypes, TRUE)) {
+      return 'last_name';
+    }
+
+    if (in_array($key, ['email', 'email_address', 'attendee_email'], TRUE)
+      && in_array($type, ['email', 'textfield', 'text'], TRUE)) {
       return 'email';
     }
 


### PR DESCRIPTION
…n totals

- Reinstate classifyBasicQuestion handling for full_name, attendee_name, first/last name synonyms, email variants, and text widget types so express checkout eligibility matches common event question patterns.
- Aggregate Contribution adjustments for optional_donation_formatted only when no donation order items contributed, avoiding double-count during adjustment vs line-item migration overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout eligibility classification and donation total calculation/formatting, which can change whether express checkout is offered and how donation amounts display on orders. Risk is moderate due to behavioral changes around payment UX and totals during donation migration overlap.
> 
> **Overview**
> Improves fast checkout eligibility by expanding `classifyBasicQuestion()` to recognize common name/email question variants (e.g., `full_name`, `attendee_name`, first/last-name synonyms) and treating both `text` and `textfield` widget types as compatible.
> 
> Prevents double-counting optional donations in the grouped checkout summary by only aggregating `Contribution` adjustments when no donation line items have already been summed (to handle line-item vs adjustment migration overlap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18a3990cb8c0b62283a7b683f6fa738b6bf3793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->