### PR TITLE
Cursor/gov templates core 5b30f

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Download release artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           name: ${{ needs.build.outputs.artifact_name }}
           path: ./artifact

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -153,6 +153,17 @@ jobs:
             exit 1
           }
 
+      - name: Validate artifact registers state_readiness_helper (staging Drush)
+        run: |
+          set -euo pipefail
+          archive_path="${{ steps.package.outputs.artifact_path }}"
+          if ! tar -xOzf "$archive_path" web/modules/custom/myeventlane_core/myeventlane_core.services.yml | grep -q 'myeventlane_surface.state_readiness_helper:'; then
+            echo "❌ Artifact myeventlane_core.services.yml missing myeventlane_surface.state_readiness_helper"
+            echo "   (remote deploy runs drush cr; without this service the container will not compile.)"
+            exit 1
+          fi
+          echo "OK: state_readiness_helper present in packaged core services.yml"
+
       - name: Upload release artifact
         uses: actions/upload-artifact@v6
         with:

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -320,7 +320,16 @@ if [ "$_mel_drush_cr_rc" -ne 0 ]; then
   exit "$_mel_drush_cr_rc"
 fi
 
-vendor/bin/drush sset system.maintenance_mode 0 --uri="$SITE_URI"
+echo "Finalize: drush sset system.maintenance_mode 0..."
+set +e
+_mel_drush_mm_out="$(vendor/bin/drush sset system.maintenance_mode 0 --uri="$SITE_URI" 2>&1)"
+_mel_drush_mm_rc=$?
+set -e
+printf '%s\n' "$_mel_drush_mm_out"
+if [ "$_mel_drush_mm_rc" -ne 0 ]; then
+  echo "ERROR: drush sset system.maintenance_mode 0 failed during finalize (exit $_mel_drush_mm_rc)." >&2
+  exit "$_mel_drush_mm_rc"
+fi
 
 echo "Finalize: drush cr (after maintenance off)..."
 set +e

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -308,9 +308,30 @@ else
 fi
 
 # ---- FINALISE ----
-vendor/bin/drush cr --uri="$SITE_URI"
+# These drush invocations are strict (no "|| true"): failures must surface in CI/SSH logs.
+echo "Finalize: drush cr (post-domain cset)..."
+set +e
+_mel_drush_cr_out="$(vendor/bin/drush cr --uri="$SITE_URI" 2>&1)"
+_mel_drush_cr_rc=$?
+set -e
+printf '%s\n' "$_mel_drush_cr_out"
+if [ "$_mel_drush_cr_rc" -ne 0 ]; then
+  echo "ERROR: drush cr failed during finalize (exit $_mel_drush_cr_rc)." >&2
+  exit "$_mel_drush_cr_rc"
+fi
+
 vendor/bin/drush sset system.maintenance_mode 0 --uri="$SITE_URI"
-vendor/bin/drush cr --uri="$SITE_URI"
+
+echo "Finalize: drush cr (after maintenance off)..."
+set +e
+_mel_drush_cr2_out="$(vendor/bin/drush cr --uri="$SITE_URI" 2>&1)"
+_mel_drush_cr2_rc=$?
+set -e
+printf '%s\n' "$_mel_drush_cr2_out"
+if [ "$_mel_drush_cr2_rc" -ne 0 ]; then
+  echo "ERROR: second drush cr failed during finalize (exit $_mel_drush_cr2_rc)." >&2
+  exit "$_mel_drush_cr2_rc"
+fi
 
 DEPLOY_SUCCEEDED=1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI/CD workflows and the remote deploy finalize sequence, which could block staging deployments if validations or Drush commands behave differently. Logic is straightforward but touches deployment-critical paths.
> 
> **Overview**
> Improves staging deployment reliability by adding an extra build-time check that the packaged artifact includes the `myeventlane_surface.state_readiness_helper` service registration needed for `drush cr`.
> 
> Updates the remote deploy finalize stage to run `drush cr`/maintenance disable with captured output and explicit non-zero exits (instead of silent failures), and adjusts the staging workflow to use `actions/download-artifact@v6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54907946d97808708c8108eb18adad2c1ab54dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->