### PR TITLE
refactor(deploy): improve artifact validation for myeventlane_core.se…

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -157,12 +157,18 @@ jobs:
         run: |
           set -euo pipefail
           archive_path="${{ steps.package.outputs.artifact_path }}"
-          if ! tar -xOzf "$archive_path" web/modules/custom/myeventlane_core/myeventlane_core.services.yml | grep -q 'myeventlane_surface.state_readiness_helper:'; then
+          # GNU tar stores paths as ./web/... when archiving "."; member must match exactly.
+          member=$(tar -tzf "$archive_path" | grep -E '(^|/)myeventlane_core\.services\.yml$' | head -1)
+          if [ -z "$member" ]; then
+            echo "❌ Artifact missing myeventlane_core.services.yml (cannot validate state_readiness_helper)."
+            exit 1
+          fi
+          if ! tar -xOzf "$archive_path" "$member" | grep -q 'myeventlane_surface.state_readiness_helper:'; then
             echo "❌ Artifact myeventlane_core.services.yml missing myeventlane_surface.state_readiness_helper"
             echo "   (remote deploy runs drush cr; without this service the container will not compile.)"
             exit 1
           fi
-          echo "OK: state_readiness_helper present in packaged core services.yml"
+          echo "OK: state_readiness_helper present in packaged core services.yml ($member)"
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
…rvices.yml in GitHub Actions workflow

Updated the validation logic in the reusable-build.yml to ensure the correct extraction of myeventlane_core.services.yml from the artifact. Enhanced error messaging for better clarity on missing components, specifically the state_readiness_helper service, during the deployment process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts how the workflow locates/extracts `myeventlane_core.services.yml` from the build artifact, with clearer failure messages; main risk is false positives/negatives in the validation step due to tar member matching.
> 
> **Overview**
> Improves the GitHub Actions artifact validation step to reliably find and extract `myeventlane_core.services.yml` from the packaged tarball (handling GNU tar’s `./`-prefixed member paths) before checking for `myeventlane_surface.state_readiness_helper:`.
> 
> Adds a clearer error when the services file is missing and includes the matched tar member path in the success output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa3fa330905328aae0ab70e099109df5605d77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->