### PR TITLE
fix(vendor-console): use placeholder for missing event images

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -81,6 +81,9 @@ services:
       - '@csrf_token'
       - '@string_translation'
       - '@logger.factory'
+      - '@file_system'
+      - '@extension.list.theme'
+      - '@request_stack'
 
   myeventlane_vendor.paid_publish_stripe_gate:
     class: Drupal\myeventlane_vendor\Service\PaidPublishStripeGate
@@ -292,6 +295,7 @@ services:
       - '@current_user'
       - '@messenger'
       - '@myeventlane_vendor.dashboard_view_model_builder'
+      - '@myeventlane_vendor.vendor_event_removal'
       - '@router.route_provider'
       - '@myeventlane_vendor.service.rsvp_stats'
       - '@entity_type.manager'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -31,6 +31,7 @@ use Drupal\myeventlane_vendor\Service\RsvpStatsService;
 use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\myeventlane_vendor\Service\TicketSalesService;
 use Drupal\myeventlane_vendor\Service\VendorDashboardViewModelBuilder;
+use Drupal\myeventlane_vendor\Service\VendorEventRemovalService;
 use Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface;
 use Drupal\myeventlane_domain_events\ProjectionReadModel\VendorMetricsReadModel;
 use Drupal\myeventlane_event_studio\DTO\MelEventData;
@@ -168,6 +169,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
    */
   protected VendorDashboardViewModelBuilder $dashboardViewModelBuilder;
 
+  protected VendorEventRemovalService $vendorEventRemoval;
+
   /**
    * Constructs the controller.
    */
@@ -176,6 +179,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     AccountProxyInterface $current_user,
     MessengerInterface $messenger,
     VendorDashboardViewModelBuilder $dashboard_view_model_builder,
+    VendorEventRemovalService $vendor_event_removal,
     RouteProviderInterface $route_provider,
     RsvpStatsService $rsvp_stats,
     EntityTypeManagerInterface $entity_type_manager,
@@ -203,6 +207,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
     $this->dashboardViewModelBuilder = $dashboard_view_model_builder;
+    $this->vendorEventRemoval = $vendor_event_removal;
     $this->routeProvider = $route_provider;
     $this->rsvpStats = $rsvp_stats;
     $this->entityTypeManager = $entity_type_manager;
@@ -238,6 +243,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $container->get('current_user'),
       $container->get('messenger'),
       $container->get('myeventlane_vendor.dashboard_view_model_builder'),
+      $container->get('myeventlane_vendor.vendor_event_removal'),
       $container->get('router.route_provider'),
       $container->get('myeventlane_vendor.service.rsvp_stats'),
       $container->get('entity_type.manager'),
@@ -1136,7 +1142,10 @@ final class VendorDashboardController extends VendorConsoleBaseController {
           'rsvp_state' => 'unset',
           'capacity' => 0,
         ];
-      $eventImageUrl = $dto->image_url;
+      $thumb = $eventNode instanceof NodeInterface
+        ? $this->vendorEventRemoval->buildEventThumbnailData($eventNode)
+        : $this->vendorEventRemoval->buildPlaceholderThumbnailData($dto->title);
+      $eventImageUrl = $thumb['url'];
 
       $startDate = $dto->start_timestamp > 0 ? date('M j, Y', $dto->start_timestamp) : '';
       $startTimestamp = $dto->start_timestamp;

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -19,6 +19,7 @@ use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\VendorCardBuilder;
+use Drupal\myeventlane_vendor\Service\VendorEventRemovalService;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -35,6 +36,7 @@ final class VendorDetailController extends ControllerBase {
     private readonly EntityIdNormalizer $entityIdNormalizer,
     private readonly ?EventRepository $eventRepository,
     private readonly VendorCardBuilder $vendorCardBuilder,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly VendorFollowService $vendorFollowService,
     private readonly AnalyticsService $analytics,
     private readonly AccountInterface $account,
@@ -52,6 +54,7 @@ final class VendorDetailController extends ControllerBase {
       $container->get('myeventlane_core.entity_id_normalizer'),
       $container->has('myeventlane_event_studio.repository') ? $container->get('myeventlane_event_studio.repository') : NULL,
       $container->get('myeventlane_vendor.vendor_card_builder'),
+      $container->get('myeventlane_vendor.vendor_event_removal'),
       $container->get('myeventlane_core.vendor_follow'),
       $container->get('myeventlane_core.analytics'),
       $container->get('current_user'),
@@ -231,11 +234,16 @@ final class VendorDetailController extends ControllerBase {
 
     foreach ($this->eventRepository->loadMany($nids) as $dto) {
       $node = $nodes[$dto->id] ?? NULL;
+      $thumb = $node instanceof NodeInterface
+        ? $this->vendorEventRemovalService->buildEventThumbnailData($node)
+        : $this->vendorEventRemovalService->buildPlaceholderThumbnailData($dto->title);
+
       $cards[] = [
         'event_id' => $dto->id,
         'title' => $dto->title,
         'url' => Url::fromRoute('entity.node.canonical', ['node' => $dto->id])->toString(),
-        'image_render' => $node instanceof NodeInterface ? $this->eventImage($node) : NULL,
+        'card_image_url' => $thumb['url'],
+        'card_image_alt' => $thumb['alt'],
         'date_full' => $dto->start_timestamp > 0
           ? $this->dateFormatter->format($dto->start_timestamp, 'custom', 'M j, Y')
           : '',
@@ -246,24 +254,6 @@ final class VendorDetailController extends ControllerBase {
     }
 
     return $cards;
-  }
-
-  /**
-   * Builds a styled event card image render array.
-   */
-  private function eventImage(NodeInterface $event): ?array {
-    if (!$event->hasField('field_event_image') || $event->get('field_event_image')->isEmpty()) {
-      return NULL;
-    }
-
-    return $event->get('field_event_image')->view([
-      'type' => 'image',
-      'label' => 'hidden',
-      'settings' => [
-        'image_style' => 'mel_event_card_standard',
-        'image_link' => '',
-      ],
-    ]);
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -18,6 +18,7 @@ use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_metrics\Service\EventMetricsServiceInterface;
 use Drupal\myeventlane_vendor\Service\RsvpStatsService;
 use Drupal\myeventlane_vendor\Service\TicketSalesService;
+use Drupal\myeventlane_vendor\Service\VendorEventRemovalService;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Psr\Log\LoggerInterface;
@@ -52,6 +53,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
     private readonly EventStudioSaveService $eventStudioSave,
     private readonly EntityIdNormalizer $entityIdNormalizer,
     private readonly EventRepository $eventRepository,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly ?TicketSalesService $ticketSalesService = NULL,
     private readonly ?RsvpStatsService $rsvpStatsService = NULL,
     private readonly ?EventMetricsServiceInterface $eventMetricsService = NULL,
@@ -73,6 +75,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       $container->get('myeventlane_event_studio.save'),
       $container->get('myeventlane_core.entity_id_normalizer'),
       $container->get('myeventlane_event_studio.repository'),
+      $container->get('myeventlane_vendor.vendor_event_removal'),
       $container->has('myeventlane_vendor.service.ticket_sales') ? $container->get('myeventlane_vendor.service.ticket_sales') : NULL,
       $container->has('myeventlane_vendor.service.rsvp_stats') ? $container->get('myeventlane_vendor.service.rsvp_stats') : NULL,
       $container->has('myeventlane_metrics.service') ? $container->get('myeventlane_metrics.service') : NULL,
@@ -969,6 +972,8 @@ final class VendorStudioController extends VendorConsoleBaseController implement
     }
 
     $melEvents = $this->eventRepository->loadMany($event_ids);
+    /** @var \Drupal\node\NodeInterface[] $nodes */
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($event_ids);
     $cards = [];
 
     foreach ($melEvents as $event) {
@@ -981,13 +986,20 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       $moderation = $event->moderation_state !== ''
         ? $event->moderation_state
         : ($event->published ? 'published' : 'draft');
+      $node = $nodes[$event_id] ?? NULL;
+      $thumb = ($node instanceof NodeInterface && $node->bundle() === 'event')
+        ? $this->vendorEventRemovalService->buildEventThumbnailData($node)
+        : $this->vendorEventRemovalService->buildPlaceholderThumbnailData($event->title);
+
       $cards[] = [
         'id' => $event_id,
         'nid' => $event_id,
         'title' => $event->title,
         'date' => $this->extractMelEventDateLabel($event),
         'location' => $this->extractMelEventLocationLabel($event),
-        'image' => $event->image_url ?? '',
+        'image' => $thumb['url'],
+        'image_alt' => $thumb['alt'],
+        'image_is_placeholder' => $thumb['is_placeholder'],
         'status' => $this->normalizeModerationState($moderation),
         'tickets_sold' => 0,
         'rsvp_count' => 0,

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventRemovalService.php
@@ -6,6 +6,8 @@ namespace Drupal\myeventlane_vendor\Service;
 
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ThemeExtensionList;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -14,6 +16,7 @@ use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Safe archive/delete decisions and thumbnail data for vendor console cards.
@@ -27,6 +30,13 @@ final class VendorEventRemovalService {
 
   private const THUMB_STYLE = 'thumbnail';
 
+  /**
+   * Vendor theme that ships the shared MEL event placeholder asset.
+   */
+  private const PLACEHOLDER_THEME = 'myeventlane_vendor_theme';
+
+  private const PLACEHOLDER_FILE = 'images/mel-event-placeholder.svg';
+
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TicketSalesService $ticketSalesService,
@@ -36,6 +46,9 @@ final class VendorEventRemovalService {
     private readonly CsrfTokenGenerator $csrfToken,
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly FileSystemInterface $fileSystem,
+    private readonly ThemeExtensionList $themeExtensionList,
+    private readonly RequestStack $requestStack,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -44,40 +57,101 @@ final class VendorEventRemovalService {
    * Builds event card image data for Twig (no entity loading in templates).
    *
    * @return array<string, mixed>
-   *   Keys: url (string|null), alt (string), is_placeholder (bool).
+   *   Keys: url (string), alt (string), is_placeholder (bool).
    */
   public function buildEventThumbnailData(NodeInterface $event): array {
-    $alt = trim((string) $event->getTitle());
-    if ($alt === '') {
-      $alt = (string) $this->t('Event image');
+    $placeholder_url = $this->getMelEventPlaceholderAssetUrl();
+
+    $title_alt = trim((string) $event->getTitle());
+    if ($title_alt === '') {
+      $title_alt = (string) $this->t('Event image');
     }
 
-    $url = NULL;
+    $field_alt = NULL;
     if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
-      $file = $event->get('field_event_image')->entity;
-      if ($file instanceof FileInterface) {
-        try {
-          $style = $this->entityTypeManager->getStorage('image_style')->load(self::THUMB_STYLE);
-          if ($style) {
-            // ImageStyle::buildUrl() returns the usable URL; do not pass it to
-            // FileUrlGenerator (expects a stream wrapper URI).
-            $url = $style->buildUrl($file->getFileUri());
-          }
-        }
-        catch (\Throwable $e) {
-          $this->loggerFactory->get('myeventlane_vendor')->warning('Event card thumbnail URL failed for nid @nid: @message', [
-            '@nid' => (string) $event->id(),
-            '@message' => $e->getMessage(),
-          ]);
+      $first = $event->get('field_event_image')->first();
+      if ($first !== NULL) {
+        $trim = trim((string) ($first->alt ?? ''));
+        if ($trim !== '') {
+          $field_alt = $trim;
         }
       }
     }
 
+    $use_placeholder = TRUE;
+    $url = $placeholder_url;
+
+    if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
+      $file = $event->get('field_event_image')->entity;
+      if ($file instanceof FileInterface) {
+        $uri = $file->getFileUri();
+        if ($uri !== '' && $this->eventImageSourceIsReadable($uri)) {
+          try {
+            $style = $this->entityTypeManager->getStorage('image_style')->load(self::THUMB_STYLE);
+            if ($style) {
+              $url = $style->buildUrl($uri);
+              $use_placeholder = FALSE;
+            }
+          }
+          catch (\Throwable $e) {
+            $this->loggerFactory->get('myeventlane_vendor')->warning('Event card thumbnail URL failed for nid @nid: @message', [
+              '@nid' => (string) $event->id(),
+              '@message' => $e->getMessage(),
+            ]);
+            $url = $placeholder_url;
+            $use_placeholder = TRUE;
+          }
+        }
+      }
+    }
+
+    $alt = $use_placeholder ? $title_alt : ($field_alt ?? $title_alt);
+
     return [
       'url' => $url,
       'alt' => $alt,
-      'is_placeholder' => $url === NULL,
+      'is_placeholder' => $use_placeholder,
     ];
+  }
+
+  /**
+   * Whether the image URI resolves to a readable local file (no derivative IO).
+   */
+  private function eventImageSourceIsReadable(string $uri): bool {
+    $real = $this->fileSystem->realpath($uri);
+
+    return $real !== FALSE && is_file($real);
+  }
+
+  /**
+   * Placeholder thumbnail when no node is available (edge cases only).
+   *
+   * @return array<string, mixed>
+   *   Keys: url (string), alt (string), is_placeholder (TRUE).
+   */
+  public function buildPlaceholderThumbnailData(?string $event_title = NULL): array {
+    $alt = trim((string) ($event_title ?? ''));
+    if ($alt === '') {
+      $alt = (string) $this->t('Event image');
+    }
+
+    return [
+      'url' => $this->getMelEventPlaceholderAssetUrl(),
+      'alt' => $alt,
+      'is_placeholder' => TRUE,
+    ];
+  }
+
+  /**
+   * Public URL for the static placeholder SVG (theme asset, no derivative IO).
+   */
+  public function getMelEventPlaceholderAssetUrl(): string {
+    $relative = $this->themeExtensionList->getPath(self::PLACEHOLDER_THEME) . '/' . self::PLACEHOLDER_FILE;
+    $request = $this->requestStack->getCurrentRequest();
+    $base = $request ? $request->getBasePath() : '';
+    $base = rtrim($base, '/');
+
+    return ($base === '' ? '' : $base) . '/' . $relative;
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1716,6 +1716,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
 
     // MyEventLane Illustration System: Compute image URL, category slug, and placeholder URL.
     $file_url_generator = \Drupal::service('file_url_generator');
+    $file_system = \Drupal::service('file_system');
     $extension_list = \Drupal::service('extension.list.theme');
     $theme_path = $extension_list->getPath('myeventlane_theme');
     $base_path = base_path();
@@ -1752,8 +1753,12 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       $event_files = $node->get('field_event_image')->referencedEntities();
       $image_entity = !empty($event_files) ? reset($event_files) : NULL;
       if ($image_entity) {
-        $event_image_uri = $image_entity->getFileUri();
-        $event_image_url = $file_url_generator->generateAbsoluteString($event_image_uri);
+        $candidate_uri = $image_entity->getFileUri();
+        $real_candidate = $candidate_uri !== '' ? $file_system->realpath($candidate_uri) : FALSE;
+        if ($real_candidate !== FALSE && is_file($real_candidate)) {
+          $event_image_uri = $candidate_uri;
+          $event_image_url = $file_url_generator->generateAbsoluteString($candidate_uri);
+        }
       }
     }
     $variables['mel_event_image_url'] = $event_image_url;
@@ -3023,6 +3028,7 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
   }
 
   $file_url_generator = \Drupal::service('file_url_generator');
+  $file_system = \Drupal::service('file_system');
   $image_url = NULL;
 
   // 1. Event image field.
@@ -3030,7 +3036,11 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
     $files = $node->get('field_event_image')->referencedEntities();
     $file = !empty($files) ? reset($files) : NULL;
     if ($file instanceof File) {
-      $image_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $uri = $file->getFileUri();
+      $real_uri = $uri !== '' ? $file_system->realpath($uri) : FALSE;
+      if ($real_uri !== FALSE && is_file($real_uri)) {
+        $image_url = $file_url_generator->generateAbsoluteString($uri);
+      }
     }
   }
 
@@ -3044,7 +3054,11 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
         $category_files = $term->get('field_category_image')->referencedEntities();
         $file = !empty($category_files) ? reset($category_files) : NULL;
         if ($file instanceof File) {
-          $image_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+          $uri = $file->getFileUri();
+          $real_cat_uri = $uri !== '' ? $file_system->realpath($uri) : FALSE;
+          if ($real_cat_uri !== FALSE && is_file($real_cat_uri)) {
+            $image_url = $file_url_generator->generateAbsoluteString($uri);
+          }
         }
       }
     }

--- a/web/themes/custom/myeventlane_vendor_theme/images/mel-event-placeholder.svg
+++ b/web/themes/custom/myeventlane_vendor_theme/images/mel-event-placeholder.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120" role="img" aria-labelledby="mel-ph-title">
+  <title id="mel-ph-title">MyEventLane</title>
+  <defs>
+    <linearGradient id="mel-ph-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#faf8f5"/>
+      <stop offset="100%" stop-color="#f0ebe3"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="18" fill="url(#mel-ph-bg)"/>
+  <!-- Ticket / lane motif -->
+  <path d="M26 36h52a4 4 0 0 1 4 4v10a7 7 0 0 0 0 14v10a4 4 0 0 1-4 4H26a4 4 0 0 1-4-4V74a7 7 0 0 0 0-14V40a4 4 0 0 1 4-4z" fill="none" stroke="#c9bfb2" stroke-width="2.25" stroke-linejoin="round"/>
+  <circle cx="36" cy="54" r="3.5" fill="#a89888"/>
+  <path d="M46 49h22M46 57h16" stroke="#b8ab9e" stroke-width="2" stroke-linecap="round"/>
+  <path d="M72 44v22" stroke="#d4cec4" stroke-width="2" stroke-dasharray="4 5" stroke-linecap="round"/>
+  <text x="60" y="100" text-anchor="middle" font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="10" font-weight="650" fill="#6e655a">MyEventLane</text>
+</svg>

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
@@ -25,14 +25,12 @@
   }
 
   &--placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    color: c.$ml-vendor-slate;
-    text-transform: uppercase;
+    background: #f7f4ef;
+    border-color: rgba(201, 191, 178, 0.55);
+
+    .mel-event-card-thumb__img {
+      object-fit: cover;
+    }
   }
 }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/workspace.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/workspace.scss
@@ -114,6 +114,11 @@
     object-fit: cover;
     display: block;
   }
+
+  .mel-event-thumb__img--placeholder {
+    object-fit: cover;
+    background: #f7f4ef;
+  }
   
   .mel-event-title {
     margin: 0;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-card.html.twig
@@ -61,9 +61,12 @@
   data-event-id="{{ event.id|default('') }}"
   data-title="{{ event_title }}">
 {% endif %}
-  <div class="mel-event-card__thumb mel-event-thumb" aria-hidden="true">
-    {% if event.image is defined and event.image %}
-      <img src="{{ event.image }}" alt="{{ event_title }}">
+  {% set img_url = event.image|default('') %}
+  {% set img_alt = event.image_alt|default(event_title) %}
+  {% set img_ph = event.image_is_placeholder|default(false) %}
+  <div class="mel-event-card__thumb mel-event-thumb"{% if not img_ph %} aria-hidden="true"{% endif %}>
+    {% if img_url %}
+      <img class="mel-event-thumb__img{% if img_ph %} mel-event-thumb__img--placeholder{% endif %}" src="{{ img_url }}" alt="{{ img_alt|e('html_attr') }}" loading="lazy" width="72" height="58">
     {% else %}
       <div class="mel-event-thumb-placeholder"></div>
     {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -252,12 +252,13 @@
           <article class="mel-vendor-dashboard-v2__event-card">
             <div class="mel-vendor-dashboard-v2__event-card-top">
               {% set img = ev.image|default({}) %}
-              {% if img.url is defined and img.url %}
-                <div class="mel-event-card-thumb" aria-hidden="true">
-                  <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+              {% set img_url = img.url|default('') %}
+              {% set img_alt = img.alt|default('') %}
+              {% set img_ph = img.is_placeholder|default(false) %}
+              {% if img_url %}
+                <div class="mel-event-card-thumb{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
+                  <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_alt|e('html_attr') }}" loading="lazy" width="56" height="56"/>
                 </div>
-              {% else %}
-                <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
               {% endif %}
               <div class="mel-vendor-dashboard-v2__event-card-main">
                 <div class="mel-vendor-dashboard-v2__event-card-head">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
@@ -108,12 +108,13 @@
         <article class="mel-vendor-events-v2__card">
           <div class="mel-vendor-events-v2__card-top">
             {% set img = ev.image|default({}) %}
-            {% if img.url is defined and img.url %}
-              <div class="mel-event-card-thumb" aria-hidden="true">
-                <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+            {% set img_url = img.url|default('') %}
+            {% set img_alt = img.alt|default('') %}
+            {% set img_ph = img.is_placeholder|default(false) %}
+            {% if img_url %}
+              <div class="mel-event-card-thumb{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
+                <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_alt|e('html_attr') }}" loading="lazy" width="56" height="56"/>
               </div>
-            {% else %}
-              <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
             {% endif %}
             <div class="mel-vendor-events-v2__card-body">
               <div class="mel-vendor-events-v2__card-header">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig
@@ -9,12 +9,13 @@
 <article{{ attributes.addClass('mel-card') }} data-view-mode>
   <div class="mel-card__image">
     {% set img = mel_event_card_image|default({}) %}
-    {% if img.url is defined and img.url %}
-      <div class="mel-event-card-thumb" aria-hidden="true">
-        <img class="mel-event-card-thumb__img" src="{{ img.url }}" alt="{{ img.alt|default('')|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+    {% set img_url = img.url|default('') %}
+    {% set img_alt = img.alt|default('') %}
+    {% set img_ph = img.is_placeholder|default(false) %}
+    {% if img_url %}
+      <div class="mel-event-card-thumb{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
+        <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_alt|e('html_attr') }}" loading="lazy" width="56" height="56"/>
       </div>
-    {% else %}
-      <div class="mel-event-card-thumb mel-event-card-thumb--placeholder" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</div>
     {% endif %}
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates thumbnail generation and template consumption across multiple vendor/public controllers and themes; risk is mainly UI regressions (broken image URLs/alt text or incorrect placeholder detection) rather than data/security changes.
> 
> **Overview**
> Ensures vendor console (dashboard, events grid, studio navigator) and public vendor event cards always have a usable thumbnail by centralizing thumbnail/placeholder generation in `VendorEventRemovalService` and injecting it into relevant controllers.
> 
> Thumbnail resolution now **falls back to a static SVG placeholder** (added to `myeventlane_vendor_theme`) and only uses real event images when the source file is readable; templates were updated to consume `url`/`alt` plus an `is_placeholder` flag for accessibility and styling, and theme preprocess logic similarly avoids emitting URLs for missing/unreadable files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ecb2b1c77ed3560877331c816e944a4dcd8f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->