### PR TITLE
Fix/bugbot vendor console review

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -74,7 +74,6 @@ services:
     class: Drupal\myeventlane_vendor\Service\VendorEventRemovalService
     arguments:
       - '@entity_type.manager'
-      - '@file_url_generator'
       - '@myeventlane_vendor.service.ticket_sales'
       - '@myeventlane_vendor.service.rsvp_stats'
       - '@myeventlane_event_studio.save'

--- a/web/modules/custom/myeventlane_vendor/src/Access/VendorManagedEventConsoleAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Access/VendorManagedEventConsoleAccess.php
@@ -31,6 +31,13 @@ final class VendorManagedEventConsoleAccess {
       return AccessResult::forbidden();
     }
 
+    // Align with VendorConsoleBaseController::assertEventOwnership().
+    if ($account->hasPermission('administer nodes')) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user.permissions']);
+    }
+
     if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
       return AccessResult::forbidden();
     }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
@@ -6,7 +6,6 @@ namespace Drupal\myeventlane_vendor\Service;
 
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -30,7 +29,6 @@ final class VendorEventRemovalService {
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
     private readonly TicketSalesService $ticketSalesService,
     private readonly RsvpStatsService $rsvpStatsService,
     private readonly EventStudioSaveService $eventStudioSaveService,
@@ -61,8 +59,9 @@ final class VendorEventRemovalService {
         try {
           $style = $this->entityTypeManager->getStorage('image_style')->load(self::THUMB_STYLE);
           if ($style) {
-            $relative = $style->buildUrl($file->getFileUri());
-            $url = $this->fileUrlGenerator->generateString($relative);
+            // ImageStyle::buildUrl() returns the usable URL; do not pass it to
+            // FileUrlGenerator (expects a stream wrapper URI).
+            $url = $style->buildUrl($file->getFileUri());
           }
         }
         catch (\Throwable $e) {

--- a/web/themes/custom/myeventlane_vendor_theme/js/mel-event-card-remove.js
+++ b/web/themes/custom/myeventlane_vendor_theme/js/mel-event-card-remove.js
@@ -5,17 +5,6 @@
 (function (Drupal, once) {
   'use strict';
 
-  /**
-   * @param {HTMLDialogElement} dialog
-   */
-  function trapReturn(dialog) {
-    dialog.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') {
-        dialog.close();
-      }
-    });
-  }
-
   Drupal.behaviors.melEventCardRemove = {
     attach(context) {
       once('mel-event-card-remove-open', '[data-mel-open-dialog]', context).forEach((btn) => {
@@ -27,7 +16,6 @@
           const dialog = document.getElementById(id);
           if (dialog && dialog.tagName === 'DIALOG' && typeof dialog.showModal === 'function') {
             dialog.showModal();
-            trapReturn(dialog);
             const focusTarget = dialog.querySelector(
               'button[data-mel-dialog-close], button[type="submit"], a[href]',
             );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts vendor console access control (admins now bypass workspace-parity checks) and changes how event thumbnail URLs are generated, which could affect authorization behavior and image rendering in the vendor UI.
> 
> **Overview**
> **Vendor console access rules were updated** so users with `administer nodes` can access managed-event console routes without failing workspace-parity checks, with permission-aware caching added.
> 
> **Event removal card thumbnails now use `ImageStyle::buildUrl()` directly**, removing the `file_url_generator` dependency and avoiding incorrect URL generation. Separately, the event-card removal dialog JS drops an unused Escape-key handler, relying on native dialog behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a7422a7bd192924a1bf7c3113824643927e0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->