### PR TITLE
fix(config-sync): install mel_maintenance theme so block.* configs ca…

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -206,4 +206,5 @@ theme:
   myeventlane_admin: 0
   radix: 0
   myeventlane_radix: 0
+  mel_maintenance: 0
 profile: standard


### PR DESCRIPTION
…n be imported

The 19 config/sync/block.block.mel_maintenance_*.yml files declare `theme: mel_maintenance` and a hard dependency on the theme, but config/sync/core.extension.yml did not list it under `theme:`, so `drush cim` failed validation on every environment trying to converge canonical sync ("Configuration block.block.mel_maintenance_* depends on the MEL Maintenance theme that will not be installed after import.").

Adds `mel_maintenance: 0` to the `theme:` block. The theme already exists at web/themes/custom/mel_maintenance/ (added in 090b1a78); this commit just makes core.extension.yml consistent with the codebase and the existing block exports.

Surfaced while recovering staging from a failed deploy: cim was blocked on this validation error after the surface-related container compile issues were resolved. No service, route, schema, or migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only change that just ensures the `mel_maintenance` theme is installed during config import so existing block configs validate/import cleanly.
> 
> **Overview**
> Fixes config import validation failures by adding the missing `mel_maintenance` theme entry to `config/sync/core.extension.yml`.
> 
> This makes the exported `block.block.mel_maintenance_*` configs (which depend on that theme) importable via `drush cim` across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63031bb4a5ca4df5f6f65692157af14ee7fa4a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->