### PR TITLE
Cursor/mel builder 9bb17

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Download release artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.build.outputs.artifact_name }}
           path: ./artifact

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -95,8 +95,8 @@ jobs:
           [ -n "$JS_FILES" ] || exit 1
 
           rm -f "$MANIFEST"
-          shasum $ASSET_DIR/main*.css > "$MANIFEST"
-          shasum $ASSET_DIR/*.js >> "$MANIFEST"
+          sha1sum $ASSET_DIR/main*.css > "$MANIFEST"
+          sha1sum $ASSET_DIR/*.js >> "$MANIFEST"
 
           [ -s "$MANIFEST" ] || exit 1
 

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -92,11 +92,16 @@ if [ -n "$INVALID_FILES" ]; then
   exit 1
 fi
 
-# 6. Checksum verification
+# 6. Checksum verification (sha1sum: coreutils; staging hosts often omit Perl's shasum)
 cd "$RELEASE_PATH"
 
+if ! command -v sha1sum >/dev/null 2>&1; then
+  echo "ERROR: sha1sum not found — install coreutils (GNU coreutils busybox)."
+  exit 1
+fi
+
 echo "Running checksum verification..."
-shasum -c dist-checksums.txt
+sha1sum -c dist-checksums.txt
 
 echo "Checksum verification passed"
 echo "== MEL deploy asset validation complete =="
@@ -161,6 +166,15 @@ vendor/bin/drush cr --uri="$SITE_URI" || true
 ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
 
 cd "$CURRENT_PATH"
+
+# Fail fast after switching current: clearer than a later obscure drush exit.
+echo "Verifying Drupal bootstrap (Drush against new release)..."
+BOOTSTRAP="$(vendor/bin/drush status --uri="$SITE_URI" --field=bootstrap 2>/dev/null | tr -d '\r\n' || true)"
+if [ "$BOOTSTRAP" != "Successful" ]; then
+  echo "ERROR: Drupal did not bootstrap after release switch (bootstrap field: '${BOOTSTRAP:-empty}')." >&2
+  vendor/bin/drush status --uri="$SITE_URI" || true
+  exit 1
+fi
 
 # ---- CONFIG SYNC: mirror artifact → shared sync directory (single source of truth per release) ----
 # Staging uses a shared path (e.g. /home/mel/staging/config/sync) referenced by settings.php.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI/build checksum generation and server-side deploy validation/abort behavior, which can block releases if environments differ or bootstrap checks fail unexpectedly.
> 
> **Overview**
> Improves staging deploy reliability by updating workflows and the remote deploy script to use GNU `sha1sum` for asset checksum generation/verification (instead of Perl `shasum`), with an explicit dependency check and clearer errors.
> 
> Also updates staging deployment to use `actions/download-artifact@v7` and adds a fail-fast Drupal bootstrap verification immediately after switching the `current` symlink, aborting the deploy early if the new release can’t bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e565db7b87c010a048eacfe9d19d3e5081c21360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->