### PR TITLE
feat(event-studio): refine MEL builder workspace UX

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -209,8 +209,284 @@
   /** @type {WeakMap<HTMLFormElement, number>} */
   var melBuilderCardFocusRafIds = new WeakMap();
 
+  /** @type {WeakMap<HTMLFormElement, Record<string, unknown>>} */
+  var melGovernanceRuntimeByForm = new WeakMap();
+
+  /** @type {WeakMap<HTMLFormElement, Set<string>>} */
+  var melGovernancePendingComponentsByForm = new WeakMap();
+
+  /** @type {WeakMap<HTMLFormElement, number>} */
+  var melGovernanceRefreshGenerationByForm = new WeakMap();
+
   function getSettings() {
     return (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudio) || {};
+  }
+
+  /**
+   * @param {HTMLFormElement|null} [form]
+   * @return {Record<string, unknown>}
+   */
+  function getGovernanceSettings(form) {
+    var base =
+      (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudioGovernance) || {};
+    if (!form) {
+      return base;
+    }
+    var overlay = melGovernanceRuntimeByForm.get(form);
+    if (!overlay) {
+      return base;
+    }
+    return /** @type {Record<string, unknown>} */ (Object.assign({}, base, overlay));
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {Record<string, unknown>} delta
+   */
+  function mergeGovernanceRuntime(form, delta) {
+    if (!form || !delta || typeof delta !== 'object') {
+      return;
+    }
+    var cur = melGovernanceRuntimeByForm.get(form) || {};
+    melGovernanceRuntimeByForm.set(form, Object.assign({}, cur, delta));
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @return {Record<string, unknown>}
+   */
+  function governanceBaselineSnapshot(form) {
+    var base =
+      (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudioGovernance) || {};
+    var overlay = melGovernanceRuntimeByForm.get(form) || {};
+    return /** @type {Record<string, unknown>} */ (Object.assign({}, base, overlay));
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @return {Promise<void>}
+   */
+  function fetchGovernanceIncrementalRefresh(form) {
+    var studio = getSettings();
+    var url = studio.urls && studio.urls.governanceRefresh;
+    if (!url || !form) {
+      return Promise.resolve();
+    }
+    var baseGov =
+      (typeof drupalSettings !== 'undefined' && drupalSettings.melEventStudioGovernance) || {};
+    if (!baseGov.enabled) {
+      return Promise.resolve();
+    }
+    var baseline = governanceBaselineSnapshot(form);
+    return melGetCsrfToken()
+      .then(function (token) {
+        if (!token) {
+          return Promise.reject(new Error('empty_csrf_token'));
+        }
+        return fetch(url, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': token,
+          },
+          body: JSON.stringify({ baseline: baseline }),
+        });
+      })
+      .then(function (response) {
+        return response.json().then(function (data) {
+          return { ok: response.ok, status: response.status, data: data };
+        });
+      })
+      .then(function (result) {
+        if (!result.ok || !result.data || !result.data.ok) {
+          return;
+        }
+        var d = result.data.delta;
+        if (d && typeof d === 'object') {
+          mergeGovernanceRuntime(form, /** @type {Record<string, unknown>} */ (d));
+        }
+      })
+      .catch(function (err) {
+        if (window.console && window.console.warn) {
+          window.console.warn('Event Studio governance refresh failed.', err);
+        }
+      });
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {Record<string, unknown>} urls
+   */
+  function updateGovernanceUrls(form, urls) {
+    if (!form || !urls || typeof urls !== 'object') {
+      return;
+    }
+    var studio = getSettings();
+    studio.urls = studio.urls || {};
+    if (urls.governanceRefresh) {
+      studio.urls.governanceRefresh = String(urls.governanceRefresh);
+    }
+    if (urls.governanceComponents && typeof urls.governanceComponents === 'object') {
+      studio.urls.governanceComponents = Object.assign(
+        {},
+        studio.urls.governanceComponents || {},
+        urls.governanceComponents,
+      );
+    }
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {string[]} components
+   */
+  function markGovernanceComponentsDirty(form, components) {
+    if (!form || !components || !components.length) {
+      return;
+    }
+    var set = melGovernancePendingComponentsByForm.get(form);
+    if (!set) {
+      set = new Set();
+      melGovernancePendingComponentsByForm.set(form, set);
+    }
+    components.forEach(function (component) {
+      set.add(component);
+    });
+  }
+
+  /**
+   * @param {Event} event
+   * @return {string[]}
+   */
+  function governanceComponentsForEvent(event) {
+    var target = event && event.target && event.target.nodeType === 1 ? event.target : null;
+    if (!target) {
+      return ['state', 'workflow'];
+    }
+    var name = String(target.getAttribute('name') || target.id || '');
+    if (/(ticket|product|external_url|field_event_type|rsvp|donation)/.test(name)) {
+      return ['workflow', 'state'];
+    }
+    if (/(venue|location|start_date|end_date|sales|publish)/.test(name)) {
+      return ['workflow', 'state'];
+    }
+    if (/(onboarding|payout|vendor)/.test(name)) {
+      return ['continuity', 'workflow'];
+    }
+    if (/(moderation|status|visibility|summary|body|title|category|image|highlight)/.test(name)) {
+      return ['state', 'intelligence'];
+    }
+    return ['state', 'intelligence'];
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @return {string[]}
+   */
+  function consumeGovernanceComponents(form) {
+    var set = melGovernancePendingComponentsByForm.get(form);
+    if (!set || !set.size) {
+      return ['state', 'workflow'];
+    }
+    var out = Array.from(set);
+    set.clear();
+    return out;
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {string[]} components
+   * @return {Promise<void>}
+   */
+  function fetchGovernanceComponents(form, components) {
+    var gov = getGovernanceSettings(form);
+    if (!form || !gov.enabled || !components || !components.length) {
+      return Promise.resolve();
+    }
+    var studio = getSettings();
+    var urls = (studio.urls && studio.urls.governanceComponents) || {};
+    if (!urls || typeof urls !== 'object') {
+      return Promise.resolve();
+    }
+    var generation = (melGovernanceRefreshGenerationByForm.get(form) || 0) + 1;
+    melGovernanceRefreshGenerationByForm.set(form, generation);
+    var unique = Array.from(new Set(components)).filter(function (component) {
+      return !!urls[component];
+    });
+    if (!unique.length) {
+      return Promise.resolve();
+    }
+
+    return melGetCsrfToken()
+      .then(function (token) {
+        if (!token) {
+          return Promise.reject(new Error('empty_csrf_token'));
+        }
+        return Promise.all(
+          unique.map(function (component) {
+            return fetch(String(urls[component]), {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: {
+                Accept: 'application/json',
+                'X-CSRF-Token': token,
+              },
+            })
+              .then(function (response) {
+                return response.json().then(function (data) {
+                  return { ok: response.ok, status: response.status, data: data };
+                });
+              })
+              .then(function (result) {
+                if (melGovernanceRefreshGenerationByForm.get(form) !== generation) {
+                  return;
+                }
+                if (!result.ok || !result.data || !result.data.ok || !result.data.html) {
+                  return;
+                }
+                replaceGovernanceComponent(form, String(result.data.component || component), String(result.data.html));
+              });
+          }),
+        );
+      })
+      .then(function () {})
+      .catch(function (err) {
+        if (window.console && window.console.warn) {
+          window.console.warn('Event Studio governance component refresh failed.', err);
+        }
+      });
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {string} component
+   * @param {string} html
+   */
+  function replaceGovernanceComponent(form, component, html) {
+    if (!component || !html) {
+      return;
+    }
+    var shell = form ? form.closest('[data-mel-studio-shell="1"]') : document;
+    var current = shell.querySelector('[data-mel-governance-component="' + component + '"]');
+    if (!current) {
+      return;
+    }
+    var active = document.activeElement;
+    var focusId = active && current.contains(active) ? active.id || '' : '';
+    var template = document.createElement('template');
+    template.innerHTML = html.trim();
+    var next = template.content.firstElementChild;
+    if (!next) {
+      return;
+    }
+    current.replaceWith(next);
+    if (focusId) {
+      var replacementFocus = document.getElementById(focusId);
+      if (replacementFocus && replacementFocus.focus) {
+        replacementFocus.focus({ preventScroll: true });
+      }
+    }
   }
 
   function formRoot(form) {
@@ -2618,6 +2894,9 @@
     if (!el || !form) {
       return;
     }
+    if (getGovernanceSettings(form).enabled) {
+      return;
+    }
     var rows = buildStructuredInsights(form);
     if (!rows || !rows.length || !rows[0].text) {
       el.textContent = '';
@@ -2630,6 +2909,9 @@
   function melUpdatePrimaryCta(form) {
     var btn = document.getElementById('mel-builder-primary-cta');
     if (!btn || !form) {
+      return;
+    }
+    if (getGovernanceSettings(form).enabled) {
       return;
     }
     var rows = buildStructuredInsights(form);
@@ -2769,6 +3051,9 @@
   function updateInsightsChecklist(form) {
     var insights = document.getElementById('mel-insights-list');
     if (!insights) {
+      return;
+    }
+    if (getGovernanceSettings(form).enabled) {
       return;
     }
     var items = buildStructuredInsights(form);
@@ -4112,6 +4397,7 @@
     var init = getSettings().initial || {};
     var str = getSettings().strings || {};
     var root = formRoot(form);
+    var governanceEnabled = !!getGovernanceSettings(form).enabled;
 
     syncTicketBuilderEventType(form);
     syncTicketTiersFromDomToHidden(form);
@@ -4137,7 +4423,7 @@
     updateFooterCtaState(form);
 
     var pr = document.getElementById('mel-publish-readiness');
-    if (pr) {
+    if (pr && !governanceEnabled) {
       pr.textContent = publishReadiness(form, init, str);
     }
 
@@ -4941,35 +5227,43 @@
 
         form.addEventListener(
           'input',
-          function () {
+          function (e) {
             setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
+            markGovernanceComponentsDirty(form, governanceComponentsForEvent(e));
           },
           true,
         );
         form.addEventListener(
           'change',
-          function () {
+          function (e) {
             setFormState(form, 'mel-studio--dirty', Drupal.t('Unsaved changes'));
+            markGovernanceComponentsDirty(form, governanceComponentsForEvent(e));
           },
           true,
         );
 
         var melBuilderShell = form.querySelector('[data-mel-builder="1"]');
-        if (melBuilderShell) {
-          var primaryCta = melBuilderShell.querySelector('#mel-builder-primary-cta');
-          if (primaryCta && !primaryCta.dataset.melBuilderBound) {
-            primaryCta.dataset.melBuilderBound = '1';
-            primaryCta.addEventListener('click', function (e) {
-              e.preventDefault();
-              syncAiControlsToForm(form);
-              var jumpName = primaryCta.getAttribute('data-mel-insight-target');
-              if (jumpName) {
-                melJumpToField(form, jumpName);
-              } else {
-                melScrollToSelector('#mel-step-publish');
-              }
-            });
-          }
+        if (melBuilderShell && !melBuilderShell.dataset.melBuilderPrimaryCtaBound) {
+          melBuilderShell.dataset.melBuilderPrimaryCtaBound = '1';
+          melBuilderShell.addEventListener('click', function (e) {
+            var primaryCta = e.target.closest('#mel-builder-primary-cta');
+            if (!primaryCta || !melBuilderShell.contains(primaryCta)) {
+              return;
+            }
+            e.preventDefault();
+            syncAiControlsToForm(form);
+            var workflowHref = primaryCta.getAttribute('data-mel-primary-cta-href');
+            if (workflowHref) {
+              window.location.href = workflowHref;
+              return;
+            }
+            var jumpName = primaryCta.getAttribute('data-mel-insight-target');
+            if (jumpName) {
+              melJumpToField(form, jumpName);
+            } else {
+              melScrollToSelector('#mel-step-publish');
+            }
+          });
         }
 
         if (!form.dataset.melBuilderValidationUiBound) {
@@ -5259,7 +5553,17 @@
                     form.appendChild(hidden);
                   }
                   hidden.value = String(nid);
-                  refreshIntelligence(form);
+                  if (result.data.governance_urls && typeof result.data.governance_urls === 'object') {
+                    updateGovernanceUrls(form, result.data.governance_urls);
+                  }
+                  var governanceComponents = consumeGovernanceComponents(form);
+                  fetchGovernanceIncrementalRefresh(form)
+                    .then(function () {
+                      return fetchGovernanceComponents(form, governanceComponents);
+                    })
+                    .finally(function () {
+                      refreshIntelligence(form);
+                    });
                   setFormState(form, 'mel-studio--saved', Drupal.t('Draft saved'));
                   window.setTimeout(function () {
                     if (!form.classList.contains('mel-studio--dirty')) {
@@ -5310,6 +5614,7 @@
           if (hLng && d.lng != null) {
             hLng.value = String(d.lng);
           }
+          markGovernanceComponentsDirty(form, ['workflow', 'state']);
           refreshIntelligence(form);
         });
       });

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
@@ -18,3 +18,6 @@ dependencies:
   - myeventlane_venue:myeventlane_venue
   - myeventlane_location:myeventlane_location
   - myeventlane_questions:myeventlane_questions
+
+optional_dependencies:
+  - myeventlane_surface:myeventlane_surface

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -296,4 +296,5 @@ function myeventlane_event_studio_preprocess_mel_event_studio(&$variables): void
   $preprocess->preprocess($variables);
 
   $variables['mel_advanced_ticket_manager_url'] = $element['#mel_advanced_ticket_manager_url'] ?? NULL;
+  $variables['mel_studio_governance'] = $element['#mel_studio_governance'] ?? ['enabled' => FALSE];
 }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -101,6 +101,39 @@ myeventlane_event_studio.autosave:
     _permission: 'access content'
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 
+myeventlane_event_studio.governance_refresh:
+  path: '/vendor/events/{node}/studio/governance-refresh'
+  defaults:
+    _controller: myeventlane_event_studio.governance_refresh_controller:refresh
+  methods: [POST]
+  requirements:
+    _permission: 'access content'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _entity_access: 'node.update'
+    _csrf_request_header_token: 'TRUE'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.governance_component:
+  path: '/vendor/events/{node}/studio/component/{component}'
+  defaults:
+    _controller: myeventlane_event_studio.governance_component_controller:render
+  methods: [POST]
+  requirements:
+    _permission: 'access content'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _entity_access: 'node.update'
+    _csrf_request_header_token: 'TRUE'
+    node: \d+
+    component: 'intelligence|workflow|state|continuity'
+  options:
+    parameters:
+      node:
+        type: entity:node
+
 # Header CSRF: JS sends X-CSRF-Token from GET /session/token (same salt as
 # CsrfRequestHeaderAccessCheck). Do NOT use _csrf_token — that only validates ?token=.
 myeventlane_event_studio.ai_generate:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -78,6 +78,27 @@ services:
       - '@database'
       - '@logger.channel.myeventlane_event_studio'
 
+  myeventlane_event_studio.governance_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder
+    arguments:
+      - '@?myeventlane_surface.workflow_manager'
+      - '@?myeventlane_surface.state_manager'
+      - '@?myeventlane_surface.operational_policy_manager'
+      - '@?myeventlane_surface.experience_manager'
+      - '@?myeventlane_surface.intelligence_manager'
+      - '@?myeventlane_surface.observability_manager'
+      - '@current_user'
+      - '@?myeventlane_surface.observability_diagnostics_access'
+      - '@?myeventlane_surface.resolver'
+      - '@?myeventlane_surface.governance_presentation_sanitizer'
+      - '@string_translation'
+
+  myeventlane_event_studio.governance_component_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder
+    arguments:
+      - '@string_translation'
+      - '@myeventlane_surface.state_readiness_helper'
+
   myeventlane_event_studio.repository:
     class: Drupal\myeventlane_event_studio\Service\EventRepository
     arguments:
@@ -97,6 +118,28 @@ services:
       - '@myeventlane_vendor.paid_publish_stripe_gate'
       - '@myeventlane_vendor.publish_requirements_gate'
       - '@?myeventlane_questions.template_cloner'
+
+  myeventlane_event_studio.governance_refresh_controller:
+    class: Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceRefreshController
+    arguments:
+      - '@myeventlane_event_studio.governance_builder'
+      - '@current_user'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@logger.channel.myeventlane_event_studio'
+    tags:
+      - { name: controller.service_arguments }
+
+  myeventlane_event_studio.governance_component_controller:
+    class: Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceComponentController
+    arguments:
+      - '@myeventlane_event_studio.governance_builder'
+      - '@myeventlane_event_studio.governance_component_builder'
+      - '@renderer'
+      - '@current_user'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@logger.channel.myeventlane_event_studio'
+    tags:
+      - { name: controller.service_arguments }
 
   myeventlane_event_studio.autosave_controller:
     class: Drupal\myeventlane_event_studio\Controller\EventStudioAutosaveController

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
@@ -136,7 +137,40 @@ final class EventStudioAutosaveController {
     return new JsonResponse([
       'ok' => TRUE,
       'nid' => $saved_node?->id(),
+      'governance_urls' => $saved_node instanceof NodeInterface ? $this->buildGovernanceUrls($saved_node) : [],
     ]);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildGovernanceUrls(NodeInterface $node): array {
+    $nid = (int) $node->id();
+    if ($nid <= 0) {
+      return [];
+    }
+
+    return [
+      'governanceRefresh' => Url::fromRoute('myeventlane_event_studio.governance_refresh', ['node' => $nid])->toString(),
+      'governanceComponents' => [
+        'intelligence' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+          'node' => $nid,
+          'component' => 'intelligence',
+        ])->toString(),
+        'workflow' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+          'node' => $nid,
+          'component' => 'workflow',
+        ])->toString(),
+        'state' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+          'node' => $nid,
+          'component' => 'state',
+        ])->toString(),
+        'continuity' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+          'node' => $nid,
+          'component' => 'continuity',
+        ])->toString(),
+      ],
+    ];
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceComponentController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceComponentController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Controller;
+
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * POST vendor-only governed component refresh for Event Studio.
+ */
+final class EventStudioGovernanceComponentController {
+
+  public function __construct(
+    private readonly EventStudioGovernanceBuilder $governanceBuilder,
+    private readonly EventStudioGovernanceComponentBuilder $componentBuilder,
+    private readonly RendererInterface $renderer,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  public function render(NodeInterface $node, string $component, Request $request): JsonResponse {
+    if (!$request->isMethod('POST')) {
+      return new JsonResponse(['ok' => FALSE], 405);
+    }
+
+    if ($node->bundle() !== 'event') {
+      return new JsonResponse(['ok' => FALSE, 'message' => 'Not found'], 404);
+    }
+
+    if (!$this->componentBuilder->isAllowedComponent($component)) {
+      $this->logger->notice('Event Studio component refresh rejected invalid component=@component nid=@nid', [
+        '@component' => $component,
+        '@nid' => (string) $node->id(),
+      ]);
+      return new JsonResponse(['ok' => FALSE, 'message' => 'Unknown component'], 404);
+    }
+
+    $account = $this->currentUser;
+    if ($account->isAnonymous()) {
+      $this->logger->warning('Event Studio component refresh denied: anonymous component=@component nid=@nid', [
+        '@component' => $component,
+        '@nid' => (string) $node->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+
+    if (!$account->hasPermission('administer nodes')) {
+      if (!$node->access('update', $account)) {
+        $this->logger->warning('Event Studio component refresh denied: node update component=@component nid=@nid uid=@uid', [
+          '@component' => $component,
+          '@nid' => (string) $node->id(),
+          '@uid' => (string) $account->id(),
+        ]);
+        throw new AccessDeniedHttpException();
+      }
+      if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+        $this->logger->warning('Event Studio component refresh denied: workspace parity component=@component nid=@nid uid=@uid', [
+          '@component' => $component,
+          '@nid' => (string) $node->id(),
+          '@uid' => (string) $account->id(),
+        ]);
+        throw new AccessDeniedHttpException();
+      }
+    }
+
+    $governance_bundle = $this->governanceBuilder->buildForEvent($node);
+    if (empty($governance_bundle['enabled'])) {
+      $response = new JsonResponse([
+        'ok' => TRUE,
+        'governance_enabled' => FALSE,
+        'component' => $component,
+        'html' => '',
+      ]);
+      $response->headers->set('Cache-Control', 'private, no-store');
+      return $response;
+    }
+
+    $build = $this->componentBuilder->buildComponent($governance_bundle, $component);
+    $html = (string) $this->renderer->renderRoot($build);
+    $response = new JsonResponse([
+      'ok' => TRUE,
+      'governance_enabled' => TRUE,
+      'component' => $component,
+      'html' => $html,
+    ]);
+    $response->headers->set('Cache-Control', 'private, no-store');
+    return $response;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceRefreshController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceRefreshController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Controller;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * POST vendor-only incremental governance refresh for Event Studio (saved events).
+ */
+final class EventStudioGovernanceRefreshController {
+
+  public function __construct(
+    private readonly EventStudioGovernanceBuilder $governanceBuilder,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  public function refresh(NodeInterface $node, Request $request): JsonResponse {
+    if (!$request->isMethod('POST')) {
+      return new JsonResponse(['ok' => FALSE], 405);
+    }
+
+    if ($node->bundle() !== 'event') {
+      return new JsonResponse(['ok' => FALSE, 'message' => 'Not found'], 404);
+    }
+
+    $account = $this->currentUser;
+    if ($account->isAnonymous()) {
+      $this->logger->warning('Event Studio governance refresh denied: anonymous nid=@nid', [
+        '@nid' => (string) $node->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+
+    if (!$account->hasPermission('administer nodes')) {
+      if (!$node->access('update', $account)) {
+        $this->logger->warning('Event Studio governance refresh denied: node update nid=@nid uid=@uid', [
+          '@nid' => (string) $node->id(),
+          '@uid' => (string) $account->id(),
+        ]);
+        throw new AccessDeniedHttpException();
+      }
+      if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+        $this->logger->warning('Event Studio governance refresh denied: workspace parity nid=@nid uid=@uid', [
+          '@nid' => (string) $node->id(),
+          '@uid' => (string) $account->id(),
+        ]);
+        throw new AccessDeniedHttpException();
+      }
+    }
+
+    $baseline = NULL;
+    $raw = $request->getContent();
+    if ($raw !== '') {
+      try {
+        $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+        if (is_array($decoded) && isset($decoded['baseline']) && is_array($decoded['baseline'])) {
+          $baseline = $decoded['baseline'];
+        }
+      }
+      catch (\JsonException $e) {
+        $this->logger->notice('Event Studio governance refresh: invalid JSON uid=@uid @message', [
+          '@uid' => (string) $account->id(),
+          '@message' => $e->getMessage(),
+        ]);
+        return new JsonResponse(['ok' => FALSE, 'message' => 'Invalid JSON'], 400);
+      }
+    }
+
+    $delta_bundle = $this->governanceBuilder->buildDeltaPayload($node, $baseline);
+    $response = new JsonResponse([
+      'ok' => TRUE,
+      'governance_enabled' => $delta_bundle['governance_enabled'],
+      'unchanged' => $delta_bundle['unchanged'],
+      'delta' => $delta_bundle['delta'],
+    ]);
+    $response->headers->set('Cache-Control', 'private, no-store');
+    return $response;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Form;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -23,6 +24,8 @@ use Drupal\myeventlane_event\Service\TicketTypeManager;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_vendor\Form\EventTicketManagerForm;
@@ -78,6 +81,10 @@ final class EventStudioForm extends FormBase {
 
   protected BookingFlowResolver $bookingFlowResolver;
 
+  protected EventStudioGovernanceBuilder $eventStudioGovernanceBuilder;
+
+  protected EventStudioGovernanceComponentBuilder $eventStudioGovernanceComponentBuilder;
+
   /**
    * Lazily restored for cached form AJAX (see {@see getMelPlatformSupportWizardForm()}).
    *
@@ -109,6 +116,8 @@ final class EventStudioForm extends FormBase {
     $instance->publishRequirementsGate = $container->get('myeventlane_vendor.publish_requirements_gate');
     $instance->bookingFlowResolver = $container->get('myeventlane_event.booking_flow_resolver');
     $instance->melPlatformSupportWizardForm = $container->get('myeventlane_event.mel_platform_support_wizard_form');
+    $instance->eventStudioGovernanceBuilder = $container->get('myeventlane_event_studio.governance_builder');
+    $instance->eventStudioGovernanceComponentBuilder = $container->get('myeventlane_event_studio.governance_component_builder');
     return $instance;
   }
 
@@ -128,7 +137,7 @@ final class EventStudioForm extends FormBase {
    * subclass properties can still be uninitialized on some paths; repull then.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->formBuilder, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->ticketTypeManager, $this->ticketTierLifecycle, $this->eventTicketReconciliation, $this->logger, $this->melPayloadService, $this->entityAutocompleteMelNormalizer, $this->publishRequirementsGate, $this->bookingFlowResolver)
+    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->formBuilder, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->ticketTypeManager, $this->ticketTierLifecycle, $this->eventTicketReconciliation, $this->logger, $this->melPayloadService, $this->entityAutocompleteMelNormalizer, $this->publishRequirementsGate, $this->bookingFlowResolver, $this->eventStudioGovernanceBuilder, $this->eventStudioGovernanceComponentBuilder)
       && isset($this->melPlatformSupportWizardForm)) {
       return;
     }
@@ -180,6 +189,12 @@ final class EventStudioForm extends FormBase {
     }
     if (!isset($this->melPlatformSupportWizardForm)) {
       $this->melPlatformSupportWizardForm = $container->get('myeventlane_event.mel_platform_support_wizard_form');
+    }
+    if (!isset($this->eventStudioGovernanceBuilder)) {
+      $this->eventStudioGovernanceBuilder = $container->get('myeventlane_event_studio.governance_builder');
+    }
+    if (!isset($this->eventStudioGovernanceComponentBuilder)) {
+      $this->eventStudioGovernanceComponentBuilder = $container->get('myeventlane_event_studio.governance_component_builder');
     }
   }
 
@@ -1329,6 +1344,29 @@ final class EventStudioForm extends FormBase {
       'vendorQuestionLibrary' => $this->buildVendorQuestionLibraryPayload(),
       'urls' => [
         'book' => $book_url,
+        'governanceRefresh' => !$event->isNew()
+          ? Url::fromRoute('myeventlane_event_studio.governance_refresh', ['node' => (int) $event->id()])->toString()
+          : '',
+        'governanceComponents' => !$event->isNew()
+          ? [
+            'intelligence' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+              'node' => (int) $event->id(),
+              'component' => 'intelligence',
+            ])->toString(),
+            'workflow' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+              'node' => (int) $event->id(),
+              'component' => 'workflow',
+            ])->toString(),
+            'state' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+              'node' => (int) $event->id(),
+              'component' => 'state',
+            ])->toString(),
+            'continuity' => Url::fromRoute('myeventlane_event_studio.governance_component', [
+              'node' => (int) $event->id(),
+              'component' => 'continuity',
+            ])->toString(),
+          ]
+          : [],
       ],
       'previewResolver' => $preview_resolver,
       'previewStrings' => [
@@ -1361,6 +1399,33 @@ final class EventStudioForm extends FormBase {
     ];
 
     $form['#mel_studio_node'] = $event;
+
+    $governance_bundle = $this->eventStudioGovernanceBuilder->buildForEvent($event);
+    CacheableMetadata::createFromRenderArray([
+      '#cache' => $governance_bundle['#cache'] ?? ['contexts' => [], 'tags' => []],
+    ])->applyTo($form);
+    $form['#mel_studio_governance'] = $governance_bundle['twig'] ?? ['enabled' => FALSE];
+    if (!empty($governance_bundle['enabled'])) {
+      $form['#mel_studio_governance']['components'] = $this->eventStudioGovernanceComponentBuilder->buildAll($governance_bundle);
+    }
+    if (!empty($governance_bundle['enabled']) && is_array($governance_bundle['js'] ?? NULL)) {
+      $form['#attached']['drupalSettings']['melEventStudioGovernance'] = $governance_bundle['js'];
+      foreach ([
+        'myeventlane_surface/interactions',
+        'myeventlane_surface/experience',
+        'myeventlane_surface/intelligence',
+        'myeventlane_surface/operational_policy',
+      ] as $mel_library) {
+        $form['#attached']['library'][] = $mel_library;
+      }
+      if (($governance_bundle['js']['observabilityTier'] ?? '') !== '') {
+        $form['#attached']['library'][] = 'myeventlane_surface/observability';
+        $form['#attached']['drupalSettings']['melObservability'] = [
+          'enabled' => TRUE,
+          'tier' => (string) $governance_bundle['js']['observabilityTier'],
+        ];
+      }
+    }
 
     // Optional advanced Commerce ticket workspace — surfaced in sidebar only (access-checked).
     $form['#mel_advanced_ticket_manager_url'] = NULL;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioGovernanceBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioGovernanceBuilder.php
@@ -1,0 +1,674 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_surface\MelObservabilityDiagnosticsAccess;
+use Drupal\myeventlane_surface\MelExperienceManager;
+use Drupal\myeventlane_surface\MelIntelligenceManager;
+use Drupal\myeventlane_surface\MelObservabilityManager;
+use Drupal\myeventlane_surface\MelGovernancePresentationSanitizer;
+use Drupal\myeventlane_surface\MelOperationalPolicyManager;
+use Drupal\myeventlane_surface\MelStateManager;
+use Drupal\myeventlane_surface\MelSurfaceId;
+use Drupal\myeventlane_surface\MelWorkflowManager;
+use Drupal\myeventlane_surface\SurfaceResolver;
+use Drupal\node\NodeInterface;
+
+/**
+ * Single facade: gathers MEL governance payloads for Event Studio (no new orchestration).
+ *
+ * Composes existing surface managers in the same order as SurfaceNegotiator memoisation.
+ */
+final class EventStudioGovernanceBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly ?MelWorkflowManager $workflowManager,
+    private readonly ?MelStateManager $stateManager,
+    private readonly ?MelOperationalPolicyManager $operationalPolicyManager,
+    private readonly ?MelExperienceManager $experienceManager,
+    private readonly ?MelIntelligenceManager $intelligenceManager,
+    private readonly ?MelObservabilityManager $observabilityManager,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly ?MelObservabilityDiagnosticsAccess $observabilityDiagnosticsAccess,
+    private readonly ?SurfaceResolver $surfaceResolver,
+    private readonly ?MelGovernancePresentationSanitizer $governancePresentationSanitizer,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  public function isEnabled(): bool {
+    return $this->workflowManager instanceof MelWorkflowManager
+      && $this->stateManager instanceof MelStateManager
+      && $this->operationalPolicyManager instanceof MelOperationalPolicyManager
+      && $this->experienceManager instanceof MelExperienceManager
+      && $this->intelligenceManager instanceof MelIntelligenceManager
+      && $this->observabilityManager instanceof MelObservabilityManager
+      && $this->surfaceResolver instanceof SurfaceResolver
+      && $this->governancePresentationSanitizer instanceof MelGovernancePresentationSanitizer;
+  }
+
+  /**
+   * Alias for buildForEvent() — full page / form governance bundle.
+   *
+   * @return array<string, mixed>
+   *   Keys: enabled, twig, js, #cache.
+   */
+  public function buildGovernancePayload(NodeInterface $event): array {
+    return $this->buildForEvent($event);
+  }
+
+  /**
+   * Incremental JSON-oriented bundle for AJAX refresh (no Twig).
+   *
+   * @return array<string, mixed>
+   *   Keys: enabled, js, #cache.
+   */
+  public function buildIncrementalPayload(NodeInterface $event): array {
+    $full = $this->buildForEvent($event);
+    return [
+      'enabled' => $full['enabled'],
+      'js' => is_array($full['js'] ?? NULL) ? $full['js'] : ['enabled' => FALSE],
+      '#cache' => $full['#cache'] ?? ['contexts' => ['user', 'route'], 'tags' => $this->nodeCacheTags($event)],
+    ];
+  }
+
+  /**
+   * Governance delta for Event Studio JS versus an optional client baseline snapshot.
+   *
+   * @param array<string, mixed>|null $baseline_js
+   *   Prior merged melEventStudioGovernance-shaped object from the client.
+   *
+   * @return array<string, mixed>
+   *   Keys: governance_enabled, unchanged, delta (array subset or full js).
+   */
+  public function buildDeltaPayload(NodeInterface $event, ?array $baseline_js): array {
+    $incremental = $this->buildIncrementalPayload($event);
+    $js = $incremental['js'];
+    if (!is_array($js)) {
+      $js = ['enabled' => FALSE];
+    }
+    if (!$incremental['enabled']) {
+      return [
+        'governance_enabled' => FALSE,
+        'unchanged' => FALSE,
+        'delta' => $js,
+      ];
+    }
+    if ($baseline_js === NULL || $baseline_js === []) {
+      return [
+        'governance_enabled' => TRUE,
+        'unchanged' => FALSE,
+        'delta' => $js,
+      ];
+    }
+    $delta = self::computeJsDelta($js, $baseline_js);
+    return [
+      'governance_enabled' => TRUE,
+      'unchanged' => $delta === [],
+      'delta' => $delta,
+    ];
+  }
+
+  /**
+   * Computes a shallow key-level delta for governance JS snapshots.
+   *
+   * @param array<string, mixed> $next_js
+   * @param array<string, mixed> $baseline_js
+   *
+   * @return array<string, mixed>
+   */
+  public static function computeJsDelta(array $next_js, array $baseline_js): array {
+    $delta = [];
+    foreach ($next_js as $key => $value) {
+      $prev = $baseline_js[$key] ?? NULL;
+      if (json_encode($prev) !== json_encode($value)) {
+        $delta[$key] = $value;
+      }
+    }
+    return $delta;
+  }
+
+  /**
+   * Build Twig variables, drupalSettings subset, and merged cache metadata.
+   *
+   * @return array<string, mixed>
+   *   Keys: enabled, twig, js, #cache.
+   */
+  public function buildForEvent(NodeInterface $event): array {
+    if (!$this->isEnabled()) {
+      return [
+        'enabled' => FALSE,
+        'twig' => ['enabled' => FALSE],
+        'js' => ['enabled' => FALSE],
+        '#cache' => [
+          'contexts' => ['user', 'route'],
+          'tags' => $this->nodeCacheTags($event),
+        ],
+      ];
+    }
+
+    $workflow = $this->workflowManager->buildPageAttachments();
+    $state = $this->stateManager->buildPageInterpretation();
+    $policy = $this->operationalPolicyManager->buildPageInterpretation();
+    $experience = $this->experienceManager->buildPageAttachments($policy);
+    $surface = $this->surfaceResolver->resolve();
+    $intelligence = $this->intelligenceManager->buildPagePayload($experience, $policy);
+    $observability = $this->observabilityManager->buildPagePayload(
+      $state,
+      $workflow,
+      $experience,
+      $intelligence,
+      $policy,
+    );
+    $intelligence_presented = $this->governancePresentationSanitizer->sanitizeIntelligencePayloadForPresentation(
+      $intelligence,
+      $surface,
+    );
+
+    $meta = CacheableMetadata::createFromRenderArray(['#cache' => $workflow['#cache'] ?? []]);
+    $meta->merge(CacheableMetadata::createFromRenderArray(['#cache' => $state['#cache'] ?? []]));
+    $meta->merge(CacheableMetadata::createFromRenderArray(['#cache' => $policy['#cache'] ?? []]));
+    $meta->merge(CacheableMetadata::createFromRenderArray(['#cache' => $experience['#cache'] ?? []]));
+    $meta->merge(CacheableMetadata::createFromRenderArray(['#cache' => $intelligence['#cache'] ?? []]));
+    $meta->merge(CacheableMetadata::createFromRenderArray(['#cache' => $observability['#cache'] ?? []]));
+    foreach ($this->nodeCacheTags($event) as $tag) {
+      $meta->addCacheTags([$tag]);
+    }
+
+    $cache = $meta->getCacheTags() !== [] || $meta->getCacheContexts() !== []
+      ? [
+        'contexts' => $meta->getCacheContexts(),
+        'tags' => $meta->getCacheTags(),
+        'max-age' => $meta->getCacheMaxAge(),
+      ]
+      : ['contexts' => ['user', 'route'], 'tags' => $this->nodeCacheTags($event)];
+
+    $primary_cta = $this->resolvePrimaryCtaDescriptor($workflow, $intelligence_presented);
+
+    $twig = [
+      'enabled' => TRUE,
+      'surface' => $surface->value,
+      'state' => $this->stripCacheDeep($state),
+      'workflow_primary' => $workflow['region_primary'] ?? [],
+      'experience' => $this->experienceTwigSubset($experience),
+      'intelligence' => $this->buildIntelligencePanelVars($intelligence_presented, $surface),
+      'policy' => $this->policyTwigSubset($policy),
+      'observability_panel' => $this->buildObservabilityPanelRenderArray($observability, $surface),
+    ];
+
+    $js_raw = $this->buildJsPayload(
+      $state,
+      $primary_cta,
+      $intelligence_presented,
+      $experience,
+      $policy,
+      $observability,
+      $surface,
+    );
+    $js = $this->governancePresentationSanitizer
+      ->sanitizeEventStudioGovernanceJs($js_raw, $surface);
+
+    return [
+      'enabled' => TRUE,
+      'twig' => $twig,
+      'js' => $js,
+      '#cache' => $cache,
+    ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function nodeCacheTags(NodeInterface $event): array {
+    if ($event->isNew()) {
+      return [];
+    }
+    return ['node:' . $event->id()];
+  }
+
+  /**
+   * @param array<string, mixed> $workflow
+   * @param array<string, mixed> $intelligence
+   *
+   * @return array<string, string>
+   */
+  private function resolvePrimaryCtaDescriptor(array $workflow, array $intelligence): array {
+    $region = $workflow['region_primary'] ?? [];
+    $link = is_array($region) && $region !== [] ? $this->findFirstLinkInRenderArray($region) : NULL;
+    if ($link !== NULL) {
+      return [
+        'mode' => 'workflow_navigate',
+        'label' => $link['title'],
+        'href' => $link['url'],
+      ];
+    }
+
+    $items = $intelligence['items'] ?? [];
+    if (is_array($items) && $items !== []) {
+      $first = $items[0];
+      if (is_array($first)) {
+        $headline = trim((string) ($first['headline'] ?? ''));
+        if ($headline !== '') {
+          return [
+            'mode' => 'publish_step',
+            'label' => (string) $this->t('Review publish'),
+            'headline' => $headline,
+          ];
+        }
+      }
+    }
+
+    return [
+      'mode' => 'publish_step',
+      'label' => (string) $this->t('Review publish'),
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $element
+   *
+   * @return array{title: string, url: string}|null
+   */
+  private function findFirstLinkInRenderArray(array $element): ?array {
+    if (isset($element['#type']) && $element['#type'] === 'link' && isset($element['#url']) && $element['#url'] instanceof Url) {
+      return [
+        'title' => (string) ($element['#title'] ?? ''),
+        'url' => $element['#url']->toString(),
+      ];
+    }
+    foreach (Element::children($element) as $key) {
+      $child = $element[$key];
+      if (is_array($child)) {
+        $found = $this->findFirstLinkInRenderArray($child);
+        if ($found !== NULL) {
+          return $found;
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @param array<string, mixed> $experience
+   *
+   * @return array<string, mixed>
+   */
+  private function experienceTwigSubset(array $experience): array {
+    $resume = $experience['resume_candidates'] ?? [];
+    $continuation = $experience['continuation'] ?? [];
+    $escalation = $experience['escalation_safe'] ?? [];
+    if (!is_array($resume)) {
+      $resume = [];
+    }
+    if (!is_array($continuation)) {
+      $continuation = [];
+    }
+    if (!is_array($escalation)) {
+      $escalation = [];
+    }
+    $resume_lines = [];
+    foreach ($resume as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $id = (string) ($row['experience_id'] ?? '');
+      if ($id !== '') {
+        $resume_lines[] = ucfirst(str_replace('_', ' ', $id));
+      }
+    }
+    $sequencing = [];
+    if (isset($continuation['cta_sequencing_notes']) && is_array($continuation['cta_sequencing_notes'])) {
+      $sequencing = $continuation['cta_sequencing_notes'];
+    }
+    return [
+      'resume_candidates' => $resume,
+      'resume_lines' => $resume_lines,
+      'continuation' => $continuation,
+      'continuation_notes' => $sequencing,
+      'escalation_safe' => $escalation,
+      'primary_experience_id' => $experience['primary_experience_id'] ?? NULL,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $policy
+   *
+   * @return array<string, mixed>
+   */
+  private function policyTwigSubset(array $policy): array {
+    $hints = $policy['communication_hints'] ?? [];
+    $lifecycle = $policy['lifecycle_safety'] ?? [];
+    if (!is_array($hints)) {
+      $hints = [];
+    }
+    if (!is_array($lifecycle)) {
+      $lifecycle = [];
+    }
+    return [
+      'surface_policy_profile' => (string) ($policy['surface_policy_profile'] ?? ''),
+      'communication_hints' => $hints,
+      'lifecycle_safety' => $lifecycle,
+      'hint_lines' => $this->policyHintLines($hints),
+      'lifecycle_lines' => $this->lifecycleSafetyLines($lifecycle),
+    ];
+  }
+
+  /**
+   * @param array<string, bool> $hints
+   *
+   * @return list<string>
+   */
+  private function policyHintLines(array $hints): array {
+    $lines = [];
+    if (!empty($hints['trust_sensitive_tone'])) {
+      $lines[] = (string) $this->t('Trust-sensitive tone is active.');
+    }
+    if (!empty($hints['escalation_tone'])) {
+      $lines[] = (string) $this->t('Escalation-aware messaging is active.');
+    }
+    if (!empty($hints['moderation_safe_tone'])) {
+      $lines[] = (string) $this->t('Moderation-safe tone hints apply.');
+    }
+    if (!empty($hints['reduced_urgency_mode'])) {
+      $lines[] = (string) $this->t('Urgency and promotional cadence are reduced.');
+    }
+    if (!empty($hints['reassurance_priority'])) {
+      $lines[] = (string) $this->t('Reassurance is emphasised for this moment.');
+    }
+    return $lines;
+  }
+
+  /**
+   * @param array<string, bool> $lifecycle
+   *
+   * @return list<string>
+   */
+  private function lifecycleSafetyLines(array $lifecycle): array {
+    $lines = [];
+    foreach ($lifecycle as $id => $active) {
+      if (!$active) {
+        continue;
+      }
+      $lines[] = match ($id) {
+        'stale_draft_protection' => (string) $this->t('Draft lifecycle prompts favour completion.'),
+        'abandoned_checkout_safety' => (string) $this->t('Checkout recovery tone may apply elsewhere in the product.'),
+        'inactive_vendor_safeguard' => (string) $this->t('Vendor setup prompts stay focused until onboarding completes.'),
+        'cancelled_event_suppression' => (string) $this->t('Growth prompts are reduced for cancelled events.'),
+        default => '',
+      };
+    }
+    return array_values(array_filter($lines, static fn (string $s): bool => $s !== ''));
+  }
+
+  /**
+   * @param array<string, mixed> $intelligence
+   *
+   * @return array<string, mixed>
+   */
+  private function buildIntelligencePanelVars(array $intelligence, MelSurfaceId $surface): array {
+    $items = $intelligence['items'] ?? [];
+    $insights = $intelligence['insights'] ?? [];
+    if (!is_array($items)) {
+      $items = [];
+    }
+    if (!is_array($insights)) {
+      $insights = [];
+    }
+    $region = $intelligence['accessibility']['region_attributes'] ?? [];
+    $reduced = $intelligence['accessibility']['reduced_motion'] ?? [];
+    if (!is_array($region)) {
+      $region = [];
+    }
+    if (!is_array($reduced)) {
+      $reduced = [];
+    }
+    $merged = array_merge($region, $reduced);
+    $classes = $merged['class'] ?? [];
+    if (is_string($classes)) {
+      $classes = array_values(array_filter(preg_split('/\s+/', trim($classes)) ?: []));
+    }
+    elseif (!is_array($classes)) {
+      $classes = [];
+    }
+    $classes[] = 'mel-intelligence-panel';
+    $classes[] = 'mel-studio-intelligence-panel';
+    $merged['class'] = array_values(array_unique(array_filter($classes)));
+
+    return [
+      'attributes' => $merged,
+      'items' => $items,
+      'insights' => $insights,
+      'explainability_details' => $surface === MelSurfaceId::Staff,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   * @param array<string, mixed> $cache_meta
+   *
+   * @return array<string, mixed>|null
+   */
+  private function buildObservabilityPanelRenderArray(array $payload, MelSurfaceId $surface): ?array {
+    if (!$this->observabilityDiagnosticsAccess instanceof MelObservabilityDiagnosticsAccess) {
+      return NULL;
+    }
+    if (!$this->observabilityDiagnosticsAccess->mayViewDiagnostics($surface, $this->currentUser)) {
+      return NULL;
+    }
+    $traces = $payload['traces'] ?? [];
+    if (!is_array($traces) || $traces === []) {
+      return NULL;
+    }
+    $cache_meta = $payload['#cache'] ?? ['contexts' => ['user', 'route'], 'tags' => []];
+
+    $panel_attrs = $payload['accessibility']['diagnostic_region_attributes'] ?? [];
+    if (!is_array($panel_attrs)) {
+      $panel_attrs = [];
+    }
+    $classes = $panel_attrs['class'] ?? [];
+    if (is_string($classes)) {
+      $classes = array_values(array_filter(preg_split('/\s+/', trim($classes)) ?: []));
+    }
+    elseif (!is_array($classes)) {
+      $classes = [];
+    }
+    $classes[] = 'mel-observability-panel';
+    $classes[] = 'mel-studio-observability-panel';
+    $panel_attrs['class'] = array_values(array_unique(array_filter($classes)));
+
+    $registry_meta = $payload['registry_meta'] ?? [];
+    if (!is_array($registry_meta)) {
+      $registry_meta = [];
+    }
+    $telemetry = $payload['telemetry_boundary_reference'] ?? [];
+    if (!is_array($telemetry)) {
+      $telemetry = [];
+    }
+
+    return [
+      '#theme' => 'mel_observability_panel',
+      '#attributes' => $panel_attrs,
+      '#traces' => $traces,
+      '#registry_meta' => $registry_meta,
+      '#telemetry_boundary_reference' => $telemetry,
+      '#cache' => $cache_meta,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $state
+   * @param array<string, string> $primary_cta
+   * @param array<string, mixed> $intelligence
+   * @param array<string, mixed> $experience
+   * @param array<string, mixed> $policy
+   * @param array<string, mixed> $observability
+   *
+   * @return array<string, mixed>
+   */
+  private function buildJsPayload(
+    array $state,
+    array $primary_cta,
+    array $intelligence,
+    array $experience,
+    array $policy,
+    array $observability,
+    MelSurfaceId $surface,
+  ): array {
+    $summaries = $state['readiness_summaries'] ?? [];
+    if (!is_array($summaries)) {
+      $summaries = [];
+    }
+    $summaries = array_values(array_filter(array_map(static fn ($s): string => is_string($s) ? trim($s) : '', $summaries)));
+
+    $next_best = '';
+    $items = $intelligence['items'] ?? [];
+    if (is_array($items) && $items !== []) {
+      $first = $items[0];
+      if (is_array($first)) {
+        $next_best = trim((string) ($first['headline'] ?? ''));
+      }
+    }
+    if ($next_best === '') {
+      $insights = $intelligence['insights'] ?? [];
+      if (is_array($insights) && $insights !== []) {
+        $ins = $insights[0];
+        if (is_array($ins) && isset($ins['headline'])) {
+          $next_best = trim((string) $ins['headline']);
+        }
+      }
+    }
+
+    $checklist = [];
+    if (is_array($items)) {
+      foreach ($items as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
+        $checklist[] = [
+          'kind' => 'governance_item',
+          'id' => (string) ($row['id'] ?? ''),
+          'text' => trim((string) ($row['headline'] ?? '')),
+          'target' => '',
+        ];
+      }
+    }
+    $insights_rows = $intelligence['insights'] ?? [];
+    if (is_array($insights_rows)) {
+      foreach ($insights_rows as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
+        $checklist[] = [
+          'kind' => 'governance_insight',
+          'id' => (string) ($row['id'] ?? ''),
+          'text' => trim((string) ($row['headline'] ?? '')),
+          'target' => '',
+        ];
+      }
+    }
+
+    $telemetry_tier = '';
+    if ($this->observabilityDiagnosticsAccess instanceof MelObservabilityDiagnosticsAccess
+      && $this->observabilityDiagnosticsAccess->mayViewDiagnostics($surface, $this->currentUser)) {
+      $tr = $observability['traces'] ?? [];
+      if (is_array($tr) && $tr !== []) {
+        $telemetry_tier = (string) ($observability['visibility_tier'] ?? '');
+      }
+    }
+
+    $experience_subset = $this->experienceTwigSubset($experience);
+    $continuation_notes = $experience_subset['continuation_notes'] ?? [];
+    if (!is_array($continuation_notes)) {
+      $continuation_notes = [];
+    }
+    $continuity_lines = array_merge($experience_subset['resume_lines'], $continuation_notes);
+    $continuity_lines = array_values(array_filter(array_map(
+      static fn ($s): string => is_string($s) ? trim($s) : '',
+      $continuity_lines,
+    ), static fn (string $s): bool => $s !== ''));
+
+    $policy_subset = $this->policyTwigSubset($policy);
+    $policy_lines = array_merge($policy_subset['hint_lines'], $policy_subset['lifecycle_lines']);
+
+    $escalation = $experience['escalation_safe'] ?? [];
+    $escalation_active_ids = [];
+    if (is_array($escalation)) {
+      foreach ($escalation as $key => $active) {
+        if (!empty($active)) {
+          $escalation_active_ids[] = (string) $key;
+        }
+      }
+    }
+    sort($escalation_active_ids);
+
+    $op_suppression = $intelligence['operational_policy']['suppression'] ?? [];
+    $suppression_active_ids = [];
+    if (is_array($op_suppression)) {
+      foreach ($op_suppression as $key => $active) {
+        if (!empty($active)) {
+          $suppression_active_ids[] = (string) $key;
+        }
+      }
+    }
+    sort($suppression_active_ids);
+
+    $orchestration = $intelligence['orchestration'] ?? [];
+    $visible_ids = $orchestration['visible_ids'] ?? [];
+    if (!is_array($visible_ids)) {
+      $visible_ids = [];
+    }
+    $visible_ids = array_values(array_map(static fn ($id): string => (string) $id, $visible_ids));
+
+    return [
+      'enabled' => TRUE,
+      'version' => 2,
+      'primaryCta' => $primary_cta,
+      'nextBestText' => $next_best,
+      'publishReadinessLead' => $summaries !== [] ? implode(' ', $summaries) : '',
+      'stateSummaryLines' => $summaries,
+      'continuityLines' => $continuity_lines,
+      'policyLines' => $policy_lines,
+      'suppressionActiveIds' => $suppression_active_ids,
+      'intelligenceVisibleIds' => $visible_ids,
+      'checklist' => $checklist,
+      'experience' => [
+        'primary_experience_id' => $experience['primary_experience_id'] ?? NULL,
+        'resume_count' => is_array($experience['resume_candidates'] ?? NULL) ? count($experience['resume_candidates']) : 0,
+        'resume_labels' => $experience_subset['resume_lines'],
+        'escalation_active_ids' => $escalation_active_ids,
+      ],
+      'policy' => [
+        'surface_profile' => (string) ($policy['surface_policy_profile'] ?? ''),
+        'reduced_urgency' => !empty(($policy['communication_hints'] ?? [])['reduced_urgency_mode']),
+      ],
+      'observabilityTier' => $telemetry_tier,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $data
+   *
+   * @return array<string, mixed>
+   */
+  private function stripCacheDeep(array $data): array {
+    unset($data['#cache']);
+    foreach ($data as $k => $v) {
+      if (is_array($v)) {
+        $data[$k] = $this->stripCacheDeep($v);
+      }
+    }
+    return $data;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioGovernanceComponentBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioGovernanceComponentBuilder.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_surface\MelReadinessHelper;
+use Drupal\myeventlane_surface\MelSurfaceId;
+
+/**
+ * Builds Event Studio governance component render arrays.
+ *
+ * This adapter only renders the payload produced by EventStudioGovernanceBuilder.
+ * It does not recompute workflow, state, experience, policy, or intelligence.
+ */
+final class EventStudioGovernanceComponentBuilder {
+
+  use StringTranslationTrait;
+
+  public const COMPONENT_INTELLIGENCE = 'intelligence';
+  public const COMPONENT_WORKFLOW = 'workflow';
+  public const COMPONENT_STATE = 'state';
+  public const COMPONENT_CONTINUITY = 'continuity';
+
+  private const COMPONENTS = [
+    self::COMPONENT_INTELLIGENCE,
+    self::COMPONENT_WORKFLOW,
+    self::COMPONENT_STATE,
+    self::COMPONENT_CONTINUITY,
+  ];
+
+  public function __construct(
+    TranslationInterface $string_translation,
+    private readonly MelReadinessHelper $readinessHelper,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function allowedComponents(): array {
+    return self::COMPONENTS;
+  }
+
+  public function isAllowedComponent(string $component): bool {
+    return in_array($component, self::COMPONENTS, TRUE);
+  }
+
+  /**
+   * @param array<string, mixed> $governance_bundle
+   *
+   * @return array<string, mixed>
+   */
+  public function buildAll(array $governance_bundle): array {
+    $regions = [];
+    foreach (self::COMPONENTS as $component) {
+      $regions[$component] = $this->buildComponent($governance_bundle, $component);
+    }
+    return $regions;
+  }
+
+  /**
+   * @param array<string, mixed> $governance_bundle
+   *
+   * @return array<string, mixed>
+   */
+  public function buildComponent(array $governance_bundle, string $component): array {
+    if (!$this->isAllowedComponent($component)) {
+      throw new \InvalidArgumentException(sprintf('Unsupported Event Studio governance component "%s".', $component));
+    }
+
+    $twig = is_array($governance_bundle['twig'] ?? NULL) ? $governance_bundle['twig'] : [];
+    $js = is_array($governance_bundle['js'] ?? NULL) ? $governance_bundle['js'] : [];
+    $cache = is_array($governance_bundle['#cache'] ?? NULL)
+      ? $governance_bundle['#cache']
+      : ['contexts' => ['user', 'route'], 'tags' => []];
+
+    $build = match ($component) {
+      self::COMPONENT_INTELLIGENCE => $this->buildIntelligence($twig, $js),
+      self::COMPONENT_WORKFLOW => $this->buildWorkflow($twig, $js),
+      self::COMPONENT_STATE => $this->buildState($twig, $js),
+      self::COMPONENT_CONTINUITY => $this->buildContinuity($twig, $js),
+      default => [],
+    };
+
+    CacheableMetadata::createFromRenderArray(['#cache' => $cache])->applyTo($build);
+    return $build;
+  }
+
+  /**
+   * @param array<string, mixed> $twig
+   * @param array<string, mixed> $js
+   *
+   * @return array<string, mixed>
+   */
+  private function buildState(array $twig, array $js): array {
+    $state = is_array($twig['state'] ?? NULL) ? $twig['state'] : [];
+    $summaries = $this->stringList($state['readiness_summaries'] ?? $js['stateSummaryLines'] ?? []);
+    $readiness = trim((string) ($js['publishReadinessLead'] ?? ''));
+    if ($readiness === '' && $summaries !== []) {
+      $readiness = implode(' ', $summaries);
+    }
+
+    $summary_list = $summaries !== []
+      ? $this->itemList('mel-governance-state-summary-list', ['mel-state-summary__list'], $summaries, 'mel-state-summary__item')
+      : [
+        '#theme' => 'mel_empty_state',
+        '#attributes' => ['class' => ['mel-state-summary__empty']],
+        '#heading' => (string) $this->t('No readiness signals yet.'),
+        '#heading_element' => 'p',
+        '#why_empty' => (string) $this->t('Save your event details to refresh publishing readiness.'),
+      ];
+
+    $readiness_text = $readiness !== ''
+      ? $readiness
+      : (string) $this->t('Save your event details to refresh publishing readiness.');
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<section id="mel-state-summary" class="mel-studio-governance-region mel-state-summary" aria-label="{{ aria_label }}" role="region" aria-live="polite" data-mel-governance-component="state">{{ content }}</section>',
+      '#context' => [
+        'aria_label' => (string) $this->t('Account and publishing status'),
+        'content' => [
+          'heading' => [
+            '#markup' => '<h3 class="mel-aside-card__title">' . (string) $this->t('Status') . '</h3>',
+          ],
+          'summary' => $summary_list,
+          'readiness' => [
+            '#theme' => 'mel_card',
+            '#attributes' => [
+              'class' => [
+                'mel-publish-readiness-card',
+                'mel-publish-card',
+                'mel-publish-readiness-card--governance',
+              ],
+            ],
+            '#title' => (string) $this->t('Publish readiness'),
+            '#title_element' => 'h4',
+            '#content' => [
+              '#type' => 'container',
+              '#attributes' => [
+                'id' => 'mel-publish-readiness',
+                'class' => ['mel-publish-readiness-body'],
+                'data-mel-publish-readiness-host' => '1',
+              ],
+              'text' => ['#plain_text' => $readiness_text],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $twig
+   * @param array<string, mixed> $js
+   *
+   * @return array<string, mixed>
+   */
+  private function buildWorkflow(array $twig, array $js): array {
+    $primary_cta = is_array($js['primaryCta'] ?? NULL) ? $js['primaryCta'] : [];
+    $primary_label = trim((string) ($primary_cta['label'] ?? ''));
+    $next_best = trim((string) ($js['nextBestText'] ?? ''));
+    $href = (string) ($primary_cta['mode'] ?? '') === 'workflow_navigate'
+      ? trim((string) ($primary_cta['href'] ?? ''))
+      : '';
+    $workflow_primary = is_array($twig['workflow_primary'] ?? NULL) ? $twig['workflow_primary'] : [];
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<section id="mel-workflow-panel" class="mel-studio-governance-region mel-workflow-panel" aria-label="{{ aria_label }}" role="region" aria-live="polite" data-mel-governance-component="workflow">{{ content }}</section>',
+      '#context' => [
+        'aria_label' => (string) $this->t('Guided next step'),
+        'content' => [
+          'primary' => $workflow_primary !== [] ? [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['mel-workflow-panel__surface-region']],
+            'region' => $workflow_primary,
+          ] : [],
+          'next' => [
+            '#theme' => 'mel_guided_next_step',
+            '#attributes' => ['class' => ['mel-builder-next-best-block']],
+            '#content' => [
+              '#type' => 'inline_template',
+              '#template' => '<p class="mel-builder-next-best-label">{{ label }}</p><p id="mel-builder-next-best" class="mel-builder-next-best" aria-live="polite">{{ next_best }}</p><button type="button" class="mel-btn mel-btn--primary mel-builder-primary-cta" id="mel-builder-primary-cta"{% if href %} data-mel-primary-cta-href="{{ href }}"{% endif %}>{{ cta_label }}</button>',
+              '#context' => [
+                'label' => (string) $this->t('Next best action'),
+                'next_best' => $next_best,
+                'cta_label' => $primary_label !== '' ? $primary_label : (string) $this->t('Review publish'),
+                'href' => $href,
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $twig
+   * @param array<string, mixed> $js
+   *
+   * @return array<string, mixed>
+   */
+  private function buildContinuity(array $twig, array $js): array {
+    $experience = is_array($twig['experience'] ?? NULL) ? $twig['experience'] : [];
+    $resume_lines = $this->stringList($experience['resume_lines'] ?? []);
+    $notes = $this->stringList($experience['continuation_notes'] ?? []);
+    $lines = $this->stringList($js['continuityLines'] ?? array_merge($resume_lines, $notes));
+    $has_lines = $lines !== [];
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<section id="mel-experience-panel" class="mel-studio-governance-region mel-experience-panel" aria-label="{{ aria_label }}" role="region" aria-live="polite" data-mel-governance-component="continuity">{{ content }}</section>',
+      '#context' => [
+        'aria_label' => (string) $this->t('Continuity'),
+        'content' => [
+          'heading' => [
+            '#markup' => '<h3 class="mel-aside-card__title">' . (string) $this->t('Continuity') . '</h3>',
+          ],
+          'lines' => $has_lines
+            ? $this->itemList('mel-governance-continuity-list', ['mel-experience-panel__list'], $lines)
+            : [
+              '#theme' => 'mel_empty_state',
+              '#attributes' => [
+                'id' => 'mel-governance-continuity-empty',
+                'class' => ['mel-experience-panel__empty'],
+              ],
+              '#heading' => (string) $this->t('No continuity prompts for this moment.'),
+              '#heading_element' => 'p',
+            ],
+          'notes_anchor' => [
+            '#markup' => '<ul id="mel-governance-continuity-notes" class="mel-experience-panel__notes" hidden></ul>',
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $twig
+   * @param array<string, mixed> $js
+   *
+   * @return array<string, mixed>
+   */
+  private function buildIntelligence(array $twig, array $js): array {
+    $intelligence = is_array($twig['intelligence'] ?? NULL) ? $twig['intelligence'] : [];
+    $items = is_array($intelligence['items'] ?? NULL) ? $intelligence['items'] : [];
+    $insights = is_array($intelligence['insights'] ?? NULL) ? $intelligence['insights'] : [];
+    $attributes = is_array($intelligence['attributes'] ?? NULL) ? $intelligence['attributes'] : [];
+    $checklist = $this->checklistRows($js['checklist'] ?? []);
+
+    $explainability_details = !empty($intelligence['explainability_details']);
+    $surface_value = isset($twig['surface']) && is_string($twig['surface']) ? $twig['surface'] : MelSurfaceId::Vendor->value;
+    $presentation_surface = MelSurfaceId::tryFrom($surface_value) ?? MelSurfaceId::Vendor;
+    $presentation = $this->readinessHelper->intelligencePanelThemeVariables($presentation_surface);
+
+    $panel = ($items !== [] || $insights !== [])
+      ? [
+        '#theme' => 'mel_intelligence_panel',
+        '#attributes' => $attributes,
+        '#items' => $items,
+        '#insights' => $insights,
+        '#explainability_details' => $explainability_details,
+        '#intelligence_region_heading' => $presentation['intelligence_region_heading'],
+        '#explainability_summary_label' => $presentation['explainability_summary_label'],
+        '#explainability_signals_label' => $presentation['explainability_signals_label'],
+        '#insights_aria_label' => $presentation['insights_aria_label'],
+        '#dismiss_hint_template' => $presentation['dismiss_hint_template'],
+      ]
+      : [
+        '#theme' => 'mel_empty_state',
+        '#attributes' => ['class' => ['mel-intelligence-panel__empty']],
+        '#heading' => $this->readinessHelper->eventStudioIntelligenceEmptyHeading(),
+        '#heading_element' => 'p',
+        '#why_empty' => $this->readinessHelper->eventStudioIntelligenceEmptyBody(),
+      ];
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<section id="mel-intelligence-panel-region" class="mel-studio-governance-region mel-intelligence-panel-region" aria-label="{{ aria_label }}" role="region" aria-live="polite" data-mel-governance-component="intelligence">{{ content }}</section>',
+      '#context' => [
+        'aria_label' => (string) $this->t('Guidance suggestions'),
+        'content' => [
+          'panel' => $panel,
+          'checklist' => [
+            '#type' => 'inline_template',
+            '#template' => '<details class="mel-builder-checklist-details mel-insights-card mel-insights-card--sidebar mel-insights-card--governed"><summary class="mel-builder-checklist-summary">{{ summary }}</summary><div id="mel-insights-list" class="mel-insights-checklist" role="list" data-mel-field-tips-list="1">{{ rows }}</div></details>',
+            '#context' => [
+              'summary' => (string) $this->t('Field tips (live)'),
+              'rows' => $checklist !== []
+                ? $this->buildChecklistRows($checklist)
+                : [
+                  '#theme' => 'mel_empty_state',
+                  '#attributes' => ['class' => ['mel-insight-item', 'mel-insight-item--governance']],
+                  '#heading' => $this->readinessHelper->eventStudioFieldTipsEmptyHeading(),
+                  '#heading_element' => 'p',
+                ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param mixed $rows
+   *
+   * @return list<array{text: string}>
+   */
+  private function checklistRows(mixed $rows): array {
+    if (!is_array($rows)) {
+      return [];
+    }
+    $out = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $text = trim((string) ($row['text'] ?? ''));
+      if ($text !== '') {
+        $out[] = ['text' => $text];
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param list<array{text: string}> $rows
+   *
+   * @return array<string, mixed>
+   */
+  private function buildChecklistRows(array $rows): array {
+    $items = [];
+    foreach ($rows as $row) {
+      $items[] = [
+        '#type' => 'inline_template',
+        '#template' => '<div class="mel-insight-item mel-insight-item--governance mel-insight-item--low" role="listitem"><span class="mel-insight-item__text">{{ text }}</span></div>',
+        '#context' => ['text' => $row['text']],
+      ];
+    }
+    return $items;
+  }
+
+  /**
+   * @param mixed $raw
+   *
+   * @return list<string>
+   */
+  private function stringList(mixed $raw): array {
+    if (!is_array($raw)) {
+      return [];
+    }
+    $values = [];
+    foreach ($raw as $value) {
+      $value = trim((string) $value);
+      if ($value !== '') {
+        $values[] = $value;
+      }
+    }
+    return $values;
+  }
+
+  /**
+   * @param list<string> $classes
+   * @param list<string> $items
+   *
+   * @return array<string, mixed>
+   */
+  private function itemList(string $id, array $classes, array $items, string $item_class = ''): array {
+    $list_items = [];
+    foreach ($items as $item) {
+      $list_items[] = $item_class !== ''
+        ? ['value' => ['#plain_text' => $item], 'attributes' => ['class' => [$item_class]]]
+        : ['#plain_text' => $item];
+    }
+
+    return [
+      '#theme' => 'item_list',
+      '#list_type' => 'ul',
+      '#items' => $list_items,
+      '#attributes' => [
+        'id' => $id,
+        'class' => $classes,
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -12,7 +12,7 @@
     {{ element.mel_contextual_help_card }}
   {% endif %}
 
-  <div class="mel-event-studio mel-event-studio--builder-inline-validation mel-event-studio--{{ mode|default('create') }}" data-mel-studio-shell="1">
+  <div class="mel-event-studio mel-event-studio--builder-inline-validation mel-event-studio--{{ mode|default('create') }}{% if mel_studio_governance.enabled|default(false) %} mel-event-studio--governance{% endif %}" data-mel-studio-shell="1">
     {{ element.mel.ai_settings }}
     <h1 class="mel-event-studio__page-title visually-hidden">
       {% if mode == 'create' %}
@@ -165,16 +165,44 @@
             </div>
           </div>
 
-          <div class="mel-builder-next-best-block">
-            <p class="mel-builder-next-best-label">{{ 'Next best action'|t }}</p>
-            <p id="mel-builder-next-best" class="mel-builder-next-best" aria-live="polite"></p>
-            <button type="button" class="mel-btn mel-btn--primary mel-builder-primary-cta" id="mel-builder-primary-cta">{{ 'Review publish'|t }}</button>
-          </div>
+          {% set gov = mel_studio_governance|default({'enabled': false}) %}
 
-          <div class="mel-publish-readiness-card mel-publish-card">
-            <h3 class="mel-aside-card__title">{{ 'Publish readiness'|t }}</h3>
-            <div id="mel-publish-readiness" class="mel-publish-readiness-body"></div>
-          </div>
+          {% if gov.enabled %}
+            <div class="mel-studio-governance-sidebar" data-mel-studio-governance-root="1">
+              {{ gov.components.state }}
+              {{ gov.components.workflow }}
+              {{ gov.components.continuity }}
+              {{ gov.components.intelligence }}
+
+              {% set policy_lines = gov.policy.hint_lines|default([])|merge(gov.policy.lifecycle_lines|default([])) %}
+              <section id="mel-operational-policy-panel" class="mel-studio-governance-region mel-operational-policy-panel" aria-label="{{ 'Operational tone'|t }}" role="region">
+                <h3 class="mel-aside-card__title">{{ 'Operational tone'|t }}</h3>
+                <ul id="mel-governance-policy-list" class="mel-operational-policy-panel__list">
+                  {% for line in policy_lines %}
+                    <li>{{ line }}</li>
+                  {% endfor %}
+                </ul>
+                <p id="mel-governance-policy-empty" class="mel-operational-policy-panel__empty"{% if policy_lines is not empty %} hidden{% endif %}>{{ 'Standard vendor workspace tone.'|t }}</p>
+              </section>
+
+              {% if gov.observability_panel %}
+                <section id="mel-observability-panel" class="mel-studio-governance-region mel-observability-panel" aria-label="{{ 'Diagnostics'|t }}" role="region">
+                  {{ gov.observability_panel }}
+                </section>
+              {% endif %}
+            </div>
+          {% else %}
+            <div class="mel-builder-next-best-block">
+              <p class="mel-builder-next-best-label">{{ 'Next best action'|t }}</p>
+              <p id="mel-builder-next-best" class="mel-builder-next-best" aria-live="polite"></p>
+              <button type="button" class="mel-btn mel-btn--primary mel-builder-primary-cta" id="mel-builder-primary-cta">{{ 'Review publish'|t }}</button>
+            </div>
+
+            <div class="mel-publish-readiness-card mel-publish-card">
+              <h3 class="mel-aside-card__title">{{ 'Publish readiness'|t }}</h3>
+              <div id="mel-publish-readiness" class="mel-publish-readiness-body"></div>
+            </div>
+          {% endif %}
 
           <div class="mel-ai-controls mel-ai-controls--sidebar" role="region" aria-label="{{ 'AI style for generation'|t }}">
             <div class="mel-ai-controls__row">
@@ -201,10 +229,12 @@
             </div>
           </div>
 
-          <details class="mel-builder-checklist-details mel-insights-card mel-insights-card--sidebar">
-            <summary class="mel-builder-checklist-summary">{{ 'Show full checklist'|t }}</summary>
-            <div id="mel-insights-list" class="mel-insights-checklist" role="list" aria-live="polite"></div>
-          </details>
+          {% if not mel_studio_governance.enabled|default(false) %}
+            <details class="mel-builder-checklist-details mel-insights-card mel-insights-card--sidebar">
+              <summary class="mel-builder-checklist-summary">{{ 'Show full checklist'|t }}</summary>
+              <div id="mel-insights-list" class="mel-insights-checklist" role="list" aria-live="polite" data-mel-field-tips-list="1"></div>
+            </details>
+          {% endif %}
 
           <div class="mel-builder-sidebar__save">
             <button type="button" class="mel-btn mel-btn--primary mel-builder-save-sidebar" id="mel-builder-save-sidebar" aria-label="{{ 'Save event'|t }}">
@@ -215,7 +245,7 @@
           <p class="mel-aside-footnote" id="mel-studio-form-state" role="status"></p>
         </div>
       </aside>
-      <main class="mel-main mel-es-workspace__main">
+      <main id="mel-studio-content" class="mel-main mel-es-workspace__main mel-studio-content">
 
     <div class="mel-studio-form-wrapper mel-event-studio__form-full mel-studio-main-full">
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceBuilderDeltaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceBuilderDeltaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioGovernanceBuilderDeltaTest extends TestCase {
+
+  /**
+   * @covers ::computeJsDelta
+   */
+  public function testComputeJsDeltaIncludesChangedKeys(): void {
+    $next = [
+      'version' => 2,
+      'nextBestText' => 'a',
+      'nested' => ['x' => 1],
+    ];
+    $baseline = [
+      'version' => 2,
+      'nextBestText' => 'b',
+      'nested' => ['x' => 1],
+    ];
+    $delta = EventStudioGovernanceBuilder::computeJsDelta($next, $baseline);
+    $this->assertArrayHasKey('nextBestText', $delta);
+    $this->assertSame('a', $delta['nextBestText']);
+    $this->assertArrayNotHasKey('nested', $delta);
+  }
+
+  /**
+   * @covers ::computeJsDelta
+   */
+  public function testComputeJsDeltaEmptyWhenIdentical(): void {
+    $payload = ['version' => 2, 'checklist' => [['id' => 'x']]];
+    $delta = EventStudioGovernanceBuilder::computeJsDelta($payload, $payload);
+    $this->assertSame([], $delta);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceComponentBuilderTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceComponentBuilderTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder;
+use Drupal\myeventlane_surface\MelReadinessHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioGovernanceComponentBuilderTest extends TestCase {
+
+  /**
+   * @covers ::allowedComponents
+   * @covers ::isAllowedComponent
+   */
+  public function testAllowedComponentsAreBounded(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $this->assertSame([
+      'intelligence',
+      'workflow',
+      'state',
+      'continuity',
+    ], $builder->allowedComponents());
+    $this->assertTrue($builder->isAllowedComponent('workflow'));
+    $this->assertFalse($builder->isAllowedComponent('observability'));
+  }
+
+  /**
+   * @covers ::buildComponent
+   */
+  public function testStateComponentUsesServerReadinessPayload(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $build = $builder->buildComponent([
+      'twig' => [
+        'state' => [
+          'readiness_summaries' => ['Ticket setup is ready.', 'Venue details are ready.'],
+        ],
+      ],
+      'js' => [
+        'publishReadinessLead' => 'Ticket setup is ready. Venue details are ready.',
+      ],
+      '#cache' => ['contexts' => ['user'], 'tags' => ['node:12']],
+    ], 'state');
+
+    $this->assertSame('inline_template', $build['#type']);
+    $this->assertStringContainsString('data-mel-governance-component="state"', $build['#template']);
+    $this->assertSame(['user'], $build['#cache']['contexts']);
+    $this->assertSame(['node:12'], $build['#cache']['tags']);
+    $this->assertSame(
+      'Ticket setup is ready. Venue details are ready.',
+      $build['#context']['content']['readiness']['#content']['text']['#plain_text'],
+    );
+  }
+
+  /**
+   * @covers ::buildComponent
+   */
+  public function testWorkflowComponentUsesServerCtaDescriptor(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $build = $builder->buildComponent([
+      'twig' => ['workflow_primary' => []],
+      'js' => [
+        'nextBestText' => 'Finish ticket setup.',
+        'primaryCta' => [
+          'mode' => 'workflow_navigate',
+          'label' => 'Continue setup',
+          'href' => '/vendor/events/12/edit/tickets',
+        ],
+      ],
+    ], 'workflow');
+
+    $next = $build['#context']['content']['next']['#content']['#context'];
+    $this->assertSame('Finish ticket setup.', $next['next_best']);
+    $this->assertSame('Continue setup', $next['cta_label']);
+    $this->assertSame('/vendor/events/12/edit/tickets', $next['href']);
+  }
+
+  /**
+   * @covers ::buildComponent
+   */
+  public function testIntelligenceComponentUsesSuppressedServerRowsOnly(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $build = $builder->buildComponent([
+      'twig' => [
+        'surface' => 'vendor',
+        'intelligence' => [
+          'attributes' => ['class' => ['mel-intelligence-panel']],
+          'items' => [
+            ['id' => 'visible', 'headline' => 'Visible prompt'],
+          ],
+          'insights' => [],
+        ],
+      ],
+      'js' => [
+        'checklist' => [
+          ['id' => 'visible', 'text' => 'Visible prompt'],
+        ],
+      ],
+    ], 'intelligence');
+
+    $panel = $build['#context']['content']['panel'];
+    $this->assertSame('mel_intelligence_panel', $panel['#theme']);
+    $this->assertCount(1, $panel['#items']);
+    $this->assertSame('visible', $panel['#items'][0]['id']);
+    $this->assertFalse($panel['#explainability_details']);
+    $this->assertArrayHasKey('#dismiss_hint_template', $panel);
+    $this->assertNotSame('', $panel['#intelligence_region_heading']);
+  }
+
+  /**
+   * @covers ::buildComponent
+   */
+  public function testIntelligenceComponentStaffExplainabilityFlag(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $build = $builder->buildComponent([
+      'twig' => [
+        'surface' => 'staff',
+        'intelligence' => [
+          'attributes' => [],
+          'items' => [],
+          'insights' => [
+            ['id' => 'staff_fixture', 'headline' => 'Operational note'],
+          ],
+          'explainability_details' => TRUE,
+        ],
+      ],
+      'js' => ['checklist' => []],
+    ], 'intelligence');
+
+    $panel = $build['#context']['content']['panel'];
+    $this->assertTrue($panel['#explainability_details']);
+    $this->assertNotSame('', $panel['#explainability_summary_label']);
+    $this->assertSame('', $panel['#dismiss_hint_template']);
+  }
+
+  /**
+   * @covers ::buildComponent
+   */
+  public function testUnknownComponentFailsClosed(): void {
+    $builder = new EventStudioGovernanceComponentBuilder($this->translator(), $this->readiness());
+
+    $this->expectException(\InvalidArgumentException::class);
+    $builder->buildComponent([], 'observability');
+  }
+
+  private function translator(): TranslationInterface {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    return $translator;
+  }
+
+  private function readiness(): MelReadinessHelper {
+    return new MelReadinessHelper($this->translator());
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceComponentControllerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceComponentControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceComponentController;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceComponentBuilder;
+use Drupal\myeventlane_surface\MelReadinessHelper;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceComponentController
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioGovernanceComponentControllerTest extends TestCase {
+
+  /**
+   * @covers ::render
+   */
+  public function testInvalidComponentFailsBeforeRendering(): void {
+    $controller = $this->controller(FALSE);
+    $node = $this->eventNode();
+
+    $response = $controller->render($node, 'observability', Request::create('/test', 'POST'));
+    $data = json_decode((string) $response->getContent(), TRUE);
+
+    $this->assertSame(404, $response->getStatusCode());
+    $this->assertSame(FALSE, $data['ok']);
+  }
+
+  /**
+   * @covers ::render
+   */
+  public function testAnonymousComponentRefreshIsDenied(): void {
+    $controller = $this->controller(TRUE);
+    $node = $this->eventNode();
+
+    $this->expectException(AccessDeniedHttpException::class);
+    $controller->render($node, 'state', Request::create('/test', 'POST'));
+  }
+
+  private function controller(bool $anonymous): EventStudioGovernanceComponentController {
+    $translator = $this->translator();
+    $account = $this->createMock(AccountProxyInterface::class);
+    $account->method('isAnonymous')->willReturn($anonymous);
+
+    $governance_builder = new EventStudioGovernanceBuilder(
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      $account,
+      NULL,
+      NULL,
+      NULL,
+      $translator,
+    );
+
+    return new EventStudioGovernanceComponentController(
+      $governance_builder,
+      new EventStudioGovernanceComponentBuilder($translator, new MelReadinessHelper($translator)),
+      $this->createMock(RendererInterface::class),
+      $account,
+      new EventVendorAccessChecker(),
+      $this->createMock(LoggerInterface::class),
+    );
+  }
+
+  private function eventNode(): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('event');
+    $node->method('id')->willReturn(12);
+    return $node;
+  }
+
+  private function translator(): TranslationInterface {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    return $translator;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 lifecycle: stable
 
 dependencies:
+  - myeventlane_surface:myeventlane_surface
   - myeventlane_event_studio:myeventlane_event_studio
   - myeventlane_legal:myeventlane_legal
   - myeventlane_core:myeventlane_core

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -201,6 +201,8 @@ services:
       - '@router.route_provider'
       - '@access_manager'
       - '@logger.factory'
+      - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_surface.vendor_dashboard_action_queue_governance'
       - '@string_translation'
 
   myeventlane_vendor.event_presentation_alerts:
@@ -240,6 +242,7 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_vendor.vendor_event_removal'
+      - '@myeventlane_surface.state_readiness_helper'
 
   myeventlane_vendor.dashboard_view_model_builder:
     class: Drupal\myeventlane_vendor\Service\VendorDashboardViewModelBuilder
@@ -260,6 +263,8 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_vendor.vendor_event_removal'
+      - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_surface.data_presentation_manager'
 
   myeventlane_vendor.service.event_tabs:
     class: Drupal\myeventlane_vendor\Service\VendorEventTabsService
@@ -320,6 +325,8 @@ services:
       - '@?myeventlane_growth.tracking'
       - '@csrf_token'
       - '@?myeventlane_boost.performance'
+      - '@?myeventlane_surface.operational_policy_manager'
+      - '@?myeventlane_surface.workflow_manager'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/CreateEventGatewayController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_vendor\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_legal\Service\LegalGatekeeper;
@@ -26,11 +25,6 @@ class CreateEventGatewayController extends ControllerBase {
    * The onboarding manager.
    */
   private readonly OnboardingManager $onboardingManager;
-
-  /**
-   * The renderer.
-   */
-  private readonly RendererInterface $renderer;
 
   /**
    * The legal gatekeeper.
@@ -57,14 +51,12 @@ class CreateEventGatewayController extends ControllerBase {
    */
   public function __construct(
     OnboardingManager $onboarding_manager,
-    RendererInterface $renderer,
     LegalGatekeeper $legal_gatekeeper,
     RequestStack $request_stack,
     UserVendorMembershipQuery $user_vendor_membership_query,
     VendorEventStudioCreateService $event_studio_create,
   ) {
     $this->onboardingManager = $onboarding_manager;
-    $this->renderer = $renderer;
     $this->legalGatekeeper = $legal_gatekeeper;
     $this->requestStack = $request_stack;
     $this->userVendorMembershipQuery = $user_vendor_membership_query;
@@ -77,7 +69,6 @@ class CreateEventGatewayController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_onboarding.manager'),
-      $container->get('renderer'),
       $container->get('myeventlane_legal.gatekeeper'),
       $container->get('request_stack'),
       $container->get('myeventlane_vendor.user_vendor_membership_query'),
@@ -92,7 +83,7 @@ class CreateEventGatewayController extends ControllerBase {
    * - Anonymous → login with return to /create-event (MEL continue when available)
    * - No vendor entity → organiser profile onboarding (destination /create-event)
    * - Stripe not ready (non-admin) → soft warning; Connect only required at publish
-   * - Vendor + incomplete onboarding → non-blocking messenger guidance
+   * - Vendor + incomplete onboarding → status warning; Event Studio shows MEL workflow
    * - Legal terms → soft warning if not accepted; accept before publish
    * - Unpublished draft event → Event Studio edit
    * - Else → Event Studio create
@@ -203,39 +194,8 @@ class CreateEventGatewayController extends ControllerBase {
       );
     }
 
-    try {
-      $user = $this->entityTypeManager()->getStorage('user')->load((int) $current_user->id());
-      if ($vendor instanceof Vendor && $user instanceof UserInterface && $vendor->id()) {
-        $state = $this->onboardingManager->loadOrCreateVendor($user, $vendor);
-        $this->onboardingManager->refreshFlags($state);
-        if (!$this->onboardingManager->isCompleted($state)) {
-          $stage = $state->getStage();
-          $stage_labels = [
-            'probe' => $this->t('Get started'),
-            'present' => $this->t('Profile'),
-            'listen' => $this->t('Payments'),
-            'ask' => $this->t('First event'),
-            'invite' => $this->t('Boost'),
-            'complete' => $this->t('Complete'),
-          ];
-          $next = $this->onboardingManager->getNextActionForAuthenticatedVendor($state);
-          $panel = [
-            '#theme' => 'myeventlane_vendor_onboarding_panel',
-            '#stage_label' => $stage_labels[$stage] ?? $stage,
-            '#flags' => $state->getFlags(),
-            '#next_action' => $next,
-            '#vendor' => $vendor,
-          ];
-          $markup = (string) $this->renderer->renderInIsolation($panel);
-          if (trim($markup) !== '') {
-            $this->messenger()->addStatus($markup);
-          }
-        }
-      }
-    }
-    catch (\Throwable $e) {
-      $this->getLogger('myeventlane_vendor')->warning('Create-event gateway onboarding flash failed: @m', ['@m' => $e->getMessage()]);
-    }
+    // Onboarding CTAs: Event Studio (create/edit) renders MELWorkflowSystem primary
+    // progress — do not duplicate myeventlane_vendor_onboarding_panel in messenger.
 
     if (!$this->legalGatekeeper->hasVendorAcceptedTerms()) {
       $this->messenger()->addWarning($this->t('Accept terms to publish.'));

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -38,6 +38,8 @@ use Drupal\myeventlane_event_studio\DTO\MelEventData;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
 use Drupal\myeventlane_vendor_analytics\Service\VendorKpiService;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
+use Drupal\myeventlane_surface\MelOperationalPolicyManager;
+use Drupal\myeventlane_surface\MelWorkflowManager;
 use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -172,6 +174,16 @@ final class VendorDashboardController extends VendorConsoleBaseController {
   protected VendorEventRemovalService $vendorEventRemoval;
 
   /**
+   * Optional MELOperationalPolicySystem (suppresses duplicate upsell paths).
+   */
+  protected ?MelOperationalPolicyManager $operationalPolicyManager = NULL;
+
+  /**
+   * Optional MEL workflow orchestration (dedupes dashboard onboarding CTAs).
+   */
+  protected ?MelWorkflowManager $melWorkflowManager = NULL;
+
+  /**
    * Constructs the controller.
    */
   public function __construct(
@@ -204,6 +216,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     ?GrowthTrackingService $growth_tracking = NULL,
     ?CsrfTokenGenerator $csrf_token = NULL,
     mixed $boost_performance = NULL,
+    ?MelOperationalPolicyManager $operational_policy_manager = NULL,
+    ?MelWorkflowManager $mel_workflow_manager = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
     $this->dashboardViewModelBuilder = $dashboard_view_model_builder;
@@ -232,6 +246,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $this->growthTracking = $growth_tracking;
     $this->csrfToken = $csrf_token;
     $this->boostPerformance = $boost_performance;
+    $this->operationalPolicyManager = $operational_policy_manager;
+    $this->melWorkflowManager = $mel_workflow_manager;
   }
 
   /**
@@ -268,6 +284,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       $container->has('myeventlane_growth.tracking') ? $container->get('myeventlane_growth.tracking') : NULL,
       $container->get('csrf_token'),
       $container->has('myeventlane_boost.performance') ? $container->get('myeventlane_boost.performance') : NULL,
+      $container->has('myeventlane_surface.operational_policy_manager') ? $container->get('myeventlane_surface.operational_policy_manager') : NULL,
+      $container->has('myeventlane_surface.workflow_manager') ? $container->get('myeventlane_surface.workflow_manager') : NULL,
     );
   }
 
@@ -298,7 +316,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     // Build all dashboard data.
     $kpis = $this->buildKpiCards($eventNodes, $vendor);
     $events = $this->getEventsTableData($userEvents);
-    $melTopBoostOpportunity = $this->getTopBoostOpportunity($events);
+    $suppress_promotional = $this->shouldSuppressVendorDashboardPromotions();
+    $melTopBoostOpportunity = $suppress_promotional ? NULL : $this->getTopBoostOpportunity($events);
     $bestEvent = $this->getBestPerformingEvent($userEvents);
     $stripeStatus = $this->getStripeConnectStatus($userId, $vendor);
     $notifications = $this->getNotifications($userId, $userEvents, $vendor);
@@ -432,7 +451,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
             $pageVars['show_onboarding_badge'] = TRUE;
             $pageVars['next_onboarding_route'] = $next_route ?: 'myeventlane_vendor.onboard.profile';
           }
-          if ($show_panel) {
+          $governed_primary = $this->melWorkflowManager !== NULL
+            && $this->melWorkflowManager->willRenderPrimaryWorkflowRegion();
+          if ($show_panel && !$governed_primary) {
             $stage = $state->getStage();
             $stage_labels = [
               'probe' => $this->t('Get started'),
@@ -459,7 +480,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     }
 
     $pageVars['growth_cards'] = [];
-    if ($this->growthInsight && $this->growthTracking) {
+    if (!$suppress_promotional && $this->growthInsight && $this->growthTracking) {
       $publishedIds = $this->getPublishedUserEvents($userId, $vendor);
       $publishedCount = count($publishedIds);
       $lastLoginTs = 0;
@@ -1638,6 +1659,31 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     }
 
     return $bestEvent;
+  }
+
+  /**
+   * Uses MELOperationalPolicySystem suppression instead of ad hoc Twig checks.
+   */
+  private function shouldSuppressVendorDashboardPromotions(): bool {
+    if ($this->operationalPolicyManager === NULL) {
+      return FALSE;
+    }
+    try {
+      $interpretation = $this->operationalPolicyManager->buildPageInterpretation();
+      $suppression = $interpretation['suppression'] ?? [];
+      if (!is_array($suppression)) {
+        return FALSE;
+      }
+      return !empty($suppression['suppress_boost_prompts'])
+        || !empty($suppression['suppress_marketing_guidance'])
+        || !empty($suppression['suppress_cross_sell_guidance']);
+    }
+    catch (\Throwable $e) {
+      $this->melDebugLogger->warning('Vendor dashboard operational policy read failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/EventStudioVendorOnboardingGateSubscriber.php
@@ -63,6 +63,7 @@ final class EventStudioVendorOnboardingGateSubscriber implements EventSubscriber
 
     $is_studio = $route_name === 'myeventlane_event_studio.create'
       || str_starts_with($route_name, 'myeventlane_event_studio.edit')
+      || $route_name === 'myeventlane_event_studio.governance_refresh'
       || $route_name === 'myeventlane_vendor.manage_event.edit'
       || $route_name === 'myeventlane_vendor.console.event_editor';
     if (!$is_studio) {

--- a/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
@@ -16,7 +16,7 @@ use Drupal\node\NodeInterface;
  * This does not assert vendor domain or global vendor console permissions; those
  * belong on routes or calling code. Admin/staff bypasses are left to callers.
  */
-final class EventVendorAccessChecker {
+final class EventVendorAccessChecker implements EventVendorAccessCheckerInterface {
 
   /**
    * TRUE when the account is the event author or listed on the linked vendor.

--- a/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessCheckerInterface.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessCheckerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Interface for {@see EventVendorAccessChecker}.
+ *
+ * Extracted so MEL Attendee Operations Layer access policy can be unit-tested
+ * without doubling the final implementation. The implementation remains
+ * `final`; existing consumers that type-hint the concrete class continue to
+ * work because the implementation now also implements this interface.
+ */
+interface EventVendorAccessCheckerInterface {
+
+  /**
+   * TRUE when the account is the event author or listed on the linked vendor.
+   */
+  public function accountHasWorkspaceParityForEvent(NodeInterface $event, AccountInterface $account): bool;
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php
@@ -11,12 +11,16 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_surface\MelReadinessHelper;
+use Drupal\myeventlane_surface\MelVendorDashboardActionQueueGovernance;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Builds a prioritised vendor dashboard action queue from the TASK 3 view model.
  *
  * Uses only data already present on the dashboard model plus route/access checks.
+ * Readiness wording is sourced from MELStateSystem (MelReadinessHelper); prioritisation is
+ * adjusted by workflow and operational-policy governance (presentation only).
  */
 final class VendorActionQueueBuilder {
 
@@ -26,20 +30,12 @@ final class VendorActionQueueBuilder {
 
   private const MAX_DRAFT_EVENT_ACTIONS = 2;
 
-  /**
-   * Severity rank for tie-breaking (lower = earlier when priority matches).
-   */
-  private const SEVERITY_RANK = [
-    'error' => 0,
-    'warning' => 1,
-    'info' => 2,
-    'success' => 3,
-  ];
-
   public function __construct(
     private readonly RouteProviderInterface $routeProvider,
     private readonly AccessManagerInterface $accessManager,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly MelReadinessHelper $readinessHelper,
+    private readonly MelVendorDashboardActionQueueGovernance $actionGovernance,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -87,13 +83,14 @@ final class VendorActionQueueBuilder {
 
     // 1. No vendor profile.
     if ($vendorMissing) {
+      $copy = $this->readinessHelper->vendorActionNoVendorProfileStrings();
       $actions[] = [
         'key' => 'no_vendor_profile',
         'priority' => 10,
         'severity' => 'warning',
-        'title' => (string) $this->t('Complete your organiser setup'),
-        'message' => (string) $this->t('Set up your organiser profile before creating or managing events.'),
-        'action_label' => (string) $this->t('Set up profile'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.settings', [], $account),
         'context' => [
           'type' => 'vendor_profile',
@@ -108,13 +105,14 @@ final class VendorActionQueueBuilder {
     $profileIncomplete = !$profileCompleteTop || $profileItemComplete === FALSE;
     if (!$vendorMissing && $profileIncomplete) {
       $vid = is_int($vendorId) ? $vendorId : NULL;
+      $copy = $this->readinessHelper->vendorActionProfileIncompleteStrings();
       $actions[] = [
         'key' => 'profile_incomplete',
         'priority' => 20,
         'severity' => 'warning',
-        'title' => (string) $this->t('Complete your public profile'),
-        'message' => (string) $this->t('Add the basics so attendees know who is running your events.'),
-        'action_label' => (string) $this->t('Edit profile'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.settings', [], $account),
         'context' => [
           'type' => 'vendor_profile',
@@ -137,14 +135,15 @@ final class VendorActionQueueBuilder {
 
       $nid = isset($event['nid']) ? (int) $event['nid'] : 0;
       $url = $this->pickEventEditOrTicketsUrl($event);
+      $copy = $this->readinessHelper->vendorActionMissingBookingStrings();
 
       $actions[] = [
         'key' => 'missing_booking_' . ($nid > 0 ? (string) $nid : 'unknown'),
         'priority' => 25,
         'severity' => 'error',
-        'title' => (string) $this->t('Add RSVP or tickets'),
-        'message' => (string) $this->t('This event is visible but does not appear to have a booking option.'),
-        'action_label' => (string) $this->t('Edit tickets'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $url,
         'context' => [
           'type' => 'event',
@@ -162,17 +161,15 @@ final class VendorActionQueueBuilder {
     if ($needsStripeAction && !$vendorMissing) {
       $severity = $hasPaidOrBoth ? 'error' : 'warning';
       $priority = $hasPaidOrBoth ? 30 : 80;
-      $message = $hasPaidOrBoth
-        ? (string) $this->t('Connect Stripe before publishing or selling paid tickets.')
-        : (string) $this->t('Connect payouts when you are ready to sell paid tickets.');
+      $copy = $this->readinessHelper->vendorActionStripePayoutStrings($hasPaidOrBoth);
 
       $actions[] = [
         'key' => 'stripe_payout_incomplete',
         'priority' => $priority,
         'severity' => $severity,
-        'title' => (string) $this->t('Finish payout setup'),
-        'message' => $message,
-        'action_label' => (string) $this->t('Connect Stripe'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $this->stripeDashboardUrl($account),
         'context' => [
           'type' => 'stripe',
@@ -183,13 +180,14 @@ final class VendorActionQueueBuilder {
 
     // 4. No events yet.
     if ($events === []) {
+      $copy = $this->readinessHelper->vendorActionNoEventsStrings();
       $actions[] = [
         'key' => 'no_events_yet',
         'priority' => 40,
         'severity' => 'info',
-        'title' => (string) $this->t('Create your first event'),
-        'message' => (string) $this->t('Start with the event basics, then add RSVP or tickets.'),
-        'action_label' => (string) $this->t('Create event'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $this->routeUrlIfAccessible('myeventlane_event_studio.create', [], $account),
         'context' => [
           'type' => 'events',
@@ -213,13 +211,15 @@ final class VendorActionQueueBuilder {
         ? $links['edit']
         : NULL;
 
+      $copy = $this->readinessHelper->vendorActionDraftEventStrings();
+
       $actions[] = [
         'key' => 'draft_event_' . ($nid > 0 ? (string) $nid : (string) $draftCount),
         'priority' => 50,
         'severity' => 'warning',
-        'title' => (string) $this->t('Finish your draft event'),
-        'message' => (string) $this->t('Complete the missing details and publish when ready.'),
-        'action_label' => (string) $this->t('Continue editing'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $url,
         'context' => [
           'type' => 'event',
@@ -233,13 +233,14 @@ final class VendorActionQueueBuilder {
 
     // 8. Analytics unavailable but paid activity exists.
     if (!$analyticsAvailable && $hasPaidOrBoth) {
+      $copy = $this->readinessHelper->vendorActionAnalyticsUnavailableStrings();
       $actions[] = [
         'key' => 'analytics_unavailable',
         'priority' => 90,
         'severity' => 'info',
-        'title' => (string) $this->t('Analytics are not available'),
-        'message' => (string) $this->t('Ticket sales are visible, but advanced analytics are not available for this account.'),
-        'action_label' => (string) $this->t('View events'),
+        'title' => $copy['title'],
+        'message' => $copy['message'],
+        'action_label' => $copy['action_label'],
         'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.events', [], $account),
         'context' => [
           'type' => 'analytics',
@@ -248,7 +249,7 @@ final class VendorActionQueueBuilder {
       ];
     }
 
-    $this->sortActions($actions);
+    $actions = $this->actionGovernance->apply($actions);
 
     if (count($actions) > self::MAX_ACTIONS) {
       $actions = array_slice($actions, 0, self::MAX_ACTIONS);
@@ -353,24 +354,6 @@ final class VendorActionQueueBuilder {
       return $url;
     }
     return $this->routeUrlIfAccessible('myeventlane_vendor.stripe_manage', [], $account);
-  }
-
-  /**
-   * @param list<array<string, mixed>> $actions
-   */
-  private function sortActions(array &$actions): void {
-    usort($actions, function (array $a, array $b): int {
-      $pa = (int) ($a['priority'] ?? 1000);
-      $pb = (int) ($b['priority'] ?? 1000);
-      if ($pa !== $pb) {
-        return $pa <=> $pb;
-      }
-      $sa = (string) ($a['severity'] ?? '');
-      $sb = (string) ($b['severity'] ?? '');
-      $ra = self::SEVERITY_RANK[$sa] ?? 99;
-      $rb = self::SEVERITY_RANK[$sb] ?? 99;
-      return $ra <=> $rb;
-    });
   }
 
   private function routeExists(string $routeName): bool {

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -16,6 +16,8 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
+use Drupal\myeventlane_surface\MelDataPresentationManager;
+use Drupal\myeventlane_surface\MelReadinessHelper;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\node\NodeInterface;
@@ -49,6 +51,8 @@ final class VendorDashboardViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly VendorEventRemovalService $vendorEventRemovalService,
+    private readonly MelReadinessHelper $readinessHelper,
+    private readonly MelDataPresentationManager $dataPresentationManager,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -97,7 +101,7 @@ final class VendorDashboardViewModelBuilder {
     $model = [
       'vendor' => $vendorPayload,
       'readiness' => $readiness,
-      'kpis' => $kpis,
+      'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip($kpis),
       'action_queue' => [],
       'events' => $events,
       'analytics_summary' => $analyticsSummary,
@@ -113,6 +117,8 @@ final class VendorDashboardViewModelBuilder {
       ]);
       $model['action_queue'] = [];
     }
+
+    $model['hero_shell_hint'] = $this->heroShellHint($model);
 
     return $model;
   }
@@ -134,14 +140,17 @@ final class VendorDashboardViewModelBuilder {
         'has_public_profile' => FALSE,
         'score' => 0,
         'items' => [],
+        'row_complete_label' => $this->readinessHelper->vendorReadinessRowCompleteLabel(),
+        'row_incomplete_label' => $this->readinessHelper->vendorReadinessRowIncompleteLabel(),
       ],
-      'kpis' => [],
+      'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip([]),
       'action_queue' => [],
       'events' => [],
       'analytics_summary' => [
         'available' => FALSE,
         'items' => [],
       ],
+      'hero_shell_hint' => $this->readinessHelper->vendorHeroShellLaunchHint(),
       'empty_state' => $this->buildEmptyState($account, TRUE),
     ];
   }
@@ -190,11 +199,13 @@ final class VendorDashboardViewModelBuilder {
       $stripeReady = $this->readStripeReadyFromVendorStore($vendor, $account);
     }
 
+    $labels = $this->readinessHelper->vendorReadinessPresentationLabels();
+
     $items = [];
 
     $items[] = [
       'key' => 'profile',
-      'label' => (string) $this->t('Organiser profile'),
+      'label' => $labels['profile'],
       'complete' => $profileComplete,
       'severity' => $profileComplete ? 'success' : 'warning',
       'url' => $this->routeExists('myeventlane_vendor.console.settings')
@@ -204,7 +215,7 @@ final class VendorDashboardViewModelBuilder {
 
     $items[] = [
       'key' => 'public_profile',
-      'label' => (string) $this->t('Public organiser page'),
+      'label' => $labels['public_profile'],
       'complete' => $hasPublicProfile && $vendor instanceof Vendor,
       'severity' => ($hasPublicProfile && $vendor instanceof Vendor) ? 'success' : 'neutral',
       'url' => ($vendor instanceof Vendor && $this->routeExists('entity.myeventlane_vendor.canonical'))
@@ -215,7 +226,7 @@ final class VendorDashboardViewModelBuilder {
     $stripeSeverity = $stripeReady ? 'success' : 'warning';
     $items[] = [
       'key' => 'stripe',
-      'label' => (string) $this->t('Stripe payments'),
+      'label' => $labels['stripe'],
       'complete' => $stripeReady,
       'severity' => $stripeSeverity,
       'url' => $this->routeExists('myeventlane_vendor.stripe_connect')
@@ -239,6 +250,8 @@ final class VendorDashboardViewModelBuilder {
       'has_public_profile' => $hasPublicProfile && $vendor instanceof Vendor,
       'score' => $score,
       'items' => $items,
+      'row_complete_label' => $this->readinessHelper->vendorReadinessRowCompleteLabel(),
+      'row_incomplete_label' => $this->readinessHelper->vendorReadinessRowIncompleteLabel(),
     ];
   }
 
@@ -339,12 +352,13 @@ final class VendorDashboardViewModelBuilder {
    */
   private function fallbackKpisUnavailable(): array {
     $na = (string) $this->t('Unavailable');
+    $ctx = $this->readinessHelper->vendorKpiUnavailableContextLine();
     return [
       [
         'key' => 'revenue',
         'label' => (string) $this->t('Revenue'),
         'value' => $na,
-        'context' => (string) $this->t('Could not load metrics'),
+        'context' => $ctx,
         'trend' => NULL,
         'severity' => 'neutral',
         'url' => NULL,
@@ -353,7 +367,7 @@ final class VendorDashboardViewModelBuilder {
         'key' => 'tickets_sold',
         'label' => (string) $this->t('Tickets sold'),
         'value' => $na,
-        'context' => (string) $this->t('Could not load metrics'),
+        'context' => $ctx,
         'trend' => NULL,
         'severity' => 'neutral',
         'url' => NULL,
@@ -362,7 +376,7 @@ final class VendorDashboardViewModelBuilder {
         'key' => 'rsvps',
         'label' => (string) $this->t('RSVPs'),
         'value' => $na,
-        'context' => (string) $this->t('Could not load metrics'),
+        'context' => $ctx,
         'trend' => NULL,
         'severity' => 'neutral',
         'url' => NULL,
@@ -371,7 +385,7 @@ final class VendorDashboardViewModelBuilder {
         'key' => 'upcoming_events',
         'label' => (string) $this->t('Upcoming events'),
         'value' => $na,
-        'context' => (string) $this->t('Could not load metrics'),
+        'context' => $ctx,
         'trend' => NULL,
         'severity' => 'neutral',
         'url' => NULL,
@@ -446,15 +460,15 @@ final class VendorDashboardViewModelBuilder {
 
     if (!$published) {
       $status = 'draft';
-      $statusLabel = (string) $this->t('Draft');
+      $statusLabel = $this->readinessHelper->vendorLifecycleDraftLabel();
     }
     elseif ($endTs > 0 && $endTs < $now) {
       $status = 'past';
-      $statusLabel = (string) $this->t('Past');
+      $statusLabel = $this->readinessHelper->vendorLifecyclePastLabel();
     }
     else {
       $status = 'upcoming';
-      $statusLabel = (string) $this->t('Upcoming');
+      $statusLabel = $this->readinessHelper->vendorLifecycleUpcomingLabel();
     }
 
     $dateLabel = '';
@@ -593,9 +607,10 @@ final class VendorDashboardViewModelBuilder {
    * @return array<string, string|\Drupal\Core\Url|null>
    */
   private function buildEmptyState(AccountInterface $account, bool $noEvents): array {
-    $title = (string) $this->t('Welcome to your organiser dashboard');
-    $message = (string) $this->t('Create your first event to start selling tickets or collecting RSVPs.');
-    $actionLabel = (string) $this->t('Create event');
+    $copy = $this->readinessHelper->vendorDashboardEmptyStrings(!$noEvents);
+    $title = $copy['empty_title'];
+    $message = $copy['empty_message'];
+    $actionLabel = $copy['empty_action_label'];
     $url = NULL;
 
     if ($noEvents && $this->routeExists('myeventlane_event_studio.create')) {
@@ -609,8 +624,8 @@ final class VendorDashboardViewModelBuilder {
       }
     }
     elseif (!$noEvents) {
-      $message = (string) $this->t('Use the event list and workspace tabs to manage ticket sales, RSVPs, and orders.');
-      $actionLabel = (string) $this->t('View events');
+      $message = $copy['empty_message'];
+      $actionLabel = $copy['empty_action_label'];
       if ($this->routeExists('myeventlane_vendor.console.events')) {
         try {
           if ($this->accessManager->checkNamedRoute('myeventlane_vendor.console.events', [], $account, TRUE)->isAllowed()) {
@@ -629,6 +644,21 @@ final class VendorDashboardViewModelBuilder {
       'action_label' => $actionLabel,
       'url' => $url,
     ];
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function heroShellHint(array $model): string {
+    $actions = $model['action_queue'] ?? [];
+    if (is_array($actions) && $actions !== []) {
+      return $this->readinessHelper->vendorHeroShellNeedsAttentionHint();
+    }
+    $events = $model['events'] ?? [];
+    if (is_array($events) && $events !== []) {
+      return $this->readinessHelper->vendorHeroShellEventsComfortableHint();
+    }
+    return $this->readinessHelper->vendorHeroShellLaunchHint();
   }
 
   private function routeExists(string $name): bool {

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
@@ -15,6 +15,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\EventStateResolver;
+use Drupal\myeventlane_surface\MelReadinessHelper;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -45,6 +46,7 @@ final class VendorEventIndexViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly VendorEventRemovalService $vendorEventRemovalService,
+    private readonly MelReadinessHelper $readinessHelper,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -135,8 +137,8 @@ final class VendorEventIndexViewModelBuilder {
       ],
       'events' => [],
       'empty_state' => [
-        'title' => (string) $this->t('Sign in to manage events'),
-        'message' => (string) $this->t('You need an organiser account to view this page.'),
+        'title' => $this->readinessHelper->vendorOrganiserPortalSignInTitle(),
+        'message' => $this->readinessHelper->vendorOrganiserPortalSignInEventsBody(),
         'action_label' => (string) $this->t('Create event'),
         'url' => NULL,
       ],

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_buttons.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_buttons.scss
@@ -133,6 +133,22 @@
   }
 }
 
+// Soft destructive (MELFormSystem — aligns with public theme mel-btn--destructive)
+.mel-btn--destructive {
+  color: color.adjust($danger, $lightness: -12%);
+  background-color: rgba($danger, 0.12);
+  border-color: rgba($danger, 0.45);
+
+  &:hover {
+    background-color: rgba($danger, 0.18);
+    border-color: rgba($danger, 0.55);
+  }
+
+  &:focus {
+    box-shadow: $shadow-focus-danger;
+  }
+}
+
 // Success button
 .mel-btn--success {
   background-color: $success;

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -93,6 +93,12 @@
   @include meta.load-css('../../../myeventlane_theme/src/scss/components/help-centre');
   // Event Studio layout (preview + insights grid, full-width form) — shared with public theme.
   @include meta.load-css('../../../myeventlane_theme/src/scss/components/event-studio');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-components');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-cards');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-navigation');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-empty-states');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-status-panels');
+  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-cta');
 
   @include meta.load-css('pages/dashboard');
   @include meta.load-css('pages/dashboard-mel-support');

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard.scss
@@ -471,6 +471,41 @@
   }
 }
 
+.mel-vendor-dashboard-governance {
+  display: grid;
+  gap: $spacing-4;
+  margin-bottom: $spacing-6;
+  padding: $spacing-4;
+  border: 1px solid rgba($ml-vendor-navy, 0.12);
+  border-radius: $radius-card;
+  background: #fff;
+
+  &__heading {
+    margin: 0 0 $spacing-2;
+    font-size: 1rem;
+    color: $ml-vendor-navy;
+  }
+
+  &__list {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: $text-secondary;
+  }
+
+  &__list--policy {
+    list-style: disc;
+  }
+
+  &__item {
+    margin-bottom: $spacing-1;
+  }
+
+  &__block + &__block {
+    padding-top: $spacing-3;
+    border-top: 1px solid rgba($ml-vendor-navy, 0.08);
+  }
+}
+
 .mel-workspace-page {
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -16,15 +16,16 @@
 {% set analytics_items = analytics_summary.items|default([]) %}
 {% set dashboard_vendor_id = vendor.id|default(null) %}
 
-{% set hero_body %}
-  {% if actions is iterable and actions|length > 0 %}
-    {{ 'Start with the most important task below.'|t }}
-  {% elseif model_events is iterable and model_events|length > 0 %}
-    {{ 'Your events are set up. Keep an eye on bookings and upcoming activity.'|t }}
-  {% else %}
-    {{ 'Create your first event and start taking RSVPs or selling tickets.'|t }}
-  {% endif %}
-{% endset %}
+{% set hero_body = '' %}
+{% if model.hero_shell_hint is defined and model.hero_shell_hint %}
+  {% set hero_body = model.hero_shell_hint %}
+{% elseif actions is iterable and actions|length > 0 %}
+  {% set hero_body = 'Start with the most important task below.'|t %}
+{% elseif model_events is iterable and model_events|length > 0 %}
+  {% set hero_body = 'Your events are set up. Keep an eye on bookings and upcoming activity.'|t %}
+{% else %}
+  {% set hero_body = 'Create your first event and start taking RSVPs or selling tickets.'|t %}
+{% endif %}
 
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
 {% set hero_primary_url = NULL %}
@@ -132,9 +133,9 @@
               <span class="mel-vendor-dashboard-v2__readiness-label">{{ item.label|default('') }}</span>
               <span class="mel-vendor-dashboard-v2__readiness-status{% if done %} mel-vendor-dashboard-v2__readiness-status--done{% else %} mel-vendor-dashboard-v2__readiness-status--todo{% endif %}">
                 {% if done %}
-                  {{ 'Done'|t }}
+                  {{ readiness.row_complete_label|default('Complete'|t) }}
                 {% else %}
-                  {{ 'Needs attention'|t }}
+                  {{ readiness.row_incomplete_label|default('Action required'|t) }}
                 {% endif %}
               </span>
             {% endset %}
@@ -164,9 +165,10 @@
       <p class="mel-vendor-dashboard-v2__section-sub">{{ 'Based on published events you manage.'|t }}</p>
     </div>
     <div class="mel-vendor-dashboard-v2__kpi-grid">
-      {% for kpi in kpis %}
-        {% set ksev = kpi.severity|default('neutral') %}
-        {% set kpi_inner %}
+        {% for kpi in kpis %}
+          {% set ksev = kpi.severity|default('neutral') %}
+          {% set kpi_contract = kpi.mel_data_presentation_contract|default('') %}
+          {% set kpi_inner %}
           <span class="mel-vendor-dashboard-v2__kpi-label">{{ kpi.label|default('') }}</span>
           <span class="mel-vendor-dashboard-v2__kpi-value">{{ kpi.value|default('—') }}</span>
           {% if kpi.context is defined and kpi.context %}
@@ -174,9 +176,9 @@
           {% endif %}
         {% endset %}
         {% if kpi.url is defined and kpi.url %}
-          <a class="mel-vendor-dashboard-v2__kpi mel-vendor-dashboard-v2__kpi--linked mel-vendor-dashboard-v2__kpi--{{ ksev }}" href="{{ kpi.url }}">{{ kpi_inner }}</a>
+          <a class="mel-vendor-dashboard-v2__kpi mel-vendor-dashboard-v2__kpi--linked mel-vendor-dashboard-v2__kpi--{{ ksev }}" href="{{ kpi.url }}" {% if kpi_contract %}data-mel-presentation-contract="{{ kpi_contract }}" data-mel-component-contract="{{ kpi.mel_component_contract|default('') }}"{% endif %}>{{ kpi_inner }}</a>
         {% else %}
-          <article class="mel-vendor-dashboard-v2__kpi mel-vendor-dashboard-v2__kpi--{{ ksev }}">{{ kpi_inner }}</article>
+          <article class="mel-vendor-dashboard-v2__kpi mel-vendor-dashboard-v2__kpi--{{ ksev }}" {% if kpi_contract %}data-mel-presentation-contract="{{ kpi_contract }}" data-mel-component-contract="{{ kpi.mel_component_contract|default('') }}"{% endif %}>{{ kpi_inner }}</article>
         {% endif %}
       {% else %}
         {% if dashboard_vendor_id %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/mel-vendor-dashboard-governance-stack.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/mel-vendor-dashboard-governance-stack.html.twig
@@ -1,0 +1,80 @@
+{#
+/**
+ * MEL governance stack for vendor dashboard — consumes page preprocess payloads only.
+ */
+#}
+{% set state = mel_state|default({}) %}
+{% set policy = mel_operational_policy|default({}) %}
+{% set experience = mel_experience|default({}) %}
+{% set explain = policy.explainability|default({}) %}
+{% set explain_lines = explain.lines|default([]) %}
+{% set readiness = state.readiness_summaries|default([]) %}
+{% set resume = experience.resume_candidates|default([]) %}
+{% set dp = mel_data_presentation_context|default({}) %}
+
+<div
+  class="mel-vendor-dashboard-governance mel-guidance-stack"
+  role="region"
+  aria-label="{{ 'Console guidance and readiness'|t }}"
+  data-mel-layout-profile="{{ dp.layout_profile|default('') }}"
+  data-mel-data-density="{{ dp.density|default('') }}"
+>
+  {% if readiness is iterable and readiness|length > 0 %}
+    <section class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__state" aria-labelledby="mel-vendor-gov-state-heading">
+      <h2 id="mel-vendor-gov-state-heading" class="mel-vendor-dashboard-governance__heading">{{ 'Readiness signals'|t }}</h2>
+      <ul class="mel-vendor-dashboard-governance__list">
+        {% for summary in readiness %}
+          <li class="mel-vendor-dashboard-governance__item">{{ summary }}</li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if mel_workflow_region_primary is defined and mel_workflow_region_primary %}
+    <div class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__workflow-primary">
+      {{ mel_workflow_region_primary }}
+    </div>
+  {% endif %}
+
+  {% if mel_workflow_region_progress is defined and mel_workflow_region_progress %}
+    <div class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__workflow-progress">
+      {{ mel_workflow_region_progress }}
+    </div>
+  {% endif %}
+
+  {% if resume is iterable and resume|length > 0 %}
+    <section class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__experience" aria-labelledby="mel-vendor-gov-exp-heading">
+      <h2 id="mel-vendor-gov-exp-heading" class="mel-vendor-dashboard-governance__heading">{{ 'Continue where you left off'|t }}</h2>
+      <ul class="mel-vendor-dashboard-governance__list">
+        {% for item in resume %}
+          {% if item.experience_id is defined and item.experience_id %}
+            <li class="mel-vendor-dashboard-governance__item">{{ 'Resume path: @id'|t({'@id': item.experience_id}) }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if explain_lines is iterable and explain_lines|length > 0 %}
+    <section class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__policy" aria-labelledby="mel-vendor-gov-policy-heading">
+      <h2 id="mel-vendor-gov-policy-heading" class="mel-vendor-dashboard-governance__heading">{{ 'Operational notices'|t }}</h2>
+      <ul class="mel-vendor-dashboard-governance__list mel-vendor-dashboard-governance__list--policy">
+        {% for line in explain_lines %}
+          <li class="mel-vendor-dashboard-governance__item">{{ line }}</li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if mel_intelligence_panel is defined and mel_intelligence_panel %}
+    <div class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__intelligence">
+      {{ mel_intelligence_panel }}
+    </div>
+  {% endif %}
+
+  {% if mel_observability_panel is defined and mel_observability_panel %}
+    <div class="mel-vendor-dashboard-governance__block mel-vendor-dashboard-governance__observability">
+      {{ mel_observability_panel }}
+    </div>
+  {% endif %}
+</div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -73,7 +73,10 @@
         <div class="mel-shell-layout mel-shell-layout--with-utility">
           <div class="mel-shell-layout__main">
             {% if is_dashboard_route %}
-              <section class="mel-dashboard-page">
+              <section class="mel-dashboard-page mel-dashboard-page--governed">
+                {% if mel_surface|default('') == 'vendor' %}
+                  {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+                {% endif %}
                 {{ page.content }}
               </section>
             {% elseif page.mel_vendor_route_tabs %}
@@ -88,7 +91,10 @@
         </div>
       {% else %}
         {% if is_dashboard_route %}
-          <section class="mel-dashboard-page">
+          <section class="mel-dashboard-page mel-dashboard-page--governed">
+            {% if mel_surface|default('') == 'vendor' %}
+              {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+            {% endif %}
             {{ page.content }}
           </section>
         {% elseif page.mel_vendor_route_tabs %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new vendor-only POST endpoints and client-side fetch logic to incrementally refresh governance/state UI, which touches access control, CSRF handling, and dynamic HTML replacement. Also changes vendor dashboard/action-queue behavior via optional MEL governance services, which could affect what CTAs/promotions users see.
> 
> **Overview**
> When MEL governance is enabled, Event Studio now renders a new governance sidebar (state/workflow/continuity/intelligence, operational tone, optional diagnostics) and **disables the legacy client-side “insights/next best/publish readiness” updates**.
> 
> Adds vendor-only POST routes/controllers for `governance-refresh` (returns a JS delta vs a client baseline) and `component/{component}` (returns refreshed HTML for specific governed components), wires them into autosave responses and the Event Studio form (drupalSettings + required surface libraries), and updates the JS to track “dirty” components and replace refreshed component HTML safely.
> 
> Vendor console is updated to depend on `myeventlane_surface`, suppress certain promotional/dashboard elements based on operational policy/workflow presence, and standardize dashboard copy/metric presentation/action ordering via MEL helpers/governance; also adds a small button style and governed dashboard layout include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd4f386137f48e5880662f6c4880d13ac66278e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->