### PR TITLE
Cursor/gov templates core 5b30f

### DIFF
--- a/docs/adoption/mel-attendee-operations-audit.md
+++ b/docs/adoption/mel-attendee-operations-audit.md
@@ -288,7 +288,7 @@ Governance / observability / surface integration:
 - `web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.info.yml`
 - `web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.services.yml`
 - `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php` (new attendee operations slots)
-- `web/modules/custom/myeventlane_surface/src/GovernedOperationalTemplates.php` (matching builders)
+- `web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php` (matching builders)
 - `web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-vendor-attendees-dashboard.html.twig` (operational summaries section)
 
 Theme:

--- a/docs/adoption/mel-governance-template-parity-empty-states-slice.md
+++ b/docs/adoption/mel-governance-template-parity-empty-states-slice.md
@@ -111,7 +111,7 @@ Per-template operational sentences for the migrated screens were removed from Tw
 | `mel-template-parity.json` | New registry. |
 | `scripts/governance/template-parity-audit.php` | New audit script. |
 | `composer.json` | `governance:audit` runs template parity. |
-| `web/modules/custom/myeventlane_surface/src/GovernedOperationalTemplates.php` | New — builds `mel_empty_state` render arrays. |
+| `web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php` | New — builds `mel_empty_state` render arrays. |
 | `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php` | Customer empty + browse CTA vocabulary. |
 | `web/modules/custom/myeventlane_surface/myeventlane_surface.services.yml` | Registers `governed_operational_templates`. |
 | `web/modules/custom/myeventlane_surface/myeventlane_surface.module` | Preprocess: my tickets, categories, analytics, vendor attendees, account dashboard, past events. |

--- a/docs/adoption/wave-b-empty-state-convergence-report.md
+++ b/docs/adoption/wave-b-empty-state-convergence-report.md
@@ -69,7 +69,7 @@ These join existing customer empty slots (`customerMyTicketsOverviewEmptySlots`,
 | File | Change |
 | --- | --- |
 | `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php` | New customer vocabulary for My Events empty + category quiet week |
-| `web/modules/custom/myeventlane_surface/src/GovernedOperationalTemplates.php` | `categoryFollowWeeklyQuietEmpty`, `customerMyEventsDashboardUpcomingEmpty`, `vendorAnalyticsNoEventRowsEmpty` |
+| `web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php` | `categoryFollowWeeklyQuietEmpty`, `customerMyEventsDashboardUpcomingEmpty`, `vendorAnalyticsNoEventRowsEmpty` |
 | `web/modules/custom/myeventlane_surface/src/MelComponentAccessibilityHelper.php` | `applyEmptyStateSemantics()` |
 | `web/modules/custom/myeventlane_surface/src/MelComponentPreprocess.php` | Wire empty-state preprocess to accessibility helper |
 | `web/modules/custom/myeventlane_surface/myeventlane_surface.module` | Categories preprocess branch + analytics empty fallback |

--- a/docs/architecture/mel-state-system.md
+++ b/docs/architecture/mel-state-system.md
@@ -146,6 +146,7 @@ Full metadata (severity, UX/CTA implications, accessibility notes) lives on each
 | `MelStateResolver.php` | Merge workflow signals + `hook_mel_state_domain_facts_alter` + aliases |
 | `MelStateManager.php` | Page interpretation + CTA governance hints |
 | `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php` | Readiness copy (DI: service id `myeventlane_surface.state_readiness_helper` in `myeventlane_core.services.yml`) |
+| `web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php` | `mel_empty_state` compositions from readiness slots (DI: service id `myeventlane_surface.governed_operational_templates` in `myeventlane_core.services.yml`) |
 | `MelLifecycleHelper.php` | Lifecycle precedence |
 | `MelTrustStateHelper.php` | Role-aware trust visibility |
 | `MelEligibilityHelper.php` | Feature eligibility listing |

--- a/scripts/deploy/verify-readiness-service-on-release.sh
+++ b/scripts/deploy/verify-readiness-service-on-release.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run on the staging host (or locally) to confirm the container can resolve
+# myeventlane_surface.state_readiness_helper (defined in myeventlane_core.services.yml).
+#
+# Usage:
+#   bash scripts/deploy/verify-readiness-service-on-release.sh
+#   bash scripts/deploy/verify-readiness-service-on-release.sh "$HOME/staging/current"
+#
+set -euo pipefail
+
+ROOT="${1:-$HOME/staging/current}"
+FILE="$ROOT/web/modules/custom/myeventlane_core/myeventlane_core.services.yml"
+MIN_SHA="3b6bf8742c9186e16210a71a3f323f1825425d6c"
+
+echo "Release root: $ROOT"
+echo "Expected file: $FILE"
+echo ""
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "ERROR: directory does not exist: $ROOT"
+  exit 1
+fi
+
+if [[ ! -f "$FILE" ]]; then
+  echo "ERROR: myeventlane_core.services.yml not found (wrong ROOT or incomplete deploy)."
+  exit 1
+fi
+
+echo "--- myeventlane_surface.state_readiness_helper (must appear) ---"
+if grep -n 'myeventlane_surface.state_readiness_helper:' "$FILE"; then
+  echo "OK: service id is defined in myeventlane_core.services.yml"
+else
+  echo "FAIL: block myeventlane_surface.state_readiness_helper: missing from $FILE"
+  exit 1
+fi
+
+echo ""
+if [[ -d "$ROOT/.git" ]]; then
+  cd "$ROOT"
+  HEAD="$(git rev-parse HEAD)"
+  echo "GIT_HEAD=$HEAD"
+  if git merge-base --is-ancestor "$MIN_SHA" HEAD 2>/dev/null; then
+    echo "OK: $MIN_SHA is an ancestor of HEAD"
+  else
+    echo "WARN: $MIN_SHA is not an ancestor of HEAD (old checkout or forked history)."
+  fi
+else
+  echo "NOTE: no .git under release (normal for CI artifact deploy)."
+  echo "      Commit ancestry cannot be checked here; YAML presence above is authoritative."
+  echo "      Ensure this tree came from main at or after merge 814228f0 (or commit $MIN_SHA)."
+fi
+
+echo ""
+echo "verify-readiness-service-on-release: all checks passed"

--- a/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
+++ b/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
@@ -12,7 +12,7 @@ use Drupal\image\ImageStyleInterface;
 use Drupal\myeventlane_account\Service\AccountLinksService;
 use Drupal\myeventlane_core\Service\DisplayNameResolver;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
-use Drupal\myeventlane_surface\GovernedOperationalTemplates;
+use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorAttendeesController.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorAttendeesController.php
@@ -13,7 +13,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_checkout_flow\Service\AttendeeEventStatsService;
 use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsPresenter;
 use Drupal\myeventlane_core\Service\TicketLabelResolver;
-use Drupal\myeventlane_surface\GovernedOperationalTemplates;
+use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
@@ -6,7 +6,7 @@ namespace Drupal\myeventlane_checkout_flow\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Cache\Cache;
-use Drupal\myeventlane_surface\GovernedOperationalTemplates;
+use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\myeventlane_core\MelReadinessHelper;
 
 /**

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\myeventlane_checkout_flow\Unit;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\myeventlane_checkout_flow\Service\CheckoutGroupedSummaryBuilderInterface;
 use Drupal\myeventlane_checkout_flow\Service\MelCheckoutSummaryPresenter;
-use Drupal\myeventlane_surface\GovernedOperationalTemplates;
+use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\Tests\UnitTestCase;
 

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -302,3 +302,9 @@ services:
   myeventlane_surface.state_readiness_helper:
     class: Drupal\myeventlane_core\MelReadinessHelper
     arguments: ['@string_translation']
+
+  # Same rationale as state_readiness_helper: checkout/account depend on this id while
+  # myeventlane_surface may be disabled on some envs until config is aligned.
+  myeventlane_surface.governed_operational_templates:
+    class: Drupal\myeventlane_core\GovernedOperationalTemplates
+    arguments: ['@myeventlane_surface.state_readiness_helper']

--- a/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
+++ b/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Drupal\myeventlane_surface;
+namespace Drupal\myeventlane_core;
 
 use Drupal\Core\Url;
-use Drupal\myeventlane_core\MelReadinessHelper;
 
 /**
  * Builds governed presentation render arrays (mel_empty_state) for operational surfaces.

--- a/web/modules/custom/myeventlane_dashboard/myeventlane_dashboard.module
+++ b/web/modules/custom/myeventlane_dashboard/myeventlane_dashboard.module
@@ -147,7 +147,7 @@ function myeventlane_dashboard_preprocess_myeventlane_customer_dashboard(array &
   if (!is_array($upcoming) || $upcoming !== [] || !\Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
     return;
   }
-  /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $templates */
+  /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $templates */
   $templates = \Drupal::service('myeventlane_surface.governed_operational_templates');
   $variables['mel_customer_dashboard_upcoming_empty'] = $templates->customerMyEventsDashboardUpcomingEmpty();
 }

--- a/web/modules/custom/myeventlane_surface/myeventlane_surface.module
+++ b/web/modules/custom/myeventlane_surface/myeventlane_surface.module
@@ -1178,7 +1178,7 @@ function myeventlane_surface_preprocess_myeventlane_my_tickets(array &$variables
   $upcoming = $variables['upcoming_orders'] ?? [];
   $past = $variables['past_orders'] ?? [];
   if (is_array($upcoming) && is_array($past) && $upcoming === [] && $past === [] && \Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
-    /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $templates */
+    /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $templates */
     $templates = \Drupal::service('myeventlane_surface.governed_operational_templates');
     $variables['mel_my_tickets_empty'] = $templates->myTicketsOverviewEmpty();
   }
@@ -1191,7 +1191,7 @@ function myeventlane_surface_preprocess_myeventlane_my_categories(array &$variab
   if (!\Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
     return;
   }
-  /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $templates */
+  /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $templates */
   $templates = \Drupal::service('myeventlane_surface.governed_operational_templates');
   $followed = $variables['followed_categories'] ?? [];
   if (is_array($followed) && $followed === []) {
@@ -1219,7 +1219,7 @@ function myeventlane_surface_preprocess_myeventlane_analytics_dashboard(array &$
   if (!\Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
     return;
   }
-  /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $templates */
+  /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $templates */
   $templates = \Drupal::service('myeventlane_surface.governed_operational_templates');
   $empty = $model['empty_state'] ?? [];
   $empty = is_array($empty) ? $empty : [];
@@ -1246,7 +1246,7 @@ function myeventlane_surface_preprocess_myeventlane_vendor_attendees_dashboard(a
   if (!\Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
     return;
   }
-  /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $templates */
+  /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $templates */
   $templates = \Drupal::service('myeventlane_surface.governed_operational_templates');
   $variables['mel_vendor_attendees_dashboard_empty'] = $templates->vendorAttendeesDashboardEmpty();
 }

--- a/web/modules/custom/myeventlane_surface/myeventlane_surface.services.yml
+++ b/web/modules/custom/myeventlane_surface/myeventlane_surface.services.yml
@@ -425,11 +425,6 @@ services:
       - '@myeventlane_surface.workflow_resolver'
       - '@module_handler'
 
-  myeventlane_surface.governed_operational_templates:
-    class: Drupal\myeventlane_surface\GovernedOperationalTemplates
-    arguments:
-      - '@myeventlane_surface.state_readiness_helper'
-
   myeventlane_surface.state_lifecycle_helper:
     class: Drupal\myeventlane_surface\MelLifecycleHelper
 

--- a/web/modules/custom/myeventlane_surface/tests/src/Unit/GovernedOperationalTemplatesCheckoutCartTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Unit/GovernedOperationalTemplatesCheckoutCartTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_surface\Unit;
 
-use Drupal\myeventlane_surface\GovernedOperationalTemplates;
+use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\Tests\UnitTestCase;
 
 /**
- * @coversDefaultClass \Drupal\myeventlane_surface\GovernedOperationalTemplates
+ * @coversDefaultClass \Drupal\myeventlane_core\GovernedOperationalTemplates
  *
  * @group myeventlane_surface
  */

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3458,7 +3458,7 @@ function myeventlane_theme_preprocess_commerce_cart_form(array &$variables): voi
   $order_items = (isset($form['#order_items']) && is_array($form['#order_items'])) ? $form['#order_items'] : [];
   if ($order_items === []) {
     if (\Drupal::moduleHandler()->moduleExists('myeventlane_surface')) {
-      /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $gov */
+      /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $gov */
       $gov = \Drupal::service('myeventlane_surface.governed_operational_templates');
       $variant = (string) ($form['#mel_cart_empty_variant'] ?? 'default');
       $variables['mel_cart_empty_state'] = match ($variant) {
@@ -3536,7 +3536,7 @@ function myeventlane_theme_preprocess_commerce_cart_empty_page(array &$variables
     /** @var \Drupal\myeventlane_core\MelReadinessHelper $readiness */
     $readiness = \Drupal::service('myeventlane_surface.state_readiness_helper');
     $variables['mel_cart_shell_labels'] = $readiness->customerCartShellLabels();
-    /** @var \Drupal\myeventlane_surface\GovernedOperationalTemplates $gov */
+    /** @var \Drupal\myeventlane_core\GovernedOperationalTemplates $gov */
     $gov = \Drupal::service('myeventlane_surface.governed_operational_templates');
     $variables['mel_cart_empty_state'] = $gov->checkoutCartEmpty('h1');
   }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -80,25 +80,25 @@
   @include meta.load-css('components/mel-header-footer');
   @include meta.load-css('components/wizard');
   @include meta.load-css('components/support');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/support-panel');
+  @include meta.load-css('@mel-theme/components/support-panel');
   @include meta.load-css('components/help-assistant');
   @include meta.load-css('components/refund');
   @include meta.load-css('components/ai-panels');
   @include meta.load-css('components/klaro-consent');
 
   // Shared partials from the public theme (SCSS only — no public CSS library).
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/vendor-events');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/vendor-studio-editor');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/studio-inspector');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/help-centre');
+  @include meta.load-css('@mel-theme/components/vendor-events');
+  @include meta.load-css('@mel-theme/components/vendor-studio-editor');
+  @include meta.load-css('@mel-theme/components/studio-inspector');
+  @include meta.load-css('@mel-theme/components/help-centre');
   // Event Studio layout (preview + insights grid, full-width form) — shared with public theme.
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/event-studio');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-components');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-cards');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-navigation');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-empty-states');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-status-panels');
-  @include meta.load-css('../../../myeventlane_theme/src/scss/components/mel-cta');
+  @include meta.load-css('@mel-theme/components/event-studio');
+  @include meta.load-css('@mel-theme/components/mel-components');
+  @include meta.load-css('@mel-theme/components/mel-cards');
+  @include meta.load-css('@mel-theme/components/mel-navigation');
+  @include meta.load-css('@mel-theme/components/mel-empty-states');
+  @include meta.load-css('@mel-theme/components/mel-status-panels');
+  @include meta.load-css('@mel-theme/components/mel-cta');
 
   @include meta.load-css('pages/dashboard');
   @include meta.load-css('pages/dashboard-mel-support');

--- a/web/themes/custom/myeventlane_vendor_theme/vite.config.js
+++ b/web/themes/custom/myeventlane_vendor_theme/vite.config.js
@@ -48,6 +48,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
+      // Stable path to public theme SCSS for shared partials (CI-safe; no ../../../).
+      '@mel-theme': resolve(__dirname, '../myeventlane_theme/src/scss'),
     },
   },
   server: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moves the `myeventlane_surface.governed_operational_templates` implementation into `myeventlane_core` and updates DI/typehints across multiple modules, which can break runtime service resolution if any wiring is missed. Also changes the vendor theme build aliasing, which could impact CSS compilation in CI/deploys.
> 
> **Overview**
> **Governed empty-state composition is moved from `myeventlane_surface` into `myeventlane_core`.** `GovernedOperationalTemplates` is re-namespaced to `Drupal\myeventlane_core`, registered in `myeventlane_core.services.yml` under the existing service id `myeventlane_surface.governed_operational_templates`, and removed from `myeventlane_surface.services.yml`; call sites across checkout, account, dashboard, surface preprocess, and unit tests are updated to the new class.
> 
> **Build/deploy plumbing is hardened.** Adds `scripts/deploy/verify-readiness-service-on-release.sh` to validate the readiness-helper service presence in a release tree, and updates `myeventlane_vendor_theme` SCSS imports to use a new `@mel-theme` Vite alias instead of brittle `../../../` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd142517cb10c9a029109ae7d297503e5b0e74fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->