### PR TITLE
fix(account): guard optional dashboard route and dedupe preprocess

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -205,7 +205,6 @@ function myeventlane_account_preprocess_page__account(array &$variables): void {
     $variables['display_name'] = $account->getDisplayName();
   }
 
-  $route_name = \Drupal::routeMatch()->getRouteName();
   $variables['account_show_header_logo'] = $route_name === 'myeventlane_account.dashboard';
   $variables['account_heading'] = _myeventlane_account_page_heading($route_name);
 

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -96,8 +96,15 @@ final class AccountLinksService {
     }
 
     $ticketsUrl = Url::fromRoute('myeventlane_checkout_flow.my_tickets', [], ['absolute' => FALSE])->toString();
-    $eventsUrl = Url::fromRoute('myeventlane_dashboard.customer', [], ['absolute' => FALSE])->toString();
     $dashboardUrl = Url::fromRoute('myeventlane_account.dashboard', [], ['absolute' => FALSE])->toString();
+
+    // myeventlane_dashboard is optional; mirror other hub links that guard optional routes.
+    $eventsUrl = $dashboardUrl;
+    try {
+      $eventsUrl = Url::fromRoute('myeventlane_dashboard.customer', [], ['absolute' => FALSE])->toString();
+    }
+    catch (\Throwable) {
+    }
 
     $definitions = [
       [


### PR DESCRIPTION
- Resolve myeventlane_dashboard.customer via try/catch with account dashboard URL fallback when the dashboard module or route is unavailable.
- Reuse single $route_name from routeMatch in page__account preprocess.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive changes to account navigation URL generation and page preprocess variables, with no data or security logic impacted.
> 
> **Overview**
> **Improves resilience of account hub navigation.** The “All my events” link now attempts to resolve `myeventlane_dashboard.customer` but falls back to the account dashboard URL when that optional route/module isn’t available.
> 
> **Minor preprocess cleanup.** `page__account` preprocessing now consistently reuses a single `$route_name` for header logo/heading variables instead of re-fetching it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a60657160a03ab575da17dc3f0f877080401f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->