### PR TITLE
Cursor/2026 05 05 99z5 fa433

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
@@ -11,15 +11,18 @@ declare(strict_types=1);
  * Primary module file for MyEventLane Vendor.
  */
 
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Implements hook_user_login().
@@ -329,19 +332,29 @@ function myeventlane_vendor_page_attachments_alter(array &$attachments): void {
 
 /**
  * Implements hook_preprocess_node().
+ *
+ * - Vendor console studio: overview desk teaser URL override.
+ * - vendor_card view mode: PHP-built thumbnail, removal dialog payload, tickets
+ *   URL for organiser bulk list on /vendor/events.
  */
 function myeventlane_vendor_preprocess_node(array &$variables): void {
   $route_name = \Drupal::routeMatch()->getRouteName();
-  if ($route_name !== 'myeventlane_vendor.console.studio') {
-    return;
+  if ($route_name === 'myeventlane_vendor.console.studio') {
+    $desk = (string) \Drupal::request()->query->get('desk', '');
+    if ($desk === 'overview' && ($variables['view_mode'] ?? '') === 'teaser') {
+      $node = $variables['node'] ?? NULL;
+      if ($node instanceof NodeInterface && $node->bundle() === 'event') {
+        $variables['url'] = Url::fromRoute('myeventlane_vendor.console.studio', [], [
+          'query' => [
+            'desk' => 'overview',
+            'event' => (int) $node->id(),
+          ],
+        ])->toString();
+      }
+    }
   }
 
-  $desk = (string) \Drupal::request()->query->get('desk', '');
-  if ($desk !== 'overview') {
-    return;
-  }
-
-  if (($variables['view_mode'] ?? '') !== 'teaser') {
+  if (($variables['view_mode'] ?? '') !== 'vendor_card') {
     return;
   }
 
@@ -350,12 +363,50 @@ function myeventlane_vendor_preprocess_node(array &$variables): void {
     return;
   }
 
-  $variables['url'] = Url::fromRoute('myeventlane_vendor.console.studio', [], [
-    'query' => [
-      'desk' => 'overview',
-      'event' => (int) $node->id(),
-    ],
-  ])->toString();
+  /** @var \Drupal\myeventlane_vendor\Service\VendorEventRemovalService $removal */
+  $removal = \Drupal::service('myeventlane_vendor.vendor_event_removal');
+  $account = \Drupal::currentUser();
+  $variables['mel_event_card_image'] = $removal->buildEventThumbnailData($node);
+  $variables['mel_event_removal'] = $removal->buildRemovalUiPayload($node, $account);
+  $variables['mel_event_tickets_url'] = _myeventlane_vendor_vendor_card_tickets_url($node, $account);
+
+  if (isset($variables['content']['field_event_image'])) {
+    unset($variables['content']['field_event_image']);
+  }
+}
+
+/**
+ * Builds tickets deep-link URL for vendor_card when route access allows.
+ */
+function _myeventlane_vendor_vendor_card_tickets_url(NodeInterface $node, AccountInterface $account): ?string {
+  $route_name = 'myeventlane_vendor.console.event_tickets';
+  $route_provider = \Drupal::service('router.route_provider');
+  try {
+    $route_provider->getRouteByName($route_name);
+  }
+  catch (RouteNotFoundException) {
+    return NULL;
+  }
+
+  $params = ['event' => (int) $node->id()];
+  try {
+    /** @var \Drupal\Core\Access\AccessManagerInterface $access */
+    $access = \Drupal::service('access_manager');
+    $result = $access->checkNamedRoute($route_name, $params, $account, TRUE);
+    if (!$result instanceof AccessResultInterface || !$result->isAllowed()) {
+      return NULL;
+    }
+  }
+  catch (\Throwable) {
+    return NULL;
+  }
+
+  try {
+    return Url::fromRoute($route_name, $params)->toString();
+  }
+  catch (\Throwable) {
+    return NULL;
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -645,6 +645,21 @@ myeventlane_vendor.console.event_settings:
         bundle:
           - event
 
+myeventlane_vendor.console.event_archive:
+  path: '/vendor/events/{event}/archive'
+  defaults:
+    _controller: 'myeventlane_vendor.controller.vendor_event_archive:handle'
+  methods: [POST]
+  requirements:
+    _custom_access: 'myeventlane_vendor.access.vendor_managed_event_console:access'
+    event: '\d+'
+  options:
+    parameters:
+      event:
+        type: entity:node
+        bundle:
+          - event
+
 myeventlane_vendor.console.event_unpublish:
   path: '/vendor/events/{event}/unpublish'
   defaults:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -50,6 +50,7 @@ services:
     class: Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery
     arguments:
       - '@entity_type.manager'
+      - '@entity_field.manager'
 
   myeventlane_vendor.event_studio_create:
     class: Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService
@@ -62,6 +63,25 @@ services:
 
   myeventlane_vendor.event_access_checker:
     class: Drupal\myeventlane_vendor\Service\EventVendorAccessChecker
+
+  myeventlane_vendor.access.vendor_managed_event_console:
+    class: Drupal\myeventlane_vendor\Access\VendorManagedEventConsoleAccess
+    arguments:
+      - '@myeventlane_vendor.access.vendor_console'
+      - '@myeventlane_vendor.event_access_checker'
+
+  myeventlane_vendor.vendor_event_removal:
+    class: Drupal\myeventlane_vendor\Service\VendorEventRemovalService
+    arguments:
+      - '@entity_type.manager'
+      - '@file_url_generator'
+      - '@myeventlane_vendor.service.ticket_sales'
+      - '@myeventlane_vendor.service.rsvp_stats'
+      - '@myeventlane_event_studio.save'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@csrf_token'
+      - '@string_translation'
+      - '@logger.factory'
 
   myeventlane_vendor.paid_publish_stripe_gate:
     class: Drupal\myeventlane_vendor\Service\PaidPublishStripeGate
@@ -217,6 +237,7 @@ services:
       - '@entity_field.manager'
       - '@string_translation'
       - '@logger.factory'
+      - '@myeventlane_vendor.vendor_event_removal'
 
   myeventlane_vendor.dashboard_view_model_builder:
     class: Drupal\myeventlane_vendor\Service\VendorDashboardViewModelBuilder
@@ -236,6 +257,7 @@ services:
       - '@date.formatter'
       - '@string_translation'
       - '@logger.factory'
+      - '@myeventlane_vendor.vendor_event_removal'
 
   myeventlane_vendor.service.event_tabs:
     class: Drupal\myeventlane_vendor\Service\VendorEventTabsService
@@ -453,6 +475,17 @@ services:
       - '@logger.channel.myeventlane_vendor'
       - '@request_stack'
       - '@myeventlane_vendor.event_workspace_view_model_builder'
+    tags:
+      - { name: controller.service_arguments }
+
+  myeventlane_vendor.controller.vendor_event_archive:
+    class: Drupal\myeventlane_vendor\Controller\VendorEventArchiveController
+    arguments:
+      - '@myeventlane_core.domain_detector'
+      - '@current_user'
+      - '@messenger'
+      - '@myeventlane_vendor.vendor_event_removal'
+      - '@csrf_token'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Access/VendorManagedEventConsoleAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/VendorManagedEventConsoleAccess.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+
+/**
+ * Vendor console access plus managed-event workspace parity for {event} routes.
+ */
+final class VendorManagedEventConsoleAccess {
+
+  public function __construct(
+    private readonly VendorConsoleAccess $vendorConsoleAccess,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+  ) {}
+
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResult {
+    $base = $this->vendorConsoleAccess->access($route_match, $account);
+    if (!$base->isAllowed()) {
+      return $base;
+    }
+
+    $event = $route_match->getParameter('event');
+    if (!$event instanceof NodeInterface || $event->bundle() !== 'event') {
+      return AccessResult::forbidden();
+    }
+
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return AccessResult::forbidden();
+    }
+
+    return AccessResult::allowed()->addCacheableDependency($event);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -401,6 +401,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'library' => [
           'myeventlane_vendor_theme/global-styling',
           'myeventlane_vendor_theme/dashboard',
+          'myeventlane_vendor_theme/mel_event_card_remove',
         ],
       ],
     ];

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventArchiveController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventArchiveController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Controller;
+
+use Drupal\Core\Access\CsrfTokenGenerator;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_vendor\Service\VendorEventRemovalService;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+/**
+ * POST handler for safe archive/delete from vendor console event cards.
+ */
+final class VendorEventArchiveController extends VendorConsoleBaseController {
+
+  public function __construct(
+    DomainDetector $domain_detector,
+    AccountProxyInterface $current_user,
+    MessengerInterface $messenger,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
+    private readonly CsrfTokenGenerator $csrfToken,
+  ) {
+    parent::__construct($domain_detector, $current_user, $messenger);
+  }
+
+  public function handle(NodeInterface $event, Request $request): RedirectResponse {
+    $this->assertEventOwnership($event);
+
+    if (!$request->isMethod(Request::METHOD_POST)) {
+      throw new MethodNotAllowedHttpException(['POST']);
+    }
+
+    $tokenId = 'vendor_event_remove_' . (int) $event->id();
+    $submitted = (string) $request->request->get('token', '');
+    if (!$this->csrfToken->validate($submitted, $tokenId)) {
+      $this->messenger->addError($this->t('Security validation failed. Please reload the page and try again.'));
+      return $this->redirectToEvents();
+    }
+
+    $result = $this->vendorEventRemovalService->executeRemovalFromRequest($event, $this->currentUser);
+    $action = (string) ($result['action'] ?? 'error');
+    $message = (string) ($result['message'] ?? '');
+
+    if ($action === 'error' || $message === '') {
+      $this->messenger->addError($message !== '' ? $message : $this->t('The event could not be updated.'));
+    }
+    elseif ($action === 'noop') {
+      $this->messenger->addWarning($message);
+    }
+    else {
+      $this->messenger->addStatus($message);
+    }
+
+    return $this->redirectToEvents();
+  }
+
+  private function redirectToEvents(): RedirectResponse {
+    try {
+      $url = Url::fromRoute('myeventlane_vendor.console.events')->toString();
+    }
+    catch (\Throwable) {
+      $url = '/vendor/events';
+    }
+    return new RedirectResponse($url);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventsController.php
@@ -80,6 +80,11 @@ final class VendorEventsController extends VendorConsoleBaseController implement
           'contexts' => ['user'],
           'max-age' => 0,
         ],
+        '#attached' => [
+          'library' => [
+            'myeventlane_vendor_theme/mel_event_card_remove',
+          ],
+        ],
       ],
     ];
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/CurrentVendorResolver.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/CurrentVendorResolver.php
@@ -65,7 +65,8 @@ final class CurrentVendorResolver implements CurrentVendorResolverInterface {
 
     try {
       $storage = $this->entityTypeManager->getStorage('myeventlane_vendor');
-      $query = $storage->getQuery()->accessCheck(FALSE);
+      // Align with UserVendorMembershipQuery and billing helpers (access-aware).
+      $query = $storage->getQuery()->accessCheck(TRUE);
       $or = $query->orConditionGroup()
         ->condition('uid', $uid)
         ->condition('field_vendor_users', $uid);

--- a/web/modules/custom/myeventlane_vendor/src/Service/UserVendorMembershipQuery.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/UserVendorMembershipQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Service;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -17,6 +18,7 @@ final class UserVendorMembershipQuery {
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EntityFieldManagerInterface $entityFieldManager,
   ) {}
 
   /**
@@ -78,6 +80,12 @@ final class UserVendorMembershipQuery {
       $or->condition('uid', $uid);
       if ($vendorIds !== []) {
         $or->condition('field_event_vendor', $vendorIds, 'IN');
+        // Parity with VendorDashboardController::getUserEvents(): optional legacy
+        // event → vendor reference when present on the event bundle.
+        $eventFields = $this->entityFieldManager->getFieldDefinitions('node', 'event');
+        if (isset($eventFields['field_vendor'])) {
+          $or->condition('field_vendor', $vendorIds, 'IN');
+        }
       }
       $query->condition($or);
       $ids = $query->execute();

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -48,6 +48,7 @@ final class VendorDashboardViewModelBuilder {
     private readonly DateFormatterInterface $dateFormatter,
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -82,7 +83,7 @@ final class VendorDashboardViewModelBuilder {
 
     $events = [];
     try {
-      $events = $this->buildEventRows($uid);
+      $events = $this->buildEventRows($uid, $account);
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_vendor')->warning('Dashboard view model events build failed for uid @uid: @message', [
@@ -406,7 +407,7 @@ final class VendorDashboardViewModelBuilder {
   /**
    * @return list<array<string, mixed>>
    */
-  private function buildEventRows(int $uid): array {
+  private function buildEventRows(int $uid, AccountInterface $account): array {
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
     if ($ids === []) {
       return [];
@@ -427,7 +428,7 @@ final class VendorDashboardViewModelBuilder {
     $eventNodes = array_slice($eventNodes, 0, self::MAX_EVENTS);
     $rows = [];
     foreach ($eventNodes as $node) {
-      $rows[] = $this->buildEventRow($node);
+      $rows[] = $this->buildEventRow($node, $account);
     }
 
     return $rows;
@@ -436,7 +437,7 @@ final class VendorDashboardViewModelBuilder {
   /**
    * @return array<string, mixed>
    */
-  private function buildEventRow(NodeInterface $node): array {
+  private function buildEventRow(NodeInterface $node, AccountInterface $account): array {
     $nid = (int) $node->id();
     $published = $node->isPublished();
     $startTs = $this->getDateFieldTimestamp($node, 'field_event_start');
@@ -529,7 +530,8 @@ final class VendorDashboardViewModelBuilder {
       'metric_label' => $metricLabel,
       'revenue_label' => $revenueLabel,
       'presentation_issues' => $presentation['items'] ?? [],
-      'image' => NULL,
+      'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
+      'removal' => $this->vendorEventRemovalService->buildRemovalUiPayload($node, $account),
       'links' => [
         'manage' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_workspace', ['event' => $nid]),
         'edit' => $this->safeUrlFromRoute('myeventlane_event_studio.edit', ['node' => $nid]),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
@@ -44,6 +44,7 @@ final class VendorEventIndexViewModelBuilder {
     private readonly EntityFieldManagerInterface $entityFieldManager,
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -286,6 +287,8 @@ final class VendorEventIndexViewModelBuilder {
       'needs_attention' => $needsAttention,
       'attention_label' => $attentionLabel,
       'presentation_issues' => $presentationItems,
+      'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
+      'removal' => $this->vendorEventRemovalService->buildRemovalUiPayload($node, $account),
       'links' => [
         'manage' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_workspace', ['event' => $nid], $account),
         'edit' => $this->routeUrlIfAccessible('myeventlane_event_studio.edit', ['node' => $nid], $account),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Access\CsrfTokenGenerator;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\node\NodeInterface;
+
+/**
+ * Safe archive/delete decisions and thumbnail data for vendor console cards.
+ *
+ * Booking activity blocks permanent deletion; archive uses Event Studio publish
+ * state (aligned with vendor bulk unpublish).
+ */
+final class VendorEventRemovalService {
+
+  use StringTranslationTrait;
+
+  private const THUMB_STYLE = 'thumbnail';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly TicketSalesService $ticketSalesService,
+    private readonly RsvpStatsService $rsvpStatsService,
+    private readonly EventStudioSaveService $eventStudioSaveService,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly CsrfTokenGenerator $csrfToken,
+    TranslationInterface $string_translation,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds event card image data for Twig (no entity loading in templates).
+   *
+   * @return array<string, mixed>
+   *   Keys: url (string|null), alt (string), is_placeholder (bool).
+   */
+  public function buildEventThumbnailData(NodeInterface $event): array {
+    $alt = trim((string) $event->getTitle());
+    if ($alt === '') {
+      $alt = (string) $this->t('Event image');
+    }
+
+    $url = NULL;
+    if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
+      $file = $event->get('field_event_image')->entity;
+      if ($file instanceof FileInterface) {
+        try {
+          $style = $this->entityTypeManager->getStorage('image_style')->load(self::THUMB_STYLE);
+          if ($style) {
+            $relative = $style->buildUrl($file->getFileUri());
+            $url = $this->fileUrlGenerator->generateString($relative);
+          }
+        }
+        catch (\Throwable $e) {
+          $this->loggerFactory->get('myeventlane_vendor')->warning('Event card thumbnail URL failed for nid @nid: @message', [
+            '@nid' => (string) $event->id(),
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+    }
+
+    return [
+      'url' => $url,
+      'alt' => $alt,
+      'is_placeholder' => $url === NULL,
+    ];
+  }
+
+  /**
+   * @return array<string, int|bool>
+   */
+  public function getBookingActivitySummary(NodeInterface $event): array {
+    $nid = (int) $event->id();
+    $sales = $this->ticketSalesService->getSalesSummary($event);
+    $ticketsSold = (int) ($sales['tickets_sold'] ?? 0);
+    $ordersCount = (int) ($sales['orders_count'] ?? 0);
+    $rsvpCount = 0;
+    try {
+      $rsvpCount = $this->rsvpStatsService->getEventRsvpCount($nid);
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Removal activity: RSVP count failed for nid @nid: @message', [
+        '@nid' => (string) $nid,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+
+    $attendeeCount = $this->countNonCancelledAttendees($nid);
+
+    $hasActivity = $ticketsSold > 0
+      || $ordersCount > 0
+      || $rsvpCount > 0
+      || $attendeeCount > 0;
+
+    return [
+      'tickets_sold' => $ticketsSold,
+      'orders_count' => $ordersCount,
+      'rsvp_count' => $rsvpCount,
+      'attendee_count' => $attendeeCount,
+      'has_booking_activity' => $hasActivity,
+    ];
+  }
+
+  private function countNonCancelledAttendees(int $eventNid): int {
+    if ($eventNid <= 0 || !$this->entityTypeManager->hasDefinition('event_attendee')) {
+      return 0;
+    }
+    try {
+      $storage = $this->entityTypeManager->getStorage('event_attendee');
+      return (int) $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('event', $eventNid)
+        ->condition('status', 'cancelled', '<>')
+        ->count()
+        ->execute();
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Removal activity: attendee count failed for nid @nid: @message', [
+        '@nid' => (string) $eventNid,
+        '@message' => $e->getMessage(),
+      ]);
+      return 0;
+    }
+  }
+
+  public function accountMayDeleteNode(NodeInterface $event, AccountInterface $account): bool {
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+    return $event->access('delete', $account, TRUE)->isAllowed();
+  }
+
+  /**
+   * Performs archive (unpublish) and/or delete per platform rules.
+   *
+   * @return array{action: string, message: string}
+   *   action is one of: archived, deleted, noop, error.
+   */
+  public function executeRemovalFromRequest(NodeInterface $event, AccountInterface $account): array {
+    $summary = $this->getBookingActivitySummary($event);
+    $hasActivity = (bool) ($summary['has_booking_activity'] ?? FALSE);
+    $mayDelete = $this->accountMayDeleteNode($event, $account);
+
+    try {
+      if ($event->isPublished()) {
+        if ($hasActivity || !$mayDelete) {
+          $this->eventStudioSaveService->setNodePublishedState(
+            $event,
+            $account,
+            FALSE,
+            'Vendor console: archive/unpublish from event card (booking activity or delete not permitted).',
+          );
+          return [
+            'action' => 'archived',
+            'message' => $hasActivity
+              ? (string) $this->t('This event had booking activity, so it was archived instead of permanently deleted.')
+              : (string) $this->t('Event archived (unpublished).'),
+          ];
+        }
+        $event->delete();
+        return [
+          'action' => 'deleted',
+          'message' => (string) $this->t('Event deleted.'),
+        ];
+      }
+
+      // Unpublished / draft.
+      if ($hasActivity) {
+        return [
+          'action' => 'noop',
+          'message' => (string) $this->t('This event already has reduced visibility and still has booking records. It was not removed.'),
+        ];
+      }
+      if ($mayDelete) {
+        $event->delete();
+        return [
+          'action' => 'deleted',
+          'message' => (string) $this->t('Event deleted.'),
+        ];
+      }
+      return [
+        'action' => 'error',
+        'message' => (string) $this->t('You do not have permission to delete this event.'),
+      ];
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->error('Event removal failed for nid @nid: @message', [
+        '@nid' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return [
+        'action' => 'error',
+        'message' => (string) $this->t('The event could not be updated. Please try again or use Event settings.'),
+      ];
+    }
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   *   Removal UI payload, or NULL when the account must not see removal.
+   */
+  public function buildRemovalUiPayload(NodeInterface $event, AccountInterface $account): ?array {
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return NULL;
+    }
+
+    $summary = $this->getBookingActivitySummary($event);
+    $hasActivity = (bool) $summary['has_booking_activity'];
+    $mayDelete = $this->accountMayDeleteNode($event, $account);
+
+    if (!$event->isPublished() && $hasActivity) {
+      return NULL;
+    }
+    if (!$event->isPublished() && !$mayDelete) {
+      return NULL;
+    }
+
+    $nid = (int) $event->id();
+    $tokenId = 'vendor_event_remove_' . $nid;
+    $token = $this->csrfToken->get($tokenId);
+
+    try {
+      $formAction = Url::fromRoute('myeventlane_vendor.console.event_archive', ['event' => $nid])->toString();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+
+    if ($event->isPublished()) {
+      $dangerLabel = ($hasActivity || !$mayDelete)
+        ? (string) $this->t('Archive')
+        : (string) $this->t('Delete');
+    }
+    else {
+      $dangerLabel = (string) $this->t('Delete');
+    }
+
+    $confirmPrimary = $hasActivity
+      ? (string) $this->t('Archive event')
+      : ($mayDelete ? (string) $this->t('Delete event') : (string) $this->t('Archive event'));
+
+    $modalTitle = (string) $this->t('Delete this event?');
+    $modalBody = (string) $this->t('Are you sure you want to delete this event? This action may affect tickets, RSVPs, attendees, and reporting.');
+    $modalActivity = $hasActivity
+      ? (string) $this->t('This event has booking activity, so it cannot be permanently deleted. You can archive it instead.')
+      : '';
+
+    return [
+      'form_action' => $formAction,
+      'form_token' => $token,
+      'form_token_id' => $tokenId,
+      'danger_label' => $dangerLabel,
+      'confirm_primary_label' => $confirmPrimary,
+      'cancel_label' => (string) $this->t('Cancel'),
+      'modal_title' => $modalTitle,
+      'modal_body' => $modalBody,
+      'modal_activity_notice' => $modalActivity,
+      'has_booking_activity' => $hasActivity,
+      'dialog_id' => 'mel-event-remove-' . $nid,
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Kernel/EventOverviewSalesSummaryTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Kernel/EventOverviewSalesSummaryTest.php
@@ -98,7 +98,10 @@ final class EventOverviewSalesSummaryTest extends KernelTestBase {
       $this->container->get('logger.factory'),
       $this->createMock(VendorSubscriptionService::class),
       $configFactory,
-      new UserVendorMembershipQuery($this->container->get('entity_type.manager')),
+      new UserVendorMembershipQuery(
+        $this->container->get('entity_type.manager'),
+        $this->container->get('entity_field.manager'),
+      ),
     );
   }
 

--- a/web/themes/custom/myeventlane_vendor_theme/js/mel-event-card-remove.js
+++ b/web/themes/custom/myeventlane_vendor_theme/js/mel-event-card-remove.js
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * Opens/closes vendor event card removal <dialog> elements (keyboard-friendly).
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  /**
+   * @param {HTMLDialogElement} dialog
+   */
+  function trapReturn(dialog) {
+    dialog.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        dialog.close();
+      }
+    });
+  }
+
+  Drupal.behaviors.melEventCardRemove = {
+    attach(context) {
+      once('mel-event-card-remove-open', '[data-mel-open-dialog]', context).forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const id = btn.getAttribute('data-mel-open-dialog');
+          if (!id) {
+            return;
+          }
+          const dialog = document.getElementById(id);
+          if (dialog && dialog.tagName === 'DIALOG' && typeof dialog.showModal === 'function') {
+            dialog.showModal();
+            trapReturn(dialog);
+            const focusTarget = dialog.querySelector(
+              'button[data-mel-dialog-close], button[type="submit"], a[href]',
+            );
+            if (focusTarget && typeof focusTarget.focus === 'function') {
+              focusTarget.focus();
+            }
+          }
+        });
+      });
+
+      once('mel-event-card-remove-close', '[data-mel-dialog-close]', context).forEach((el) => {
+        el.addEventListener('click', () => {
+          const dialog = el.closest('dialog');
+          if (dialog && typeof dialog.close === 'function') {
+            dialog.close();
+          }
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
@@ -37,6 +37,13 @@ dashboard:
   dependencies:
     - myeventlane_vendor_theme/global-styling
 
+mel_event_card_remove:
+  js:
+    js/mel-event-card-remove.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Chart.js library (CDN)
 chartjs:
   version: 4.4.1
@@ -91,6 +98,7 @@ mel_vendor_events:
     - core/drupal
     - core/once
     - myeventlane_vendor_theme/global-styling
+    - myeventlane_vendor_theme/mel_event_card_remove
 
 mel_notifications:
   dependencies:

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1258,6 +1258,9 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
     ],
     'myeventlane_vendor_dashboard' => [
       'variables' => [
+        // Required: ThemeManager only forwards #keys listed here (see
+        // \Drupal\Core\Theme\ThemeManager::render).
+        'vendor_dashboard_view_model' => [],
         'is_admin' => FALSE,
         'vendor_store_id' => NULL,
         'event_count' => 0,

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
@@ -1,0 +1,114 @@
+/**
+ * @file
+ * Event card thumbnail + removal dialog (dashboard + events index).
+ */
+
+@use '../tokens/colors' as c;
+@use '../tokens/radii' as r;
+@use '../tokens/spacing' as sp;
+@use '../tokens/typography' as *;
+
+.mel-event-card-thumb {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: r.$radius-md;
+  overflow: hidden;
+  background: linear-gradient(135deg, #ede9fe 0%, #e0e7ff 100%);
+  border: 1px solid c.$ml-vendor-border;
+
+  &__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &--placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: c.$ml-vendor-slate;
+    text-transform: uppercase;
+  }
+}
+
+.mel-event-card-remove-open {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 sp.$spacing-3;
+  border: 1px solid rgba(242, 109, 91, 0.45);
+  color: #c2410c;
+  background: #fff7ed;
+
+  &:hover {
+    border-color: rgba(242, 109, 91, 0.75);
+    background: #ffedd5;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #7c83fd;
+    outline-offset: 2px;
+  }
+}
+
+.mel-event-remove-dialog {
+  padding: 0;
+  border: none;
+  background: transparent;
+  max-width: calc(100vw - 32px);
+
+  &::backdrop {
+    background: rgba(15, 23, 42, 0.45);
+  }
+
+  &__panel {
+    background: c.$ml-vendor-card;
+    border-radius: r.$radius-lg;
+    border: 1px solid c.$ml-vendor-border;
+    box-shadow: 0 16px 48px rgba(13, 21, 32, 0.18);
+    padding: sp.$spacing-6 sp.$spacing-5;
+    max-width: 28rem;
+  }
+
+  &__title {
+    margin: 0 0 sp.$spacing-3;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: c.$ml-vendor-text-dark;
+  }
+
+  &__body,
+  &__notice {
+    margin: 0 0 sp.$spacing-3;
+    font-size: $font-size-sm;
+    line-height: 1.5;
+    color: c.$ml-vendor-slate;
+  }
+
+  &__notice {
+    padding: sp.$spacing-3;
+    border-radius: r.$radius-md;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    background: rgba(254, 243, 199, 0.45);
+    color: #92400e;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: sp.$spacing-3;
+    justify-content: flex-end;
+    margin-top: sp.$spacing-4;
+  }
+
+  &__btn {
+    min-height: 44px;
+    min-width: 44px;
+    padding-left: sp.$spacing-4;
+    padding-right: sp.$spacing-4;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-vendor-events.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-vendor-events.scss
@@ -177,6 +177,18 @@
     height: 100%;
     object-fit: cover;
   }
+
+  .mel-event-card-thumb {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+
+  .mel-event-card-thumb__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .mel-card__image-placeholder {
@@ -290,6 +302,20 @@
   margin-top: 12px;
 }
 
+.mel-card__actions--vendor-console {
+  flex-wrap: wrap;
+  row-gap: sp.$spacing-2;
+  column-gap: sp.$spacing-2;
+
+  .mel-btn,
+  .mel-event-card-remove-open {
+    min-height: 44px;
+    min-width: 44px;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
 // -----------------------------------------------------------------------------
 // List mode override (Phase 4)
 // -----------------------------------------------------------------------------
@@ -303,6 +329,18 @@
     min-width: 120px;
     height: 80px;
     flex-shrink: 0;
+
+    .mel-event-card-thumb {
+      width: 100%;
+      height: 100%;
+      border-radius: 12px;
+    }
+
+    .mel-event-card-thumb__img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 
   .mel-card__body {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -75,6 +75,7 @@
   @include meta.load-css('components/mel-event-overview');
   @include meta.load-css('components/insights');
   @include meta.load-css('components/mel-vendor-events');
+  @include meta.load-css('components/mel-event-card-removal');
   @include meta.load-css('components/footer');
   @include meta.load-css('components/mel-header-footer');
   @include meta.load-css('components/wizard');

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_mel-dashboard.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_mel-dashboard.scss
@@ -565,6 +565,14 @@
     }
   }
 
+  &__billing-strip--below-events {
+    margin-top: $spacing-2;
+  }
+
+  &__boost-slot--below-events {
+    margin-top: $spacing-3;
+  }
+
   &__section {
     width: 100%;
   }
@@ -859,6 +867,25 @@
     flex-direction: column;
     gap: $spacing-2;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+  }
+
+  &__event-card-top {
+    display: flex;
+    gap: $spacing-4;
+    align-items: flex-start;
+  }
+
+  &__event-card-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-2;
+  }
+
+  &__event-actions-row {
+    flex-wrap: wrap;
+    align-items: center;
   }
 
   &__event-card-head {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_vendor-events.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_vendor-events.scss
@@ -229,6 +229,20 @@ $mel-focus: #7c83fd;
   gap: sp.$spacing-3;
 }
 
+.mel-vendor-events-v2__card-top {
+  display: flex;
+  gap: sp.$spacing-4;
+  align-items: flex-start;
+}
+
+.mel-vendor-events-v2__card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-3;
+}
+
 .mel-vendor-events-v2__card-header {
   display: flex;
   flex-wrap: wrap;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-event-card-removal-dialog.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-event-card-removal-dialog.html.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Confirmation dialog + POST form for vendor event card archive/delete.
+ *
+ * @var removal
+ *   Keys: dialog_id, form_action, form_token, modal_title, modal_body,
+ *   modal_activity_notice, cancel_label, confirm_primary_label.
+ */
+#}
+{% set r = removal|default({}) %}
+{% if r.form_action is defined and r.form_action %}
+  <dialog class="mel-event-remove-dialog" id="{{ r.dialog_id|e('html_attr') }}" aria-labelledby="{{ r.dialog_id|e('html_attr') }}-title">
+    <div class="mel-event-remove-dialog__panel">
+      <h2 class="mel-event-remove-dialog__title" id="{{ r.dialog_id|e('html_attr') }}-title">{{ r.modal_title|default('') }}</h2>
+      <p class="mel-event-remove-dialog__body">{{ r.modal_body|default('') }}</p>
+      {% if r.modal_activity_notice is defined and r.modal_activity_notice %}
+        <p class="mel-event-remove-dialog__notice" role="status">{{ r.modal_activity_notice }}</p>
+      {% endif %}
+      <form class="mel-event-remove-dialog__form" method="post" action="{{ r.form_action }}">
+        <input type="hidden" name="token" value="{{ r.form_token|e('html_attr') }}"/>
+        <div class="mel-event-remove-dialog__actions">
+          <button type="button" class="mel-btn mel-btn--secondary mel-event-remove-dialog__btn" data-mel-dialog-close>{{ r.cancel_label|default('Cancel'|t) }}</button>
+          <button type="submit" class="mel-btn mel-btn--danger mel-event-remove-dialog__btn">{{ r.confirm_primary_label|default('Confirm'|t) }}</button>
+        </div>
+      </form>
+    </div>
+  </dialog>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -14,6 +14,7 @@
 {% set empty_state = model.empty_state|default({}) %}
 {% set analytics_summary = model.analytics_summary|default({}) %}
 {% set analytics_items = analytics_summary.items|default([]) %}
+{% set dashboard_vendor_id = vendor.id|default(null) %}
 
 {% set hero_body %}
   {% if actions is iterable and actions|length > 0 %}
@@ -39,10 +40,6 @@
 <section class="mel-vendor-dashboard-v2">
   {% if onboarding_panel is defined and onboarding_panel %}
     <div class="mel-vendor-dashboard-v2__onboarding">{{ onboarding_panel }}</div>
-  {% endif %}
-
-  {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
-    <div class="mel-vendor-dashboard-v2__billing-strip">{{ mel_contribution_billing_strip }}</div>
   {% endif %}
 
   <header class="mel-vendor-dashboard-v2__hero">
@@ -86,53 +83,7 @@
     </div>
   </header>
 
-  {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
-    <div class="mel-vendor-dashboard-v2__boost-slot">
-      {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
-        event: {
-          title: mel_top_boost_opportunity.title,
-          image: mel_top_boost_opportunity.image|default(null),
-        },
-        performance: mel_top_boost_opportunity.performance,
-      } only %}
-    </div>
-  {% endif %}
-
   <div class="mel-vendor-dashboard-v2__mid-grid">
-    <section class="mel-vendor-dashboard-v2__section mel-vendor-dashboard-v2__readiness" aria-labelledby="mel-dash-readiness-title">
-      <div class="mel-vendor-dashboard-v2__section-header">
-        <h3 class="mel-vendor-dashboard-v2__section-title" id="mel-dash-readiness-title">{{ 'Readiness'|t }}</h3>
-        {% if readiness.score is defined %}
-          <p class="mel-vendor-dashboard-v2__section-meta">{{ '@pct% complete'|t({'@pct': readiness.score}) }}</p>
-        {% endif %}
-      </div>
-      <div class="mel-vendor-dashboard-v2__readiness-grid" role="list">
-        {% for item in readiness_items %}
-          {% set done = item.complete|default(false) %}
-          {% set sev = item.severity|default('neutral') %}
-          {% set row_content %}
-            <span class="mel-vendor-dashboard-v2__readiness-label">{{ item.label|default('') }}</span>
-            <span class="mel-vendor-dashboard-v2__readiness-status{% if done %} mel-vendor-dashboard-v2__readiness-status--done{% else %} mel-vendor-dashboard-v2__readiness-status--todo{% endif %}">
-              {% if done %}
-                {{ 'Done'|t }}
-              {% else %}
-                {{ 'Needs attention'|t }}
-              {% endif %}
-            </span>
-          {% endset %}
-          <div class="mel-vendor-dashboard-v2__readiness-item mel-vendor-dashboard-v2__readiness-item--{{ sev }}" role="listitem">
-            {% if item.url is defined and item.url %}
-              <a class="mel-vendor-dashboard-v2__readiness-link" href="{{ item.url }}">{{ row_content }}</a>
-            {% else %}
-              <div class="mel-vendor-dashboard-v2__readiness-static">{{ row_content }}</div>
-            {% endif %}
-          </div>
-        {% else %}
-          <p class="mel-vendor-dashboard-v2__muted">{{ 'Readiness checks will appear here once your account is set up.'|t }}</p>
-        {% endfor %}
-      </div>
-    </section>
-
     <section class="mel-vendor-dashboard-v2__section mel-vendor-dashboard-v2__actions" aria-labelledby="mel-dash-actions-title">
       <div class="mel-vendor-dashboard-v2__section-header">
         <h3 class="mel-vendor-dashboard-v2__section-title" id="mel-dash-actions-title">{{ 'What needs attention now'|t }}</h3>
@@ -164,6 +115,47 @@
         </div>
       {% endif %}
     </section>
+
+    <section class="mel-vendor-dashboard-v2__section mel-vendor-dashboard-v2__readiness" aria-labelledby="mel-dash-readiness-title">
+      <div class="mel-vendor-dashboard-v2__section-header">
+        <h3 class="mel-vendor-dashboard-v2__section-title" id="mel-dash-readiness-title">{{ 'Readiness'|t }}</h3>
+        {% if readiness.score is defined %}
+          <p class="mel-vendor-dashboard-v2__section-meta">{{ '@pct% complete'|t({'@pct': readiness.score}) }}</p>
+        {% endif %}
+      </div>
+      <div class="mel-vendor-dashboard-v2__readiness-grid" role="list">
+        {% if readiness_items is iterable and readiness_items|length > 0 %}
+          {% for item in readiness_items %}
+            {% set done = item.complete|default(false) %}
+            {% set sev = item.severity|default('neutral') %}
+            {% set row_content %}
+              <span class="mel-vendor-dashboard-v2__readiness-label">{{ item.label|default('') }}</span>
+              <span class="mel-vendor-dashboard-v2__readiness-status{% if done %} mel-vendor-dashboard-v2__readiness-status--done{% else %} mel-vendor-dashboard-v2__readiness-status--todo{% endif %}">
+                {% if done %}
+                  {{ 'Done'|t }}
+                {% else %}
+                  {{ 'Needs attention'|t }}
+                {% endif %}
+              </span>
+            {% endset %}
+            <div class="mel-vendor-dashboard-v2__readiness-item mel-vendor-dashboard-v2__readiness-item--{{ sev }}" role="listitem">
+              {% if item.url is defined and item.url %}
+                <a class="mel-vendor-dashboard-v2__readiness-link" href="{{ item.url }}">{{ row_content }}</a>
+              {% else %}
+                <div class="mel-vendor-dashboard-v2__readiness-static">{{ row_content }}</div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        {% elseif dashboard_vendor_id %}
+          <div class="mel-vendor-dashboard-v2__empty mel-vendor-dashboard-v2__empty--positive">
+            <h4 class="mel-vendor-dashboard-v2__empty-title">{{ 'Your setup looks good.'|t }}</h4>
+            <p class="mel-vendor-dashboard-v2__empty-message">{{ 'Readiness checks are clear for your organiser account.'|t }}</p>
+          </div>
+        {% else %}
+          <p class="mel-vendor-dashboard-v2__muted">{{ 'Readiness checks will appear here once your account is set up.'|t }}</p>
+        {% endif %}
+      </div>
+    </section>
   </div>
 
   <section class="mel-vendor-dashboard-v2__section mel-vendor-dashboard-v2__kpis" aria-labelledby="mel-dash-kpis-title">
@@ -187,7 +179,11 @@
           <article class="mel-vendor-dashboard-v2__kpi mel-vendor-dashboard-v2__kpi--{{ ksev }}">{{ kpi_inner }}</article>
         {% endif %}
       {% else %}
-        <p class="mel-vendor-dashboard-v2__muted">{{ 'Metrics will appear here when available.'|t }}</p>
+        {% if dashboard_vendor_id %}
+          <p class="mel-vendor-dashboard-v2__muted">{{ 'Performance data will appear after your first RSVP, ticket sale, or event view.'|t }}</p>
+        {% else %}
+          <p class="mel-vendor-dashboard-v2__muted">{{ 'Metrics will appear here when available.'|t }}</p>
+        {% endif %}
       {% endfor %}
     </div>
   </section>
@@ -254,44 +250,66 @@
             {% set type_label = 'Setup needed'|t %}
           {% endif %}
           <article class="mel-vendor-dashboard-v2__event-card">
-            <div class="mel-vendor-dashboard-v2__event-card-head">
-              <span class="mel-vendor-dashboard-v2__event-status">{{ ev.status_label|default('') }}</span>
-              <h4 class="mel-vendor-dashboard-v2__event-title">{{ ev.title|default('') }}</h4>
-            </div>
-            {% if ev.date_label is defined and ev.date_label %}
-              <p class="mel-vendor-dashboard-v2__event-date">{{ ev.date_label }}</p>
-            {% endif %}
-            <p class="mel-vendor-dashboard-v2__event-type">{{ type_label }}</p>
-            {% set issues = ev.presentation_issues|default([]) %}
-            {% if issues is iterable and issues|length > 0 %}
-              <div class="mel-vendor-dashboard-v2__event-issues" role="group" aria-label="{{ 'Setup issues'|t }}">
-                {% for issue in issues %}
-                  {% set isev = issue.severity|default('warning') %}
-                  <span class="mel-vendor-dashboard-v2__issue-chip mel-vendor-dashboard-v2__issue-chip--{{ isev|e('html_attr') }}">
-                    <span class="mel-vendor-dashboard-v2__issue-dot" aria-hidden="true"></span>
-                    {{ issue.label|default('') }}
-                  </span>
-                {% endfor %}
+            <div class="mel-vendor-dashboard-v2__event-card-top">
+              {% set img = ev.image|default({}) %}
+              {% if img.url is defined and img.url %}
+                <div class="mel-event-card-thumb" aria-hidden="true">
+                  <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+                </div>
+              {% else %}
+                <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
+              {% endif %}
+              <div class="mel-vendor-dashboard-v2__event-card-main">
+                <div class="mel-vendor-dashboard-v2__event-card-head">
+                  <span class="mel-vendor-dashboard-v2__event-status">{{ ev.status_label|default('') }}</span>
+                  <h4 class="mel-vendor-dashboard-v2__event-title">{{ ev.title|default('') }}</h4>
+                </div>
+                {% if ev.date_label is defined and ev.date_label %}
+                  <p class="mel-vendor-dashboard-v2__event-date">{{ ev.date_label }}</p>
+                {% endif %}
+                <p class="mel-vendor-dashboard-v2__event-type">{{ type_label }}</p>
+                {% set issues = ev.presentation_issues|default([]) %}
+                {% if issues is iterable and issues|length > 0 %}
+                  <div class="mel-vendor-dashboard-v2__event-issues" role="group" aria-label="{{ 'Setup issues'|t }}">
+                    {% for issue in issues %}
+                      {% set isev = issue.severity|default('warning') %}
+                      <span class="mel-vendor-dashboard-v2__issue-chip mel-vendor-dashboard-v2__issue-chip--{{ isev|e('html_attr') }}">
+                        <span class="mel-vendor-dashboard-v2__issue-dot" aria-hidden="true"></span>
+                        {{ issue.label|default('') }}
+                      </span>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+                {% if ev.metric_label is defined and ev.metric_label %}
+                  <p class="mel-vendor-dashboard-v2__event-metric">{{ ev.metric_label }}</p>
+                {% endif %}
+                {% if ev.revenue_label is defined and ev.revenue_label %}
+                  <p class="mel-vendor-dashboard-v2__event-revenue">{{ 'Revenue: @r'|t({'@r': ev.revenue_label}) }}</p>
+                {% endif %}
+                {% if ev.capacity_label is defined and ev.capacity_label %}
+                  <p class="mel-vendor-dashboard-v2__event-capacity">{{ 'Capacity: @c'|t({'@c': ev.capacity_label}) }}</p>
+                {% endif %}
               </div>
-            {% endif %}
-            {% if ev.metric_label is defined and ev.metric_label %}
-              <p class="mel-vendor-dashboard-v2__event-metric">{{ ev.metric_label }}</p>
-            {% endif %}
-            {% if ev.revenue_label is defined and ev.revenue_label %}
-              <p class="mel-vendor-dashboard-v2__event-revenue">{{ 'Revenue: @r'|t({'@r': ev.revenue_label}) }}</p>
-            {% endif %}
-            {% if ev.capacity_label is defined and ev.capacity_label %}
-              <p class="mel-vendor-dashboard-v2__event-capacity">{{ 'Capacity: @c'|t({'@c': ev.capacity_label}) }}</p>
-            {% endif %}
-            <div class="mel-vendor-dashboard-v2__event-actions">
+            </div>
+            <div class="mel-vendor-dashboard-v2__event-actions mel-vendor-dashboard-v2__event-actions-row">
               {% if links.manage is defined and links.manage %}
                 <a class="mel-btn mel-btn--primary mel-btn--sm mel-vendor-dashboard-v2__event-btn" href="{{ links.manage }}">{{ 'Manage'|t }}</a>
               {% endif %}
               {% if links.edit is defined and links.edit %}
                 <a class="mel-btn mel-btn--secondary mel-btn--sm mel-vendor-dashboard-v2__event-btn" href="{{ links.edit }}">{{ 'Edit'|t }}</a>
               {% endif %}
+              {% if links.tickets is defined and links.tickets %}
+                <a class="mel-btn mel-btn--secondary mel-btn--sm mel-vendor-dashboard-v2__event-btn" href="{{ links.tickets }}">{{ 'Tickets'|t }}</a>
+              {% endif %}
               {% if links.analytics is defined and links.analytics %}
                 <a class="mel-btn mel-btn--ghost mel-btn--sm mel-vendor-dashboard-v2__event-btn" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
+              {% endif %}
+              {% set removal = ev.removal|default(null) %}
+              {% if removal %}
+                <button type="button" class="mel-btn mel-btn--sm mel-event-card-remove-open" data-mel-open-dialog="{{ removal.dialog_id|e('html_attr') }}" aria-haspopup="dialog">
+                  {{ removal.danger_label|default('Archive'|t) }}
+                </button>
+                {% include '@myeventlane_vendor_theme/components/mel-event-card-removal-dialog.html.twig' with { removal: removal } only %}
               {% endif %}
             </div>
           </article>
@@ -308,4 +326,20 @@
       </div>
     {% endif %}
   </section>
+
+  {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
+    <div class="mel-vendor-dashboard-v2__billing-strip mel-vendor-dashboard-v2__billing-strip--below-events">{{ mel_contribution_billing_strip }}</div>
+  {% endif %}
+
+  {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
+    <div class="mel-vendor-dashboard-v2__boost-slot mel-vendor-dashboard-v2__boost-slot--below-events">
+      {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
+        event: {
+          title: mel_top_boost_opportunity.title,
+          image: mel_top_boost_opportunity.image|default(null),
+        },
+        performance: mel_top_boost_opportunity.performance,
+      } only %}
+    </div>
+  {% endif %}
 </section>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
@@ -106,50 +106,65 @@
         {% set links = ev.links|default({}) %}
         {% set sev = ev.status_severity|default('neutral') %}
         <article class="mel-vendor-events-v2__card">
-          <div class="mel-vendor-events-v2__card-header">
-            <span class="mel-vendor-events-v2__status mel-vendor-events-v2__status--{{ sev|e('html_attr') }}">{{ ev.status_label|default('') }}</span>
-            {% if ev.needs_attention and ev.attention_label %}
-              <span class="mel-vendor-events-v2__attention">{{ ev.attention_label }}</span>
+          <div class="mel-vendor-events-v2__card-top">
+            {% set img = ev.image|default({}) %}
+            {% if img.url is defined and img.url %}
+              <div class="mel-event-card-thumb" aria-hidden="true">
+                <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+              </div>
+            {% else %}
+              <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
             {% endif %}
-          </div>
-          {% set issues = ev.presentation_issues|default([]) %}
-          {% if issues is iterable and issues|length > 0 %}
-            <div class="mel-vendor-events-v2__issues" role="group" aria-label="{{ 'Setup issues'|t }}">
-              {% for issue in issues %}
-                {% set isev = issue.severity|default('warning') %}
-                <span class="mel-vendor-events-v2__issue-chip mel-vendor-events-v2__issue-chip--{{ isev|e('html_attr') }}">
-                  <span class="mel-vendor-events-v2__issue-dot" aria-hidden="true"></span>
-                  {{ issue.label|default('') }}
-                </span>
-              {% endfor %}
+            <div class="mel-vendor-events-v2__card-body">
+              <div class="mel-vendor-events-v2__card-header">
+                <span class="mel-vendor-events-v2__status mel-vendor-events-v2__status--{{ sev|e('html_attr') }}">{{ ev.status_label|default('') }}</span>
+                {% if ev.needs_attention and ev.attention_label %}
+                  <span class="mel-vendor-events-v2__attention">{{ ev.attention_label }}</span>
+                {% endif %}
+              </div>
+              {% set issues = ev.presentation_issues|default([]) %}
+              {% if issues is iterable and issues|length > 0 %}
+                <div class="mel-vendor-events-v2__issues" role="group" aria-label="{{ 'Setup issues'|t }}">
+                  {% for issue in issues %}
+                    {% set isev = issue.severity|default('warning') %}
+                    <span class="mel-vendor-events-v2__issue-chip mel-vendor-events-v2__issue-chip--{{ isev|e('html_attr') }}">
+                      <span class="mel-vendor-events-v2__issue-dot" aria-hidden="true"></span>
+                      {{ issue.label|default('') }}
+                    </span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+              <h2 class="mel-vendor-events-v2__card-title">{{ ev.title|default('') }}</h2>
+              <div class="mel-vendor-events-v2__meta">
+                {% if ev.date_label %}
+                  <span class="mel-vendor-events-v2__meta-line">{{ ev.date_label }}</span>
+                {% endif %}
+                {% if ev.event_type_label %}
+                  <span class="mel-vendor-events-v2__meta-line">{{ ev.event_type_label }}</span>
+                {% endif %}
+              </div>
+              <div class="mel-vendor-events-v2__metrics">
+                {% if ev.metric_label %}
+                  <span class="mel-vendor-events-v2__metric">{{ ev.metric_label }}</span>
+                {% endif %}
+                {% if ev.revenue_label %}
+                  <span class="mel-vendor-events-v2__metric mel-vendor-events-v2__metric--revenue">{{ ev.revenue_label }}</span>
+                {% endif %}
+                {% if ev.capacity_label %}
+                  <span class="mel-vendor-events-v2__metric">{{ ev.capacity_label }}</span>
+                {% endif %}
+              </div>
             </div>
-          {% endif %}
-          <h2 class="mel-vendor-events-v2__card-title">{{ ev.title|default('') }}</h2>
-          <div class="mel-vendor-events-v2__meta">
-            {% if ev.date_label %}
-              <span class="mel-vendor-events-v2__meta-line">{{ ev.date_label }}</span>
-            {% endif %}
-            {% if ev.event_type_label %}
-              <span class="mel-vendor-events-v2__meta-line">{{ ev.event_type_label }}</span>
-            {% endif %}
-          </div>
-          <div class="mel-vendor-events-v2__metrics">
-            {% if ev.metric_label %}
-              <span class="mel-vendor-events-v2__metric">{{ ev.metric_label }}</span>
-            {% endif %}
-            {% if ev.revenue_label %}
-              <span class="mel-vendor-events-v2__metric mel-vendor-events-v2__metric--revenue">{{ ev.revenue_label }}</span>
-            {% endif %}
-            {% if ev.capacity_label %}
-              <span class="mel-vendor-events-v2__metric">{{ ev.capacity_label }}</span>
-            {% endif %}
           </div>
           <div class="mel-vendor-events-v2__card-actions">
             {% if links.manage is defined and links.manage %}
               <a class="mel-btn mel-btn--primary mel-vendor-events-v2__action-primary" href="{{ links.manage }}">{{ 'Manage'|t }}</a>
             {% endif %}
             {% if links.edit is defined and links.edit %}
-              <a class="mel-btn mel-btn--secondary mel-vendor-events-v2__action-secondary" href="{{ links.edit }}">{{ 'Edit event'|t }}</a>
+              <a class="mel-btn mel-btn--secondary mel-vendor-events-v2__action-secondary" href="{{ links.edit }}">{{ 'Edit'|t }}</a>
+            {% endif %}
+            {% if links.tickets is defined and links.tickets %}
+              <a class="mel-btn mel-btn--secondary mel-vendor-events-v2__action-secondary" href="{{ links.tickets }}">{{ 'Tickets'|t }}</a>
             {% endif %}
             <div class="mel-vendor-events-v2__optional-links">
               {% if links.rsvps is defined and links.rsvps %}
@@ -164,10 +179,14 @@
               {% if links.analytics is defined and links.analytics %}
                 <a class="mel-vendor-events-v2__link" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
               {% endif %}
-              {% if links.tickets is defined and links.tickets %}
-                <a class="mel-vendor-events-v2__link" href="{{ links.tickets }}">{{ 'Advanced ticket manager'|t }}</a>
-              {% endif %}
             </div>
+            {% set removal = ev.removal|default(null) %}
+            {% if removal %}
+              <button type="button" class="mel-btn mel-event-card-remove-open mel-vendor-events-v2__action-secondary" data-mel-open-dialog="{{ removal.dialog_id|e('html_attr') }}" aria-haspopup="dialog">
+                {{ removal.danger_label|default('Archive'|t) }}
+              </button>
+              {% include '@myeventlane_vendor_theme/components/mel-event-card-removal-dialog.html.twig' with { removal: removal } only %}
+            {% endif %}
           </div>
         </article>
       {% endfor %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
@@ -8,10 +8,13 @@
 #}
 <article{{ attributes.addClass('mel-card') }} data-view-mode>
   <div class="mel-card__image">
-    {% if content.field_event_image is defined and content.field_event_image|render|trim is not empty %}
-      {{ content.field_event_image }}
+    {% set img = mel_event_card_image|default({}) %}
+    {% if img.url is defined and img.url %}
+      <div class="mel-event-card-thumb" aria-hidden="true">
+        <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+      </div>
     {% else %}
-      <div class="mel-card__image-placeholder" aria-hidden="true"></div>
+      <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
     {% endif %}
   </div>
 
@@ -34,9 +37,19 @@
       {% endif %}
     </div>
 
-    <div class="mel-card__actions">
+    <div class="mel-card__actions mel-card__actions--vendor-console">
       <a href="{{ path('myeventlane_vendor.console.event_overview', {'event': node.id}) }}" class="mel-btn mel-btn--primary mel-btn--sm">{{ 'Manage'|t }}</a>
-      <a href="{{ path('myeventlane_event_studio.edit', {'node': node.id}) }}" class="mel-btn mel-btn--ghost mel-btn--sm">{{ 'Edit event'|t }}</a>
+      <a href="{{ path('myeventlane_event_studio.edit', {'node': node.id}) }}" class="mel-btn mel-btn--secondary mel-btn--sm">{{ 'Edit'|t }}</a>
+      {% if mel_event_tickets_url is defined and mel_event_tickets_url %}
+        <a href="{{ mel_event_tickets_url }}" class="mel-btn mel-btn--secondary mel-btn--sm">{{ 'Tickets'|t }}</a>
+      {% endif %}
+      {% set removal = mel_event_removal|default(null) %}
+      {% if removal %}
+        <button type="button" class="mel-btn mel-btn--sm mel-event-card-remove-open" data-mel-open-dialog="{{ removal.dialog_id|e('html_attr') }}" aria-haspopup="dialog">
+          {{ removal.danger_label|default('Archive'|t) }}
+        </button>
+        {% include '@myeventlane_vendor_theme/components/mel-event-card-removal-dialog.html.twig' with { removal: removal } only %}
+      {% endif %}
     </div>
   </div>
 </article>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new vendor-console POST route that can unpublish or permanently delete events based on booking activity and permissions, which impacts content lifecycle and requires careful access/CSRF validation. Also changes event listing/dashboard rendering to rely on new service-built payloads and thumbnails, affecting multiple key vendor UI surfaces.
> 
> **Overview**
> **Vendor event cards now support safe removal (archive/delete).** This introduces `POST /vendor/events/{event}/archive` handled by a new `VendorEventArchiveController` with CSRF validation, and a new access service `VendorManagedEventConsoleAccess` to ensure managed-event workspace parity for `{event}` routes.
> 
> **Event removal logic is centralized.** A new `VendorEventRemovalService` decides between unpublishing (archive) vs permanent delete based on ticket/RSVP/attendee activity and delete permission, and also builds Twig-safe thumbnail data + removal dialog payloads.
> 
> **Dashboard and events UIs are updated to use the new payloads.** Dashboard and `/vendor/events` view models/templates now render PHP-built thumbnails, add `Tickets` links where accessible, include a new removal confirmation `<dialog>` component, and attach a new theme library (`mel_event_card_remove`) plus associated JS/SCSS; the dashboard layout also reorders readiness/billing/boost sections and tweaks empty-state copy.
> 
> **Membership queries/permissions are tightened.** `CurrentVendorResolver` becomes access-aware for vendor lookup, and `UserVendorMembershipQuery` now optionally includes legacy `field_vendor` event references (with updated test wiring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77a4eac7bce802edb881430e2e9b0e55bfe1967d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->