### PR TITLE
Feature/platform consolidation audit

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -170,6 +170,22 @@ jobs:
           fi
           echo "OK: state_readiness_helper present in packaged core services.yml ($member)"
 
+      - name: Validate artifact registers followed organisers route (customer hub)
+        run: |
+          set -euo pipefail
+          archive_path="${{ steps.package.outputs.artifact_path }}"
+          member=$(tar -tzf "$archive_path" | grep -E '(^|/)myeventlane_account\.routing\.yml$' | head -1)
+          if [ -z "$member" ]; then
+            echo "❌ Artifact missing myeventlane_account.routing.yml (cannot validate followed_organisers route)."
+            exit 1
+          fi
+          if ! tar -xOzf "$archive_path" "$member" | grep -q 'myeventlane_account\.followed_organisers:'; then
+            echo "❌ Artifact myeventlane_account.routing.yml missing myeventlane_account.followed_organisers"
+            echo "   (/my-organisers must ship with releases or staging returns 404.)"
+            exit 1
+          fi
+          echo "OK: followed_organisers route present in packaged account routing.yml ($member)"
+
       - name: Upload release artifact
         uses: actions/upload-artifact@v6
         with:

--- a/config/sync/user.role.mel_pro.yml
+++ b/config/sync/user.role.mel_pro.yml
@@ -13,6 +13,7 @@ dependencies:
     - myeventlane_boost
     - myeventlane_escalations_refunds
     - myeventlane_event_state
+    - myeventlane_help_centre
     - myeventlane_refunds
     - myeventlane_vendor
     - myeventlane_vendor_ai
@@ -52,4 +53,5 @@ permissions:
   - 'view paragraph content event_highlight'
   - 'view stripe dashboard links'
   - 'view unpublished paragraphs'
+  - 'view vendor help centre'
   - 'view vendor refund summary'

--- a/config/sync/user.role.vendor.yml
+++ b/config/sync/user.role.vendor.yml
@@ -31,6 +31,7 @@ dependencies:
     - myeventlane_event_attendees
     - myeventlane_event_state
     - myeventlane_finance
+    - myeventlane_help_centre
     - myeventlane_messaging
     - myeventlane_refunds
     - myeventlane_rsvp
@@ -134,4 +135,5 @@ permissions:
   - 'view user email addresses'
   - 'view vendor bas reports'
   - 'view vendor escalations'
+  - 'view vendor help centre'
   - 'view vendor refund summary'

--- a/docs/platform-canonical-surface-map.md
+++ b/docs/platform-canonical-surface-map.md
@@ -1,0 +1,182 @@
+# Platform canonical surface map
+
+**Branch:** `feature/platform-consolidation-audit`  
+**Purpose:** Single reference for terminology, route ownership, placeholders, help/AI boundaries, and navigation mental models.  
+**Method:** Inspection of routing YAML, controllers, Search API config, help modules, menu links, and preprocess hooks referenced below—no inferred entities or permissions.
+
+---
+
+## Section A — Canonical terminology
+
+Approved **public-facing** language below is **prescriptive for future copy**; legacy strings are **not** bulk-rewritten in this pass.
+
+| Internal / legacy | Canonical public | Audience | Legacy still appears (examples) |
+|-------------------|------------------|----------|--------------------------------|
+| Vendor | **Organiser** | Public + authenticated | Route `/vendors`, entity label “Vendor”, role label `Vendor`, admin paths “Vendor settings”, UI “Vendor help”, `myeventlane_vendor.public_list` title “Event Organisers” (mixed model: URL `/vendors` vs title organiser-forward) |
+| Vendor Dashboard | **Organiser Dashboard** | Organiser | Route default `_title: 'Vendor dashboard'` (`myeventlane_vendor.console.dashboard`), mixed with `/dashboard` shell |
+| Vendor Settings | **Organiser Settings** | Organiser | Admin menu `Organiser settings`; console settings via `myeventlane_vendor.console.settings` (vendor_settings module) |
+| Attendee | **Ticket holder** (canonical); **Attendee** retained where aligned with routes/help (“Help for Attendees”, attendee help articles) | Customer | Help routes `/help/attendees`, “Attendee help”, article audience “Attendees”; product language sometimes “attendee” in permissions (`access attendee repository`) |
+| Escalation | **Support request** | Customer + organiser + staff | Module/vendor naming `myeventlane_escalations*`, permissions `view vendor escalations`; customer menu “Support” (`myeventlane_escalations_portal.customer_support`) |
+| Workspace | **Event Manager** | Organiser | Route `myeventlane_vendor.console.event_workspace` path `/vendor/events/{event}/workspace`, Event Studio vs “manage event” legacy shell |
+| Studio | **Event Editor** | Organiser | Routes `myeventlane_vendor.console.studio`, `console.event_editor` use `_title: 'Event Editor'` |
+| Boost | **Promote Event** (canonical marketing surface); **Boost** remains **internal/product** where tied to commerce SKU (`boost_upgrade`, `purchase boost for events`) | Organiser | Onboarding “Promote your event with Boost”; vendor analytics/boost surfaces |
+
+**Staff-only language:** Staff playbooks, internal docs, and admin help insights remain **non-public** and **out of vendor/public AI grounding** (see Section D).
+
+---
+
+## Section B — Route ownership (vendor-related patterns)
+
+**Legend:** Canonical = intended primary UX; Legacy = kept for bookmarks/integration; Alias = same behaviour as another path.
+
+### Shell and dashboard entrypoints
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/dashboard` | Shell redirect | No | `myeventlane_vendor.shell.dashboard` → entrypoint redirect |
+| `/vendor` | Shell redirect | No | `myeventlane_vendor.shell.vendor_root` |
+| `/vendor/dashboard` | **Canonical** organiser dashboard | No | `VendorConsoleAccess`; `_title` still “Vendor dashboard” (terminology drift) |
+| `/vendor/studio`, `/vendor/events/{event}/editor` | **Canonical** Event Editor | No | Vendor theme |
+
+### Event operations (workspace / console)
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/vendor/events`, `/vendor/events/add` | Canonical listing/create | No | |
+| `/vendor/events/{event}/workspace` | Canonical workspace shell | No | “Event Manager” in governance wording |
+| `/vendor/console/...` API-style paths | Mixed | Partial legacy naming | Many routes under `myeventlane_vendor.console.*` |
+| `/vendor/event/{event}/*` manage-event steps | **Mixed** | Partial legacy | Singular `event`; some steps redirect to workspace/studio elsewhere |
+
+### Placeholders (see Section C)
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/vendor/event/{event}/promote` | Placeholder | No | Coming soon |
+| `/vendor/event/{event}/payments` | Placeholder | No | |
+| `/vendor/event/{event}/comms` | Placeholder | No | |
+| `/vendor/event/{event}/advanced` | Placeholder | No | |
+
+### Help
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/help` | **Canonical** hub | No | |
+| `/help/index` | Legacy | Yes | 301 → `/help` |
+| `/vendor/help` | Legacy entry | Redirect | 301 → `/help` (`HelpCentreController::vendorHelp`); permission `access content` |
+| `/vendor/help/topic/{category}` | Canonical scoped topic | No | Requires **`view vendor help centre`** |
+
+### Stripe / onboarding (selected)
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/stripe/connect`, `/stripe/manage` | Canonical | No | Custom Stripe access |
+| `/stripe/callback`, `/stripe/connect/callback` | Callback | Legacy pathsecond | Legacy callback retained |
+| `/vendor/onboard/*` | Canonical onboarding | No | Mixed `_permission: access content` + login |
+
+### Public organiser directory
+
+| Route pattern | Canonical? | Deprecated? | Notes |
+|---------------|------------|---------------|-------|
+| `/vendors`, `/organisers` | Alias pair | No | Same controller; title “Event Organisers” |
+| `/vendor/{entity}` | Canonical organiser profile | No | Entity `myeventlane_vendor` |
+
+---
+
+## Section C — Placeholder surfaces (`ManageEventPlaceholderController`)
+
+| Route name | Path | Visibility | Linked from nav? | Indexed (risk) | Contextual help | AI grounding |
+|------------|------|------------|------------------|----------------|-----------------|--------------|
+| `myeventlane_vendor.manage_event.promote` | `/vendor/event/{event}/promote` | Event owners + vendor team members (+ node admins) via `ManageEventControllerBase::access` | Yes — manage-event sidebar steps | **Mitigated:** `noindex,nofollow` meta + `X-Robots-Tag` | No card on `myeventlane_manage_event` layout | Not in HelpRetriever (`help_article` only) |
+| `manage_event.payments` | `/vendor/event/{event}/payments` | Same | Yes | Same | Same | Same |
+| `manage_event.comms` | `/vendor/event/{event}/comms` | Same | Yes | Same | Same | Same |
+| `manage_event.advanced` | `/vendor/event/{event}/advanced` | Same | Yes | Same | Same | Same |
+
+**Support risk:** Users can open real URLs that only show “coming soon”; mitigate with product comms and prioritisation (out of scope here).
+
+**Implementation (this pass):** Meta robots + `X-Robots-Tag`, TWIG shell classes `mel-coming-soon-shell`, subscriber `ManageEventPlaceholderNoIndexSubscriber`.
+
+---
+
+## Section D — Help, search, and AI grounding
+
+### Modules inspected
+
+- `myeventlane_help_assistant` — `HelpRetriever`
+- `myeventlane_help_centre` — routes, `HelpCentreController`, `ContextualHelpResolver`, `myeventlane_help_centre.module` preprocess
+- `myeventlane_help_shared` — `UnifiedHelpRetriever`
+- Config: `config/sync/search_api.index.mel_content.yml`, `config/sync/myeventlane_help_centre.contextual_help.yml`
+
+### Help assistant security model (verified)
+
+| Requirement | Status | Mechanism |
+|-------------|--------|-----------|
+| Staff audience excluded from assistant | Enforced | Query filter + `nodeAudienceAllowedForAssistant` rejects `staff`; Search API OR group only `public`/`vendor` list values |
+| Unpublished excluded | Enforced | `status` condition + `$node->isPublished()` |
+| `field_help_ai_allowed` | Enforced | Required truthy in `isNodeRetrievableForAssistant` / `UnifiedHelpRetriever::validateNode` |
+| Node access | Enforced | `$node->access('view', $user)` |
+| Audience filtering | Enforced | Per-user allowed audience list + per-node audience intersection |
+
+**Do not weaken** the above when changing retrieval.
+
+### Vendor help permission drift (fixed in sync)
+
+- Permission **`view vendor help centre`** exists (`myeventlane_help_centre.permissions.yml`) and gates **`myeventlane_help_centre.vendor_topic`**.
+- **`user.role.vendor`** and **`user.role.mel_pro`** now include this permission so organisers with console access can open topic URLs without false 403s.
+- **`myeventlane_help_centre.vendor_help`** remains a **301 redirect** with **`access content`** so bookmarks still clear.
+
+### FAQ vs Search API (`mel_content`)
+
+| Surface | FAQ (`node.type.faq`) | Notes |
+|---------|----------------------|-------|
+| Help hub | Yes | `HelpCentreController::homepage` embeds view `mel_help_faq` |
+| Help search view `mel_help_search` | **No** | Filters **bundle = `help_article` only** (`views.view.mel_help_search.yml`) |
+| `mel_content` index | **No** | Selected bundles: `article`, `event`, `help_article`, `help_landing_page`, `page` |
+| Site `/search` “Pages / Blog” group | **No** for FAQ | `SearchController::runContentQuery` keeps only `article` + `page` rows from results |
+
+**Recommendation:** Keep FAQ **out of `mel_content`** unless product explicitly wants FAQs in **site-wide** search; adding them would require teaser/view-mode mapping, field parity, and a deliberate decision on `/search` grouping—not done here.
+
+---
+
+## Section E — Canonical navigation models (target mental models)
+
+### Customer (account menu + primary IA)
+
+**Target hierarchy:** Discover → Event → Booking → Tickets → Support → Organisers → Saved Events → Categories → Notifications → Settings.
+
+**Observed deviations (non-exhaustive):**
+
+- Account menu links are **split across modules** (vendor dashboard/events vs RSVP export vs Support vs Help centre)—there is **no single YAML** declaring the full hierarchy.
+- **Discover** is primarily theme/global IA, not one menu plugin.
+- **Settings** for organisers routes through **`myeventlane_vendor.console.settings`** (weight −47) labelled “Settings”; customer profile settings may live under core user routes—verify per environment.
+
+### Organiser (vendor console)
+
+**Target hierarchy:** Dashboard → Events → Event Editor → Orders → Attendees → Check-in → Payouts → Promote → Messaging → Analytics → Support → Settings.
+
+**Observed deviations:**
+
+- **Promote** appears both as **Boost/commerce** surfaces and as a **placeholder** manage-event step (`/vendor/event/{event}/promote`).
+- **Event Editor** vs **legacy manage-event** sidebar coexist (terminology and URLs overlap).
+- Console **tabs** are built in PHP (`VendorEventTabsService`, workspace view models)—compare to target list in ongoing consolidation.
+
+---
+
+## Section F — Security & access snapshot (audit-only)
+
+**Themes for detailed findings:** See `docs/platform-governance-audit.md`.
+
+- **`_access: 'TRUE'`** appears on intentional surfaces (e.g. Stripe callbacks, login alias, some analytics POST endpoints)—each needs route-by-route justification (documented in governance file summary).
+- **Vendor isolation:** `VendorConsoleAccess`, `VendorPathMembershipGuardSubscriber`, `ManageEventControllerBase::access`, `VendorManagedEventConsoleAccess` — **do not consolidate without a single ownership review** (risk of bypass).
+
+---
+
+## File references (inspection anchors)
+
+- `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml`
+- `web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml`
+- `web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php`
+- `web/modules/custom/myeventlane_help_assistant/src/Service/HelpRetriever.php`
+- `web/modules/custom/myeventlane_help_shared/src/Service/UnifiedHelpRetriever.php`
+- `config/sync/search_api.index.mel_content.yml`
+- `config/sync/views.view.mel_help_search.yml`
+- `web/modules/custom/myeventlane_search/src/Controller/SearchController.php`

--- a/docs/platform-governance-audit.md
+++ b/docs/platform-governance-audit.md
@@ -1,0 +1,126 @@
+# Platform governance audit
+
+Companion to **`docs/platform-canonical-surface-map.md`**. This document captures governance decisions, inventories, risks, and recommended follow-ups from the consolidation pass (`feature/platform-consolidation-audit`).
+
+---
+
+## Canonical terminology
+
+Public-facing consolidation targets are listed in **Section A** of the surface map. Governance rule: **new user-visible strings** should prefer **Organiser**, **Organiser Dashboard**, **Ticket holder** (except established Help paths titled “Attendees”), **Support request** for customer-facing escalation language, **Event Manager** / **Event Editor**, and **Promote Event** for marketing surfaces—not internal Boost SKU naming.
+
+---
+
+## Canonical route ownership
+
+**Authoritative tables:** `docs/platform-canonical-surface-map.md` Section B.
+
+**Governance rule:** Prefer **`/vendor/dashboard`**, **`/vendor/events/{event}/workspace`**, and **Event Editor** routes for organiser UX; treat **`/vendor/event/{event}/*`** manage-event steps as **legacy/secondary** except where they remain the only implementation.
+
+---
+
+## Deprecated surface inventory
+
+| Surface | Behaviour | Notes |
+|---------|-----------|-------|
+| `/help/index` | 301 → `/help` | Public index consolidation |
+| `/vendor/help` | 301 → `/help` | Legacy vendor entry |
+| `/stripe/connect/callback` | Stripe callback | Parallel to `/stripe/callback` for in-flight Account Links |
+| Manage-event singular paths | Some redirect to workspace/studio | See vendor routing (e.g. tickets redirect controller) |
+
+---
+
+## Placeholder surface inventory
+
+All **`ManageEventPlaceholderController`** routes: **`promote`**, **`payments`**, **`comms`**, **`advanced`** under **`/vendor/event/{event}/…`**.
+
+**Controls:** `noindex,nofollow`, `X-Robots-Tag`, themed shell classes on `myeventlane_manage_event`.
+
+---
+
+## AI grounding rules
+
+1. **Bundles:** `HelpRetriever` queries **`help_article`** only on index **`mel_content`**.
+2. **Published + status:** Published nodes; `field_help_status` must be `published` or `approved` when present.
+3. **Allow list:** `field_help_ai_allowed` must be truthy.
+4. **Audience:** No `staff`; only **`public`** / **`vendor`** consistent with current user.
+5. **Node access:** `$node->access('view')` required.
+6. **Unified path:** `UnifiedHelpRetriever` repeats policy validation—preserve defence in depth.
+
+**Explicit non-goals:** Staff playbooks and internal-only nodes must never enter vendor/public retrieval pipelines.
+
+---
+
+## Help Centre governance
+
+- **Public hub:** `/help` (`access content` for home; several sub-paths `_access: 'TRUE'` for listings—ensure content access still enforced inside views/controllers).
+- **Vendor topics:** `/vendor/help/topic/{category}` requires **`view vendor help centre`** — now granted to **`vendor`** and **`mel_pro`** roles in sync.
+- **Contextual map:** `config/sync/myeventlane_help_centre.contextual_help.yml` drives structured links; resolver uses register IDs / titles (`ContextualHelpResolver`).
+- **Staff authoring:** Separate admin paths (`administer escalations`, `view mel help insights`) — keep segregated from vendor menus.
+
+---
+
+## Customer journey map
+
+See surface map **Section E (Customer)**. **Gap:** customer IA is assembled from **multiple menu plugins and theme regions**; a future task should generate a single **`links.menu.yml` tree** or dashboard builder output aligned to the canonical list without duplicating builders.
+
+---
+
+## Organiser journey map
+
+See surface map **Section E (Organiser)**. **Gap:** reconcile **Boost**, **Promote placeholder**, and **Event Studio** naming in shell chrome (`VendorConsolePagePreprocess`, dashboard templates).
+
+---
+
+## Security & access findings
+
+| Area | Assessment | Detail |
+|------|------------|--------|
+| Manage-event placeholders | **Safe** | Inherits `ManageEventControllerBase::access` (owner/vendor team/admin) |
+| `/vendor/help` redirect | **Safe** | Broad `access content`; redirect only |
+| `/vendor/help/topic/*` | **Safe post-fix** | Permission now on organiser roles |
+| Stripe `_access: TRUE` callbacks | **Needs operational discipline** | Expected for webhooks/returns; must retain signature/idempotency elsewhere |
+| Site search `mel_content` | **Safe** | Content access processor on index; `/search` filters non-event bundles |
+| Vendor AI `HelpArticleRetriever` | **Risk: note** | Uses `accessCheck(FALSE)` then loads nodes—ensure callers never expose raw output without equivalent checks |
+
+**Governance:** Any consolidation of access services must preserve **`VendorConsoleAccess`** onboarding/domain behaviour.
+
+---
+
+## Recommended future consolidations
+
+1. **Terminology pass:** Update `_title` defaults and prominent Twig headings (`Vendor dashboard` → Organiser Dashboard) with content/design sign-off.
+2. **Customer menu:** Single builder or ordered plugin list matching canonical hierarchy.
+3. **FAQ in Search API:** Only if product wants FAQs on **`/search`**; requires bundle fields, view modes, and grouping rules.
+4. **Access audit sprint:** Inventory every `_access: 'TRUE'` route into staff/public/vendor buckets (spreadsheet), no code change required first.
+
+---
+
+## Launch risks
+
+- **Placeholder URLs** are reachable from manage-event navigation—users may perceive incomplete product.
+- **Dual naming** (Vendor vs Organiser) persists in role labels and routes—support and AI agents must rely on this governance doc until copy alignment ships.
+
+---
+
+## Operational risks
+
+- **Search reindex** not required for permission-only config change; if `mel_content` changes later, schedule **`search-api-reindex`**.
+- **Caches:** Route/service changes require **`drush cr`**.
+
+---
+
+## AI support risks
+
+- **Terminology drift** increases hallucinated navigation (“Vendor Dashboard” vs `/vendor/dashboard` vs “Organiser”).
+- **Misrouting** if staff-only paths are ever added to public contextual maps—guard with audience checks (current resolver uses published `help_article` + access).
+
+---
+
+## Changes applied in this branch (implementation ledger)
+
+| Change | Location |
+|--------|----------|
+| Placeholder `noindex` meta + shell TWIG classes | `ManageEventPlaceholderController`, `myeventlane-manage-event.html.twig`, `myeventlane_vendor.module` theme vars |
+| `X-Robots-Tag` | `ManageEventPlaceholderNoIndexSubscriber` |
+| Organiser help permission | `config/sync/user.role.vendor.yml`, `config/sync/user.role.mel_pro.yml` |
+| Routing commentary | `myeventlane_vendor.routing.yml`, `myeventlane_help_centre.routing.yml` |

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.routing.yml
@@ -89,6 +89,8 @@ myeventlane_help_centre.article_feedback:
       node:
         type: entity:node
 
+# Legacy entrypoint: redirects (301) to myeventlane_help_centre.home. Looser gate so
+# bookmarks still resolve; topic pages require view vendor help centre (see vendor_topic).
 myeventlane_help_centre.vendor_help:
   path: '/vendor/help'
   defaults:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
@@ -84,6 +84,7 @@ function myeventlane_vendor_theme($existing, $type, $theme, $path): array {
         'steps' => [],
         'current_step' => NULL,
         'content' => NULL,
+        'placeholder_shell' => FALSE,
       ],
       'template' => 'myeventlane-manage-event',
     ],

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -835,6 +835,9 @@ myeventlane_vendor.manage_event.series:
         bundle:
           - event
 
+# Placeholder surfaces (ManageEventPlaceholderController): non-functional UX stubs;
+# noindex via controller + ManageEventPlaceholderNoIndexSubscriber. Not linked from
+# contextual help panels (manage-event layout has no mel_vendor_contextual_help).
 myeventlane_vendor.manage_event.promote:
   path: '/vendor/event/{event}/promote'
   defaults:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -121,6 +121,13 @@ services:
     tags:
       - { name: event_subscriber }
 
+  myeventlane_vendor.manage_event_placeholder_noindex:
+    class: Drupal\myeventlane_vendor\EventSubscriber\ManageEventPlaceholderNoIndexSubscriber
+    arguments:
+      - '@current_route_match'
+    tags:
+      - { name: event_subscriber }
+
   myeventlane_vendor.event_studio_onboarding_gate:
     class: Drupal\myeventlane_vendor\EventSubscriber\EventStudioVendorOnboardingGateSubscriber
     arguments:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
@@ -4,12 +4,32 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Controller;
 
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\myeventlane_vendor\Service\ManageEventNavigation;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller for placeholder steps (Promote, Payments, Comms, Advanced).
  */
 final class ManageEventPlaceholderController extends ManageEventControllerBase {
+
+  public function __construct(
+    ManageEventNavigation $navigation,
+    private readonly RouteMatchInterface $routeMatch,
+  ) {
+    parent::__construct($navigation);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_vendor.manage_event_navigation'),
+      $container->get('current_route_match'),
+    );
+  }
 
   /**
    * Renders a placeholder page.
@@ -21,10 +41,8 @@ final class ManageEventPlaceholderController extends ManageEventControllerBase {
    *   Render array.
    */
   public function placeholder(NodeInterface $event): array {
-    // Get step and title from current route.
-    $route_name = \Drupal::routeMatch()->getRouteName();
-    $route = \Drupal::routeMatch()->getRouteObject();
-    $step = $route_name;
+    $route = $this->routeMatch->getRouteObject();
+    $step = $this->routeMatch->getRouteName() ?? '';
     $title = '';
 
     if ($route) {
@@ -33,7 +51,13 @@ final class ManageEventPlaceholderController extends ManageEventControllerBase {
     }
     $content = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-manage-event-content', 'mel-placeholder']],
+      '#attributes' => [
+        'class' => [
+          'mel-manage-event-content',
+          'mel-placeholder',
+          'mel-coming-soon-inner',
+        ],
+      ],
       'message' => [
         '#type' => 'html_tag',
         '#tag' => 'div',
@@ -52,14 +76,27 @@ final class ManageEventPlaceholderController extends ManageEventControllerBase {
       ],
     ];
 
-    return $this->buildPage($event, $step, $content, $title);
+    $page = $this->buildPage($event, $step, $content, (string) $title);
+    $page['#placeholder_shell'] = TRUE;
+    $page['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'robots',
+          'content' => 'noindex, nofollow',
+        ],
+      ],
+      'mel_manage_event_placeholder_robots',
+    ];
+
+    return $page;
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getPageTitle(NodeInterface $event): string {
-    $route = \Drupal::routeMatch()->getRouteObject();
+    $route = $this->routeMatch->getRouteObject();
     if ($route) {
       $defaults = $route->getDefaults();
       return (string) ($defaults['title'] ?? '');

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/ManageEventPlaceholderNoIndexSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/ManageEventPlaceholderNoIndexSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\EventSubscriber;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds crawler directives for manage-event placeholder surfaces.
+ *
+ * Complements per-response meta tags from the placeholder controller so
+ * intermediaries that only honour HTTP headers still suppress indexing.
+ */
+final class ManageEventPlaceholderNoIndexSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Routes rendered by ManageEventPlaceholderController.
+   *
+   * @var list<string>
+   */
+  private const PLACEHOLDER_ROUTE_NAMES = [
+    'myeventlane_vendor.manage_event.promote',
+    'myeventlane_vendor.manage_event.payments',
+    'myeventlane_vendor.manage_event.comms',
+    'myeventlane_vendor.manage_event.advanced',
+  ];
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::RESPONSE => ['onResponse', -10],
+    ];
+  }
+
+  public function onResponse(ResponseEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+    $route_name = $this->routeMatch->getRouteName();
+    if ($route_name === NULL || !in_array($route_name, self::PLACEHOLDER_ROUTE_NAMES, TRUE)) {
+      return;
+    }
+    $event->getResponse()->headers->set('X-Robots-Tag', 'noindex, nofollow', FALSE);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/templates/myeventlane-manage-event.html.twig
+++ b/web/modules/custom/myeventlane_vendor/templates/myeventlane-manage-event.html.twig
@@ -18,7 +18,7 @@
  * - prev_step_url: URL to previous step
  */
 #}
-<div class="mel-manage-event-wrapper">
+<div class="mel-manage-event-wrapper{% if placeholder_shell %} mel-coming-soon-shell{% endif %}">
   <div class="mel-manage-event-header">
     <div class="mel-manage-event-header-content">
       <div class="mel-event-info">
@@ -74,7 +74,7 @@
           <h2 class="mel-page-title">{{ page_title }}</h2>
         </div>
 
-        <div class="mel-content-area">
+        <div class="mel-content-area{% if placeholder_shell %} mel-coming-soon-content-shell{% endif %}">
           {{ content }}
         </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Drupal routing/rendering and role permissions: changes could affect organiser access to `/vendor/help/topic/*` and SEO/indexing behaviour for placeholder manage-event pages. CI workflow assertions may fail builds if routing artifacts aren’t packaged as expected.
> 
> **Overview**
> Adds SEO suppression and clearer “coming soon” shell styling for organiser *manage-event* placeholder steps (`/vendor/event/{event}/promote|payments|comms|advanced`) by injecting `noindex,nofollow` meta and an `X-Robots-Tag` header via a new event subscriber.
> 
> Fixes organiser access drift by granting the `view vendor help centre` permission to the `vendor` and `mel_pro` roles, while documenting `/vendor/help` as a legacy redirect entrypoint.
> 
> Extends the reusable build workflow to validate the release artifact includes the `myeventlane_account.followed_organisers` route, and adds consolidation/governance audit docs capturing canonical terminology and route ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6db50de624dfd8bebc733ddaefdc3ae3ef51dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->