### PR TITLE
Feature/mission control dashboard refinement

### DIFF
--- a/config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml
+++ b/config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml
@@ -1,17 +1,17 @@
 key: vendor_ai.answer
 version: v1
 system: |
-  You are the MyEventLane (MEL) Assistant. You help vendors understand policies and next steps.
+  You are the MyEventLane (MEL) Assistant. You help event organisers understand policies and next steps.
   Respond in Australian English. Be calm, gender-neutral, and politically correct.
   Only answer based on the provided Help Centre excerpts. If the excerpts do not contain enough information, say:
   "I can't confirm from guidance. Please contact MyEventLane support for details."
   Keep responses concise (2–4 short paragraphs). Do not make up policies.
 template: |
-  Escalation context: {{context_block}}
+  Support request context: {{context_block}}
 
   Help Centre excerpts:{{excerpts}}
 
-  Vendor question: {{question}}
+  Organiser question: {{question}}
 
   Answer:
 placeholders:
@@ -19,4 +19,4 @@ placeholders:
   - excerpts
   - question
 status: active
-notes: 'Vendor AI assistant answering vendor questions from escalation context.'
+notes: 'Organiser AI assistant answering organiser questions from support context.'

--- a/config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml
+++ b/config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml
@@ -4,7 +4,7 @@ system: |
   You are the MyEventLane (MEL) Assistant. You help event organisers understand policies and next steps.
   Respond in Australian English. Be calm, gender-neutral, and politically correct.
   Only answer based on the provided Help Centre excerpts. If the excerpts do not contain enough information, say:
-  "I can't confirm from guidance. Please contact MyEventLane support for details."
+  "I'm not sure from the guidance. Please contact MyEventLane Support for a personal answer."
   Keep responses concise (2–4 short paragraphs). Do not make up policies.
 template: |
   Support request context: {{context_block}}

--- a/config/sync/myeventlane_messaging.template.boost_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.boost_confirmation.yml
@@ -61,7 +61,7 @@ body_html: |
 
       <div style="text-align: center; margin: 15px 0 30px 0;">
         <a href="{{ support_url }}" style="color: #f26d5b; font-size: 14px; text-decoration: underline;">
-          Need help? Contact Vendor Support
+          Need help? Contact MyEventLane support
         </a>
       </div>
 

--- a/config/sync/myeventlane_messaging.template.cart_abandoned.yml
+++ b/config/sync/myeventlane_messaging.template.cart_abandoned.yml
@@ -1,7 +1,7 @@
 enabled: true
-subject: 'Forgot something? Your tickets are waiting'
+subject: 'Still interested? Your cart is waiting'
 body: |
-  <p>Hi {{ first_name }}, you left tickets in your cart on MyEventLane.</p>
+  <p>Hi {{ first_name }}, your tickets are still in your cart on MyEventLane whenever you're ready.</p>
   <p><a href="{{ cart_url }}" style="display:inline-block;padding:12px 16px;border-radius:999px;background:#6e7ef2;color:#fff;text-decoration:none;">Return to cart</a></p>
 utm:
   enable: true

--- a/config/sync/myeventlane_messaging.template.order_receipt.yml
+++ b/config/sync/myeventlane_messaging.template.order_receipt.yml
@@ -4,7 +4,7 @@ body_html: |
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #fef5ec; padding: 20px;">
     <div style="background-color: #ffffff; border-radius: 8px; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
       <div style="text-align: center; margin-bottom: 30px;">
-        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">🎉 Thank you for your order!</h1>
+        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">Thank you for your order</h1>
       </div>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
@@ -77,7 +77,7 @@ body_html: |
             <strong>Donation Amount:</strong> {{ donation_total }}
           </p>
           <p style="color: #856404; font-size: 14px; margin: 10px 0 0 0;">
-            Thank you for your generous donation! Your contribution helps support our platform and events.
+            Thank you — your contribution is included with this booking.
           </p>
         </div>
       {% endif %}
@@ -154,13 +154,13 @@ body_html: |
 
       <div style="text-align: center; margin: 30px 0;">
         <a href="{{ order_url }}" style="display: inline-block; background-color: #ff6b9d; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; font-size: 16px;">
-          View My Tickets
+          View your tickets
         </a>
       </div>
 
       <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #e0e0e0; text-align: center; color: #7f8c8d; font-size: 12px;">
         <p style="margin: 5px 0;">This email was sent to {{ order_email }}</p>
-        <p style="margin: 5px 0;">If you have any questions, please contact us.</p>
+        <p style="margin: 5px 0;">Questions? Reply to this email or visit Support.</p>
       </div>
     </div>
   </div>

--- a/config/sync/myeventlane_messaging.template.refund_failed_buyer.yml
+++ b/config/sync/myeventlane_messaging.template.refund_failed_buyer.yml
@@ -5,9 +5,9 @@ body_html: |-
 
   Your refund for <strong>{{ event_title }}</strong> (Order {{ order_number }}) could not be fully confirmed yet.
 
-  Our team has been notified and will review this.
+  Our team has been notified and will review this. We'll email you again once it's resolved.
 
-  Reference: {{ error_message }}
+  Order reference: {{ order_number }}
 utm:
   enable: true
   params:

--- a/config/sync/views.view.mel_help_attendee_help.yml
+++ b/config/sync/views.view.mel_help_attendee_help.yml
@@ -51,8 +51,8 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          tokenize: false
           content: '<div class="mel-help-listing__empty" role="status"><h2>No articles match yet</h2><p>Try the search at the top of the page, or browse the Help Centre for more topics.</p></div>'
+          tokenize: false
       sorts:
         changed:
           id: changed

--- a/config/sync/views.view.mel_help_attendee_help.yml
+++ b/config/sync/views.view.mel_help_attendee_help.yml
@@ -41,6 +41,18 @@ display:
       cache:
         type: tag
         options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          tokenize: false
+          content: '<div class="mel-help-listing__empty" role="status"><h2>No articles match yet</h2><p>Try the search at the top of the page, or browse the Help Centre for more topics.</p></div>'
       sorts:
         changed:
           id: changed

--- a/config/sync/views.view.mel_help_organiser_help.yml
+++ b/config/sync/views.view.mel_help_organiser_help.yml
@@ -51,8 +51,8 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          tokenize: false
           content: '<div class="mel-help-listing__empty" role="status"><h2>No articles match yet</h2><p>Try the search at the top of the page, or browse the Help Centre for more topics.</p></div>'
+          tokenize: false
       sorts:
         changed:
           id: changed

--- a/config/sync/views.view.mel_help_organiser_help.yml
+++ b/config/sync/views.view.mel_help_organiser_help.yml
@@ -41,6 +41,18 @@ display:
       cache:
         type: tag
         options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          tokenize: false
+          content: '<div class="mel-help-listing__empty" role="status"><h2>No articles match yet</h2><p>Try the search at the top of the page, or browse the Help Centre for more topics.</p></div>'
       sorts:
         changed:
           id: changed

--- a/config/sync/views.view.mel_vendor_events.yml
+++ b/config/sync/views.view.mel_vendor_events.yml
@@ -49,8 +49,8 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          tokenize: false
           content: '<div class="mel-vendor-events__empty" role="status"><h2>No events yet</h2><p>Create an event to add details, RSVPs, or tickets.</p></div>'
+          tokenize: false
       sorts:
         created:
           id: created

--- a/config/sync/views.view.mel_vendor_events.yml
+++ b/config/sync/views.view.mel_vendor_events.yml
@@ -39,7 +39,18 @@ display:
       cache:
         type: tag
         options: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          tokenize: false
+          content: '<div class="mel-vendor-events__empty" role="status"><h2>No events yet</h2><p>Create an event to add details, RSVPs, or tickets.</p></div>'
       sorts:
         created:
           id: created

--- a/config/sync/views.view.myeventlane_vendor_rsvps.yml
+++ b/config/sync/views.view.myeventlane_vendor_rsvps.yml
@@ -108,6 +108,18 @@ display:
           label: Updated
           order: DESC
           plugin_id: date
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          tokenize: false
+          content: '<div class="mel-vendor-rsvps__empty" role="status"><h2>No RSVPs yet</h2><p>RSVPs will appear here as people respond. You can share your event link from the Event Editor.</p></div>'
       display_extenders: {  }
   page_1:
     id: page_1

--- a/config/sync/views.view.myeventlane_vendor_rsvps.yml
+++ b/config/sync/views.view.myeventlane_vendor_rsvps.yml
@@ -21,20 +21,73 @@ display:
     position: 0
     display_options:
       title: 'RSVP Submissions'
+      fields:
+        id:
+          id: id
+          table: rsvp_submission
+          field: id
+          plugin_id: numeric
+          label: 'RSVP ID'
+        attendee_name:
+          id: attendee_name
+          table: rsvp_submission
+          field: attendee_name
+          plugin_id: string
+          label: Attendee
+        status:
+          id: status
+          table: rsvp_submission
+          field: status
+          plugin_id: string
+          label: Status
+        changed:
+          id: changed
+          table: rsvp_submission
+          field: changed
+          plugin_id: date
+          label: Updated
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
       access:
         type: myeventlane_rsvp_vendor_access
         options: {  }
       cache:
         type: tag
         options: {  }
-      query:
-        type: views_query
-        options: {  }
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<div class="mel-vendor-rsvps__empty" role="status"><h2>No RSVPs yet</h2><p>RSVPs will appear here as people respond. You can share your event link from the Event Editor.</p></div>'
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: rsvp_submission
+          field: changed
+          plugin_id: date
+          order: DESC
+          label: Updated
+      filters:
+        status:
+          id: status
+          table: rsvp_submission
+          field: status
+          plugin_id: string
+          operator: '!='
+          value: cancelled
+          group: 1
+          exposed: false
+          label: Status
       style:
         type: table
         options:
@@ -64,62 +117,9 @@ display:
       row:
         type: fields
         options: {  }
-      fields:
-        id:
-          id: id
-          table: rsvp_submission
-          field: id
-          label: 'RSVP ID'
-          plugin_id: numeric
-        attendee_name:
-          id: attendee_name
-          table: rsvp_submission
-          field: attendee_name
-          label: Attendee
-          plugin_id: string
-        status:
-          id: status
-          table: rsvp_submission
-          field: status
-          label: Status
-          plugin_id: string
-        changed:
-          id: changed
-          table: rsvp_submission
-          field: changed
-          label: Updated
-          plugin_id: date
-      filters:
-        status:
-          id: status
-          table: rsvp_submission
-          field: status
-          plugin_id: string
-          label: Status
-          operator: '!='
-          value: cancelled
-          group: 1
-          exposed: false
-      sorts:
-        changed:
-          id: changed
-          table: rsvp_submission
-          field: changed
-          label: Updated
-          order: DESC
-          plugin_id: date
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          tokenize: false
-          content: '<div class="mel-vendor-rsvps__empty" role="status"><h2>No RSVPs yet</h2><p>RSVPs will appear here as people respond. You can share your event link from the Event Editor.</p></div>'
+      query:
+        type: views_query
+        options: {  }
       display_extenders: {  }
   page_1:
     id: page_1
@@ -127,10 +127,10 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      path: dashboard/rsvps
-      menu:
-        type: none
       access:
         type: myeventlane_rsvp_vendor_access
         options: {  }
       display_extenders: {  }
+      path: dashboard/rsvps
+      menu:
+        type: none

--- a/docs/event-first-dashboard-audit.md
+++ b/docs/event-first-dashboard-audit.md
@@ -1,0 +1,44 @@
+# Event-First Dashboard Audit
+
+## Inspected Sources
+
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php`
+- `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml`
+- `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`
+- `web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss`
+- `web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_mel-dashboard.scss`
+- `web/modules/custom/myeventlane_dashboard/myeventlane_dashboard.module`
+- `web/modules/custom/myeventlane_event/myeventlane_event.module`
+
+## Current Structure Audit
+
+| Surface | Current Purpose | Keep | Move | Collapse | Remove |
+|----------|----------------|------|------|-----------|--------|
+| Vendor dashboard route | `/vendor/dashboard` renders `myeventlane_vendor.controller.vendor_dashboard:dashboard` through `myeventlane_vendor_dashboard` using `myeventlane_vendor_theme`. | Yes. Existing route, theme option, and access callback stay canonical. | No. | No. | No. |
+| `VendorDashboardViewModelBuilder` | Builds vendor payload, readiness, operational readiness, lifecycle guidance, KPI strip, events, analytics availability, action queue, hero hint, and empty state. | Yes. Reuse as canonical dashboard view model. | No. | Presentation output can be reorganised by Twig. | No. |
+| `VendorActionQueueBuilder` | Builds prioritised action queue from dashboard model, readiness, event state, route availability, and access checks. | Yes. | Secondary recommendations move behind progressive disclosure. | Yes, all but one visible priority action. | No. |
+| Readiness payload | Tracks profile, public profile, Stripe readiness, score, labels, and readiness row state. | Yes. | Into `Review event setup`. | Yes. | Remove giant score/ring presentation only. |
+| Operational readiness payload | Summarises publishing, bookings, payouts, attendees, and discovery with `MelReadinessHelper`. | Yes. | Into `Review event setup`. | Yes. | No. |
+| Lifecycle guidance payload | Summarises lifecycle stages from existing readiness helper logic and analytics availability. | Yes. | Into `Review event setup`. | Yes. | No. |
+| KPI strip | Decorated through `MelDataPresentationManager`; previously shown as a performance snapshot after multiple guidance panels. | Yes. | Immediately below current event hero. | No, but keep lightweight. | No charts/KPI walls on dashboard homepage. |
+| Events roster | Lists up to six managed events with image, state, type, metrics, links, and removal UI. | Yes. | Under secondary event list. | Yes. | No. |
+| Current event data | Existing event rows include title, status, date label, type, capacity, metrics, image, presentation issues, removal, and links. | Yes. | Promote one selected event into dashboard hero. | No. | No. |
+| Quick actions | Existing top quick bar showed several action queue CTAs. | Yes. | Convert to current-event actions. | No. | Remove stacked priority-action quick bar pattern. |
+| Activity feed | `VendorDashboardController::buildDashboardActivity()` exists and the builder can derive lightweight event-state activity from event summaries. | Yes. | Below quick actions. | Yes on dashboard as a details panel. | No fake activity service. |
+| Analytics summary | Builder currently exposes availability and empty items; controller has activity and KPI data. | Yes. | Detailed analytics stay on analytics/event analytics pages. | Yes if rendered on dashboard. | No graphing on dashboard homepage. |
+| Growth cards | Controller builds growth cards through existing growth insight/tracking services. | Yes. | Secondary guidance. | Yes. | No. |
+| Boost/promote surfaces | Existing boost routes and dashboard top boost opportunity are presentation surfaces. | Yes. | Footer or secondary panels. | Yes. | No Stripe/Commerce/Boost flow changes. |
+| Billing/contribution strip | Existing contribution strip is injected as `mel_contribution_billing_strip`. | Yes. | Footer micro surface/settings/billing context. | Yes. | No. |
+| Onboarding panel | Existing onboarding manager builds a panel when vendor setup is incomplete. | Yes. | `Review event setup`. | Yes. | No new onboarding engine. |
+| Contextual help | Help preprocessors attach dashboard help/support content. | Yes. | Keep contextual and secondary. | Yes when part of dashboard chrome. | No public/staff boundary changes. |
+| Shell navigation | Vendor console shell is route/theme driven; page template delegates to vendor layout. | Yes. | No. | No. | No. |
+| Preprocessors | Dashboard, event, help, donations, pro, automation, and launch modules enrich existing variables. | Yes. | No logic duplication in Twig. | Presentation only. | No. |
+| Mobile layout | Live-ops primitives and vendor dashboard SCSS provide responsive grids and spacing. | Yes. | Current dashboard order should start with priority, event, metrics, actions. | Yes for operational intelligence. | No new responsive framework. |
+
+## Audit Conclusion
+
+The dashboard already has the required backend systems: view model builder, readiness helper, lifecycle summaries, action queue, metrics, event state, shell, contextual help, and secondary promotional/billing surfaces. The overload comes from presentation order and visual weighting, not from missing backend engines.
+
+The refactor should therefore keep routing, access, data ownership, readiness logic, lifecycle logic, and analytics sources intact while changing the homepage hierarchy to event-first progressive disclosure.

--- a/docs/event-first-dashboard-governance-final.md
+++ b/docs/event-first-dashboard-governance-final.md
@@ -1,0 +1,128 @@
+# Event-First Dashboard Principles
+
+The organiser dashboard is event-first, not system-first. It starts with the organiser's current or most important event, then shows only the operational signals needed to decide what to do next.
+
+The refactor consolidates dashboard attention around existing systems: `VendorDashboardViewModelBuilder`, `VendorActionQueueBuilder`, `MelReadinessHelper`, event state resolution, existing metrics summaries, existing route/access checks, and existing MEL live-ops/card styling.
+
+# Dashboard Hierarchy Rules
+
+Canonical order:
+
+1. Priority Attention
+2. Current Event Hero
+3. Quick Metrics Strip
+4. Quick Actions
+5. Activity Feed
+6. Secondary Guidance
+7. Expandable Operational Panels
+
+No dashboard section may outrank the current event unless it is the single priority attention card.
+
+# Alert Priority Rules
+
+- Show one primary alert only.
+- Source the alert from `VendorActionQueueBuilder`.
+- Put additional action queue items inside secondary disclosure.
+- Never rebuild priority scoring in Twig.
+- Never stack dashboard alerts above the current event.
+
+# Event Hero Rules
+
+- Show one current event focus.
+- Use existing event view-model data.
+- Show title, image/banner, date, visibility state, booking state, attendee summary, and event actions.
+- Use human-readable operational summaries.
+- Do not return readiness rings, giant readiness percentages, or gamified completion meters to the dashboard hero.
+
+# Metrics Strip Rules
+
+- Keep dashboard metrics lightweight.
+- Prefer event-level bookings, attendees, RSVPs, revenue, and capacity.
+- Use existing metric summaries and decorated KPI rows.
+- Keep graphs and deep analytics on analytics pages or event-specific analytics.
+
+# Progressive Disclosure Rules
+
+- Readiness details, lifecycle guidance, operational guidance, growth suggestions, event rosters, and analytics snippets are secondary.
+- Use collapsible disclosure for operational intelligence.
+- On mobile, the initial view must prioritise primary alert, current event, metrics, and quick actions.
+
+# Contextual Intelligence Rules
+
+- Dashboard shows current operational state, current event, and important next action.
+- Event editor owns publishing, visibility, and ticket setup guidance.
+- Attendee pages own attendee readiness, check-in readiness, and attendee momentum.
+- Promote event pages own discovery, banner, promotion, and momentum guidance.
+
+# Mobile Dashboard Rules
+
+- Initial mobile order is priority alert, current event, metrics strip, quick actions.
+- Secondary intelligence remains collapsed.
+- Use existing MEL responsive grids and live-ops spacing.
+- Do not introduce a new responsive framework.
+
+# Visual Hierarchy Rules
+
+- White surfaces and subtle borders are the default.
+- Pastel accents are reserved for states, alerts, and actions.
+- Avoid competing cards with equal visual weight.
+- Keep spacing generous enough that the dashboard feels calm.
+
+# Operational Surface Boundaries
+
+The dashboard must not become:
+
+- A full analytics dashboard.
+- A notification centre.
+- A Stripe or Commerce rewrite.
+- A readiness engine.
+- A lifecycle engine.
+- An onboarding engine.
+- An AI retrieval surface.
+
+# What Was Consolidated
+
+- Action queue items now produce one visible priority card.
+- The event list now supports one primary current event hero.
+- Event metrics are presented as a lightweight dashboard strip.
+- Quick actions are tied to the current event.
+- Activity is lightweight and sourced from existing dashboard/event summaries.
+
+# What Was Relocated
+
+- Readiness details moved into `Review event setup`.
+- Lifecycle guidance moved into `Review event setup`.
+- Secondary action queue recommendations moved into disclosure.
+- Growth and promotion guidance moved into secondary panels.
+- Billing/contribution and boost opportunity surfaces moved into footer micro surfaces.
+
+# What Stayed Contextual
+
+- Event setup guidance stays tied to event/editor surfaces.
+- Attendee and check-in readiness stay tied to attendee/check-in surfaces.
+- Promotion and discovery guidance stay secondary to the dashboard and should live primarily on promote/event marketing surfaces.
+- Detailed analytics stay outside the dashboard homepage.
+
+# Canonical Dashboard Owner
+
+The canonical organiser dashboard owner remains `myeventlane_vendor.console.dashboard` and `VendorDashboardViewModelBuilder`, rendered by `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`.
+
+# Canonical Operational Intelligence Boundaries
+
+Operational intelligence is allowed on the dashboard only when it answers one of these questions:
+
+- What needs attention now?
+- Which event am I operating right now?
+- How is that event doing at a glance?
+- What action can I take immediately?
+
+Anything broader belongs in a contextual page, secondary panel, analytics surface, help surface, settings, billing, or event workspace.
+
+# Future Dashboard Governance
+
+- Add new dashboard sections only when they support the canonical hierarchy.
+- Prefer extending `VendorDashboardViewModelBuilder` over adding parallel dashboard builders.
+- Reuse `VendorActionQueueBuilder` for prioritisation.
+- Reuse `MelReadinessHelper` for readiness and lifecycle wording.
+- Keep access enforcement server-side.
+- Keep dashboard presentation cache-safe, translation-safe, mobile-safe, support-safe, and trust-safe.

--- a/docs/event-first-dashboard-governance.md
+++ b/docs/event-first-dashboard-governance.md
@@ -1,0 +1,140 @@
+# Event-First Dashboard Governance
+
+## Canonical Dashboard Hierarchy
+
+1. Priority Attention
+2. Current Event Hero
+3. Quick Metrics Strip
+4. Quick Actions
+5. Activity Feed
+6. Secondary Guidance
+7. Expandable Operational Panels
+
+## Priority Attention
+
+The dashboard shows one visible priority card sourced from `VendorActionQueueBuilder`.
+
+Rules:
+
+- Render only the first priority action as the primary dashboard alert.
+- Keep remaining action queue items in a secondary expandable area.
+- Do not duplicate priority logic in Twig or a new service.
+- Do not stack alerts above the event hero.
+- Keep action URLs sourced from existing route/access logic.
+
+## Current Event Hero
+
+The current event is the primary dashboard surface. It is selected from the existing event rows built by `VendorDashboardViewModelBuilder`.
+
+Rules:
+
+- Show one event focus only.
+- Use existing event image, title, date, visibility state, booking state, attendee summary, and event links.
+- Prefer human-readable operational copy over readiness percentages.
+- Do not show readiness rings, gamified completion meters, or giant setup scores in the hero.
+- If there are no events, the hero becomes the existing empty state.
+
+## Quick Metrics Strip
+
+Metrics stay lightweight and operational.
+
+Allowed dashboard metrics:
+
+- Bookings
+- Attendees
+- RSVPs
+- Revenue
+- Capacity or similarly direct operational state
+
+Rules:
+
+- Use existing event metrics or existing decorated dashboard KPI rows.
+- Do not introduce charts or analytics dashboards on the organiser dashboard homepage.
+- Keep detailed analytics on analytics pages or event-specific analytics surfaces.
+
+## Quick Actions
+
+Quick actions are event-first.
+
+Canonical actions:
+
+- Edit event
+- View attendees
+- Open check-in
+- Share event
+- Promote event
+- Open support
+
+Rules:
+
+- Reuse existing route generation and route access checks.
+- Do not hardcode permission decisions in Twig.
+- Do not create duplicate route names or placeholder workflow engines.
+
+## Activity Feed
+
+The dashboard may show lightweight activity if it is sourced from existing systems.
+
+Allowed sources:
+
+- Existing dashboard activity rows.
+- Existing event summaries.
+- Existing operational state from the event view model.
+- Existing metric summaries.
+
+Rules:
+
+- Do not invent a fake feed.
+- Do not create a new activity service in this refactor.
+- If no activity exists, show a calm empty message.
+
+## Progressive Disclosure
+
+Readiness, lifecycle guidance, operational guidance, growth suggestions, and secondary event lists are secondary dashboard surfaces.
+
+Rules:
+
+- Use native details/accordion-style disclosure or existing MEL disclosure primitives.
+- Keep guidance discoverable but not visually dominant.
+- Keep mobile initial view focused on priority, current event, metrics, and quick actions.
+
+## Contextual Intelligence Boundaries
+
+Dashboard:
+
+- Current operational state.
+- Current event.
+- Important next action.
+
+Event editor:
+
+- Publishing guidance.
+- Visibility guidance.
+- Ticket setup guidance.
+
+Attendee page:
+
+- Attendee readiness.
+- Check-in readiness.
+- Attendee momentum.
+
+Promote event page:
+
+- Discovery guidance.
+- Banner suggestions.
+- Promotion guidance.
+- Momentum guidance.
+
+## Visual Hierarchy Rules
+
+- Use white surfaces and subtle borders for core dashboard regions.
+- Use pastel accents for states, actions, and alerts only.
+- Avoid stacked pastel containers.
+- Keep one primary action visible per region.
+- Preserve accessible focus states and touch-friendly action sizing.
+
+## Operational Surface Boundaries
+
+The organiser dashboard is not an analytics product, onboarding engine, lifecycle engine, notification centre, Stripe console, Commerce console, or AI retrieval surface.
+
+It is a calm operational starting point for the organiser's current event.

--- a/docs/lifecycle-intelligence-audit.md
+++ b/docs/lifecycle-intelligence-audit.md
@@ -1,0 +1,42 @@
+# Lifecycle Intelligence Signal Audit
+
+Lifecycle intelligence is a presentation layer. It explains state already owned by existing services, builders, gates, and governed templates. It does not create new business rules, new workflow states, new analytics calculations, or new enforcement paths.
+
+## Signal Inventory
+
+| Signal | Existing Owner | Reusable? | Presentation Opportunity |
+| --- | --- | --- | --- |
+| Account readiness summaries | `MelReadinessHelper` | Yes | Keep canonical organiser setup, payout, publishing, attendee, and discovery copy in one translation-safe helper. |
+| Public event lifecycle state | `myeventlane_event_state\EventStateResolver` | Yes, when caller already has access | Explain draft, scheduled, live, sold-out, ended, cancelled, and archived states without duplicating resolver logic. |
+| Event domain state | `myeventlane_core\Service\EventStateResolver` | Yes | Interpret existing booking, RSVP, product, capacity, and promoted-event facts for organiser guidance. |
+| Dashboard readiness | `VendorDashboardViewModelBuilder` | Yes | Add dashboard lifecycle cards from existing `readiness`, `events`, operational readiness, and route-access results. |
+| Event workspace readiness | `VendorEventWorkspaceViewModelBuilder` | Yes | Add event-scoped lifecycle guidance from current status, booking type, existing metrics, banner, category/tag, and promoted signals. |
+| Action queue | `VendorActionQueueBuilder` and `MelVendorDashboardActionQueueGovernance` | Yes | Keep priority/action ordering separate from lifecycle explanation. Lifecycle guidance should not add urgent tasks. |
+| Event Studio publish hints | `EventStudioForm` with `VendorPublishRequirementsGate::getReadinessFlags()` | Yes | Explain publish readiness in Event Studio without adding publishing blocks or save logic. |
+| Live publish requirements | `VendorPublishRequirementsGate` | Use with care | Reuse soft readiness flags and existing denial reasons only as explanations. Enforcement stays in the gate. |
+| Paid publish Stripe gate | `PaidPublishStripeGate` | Use with care | Reuse existing outcome/copy to explain paid-ticket requirements. Do not inspect or expose Stripe internals. |
+| Ticket presentation alerts | `VendorEventPresentationAlertsBuilder` | Yes | Keep ticket-mapping and price-display guidance in the existing vendor-console presentation builder. |
+| Ticket availability | `TicketAvailabilityService` | Use with care | `resolveTierForVariation()` is safe for presentation. Buyer/session purchasability filtering remains checkout-owned. |
+| Booking mode and CTA availability | `BookingFlowResolver` | Yes, through existing callers | Explain booking availability without duplicating checkout or public CTA rules. |
+| Analytics summary availability | `VendorDashboardViewModelBuilder` and `VendorAnalyticsViewModelBuilder` | Yes | Mention analytics only when existing routes/access allow it. Do not calculate analytics in lifecycle guidance. |
+| Attendee operations empty state | `GovernedOperationalTemplates` and `MelReadinessHelper` | Yes | Reuse attendee empty-state copy: bookings and RSVPs appear after they begin. |
+| Attendee list/check-in state | `myeventlane_event_attendees` controllers and check-in services | Yes, via existing links/models | Explain that attendee and check-in tools are ready when bookings exist. Do not expose attendee PII. |
+| Promote event state | `BoostEntitlementManager`, `VendorBoostController`, `field_promoted`, and core event state resolver | Yes | Explain promoted placement only as an existing signal. Do not create promotion scoring. |
+| Banner image | `field_event_image` and existing thumbnail/presentation helpers | Yes | Suggest adding visual content for discovery and sharing. |
+| Category and tag state | `field_category` and `field_tags` | Yes | Explain category/tag discovery support without SEO scoring. |
+| Event overview metrics | `VendorEventOverviewController`, `MetricsAggregator`, `TicketSalesService`, `RsvpStatsService` | Yes | Reuse metrics already present on organiser surfaces. Do not add new queries to Twig. |
+| Public visibility | Node published state, content moderation state, workspace status resolver | Yes | Explain draft/private, review, live, and past states using existing status payloads. |
+| Help and contextual help | `ContextualHelpResolver`, `SupportPanelBuilder`, Help Centre config | Yes | Align wording with existing help surfaces without adding new retrieval or AI grounding. |
+| Help Assistant and organiser AI | `HelpRetriever`, `UnifiedHelpRetriever`, `VendorAiAssistantForm`, configured prompts | No code change | Lifecycle copy may align in tone only. Retrieval, prompts, and AI behaviour stay unchanged. |
+
+## Audit Findings
+
+- `MelReadinessHelper` is already the canonical presentation-copy owner for readiness and empty-state guidance.
+- Dashboard and event workspace builders already gather the reusable signals needed for lifecycle cards.
+- Publishing, paid ticket, Stripe, Commerce, checkout, attendee, and check-in logic already have owning services and must remain authoritative.
+- Existing live-ops panels, timeline cards, chips, and empty-state patterns are sufficient for the UI layer.
+- Help and AI governance explicitly prevents widening retrieval, exposing staff-only content, or surfacing readiness internals to AI.
+
+## Implementation Boundary
+
+Lifecycle guidance may add reusable payloads and calm cards. It must not add notifications, modal onboarding, scores, new entities, permissions, dashboards, analytics engines, workflow states, Stripe logic, Commerce logic, or AI retrieval changes.

--- a/docs/lifecycle-intelligence-governance.md
+++ b/docs/lifecycle-intelligence-governance.md
@@ -1,0 +1,47 @@
+# Lifecycle Intelligence Governance
+
+Lifecycle intelligence explains existing organiser and event state. It is presentational, translation-safe, cache-aware, and grounded in the services that already own setup, publishing, booking, discovery, attendee, day-of-event, analytics, and support state.
+
+## Canonical Owner
+
+`MelReadinessHelper` owns lifecycle guidance copy and reusable summary payloads. Dashboard and workspace builders may compose existing signals and pass payloads to Twig. Twig renders supplied arrays only.
+
+## Canonical Lifecycle Stages
+
+1. **Event Setup** reuses organiser dashboard models, event workspace models, Event Studio state, title/date/description/banner readiness, and existing create/edit routes.
+2. **Publishing Readiness** reuses node publication state, workspace status resolution, `VendorPublishRequirementsGate`, `PaidPublishStripeGate`, and Event Studio publish readiness flags.
+3. **Booking Readiness** reuses `BookingFlowResolver`, core event domain state, ticket product state, RSVP state, `TicketAvailabilityService` presentation-safe tier mapping, and vendor ticket presentation alerts.
+4. **Discovery Readiness** reuses `field_event_image`, `field_category`, `field_tags`, `field_promoted`, public visibility state, and existing promote-event surfaces.
+5. **Attendee Activity** reuses ticket sales summaries, RSVP summaries, attendee operations, and event overview metrics already available to the organiser.
+6. **Day-of-Event Readiness** reuses attendee and check-in surfaces. It explains availability without changing scanner or validation logic.
+7. **Event Momentum** reuses existing bookings, RSVPs, analytics availability, operational readiness, and event overview metrics. It must not create pressure or arbitrary scores.
+8. **Post-Event Follow-up** reuses event end/past state, attendee tools, order/RSVP surfaces, analytics pages, and support entry points.
+
+## Presentation Rules
+
+- Explain what existing systems already know.
+- Prefer calm copy: ready, visible, draft, available, active, appears after bookings begin.
+- Avoid fake urgency, scarcity, growth-hack language, addiction loops, and arbitrary quality scores.
+- Do not duplicate readiness, publishing, Commerce, Stripe, checkout, attendee, or event-state logic.
+- Do not calculate analytics in Twig.
+- Do not hardcode route access in Twig.
+- Do not expose internal diagnostics, moderation internals, Stripe identifiers, Commerce internals, support queue state, staff playbooks, or attendee PII.
+
+## Stage Boundaries
+
+- **Event Setup** can say details are ready or still editable. It cannot decide whether an event is operationally valid.
+- **Publishing Readiness** can explain draft/live/review state. It cannot add blocking rules.
+- **Booking Readiness** can explain RSVP, paid ticket, hybrid, or unavailable states from existing resolvers. It cannot change checkout paths.
+- **Discovery Readiness** can suggest banner, category, tags, visibility, sharing, or Promote event. It cannot add SEO or quality scoring.
+- **Attendee Activity** can explain where bookings, RSVPs, attendees, and check-in appear. It cannot expose attendee details outside existing access-controlled surfaces.
+- **Day-of-Event Readiness** can point to check-in tools. It cannot duplicate validation.
+- **Event Momentum** can explain current activity. It cannot predict demand or imply underperformance.
+- **Post-Event Follow-up** can explain that records remain available. It cannot create campaigns, CRM workflows, or marketing automation.
+
+## AI and Help Alignment
+
+Lifecycle guidance may align with Help Centre and organiser AI tone. It must not widen Help Assistant retrieval, alter audience filtering, add organiser AI prompts, expose lifecycle internals to AI, or include staff-only help in vendor/public surfaces.
+
+## Accessibility and Mobile Standards
+
+Guidance renders in existing MEL live-ops cards and chips. Cards must stack on mobile, keep semantic headings, use text in addition to colour, preserve aria labels, and avoid notification overload.

--- a/docs/lifecycle-intelligence-guidance-governance.md
+++ b/docs/lifecycle-intelligence-guidance-governance.md
@@ -1,0 +1,80 @@
+# Lifecycle Intelligence Guidance Governance
+
+## Lifecycle Intelligence Principles
+
+Lifecycle intelligence is presentational. It explains existing organiser and event state with calm, concise guidance. It does not enforce publishing, calculate checkout availability, run analytics, send notifications, create onboarding flows, or change AI behaviour.
+
+## Lifecycle Stages
+
+The canonical lifecycle stages are Event Setup, Publishing Readiness, Booking Readiness, Discovery Readiness, Attendee Activity, Day-of-Event Readiness, Event Momentum, and Post-Event Follow-up.
+
+Each stage must reuse the existing owner of the underlying signal. If a stage needs a new operational rule, that rule belongs in the owning domain service first. Lifecycle guidance can explain it only after the source of truth exists.
+
+## Momentum Guidance Standards
+
+- Use neutral awareness language: "ready", "visible", "appears after bookings begin", "available when you need it".
+- Avoid pressure language, urgency, countdowns, gamification, rankings, arbitrary scores, and growth-hack framing.
+- Do not predict demand unless the data and product governance explicitly support that claim.
+
+## Discovery Guidance Standards
+
+Discovery guidance may mention banner images, categories, tags, promoted placement, public visibility, and sharing readiness. It must not implement SEO scoring, quality scores, ranking advice, or analytics engines.
+
+## Publishing Intelligence Standards
+
+Publishing guidance reuses node publication state, workspace status resolution, Event Studio readiness flags, `VendorPublishRequirementsGate`, and `PaidPublishStripeGate`. It may explain draft, live, review, paid-ticket, Stripe, RSVP, and ticket-sales state. It must not create new workflow states, moderation logic, or blocking rules.
+
+## Attendee Momentum Standards
+
+Attendee guidance reuses existing booking summaries, RSVP summaries, attendee operations, check-in links, and event overview metrics. It may explain that bookings, RSVPs, ticket holders, and check-in tools appear after activity begins. It must not expose attendee PII or duplicate attendee queries.
+
+## Post-Event Standards
+
+Post-event guidance may explain that an event has ended, attendee/order/RSVP records remain available through existing organiser tools, and support is available from organiser support surfaces. It must not create marketing automation, CRM features, or follow-up campaign systems.
+
+## Accessibility Standards
+
+Lifecycle cards use existing MEL live-ops card, timeline, chip, and panel classes. They must preserve semantic headings, render concise text, avoid colour-only meaning, stack cleanly on mobile, and keep decorative icons hidden from assistive technology.
+
+## AI Alignment Rules
+
+Lifecycle guidance may align with Help Centre, organiser AI, readiness governance, trust guidance governance, and product language governance. It must not widen retrieval, change audience filtering, add prompts, expose lifecycle internals, expose analytics internals, or surface staff-only help.
+
+## What Must Never Be Exposed
+
+Never expose staff-only diagnostics, moderation internals, internal SLAs, escalation levels, support queue state, private Stripe or Connect identifiers, webhook payloads, Commerce internals, checkout internals, attendee PII outside existing access-controlled surfaces, cross-vendor data, or raw analytics internals.
+
+## Canonical Lifecycle Owner
+
+`MelReadinessHelper` is the canonical owner for lifecycle guidance copy and reusable summary payloads. Builders may supply already-authorised and already-computed signals. Templates render payloads only.
+
+## Reused Systems
+
+- `MelReadinessHelper`
+- `EventStateResolver` implementations
+- `VendorDashboardViewModelBuilder`
+- `VendorEventWorkspaceViewModelBuilder`
+- `VendorActionQueueBuilder`
+- `EventStudioForm`
+- `VendorPublishRequirementsGate`
+- `PaidPublishStripeGate`
+- `VendorEventPresentationAlertsBuilder`
+- `TicketAvailabilityService`
+- `BookingFlowResolver`
+- Existing analytics summaries and event overview metrics
+- Existing attendee operations and check-in surfaces
+- Existing promote-event surfaces
+- Existing contextual help and Help Assistant architecture without retrieval changes
+- Existing MEL card, chip, timeline, and live-ops styles
+
+## Presentation Boundaries
+
+Lifecycle guidance stays in dashboard and workspace payloads. It does not own vendor isolation, route access, event publishing, Stripe readiness, checkout availability, ticket purchasability, attendee queries, check-in validation, analytics aggregation, help retrieval, or AI grounding.
+
+## What Intentionally Stayed Operational
+
+Publishing gates, paid-ticket gates, Stripe/Connect state, Commerce order and checkout logic, RSVP logic, attendee operations, check-in validation, boost entitlement, analytics aggregation, Help Assistant retrieval, and staff-only support tooling remain operational and unchanged.
+
+## Future Lifecycle Governance
+
+Future lifecycle work must start with an audit of existing signal owners. New guidance should be added as reusable `MelReadinessHelper` payloads and rendered through existing MEL surfaces. Any request for enforcement, prediction, scoring, notification delivery, AI behaviour, CRM workflows, or analytics calculations is outside lifecycle intelligence and requires separate product and technical governance.

--- a/docs/mission-control-dashboard-audit.md
+++ b/docs/mission-control-dashboard-audit.md
@@ -1,0 +1,53 @@
+# Mission Control Dashboard Audit
+
+## Inspected Sources
+
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/RsvpStatsService.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/UserVendorMembershipQuery.php`
+- `web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php`
+- `web/modules/custom/myeventlane_vendor/src/Controller/VendorPayoutsController.php`
+- `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php`
+- `web/modules/custom/myeventlane_core/src/Service/EventStateResolver.php`
+- `web/modules/custom/myeventlane_escalations_refunds/src/Service/RefundsMetricsCalculator.php`
+- `web/modules/custom/myeventlane_escalations_refunds/src/Service/RefundsAccessGuard.php`
+- `web/modules/custom/myeventlane_stripe/src/Service/VendorStripeService.php`
+- `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`
+- `web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss`
+
+## Current Structure Audit
+
+| Surface | Current Purpose | Keep | Reduce | Relocate | Expand |
+|----------|----------------|------|---------|-----------|--------|
+| Vendor dashboard route | Renders the organiser dashboard through the canonical vendor console controller and theme. | Yes. Keep `myeventlane_vendor.console.dashboard` and existing access chain. | No route changes. | No. | No. |
+| `VendorDashboardViewModelBuilder` | Builds vendor payload, readiness, operational readiness, lifecycle guidance, KPIs, event rows, action queue, current event, activity items, analytics availability, and empty state. | Yes. This remains the canonical dashboard model owner. | Reduce homepage weight by changing presentation and derived compact payloads. | No. | Add only derived mission-control payloads from existing model data. |
+| Dashboard event selection logic | Uses `UserVendorMembershipQuery`, loads managed events, ranks active/published/draft/upcoming/past events, and selects `events[0]` as the current event. | Yes. | No duplicate selection logic in Twig. | No. | No. |
+| Current event hero | Presents the primary event title, status, booking state, date, attendee summary, media, and primary event action. | Yes. | Reduce large visual weight and oversized media. | No. | Clarify that this is one event focus inside a broader organiser home. |
+| Quick metrics | Uses current event `metrics` when available, otherwise decorated vendor KPIs from `MelDataPresentationManager`. | Yes. | Keep to five compact signals. | Deep analytics stay off the dashboard. | No charts or trend walls. |
+| Quick actions | Uses existing event quick actions built with route/access checks. | Yes. | Keep compact and current-event scoped. | No. | No. |
+| Action queue | `VendorActionQueueBuilder` prioritises readiness, draft events, Stripe payout setup, missing booking setup, and analytics availability using existing model data. | Yes. | Show one primary alert. | Secondary recommendations stay collapsed. | No duplicate priority scoring. |
+| Readiness panels | Existing readiness payload uses `MelReadinessHelper` and vendor/store fields. | Yes. | Keep out of initial dashboard view. | Collapsed `Review event setup`. | No new readiness system. |
+| Lifecycle panels | Existing lifecycle summary comes from `MelReadinessHelper`. | Yes. | Keep out of initial dashboard view. | Collapsed operational panels. | No new lifecycle system. |
+| Organiser overview strip | Not previously present as a compact cross-organiser row. | Yes, as a derived presentation payload. | Keep tiny, count-based, and operational. | No. | Add from existing event rows, KPI rows, readiness, and action queue only. |
+| Operational activity stream | Existing builder derived sparse event-state activity; controller also has older dashboard activity logic. | Yes. | Remove feed-like framing and keep a short list. | No fake feed or polling. | Improve wording from existing event/readiness payloads only. |
+| Upcoming events strip | Existing event rows include title, date, status, booking state, metrics, and links. | Yes. | Avoid large event cards and duplicate teaser systems. | Full roster remains collapsed. | Add compact row from existing dashboard event rows. |
+| Event summary builders | Dashboard and event index builders already compose event state, ticket sales, RSVP counts, thumbnails, route links, and removal payloads. | Yes. | Avoid adding a third event card model. | Full event management stays on events/event workspace pages. | No. |
+| Analytics summaries | Dashboard exposes availability only; `VendorAnalyticsViewModelBuilder` owns deeper analytics. | Yes. | Do not surface charts or deep metrics on homepage. | Analytics page and event analytics remain owners. | No. |
+| Attendee summaries | Dashboard event rows already expose attendee summary from ticket and RSVP counts. | Yes. | Keep single-line state. | Attendee and check-in pages own deeper readiness. | No. |
+| Booking summaries | `TicketSalesService`, `RsvpStatsService`, and event row metrics already expose lightweight booking counts. | Yes. | Keep count-only on dashboard. | Orders, RSVPs, and ticket setup stay contextual. | No. |
+| Support summaries | Dashboard has event support quick action and contextual help surfaces. | Yes. | Keep support entry points secondary. | Support page/help surfaces own support detail. | No. |
+| Payout summaries | Vendor payout page has payout summary and Stripe management URL; dashboard readiness has Stripe payout readiness. `VendorStripeService` can call Stripe and is not dashboard-safe for page-load expansion. | Keep readiness signal only. | Do not query Stripe from dashboard. | Payout detail stays on payouts/settings/Stripe surfaces. | No dashboard payout engine. |
+| Refund summaries | Refund request routes and escalation refund metrics exist, but vendor-level refund summary access is permission-gated and contextual. No canonical dashboard-safe refund summary payload was found. | Keep contextual refund routes. | Do not invent refund counts. | Event workspace refund requests and escalation refund summaries. | No dashboard refund engine. |
+| Billing/contribution surfaces | Existing contribution strip is injected into the dashboard template. | Yes. | Keep as footer micro surface. | Billing/settings/contextual side surfaces. | No. |
+| Promotional/boost surfaces | Existing boost and growth cards exist. | Yes. | Keep below operational focus. | Promote event and secondary panels. | No. |
+| Mobile layout | Existing MEL live-ops and dashboard SCSS provide responsive grids and horizontal strips. | Yes. | Avoid endless stacked cards. | Secondary intelligence remains collapsed. | Expand compact horizontal mission-control rows only. |
+
+## Audit Conclusion
+
+The dashboard already has the required operational systems: canonical view-model builder, event membership query, event state resolver, ticket and RSVP summaries, readiness helper, lifecycle helper, action queue, analytics owner, payout page, refund contextual routes, support links, and vendor shell. The refinement should therefore add only compact derived presentation payloads and Twig/SCSS hierarchy changes.
+
+No canonical dashboard-safe refund activity service was found. Refund intelligence must remain contextual unless a future owner exposes an access-safe summary payload. No Stripe or Commerce flow should be changed for this dashboard refinement.

--- a/docs/mission-control-dashboard-governance-final.md
+++ b/docs/mission-control-dashboard-governance-final.md
@@ -1,0 +1,140 @@
+# Mission Control Principles
+
+Mission Control is the organiser's operational home. It gives calm awareness, one current priority, one current event focus, lightweight multi-event visibility, sparse activity intelligence, and fast movement into contextual surfaces.
+
+Mission Control is not an analytics wall, onboarding wizard, notification centre, admin console, lifecycle dashboard, Stripe dashboard, Commerce dashboard, refund dashboard, or AI retrieval surface.
+
+# Dashboard Hierarchy Rules
+
+Canonical hierarchy:
+
+1. Priority Attention
+2. Current Event Hero
+3. Organiser Overview Strip
+4. Quick Metrics
+5. Quick Actions
+6. Operational Activity Stream
+7. Upcoming Events
+8. Expandable Operational Panels
+
+No section may outrank Priority Attention or the Current Event Hero unless product governance changes this hierarchy.
+
+# Event-First Rules
+
+- The dashboard has one primary event focus.
+- The current event is selected by `VendorDashboardViewModelBuilder`.
+- Twig must not rank events or duplicate event selection logic.
+- Current-event details may show title, date, status, booking state, attendee summary, event media, quick actions, and lightweight metrics.
+- Readiness percentages, readiness walls, analytics graphs, and lifecycle walls must not return to the hero.
+
+# Multi-Event Awareness Rules
+
+- Multi-event awareness is compact and operational.
+- The organiser overview strip may show live events, draft events, upcoming events, bookings, priority items, and payout readiness when sourced from existing payloads.
+- Multi-event awareness must not become a large event grid, analytics dashboard, or alert centre.
+- The dashboard must not invent refund, payout, booking, attendee, or event query systems.
+
+# Operational Stream Rules
+
+- Operational stream items are sparse and meaningful.
+- Items may be derived from existing event summary payloads, readiness state, and existing dashboard-safe activity payloads.
+- The stream must remain short and homepage-safe.
+- No real-time polling, infinite timelines, social-feed framing, or notification spam.
+
+# Activity Feed Rules
+
+- If a canonical activity service exists, use it.
+- If no canonical activity service exists, reuse event summary payloads.
+- Do not invent fake activity systems.
+- Do not expose private support, staff, refund, payout, or AI detail in dashboard activity.
+
+# Upcoming Event Rules
+
+- Upcoming events use the existing dashboard event row payload.
+- Cards remain compact and horizontally scannable.
+- Each card may show title, date, status, lightweight state chips, metric label, and an existing event link.
+- Do not duplicate event teaser systems or create heavy grids.
+
+# Progressive Disclosure Rules
+
+- Readiness, operational readiness, lifecycle guidance, secondary action queue items, promotion guidance, event roster detail, billing nudges, contribution prompts, and boost surfaces stay secondary.
+- Use existing details/accordion systems and MEL live-ops styles.
+- Deep intelligence belongs in contextual surfaces.
+
+# Mobile Mission Control Rules
+
+Mobile starts with the operational minimum: priority alert, current event, organiser overview, quick actions, and activity stream. Secondary sections must be collapsed, compact, or horizontally scrollable.
+
+Do not stack giant cards into a long-scroll dashboard.
+
+# Visual Hierarchy Rules
+
+- Use white surfaces, subtle borders, and restrained pastel accents.
+- Pastels indicate action, alert, or active state.
+- Avoid oversized pastel blocks, competing containers, oversized cards, and giant whitespace gaps.
+- Density should improve awareness without reviving dashboard fatigue.
+
+# Contextual Intelligence Boundaries
+
+- Event editor owns publishing guidance, visibility guidance, and ticket setup guidance.
+- Attendees owns check-in readiness, attendee momentum, and door guidance.
+- Promote event owns discovery guidance, banner suggestions, and momentum guidance.
+- Analytics owns deep metrics, graphs, and trend analysis.
+- Payouts/settings/Stripe surfaces own payout detail.
+- Event workspace refund requests and escalation refund summaries own refund detail.
+- Dashboard owns operational awareness only.
+
+# What Must Never Return To Dashboard
+
+- Readiness percentages or readiness score walls.
+- Giant lifecycle dashboards.
+- Large analytics panels, charts, graphs, or trend analysis.
+- Fake activity feeds.
+- Notification spam.
+- New onboarding systems.
+- New activity engines.
+- New refund or payout engines.
+- Stripe, Commerce, AI, support, or access rewrites.
+
+# What Was Consolidated
+
+- The dashboard now keeps one primary action from `VendorActionQueueBuilder`.
+- Multi-event awareness is consolidated into a compact organiser overview strip.
+- Operational activity is consolidated into a short stream sourced from existing event/readiness payloads.
+- Upcoming event awareness is consolidated into a compact row instead of a heavy roster.
+- The current event hero was visually tightened while retaining current-event clarity.
+
+# What Became Contextual
+
+- Readiness detail remains collapsed in operational panels.
+- Lifecycle guidance remains collapsed.
+- Event roster detail remains secondary.
+- Promotion and boost guidance remain secondary or contextual.
+- Billing and contribution prompts remain footer micro surfaces.
+- Refund detail remains on event workspace refund surfaces.
+- Payout detail remains on payout/settings/Stripe surfaces.
+- Deep analytics remain on analytics surfaces.
+
+# Canonical Dashboard Owner
+
+The canonical dashboard owner remains `myeventlane_vendor.console.dashboard`, `VendorDashboardViewModelBuilder`, and `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`.
+
+# Operational Awareness Boundaries
+
+Mission Control may answer:
+
+- What needs attention now?
+- Which event is the current focus?
+- What is happening across my organiser workspace?
+- What lightweight activity changed recently?
+- Where should I go next?
+
+Mission Control must not answer deep analytics, refund investigation, payout reconciliation, staff support, AI retrieval, Commerce accounting, or Stripe account-management questions.
+
+# Future Mission Control Governance
+
+- Extend the canonical view model rather than adding dashboard builders.
+- Reuse existing summaries and access-checked links.
+- Add dashboard sections only when they fit the canonical hierarchy.
+- Keep access enforcement server-side.
+- Keep dashboard presentation Drupal 11 compliant, cache-safe, translation-safe, mobile-safe, accessible, onboarding-safe, AI-safe, trust-safe, and support-safe.

--- a/docs/mission-control-dashboard-governance.md
+++ b/docs/mission-control-dashboard-governance.md
@@ -1,0 +1,109 @@
+# Mission Control Dashboard Governance
+
+The organiser dashboard is Mission Control: a calm operational home that keeps one event in focus while showing lightweight awareness across the organiser's event set.
+
+It is not an analytics wall, onboarding wizard, admin console, lifecycle dashboard, Stripe console, Commerce console, refund console, or AI surface.
+
+# Canonical Dashboard Hierarchy
+
+1. Priority Attention
+2. Current Event Hero
+3. Organiser Overview Strip
+4. Quick Metrics
+5. Quick Actions
+6. Operational Activity Stream
+7. Upcoming Events
+8. Expandable Operational Panels
+
+# Dashboard Rules
+
+- Keep one primary event focus.
+- Keep multi-event awareness lightweight and compact.
+- Use `VendorDashboardViewModelBuilder` as the canonical model owner.
+- Use `VendorActionQueueBuilder` for priority attention.
+- Use `MelReadinessHelper` for readiness and lifecycle language.
+- Use `EventStateResolver`, `TicketSalesService`, `RsvpStatsService`, and existing event row payloads for event state, booking, RSVP, attendee, and capacity signals.
+- Keep deep analytics off the dashboard homepage.
+- Keep lifecycle and readiness intelligence collapsed.
+
+# Priority Attention
+
+Priority attention shows one item only. It must come from the existing action queue and must not rebuild scoring in Twig.
+
+Secondary action queue items belong inside expandable operational panels.
+
+# Current Event Hero
+
+The hero shows the primary event selected by existing dashboard event ranking. It may show title, date, status, booking state, attendee state, image, and event-level actions.
+
+It must not show readiness percentages, readiness rings, giant setup walls, analytics graphs, or a full event roster.
+
+# Organiser Overview Strip
+
+The organiser overview strip provides compact cross-organiser awareness. It may include live events, draft events, upcoming events, bookings, priority items, and payout readiness when those values are available from existing dashboard payloads.
+
+It must remain:
+
+- Compact.
+- Count-based or short state-based.
+- Operational.
+- Glanceable.
+- Derived from existing model data.
+
+It must not introduce new event queries, refund engines, payout engines, charts, trend graphs, or analytics cards.
+
+# Quick Metrics
+
+Quick metrics are lightweight dashboard signals. Prefer current-event metrics when a focus event exists; otherwise use existing decorated vendor KPIs.
+
+Graphs, trend analysis, cohort analysis, and deep revenue intelligence belong on analytics surfaces.
+
+# Quick Actions
+
+Quick actions stay scoped to the current event. They must continue to use existing route/access-safe URLs from the dashboard model.
+
+# Operational Activity Stream
+
+The activity stream is sparse operational intelligence sourced from existing event summary payloads and readiness state. It is not a social feed, notification centre, infinite timeline, polling surface, or alert system.
+
+If no canonical activity service exists, the dashboard may derive short messages from existing event summaries only.
+
+# Upcoming Events
+
+Upcoming events are shown as a compact row. Each item may include title, date, status, booking state, lightweight metrics, and an event link from the existing event row.
+
+The row must not duplicate event teaser systems, use large cards, or expose analytics.
+
+# Expandable Operational Panels
+
+Readiness details, operational readiness, lifecycle guidance, secondary actions, event roster, promotion guidance, contribution prompts, billing nudges, and boost surfaces must stay secondary.
+
+Use existing details/accordion patterns and MEL live-ops styling.
+
+# Contextual Intelligence Boundaries
+
+- Event editor owns publishing guidance, visibility guidance, and ticket setup guidance.
+- Attendees owns check-in readiness, attendee momentum, and door guidance.
+- Promote event owns discovery guidance, banner suggestions, and momentum guidance.
+- Analytics owns deep metrics, graphs, and trend analysis.
+- Payouts/settings/Stripe surfaces own payout detail.
+- Event workspace refund requests and escalation refund summaries own refund detail.
+- Dashboard owns operational awareness only.
+
+# Mobile Mission Control
+
+On mobile, the initial dashboard should show:
+
+1. Priority alert
+2. Current event
+3. Organiser overview strip
+4. Quick actions
+5. Activity stream
+
+Everything else should be collapsed, compact, or horizontally scrollable. Do not stack large cards into long-scroll fatigue.
+
+# Visual Hierarchy
+
+Use white surfaces, subtle borders, restrained pastel accents, and compact rhythm. Pastels should indicate action, alert, or active state, not every large container.
+
+Avoid oversized pastel blocks, competing card containers, oversized event cards, and giant whitespace gaps.

--- a/docs/operational-readiness-audit.md
+++ b/docs/operational-readiness-audit.md
@@ -1,0 +1,40 @@
+# Operational Readiness Audit
+
+This audit records the existing readiness systems inspected before adding the lightweight operational readiness intelligence layer. The implementation reuses these sources and keeps business rules in their existing owners.
+
+| Surface | Existing Readiness Logic | Reusable? | Gap |
+|----------|--------------------------|------------|-----|
+| `MelReadinessHelper` | Canonical vendor/customer readiness copy, action queue strings, dashboard empty strings, checkout trust lines, intelligence copy, attendee operations empty-state slots. | Yes | Needed a presentation-only operational summary builder so dashboard/workspace copy does not drift. |
+| Organiser dashboard cards | `VendorDashboardViewModelBuilder` builds vendor profile, public profile, Stripe readiness, KPI cards, event rows, analytics availability, and action queue input. | Yes | Existing readiness was account setup focused; it did not summarize publishing, attendees, payouts, and promotion together. |
+| Dashboard attention panels | `VendorActionQueueBuilder` prioritizes missing vendor profile, profile completion, missing booking setup, Stripe/payout readiness, no events, drafts, and analytics unavailability. | Yes | No change required; the new summary sits beside this queue and does not duplicate priority logic. |
+| Event workspace | `VendorEventWorkspaceViewModelBuilder` derives event type from `EventStateResolver`, publication status, metrics, readiness items, next action, and presentation alerts. | Yes | Workspace needed a plain-language attendee-visible/public-visibility summary without recalculating state. |
+| Event Studio readiness surfaces | `EventStudioForm` uses `VendorPublishRequirementsGate::getReadinessFlags()` to show terms/profile/Stripe publish readiness and existing JS/cards for publish readiness. | Yes | Publish-readiness copy was inline; it now flows through `MelReadinessHelper`. |
+| Publishing gates | `VendorPublishRequirementsGate` blocks publishing for terms/profile/Stripe setup; `PaidPublishStripeGate` blocks paid publishing when Stripe charge readiness is missing. | Yes | No gap in enforcement; new guidance remains explanatory only. |
+| Stripe readiness checks | Dashboard reads vendor-linked store fields; `PaidPublishStripeGate` validates account id and charges readiness with logging. | Yes | No Stripe logic changes; payout guidance only references existing readiness. |
+| Ticket readiness checks | `EventStateResolver`, `VendorEventPresentationAlertsBuilder`, `TicketAvailabilityService`, `TicketTypeManager`, and `BookingFlowResolver` provide event type, mapping, product, and price display checks. | Yes | Summary needed to point organisers to the existing ticket setup status without adding Twig logic. |
+| RSVP readiness checks | `EventStateResolver` exposes RSVP state; dashboard/workspace event type labels distinguish RSVP, paid, both, and unknown. | Yes | No new RSVP checks required. |
+| Analytics cards | Dashboard KPI strip and analytics availability already use metrics and route access checks. | Yes | Summary can mention activity/readiness without querying analytics separately. |
+| Check-in screens | `MelVenueOperationsViewModelBuilder` composes `MelAttendeeCheckinManager`, `MelAttendeeOperationsPresenter`, attendance rows, metrics, and governed empty states. | Yes | Empty row copy needed calmer readiness guidance from helper. |
+| Payouts screens | Vendor dashboard and action queue already surface Stripe/payout readiness; Stripe/Connect routes remain access checked. | Yes | No payout flow changes. |
+| Attendee screens | `MelAttendeeOperationsPresenter` is the canonical attendee operational view model and uses governed helper slots supplied by callers. | Yes | Existing empty states were reusable; check-in screen now references helper copy. |
+| Event overview screens | Workspace and dashboard event rows expose status, type, metrics, and presentation issues. | Yes | New workspace summary provides attendee-visible meaning for those existing values. |
+| Contextual help mappings | Help Assistant and Help Centre services exist separately, with retrieval and block/template surfaces. | Yes | No retrieval or prompt widening was needed. |
+| Event workspace surfaces | Existing vendor theme workspace shell, live-ops cards, tabs, shortcuts, and metrics are reusable. | Yes | Added summary card using existing MEL live-ops classes. |
+
+## Audited Files
+
+- `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorPublishRequirementsGate.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/VendorEventPresentationAlertsBuilder.php`
+- `web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php`
+- `web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsPresenter.php`
+- `web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php`
+- `web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorEventOperationsController.php`
+- `web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig`
+- `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`
+- `web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig`
+- `web/modules/custom/myeventlane_help_assistant/src/Service/HelpRetriever.php`

--- a/docs/operational-readiness-governance.md
+++ b/docs/operational-readiness-governance.md
@@ -1,0 +1,55 @@
+# Operational Readiness Governance
+
+The operational readiness model is presentation-only. It explains existing readiness, publishing, payout, attendee, and discovery signals without introducing new databases, entity types, workflow states, notification systems, or duplicated business logic.
+
+## Canonical Categories
+
+1. Event Setup
+   - Reuses `EventStateResolver`, workspace readiness items, Event Studio fields, and existing dashboard event rows.
+   - Must not create alternate event completion scores outside `MelReadinessHelper` presentation summaries.
+
+2. Tickets & RSVP
+   - Reuses `EventStateResolver`, `BookingFlowResolver`, `TicketTypeManager`, `TicketAvailabilityService`, RSVP state, and vendor presentation alerts.
+   - Must not calculate ticket purchasability in Twig.
+
+3. Payments & Payouts
+   - Reuses vendor store Stripe fields, `VendorPublishRequirementsGate`, `PaidPublishStripeGate`, and existing Stripe Connect routes.
+   - Must not change Connect account type, charge model, payout rules, or Commerce checkout flow.
+
+4. Publishing
+   - Reuses node publication status, moderation-state checks already present, Event Studio save/publish handling, and publishing gates.
+   - Must not add new moderation states or block publishing beyond existing gates.
+
+5. Attendee Experience
+   - Reuses public event visibility, booking mode, checkout trust copy, attendee operations presenter, and existing empty-state slots.
+   - Must not expose attendee PII outside existing access-controlled views.
+
+6. Day-of-Event Readiness
+   - Reuses `MelAttendeeCheckinManager`, `MelVenueOperationsViewModelBuilder`, and attendee operation rows.
+   - Must not duplicate check-in eligibility logic or bypass check-in access.
+
+7. Support & Trust
+   - Reuses Help Centre, support links, checkout trust copy, refund messaging, and governed empty states.
+   - Must not expose internal SLA, escalation, moderation, or staff-only data.
+
+8. Promotion & Discovery
+   - Reuses existing event image/category/promoted-field surfaces, boost/promote surfaces, analytics summaries, and discovery systems.
+   - Must use calm, non-manipulative copy.
+
+## Canonical Owner
+
+`MelReadinessHelper` owns readiness presentation copy and reusable summary payloads. Enforcement remains with the existing services that already own the rule:
+
+- Publishing: `VendorPublishRequirementsGate`, Event Studio save services, node publication.
+- Paid publishing: `PaidPublishStripeGate`.
+- Ticket integrity: `VendorEventPresentationAlertsBuilder`, Commerce/ticket services.
+- Check-in: `MelAttendeeCheckinManager` and attendee operations services.
+- Access: route access, vendor console controllers, ownership guards, and existing access managers.
+
+## Rules
+
+- Keep readiness summaries cache-safe and derived from data already loaded for the surface where possible.
+- Keep Twig presentation-only: no business rules, field probing, route hardcoding, or duplicate readiness checks.
+- Keep copy translation-safe through PHP helpers or Twig `|t` fallbacks.
+- Use existing MEL live-ops cards, chips, panels, and spacing.
+- Do not widen Help Assistant retrieval or AI prompts for operational readiness.

--- a/docs/operational-readiness-intelligence-governance.md
+++ b/docs/operational-readiness-intelligence-governance.md
@@ -1,0 +1,67 @@
+# Readiness Principles
+
+Operational readiness intelligence explains existing system state in calm organiser language. It is not an onboarding engine, dashboard rewrite, notification system, AI overlay, workflow state, or payment/Commerce change.
+
+# Readiness Categories
+
+The canonical categories are Event Setup, Tickets & RSVP, Payments & Payouts, Publishing, Attendee Experience, Day-of-Event Readiness, Support & Trust, and Promotion & Discovery. Each category must reuse existing signals and checks.
+
+# Dashboard Guidance Standards
+
+Dashboard guidance must show what is ready, incomplete, and useful next without alarmist language. It must reuse `VendorDashboardViewModelBuilder`, `VendorActionQueueBuilder`, `MelReadinessHelper`, and existing MEL card classes.
+
+# Publishing Guidance Standards
+
+Publishing guidance must explain visibility and missing setup without adding new blocks. Enforcement stays in `VendorPublishRequirementsGate`, `PaidPublishStripeGate`, and Event Studio save/publish logic.
+
+# Payout Guidance Standards
+
+Payout copy may say that Stripe needs to be connected for paid tickets. It must not expose account internals, verification details beyond existing product language, or alter Stripe/Connect state.
+
+# Event Visibility Standards
+
+Draft events are described as not public. Published events are described as visible to attendees. Moderation and review wording must stay external and non-diagnostic.
+
+# Attendee Readiness Standards
+
+Attendee guidance must explain that ticket holders, RSVPs, and check-ins appear after bookings begin. Row loading, filtering, attendee states, and check-in eligibility remain in attendee operations services.
+
+# Day-of-Event Standards
+
+Day-of-event guidance must reuse check-in surfaces and explain validation calmly. It must not create new scanner routes, duplicate check-in logic, or bypass event ownership checks.
+
+# Promotion Guidance Standards
+
+Promotion guidance may mention banner images, sharing event links, promoted placement, and discovery fit. It must avoid urgency, scarcity pressure, or growth-hack language.
+
+# Accessibility Standards
+
+Cards must keep semantic headings, readable concise copy, non-colour status indicators, and existing MEL responsive classes. New guidance should stack inside existing live-ops panels on mobile.
+
+# AI Alignment Rules
+
+Operational readiness copy may align with Help Centre language, but it must not widen AI retrieval, expose internal readiness internals to AI, or add organiser AI prompts unless separately approved.
+
+# What Must Never Be Exposed
+
+Never expose staff-only diagnostics, internal SLAs, escalation levels, moderation internals, private Stripe/Connect identifiers, raw webhook data, hidden Commerce internals, attendee PII outside existing access-controlled surfaces, or vendor data across ownership boundaries.
+
+# Future Readiness Governance
+
+Future readiness work must add presentation copy or summary payloads through `MelReadinessHelper` and reuse existing enforcement services. If a new product rule is needed, it belongs in the owning domain service first, then readiness presentation can explain it.
+
+## Reused Systems
+
+- `MelReadinessHelper` for canonical readiness and guidance copy.
+- Organiser dashboard view model and action queue.
+- Event workspace view model and live-ops panels.
+- Event Studio publish readiness flags.
+- Stripe and paid publishing gates.
+- Ticket and RSVP state services.
+- Attendee operations and check-in services.
+- Existing MEL card, chip, and shell classes.
+- Existing Help Centre and Help Assistant architecture without retrieval changes.
+
+## Canonical Logic Location
+
+Readiness presentation lives in `MelReadinessHelper`. Business logic remains in the existing service that owns the rule. Twig renders supplied payloads only.

--- a/docs/product-language-governance.md
+++ b/docs/product-language-governance.md
@@ -1,0 +1,155 @@
+# Product language governance — MyEventLane
+
+This document defines **canonical customer- and organiser-facing language** after the harmonisation pass, what **must stay legacy internally**, and **rules for future copy**.
+
+---
+
+## Canonical product language
+
+| Legacy (public copy) | Canonical (public copy) |
+|----------------------|-------------------------|
+| Vendor (user-facing) | Organiser |
+| Vendor Dashboard | Organiser Dashboard |
+| Vendor Settings | Organiser Settings |
+| Event Workspace | Event Manager |
+| Studio (product UX) | Event Editor |
+| Escalation (customer/organiser UX) | Support / Support request |
+| Boost Event / Boost (promotional UX) | Promote event |
+
+---
+
+## Customer terminology
+
+- **Discover** — browsing events (`/events` from the account hub; storefront discovery may use other entry points).
+- **Tickets** — purchased or assigned tickets (`My Tickets` retired in hub labels).
+- **Saved events**, **Categories**, **Organisers** — saved discovery preferences.
+- **Support** — human help; individual items are **support requests**, not “escalations”.
+- **Notifications**, **Settings** — unchanged concepts; labels kept concise.
+
+Single source for hub navigation order and labels: `AccountLinksService::buildNavigationItems()`.
+
+---
+
+## Organiser terminology
+
+- **Organiser dashboard**, **Organiser settings** — console chrome.
+- **Event Manager** — per-event workspace shell (`event_workspace` route title).
+- **Event Editor** — studio / editor experience (`/vendor/studio`, event editor routes, Events submenu).
+- **Ticket holders** — replaces “Attendees” in console navigation for consistency with ticketing (RSVP-specific screens may still say RSVP).
+- **Check-in** — ticket check-in tool; surfaced when event context + access permit.
+- **Promote event** — paid visibility/boost flows.
+- **Messaging** — organiser messaging brand settings entry.
+- **Support** — `/vendor/support` escalation portal (presentation name only).
+
+Single source for console sidebar structure: `_myeventlane_vendor_theme_build_full_vendor_shell_nav_items()` in `myeventlane_vendor_theme.theme`.
+
+---
+
+## Staff / internal terminology
+
+Staff tools, Drupal admin, analytics, and risk systems **may continue to say**:
+
+- **Vendor** (entity, Connect, ownership)
+- **Escalation** (case workflow, SLA, breach language)
+- **Boost** (internal product/module naming)
+
+Do **not** reuse internal abbreviations or machine names in customer-facing sentences.
+
+---
+
+## Navigation hierarchy
+
+### Customer hub (sidebar)
+
+Discover → Tickets → Saved events → Categories → Organisers → Support → Notifications → Settings  
+
+### Organiser console (sidebar)
+
+Dashboard → Events → Event Editor → Orders → Ticket holders → Check-in → Payouts → Promote event → Messaging → Analytics → Support → Organiser settings  
+
+(Event-scoped items may appear disabled until an event context exists on the route.)
+
+---
+
+## CTA standards
+
+- **One primary action** per region; verb-first (“Submit support request”, “New support request”).
+- Avoid fear-based wording; prefer **clear next steps** (“When you contact us, your conversations will appear here”).
+- Promotional actions use **Promote event**, not “Boost Event”, in organiser-facing UI.
+
+---
+
+## Empty state standards
+
+- Replace Drupal-default **“No results”** / **“No content”** with short, **action-oriented** guidance when touching a surface.
+- Do not remove operational meaning (e.g. permission or filtering context).
+- No marketing fluff; maintain **screen reader clarity**.
+
+---
+
+## Breadcrumb standards
+
+- Breadcrumb text should match **route `_title`** and **shell headings** where breadcrumbs are derived from titles.
+- Avoid exposing internal route machine names or admin paths in labels.
+
+---
+
+## AI language standards
+
+- Customer and organiser assistants should say **organiser**, **ticket holder** (where relevant), **support request**, **Event Editor**, **Promote event**.
+- Prompt templates (`config/sync/myeventlane_ai.prompt.*`) may be updated for **wording only**; do not widen retrieval scope or remove grounding rules.
+- Staff-only prompts retain operational vocabulary (**escalation**, **vendor**) when accuracy depends on it.
+
+---
+
+## Help Centre language standards
+
+- Public Help articles may keep **Attendee** sections as-is unless editorially consolidated.
+- Do not expose staff playbooks or internal escalation mechanics in customer help.
+
+---
+
+## Support terminology rules
+
+| Context | Term |
+|---------|------|
+| Customer organiser-facing UI | Support, Support request |
+| Staff / PCC / SLA tooling | Escalation (allowed) |
+| URLs | Unchanged (`/my/support/escalations/*`, `/vendor/support/*`) |
+
+---
+
+## Future copy governance rules
+
+1. **No mass search/replace** — change strings where the surface is owned (service, route title, template).
+2. **Do not rename** modules, services, routes, permissions, or entities for copy reasons alone.
+3. **Preserve access checks** — navigation is presentation; routing and `_custom_access` stay authoritative.
+4. **Translation-safe** — user-visible strings use `t()` / `TranslatableMarkup`.
+5. **Document drift** — when adding a new hub link, update `AccountLinksService` or vendor shell builder first, then menus/templates.
+
+---
+
+## What changed in this pass (summary)
+
+- Customer hub IA order + labels (`AccountLinksService`, account headings).
+- Organiser shell nav order, labels, and active-section mapping (`myeventlane_vendor_theme.theme`).
+- Route `_title` harmonisation for key console and support routes (`myeventlane_vendor.routing.yml`, `myeventlane_escalations_portal.routing.yml`).
+- Support portal presentation strings (controllers + customer form).
+- Help Assistant fallback + suggestion labels; organiser AI prompt config; boost confirmation email footer line.
+- Minor storefront/mobile/chrome Twig (`radix` header, PCC utility bar, vendor sidebar aria).
+
+---
+
+## What intentionally remains legacy
+
+- Machine names: `myeventlane_vendor`, `escalation`, `vendor_*` permissions, `/vendor` paths.
+- Admin Views and entity field labels using “Vendor” or “Attendee” where editor-facing or historical.
+- Internal logs and access denial reason strings aimed at developers.
+
+---
+
+## What must never be exposed publicly
+
+- Staff playbook content, internal SLA breach messaging, raw escalation levels on customer pages.
+- Internal route names or module paths in user-visible headings or AI replies.
+- Unsanctioned PII in support or assistant copy.

--- a/docs/product-language-inventory.md
+++ b/docs/product-language-inventory.md
@@ -1,0 +1,105 @@
+# Product language inventory
+
+This document supports the **product language + navigation harmonisation** pass (branch `feature/product-language-harmonisation`). It records **where terminology surfaces**, **who sees it**, and **what was harmonised** versus **intentionally unchanged internals**.
+
+## Method
+
+Sources inspected (non-exhaustive scan plus targeted edits):
+
+- `web/modules/custom/**/*.routing.yml` — `_title` / `title` where customer or organiser-facing
+- `web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php` — customer hub sidebar / dropdown source of truth
+- `web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme` — organiser console shell navigation
+- `web/themes/custom/myeventlane_vendor_theme/templates/**/*.twig` — shell chrome, studio CTAs
+- `web/themes/custom/myeventlane_theme/myeventlane_theme.theme` — main menu preprocess copy
+- `web/themes/custom/myeventlane_radix/templates/includes/header.html.twig` — mobile discovery labels
+- `web/modules/custom/myeventlane_escalations_portal/**` — customer + organiser support UI
+- `web/modules/custom/myeventlane_help_assistant/**` — assistant fallback + suggestion labels
+- `config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml` — organiser AI prompt wording
+- `config/sync/myeventlane_messaging.template.boost_confirmation.yml` — transactional email copy
+
+## Classification key
+
+| Column | Meaning |
+|--------|---------|
+| **Surface** | Where the string appears |
+| **Audience** | customer · organiser · staff · mixed |
+| **Canonical?** | Whether this string follows post-harmonisation product language |
+| **Replace?** | Whether we changed visible copy in this pass |
+
+## Sample inventory table
+
+Representative rows (not every translated string in the codebase):
+
+| String | Surface | Audience | Canonical? | Replace? |
+|--------|---------|----------|-------------|----------|
+| Organiser dashboard | Route `_title`, sidebar aria-label | organiser | Yes | Yes (was “Vendor dashboard”) |
+| Event Manager | Route `_title` `event_workspace` | organiser | Yes | Yes (was “Event workspace”) |
+| Event Editor | Route `_title` studio routes; shell nav; Events submenu | organiser | Yes | Yes (submenu was “Event builder”) |
+| Promote event | Boost shell `_title`, nav label, studio CTA, suggestions | organiser | Yes | Yes (was “Boost” / “Boost Event”) |
+| Ticket holders | Vendor shell nav | organiser | Yes | Yes (was “Attendees”) |
+| Check-in | Vendor shell nav (event-scoped) | organiser | Yes | Yes (new IA slot; disabled without event context) |
+| Support | Customer + organiser support routes `_title` | customer, organiser | Yes | Yes (was “My Support” / “Vendor Support”) |
+| Support request(s) | Escalation portal UI, forms, status messages | customer, organiser | Yes | Yes (was “escalation” phrasing) |
+| Discover | Customer hub nav (`AccountLinksService`) | customer | Yes | Yes (new; links to `/events`) |
+| Tickets | Customer hub nav label | customer | Yes | Yes (was “My Tickets”) |
+| Organisers | Customer hub nav (`Followed organisers` shortened); radix mobile label | customer | Yes | Yes |
+| Vendor | Entity machine labels, permissions, admin config | staff / system | N/A (internal) | **No** — entity/API names unchanged |
+| Escalation | Route names, entity types, staff modules, access reasons | staff / system | N/A (internal) | **No** — presentation only elsewhere |
+| Attendee | Help Centre views (`mel_help_attendee_help`), paragraph types | mixed | Partial | **No** per brief — Help retains “attendee” where scoped |
+| Boost | Module IDs, config keys, commerce internals | system | N/A | **No** — product-facing labels harmonised only |
+
+## Customer navigation (canonical order)
+
+Implemented via **`AccountLinksService::buildNavigationItems()`** definition order for sidebar-visible items:
+
+1. Discover  
+2. Tickets  
+3. Saved events  
+4. Categories  
+5. Organisers  
+6. Support  
+7. Notifications  
+8. Settings  
+
+Dashboard remains in the service for route matching / dashboard context but **`show_in_sidebar` is FALSE** so the hub sidebar matches the IA above. Log out is **`show_in_sidebar` FALSE**.
+
+## Organiser navigation (canonical order)
+
+Implemented via **`_myeventlane_vendor_theme_build_full_vendor_shell_nav_items()`**:
+
+1. Dashboard  
+2. Events (submenu: **Event Editor** when an event context exists)  
+3. Event Editor (global `/vendor/studio`)  
+4. Orders (enabled when an event context exists on the route match)  
+5. Ticket holders  
+6. Check-in (enabled when an event context exists and access allows)  
+7. Payouts  
+8. Promote event  
+9. Messaging  
+10. Analytics  
+11. Support (`/vendor/support`)  
+12. Organiser settings  
+
+**Refund requests** remain **event-scoped** and append when the refunds module and permissions allow (same behaviour as before; not in the 12-item headline list).
+
+**Audience** and **Notifications** were removed from the organiser **sidebar** list in favour of the canonical IA; notifications remain available via the existing header bell pattern.
+
+## Empty states touched
+
+| Location | Before | After |
+|----------|--------|-------|
+| Customer support list (`CustomerEscalationController`) | “You have no support escalations yet.” | Calm, actionable empty copy referencing future conversations |
+
+Further empty-state harmonisation (Views, generic Drupal tables) is **out of scope** for this single pass unless product assigns priority surfaces.
+
+## Residual legacy language (intentional)
+
+- Paths such as `/vendors`, `/vendor/*`, route names (`myeventlane_vendor.*`), permissions (`view vendor escalations`), entity type `myeventlane_vendor`
+- Staff/admin Views and PCC labels that reference operational terms (“Vendor orders”, admin queues)
+- Help Centre installs that retain **Attendee** audience naming per brief
+
+## Follow-up candidates (not done here)
+
+- Broad sweep of Twig templates for “No results found” / Drupal-default empties  
+- Main navigation YAML (`system.menu.*`) if menu content overrides storefront labels independently of preprocess  
+- RSVP-specific routes still titled “RSVP Check-In” — evaluate alignment with “Check-in” for ticketed paths only  

--- a/docs/ux-trust-guidance-audit.md
+++ b/docs/ux-trust-guidance-audit.md
@@ -1,0 +1,184 @@
+# UX Trust + Guidance Audit — MyEventLane
+
+**Branch:** `feature/ux-trust-guidance-harmonisation`  
+**Builds on:**
+- `docs/platform-governance-audit.md`
+- `docs/platform-canonical-surface-map.md`
+- `docs/product-language-governance.md`
+- `docs/product-language-inventory.md`
+
+**Method:** Direct inspection of customer- and organiser-facing controllers, forms, Twig templates, Views YAML, AI prompt config, and transactional email templates. No assumptions about routes, permissions, services, or schemas were made — only presentation strings were considered for change.
+
+**Goal:** Identify presentation/copy improvements that increase trust and reduce support burden, **without** logic, route, access, payment, AI grounding, or staff isolation changes.
+
+---
+
+## Scope summary
+
+| Area | Real surfaces inspected |
+|------|------------------------|
+| Booking, cart, checkout, RSVP, receipts | `myeventlane_commerce`, `myeventlane_checkout_flow`, `myeventlane_checkout_paragraph`, `myeventlane_rsvp`, `myeventlane_core/MelReadinessHelper`, theme `commerce/*`, transactional email config |
+| Organiser onboarding, Stripe, publishing, attendees, check-in | `myeventlane_vendor`, `myeventlane_vendor_settings`, `myeventlane_vendor_theme`, `myeventlane_event_studio`, `myeventlane_event`, `myeventlane_event_attendees`, `myeventlane_boost`, `myeventlane_tickets` |
+| Support and Help | `myeventlane_escalations_portal`, `myeventlane_help_assistant`, `myeventlane_help_centre` (presentation only), `config/sync/myeventlane_ai.prompt.help_centre_answer_v1.yml`, `config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml` |
+| Empty states (Views + Twig) | `config/sync/views.view.*.yml` (customer + organiser), theme empty markup |
+
+Anything explicitly **staff-only** (PCC, Drupal admin, escalation operations, staff prompts) is out of scope and listed in the **DO NOT TOUCH** section at the bottom.
+
+---
+
+## Section A — Booking, RSVP, checkout, receipts
+
+| Surface | Existing guidance (verbatim or near-verbatim) | Risk | Improvement (presentation only) |
+|---------|-----------------------------------------------|------|--------------------------------|
+| Sold-out alert (`web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php`) | "This event is sold out." | Abrupt; no next step. | Calmer single sentence with clear next step (e.g. join the waitlist from the event page if available). |
+| Empty inventory same form | "No tickets available for this event." | Cold; ambiguous between sold out and not yet on sale. | "There are no tickets to buy here right now." with optional contextual hint. |
+| Access code description same form | "If you have an organiser code, enter it here to reveal hidden or invite-only tickets for this browser session." | "Browser session" is technical. | Plainer wording; mention how the code is remembered without exposing storage detail. |
+| Form load error in `myeventlane-event-book.html.twig` | "We couldn't load the booking form. Please refresh the page." | OK but no support fallback. | Add fallback: "If it keeps happening, contact Support." |
+| Buyer details email field description (`myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/BuyerDetailsPane.php`) | "We'll send your order confirmation and tickets to this address." | OK; can be tightened. | "We'll email your order confirmation and tickets here." |
+| Express checkout block intro (`myeventlane_checkout_flow.module`) | "Use Stripe Link, Apple Pay, or Google Pay when available for this device." | "This device" is technical. | "Pay faster with Apple Pay, Google Pay, or Link when your browser offers them." |
+| Express checkout unavailable copy | "Fast checkout isn't available for this event because additional attendee details are required." | Uses "attendee" (legacy in customer voice). | "Express checkout isn't available — this event needs a few details for each ticket first." (uses "ticket holder" / neutral voice per governance doc.) |
+| Ticket holder paragraph pane intro (`myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php`) | "Attendee questions" + "Add per-ticket details and answer organiser questions before continuing." | Mixes "attendee" (customer-facing) with canonical "ticket holder" used elsewhere in the same flow. | "Questions from the organiser" + "Answer these for each ticket before you pay." |
+| Ticket holder pane SR status | "This ticket holder entry is incomplete. Required fields or organiser questions still need answers." | Long for screen readers. | "Incomplete — required fields or organiser questions are missing." |
+| Readiness checkout warning (`myeventlane_core/src/MelReadinessHelper.php`) | "Attendee details are required before payment." | Terminology drift; canonical is "ticket holder". | "Ticket holder details are required before payment." |
+| Readiness Step 2 intro | Mixes "ticket holders" eyebrow with "Add each attendee once..." body. | Same drift in one block. | Use "ticket holder" consistently. |
+| Cart empty slot copy | "Your cart is empty" + paragraph about items being queued and "may clear if pricing or timing changes". | Honest but worry-inducing in the most common state (just empty). | Calmer: "Your cart is empty" + "Pick an event and add tickets when you're ready." |
+| Payment-unavailable slots | "Payments are paused right now" / "trusted payment route" | Slightly dramatic. | "Checkout is temporarily unavailable" + "Your card has not been charged." |
+| RSVP cancel confirm form (`myeventlane_rsvp/src/Form/RsvpCancelConfirmForm.php`) | "Are you sure you want to cancel this RSVP?" / "Your RSVP has been cancelled." | **Untranslated** (no `t()`); abrupt. | Wrap in `t()`; soften and offer recovery: "Cancel your RSVP for this event?" / "Your RSVP has been cancelled. You can RSVP again from the event page if spots are still available." |
+| Order receipt email subject (`config/sync/myeventlane_messaging.template.order_receipt.yml`) | H1: "🎉 Thank you for your order!" | Emoji in financial document; mismatched gravity. | Plain "Thank you for your order." |
+| Order receipt CTA | "View My Tickets" | Title-case inconsistency vs other emails. | "View your tickets" |
+| Refund failed buyer email (`config/sync/myeventlane_messaging.template.refund_failed_buyer.yml`) | "Reference: {{ error_message }}" | **May expose internal error strings** to buyers. | Provide a friendly reference (e.g. order number) and keep raw `error_message` in logs only. |
+| Cart abandonment subject (`config/sync/myeventlane_messaging.template.cart_abandoned.yml`) | "Forgot something? Your tickets are waiting" | Light guilt framing. | "Still interested? Your cart is waiting" |
+| Booking complete page subtitle (Readiness `completion_summary_*`) | "Your tickets and receipt are on their way to your inbox." | Strong, but no "if not received" guidance. | Optional add: "If you don't see it in a few minutes, check your spam folder." |
+| Refund-ineligible label (`web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig`) | "Support note:" prefix | "Support note" reads as internal/staff. | "Refund note:" or "Why refunds aren't available:" |
+| Customer ticket guests label same template | "Guests:" | Mixed with canonical "ticket holders". | Optional align with ticket holder language. |
+
+---
+
+## Section B — Organiser onboarding, Stripe, settings, publishing
+
+| Surface | Existing guidance | Risk | Improvement |
+|---------|-------------------|------|-------------|
+| Vendor shell `<aside aria-label="Vendor navigation">` (`myeventlane_vendor_theme/templates/layout/page.html.twig`) | "Vendor navigation" | Drift vs canonical "Organiser" chrome. | "Organiser navigation" |
+| Disabled top-level nav badge + title (`myeventlane_vendor_theme/templates/includes/sidebar.html.twig`) | title `Coming soon`; badge `Soon` | **Misleading** for items that are disabled because no event context exists (Orders, Check-in) — they look like dead features. | Differentiate: event-scoped disabled → "Open this from an event" / "Choose an event first"; reserve "Coming soon" for genuine placeholders. |
+| Vendor dashboard hero fallback (`myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig`) | Eyebrow "Vendor Console", H1 fallback "Welcome to your Vendor Console" | "Vendor" branding on canonical Organiser surface (per governance). | "Organiser console" / "Welcome to your organiser dashboard" |
+| Dashboard attention panel | "What needs attention now" / "Fix blockers early so launches stay smooth." | "Blockers" feels alarmist on first-time use. | "What to do next" / "Small setup steps now help publishing and payouts go smoothly." |
+| Stripe readiness label (`myeventlane_core/src/MelReadinessHelper.php`) | "Stripe payouts" / "Stripe connection is required before you can charge for tickets." | Slightly terse and "required" can feel abrupt. | "Stripe account" or "Payments (Stripe)"; "Connect Stripe to accept card payments for paid tickets." |
+| Moderation hold line (Readiness) | "Publishing is paused until moderation clears this event." | Exposes internal "moderation" word. | "Publishing is paused while our team finishes reviewing this listing." |
+| Events index empty inline form (`myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php`) | "No events yet" / "Create your first event and start selling tickets." | Sales-heavy for RSVP-first organisers. | "Create an event to add details, RSVPs, or tickets." |
+| Stripe Connect controller flash messages (`myeventlane_vendor/src/Controller/StripeConnectController.php`) | "No vendor profile found for your account." / "Your vendor store is not ready yet…" / raw env-debug Stripe key paragraph / "Stripe account status: @status." | Uses "vendor" (legacy) in **customer-facing** error; raw status leaks ops detail. | Use "organiser" or "your account"; replace raw status with plain-language next step + Support link. Keep machine names in logs only. |
+| Vendor settings descriptions (`myeventlane_vendor_settings/src/Form/VendorSettingsForm.php`) | Multiple references to "public vendor page", "vendor profile", journey chip "Boost". | Terminology drift on surface labelled "Organiser settings". | Replace visible "vendor" with "organiser/profile"; chip "Promote event". |
+| Vendor help panel suggestions (`myeventlane_vendor/src/Plugin/Block/VendorHelpPanelBlock.php`) | "...help with **escalation** questions in the vendor portal." | "Escalation" is staff-internal per governance. | "Support-related questions" / "organiser portal". |
+| Event Editor first-event banner (`myeventlane_event_studio/templates/mel-event-studio.html.twig`) | "✨ You're creating your first event" | OK; emoji optional. | Calmer plain text or keep emoji; not a security issue. |
+| Event Editor Operational Tone panel (same template) | Title "Operational tone"; empty fallback "Standard **vendor** workspace tone."; lines may include "Escalation-aware messaging is active." | Exposes staff vocabulary on organiser UI. | Rename to "Editing mode" / "Editing guidance"; fallback "Standard editing guidance."; rewrite policy hints in `EventStudioGovernanceBuilder` to user-facing wording. |
+| Event Studio publish form (`myeventlane_event_studio/src/Form/EventStudioPublishForm.php`) | Helper missing on what publishing exposes. | OK but could reduce uncertainty. | Add short helper under publish: "After publishing, your public page can show RSVPs or tickets you've turned on." |
+| Event Studio gating + ticket helper (`myeventlane_event_studio/src/Form/EventStudioForm.php`) | "Default off. Simpler events get more bookings — only ask what you truly need." / "Pick from venues under your **organizer** account." | Slightly fear-based; US spelling. | Calmer: "Fewer questions usually mean faster checkout."; AU spelling "organiser". |
+| Save feedback (`EventStudioBaseForm.php`) | "Saved." | Doesn't clarify draft vs published. | "Saved as draft." when unpublished. |
+| Wizard publish form (`myeventlane_event/src/Form/EventWizardPublishForm.php`) | "✨ Publish Event"; long contribution tangent post-publish. | Tone inconsistent with calm money flows. | "Publish event"; tighten contribution sentence. |
+| Boost / Promote event surfaces (`myeventlane_boost/**`, `EventIntelligenceService.php`, theme `event/analytics.html.twig`, `event/mel-event-overview-page.html.twig`, `components/mel-boost-status-panel.html.twig`) | Multiple visible mentions of "Boost" / "boosted". | Drift vs canonical "Promote event" (governance doc) — internal module names stay, but **visible labels** should harmonise. | Replace visible labels with "Promote event"; aria-label "Promotion status"; CTA "Promote my event". |
+| Vendor support panel (`myeventlane_vendor_theme/templates/mel-support-panel.html.twig`) | Emoji-heavy headings ("👀", "⚡", "🔥"); "Boost" branding; performance claims. | Tone clashes with "calm, credible for money"; product-name drift. | Plain titles; "Promote event"; soften urgency claims. |
+| Payouts empty (`myeventlane_vendor_theme/templates/vendor/payouts.html.twig`) | "No transactions yet" | OK; could add expectation. | Add: "Transactions appear after your first paid orders." |
+| Ticket holders page title (`myeventlane_event_attendees/src/Controller/VendorAttendeeController.php`) | Title "Attendees for @event"; group headings "RSVP Attendees" / "Ticket Attendees" | Sidebar nav says "Ticket holders" but page says "Attendees" — inconsistent. | "Ticket holders for @event"; group headings "RSVP responses" / "Ticket holders". |
+| Door scan UI (`myeventlane_tickets/src/Controller/TicketScanController.php`) | "Paste ticket code or payload"; "Queued: 0" | "Payload" is technical. | "Paste ticket code or QR text" |
+| Check-in failure (`myeventlane_tickets/src/Service/TicketCheckinService.php`) | "A server error occurred while checking in this ticket." | Sounds severe. | "Check-in couldn't be completed. Try again or use manual check-in." |
+
+---
+
+## Section C — Support and AI guidance
+
+| Surface | Existing guidance | Risk | Improvement |
+|---------|-------------------|------|-------------|
+| Customer support list intro (`myeventlane_escalations_portal/src/Controller/CustomerEscalationController.php::list`) | Title "Support"; intro "View and manage your support requests." | OK; could reassure new users with no requests yet. | Optional: "View your past support requests and start a new one any time." |
+| Customer support empty state same controller | "You have no support requests yet. When you contact us, your conversations will appear here." | Already calm and aligned. | Keep. |
+| Customer support add page intro (`add()`) | "Describe your issue and we'll get back to you as soon as possible." | "as soon as possible" is vague but OK; pairs well with reassurance line. | Optional shorten: "Tell us what's going on — we'll reply by email." |
+| Customer issue type select (`CustomerEscalationForm.php::buildForm`) | Includes options "Vendor Dispute" and "Customer Complaint". | "**Vendor Dispute**" exposes legacy vocabulary in customer-facing select per governance doc; "Customer Complaint" reads odd to the customer ("Customer" = themselves). | "Issue with an organiser" instead of "Vendor Dispute"; drop "Customer Complaint" or rename to "Other concern" (does **not** rename machine values — display labels only). |
+| Customer escalation submit success same form | "Your support request has been submitted. We will get back to you as soon as possible." | OK; could be slightly warmer. | "Your support request has been received. We'll reply by email — please keep an eye on your inbox." |
+| Help Assistant fallback (`myeventlane_help_assistant/src/Service/HelpAssistantService.php`) | "Sorry, the Help Assistant is unavailable right now." (disabled) / "AI help is currently unavailable. You can still browse help articles below." (AI disabled) | Disabled message has no next step. | "The Help Assistant is unavailable right now. You can browse the Help Centre or contact Support." |
+| Help Assistant low-confidence fallback (`buildFallbackPayload`) | "We couldn't find a perfect answer in the Help Centre yet. Try rephrasing your question or open one of the guides below when they appear." | Long; second clause assumes guides will appear. | "We couldn't find a clear answer in the Help Centre. Try rephrasing your question, or browse the guides below." |
+| Help Assistant escalation fallback text (`buildEscalationText`) | "I cannot confirm this from the Help Centre. For a personalised answer, open a support request at @url." | Robotic "I cannot"; "personalised" is fine. | "I'm not sure from the Help Centre. For a personal answer, open a support request: @url." |
+| Help Assistant header card (`templates/help-assistant.html.twig`) | "I'll answer using MyEventLane help content and guide you to the next step." | OK; aligned. | Keep. |
+| Help Assistant query form intro (`HelpAssistantQueryForm.php`) | Confidence printout `Confidence: @confidence`. | Exposes raw model confidence label to user. | Either hide confidence or translate to plain words ("Strong match" / "Possible match" / "I'm not sure" mapped from low/medium/high). |
+| Help Assistant query placeholder (`templates/help-assistant.html.twig`) | "Ask anything about your event, tickets, or payouts…" | Already organiser-leaning; OK. | Keep. |
+| Help Assistant "Still stuck?" card | "Still stuck?" / "Our support team can help you directly." | OK. | Keep. |
+| `myeventlane_ai.prompt.help_centre_answer_v1.yml` system instructions | Instructs Australian English, calm tone, fallback constant. | Aligned with governance. | Keep. |
+| `myeventlane_ai.prompt.vendor_ai_answer_v1.yml` system instructions | "You help event organisers understand policies and next steps." / fallback "I can't confirm from guidance. Please contact MyEventLane support for details." | Aligned; uses "support" canonical word. | Keep wording. Consider matching fallback voice to Help Assistant: "I'm not sure from the guidance. Please contact MyEventLane support for details." |
+
+**Customer-facing escalation status banner labels** (`CustomerEscalationController::buildCustomerStatusBanner`) are already calm and SLA-free per the file's own contract — keep as-is.
+
+---
+
+## Section D — Empty states (Views, Twig, controllers)
+
+| Surface | Existing guidance | Risk | Improvement |
+|---------|-------------------|------|-------------|
+| `config/sync/views.view.mel_vendor_events.yml` | `empty: { }` (Drupal default) | Cold default on the **canonical organiser events list** (`/vendor/events`). | Add a Views `text_custom` empty area with "No events yet — create your first event to get started." |
+| `config/sync/views.view.myeventlane_vendor_rsvps.yml` | No empty handler at all. | Cold default on organiser RSVP list (`dashboard/rsvps`). | Add empty area: "No RSVPs yet — they'll appear here as people respond." |
+| `config/sync/views.view.commerce_subscription_orders_customer.yml` | `empty: { }` (line 685) | Cold default on a customer-facing subscription orders list. | Add empty area: "No subscription orders yet." (only if surface is reachable to customers; verify before edit). |
+| `config/sync/views.view.mel_help_attendee_help.yml` | No empty handler. | Cold default on Help Centre attendee landing if filters return nothing. | Add empty area: "No help articles match yet — try the search above or browse the Help Centre." |
+| `config/sync/views.view.mel_help_organiser_help.yml` | No empty handler. | Same as above for organiser help. | Same calm fallback. |
+| `config/sync/views.view.mel_help_faq.yml` | No empty handler. | Same. | Same. |
+| `config/sync/views.view.mel_saved_events.yml` | Already has calm empty markup ("No saved events yet"). | OK. | Keep. |
+| `config/sync/views.view.mel_help_zero_results.yml` | `empty: { }` | Admin view (target audience = staff). | **Do not touch.** |
+
+**Twig and controller empty/disabled copy already covered above** in Sections A–C.
+
+---
+
+## Section E — Day-of-event confidence
+
+| Surface | Existing guidance | Risk | Improvement |
+|---------|-------------------|------|-------------|
+| Door scanner empty/instructions (`myeventlane_tickets/src/Controller/TicketScanController.php`) | "Ready to scan"; "Paste ticket code or payload"; "Queued: 0" | "Payload" technical. | "Paste ticket code or QR text" |
+| Check-in failure path (`myeventlane_tickets/src/Service/TicketCheckinService.php`) | "A server error occurred while checking in this ticket." | Severe wording at door. | "Check-in couldn't be completed. Try again or use manual check-in." |
+| Mel-door-checkin / vendor-checkin templates | "Loading..." inline copy | Minimal but not branded. | Optional theme-level label "Working..." / "Checking…" — low priority for this pass. |
+
+QR security, ticket validation logic, scanning logic — **NO CHANGES**.
+
+---
+
+## Section F — Accessibility & trust review
+
+The pass should preserve every existing aria-label and screen-reader-only string. Specific points to keep in mind during edits:
+
+- `CustomerEscalationController::buildCustomerStatusBanner` already uses an `aria-hidden="true"` icon span with a textual message — preserve this when changing wording.
+- `myeventlane_help_assistant` form has `<label class="visually-hidden" for="...">Your question</label>` — keep.
+- `myeventlane_vendor_theme/templates/includes/sidebar.html.twig` — disabled-link `title` attributes provide context to assistive tech; harmonise wording but **do not remove the attribute**.
+- `myeventlane_checkout_paragraph` ticket-holder paragraph SR status string — shorten but keep meaning.
+- `commerce-checkout-form.html.twig` payment-trust icon row — ensure visible decorative icons have a meaningful `visually-hidden` companion or `aria-label`.
+
+---
+
+## DO NOT TOUCH (must be preserved exactly)
+
+- **Legal copy**: `LegalConsentPane` checkbox text, links, `LegalSettingsService::getCollectionNoticeCheckout()`, terms / privacy / refund link labels, the binding agreement validation message.
+- **Tax invoice / GST labelling**: `mel-tax-invoice-section.html.twig`, receipt + invoice templates, "This document is a tax invoice for GST purposes.", "All prices include GST" — finance/legal owns these.
+- **Refund-window timelines** in buyer refund emails (e.g. "2–5 business days") — change only with finance/legal alignment.
+- **Stripe attribution and security disclosures** required by processor / compliance (e.g. "Secure payment via Stripe", Stripe Link / Apple Pay / Google Pay phrasing where mandated).
+- **Conditional refund availability hints** that honestly reflect organiser policy (`trust_footer_refund_hint`, conditional trust chips). Do not imply refunds where none exist.
+- **Anti-abuse / rate-limit messages** that double as security signals (e.g. "Too many requests", invalid waitlist link copy). Edit for tone only when the system meaning stays intact.
+- **Customer-facing escalation status banner** wording in `CustomerEscalationController::buildCustomerStatusBanner` — already SLA-free and approved.
+- **Help Assistant grounding rules** in `HelpAssistantService::buildPromptDefinition` (system message instructions: "Only answer using the provided help content", "Do not invent…", JSON schema rules). **Wording governs the model's behaviour, not just presentation.**
+- **AI prompt YAML for staff prompts** — `escalation_*`, `playbook_*` config files. Out of scope.
+- **Permission machine names**, route machine names, entity / bundle / field machine names, module IDs, config keys (e.g. `myeventlane_vendor`, `escalation`, `boost_upgrade`).
+- **Admin Views and PCC labels**: `mel_admin_review_queue.yml`, `mel_help_feedback_admin.yml`, `mel_help_zero_results.yml`, `mel_help_analytics_admin.yml`, `mel_help_internal_procedures.yml`, watchdog, advanced queue, commerce subscription **admin** orders.
+- **Staff playbooks**, internal SLA breach copy, escalation level numbers, raw `error_message` from refund failures, raw Stripe `@status` strings — must stay out of customer / organiser surfaces. Where today's copy leaks them, replacement should anonymise (not remove the safety of having an internal log).
+- **Drupal core templates** we do not override.
+- **Help Centre attendee retention**: per `docs/product-language-governance.md`, Help articles may keep "Attendee" sections — do not bulk-edit.
+- **Form validation rules** and submit handler logic — copy of validation **messages** may be softened, but logic and conditions stay.
+
+---
+
+## Output — what changes in this pass
+
+The fixes below are bounded to the items above and split per phase:
+
+- **Phase 3** — Empty states: `views.view.mel_vendor_events.yml`, `views.view.myeventlane_vendor_rsvps.yml`, plus three Help Centre audience views; calm empty area markup, no logic.
+- **Phase 4** — Checkout trust: `BuyerDetailsPane.php` description, `TicketHolderParagraphPane.php` intro + SR status, `myeventlane_checkout_flow.module` express-checkout copy, `MelReadinessHelper.php` strings flagged in Section A, `myeventlane_messaging.template.order_receipt.yml` subject + CTA, `myeventlane_messaging.template.refund_failed_buyer.yml` reference field, `myeventlane_messaging.template.cart_abandoned.yml` subject.
+- **Phase 5** — Organiser onboarding: `myeventlane_vendor_theme/page.html.twig` aria-label, `dashboard.html.twig` hero fallback + attention panel, `MelReadinessHelper.php` Stripe + moderation lines, `VendorEventsBulkActionsForm.php` empty CTA, `StripeConnectController.php` flash messages, `VendorSettingsForm.php` descriptions, `VendorHelpPanelBlock.php` suggestion copy, `EventStudioForm.php`/`EventStudioBaseForm.php` save + helper text, `EventStudioGovernanceBuilder.php` policy hint wording, `VendorAttendeeController.php` page title + group headings.
+- **Phase 6** — Support confidence: `CustomerEscalationForm.php` issue-type display labels + submit success, `HelpAssistantService.php` fallback strings, `vendor_ai_answer_v1.yml` fallback voice (wording only).
+- **Phase 7** — Publishing guidance: `EventStudioPublishForm.php` helper sentence, `EventStudioBaseForm.php` "Saved as draft" wording.
+- **Phase 8** — Day-of-event: `TicketScanController.php` field label, `TicketCheckinService.php` failure copy.
+- **Phase 9** — AI consistency: covered together with Phase 6.
+- **Phase 10** — Accessibility: validate aria/SR strings still present after each edit; no removals.
+- **Phase 12** — Governance doc: `docs/ux-trust-guidance-governance.md`.
+
+Total touched surfaces are presentational and translation-safe (`t()` / `TranslatableMarkup`) and cache-safe (no new render contexts).

--- a/docs/ux-trust-guidance-governance.md
+++ b/docs/ux-trust-guidance-governance.md
@@ -1,0 +1,168 @@
+# UX Trust + Guidance Governance — MyEventLane
+
+**Branch:** `feature/ux-trust-guidance-harmonisation`  
+**Companion to:** `docs/ux-trust-guidance-audit.md`  
+**Layered on:** `docs/product-language-governance.md`, `docs/product-language-inventory.md`, `docs/platform-canonical-surface-map.md`, `docs/platform-governance-audit.md`
+
+This document records the **trust and guidance principles** the platform applies after the harmonisation pass, the **standards future copy must follow**, and **what intentionally stayed operational or hidden**. It is **prescriptive for new copy**; legacy strings are not bulk-rewritten outside owned surfaces.
+
+---
+
+## 1. Trust language principles
+
+1. **Calm, credible, gender-neutral.** No urgency tactics, no emojis on financial moments, no fear-based "blockers".
+2. **Verb-first CTAs**, one primary action per region: "Submit support request", "Create event", "Pay now".
+3. **Plain English, Australian spelling.** Match the canonical product language: organiser, ticket holder, support, support request, Event Editor, Event Manager, Promote event.
+4. **Tell the user what happens next.** Empty / error / waiting states must give a next step.
+5. **Reuse existing systems.** No new shells, no parallel guidance frameworks, no new modal systems. Edit at the canonical source (`MelReadinessHelper`, `AccountLinksService`, vendor shell builder, etc.).
+6. **Translation-safe.** All visible strings must use `t()` / `TranslatableMarkup`. Plain literal strings in PHP are forbidden for visible UI.
+7. **Cache-safe.** No new render contexts; copy edits never widen cacheability scope.
+
+---
+
+## 2. Organiser guidance standards
+
+- Use **organiser** for all customer- and organiser-visible language. Internal entity / permission / route names remain "vendor".
+- Disabled sidebar items must distinguish **event-scoped disabled** ("Open this from an event") from **future / placeholder** ("Available soon"). Done in `templates/includes/sidebar.html.twig` using `item.key`.
+- Onboarding copy avoids "blockers" / "fix early" framing; prefer "What to do next" / "Small setup steps now help publishing and payouts go smoothly."
+- Stripe wording: never expose the raw `status` enum to organisers; show a calm next step and link to the Stripe-hosted dashboard.
+- Save feedback shows draft state when not yet published ("Saved as draft.") so organisers know the listing is not public.
+
+---
+
+## 3. Checkout trust standards
+
+- Buyer details copy is short and reassuring ("We'll email your order confirmation and tickets here.", "Optional — we'll only use this if we need to reach you about this booking.").
+- Ticket-holder pane uses **canonical "ticket holder"** in headings and SR-only status; intro line uses "Questions from the organiser" when organiser questions exist.
+- Express checkout copy says "Pay faster with Apple Pay, Google Pay, or Link when your browser offers them."
+- "Express checkout isn't available — this event needs a few details for each ticket first." replaces older mixed-vocabulary copy.
+- **Do not** modify legal consent wording, validation rules, GST / tax-invoice phrasing, refund-window timelines, or Stripe security disclosures. These are owned by legal / finance / processor compliance.
+
+---
+
+## 4. Support guidance standards
+
+- The customer escalation portal uses **support / support request** in all copy. Internal route, entity, and permission names keep "escalation".
+- Issue-type select labels read in plain English; "Vendor Dispute" → "Issue with an organiser", "Customer Complaint" → "Other concern" (machine values unchanged).
+- Submission confirmation: "Your support request has been received. We'll reply by email — please keep an eye on your inbox." No SLA hours quoted.
+- Customer-facing escalation status banner remains SLA-free, badge-free, and timestamp-free per `CustomerEscalationController::buildCustomerStatusBanner`.
+- Escalation level numbers, breach flags, internal queue state must never appear on customer- or organiser-visible surfaces.
+
+---
+
+## 5. Empty state standards
+
+- Replace Drupal-default `empty: { }` with a `text_custom` area whenever the surface is reached by customers or organisers.
+- Empty markup includes a `role="status"` container, an `<h2>` heading, and a short body sentence with a next-step verb.
+- Wording examples used in this pass:
+  - "No events yet — create an event to add details, RSVPs, or tickets."
+  - "No RSVPs yet — they'll appear here as people respond."
+  - "No articles match yet — try the search at the top of the page, or browse the Help Centre for more topics."
+- **Do not** edit admin Views (`mel_admin_review_queue`, `mel_help_*_admin`, `watchdog`, etc.) — those serve staff and may carry operational meaning.
+
+---
+
+## 6. Success state standards
+
+- Booking complete copy reassures the user that tickets and a receipt are coming by email; mentions checking spam if applicable.
+- Refund timing copy preserves the legally-aligned "2–5 business days" timeline; tone remains calm and informative.
+- Email subjects use plain headlines without emoji on financial documents (receipts, refunds, tax invoices).
+
+---
+
+## 7. Error state standards
+
+- Error messages name the user-visible failure ("Check-in couldn't be completed.") and offer a recovery path ("Try again or use manual check-in.").
+- **Never** include raw stack traces, error codes, or third-party error strings in customer- or organiser-visible messages. Log internally; surface a friendly reference (e.g. order number).
+- Refund-failed buyer email exposes the **order number** as the reference, not the raw `error_message`.
+- Stripe Connect controller flash messages now say "We couldn't find your organiser profile.", "Your organiser account isn't ready yet.", "Something didn't match with your Stripe account." — never raw status enums.
+
+---
+
+## 8. AI guidance standards
+
+- Customer- and organiser-facing fallback copy uses the same voice ("I'm not sure from the Help Centre. For a personal answer, open a support request: …"). Robotic phrasings ("I cannot confirm…") are removed.
+- The vendor AI prompt fallback (`config/sync/myeventlane_ai.prompt.vendor_ai_answer_v1.yml`) matches the same voice.
+- **Do not** widen retrieval scope, change audience filtering, change grounding rules, or remove the JSON schema constraints in `HelpAssistantService::buildPromptDefinition`. Wording inside `system` instructions stays only when it does not weaken the safety rules.
+- The Help Assistant must not display raw model `confidence` to users without translation; the existing query form is acceptable today as a developer/debug surface and may be replaced by user-friendly mapped phrases in a later pass.
+- Staff prompts (`escalation_*`, `playbook_*`) are out of scope for this pass.
+
+---
+
+## 9. Event publishing guidance rules
+
+- Publish CTA card has a calm body line: "After publishing, your public page can show RSVPs or tickets you've turned on."
+- Wizard saves communicate draft state ("Saved as draft.") when the underlying node remains unpublished.
+- Moderation hold copy reads "Publishing is paused while our team finishes reviewing this listing." — does not expose the word "moderation".
+- Connect Stripe gate copy reads "Connect Stripe to accept card payments for paid tickets." — non-blame framing.
+
+---
+
+## 10. Day-of-event guidance rules
+
+- Door scanner placeholder: "Paste ticket code or QR text" (replaces "payload").
+- Check-in failure copy: "Check-in couldn't be completed. Try again or use manual check-in."
+- **Do not** alter scanning logic, ticket validation, or QR security. Copy is presentational only.
+
+---
+
+## 11. Accessibility guidance rules
+
+- Every visible empty state markup includes `role="status"` so assistive tech is informed when content arrives or is absent.
+- Disabled sidebar links keep `aria-disabled="true"` and a `title` attribute that is now context-aware (event-scoped vs future).
+- The aria-label on the vendor shell sidebar is now "Organiser navigation" matching the inner nav and the canonical chrome.
+- Visually-hidden status messages (e.g. ticket-holder paragraph SR text) are shortened but always preserved — never removed.
+- Decorative icons keep `aria-hidden="true"`; text content carries the meaning.
+- All translated copy continues to flow through `t()` / `TranslatableMarkup`.
+
+---
+
+## 12. Future UX copy governance
+
+- **No mass search/replace.** Edit copy at the surface that owns it (controller, form, plugin, theme builder, Twig template).
+- **No new copy services.** When wording recurs (e.g. organiser dashboard slots), edit `MelReadinessHelper` slots — do not duplicate strings into Twig.
+- **Do not rename** modules, services, routes, permissions, or entities for copy reasons alone.
+- **Preserve access checks.** Copy lives in templates and forms; routing and `_custom_access` stay authoritative.
+- **Document drift.** When adding a new customer- or organiser-facing string, link the surface back to one of: `AccountLinksService::buildNavigationItems`, `_myeventlane_vendor_theme_build_full_vendor_shell_nav_items`, `MelReadinessHelper`, `CustomerEscalationController`.
+- **Translation-safe.** Visible strings always use `t()` / `TranslatableMarkup`.
+- **Test by audience.** New customer copy must be reviewed against this document plus `docs/product-language-governance.md` before merging.
+
+---
+
+## 13. What changed in this pass
+
+- **Empty states**: `views.view.mel_vendor_events.yml`, `views.view.myeventlane_vendor_rsvps.yml`, `views.view.mel_help_attendee_help.yml`, `views.view.mel_help_organiser_help.yml` — added calm `text_custom` empty areas with `role="status"` markup.
+- **Checkout**: `BuyerDetailsPane.php` (email + mobile descriptions), `TicketHolderParagraphPane.php` (intro title + body, SR status, fallback question label), `myeventlane_checkout_flow.module` (express checkout intro, multi-ticket notice, unavailable notice), `MelReadinessHelper.php` (ticket-holder canonical wording, Stripe label, moderation hold sentence).
+- **Receipts / messaging**: `myeventlane_messaging.template.order_receipt.yml` (de-emoji subject, "View your tickets", donation thank-you, footer reply line), `myeventlane_messaging.template.refund_failed_buyer.yml` (order-number reference instead of raw error), `myeventlane_messaging.template.cart_abandoned.yml` (calmer subject + body).
+- **Organiser shell**: `myeventlane_vendor_theme/templates/layout/page.html.twig` (aria-label), `templates/dashboard/dashboard.html.twig` (eyebrow, fallback H1, attention panel), `templates/includes/sidebar.html.twig` (event-scoped disabled differentiation).
+- **Stripe Connect**: `StripeConnectController.php` flash messages (organiser wording, no raw `@status` leak).
+- **Event Editor**: `EventStudioBaseForm.php` (draft-aware save message), `EventStudioPublishForm.php` (publish helper line).
+- **Ticket holders**: `VendorAttendeeController.php` (page title, group headings, empty state).
+- **Support**: `CustomerEscalationForm.php` (issue-type display labels, submission success copy), `CustomerEscalationController.php::add` (intro).
+- **AI**: `HelpAssistantService.php` (disabled / AI-disabled / fallback / escalation strings), `myeventlane_ai.prompt.vendor_ai_answer_v1.yml` (fallback wording aligned).
+- **Day-of-event**: `TicketScanController.php` (manual entry placeholder), `TicketCheckinService.php` (failure message).
+- **Vendor events bulk form**: `VendorEventsBulkActionsForm.php` (empty CTA copy).
+
+All changes are presentation-only. No routes, services, permissions, schemas, payment flows, AI grounding rules, or staff isolation contracts were modified.
+
+---
+
+## 14. What intentionally stayed operational
+
+- All machine names: modules (`myeventlane_vendor`, `myeventlane_escalations*`, `myeventlane_boost`, …), permissions, routes (`/vendor/*`, `/my/support/escalations/*`), entity types, fields, config keys, commerce SKUs.
+- Stripe technical wording where attribution / compliance demands it.
+- Tax invoice / GST labels and refund-window timing — finance / legal owns these.
+- Customer-facing escalation status banner copy — already SLA-free per the file's own contract.
+- Help Assistant grounding rules in the system prompt and the JSON schema enforcement.
+- Help Centre attendee retention per `docs/product-language-governance.md`.
+
+---
+
+## 15. What must never be exposed publicly
+
+- Staff playbook content, internal SLA breach messaging, raw escalation level numbers, raw breach flags.
+- Internal route names, module IDs, machine names in user-visible copy.
+- Raw Stripe API status enums, `@status` strings, raw error messages.
+- Refund failure raw `error_message` — use order-number reference and log the rest.
+- Drupal admin queue language, watchdog messages, advanced queue internals.
+- Any unsanctioned PII in support, AI, or transactional copy.

--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -226,7 +226,7 @@ function _myeventlane_account_page_heading(?string $route_name) {
   return match ($route_name) {
     'myeventlane_account.past_events' => t('Past events'),
     'myeventlane_account.settings', 'myeventlane_account.settings_redirect' => t('Settings'),
-    'myeventlane_checkout_flow.my_tickets' => t('My tickets'),
+    'myeventlane_checkout_flow.my_tickets' => t('Tickets'),
     'myeventlane_checkout_flow.order_detail' => t('Your booking'),
     'myeventlane_checkout_flow.order_tax_invoice_pdf' => t('Payment receipt'),
     'myeventlane_dashboard.customer' => t('My events'),

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -95,6 +95,8 @@ final class AccountLinksService {
       }
     }
 
+    $discoverUrl = '/events';
+
     $ticketsUrl = Url::fromRoute('myeventlane_checkout_flow.my_tickets', [], ['absolute' => FALSE])->toString();
     $dashboardUrl = Url::fromRoute('myeventlane_account.dashboard', [], ['absolute' => FALSE])->toString();
 
@@ -106,19 +108,39 @@ final class AccountLinksService {
     catch (\Throwable) {
     }
 
+    $supportRoutesMatch = [];
+    if ($this->moduleHandler->moduleExists('myeventlane_escalations_portal')) {
+      $supportRoutesMatch = [
+        'myeventlane_escalations_portal.customer_support',
+        'myeventlane_escalations_portal.customer_support_tickets',
+        'myeventlane_escalations_portal.customer_list',
+        'myeventlane_escalations_portal.customer_add',
+        'myeventlane_escalations_portal.customer_view',
+        'myeventlane_escalations_portal.customer_reopen',
+      ];
+    }
+
     $definitions = [
+      [
+        'id' => 'discover',
+        'title' => $this->t('Discover'),
+        'url' => $discoverUrl,
+        'in_quick' => TRUE,
+        'routes_match' => [],
+      ],
       [
         'id' => 'dashboard',
         'title' => $this->t('Dashboard'),
         'url' => $dashboardUrl,
         'in_quick' => FALSE,
+        'show_in_sidebar' => FALSE,
         'routes_match' => [
           'myeventlane_account.dashboard',
         ],
       ],
       [
         'id' => 'tickets',
-        'title' => $this->t('My Tickets'),
+        'title' => $this->t('Tickets'),
         'url' => $ticketsUrl,
         'in_quick' => TRUE,
         'show_in_sidebar' => TRUE,
@@ -148,16 +170,6 @@ final class AccountLinksService {
         ],
       ],
       [
-        'id' => 'notifications',
-        'title' => $this->t('Notifications'),
-        'url' => $notificationsUrl,
-        'in_quick' => TRUE,
-        'routes_match' => [
-          'myeventlane_notifications.inbox',
-          'myeventlane_notifications.preferences',
-        ],
-      ],
-      [
         'id' => 'categories',
         'title' => $this->t('Categories'),
         'url' => $categoriesUrl,
@@ -168,11 +180,28 @@ final class AccountLinksService {
       ],
       [
         'id' => 'followed_organisers',
-        'title' => $this->t('Followed organisers'),
+        'title' => $this->t('Organisers'),
         'url' => $followedOrganisersUrl,
         'in_quick' => TRUE,
         'routes_match' => [
           'myeventlane_account.followed_organisers',
+        ],
+      ],
+      [
+        'id' => 'support',
+        'title' => $this->t('Support'),
+        'url' => $supportUrl,
+        'in_quick' => TRUE,
+        'routes_match' => $supportRoutesMatch,
+      ],
+      [
+        'id' => 'notifications',
+        'title' => $this->t('Notifications'),
+        'url' => $notificationsUrl,
+        'in_quick' => TRUE,
+        'routes_match' => [
+          'myeventlane_notifications.inbox',
+          'myeventlane_notifications.preferences',
         ],
       ],
       [
@@ -186,17 +215,11 @@ final class AccountLinksService {
         ],
       ],
       [
-        'id' => 'support',
-        'title' => $this->t('Support'),
-        'url' => $supportUrl,
-        'in_quick' => TRUE,
-        'routes_match' => [],
-      ],
-      [
         'id' => 'logout',
         'title' => $this->t('Log out'),
         'url' => Url::fromRoute('user.logout', [], ['absolute' => FALSE])->toString(),
         'in_quick' => FALSE,
+        'show_in_sidebar' => FALSE,
         'routes_match' => [],
       ],
     ];

--- a/web/modules/custom/myeventlane_admin_dashboard/templates/mel-pcc-utility-bar.html.twig
+++ b/web/modules/custom/myeventlane_admin_dashboard/templates/mel-pcc-utility-bar.html.twig
@@ -7,7 +7,7 @@
 <div class="mel-pcc-utility-bar" role="navigation" aria-label="{{ 'Quick links'|t }}">
   <a href="{{ main_site_url }}" class="mel-pcc-utility-bar__link">{{ 'Main Site'|t }}</a>
   <span class="mel-pcc-utility-bar__sep" aria-hidden="true">|</span>
-  <a href="{{ vendor_dashboard_url }}" class="mel-pcc-utility-bar__link">{{ 'Vendor Dashboard'|t }}</a>
+  <a href="{{ vendor_dashboard_url }}" class="mel-pcc-utility-bar__link">{{ 'Organiser dashboard'|t }}</a>
   <span class="mel-pcc-utility-bar__sep" aria-hidden="true">|</span>
   <a href="{{ platform_control_url }}" class="mel-pcc-utility-bar__link">{{ 'Platform Control Centre'|t }}</a>
 </div>

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
@@ -96,14 +96,14 @@ function myeventlane_checkout_flow_attach_fast_checkout(array &$form, FormStateI
         '#markup' => '<h2 id="mel-fast-checkout-title" class="mel-fast-checkout__title">' . t('Express checkout') . '</h2>',
       ],
       'intro' => [
-        '#markup' => '<p class="mel-fast-checkout__intro">' . t('Use Stripe Link, Apple Pay, or Google Pay when available for this device.') . '</p>',
+        '#markup' => '<p class="mel-fast-checkout__intro">' . t('Pay faster with Apple Pay, Google Pay, or Link when your browser offers them.') . '</p>',
       ],
     ],
   ];
 
   if ($eligibility->hasMultipleTicketQuantity($order)) {
     $form['mel_fast_checkout']['header']['multi_ticket_notice'] = [
-      '#markup' => '<p class="mel-fast-checkout__multi-ticket-notice">' . t("You'll be able to edit individual attendee details after purchase.") . '</p>',
+      '#markup' => '<p class="mel-fast-checkout__multi-ticket-notice">' . t("You can update each ticket holder's details later from your booking, if the organiser allows it.") . '</p>',
     ];
   }
 
@@ -138,7 +138,7 @@ function myeventlane_checkout_flow_add_fast_checkout_unavailable_notice(array &$
       'class' => ['mel-fast-checkout-unavailable'],
     ],
     'message' => [
-      '#markup' => '<p>' . t("Fast checkout isn't available for this event because additional attendee details are required.") . '</p>',
+      '#markup' => '<p>' . t("Express checkout isn't available — this event needs a few details for each ticket first.") . '</p>',
     ],
   ];
 }

--- a/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorEventOperationsController.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorEventOperationsController.php
@@ -90,6 +90,7 @@ final class VendorEventOperationsController extends VendorConsoleBaseController 
       '#recent_activity' => $vm['recent_activity'],
       '#links' => $vm['links'],
       '#search' => $vm['search'],
+      '#empty_guidance' => $vm['empty_guidance'] ?? [],
       '#operational_actions' => $vm['operational_actions'],
       '#mel_venue_operations_empty' => $empty,
       '#csrf' => $vm['csrf'] ?? [],

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/BuyerDetailsPane.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/BuyerDetailsPane.php
@@ -58,7 +58,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
     $pane_form['email'] = [
       '#type' => 'email',
       '#title' => $this->t('Email address'),
-      '#description' => $this->t('We\'ll send your order confirmation and tickets to this address.'),
+      '#description' => $this->t('We\'ll email your order confirmation and tickets here.'),
       '#required' => TRUE,
       '#default_value' => $customer->getEmail() ?: $billing_profile->get('address')->first()?->get('email')?->value ?? '',
       '#attributes' => [
@@ -95,7 +95,7 @@ final class BuyerDetailsPane extends CheckoutPaneBase {
     $pane_form['mobile'] = [
       '#type' => 'tel',
       '#title' => $this->t('Mobile number'),
-      '#description' => $this->t('Optional. We may use this to contact you about your order.'),
+      '#description' => $this->t('Optional — we\'ll only use this if we need to reach you about this booking.'),
       '#default_value' => $mobile_default,
       '#attributes' => [
         'autocomplete' => 'tel',

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
@@ -153,6 +153,10 @@ final class MelVenueOperationsViewModelBuilder {
       'recent_activity' => $recent,
       'links' => $links,
       'search' => $search,
+      'empty_guidance' => [
+        'no_rows' => $this->readinessHelper->vendorAttendeeOperationsNoAttendeesYetSlots()['why_empty'],
+        'checkin' => $this->readinessHelper->vendorAttendeeCheckinGuidanceLine(),
+      ],
       'operational_actions' => $this->buildOperationalActions($eventId),
       // Per-purpose CSRF token consumed by the manual check-in form (hidden
       // `_token` field) and the AJAX behaviour (`X-CSRF-Token` header).

--- a/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
@@ -222,7 +222,8 @@
       <p class="mel-live-ops__filter-empty" data-mel-ops-filter-empty hidden role="status">{{ 'Nothing matches your search.'|t }}</p>
 
       {% if attendee_rows is empty %}
-        <p class="mel-live-ops__muted">{{ 'No attendee rows loaded yet.'|t }}</p>
+        <p class="mel-live-ops__muted">{{ empty_guidance.no_rows|default('Ticket holders will appear here after bookings begin.'|t) }}</p>
+        <p class="mel-live-ops__muted">{{ empty_guidance.checkin|default('Use check-in during your event to validate tickets.'|t) }}</p>
       {% else %}
         {% set attendee_limit = attendee_rows|length > 120 ? 120 : attendee_rows|length %}
         {% for row in attendee_rows|slice(0, attendee_limit) %}

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
@@ -141,10 +141,10 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
 
     $has_vendor_questions = $this->checkoutAttendeeSchema->orderHasMergedQuestionTemplates($this->order);
     $intro_title = $has_vendor_questions
-      ? (string) $this->t('Attendee questions')
+      ? (string) $this->t('Questions from the organiser')
       : (string) $this->t('Ticket holder details');
     $intro_body = $has_vendor_questions
-      ? (string) $this->t('Add per-ticket details and answer organiser questions before continuing.')
+      ? (string) $this->t('Answer these for each ticket before you pay.')
       : (string) $this->t('Enter the name and email for each ticket. Phone is optional unless the organiser requires it for check-in.');
 
     $pane_form['intro'] = [
@@ -303,7 +303,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       'text' => [
         '#markup' => $is_complete
           ? (string) $this->t('This ticket holder entry is complete.')
-          : (string) $this->t('This ticket holder entry is incomplete. Required fields or organiser questions still need answers.'),
+          : (string) $this->t('Incomplete — required fields or organiser questions are missing.'),
       ],
       '#weight' => -12,
     ];
@@ -388,7 +388,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
         ? (string) ($question->get('field_question_label')->value ?? '')
         : '';
       if ($label === '') {
-        $label = 'Extra Question';
+        $label = (string) $this->t('Additional question');
       }
       $type = $question->hasField('field_question_type')
         ? (string) ($question->get('field_question_type')->value ?? 'text')

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -46,7 +46,7 @@ final class MelReadinessHelper {
       }
       if (($evaluations['publishable'] ?? NULL) === MelStateEvaluation::Unsatisfied
         && ($evaluations['moderation_hold'] ?? NULL) === MelStateEvaluation::Satisfied) {
-        $messages[] = (string) $this->t('Publishing is paused until moderation clears this event.');
+        $messages[] = (string) $this->t('Publishing is paused while our team finishes reviewing this listing.');
       }
     }
 
@@ -64,7 +64,7 @@ final class MelReadinessHelper {
   }
 
   public function vendorStripeReadinessBlockingLine(): string {
-    return (string) $this->t('Stripe connection is required before you can charge for tickets.');
+    return (string) $this->t('Connect Stripe to accept card payments for paid tickets.');
   }
 
   public function vendorOrganiserProfileIncompleteLine(): string {
@@ -100,7 +100,7 @@ final class MelReadinessHelper {
       'incomplete' => $this->vendorReadinessRowIncompleteLabel(),
       'profile' => (string) $this->t('Organiser profile'),
       'public_profile' => (string) $this->t('Public organiser page'),
-      'stripe' => (string) $this->t('Stripe payouts'),
+      'stripe' => (string) $this->t('Stripe account'),
       'analytics_unavailable' => (string) $this->t('Analytics unavailable'),
     ];
   }
@@ -259,7 +259,7 @@ final class MelReadinessHelper {
    * Checkout reassurance when organiser attendee questions mandate the ticket-holder pane.
    */
   public function customerCheckoutAttendeeRequiredBeforePaymentLine(): string {
-    return (string) $this->t('Attendee details are required before payment.');
+    return (string) $this->t('Ticket holder details are required before payment.');
   }
 
   public function customerCheckoutTrustChipsRegionLabel(): string {
@@ -416,7 +416,7 @@ final class MelReadinessHelper {
     return [
       'eyebrow' => (string) $this->t('Step 2'),
       'heading' => (string) $this->t('Ticket holders'),
-      'intro' => (string) $this->t('Add each attendee once. Sections fold closed as you finish so the next ticket stays in focus.'),
+      'intro' => (string) $this->t('Add each ticket holder once. Sections fold closed as you finish so the next ticket stays in focus.'),
     ];
   }
 

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -1227,6 +1227,221 @@ final class MelReadinessHelper {
   }
 
   // -------------------------------------------------------------------------
+  // Operational readiness intelligence.
+  // Presentation-only summaries for vendor surfaces. Business rules remain in
+  // the existing state, publishing, Stripe, Commerce, RSVP, and attendee layers.
+  // -------------------------------------------------------------------------
+
+  /**
+   * @param list<array<string, mixed>> $events
+   *
+   * @return list<array{key: string, label: string, message: string, severity: string}>
+   */
+  public function vendorDashboardOperationalReadinessSummary(array $readiness, array $events): array {
+    $published = 0;
+    $draft = 0;
+    $paidOrHybrid = FALSE;
+    $bookingReady = FALSE;
+    $attendeeActivity = FALSE;
+    $promotionReady = FALSE;
+
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $status = (string) ($event['status'] ?? '');
+      if ($status === 'draft') {
+        $draft++;
+      }
+      elseif ($status === 'upcoming' || $status === 'past' || $status === 'published') {
+        $published++;
+      }
+
+      $eventType = (string) ($event['event_type'] ?? 'unknown');
+      if ($eventType !== 'unknown') {
+        $bookingReady = TRUE;
+      }
+      if ($eventType === 'paid' || $eventType === 'both') {
+        $paidOrHybrid = TRUE;
+      }
+
+      if (!empty($event['metric_label'])) {
+        $attendeeActivity = TRUE;
+      }
+
+      $image = $event['image'] ?? [];
+      if (is_array($image) && !empty($image['url']) && empty($image['is_placeholder'])) {
+        $promotionReady = TRUE;
+      }
+    }
+
+    $stripeReady = (bool) ($readiness['stripe_ready'] ?? FALSE);
+
+    return [
+      [
+        'key' => 'publishing',
+        'label' => (string) $this->t('Publishing'),
+        'message' => $published > 0
+          ? (string) $this->t('Your event is live and ready for bookings.')
+          : ($draft > 0
+            ? (string) $this->t("Your draft is saved and won't appear publicly until you publish.")
+            : (string) $this->t('Create your first event when you are ready.')),
+        'severity' => $published > 0 ? 'success' : 'info',
+      ],
+      [
+        'key' => 'tickets_rsvp',
+        'label' => (string) $this->t('Tickets & RSVP'),
+        'message' => $bookingReady
+          ? (string) $this->t('People have a clear way to book or RSVP.')
+          : (string) $this->t('Add ticket types or RSVP settings before you rely on bookings.'),
+        'severity' => $bookingReady ? 'success' : 'warning',
+      ],
+      [
+        'key' => 'payments_payouts',
+        'label' => (string) $this->t('Payments & payouts'),
+        'message' => $stripeReady
+          ? (string) $this->t('Payout setup is connected for paid ticket activity.')
+          : ($paidOrHybrid
+            ? $this->vendorStripeReadinessBlockingLine()
+            : (string) $this->t("Connect payouts when you're ready to sell paid tickets.")),
+        'severity' => $stripeReady ? 'success' : ($paidOrHybrid ? 'warning' : 'info'),
+      ],
+      [
+        'key' => 'attendees',
+        'label' => (string) $this->t('Attendee readiness'),
+        'message' => $attendeeActivity
+          ? (string) $this->t('Attendee activity is flowing into your organiser tools.')
+          : (string) $this->t('Your attendees will appear here after bookings begin.'),
+        'severity' => $attendeeActivity ? 'success' : 'info',
+      ],
+      [
+        'key' => 'promotion',
+        'label' => (string) $this->t('Promotion & discovery'),
+        'message' => $promotionReady
+          ? (string) $this->t('Your listing has visual content that can help it stand out.')
+          : (string) $this->t('Add a banner image to help your event stand out in discovery.'),
+        'severity' => $promotionReady ? 'success' : 'info',
+      ],
+    ];
+  }
+
+  /**
+   * @return list<array{key: string, message: string, severity: string}>
+   */
+  public function vendorDashboardFirstEventGuidance(bool $has_published_events, bool $has_ticket_sales, bool $stripe_ready): array {
+    if ($has_published_events || $has_ticket_sales || $stripe_ready) {
+      return [];
+    }
+    return [
+      [
+        'key' => 'create_first_event',
+        'message' => (string) $this->t('Create your first event.'),
+        'severity' => 'info',
+      ],
+      [
+        'key' => 'add_booking_mode',
+        'message' => (string) $this->t('Add tickets or RSVPs so people know how to join.'),
+        'severity' => 'info',
+      ],
+      [
+        'key' => 'connect_payouts_when_ready',
+        'message' => (string) $this->t("Connect payouts when you're ready to sell paid tickets."),
+        'severity' => 'info',
+      ],
+    ];
+  }
+
+  /**
+   * @return list<array{key: string, label: string, message: string, severity: string}>
+   */
+  public function vendorEventWorkspaceOperationalSummary(string $event_type, string $status, int $tickets_sold, int $orders_count, int $rsvp_count): array {
+    $isPublished = $status === 'published' || $status === 'past' || $status === 'upcoming';
+    $hasBooking = $event_type !== 'unknown';
+    $hasActivity = $tickets_sold > 0 || $orders_count > 0 || $rsvp_count > 0;
+    $isPaid = $event_type === 'paid' || $event_type === 'both';
+
+    return [
+      [
+        'key' => 'visibility',
+        'label' => (string) $this->t('Public visibility'),
+        'message' => $isPublished
+          ? (string) $this->t('This event page is visible to attendees.')
+          : (string) $this->t("This event is still in draft and won't appear publicly."),
+        'severity' => $isPublished ? 'success' : 'warning',
+      ],
+      [
+        'key' => 'booking',
+        'label' => (string) $this->t('Booking setup'),
+        'message' => $hasBooking
+          ? (string) $this->t('Attendees have a booking path for this event.')
+          : (string) $this->t('Add ticket types or RSVP settings before publishing.'),
+        'severity' => $hasBooking ? 'success' : 'warning',
+      ],
+      [
+        'key' => 'paid_tickets',
+        'label' => (string) $this->t('Paid ticket readiness'),
+        'message' => $isPaid
+          ? (string) $this->t('Paid ticket setup uses the existing Stripe and Commerce publish checks.')
+          : (string) $this->t('Paid tickets are not enabled for this event.'),
+        'severity' => $isPaid ? 'info' : 'neutral',
+      ],
+      [
+        'key' => 'attendees',
+        'label' => (string) $this->t('Attendees'),
+        'message' => $hasActivity
+          ? (string) $this->t('Bookings are visible in attendee and check-in tools.')
+          : (string) $this->t('Ticket holders will appear here after bookings begin.'),
+        'severity' => $hasActivity ? 'success' : 'info',
+      ],
+      [
+        'key' => 'day_of_event',
+        'label' => (string) $this->t('Day-of-event readiness'),
+        'message' => (string) $this->t('Use check-in during your event to validate tickets.'),
+        'severity' => 'info',
+      ],
+    ];
+  }
+
+  /**
+   * @param array{terms: bool, profile: bool, stripe: bool} $flags
+   *
+   * @return list<string>
+   */
+  public function eventStudioPublishReadinessLines(array $flags): array {
+    $items = [];
+    if (empty($flags['stripe'])) {
+      $items[] = $this->vendorStripeReadinessBlockingLine();
+    }
+    if (empty($flags['profile'])) {
+      $items[] = $this->vendorOrganiserProfileIncompleteLine();
+    }
+    if (empty($flags['terms'])) {
+      $items[] = (string) $this->t('Accept terms to publish.');
+    }
+    return $items;
+  }
+
+  public function vendorDashboardOperationalSummaryHeading(): string {
+    return (string) $this->t('Operational readiness');
+  }
+
+  public function vendorDashboardOperationalSummaryIntro(): string {
+    return (string) $this->t('A calm snapshot of publishing, bookings, payouts, attendees, and discovery.');
+  }
+
+  public function vendorEventWorkspaceOperationalSummaryHeading(): string {
+    return (string) $this->t('Operational readiness');
+  }
+
+  public function vendorEventWorkspaceOperationalSummaryIntro(): string {
+    return (string) $this->t('What is ready, what attendees can see, and what still needs setup.');
+  }
+
+  public function vendorAttendeeCheckinGuidanceLine(): string {
+    return (string) $this->t('Use check-in during your event to validate tickets.');
+  }
+
+  // -------------------------------------------------------------------------
   // MEL Attendee Operations Layer empty-state slots.
   // Owned by MELStateSystem; consumed by GovernedOperationalTemplates and the
   // attendee operations presenter. NEVER inline this copy in Twig.

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -1352,6 +1352,103 @@ final class MelReadinessHelper {
   }
 
   /**
+   * Builds lifecycle guidance from dashboard-ready event rows.
+   *
+   * @param list<array<string, mixed>> $events
+   *
+   * @return array{heading: string, intro: string, items: list<array{key: string, stage: string, message: string, severity: string}>}
+   */
+  public function vendorDashboardLifecycleSummary(array $readiness, array $events, bool $analytics_available): array {
+    $hasEvents = $events !== [];
+    $hasPublished = FALSE;
+    $hasDraft = FALSE;
+    $hasBooking = FALSE;
+    $hasActivity = FALSE;
+    $hasVisualContent = FALSE;
+    $hasPromotedEvent = FALSE;
+
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $status = (string) ($event['status'] ?? '');
+      $hasPublished = $hasPublished || in_array($status, ['upcoming', 'published', 'past'], TRUE);
+      $hasDraft = $hasDraft || $status === 'draft';
+
+      $eventType = (string) ($event['event_type'] ?? 'unknown');
+      $hasBooking = $hasBooking || $eventType !== 'unknown';
+      $hasActivity = $hasActivity || !empty($event['metric_label']);
+
+      $image = $event['image'] ?? [];
+      $hasVisualContent = $hasVisualContent || (is_array($image) && !empty($image['url']) && empty($image['is_placeholder']));
+      $hasPromotedEvent = $hasPromotedEvent || !empty($event['is_promoted']);
+    }
+
+    $stripeReady = (bool) ($readiness['stripe_ready'] ?? FALSE);
+
+    return [
+      'heading' => (string) $this->t('Lifecycle guidance'),
+      'intro' => (string) $this->t('Helpful context based on the organiser, event, booking, attendee, and discovery signals already shown here.'),
+      'items' => [
+        [
+          'key' => 'event_setup',
+          'stage' => (string) $this->t('Event Setup'),
+          'message' => $hasEvents
+            ? (string) $this->t('Your event workspace is ready for setup, publishing, and attendee follow-up.')
+            : (string) $this->t('Create your first event to start adding details, RSVPs, or tickets.'),
+          'severity' => $hasEvents ? 'success' : 'info',
+        ],
+        [
+          'key' => 'publishing_readiness',
+          'stage' => (string) $this->t('Publishing Readiness'),
+          'message' => $hasPublished
+            ? (string) $this->t('At least one event is visible to attendees.')
+            : ($hasDraft
+              ? (string) $this->t('Your draft event stays private until you publish it.')
+              : (string) $this->t('Publishing guidance will appear after you create an event.')),
+          'severity' => $hasPublished ? 'success' : 'info',
+        ],
+        [
+          'key' => 'booking_readiness',
+          'stage' => (string) $this->t('Booking Readiness'),
+          'message' => $hasBooking
+            ? (string) $this->t('RSVP or ticket setup is present on at least one event.')
+            : (string) $this->t('Add RSVP settings or ticket types when you are ready to accept bookings.'),
+          'severity' => $hasBooking ? 'success' : 'info',
+        ],
+        [
+          'key' => 'discovery_readiness',
+          'stage' => (string) $this->t('Discovery Readiness'),
+          'message' => $hasVisualContent
+            ? ($hasPromotedEvent
+              ? (string) $this->t('Your event has visual content and an active promoted placement signal.')
+              : (string) $this->t('Your event has visual content that can support discovery and sharing.'))
+            : (string) $this->t('Adding a banner image can help your event stand out in discovery.'),
+          'severity' => $hasVisualContent ? 'success' : 'info',
+        ],
+        [
+          'key' => 'attendee_activity',
+          'stage' => (string) $this->t('Attendee Activity'),
+          'message' => $hasActivity
+            ? (string) $this->t('Your event has active bookings or RSVPs in organiser tools.')
+            : (string) $this->t('Bookings will appear here after attendees reserve tickets or RSVP.'),
+          'severity' => $hasActivity ? 'success' : 'info',
+        ],
+        [
+          'key' => 'event_momentum',
+          'stage' => (string) $this->t('Event Momentum'),
+          'message' => $analytics_available
+            ? (string) $this->t('Analytics are available from the organiser dashboard when you want to review activity.')
+            : ($stripeReady
+              ? (string) $this->t('Your payout setup is ready for paid ticket activity when your events use paid tickets.')
+              : (string) $this->t('Connect Stripe only when you plan to sell paid tickets.')),
+          'severity' => 'info',
+        ],
+      ],
+    ];
+  }
+
+  /**
    * @return list<array{key: string, label: string, message: string, severity: string}>
    */
   public function vendorEventWorkspaceOperationalSummary(string $event_type, string $status, int $tickets_sold, int $orders_count, int $rsvp_count): array {
@@ -1398,6 +1495,74 @@ final class MelReadinessHelper {
         'label' => (string) $this->t('Day-of-event readiness'),
         'message' => (string) $this->t('Use check-in during your event to validate tickets.'),
         'severity' => 'info',
+      ],
+    ];
+  }
+
+  /**
+   * Builds event-scoped lifecycle guidance from existing workspace signals.
+   *
+   * @return array{heading: string, intro: string, items: list<array{key: string, stage: string, message: string, severity: string}>}
+   */
+  public function vendorEventWorkspaceLifecycleSummary(string $event_type, string $status, int $tickets_sold, int $orders_count, int $rsvp_count, bool $has_banner, bool $has_category, bool $has_tags, bool $is_promoted): array {
+    $isPublished = $status === 'published' || $status === 'past' || $status === 'upcoming';
+    $hasBooking = $event_type !== 'unknown';
+    $hasActivity = $tickets_sold > 0 || $orders_count > 0 || $rsvp_count > 0;
+    $hasDiscoveryTaxonomy = $has_category || $has_tags;
+    $isPast = $status === 'past';
+
+    return [
+      'heading' => (string) $this->t('Lifecycle guidance'),
+      'intro' => (string) $this->t('Contextual notes that explain this event state without adding new rules or alerts.'),
+      'items' => [
+        [
+          'key' => 'launch_readiness',
+          'stage' => (string) $this->t('Launch Readiness'),
+          'message' => $isPublished
+            ? (string) $this->t('Your event is visible to attendees.')
+            : (string) $this->t('This event is still in draft. Publish when your details and booking setup are ready.'),
+          'severity' => $isPublished ? 'success' : 'info',
+        ],
+        [
+          'key' => 'booking_readiness',
+          'stage' => (string) $this->t('Booking Readiness'),
+          'message' => $hasBooking
+            ? ($event_type === 'rsvp'
+              ? (string) $this->t('RSVPs are active for this event.')
+              : ($event_type === 'paid'
+                ? (string) $this->t('Paid tickets use the existing Stripe and Commerce publish checks.')
+                : (string) $this->t('RSVPs and paid tickets are active for this event.')))
+            : (string) $this->t('Ticket sales and RSVPs are not currently enabled.'),
+          'severity' => $hasBooking ? 'success' : 'warning',
+        ],
+        [
+          'key' => 'discovery_readiness',
+          'stage' => (string) $this->t('Discovery Readiness'),
+          'message' => $has_banner && $hasDiscoveryTaxonomy
+            ? ($is_promoted
+              ? (string) $this->t('Your event has discovery details and an active promoted placement signal.')
+              : (string) $this->t('Your banner image and category or tag details can support discovery.'))
+            : ($has_banner
+              ? (string) $this->t('Adding categories or tags can help people understand where this event fits.')
+              : (string) $this->t('Adding a banner image can help your event stand out in discovery.')),
+          'severity' => ($has_banner && $hasDiscoveryTaxonomy) ? 'success' : 'info',
+        ],
+        [
+          'key' => 'attendee_momentum',
+          'stage' => (string) $this->t('Attendee Momentum'),
+          'message' => $hasActivity
+            ? (string) $this->t('Your event already has bookings. Check-in tools are ready when you need them.')
+            : (string) $this->t('Bookings will appear here after attendees reserve tickets or RSVP.'),
+          'severity' => $hasActivity ? 'success' : 'info',
+        ],
+        [
+          'key' => 'post_event_followup',
+          'stage' => (string) $this->t('Post-Event Follow-up'),
+          'message' => $isPast
+            ? (string) $this->t('Your event has ended. Ticket holders and RSVP responses remain available from this workspace.')
+            : (string) $this->t('After the event, attendee activity remains available from your organiser dashboard and event workspace.'),
+          'severity' => $isPast ? 'neutral' : 'info',
+        ],
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_escalations_portal/myeventlane_escalations_portal.routing.yml
+++ b/web/modules/custom/myeventlane_escalations_portal/myeventlane_escalations_portal.routing.yml
@@ -3,7 +3,7 @@ myeventlane_escalations_portal.customer_support:
   path: '/my/support'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_portal\Controller\CustomerEscalationController::list'
-    _title: 'My Support'
+    _title: 'Support'
   requirements:
     _permission: 'view own escalation'
 
@@ -12,7 +12,7 @@ myeventlane_escalations_portal.customer_support_tickets:
   path: '/support/tickets'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_portal\Controller\CustomerEscalationController::list'
-    _title: 'My Support'
+    _title: 'Support'
   requirements:
     _permission: 'view own escalation'
 
@@ -20,7 +20,7 @@ myeventlane_escalations_portal.customer_list:
   path: '/my/support/escalations'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_portal\Controller\CustomerEscalationController::list'
-    _title: 'My Escalations'
+    _title: 'Support requests'
   requirements:
     _permission: 'view own escalation'
 
@@ -28,7 +28,7 @@ myeventlane_escalations_portal.customer_add:
   path: '/my/support/escalations/add'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_portal\Controller\CustomerEscalationController::add'
-    _title: 'Submit an Escalation'
+    _title: 'Submit a support request'
   requirements:
     _permission: 'create escalation'
 
@@ -54,7 +54,7 @@ myeventlane_escalations_portal.vendor_list:
   path: '/vendor/support'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_portal\Controller\VendorEscalationController::list'
-    _title: 'Vendor Support'
+    _title: 'Support'
   requirements:
     _permission: 'view vendor escalations'
 

--- a/web/modules/custom/myeventlane_escalations_portal/src/Controller/CustomerEscalationController.php
+++ b/web/modules/custom/myeventlane_escalations_portal/src/Controller/CustomerEscalationController.php
@@ -114,7 +114,7 @@ final class CustomerEscalationController extends ControllerBase {
         '#attributes' => ['class' => ['mel-support-actions']],
         'link' => [
           '#type' => 'link',
-          '#title' => $this->t('Submit a new escalation'),
+          '#title' => $this->t('New support request'),
           '#url' => Url::fromRoute('myeventlane_escalations_portal.customer_add'),
           '#attributes' => ['class' => ['button', 'button--primary']],
         ],
@@ -129,15 +129,15 @@ final class CustomerEscalationController extends ControllerBase {
           $this->t('Created'),
         ],
         '#rows' => $rows,
-        '#empty' => $this->t('You have no support escalations yet.'),
+        '#empty' => $this->t('You have no support requests yet. When you contact us, your conversations will appear here.'),
         '#attributes' => ['class' => ['mel-support-table']],
       ],
     ];
 
     return [
       '#theme' => 'mel_support_layout',
-      '#title' => $this->t('My Support'),
-      '#intro' => $this->t('View and manage your support escalations.'),
+      '#title' => $this->t('Support'),
+      '#intro' => $this->t('View and manage your support requests.'),
       '#content' => $content,
     ];
   }
@@ -149,7 +149,7 @@ final class CustomerEscalationController extends ControllerBase {
     $form = $this->formBuilder()->getForm(CustomerEscalationForm::class);
     return [
       '#theme' => 'mel_support_layout',
-      '#title' => $this->t('Submit an Escalation'),
+      '#title' => $this->t('Submit a support request'),
       '#intro' => $this->t('Describe your issue and we\'ll get back to you as soon as possible.'),
       '#content' => $form,
     ];
@@ -161,7 +161,7 @@ final class CustomerEscalationController extends ControllerBase {
   public function view(int $escalation): array {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      return ['#markup' => $this->t('Escalation not found.')];
+      return ['#markup' => $this->t('Support request not found.')];
     }
 
     /** @var \Drupal\myeventlane_escalations\Entity\Escalation $entity */
@@ -247,7 +247,7 @@ final class CustomerEscalationController extends ControllerBase {
   public function viewTitle(int $escalation): string {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      return (string) $this->t('Escalation');
+      return (string) $this->t('Support request');
     }
     return (string) $entity->get('subject')->value;
   }
@@ -258,7 +258,7 @@ final class CustomerEscalationController extends ControllerBase {
   public function reopen(int $escalation): RedirectResponse {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      $this->messenger()->addError($this->t('Escalation not found.'));
+      $this->messenger()->addError($this->t('Support request not found.'));
       return new RedirectResponse('/my/support/escalations');
     }
 
@@ -271,7 +271,7 @@ final class CustomerEscalationController extends ControllerBase {
     $entity->save();
 
     $this->mailer->notifyVendorReopened($entity);
-    $this->messenger()->addStatus($this->t('Your escalation has been reopened.'));
+    $this->messenger()->addStatus($this->t('Your support request has been reopened.'));
 
     return new RedirectResponse('/my/support/escalations/' . $escalation);
   }
@@ -302,12 +302,12 @@ final class CustomerEscalationController extends ControllerBase {
         "\xE2\x9C\x85",
       ],
       $status === 'closed' => [
-        (string) $this->t('This escalation has been closed.'),
+        (string) $this->t('This support request has been closed.'),
         'closed',
         "\xF0\x9F\x93\x81",
       ],
       $status === 'new' => [
-        (string) $this->t('Your escalation has been received and is being reviewed.'),
+        (string) $this->t('We have received your support request and are reviewing it.'),
         'info',
         "\xF0\x9F\x93\xA8",
       ],
@@ -327,7 +327,7 @@ final class CustomerEscalationController extends ControllerBase {
         "\xF0\x9F\x92\xAC",
       ],
       default => [
-        (string) $this->t('Your escalation is being handled.'),
+        (string) $this->t('Your support request is being handled.'),
         'info',
         "\xF0\x9F\x93\x8B",
       ],

--- a/web/modules/custom/myeventlane_escalations_portal/src/Controller/CustomerEscalationController.php
+++ b/web/modules/custom/myeventlane_escalations_portal/src/Controller/CustomerEscalationController.php
@@ -150,7 +150,7 @@ final class CustomerEscalationController extends ControllerBase {
     return [
       '#theme' => 'mel_support_layout',
       '#title' => $this->t('Submit a support request'),
-      '#intro' => $this->t('Describe your issue and we\'ll get back to you as soon as possible.'),
+      '#intro' => $this->t('Tell us what\'s going on — we\'ll reply by email.'),
       '#content' => $form,
     ];
   }

--- a/web/modules/custom/myeventlane_escalations_portal/src/Controller/VendorEscalationController.php
+++ b/web/modules/custom/myeventlane_escalations_portal/src/Controller/VendorEscalationController.php
@@ -51,7 +51,7 @@ final class VendorEscalationController extends ControllerBase {
   public function list(): array {
     $vendor = $this->vendorResolver->resolveFromUser($this->currentUser());
     if (!$vendor) {
-      return ['#markup' => '<p>' . $this->t('You are not associated with a vendor.') . '</p>'];
+      return ['#markup' => '<p>' . $this->t('You are not associated with an organiser account.') . '</p>'];
     }
 
     $ids = $this->entityTypeManager()->getStorage('escalation')
@@ -105,7 +105,7 @@ final class VendorEscalationController extends ControllerBase {
         $this->t('Created'),
       ],
       '#rows' => $rows,
-      '#empty' => $this->t('No escalations assigned to your vendor.'),
+      '#empty' => $this->t('No support requests are assigned to your organiser account yet.'),
       '#attributes' => ['class' => ['mel-support-table']],
     ];
 
@@ -126,8 +126,8 @@ final class VendorEscalationController extends ControllerBase {
 
     return [
       '#theme' => 'mel_support_layout',
-      '#title' => $this->t('Vendor Support'),
-      '#intro' => $this->t('Manage escalations assigned to your vendor.'),
+      '#title' => $this->t('Support'),
+      '#intro' => $this->t('Manage support requests for your organiser account.'),
       '#content' => array_filter([
         'helper' => $helper,
         'table' => $table,
@@ -141,7 +141,7 @@ final class VendorEscalationController extends ControllerBase {
   public function view(int $escalation): array {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      return ['#markup' => $this->t('Escalation not found.')];
+      return ['#markup' => $this->t('Support request not found.')];
     }
 
     /** @var \Drupal\myeventlane_escalations\Entity\Escalation $entity */
@@ -256,7 +256,7 @@ final class VendorEscalationController extends ControllerBase {
   public function viewTitle(int $escalation): string {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      return (string) $this->t('Escalation');
+      return (string) $this->t('Support request');
     }
     return (string) $entity->get('subject')->value;
   }
@@ -267,7 +267,7 @@ final class VendorEscalationController extends ControllerBase {
   public function resolve(int $escalation): RedirectResponse {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      $this->messenger()->addError($this->t('Escalation not found.'));
+      $this->messenger()->addError($this->t('Support request not found.'));
       return new RedirectResponse('/vendor/support');
     }
 
@@ -286,7 +286,7 @@ final class VendorEscalationController extends ControllerBase {
   public function reopen(int $escalation): RedirectResponse {
     $entity = $this->entityTypeManager()->getStorage('escalation')->load($escalation);
     if (!$entity) {
-      $this->messenger()->addError($this->t('Escalation not found.'));
+      $this->messenger()->addError($this->t('Support request not found.'));
       return new RedirectResponse('/vendor/support');
     }
 

--- a/web/modules/custom/myeventlane_escalations_portal/src/Form/CustomerEscalationForm.php
+++ b/web/modules/custom/myeventlane_escalations_portal/src/Form/CustomerEscalationForm.php
@@ -82,7 +82,7 @@ final class CustomerEscalationForm extends FormBase {
     ];
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Submit escalation'),
+      '#value' => $this->t('Submit support request'),
       '#attributes' => ['class' => ['button', 'button--primary']],
     ];
 
@@ -110,7 +110,7 @@ final class CustomerEscalationForm extends FormBase {
 
     $escalation->save();
 
-    $this->messenger()->addStatus($this->t('Your escalation has been submitted. We will get back to you as soon as possible.'));
+    $this->messenger()->addStatus($this->t('Your support request has been submitted. We will get back to you as soon as possible.'));
 
     // Notify vendor if one is assigned (unlikely from customer form, but safe).
     $this->mailer->notifyVendorNewEscalation($escalation);

--- a/web/modules/custom/myeventlane_escalations_portal/src/Form/CustomerEscalationForm.php
+++ b/web/modules/custom/myeventlane_escalations_portal/src/Form/CustomerEscalationForm.php
@@ -58,13 +58,13 @@ final class CustomerEscalationForm extends FormBase {
       '#required' => TRUE,
       '#options' => [
         '' => $this->t('- Select -'),
-        'payment' => $this->t('Payment Issue'),
-        'refund' => $this->t('Refund Request'),
-        'ticket' => $this->t('Ticket Issue'),
-        'event' => $this->t('Event Related'),
-        'vendor' => $this->t('Vendor Dispute'),
-        'customer' => $this->t('Customer Complaint'),
-        'technical' => $this->t('Technical Issue'),
+        'payment' => $this->t('Payment issue'),
+        'refund' => $this->t('Refund request'),
+        'ticket' => $this->t('Ticket issue'),
+        'event' => $this->t('Event-related question'),
+        'vendor' => $this->t('Issue with an organiser'),
+        'customer' => $this->t('Other concern'),
+        'technical' => $this->t('Technical issue'),
         'other' => $this->t('Other'),
       ],
     ];
@@ -110,7 +110,7 @@ final class CustomerEscalationForm extends FormBase {
 
     $escalation->save();
 
-    $this->messenger()->addStatus($this->t('Your support request has been submitted. We will get back to you as soon as possible.'));
+    $this->messenger()->addStatus($this->t('Your support request has been received. We\'ll reply by email — please keep an eye on your inbox.'));
 
     // Notify vendor if one is assigned (unlikely from customer form, but safe).
     $this->mailer->notifyVendorNewEscalation($escalation);

--- a/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
@@ -134,7 +134,7 @@ final class VendorAttendeeController extends ControllerBase {
    * Page title callback for attendee list.
    */
   public function listTitle(NodeInterface $node): string {
-    return (string) $this->t('Attendees for @event', ['@event' => $node->label()]);
+    return (string) $this->t('Ticket holders for @event', ['@event' => $node->label()]);
   }
 
   /**
@@ -236,7 +236,7 @@ final class VendorAttendeeController extends ControllerBase {
     if (!empty($grouped['rsvp'])) {
       $build['rsvp_section'] = [
         '#type' => 'details',
-        '#title' => $this->t('RSVP Attendees (@count)', ['@count' => count($grouped['rsvp'])]),
+        '#title' => $this->t('RSVP responses (@count)', ['@count' => count($grouped['rsvp'])]),
         '#open' => TRUE,
       ];
 
@@ -275,7 +275,7 @@ final class VendorAttendeeController extends ControllerBase {
       $build['ticket_section']['title'] = [
         '#type' => 'html_tag',
         '#tag' => 'h3',
-        '#value' => $this->t('Ticket Attendees (@count)', ['@count' => count($grouped['ticket'])]),
+        '#value' => $this->t('Ticket holders (@count)', ['@count' => count($grouped['ticket'])]),
       ];
 
       foreach ($ticketTypeGroups as $variationId => $group) {
@@ -386,7 +386,7 @@ final class VendorAttendeeController extends ControllerBase {
       }
     }
     return [
-      '#markup' => '<p>' . $this->t('No attendees yet. Share your event to start collecting RSVPs or ticket sales.') . '</p>',
+      '#markup' => '<p>' . $this->t('No ticket holders or RSVPs yet. Share your event link to start collecting responses or ticket sales.') . '</p>',
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
@@ -129,7 +129,10 @@ abstract class EventStudioBaseForm extends FormBase {
    * Redirect and messaging after a successful wizard step save.
    */
   protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
-    $this->messenger()->addStatus($this->t('Saved.'));
+    $message = $this->isDraftWizardSave() && !$saved->isPublished()
+      ? $this->t('Saved as draft.')
+      : $this->t('Saved.');
+    $this->messenger()->addStatus($message);
     $form_state->setRedirect($this->getNextRouteName(), ['node' => $saved->id()]);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -15,6 +15,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_questions\Entity\VendorQuestionInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
@@ -85,6 +86,8 @@ final class EventStudioForm extends FormBase {
 
   protected EventStudioGovernanceComponentBuilder $eventStudioGovernanceComponentBuilder;
 
+  protected MelReadinessHelper $readinessHelper;
+
   /**
    * Lazily restored for cached form AJAX (see {@see getMelPlatformSupportWizardForm()}).
    *
@@ -118,6 +121,7 @@ final class EventStudioForm extends FormBase {
     $instance->melPlatformSupportWizardForm = $container->get('myeventlane_event.mel_platform_support_wizard_form');
     $instance->eventStudioGovernanceBuilder = $container->get('myeventlane_event_studio.governance_builder');
     $instance->eventStudioGovernanceComponentBuilder = $container->get('myeventlane_event_studio.governance_component_builder');
+    $instance->readinessHelper = $container->get('myeventlane_surface.state_readiness_helper');
     return $instance;
   }
 
@@ -137,7 +141,7 @@ final class EventStudioForm extends FormBase {
    * subclass properties can still be uninitialized on some paths; repull then.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->formBuilder, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->ticketTypeManager, $this->ticketTierLifecycle, $this->eventTicketReconciliation, $this->logger, $this->melPayloadService, $this->entityAutocompleteMelNormalizer, $this->publishRequirementsGate, $this->bookingFlowResolver, $this->eventStudioGovernanceBuilder, $this->eventStudioGovernanceComponentBuilder)
+    if (isset($this->entityTypeManager, $this->entityFieldManager, $this->formBuilder, $this->saveService, $this->currentUser, $this->eventHighlightHelper, $this->ticketTypeManager, $this->ticketTierLifecycle, $this->eventTicketReconciliation, $this->logger, $this->melPayloadService, $this->entityAutocompleteMelNormalizer, $this->publishRequirementsGate, $this->bookingFlowResolver, $this->eventStudioGovernanceBuilder, $this->eventStudioGovernanceComponentBuilder, $this->readinessHelper)
       && isset($this->melPlatformSupportWizardForm)) {
       return;
     }
@@ -196,6 +200,9 @@ final class EventStudioForm extends FormBase {
     if (!isset($this->eventStudioGovernanceComponentBuilder)) {
       $this->eventStudioGovernanceComponentBuilder = $container->get('myeventlane_event_studio.governance_component_builder');
     }
+    if (!isset($this->readinessHelper)) {
+      $this->readinessHelper = $container->get('myeventlane_surface.state_readiness_helper');
+    }
   }
 
   protected function getMelPlatformSupportWizardForm(): MelPlatformSupportWizardFormHelper {
@@ -224,16 +231,7 @@ final class EventStudioForm extends FormBase {
 
     if (!$this->currentUser->hasPermission('administer nodes') && (int) $this->currentUser->id() > 0) {
       $flags = $this->publishRequirementsGate->getReadinessFlags($this->currentUser->getAccount());
-      $items = [];
-      if (!$flags['stripe']) {
-        $items[] = $this->t('Connect Stripe before publishing your event.');
-      }
-      if (!$flags['profile']) {
-        $items[] = $this->t('Complete your organiser profile.');
-      }
-      if (!$flags['terms']) {
-        $items[] = $this->t('Accept terms to publish.');
-      }
+      $items = $this->readinessHelper->eventStudioPublishReadinessLines($flags);
       if ($items !== []) {
         $form['mel_studio_readiness'] = [
           '#type' => 'container',

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -87,7 +87,7 @@ final class EventStudioPublishForm extends EventStudioBaseForm {
         '<div class="mel-publish-action-card" role="region" aria-labelledby="mel-publish-action-title-wizard" data-mel-publish-card="1">' .
         '<div class="mel-publish-action-card__panel mel-publish-action-card__draft"' . $draft_hidden . ' data-mel-publish-panel="draft">' .
         '<h3 id="mel-publish-action-title-wizard" class="mel-publish-action-card__title">' . $this->t('Publish event') . '</h3>' .
-        '<p class="mel-publish-action-card__desc">' . $this->t('Make your event live and visible') . '</p>' .
+        '<p class="mel-publish-action-card__desc">' . $this->t('After publishing, your public page can show RSVPs or tickets you\'ve turned on.') . '</p>' .
         '<button type="button" class="mel-btn mel-btn--primary" id="mel-publish-now">' . $this->t('Publish now') . '</button>' .
         '</div>' .
         '<div class="mel-publish-action-card__panel mel-publish-action-card__live"' . $live_hidden . ' data-mel-publish-panel="live">' .

--- a/web/modules/custom/myeventlane_help_assistant/src/Service/EventSuggestionEngine.php
+++ b/web/modules/custom/myeventlane_help_assistant/src/Service/EventSuggestionEngine.php
@@ -257,7 +257,7 @@ final class EventSuggestionEngine {
         'success',
         'revenue',
         self::P_REVENUE,
-        (string) $this->t('Boosting your event can help it reach more people and stand out in listings.'),
+        (string) $this->t('Promoting your event can help it reach more people and stand out in listings.'),
         $action,
       );
     }

--- a/web/modules/custom/myeventlane_help_assistant/src/Service/EventSuggestionFormatter.php
+++ b/web/modules/custom/myeventlane_help_assistant/src/Service/EventSuggestionFormatter.php
@@ -181,7 +181,7 @@ final class EventSuggestionFormatter {
       'missing_image' => (string) $this->t('Add an event image'),
       'missing_category' => (string) $this->t('Choose a category'),
       'missing_accessibility' => (string) $this->t('Add accessibility details'),
-      'boost_visibility' => (string) $this->t('Boost your event'),
+      'boost_visibility' => (string) $this->t('Promote your event'),
       'calendar_confirmations_off' => (string) $this->t('Turn on confirmations'),
       'calendar_ics_path' => (string) $this->t('Enable calendar downloads'),
       'near_capacity' => (string) $this->t('Nearly at capacity'),
@@ -360,7 +360,7 @@ final class EventSuggestionFormatter {
       $url = Url::fromRoute('myeventlane_boost.vendor_boost_wizard', ['event' => $event->id()])->toString();
       return [
         'type' => 'link',
-        'label' => (string) $this->t('Boost event'),
+        'label' => (string) $this->t('Promote event'),
         'url' => $url,
       ];
     }

--- a/web/modules/custom/myeventlane_help_assistant/src/Service/HelpAssistantService.php
+++ b/web/modules/custom/myeventlane_help_assistant/src/Service/HelpAssistantService.php
@@ -63,7 +63,7 @@ final class HelpAssistantService {
     if (!(bool) $config->get('enabled')) {
       return $this->withStructuredFields([
         'status' => 'disabled',
-        'answer' => 'Sorry, the Help Assistant is unavailable right now.',
+        'answer' => (string) $this->t('The Help Assistant is unavailable right now. You can browse the Help Centre or contact Support.'),
         'confidence' => 'low',
         'escalation_recommended' => TRUE,
         'message' => $this->buildEscalationText($supportUrl),
@@ -94,7 +94,7 @@ final class HelpAssistantService {
       $this->helpAnalyticsService->logAiEvent('ai_low_confidence', $question, $resultCount, 'low');
       return $this->withStructuredFields([
         'status' => 'ai_disabled',
-        'answer' => 'AI help is currently unavailable. You can still browse help articles below.',
+        'answer' => (string) $this->t('AI help is currently unavailable. You can still browse the help articles below.'),
         'confidence' => 'low',
         'escalation_recommended' => FALSE,
         'message' => '',
@@ -666,13 +666,13 @@ final class HelpAssistantService {
    */
   private function buildFallbackPayload(array $articles, string $confidence, string $supportUrl, bool $empty_retrieval = FALSE): array {
     if ($empty_retrieval) {
-      $answer = (string) $this->t('We couldn’t find a perfect answer in the Help Centre yet. Try rephrasing your question or open one of the guides below when they appear.');
+      $answer = (string) $this->t('We couldn’t find a clear answer in the Help Centre. Try rephrasing your question, or browse the guides linked below.');
     }
     elseif ($articles === []) {
-      $answer = (string) $this->t('We couldn’t find a perfect answer yet. Try contacting support with your event or booking details.');
+      $answer = (string) $this->t('We couldn’t find a clear answer yet. If you contact Support with your event or booking details, we can help directly.');
     }
     else {
-      $answer = (string) $this->t('We couldn’t find a perfect answer — here are some helpful guides from the Help Centre.');
+      $answer = (string) $this->t('We couldn’t find a clear answer — here are some related guides from the Help Centre.');
     }
 
     return $this->withStructuredFields([
@@ -687,9 +687,9 @@ final class HelpAssistantService {
 
   private function buildEscalationText(string $supportUrl): string {
     if ($supportUrl !== '') {
-      return (string) $this->t('I cannot confirm this from the Help Centre. For a personalised answer, open a support request at @url.', ['@url' => $supportUrl]);
+      return (string) $this->t('I’m not sure from the Help Centre. For a personal answer, open a support request: @url.', ['@url' => $supportUrl]);
     }
-    return (string) $this->t('I cannot confirm this from the Help Centre. Please contact support for personalised help.');
+    return (string) $this->t('I’m not sure from the Help Centre. Please contact Support for a personal answer.');
   }
 
   private function sanitiseQuestion(string $question): string {

--- a/web/modules/custom/myeventlane_help_assistant/src/Service/HelpAssistantService.php
+++ b/web/modules/custom/myeventlane_help_assistant/src/Service/HelpAssistantService.php
@@ -687,9 +687,9 @@ final class HelpAssistantService {
 
   private function buildEscalationText(string $supportUrl): string {
     if ($supportUrl !== '') {
-      return 'I cannot confirm this from the Help Centre. Please contact support via ' . $supportUrl . '.';
+      return (string) $this->t('I cannot confirm this from the Help Centre. For a personalised answer, open a support request at @url.', ['@url' => $supportUrl]);
     }
-    return 'I cannot confirm this from the Help Centre. Please contact support for personalised help.';
+    return (string) $this->t('I cannot confirm this from the Help Centre. Please contact support for personalised help.');
   }
 
   private function sanitiseQuestion(string $question): string {

--- a/web/modules/custom/myeventlane_tickets/src/Controller/TicketScanController.php
+++ b/web/modules/custom/myeventlane_tickets/src/Controller/TicketScanController.php
@@ -61,7 +61,7 @@ final class TicketScanController extends ControllerBase {
         '#markup' => '<div class="mel-checkin-camera-wrap"><div id="mel-checkin-camera" class="mel-checkin-camera"></div><div id="mel-checkin-status-overlay" class="mel-checkin-status-overlay is-idle"><div class="mel-checkin-status-icon" id="mel-checkin-status-icon">...</div><div class="mel-checkin-status-text" id="mel-checkin-status-text">' . $this->t('Ready to scan') . '</div><div class="mel-checkin-status-subtext" id="mel-checkin-status-subtext"></div></div></div>',
       ],
       'manual' => [
-        '#markup' => '<form id="mel-checkin-manual-form" class="mel-checkin-manual-form"><label for="mel-checkin-manual-input">' . $this->t('Manual entry') . '</label><input id="mel-checkin-manual-input" type="text" maxlength="512" autocomplete="off" placeholder="' . $this->t('Paste ticket code or payload') . '" /><button type="submit">' . $this->t('Validate') . '</button></form>',
+        '#markup' => '<form id="mel-checkin-manual-form" class="mel-checkin-manual-form"><label for="mel-checkin-manual-input">' . $this->t('Manual entry') . '</label><input id="mel-checkin-manual-input" type="text" maxlength="512" autocomplete="off" placeholder="' . $this->t('Paste ticket code or QR text') . '" /><button type="submit">' . $this->t('Validate') . '</button></form>',
       ],
     ];
 

--- a/web/modules/custom/myeventlane_tickets/src/Service/TicketCheckinService.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/TicketCheckinService.php
@@ -115,7 +115,7 @@ final class TicketCheckinService {
         '@event' => (string) $route_event_id,
         '@message' => $e->getMessage(),
       ]);
-      $result = $this->result(FALSE, 'error', 'A server error occurred while checking in this ticket.', (string) $ticket->get('ticket_code')->value);
+      $result = $this->result(FALSE, 'error', "Check-in couldn't be completed. Try again or use manual check-in.", (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
       return $result;
     }

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -295,7 +295,7 @@ myeventlane_vendor.shell.vendor_root:
   path: '/vendor'
   defaults:
     _controller: 'myeventlane_vendor.controller.vendor_dashboard:entrypointRedirect'
-    _title: 'Vendor'
+    _title: 'Organiser console'
   requirements:
     _access: 'TRUE'
 
@@ -307,7 +307,7 @@ myeventlane_vendor.console.dashboard:
   path: '/vendor/dashboard'
   defaults:
     _controller: 'myeventlane_vendor.controller.vendor_dashboard:dashboard'
-    _title: 'Vendor dashboard'
+    _title: 'Organiser dashboard'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
   options:
@@ -514,7 +514,7 @@ myeventlane_vendor.console.event_workspace:
   path: '/vendor/events/{event}'
   defaults:
     _controller: 'myeventlane_vendor.controller.event_workspace:workspace'
-    _title: 'Event workspace'
+    _title: 'Event Manager'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     event: '\d+'
@@ -741,7 +741,7 @@ myeventlane_vendor.console.boost:
   path: '/vendor/boost'
   defaults:
     _controller: 'myeventlane_vendor.controller.vendor_boost:boost'
-    _title: 'Boost'
+    _title: 'Promote event'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -300,6 +300,7 @@ services:
       - '@datetime.time'
       - '@string_translation'
       - '@logger.factory'
+      - '@myeventlane_surface.state_readiness_helper'
 
   # Vendor console controllers as services for DI.
   myeventlane_vendor.controller.vendor_dashboard:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -197,7 +197,7 @@ final class StripeConnectController extends ControllerBase {
       $log->error('Stripe connect: no vendor profile for user @uid', [
         '@uid' => (string) $currentUser->id(),
       ]);
-      $this->messenger()->addError($this->t('No vendor profile found for your account. Please contact support.'));
+      $this->messenger()->addError($this->t('We couldn\'t find your organiser profile. Please contact Support.'));
       return $this->redirectToDashboard();
     }
 
@@ -207,7 +207,7 @@ final class StripeConnectController extends ControllerBase {
         '@vid' => (string) $vendor->id(),
         '@uid' => (string) $currentUser->id(),
       ]);
-      $this->messenger()->addError($this->t('Your vendor store is not ready yet. Complete vendor onboarding, then return to connect Stripe.'));
+      $this->messenger()->addError($this->t('Your organiser account isn\'t ready yet. Finish onboarding, then return to connect Stripe.'));
       return $this->redirectToDashboard();
     }
     $this->syncVendorStoreReference($vendor, $store);
@@ -222,7 +222,7 @@ final class StripeConnectController extends ControllerBase {
       $store
     );
     if ($queryAccountStr !== '' && $accountId === NULL) {
-      $this->messenger()->addError($this->t('Stripe account mismatch. Please start Connect again or contact support.'));
+      $this->messenger()->addError($this->t('Something didn\'t match with your Stripe account. Please start the Stripe connection again, or contact Support.'));
       return $this->redirectToDashboard();
     }
 
@@ -353,7 +353,7 @@ final class StripeConnectController extends ControllerBase {
 
     $vendor = $this->getCurrentUserVendor();
     if (!$vendor) {
-      $this->messenger()->addError($this->t('No vendor profile found for your account.'));
+      $this->messenger()->addError($this->t('We couldn\'t find your organiser profile.'));
       return $this->redirectToDashboard();
     }
 
@@ -369,10 +369,10 @@ final class StripeConnectController extends ControllerBase {
     $accountId = $this->resolveValidatedAccountId($qidStr !== '' ? $qidStr : NULL, $store);
     if ($accountId === NULL) {
       if ($qidStr !== '') {
-        $this->messenger()->addError($this->t('Stripe account mismatch. Please use Connect from your dashboard again.'));
+        $this->messenger()->addError($this->t('Something didn\'t match with your Stripe account. Please start the Stripe connection again from your dashboard.'));
       }
       else {
-        $this->messenger()->addWarning($this->t('Stripe account not found. Please start the connection process again.'));
+        $this->messenger()->addWarning($this->t('We couldn\'t find your Stripe account. Please start the Stripe connection again.'));
       }
       return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect', [], [
         'query' => $dest ? ['destination' => $dest] : [],
@@ -393,7 +393,7 @@ final class StripeConnectController extends ControllerBase {
     }
     catch (\Exception $e) {
       $log->error('Stripe callback: @m', ['@m' => $e->getMessage()]);
-      $this->messenger()->addError($this->t('Failed to verify Stripe account status. Please try again.'));
+      $this->messenger()->addError($this->t('We couldn\'t check your Stripe account status. Please try again, or contact Support if it keeps happening.'));
       if ($dest !== '') {
         return new RedirectResponse($dest);
       }
@@ -424,9 +424,9 @@ final class StripeConnectController extends ControllerBase {
       $this->messenger()->addWarning($this->t('Please complete the remaining steps in your Stripe account setup.'));
     }
     else {
-      $this->messenger()->addWarning($this->t('Stripe account status: @status.', [
-        '@status' => (string) ($status['status'] ?? 'unknown'),
-      ]));
+      // Internal status is logged separately; show a calm next-step message
+      // to organisers instead of leaking raw Stripe state strings.
+      $this->messenger()->addWarning($this->t('Your Stripe account isn\'t fully set up yet. Open your Stripe dashboard to finish onboarding.'));
     }
 
     if ($dest !== '') {

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -119,12 +119,12 @@ final class VendorEventsBulkActionsForm extends FormBase {
         'text' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('Create your first event and start selling tickets.'),
+          '#value' => $this->t('Create an event to add details, RSVPs, or tickets.'),
           '#attributes' => ['class' => ['mel-empty__text']],
         ],
         'action' => [
           '#type' => 'link',
-          '#title' => $this->t('Create your first event'),
+          '#title' => $this->t('Create event'),
           '#url' => Url::fromRoute('myeventlane_event_studio.create'),
           '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
         ],

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -122,6 +122,8 @@ final class VendorDashboardViewModelBuilder {
       'action_queue' => [],
       'events' => $events,
       'current_event' => $events[0] ?? NULL,
+      'organiser_overview' => [],
+      'upcoming_events' => [],
       'analytics_summary' => $analyticsSummary,
       'empty_state' => $this->buildEmptyState($account, $events === []),
     ];
@@ -138,7 +140,9 @@ final class VendorDashboardViewModelBuilder {
 
     $model['priority_action'] = $this->primaryAction($model['action_queue']);
     $model['secondary_actions'] = $this->secondaryActions($model['action_queue']);
-    $model['activity_items'] = $this->buildActivityItems($events);
+    $model['organiser_overview'] = $this->buildOrganiserOverview($model);
+    $model['upcoming_events'] = $this->buildUpcomingEvents($events);
+    $model['activity_items'] = $this->buildActivityItems($events, $readiness);
     $model['hero_shell_hint'] = $this->heroShellHint($model);
 
     return $model;
@@ -175,6 +179,8 @@ final class VendorDashboardViewModelBuilder {
       'action_queue' => [],
       'events' => [],
       'current_event' => NULL,
+      'organiser_overview' => [],
+      'upcoming_events' => [],
       'priority_action' => NULL,
       'secondary_actions' => [],
       'activity_items' => [],
@@ -903,12 +909,161 @@ final class VendorDashboardViewModelBuilder {
   }
 
   /**
+   * Builds compact organiser-wide signals from existing dashboard payloads.
+   *
+   * @param array<string, mixed> $model
+   *
+   * @return list<array<string, string>>
+   */
+  private function buildOrganiserOverview(array $model): array {
+    $events = $model['events'] ?? [];
+    if (!is_array($events)) {
+      $events = [];
+    }
+
+    $publishedActive = 0;
+    $draft = 0;
+    $bookings = 0;
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $status = (string) ($event['status'] ?? '');
+      if ($status === 'draft') {
+        $draft++;
+      }
+      elseif ($status !== 'past') {
+        $publishedActive++;
+      }
+
+      $metrics = $event['metrics'] ?? [];
+      if (!is_array($metrics)) {
+        continue;
+      }
+      foreach ($metrics as $metric) {
+        if (!is_array($metric) || ($metric['key'] ?? '') !== 'bookings') {
+          continue;
+        }
+        $bookings += (int) ($metric['value'] ?? 0);
+      }
+    }
+
+    $upcoming = $this->overviewKpiValue($model['kpis'] ?? [], 'upcoming_events', (string) $publishedActive);
+    $readiness = $model['readiness'] ?? [];
+    $payoutReady = is_array($readiness) && (bool) ($readiness['stripe_ready'] ?? FALSE);
+    $priorityAction = $model['priority_action'] ?? NULL;
+    $priorityCount = is_array($priorityAction) ? 1 : 0;
+
+    return [
+      [
+        'key' => 'live_events',
+        'label' => (string) $this->t('Live events'),
+        'value' => (string) $publishedActive,
+        'context' => (string) $this->t('Published focus set'),
+        'severity' => $publishedActive > 0 ? 'success' : 'neutral',
+      ],
+      [
+        'key' => 'draft_events',
+        'label' => (string) $this->t('Draft events'),
+        'value' => (string) $draft,
+        'context' => (string) $this->t('Need publishing review'),
+        'severity' => $draft > 0 ? 'warning' : 'neutral',
+      ],
+      [
+        'key' => 'upcoming_events',
+        'label' => (string) $this->t('Upcoming events'),
+        'value' => $upcoming,
+        'context' => (string) $this->t('Published soon or ongoing'),
+        'severity' => 'neutral',
+      ],
+      [
+        'key' => 'bookings',
+        'label' => (string) $this->t('Bookings'),
+        'value' => (string) $bookings,
+        'context' => (string) $this->t('Tickets + RSVPs in view'),
+        'severity' => $bookings > 0 ? 'success' : 'neutral',
+      ],
+      [
+        'key' => 'priority',
+        'label' => (string) $this->t('Priority items'),
+        'value' => (string) $priorityCount,
+        'context' => (string) $this->t('From action queue'),
+        'severity' => $priorityCount > 0 ? 'warning' : 'success',
+      ],
+      [
+        'key' => 'payouts',
+        'label' => (string) $this->t('Payouts'),
+        'value' => $payoutReady ? (string) $this->t('Ready') : (string) $this->t('Setup'),
+        'context' => (string) $this->t('Stripe readiness'),
+        'severity' => $payoutReady ? 'success' : 'warning',
+      ],
+    ];
+  }
+
+  /**
+   * @param mixed $kpis
+   */
+  private function overviewKpiValue(mixed $kpis, string $key, string $fallback): string {
+    if (!is_array($kpis)) {
+      return $fallback;
+    }
+    foreach ($kpis as $kpi) {
+      if (is_array($kpi) && ($kpi['key'] ?? '') === $key) {
+        return (string) ($kpi['value'] ?? $fallback);
+      }
+    }
+    return $fallback;
+  }
+
+  /**
    * @param list<array<string, mixed>> $events
    *
    * @return list<array<string, mixed>>
    */
-  private function buildActivityItems(array $events): array {
+  private function buildUpcomingEvents(array $events): array {
+    $rows = [];
+    foreach (array_slice($events, 1) as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $status = (string) ($event['status'] ?? '');
+      if ($status === 'past') {
+        continue;
+      }
+      $rows[] = [
+        'title' => (string) ($event['title'] ?? ''),
+        'date_label' => (string) ($event['date_label'] ?? ''),
+        'status' => $status,
+        'status_label' => (string) ($event['status_label'] ?? ''),
+        'booking_state_label' => (string) ($event['booking_state_label'] ?? ''),
+        'metric_label' => (string) ($event['metric_label'] ?? ''),
+        'links' => is_array($event['links'] ?? NULL) ? $event['links'] : [],
+      ];
+      if (count($rows) >= 4) {
+        break;
+      }
+    }
+    return $rows;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $events
+   * @param array<string, mixed> $readiness
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function buildActivityItems(array $events, array $readiness): array {
     $items = [];
+    if ((bool) ($readiness['stripe_ready'] ?? FALSE)) {
+      $items[] = [
+        'type' => 'success',
+        'message' => (string) $this->t('Stripe payouts are active.'),
+        'url' => $this->routeExists('myeventlane_vendor.console.payouts')
+          ? $this->safeUrlFromRoute('myeventlane_vendor.console.payouts')
+          : NULL,
+      ];
+    }
+
     foreach ($events as $event) {
       if (!is_array($event)) {
         continue;
@@ -923,14 +1078,14 @@ final class VendorDashboardViewModelBuilder {
       if ($status === 'draft') {
         $items[] = [
           'type' => 'warning',
-          'message' => (string) $this->t('Draft event waiting: @event.', ['@event' => $title]),
+          'message' => (string) $this->t('@event is still in draft.', ['@event' => $title]),
           'url' => $url,
         ];
       }
       else {
         $items[] = [
           'type' => 'info',
-          'message' => (string) $this->t('Event state: @event is @state.', [
+          'message' => (string) $this->t('@event is @state.', [
             '@event' => $title,
             '@state' => (string) ($event['status_label'] ?? $status),
           ]),
@@ -942,7 +1097,7 @@ final class VendorDashboardViewModelBuilder {
       if ($metricLabel !== '') {
         $items[] = [
           'type' => 'success',
-          'message' => (string) $this->t('Activity on @event: @metrics.', [
+          'message' => (string) $this->t('@metrics for @event.', [
             '@event' => $title,
             '@metrics' => $metricLabel,
           ]),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -34,6 +34,8 @@ final class VendorDashboardViewModelBuilder {
 
   private const MAX_EVENTS = 6;
 
+  private const MAX_EVENT_QUICK_ACTIONS = 6;
+
   public function __construct(
     private readonly CurrentVendorResolverInterface $currentVendorResolver,
     private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
@@ -119,6 +121,7 @@ final class VendorDashboardViewModelBuilder {
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip($kpis),
       'action_queue' => [],
       'events' => $events,
+      'current_event' => $events[0] ?? NULL,
       'analytics_summary' => $analyticsSummary,
       'empty_state' => $this->buildEmptyState($account, $events === []),
     ];
@@ -133,6 +136,9 @@ final class VendorDashboardViewModelBuilder {
       $model['action_queue'] = [];
     }
 
+    $model['priority_action'] = $this->primaryAction($model['action_queue']);
+    $model['secondary_actions'] = $this->secondaryActions($model['action_queue']);
+    $model['activity_items'] = $this->buildActivityItems($events);
     $model['hero_shell_hint'] = $this->heroShellHint($model);
 
     return $model;
@@ -168,6 +174,10 @@ final class VendorDashboardViewModelBuilder {
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip([]),
       'action_queue' => [],
       'events' => [],
+      'current_event' => NULL,
+      'priority_action' => NULL,
+      'secondary_actions' => [],
+      'activity_items' => [],
       'analytics_summary' => [
         'available' => FALSE,
         'items' => [],
@@ -484,7 +494,20 @@ final class VendorDashboardViewModelBuilder {
       }
     }
 
-    usort($eventNodes, static function (NodeInterface $a, NodeInterface $b): int {
+    $now = (int) $this->time->getRequestTime();
+    usort($eventNodes, function (NodeInterface $a, NodeInterface $b) use ($now): int {
+      $aRank = $this->eventFocusRank($a, $now);
+      $bRank = $this->eventFocusRank($b, $now);
+      if ($aRank !== $bRank) {
+        return $aRank <=> $bRank;
+      }
+
+      $aStart = $this->getDateFieldTimestamp($a, 'field_event_start');
+      $bStart = $this->getDateFieldTimestamp($b, 'field_event_start');
+      if ($aStart > 0 && $bStart > 0 && $aStart !== $bStart) {
+        return $aStart <=> $bStart;
+      }
+
       return $b->getChangedTime() <=> $a->getChangedTime();
     });
 
@@ -592,9 +615,13 @@ final class VendorDashboardViewModelBuilder {
       'status_label' => $statusLabel,
       'date_label' => $dateLabel,
       'event_type' => $eventType,
+      'booking_state_label' => $this->bookingStateLabel($eventType),
       'capacity_label' => $capacityLabel,
       'metric_label' => $metricLabel,
       'revenue_label' => $revenueLabel,
+      'attendee_summary' => $this->attendeeSummary($ticketsSold, $rsvpCount),
+      'operation_summary' => $this->eventOperationSummary($status, $eventType),
+      'metrics' => $this->buildEventMetrics($ticketsSold, $rsvpCount, $revenueLabel, $capacityLabel),
       'presentation_issues' => $presentation['items'] ?? [],
       'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
       'is_promoted' => $isPromoted,
@@ -607,8 +634,33 @@ final class VendorDashboardViewModelBuilder {
         'orders' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_orders', ['event' => $nid]),
         'attendees' => $this->safeUrlFromRoute('myeventlane_event_attendees.vendor_list', ['node' => $nid]),
         'analytics' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $nid]),
+        'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account),
+        'share' => $published ? $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account) : NULL,
+        'promote' => $this->promoteUrl($nid, $account),
+        'support' => $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account),
       ],
+      'quick_actions' => $this->buildEventQuickActions($nid, $published, $account),
     ];
+  }
+
+  private function eventFocusRank(NodeInterface $node, int $now): int {
+    $startTs = $this->getDateFieldTimestamp($node, 'field_event_start');
+    $endTs = $this->getDateFieldTimestamp($node, 'field_event_end');
+    $published = $node->isPublished();
+
+    if ($published && $startTs > 0 && $startTs <= $now && ($endTs === 0 || $endTs >= $now)) {
+      return 0;
+    }
+    if (!$published) {
+      return 1;
+    }
+    if ($published && $startTs > 0 && $startTs > $now) {
+      return 2;
+    }
+    if ($published && $startTs === 0) {
+      return 3;
+    }
+    return 4;
   }
 
   private function getDateFieldTimestamp(NodeInterface $node, string $field): int {
@@ -620,6 +672,128 @@ final class VendorDashboardViewModelBuilder {
       return (int) $item->date->getTimestamp();
     }
     return 0;
+  }
+
+  private function bookingStateLabel(string $eventType): string {
+    return match ($eventType) {
+      'paid' => (string) $this->t('Paid ticket sales are active.'),
+      'rsvp' => (string) $this->t('RSVP collection is active.'),
+      'both' => (string) $this->t('Tickets and RSVPs are active.'),
+      default => (string) $this->t('Booking setup needs review.'),
+    };
+  }
+
+  private function attendeeSummary(int $ticketsSold, int $rsvpCount): string {
+    $parts = [];
+    if ($ticketsSold > 0) {
+      $parts[] = (string) $this->t('@count tickets sold', ['@count' => $ticketsSold]);
+    }
+    if ($rsvpCount > 0) {
+      $parts[] = (string) $this->t('@count RSVPs received', ['@count' => $rsvpCount]);
+    }
+    if ($parts === []) {
+      return (string) $this->t('No attendee activity yet.');
+    }
+    return implode(' · ', $parts);
+  }
+
+  private function eventOperationSummary(string $status, string $eventType): string {
+    if ($status === 'draft') {
+      return (string) $this->t('Your event is still in draft and not publicly visible.');
+    }
+    if ($status === 'past') {
+      return (string) $this->t('This event has finished. Use attendees and analytics for follow-up.');
+    }
+    if ($eventType === 'unknown') {
+      return (string) $this->t('Your event is live, but booking setup needs review.');
+    }
+    if ($eventType === 'paid' || $eventType === 'both') {
+      return (string) $this->t('Your event is live and paid ticket sales are active.');
+    }
+    return (string) $this->t('Your event is live and ready for attendees.');
+  }
+
+  /**
+   * @return list<array<string, string>>
+   */
+  private function buildEventMetrics(int $ticketsSold, int $rsvpCount, string $revenueLabel, ?string $capacityLabel): array {
+    $metrics = [
+      [
+        'key' => 'bookings',
+        'label' => (string) $this->t('Bookings'),
+        'value' => (string) ($ticketsSold + $rsvpCount),
+        'context' => (string) $this->t('Tickets + RSVPs'),
+      ],
+      [
+        'key' => 'attendees',
+        'label' => (string) $this->t('Attendees'),
+        'value' => (string) ($ticketsSold + $rsvpCount),
+        'context' => (string) $this->t('Expected guests'),
+      ],
+      [
+        'key' => 'revenue',
+        'label' => (string) $this->t('Revenue'),
+        'value' => $revenueLabel,
+        'context' => (string) $this->t('Gross ticket sales'),
+      ],
+      [
+        'key' => 'rsvps',
+        'label' => (string) $this->t('RSVPs'),
+        'value' => (string) $rsvpCount,
+        'context' => (string) $this->t('Confirmed responses'),
+      ],
+    ];
+
+    if ($capacityLabel !== NULL) {
+      $metrics[] = [
+        'key' => 'capacity',
+        'label' => (string) $this->t('Capacity'),
+        'value' => $capacityLabel,
+        'context' => (string) $this->t('Configured limit'),
+      ];
+    }
+
+    return $metrics;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildEventQuickActions(int $nid, bool $published, AccountInterface $account): array {
+    $actions = [];
+    $this->appendQuickAction($actions, 'edit', (string) $this->t('Edit event'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_studio.edit', ['node' => $nid], $account), 'settings');
+    $this->appendQuickAction($actions, 'attendees', (string) $this->t('View attendees'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account), 'list');
+    $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account), 'scan');
+    if ($published) {
+      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account), 'export');
+      $this->appendQuickAction($actions, 'promote', (string) $this->t('Promote event'), $this->promoteUrl($nid, $account), 'search');
+    }
+    $this->appendQuickAction($actions, 'support', (string) $this->t('Open support'), $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account), 'search');
+
+    return array_slice($actions, 0, self::MAX_EVENT_QUICK_ACTIONS);
+  }
+
+  /**
+   * @param list<array<string, mixed>> $actions
+   */
+  private function appendQuickAction(array &$actions, string $key, string $label, ?Url $url, string $icon): void {
+    if (!$url instanceof Url) {
+      return;
+    }
+    $actions[] = [
+      'key' => $key,
+      'label' => $label,
+      'url' => $url,
+      'icon' => $icon,
+    ];
+  }
+
+  private function promoteUrl(int $nid, AccountInterface $account): ?Url {
+    $url = $this->safeUrlFromRouteIfAccessible('myeventlane_boost.vendor_event_boost', ['event' => $nid], $account);
+    if ($url instanceof Url) {
+      return $url;
+    }
+    return $this->safeUrlFromRouteIfAccessible('myeventlane_vendor.manage_event.promote', ['event' => $nid], $account);
   }
 
   /**
@@ -700,6 +874,90 @@ final class VendorDashboardViewModelBuilder {
   }
 
   /**
+   * @param list<array<string, mixed>> $actions
+   *
+   * @return array<string, mixed>|null
+   */
+  private function primaryAction(array $actions): ?array {
+    foreach ($actions as $action) {
+      if (is_array($action)) {
+        return $action;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $actions
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function secondaryActions(array $actions): array {
+    $secondary = [];
+    foreach (array_slice($actions, 1) as $action) {
+      if (is_array($action)) {
+        $secondary[] = $action;
+      }
+    }
+    return $secondary;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $events
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function buildActivityItems(array $events): array {
+    $items = [];
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $title = (string) ($event['title'] ?? '');
+      if ($title === '') {
+        continue;
+      }
+      $links = $event['links'] ?? [];
+      $url = is_array($links) && isset($links['manage']) && $links['manage'] instanceof Url ? $links['manage'] : NULL;
+      $status = (string) ($event['status'] ?? '');
+      if ($status === 'draft') {
+        $items[] = [
+          'type' => 'warning',
+          'message' => (string) $this->t('Draft event waiting: @event.', ['@event' => $title]),
+          'url' => $url,
+        ];
+      }
+      else {
+        $items[] = [
+          'type' => 'info',
+          'message' => (string) $this->t('Event state: @event is @state.', [
+            '@event' => $title,
+            '@state' => (string) ($event['status_label'] ?? $status),
+          ]),
+          'url' => $url,
+        ];
+      }
+
+      $metricLabel = (string) ($event['metric_label'] ?? '');
+      if ($metricLabel !== '') {
+        $items[] = [
+          'type' => 'success',
+          'message' => (string) $this->t('Activity on @event: @metrics.', [
+            '@event' => $title,
+            '@metrics' => $metricLabel,
+          ]),
+          'url' => $url,
+        ];
+      }
+      if (count($items) >= 6) {
+        break;
+      }
+    }
+
+    return array_slice($items, 0, 6);
+  }
+
+  /**
    * @param array<string, mixed> $model
    */
   private function heroShellHint(array $model): string {
@@ -741,6 +999,31 @@ final class VendorDashboardViewModelBuilder {
       ]);
       return NULL;
     }
+  }
+
+  /**
+   * @param array<string, mixed> $parameters
+   * @param array<string, mixed> $options
+   */
+  private function safeUrlFromRouteIfAccessible(string $route, array $parameters, AccountInterface $account, array $options = []): ?Url {
+    if (!$account->isAuthenticated() || !$this->routeExists($route)) {
+      return NULL;
+    }
+    try {
+      $access = $this->accessManager->checkNamedRoute($route, $parameters, $account, TRUE);
+      if (!$access->isAllowed()) {
+        return NULL;
+      }
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Failed to check dashboard action access for route @route: @message', [
+        '@route' => $route,
+        '@message' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
+
+    return $this->safeUrlFromRoute($route, $parameters, $options);
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -111,6 +111,11 @@ final class VendorDashboardViewModelBuilder {
           (bool) ($readiness['stripe_ready'] ?? FALSE),
         ),
       ],
+      'lifecycle_guidance' => $this->readinessHelper->vendorDashboardLifecycleSummary(
+        $readiness,
+        $events,
+        (bool) ($analyticsSummary['available'] ?? FALSE),
+      ),
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip($kpis),
       'action_queue' => [],
       'events' => $events,
@@ -159,6 +164,7 @@ final class VendorDashboardViewModelBuilder {
         'items' => $this->readinessHelper->vendorDashboardOperationalReadinessSummary([], []),
         'first_event_guidance' => $this->readinessHelper->vendorDashboardFirstEventGuidance(FALSE, FALSE, FALSE),
       ],
+      'lifecycle_guidance' => $this->readinessHelper->vendorDashboardLifecycleSummary([], [], FALSE),
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip([]),
       'action_queue' => [],
       'events' => [],
@@ -536,6 +542,9 @@ final class VendorDashboardViewModelBuilder {
     }
 
     $presentation = $this->presentationAlerts->buildChipSummary($node, $hasProduct, $eventType);
+    $isPromoted = $node->hasField('field_promoted')
+      && !$node->get('field_promoted')->isEmpty()
+      && (bool) $node->get('field_promoted')->value;
 
     $capacity = (int) ($domain['capacity'] ?? 0);
     $capacityLabel = $capacity > 0
@@ -588,6 +597,7 @@ final class VendorDashboardViewModelBuilder {
       'revenue_label' => $revenueLabel,
       'presentation_issues' => $presentation['items'] ?? [],
       'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
+      'is_promoted' => $isPromoted,
       'removal' => $this->vendorEventRemovalService->buildRemovalUiPayload($node, $account),
       'links' => [
         'manage' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_workspace', ['event' => $nid]),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -101,6 +101,16 @@ final class VendorDashboardViewModelBuilder {
     $model = [
       'vendor' => $vendorPayload,
       'readiness' => $readiness,
+      'operational_readiness' => [
+        'heading' => $this->readinessHelper->vendorDashboardOperationalSummaryHeading(),
+        'intro' => $this->readinessHelper->vendorDashboardOperationalSummaryIntro(),
+        'items' => $this->readinessHelper->vendorDashboardOperationalReadinessSummary($readiness, $events),
+        'first_event_guidance' => $this->readinessHelper->vendorDashboardFirstEventGuidance(
+          $this->hasPublishedManagedEvents($uid),
+          $this->eventsIncludeTicketSales($events),
+          (bool) ($readiness['stripe_ready'] ?? FALSE),
+        ),
+      ],
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip($kpis),
       'action_queue' => [],
       'events' => $events,
@@ -142,6 +152,12 @@ final class VendorDashboardViewModelBuilder {
         'items' => [],
         'row_complete_label' => $this->readinessHelper->vendorReadinessRowCompleteLabel(),
         'row_incomplete_label' => $this->readinessHelper->vendorReadinessRowIncompleteLabel(),
+      ],
+      'operational_readiness' => [
+        'heading' => $this->readinessHelper->vendorDashboardOperationalSummaryHeading(),
+        'intro' => $this->readinessHelper->vendorDashboardOperationalSummaryIntro(),
+        'items' => $this->readinessHelper->vendorDashboardOperationalReadinessSummary([], []),
+        'first_event_guidance' => $this->readinessHelper->vendorDashboardFirstEventGuidance(FALSE, FALSE, FALSE),
       ],
       'kpis' => $this->dataPresentationManager->decorateVendorDashboardMetricStrip([]),
       'action_queue' => [],
@@ -416,6 +432,33 @@ final class VendorDashboardViewModelBuilder {
       ]);
       return 0;
     }
+  }
+
+  private function hasPublishedManagedEvents(int $uid): bool {
+    try {
+      return $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, TRUE) !== [];
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Published event readiness check failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
+  }
+
+  /**
+   * @param list<array<string, mixed>> $events
+   */
+  private function eventsIncludeTicketSales(array $events): bool {
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      if (!empty($event['metric_label']) && str_contains((string) $event['metric_label'], 'ticket')) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -14,6 +14,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -38,6 +39,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     private readonly TimeInterface $time,
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly MelReadinessHelper $readinessHelper,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -197,6 +199,17 @@ final class VendorEventWorkspaceViewModelBuilder {
         'score' => $score,
         'items' => $readinessItems,
       ],
+      'operational_readiness' => [
+        'heading' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryHeading(),
+        'intro' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryIntro(),
+        'items' => $this->readinessHelper->vendorEventWorkspaceOperationalSummary(
+          $eventType,
+          $status,
+          $ticketsSold,
+          $ordersCount,
+          $rsvpCount,
+        ),
+      ],
       'next_action' => $nextAction,
       'metrics' => $metrics,
       'tabs' => $tabs,
@@ -227,6 +240,11 @@ final class VendorEventWorkspaceViewModelBuilder {
         'public_url' => NULL,
       ],
       'readiness' => ['score' => 0, 'items' => []],
+      'operational_readiness' => [
+        'heading' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryHeading(),
+        'intro' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryIntro(),
+        'items' => [],
+      ],
       'next_action' => [
         'severity' => 'warning',
         'title' => (string) $this->t('Something went wrong'),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -144,6 +144,12 @@ final class VendorEventWorkspaceViewModelBuilder {
     $score = $readinessItems !== []
       ? (int) round(100 * $completeCount / count($readinessItems))
       : 0;
+    $hasBanner = $event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty();
+    $hasCategory = $event->hasField('field_category') && !$event->get('field_category')->isEmpty();
+    $hasTags = $event->hasField('field_tags') && !$event->get('field_tags')->isEmpty();
+    $isPromoted = $event->hasField('field_promoted')
+      && !$event->get('field_promoted')->isEmpty()
+      && (bool) $event->get('field_promoted')->value;
 
     $nextAction = $this->buildNextAction(
       $eventType,
@@ -210,6 +216,17 @@ final class VendorEventWorkspaceViewModelBuilder {
           $rsvpCount,
         ),
       ],
+      'lifecycle_guidance' => $this->readinessHelper->vendorEventWorkspaceLifecycleSummary(
+        $eventType,
+        $status,
+        $ticketsSold,
+        $ordersCount,
+        $rsvpCount,
+        $hasBanner,
+        $hasCategory,
+        $hasTags,
+        $isPromoted,
+      ),
       'next_action' => $nextAction,
       'metrics' => $metrics,
       'tabs' => $tabs,
@@ -245,6 +262,17 @@ final class VendorEventWorkspaceViewModelBuilder {
         'intro' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryIntro(),
         'items' => [],
       ],
+      'lifecycle_guidance' => $this->readinessHelper->vendorEventWorkspaceLifecycleSummary(
+        'unknown',
+        'unknown',
+        0,
+        0,
+        0,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+      ),
       'next_action' => [
         'severity' => 'warning',
         'title' => (string) $this->t('Something went wrong'),

--- a/web/themes/custom/myeventlane_radix/templates/includes/header.html.twig
+++ b/web/themes/custom/myeventlane_radix/templates/includes/header.html.twig
@@ -66,7 +66,7 @@
       <ul class="mel-nav-mobile-list">
         <li><a href="/events">Events</a></li>
         <li><a href="/categories">Categories</a></li>
-        <li><a href="/vendors">Vendors</a></li>
+        <li><a href="/vendors">{{ 'Organisers'|t }}</a></li>
         <li class="mel-mobile-divider" aria-hidden="true"></li>
         {% if logged_in %}
           {% if is_vendor|default(false) %}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -357,7 +357,7 @@ function myeventlane_theme_preprocess_menu__account(array &$variables): void {
  * Implements hook_preprocess_menu__main().
  *
  * Transforms the "Vendors" menu item into a dropdown with child links.
- * Shows "Vendor Dashboard" for vendors, "Become a Vendor" for non-vendors.
+ * Shows organiser dashboard entry for trusted organisers and discovery entry for others.
  */
 function myeventlane_theme_preprocess_menu__main(array &$variables): void {
   if (empty($variables['items'])) {

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1911,25 +1911,31 @@ function _myeventlane_vendor_theme_get_active_section(?string $route_name): stri
   $path = \Drupal::request()?->getPathInfo() ?? '';
 
   if ($route_name === 'myeventlane_vendor.console.messaging_brand') {
-    return 'profile';
+    return 'messaging';
   }
   if (str_starts_with($path, '/vendor/settings')) {
-    return 'profile';
+    return 'settings';
   }
   if (str_starts_with($path, '/vendor/analytics')) {
     return 'analytics';
   }
   if ($path === '/vendor/attendees') {
-    return 'attendees';
+    return 'ticket_holders';
+  }
+  if (preg_match('#^/event/\d+/tickets/checkin#', $path)) {
+    return 'checkin';
+  }
+  if (str_starts_with($path, '/vendor/support')) {
+    return 'support';
   }
   if (str_starts_with($path, '/vendor/studio')) {
-    return 'events';
+    return 'event_editor';
   }
   if (str_starts_with($path, '/vendor/events')) {
     return 'events';
   }
   if (str_contains($path, '/vendor/dashboard/messaging/brand')) {
-    return 'profile';
+    return 'messaging';
   }
   if ($path === '/vendor/dashboard' || str_starts_with($path, '/vendor/dashboard/')) {
     return 'dashboard';
@@ -1949,7 +1955,6 @@ function _myeventlane_vendor_theme_get_active_section(?string $route_name): stri
     'myeventlane_vendor.console.event_publish' => 'events',
     'myeventlane_vendor.console.event_promotion' => 'events',
     'myeventlane_vendor_comms.branding' => 'events',
-    'myeventlane_vendor.console.event_editor' => 'events',
     'myeventlane_vendor.console.event_analytics' => 'events',
     'myeventlane_vendor.console.event_settings' => 'events',
     'myeventlane_vendor.console.event_orders' => 'orders',
@@ -1957,32 +1962,37 @@ function _myeventlane_vendor_theme_get_active_section(?string $route_name): stri
     'myeventlane_refunds.vendor_refund_requests' => 'refund_requests',
     'myeventlane_refunds.vendor_refund_request_approve' => 'refund_requests',
     'myeventlane_refunds.vendor_refund_request_reject' => 'refund_requests',
-    'myeventlane_checkout_flow.vendor_attendees' => 'attendees',
-    'myeventlane_event_attendees.vendor_list' => 'attendees',
-    'myeventlane_vendor.console.event_rsvps' => 'attendees',
+    'myeventlane_checkout_flow.vendor_attendees' => 'ticket_holders',
+    'myeventlane_event_attendees.vendor_list' => 'ticket_holders',
+    'myeventlane_vendor.console.event_rsvps' => 'ticket_holders',
+    'myeventlane_tickets.ticket_checkin' => 'checkin',
+    'myeventlane_tickets.ticket_checkin_validate' => 'checkin',
     'myeventlane_vendor.console.payouts' => 'payouts',
-    'myeventlane_vendor.console.boost' => 'growth',
-    'myeventlane_vendor.console.audience' => 'audience',
-    'myeventlane_vendor.console.settings' => 'profile',
-    'myeventlane_pro.branding' => 'profile',
-    'myeventlane_venue.vendor_venues' => 'profile',
-    'myeventlane_venue.vendor_venue_add' => 'profile',
-    'myeventlane_venue.vendor_venue_edit' => 'profile',
-    'myeventlane_venue.vendor_venue_delete' => 'profile',
+    'myeventlane_vendor.console.boost' => 'promote',
+    'myeventlane_vendor.console.audience' => 'dashboard',
+    'myeventlane_vendor.console.settings' => 'settings',
+    'myeventlane_pro.branding' => 'settings',
+    'myeventlane_venue.vendor_venues' => 'settings',
+    'myeventlane_venue.vendor_venue_add' => 'settings',
+    'myeventlane_venue.vendor_venue_edit' => 'settings',
+    'myeventlane_venue.vendor_venue_delete' => 'settings',
     'myeventlane_analytics.dashboard' => 'analytics',
     'myeventlane_analytics.event' => 'analytics',
     'myeventlane_analytics.export_pdf' => 'analytics',
     'myeventlane_analytics.export_excel' => 'analytics',
-    'myeventlane_notifications.inbox' => 'notifications',
-    'myeventlane_notifications.preferences' => 'notifications',
-    'myeventlane_help_centre.vendor_help' => 'help',
-    'myeventlane_help_centre.home' => 'help',
+    'myeventlane_escalations_portal.vendor_list' => 'support',
+    'myeventlane_escalations_portal.vendor_view' => 'support',
+    'myeventlane_escalations_portal.vendor_resolve' => 'support',
+    'myeventlane_escalations_portal.vendor_reopen' => 'support',
+    'myeventlane_help_centre.vendor_help' => 'support',
+    'myeventlane_help_centre.home' => 'dashboard',
     'myeventlane_event_studio.create' => 'events',
-    'myeventlane_event_studio.edit' => 'events',
-    'myeventlane_vendor.console.studio' => 'events',
-    'myeventlane_vendor.console.studio.event_data' => 'events',
-    'myeventlane_vendor.studio_event_schema' => 'events',
-    'myeventlane_vendor.studio_event_save' => 'events',
+    'myeventlane_event_studio.edit' => 'event_editor',
+    'myeventlane_vendor.console.event_editor' => 'event_editor',
+    'myeventlane_vendor.console.studio' => 'event_editor',
+    'myeventlane_vendor.console.studio.event_data' => 'event_editor',
+    'myeventlane_vendor.studio_event_schema' => 'event_editor',
+    'myeventlane_vendor.studio_event_save' => 'event_editor',
     'myeventlane_event.wizard.basics' => 'events',
     'myeventlane_event.wizard.when_where' => 'events',
     'myeventlane_event.wizard.tickets' => 'events',
@@ -2025,14 +2035,14 @@ function _myeventlane_vendor_theme_build_onboarding_shell_nav_items(string $acti
       'route' => 'myeventlane_vendor.console.payouts',
     ],
     [
-      'key' => 'profile',
-      'label' => t('Profile'),
+      'key' => 'settings',
+      'label' => t('Organiser settings'),
       'icon' => 'settings',
       'route' => 'myeventlane_vendor.console.settings',
     ],
     [
-      'key' => 'help',
-      'label' => t('Help'),
+      'key' => 'support',
+      'label' => t('Support'),
       'icon' => 'help',
       'route' => 'myeventlane_help_centre.home',
       'path_fallback' => '/help',
@@ -2080,21 +2090,25 @@ function _myeventlane_vendor_theme_decorate_shell_nav_item(array $item, string $
 /**
  * Full vendor console shell nav; omits items the account cannot access.
  *
- * Primary order: Dashboard, Events, Analytics (Pro-gated), Attendees (access),
- * Profile; then secondary links (notifications, orders stub, refunds, …).
+ * Order matches product IA: dashboard → events → editor → orders → ticket
+ * holders → check-in → payouts → promote → messaging → analytics → support
+ * → organiser settings. Event-scoped links enable when an event context
+ * exists on the route match.
  *
  * @return array<int, array<string, mixed>>
  *   Sidebar items for vendor shell.
  */
 function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $active_section, ?string $route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match): array {
   $wizard_children = _myeventlane_vendor_theme_build_event_wizard_submenu($route_name, $route_match);
+  $event_id = _myeventlane_vendor_theme_resolve_event_id($route_match);
 
-  $primary = [
+  $definitions = [
     [
       'key' => 'dashboard',
       'label' => t('Dashboard'),
       'icon' => 'dashboard',
       'route' => 'myeventlane_vendor.console.dashboard',
+      'children' => [],
     ],
     [
       'key' => 'events',
@@ -2104,123 +2118,147 @@ function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $act
       'children' => $wizard_children,
     ],
     [
-      'key' => 'analytics',
-      'label' => t('Analytics'),
-      'icon' => 'analytics',
-      'route' => 'myeventlane_analytics.dashboard',
-    ],
-    [
-      'key' => 'attendees',
-      'label' => t('Attendees'),
-      'icon' => 'attendees',
-      'route' => 'myeventlane_checkout_flow.vendor_attendees',
-    ],
-    [
-      'key' => 'profile',
-      'label' => t('Profile'),
-      'icon' => 'settings',
-      'route' => 'myeventlane_vendor.console.settings',
-    ],
-  ];
-
-  $secondary = [
-    [
-      'key' => 'notifications',
-      'label' => t('Notifications'),
-      'icon' => 'notifications',
-      'route' => 'myeventlane_notifications.inbox',
+      'key' => 'event_editor',
+      'label' => t('Event Editor'),
+      'icon' => 'events',
+      'route' => 'myeventlane_vendor.console.studio',
+      'children' => [],
     ],
     [
       'key' => 'orders',
       'label' => t('Orders'),
       'icon' => 'orders',
       'route' => NULL,
+      'children' => [],
+      'event_route' => 'myeventlane_vendor.console.event_orders',
     ],
     [
-      'key' => 'refund_requests',
-      'label' => t('Refund requests'),
-      'icon' => 'refunds',
+      'key' => 'ticket_holders',
+      'label' => t('Ticket holders'),
+      'icon' => 'attendees',
+      'route' => 'myeventlane_checkout_flow.vendor_attendees',
+      'children' => [],
+    ],
+    [
+      'key' => 'checkin',
+      'label' => t('Check-in'),
+      'icon' => 'attendees',
       'route' => NULL,
-    ],
-    [
-      'key' => 'audience',
-      'label' => t('Audience'),
-      'icon' => 'audience',
-      'route' => 'myeventlane_vendor.console.audience',
+      'children' => [],
+      'event_route' => 'myeventlane_tickets.ticket_checkin',
     ],
     [
       'key' => 'payouts',
       'label' => t('Payouts'),
       'icon' => 'payouts',
       'route' => 'myeventlane_vendor.console.payouts',
+      'children' => [],
     ],
     [
-      'key' => 'growth',
-      'label' => t('Growth'),
+      'key' => 'promote',
+      'label' => t('Promote event'),
       'icon' => 'growth',
       'route' => 'myeventlane_vendor.console.boost',
+      'children' => [],
     ],
     [
-      'key' => 'help',
-      'label' => t('Help'),
+      'key' => 'messaging',
+      'label' => t('Messaging'),
+      'icon' => 'notifications',
+      'route' => 'myeventlane_vendor.console.messaging_brand',
+      'children' => [],
+    ],
+    [
+      'key' => 'analytics',
+      'label' => t('Analytics'),
+      'icon' => 'analytics',
+      'route' => 'myeventlane_analytics.dashboard',
+      'children' => [],
+    ],
+    [
+      'key' => 'support',
+      'label' => t('Support'),
       'icon' => 'help',
-      'route' => 'myeventlane_help_centre.home',
-      'path_fallback' => '/help',
+      'route' => 'myeventlane_escalations_portal.vendor_list',
+      'children' => [],
+    ],
+    [
+      'key' => 'settings',
+      'label' => t('Organiser settings'),
+      'icon' => 'settings',
+      'route' => 'myeventlane_vendor.console.settings',
+      'children' => [],
     ],
   ];
 
-  $items = array_merge($primary, $secondary);
-
   $built = [];
-  foreach ($items as $item) {
-    if ($item['key'] === 'refund_requests') {
-      if (!\Drupal::moduleHandler()->moduleExists('myeventlane_refunds')) {
-        continue;
-      }
-      if (!\Drupal::currentUser()->hasPermission('manage_refunds')) {
-        continue;
-      }
-      $event_id = _myeventlane_vendor_theme_resolve_event_id($route_match);
+  foreach ($definitions as $def) {
+    $item = [
+      'key' => $def['key'],
+      'label' => $def['label'],
+      'icon' => $def['icon'],
+      'children' => $def['children'] ?? [],
+    ];
+
+    if (!empty($def['event_route'])) {
+      $event_route = (string) $def['event_route'];
+      $item['route'] = $event_route;
       if ($event_id === NULL) {
-        continue;
+        $item['url'] = NULL;
+        $item['is_disabled'] = TRUE;
       }
-      if (!_myeventlane_vendor_theme_named_route_accessible('myeventlane_refunds.vendor_refund_requests', ['node' => $event_id])) {
-        continue;
+      else {
+        $params = ['event' => $event_id];
+        if (!_myeventlane_vendor_theme_named_route_accessible($event_route, $params)) {
+          $item['url'] = NULL;
+          $item['is_disabled'] = TRUE;
+        }
+        else {
+          $url = _myeventlane_vendor_theme_safe_route_url($event_route, $params);
+          $item['url'] = $url;
+          $item['is_disabled'] = $url === NULL;
+        }
       }
-      $url = _myeventlane_vendor_theme_safe_route_url('myeventlane_refunds.vendor_refund_requests', ['node' => $event_id]);
-      if ($url === NULL) {
-        continue;
-      }
-      $item['url'] = $url;
-      $item['route'] = 'myeventlane_refunds.vendor_refund_requests';
-      $item['is_disabled'] = FALSE;
       $built[] = _myeventlane_vendor_theme_decorate_shell_nav_item($item, $active_section);
       continue;
     }
 
-    if ($item['key'] === 'orders') {
-      $item['url'] = NULL;
-      $item['is_disabled'] = TRUE;
-      $built[] = _myeventlane_vendor_theme_decorate_shell_nav_item($item, $active_section);
+    $route = (string) ($def['route'] ?? '');
+    if ($route === '') {
       continue;
     }
-
-    if (!empty($item['route'])) {
-      if (!_myeventlane_vendor_theme_named_route_accessible((string) $item['route'], [])) {
-        continue;
-      }
-      $url = _myeventlane_vendor_theme_safe_route_url((string) $item['route']);
-      if ($url === NULL && !empty($item['path_fallback'])) {
-        $url = (string) $item['path_fallback'];
-      }
-      $is_disabled = $url === NULL;
-    }
-    else {
+    if (!_myeventlane_vendor_theme_named_route_accessible($route, [])) {
       continue;
     }
+    $url = _myeventlane_vendor_theme_safe_route_url($route);
+    if ($url === NULL && !empty($def['path_fallback'])) {
+      $url = (string) $def['path_fallback'];
+    }
+    $item['route'] = $route;
     $item['url'] = $url;
-    $item['is_disabled'] = $is_disabled;
+    $item['is_disabled'] = $url === NULL;
     $built[] = _myeventlane_vendor_theme_decorate_shell_nav_item($item, $active_section);
+  }
+
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_refunds')
+    && \Drupal::currentUser()->hasPermission('manage_refunds')) {
+    $refund_event_id = _myeventlane_vendor_theme_resolve_event_id($route_match);
+    if ($refund_event_id !== NULL
+      && _myeventlane_vendor_theme_named_route_accessible('myeventlane_refunds.vendor_refund_requests', ['node' => $refund_event_id])) {
+      $refund_url = _myeventlane_vendor_theme_safe_route_url('myeventlane_refunds.vendor_refund_requests', ['node' => $refund_event_id]);
+      if ($refund_url !== NULL) {
+        $refund_item = [
+          'key' => 'refund_requests',
+          'label' => t('Refund requests'),
+          'icon' => 'refunds',
+          'route' => 'myeventlane_refunds.vendor_refund_requests',
+          'url' => $refund_url,
+          'children' => [],
+          'is_disabled' => FALSE,
+        ];
+        $built[] = _myeventlane_vendor_theme_decorate_shell_nav_item($refund_item, $active_section);
+      }
+    }
   }
 
   return $built;
@@ -2272,7 +2310,7 @@ function _myeventlane_vendor_theme_build_event_wizard_submenu(?string $route_nam
 
   return [
     [
-      'label' => t('Event builder'),
+      'label' => t('Event Editor'),
       'url' => $url,
       'is_disabled' => $url === NULL,
       'is_active' => in_array($route_name, $studio_routes, TRUE),

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -68,8 +68,8 @@
 
   &__event-hero .mel-live-ops__hero-surface {
     background:
-      radial-gradient(900px circle at 100% 0%, rgba($ml-accent-coral, 0.1), transparent 42%),
-      linear-gradient(135deg, $bg-primary 0%, $ml-slate-50 100%);
+      radial-gradient(780px circle at 100% 0%, rgba($ml-accent-coral, 0.08), transparent 40%),
+      linear-gradient(135deg, $bg-primary 0%, rgba($ml-slate-50, 0.72) 100%);
   }
 
   &__event-hero-layout {
@@ -86,7 +86,7 @@
 
   &__event-media {
     overflow: hidden;
-    min-height: 13rem;
+    min-height: 9rem;
     border: 1px solid rgba($ml-vendor-navy, 0.1);
     border-radius: $radius-workspace-card;
     background: $ml-slate-100;
@@ -96,7 +96,7 @@
       display: block;
       width: 100%;
       height: 100%;
-      min-height: 13rem;
+      min-height: 9rem;
       object-fit: cover;
     }
   }
@@ -108,10 +108,81 @@
   }
 
   &__event-media-fallback {
-    min-height: 13rem;
+    min-height: 9rem;
     color: $text-secondary;
     font-weight: $font-weight-bold;
     letter-spacing: $letter-spacing-wider;
+  }
+
+  &__section-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-3;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: $spacing-3;
+  }
+
+  &__overview-strip,
+  &__activity-stream,
+  &__upcoming-strip {
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-xs;
+  }
+
+  &__overview-items {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: $spacing-2;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    @include respond-to(xl) {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+  }
+
+  &__overview-item {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: $bg-primary;
+  }
+
+  &__overview-item--success {
+    border-color: rgba($success, 0.24);
+  }
+
+  &__overview-item--warn {
+    border-color: rgba($warning, 0.28);
+  }
+
+  &__overview-label,
+  &__overview-context,
+  &__upcoming-date,
+  &__upcoming-meta {
+    color: $text-secondary;
+    font-size: $font-size-xs;
+    line-height: $line-height-normal;
+  }
+
+  &__overview-label {
+    text-transform: uppercase;
+    letter-spacing: $letter-spacing-wide;
+  }
+
+  &__overview-value {
+    color: $text-primary;
+    font-size: $font-size-xl;
+    line-height: $line-height-tight;
   }
 
   &__metric-strip {
@@ -141,6 +212,75 @@
     margin-bottom: 0;
     background: $bg-primary;
     border: 1px solid rgba($ml-vendor-navy, 0.08);
+  }
+
+  &__activity-list {
+    display: grid;
+    gap: $spacing-2;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__activity-item {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: $spacing-2 $spacing-3;
+    align-items: center;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: rgba($ml-slate-50, 0.62);
+
+    .mel-live-ops__readiness-link {
+      grid-column: 2;
+    }
+  }
+
+  &__activity-message {
+    margin: 0;
+    color: $text-primary;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-normal;
+  }
+
+  &__upcoming-row {
+    display: grid;
+    grid-auto-columns: minmax(15rem, 1fr);
+    grid-auto-flow: column;
+    gap: $spacing-3;
+    overflow-x: auto;
+    padding-bottom: $spacing-1;
+    scroll-snap-type: x proximity;
+
+    @include respond-to(lg) {
+      grid-auto-flow: initial;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      overflow: visible;
+    }
+  }
+
+  &__upcoming-card {
+    display: grid;
+    gap: $spacing-3;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: $bg-primary;
+    scroll-snap-align: start;
+  }
+
+  &__upcoming-title {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-base;
+    line-height: $line-height-tight;
+  }
+
+  &__upcoming-date,
+  &__upcoming-meta {
+    margin: $spacing-1 0 0;
   }
 
   &__details {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -9,10 +9,184 @@
 
 @use '../tokens/spacing' as *;
 @use '../tokens/breakpoints' as *;
+@use '../tokens/colors' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/shadows' as *;
+@use '../tokens/typography' as *;
 
 .mel-vendor-dashboard {
   .mel-live-ops__split {
     margin-top: 0;
+  }
+
+  &__priority {
+    display: grid;
+    gap: $spacing-4;
+    align-items: center;
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-vendor-navy, 0.12);
+    border-left: 4px solid $info;
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-sm;
+
+    @include respond-to(md) {
+      grid-template-columns: minmax(0, 1fr) auto;
+      padding: $spacing-5;
+    }
+  }
+
+  &__priority--warn {
+    border-left-color: $warning;
+    background: linear-gradient(135deg, $bg-primary 0%, rgba($warning-light, 0.34) 100%);
+  }
+
+  &__priority--success {
+    border-left-color: $success;
+  }
+
+  &__priority-title {
+    margin: $spacing-1 0 0;
+    color: $text-primary;
+    font-size: $font-size-xl;
+    line-height: $line-height-tight;
+  }
+
+  &__priority-message {
+    margin: $spacing-2 0 0;
+    color: $text-secondary;
+    line-height: $line-height-normal;
+  }
+
+  &__priority-action {
+    width: 100%;
+
+    @include respond-to(md) {
+      width: auto;
+    }
+  }
+
+  &__event-hero .mel-live-ops__hero-surface {
+    background:
+      radial-gradient(900px circle at 100% 0%, rgba($ml-accent-coral, 0.1), transparent 42%),
+      linear-gradient(135deg, $bg-primary 0%, $ml-slate-50 100%);
+  }
+
+  &__event-hero-layout {
+    @include respond-to(md) {
+      grid-template-columns: minmax(0, 1fr) minmax(17rem, 0.46fr);
+    }
+  }
+
+  &__event-summary {
+    margin: $spacing-4 0 0;
+    color: $text-primary;
+    font-weight: $font-weight-semibold;
+  }
+
+  &__event-media {
+    overflow: hidden;
+    min-height: 13rem;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $ml-slate-100;
+    box-shadow: $shadow-sm;
+
+    img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      min-height: 13rem;
+      object-fit: cover;
+    }
+  }
+
+  &__event-media--placeholder,
+  &__event-media-fallback {
+    display: grid;
+    place-items: center;
+  }
+
+  &__event-media-fallback {
+    min-height: 13rem;
+    color: $text-secondary;
+    font-weight: $font-weight-bold;
+    letter-spacing: $letter-spacing-wider;
+  }
+
+  &__metric-strip {
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-sm;
+
+    @include respond-to(md) {
+      padding: $spacing-5;
+    }
+  }
+
+  &__metric-board.mel-live-ops__metric-board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: $spacing-4;
+
+    @include respond-to(lg) {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+    }
+  }
+
+  &__quick-actions.mel-live-ops__quick-bar {
+    position: static;
+    margin-top: -$spacing-2;
+    margin-bottom: 0;
+    background: $bg-primary;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+  }
+
+  &__details {
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-xs;
+
+    > summary {
+      min-height: 3.25rem;
+      padding: $spacing-4;
+      color: $text-primary;
+      font-weight: $font-weight-bold;
+      cursor: pointer;
+      list-style-position: inside;
+
+      &:focus-visible {
+        outline: 3px solid rgba($primary, 0.22);
+        outline-offset: 3px;
+      }
+    }
+
+    &[open] > summary {
+      border-bottom: 1px solid rgba($ml-vendor-navy, 0.08);
+    }
+  }
+
+  &__details-grid {
+    display: grid;
+    gap: $spacing-4;
+    padding: $spacing-4;
+
+    @include respond-to(lg) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      padding: $spacing-5;
+    }
+  }
+
+  &__details--events &__details-grid {
+    @include respond-to(lg) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__panel {
+    background: $bg-primary;
   }
 
   &__metric-intro {
@@ -105,6 +279,23 @@
 
   &__events-empty-actions {
     margin-top: $spacing-4;
+  }
+
+  &__footer-surfaces {
+    display: grid;
+    gap: $spacing-3;
+    padding-top: $spacing-2;
+  }
+
+  &__micro-surface {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    align-items: center;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: $bg-primary;
   }
 }
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -1,16 +1,7 @@
 {#
 /**
  * @file
- * Vendor dashboard — renders vendor_dashboard_view_model (theme: myeventlane_vendor_dashboard unchanged).
- *
- * Slice 4 layout map (canonical live-ops primitives):
- * - Root shell: mel-live-operations mel-vendor-dashboard
- * - Hero: mel-live-ops__hero + __hero-surface / __hero-layout / __hero-primary / __hero-aside
- * - KPI strip: __kpi* → mel-live-ops__metric-board + mel-live-ops__stat-card (--total|--in|--ready|… cycle)
- * - Attention + readiness mid grid: → mel-live-ops__split / __stack / __panel + __timeline-feed + __timeline-card
- * - Action queue urgency rail: partial → mel-live-ops__quick-bar (first linked actions only)
- * - Growth: section-heading + mel-growth-stack → __panel titles + mel-vendor-dashboard__growth-feed (mel-growth-card kept for dismiss JS)
- * - Event roster: stacked __event-card → mel-live-ops__attendee-row + chips + attendee-side actions
+ * Event-first organiser dashboard.
  */
 #}
 {% set model = vendor_dashboard_view_model|default({}) %}
@@ -24,27 +15,28 @@
 {% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
 {% set kpis = model.kpis|default([]) %}
 {% set actions = model.action_queue|default([]) %}
+{% set priority_action = model.priority_action|default(actions|first|default(null)) %}
+{% set secondary_actions = model.secondary_actions|default(actions|slice(1)) %}
 {% set model_events = model.events|default([]) %}
+{% set focus_event = model.current_event|default(model_events|first|default({})) %}
 {% set empty_state = model.empty_state|default({}) %}
 {% set analytics_summary = model.analytics_summary|default({}) %}
 {% set analytics_items = analytics_summary.items|default([]) %}
+{% set activity_items = model.activity_items|default(dashboard_activity_items|default([])) %}
 {% set dashboard_vendor_id = vendor.id|default(null) %}
-
-{% set hero_body = '' %}
-{% if model.hero_shell_hint is defined and model.hero_shell_hint %}
-  {% set hero_body = model.hero_shell_hint %}
-{% elseif actions is iterable and actions|length > 0 %}
-  {% set hero_body = 'Start with the most important task below.'|t %}
-{% elseif model_events is iterable and model_events|length > 0 %}
-  {% set hero_body = 'Your events are set up. Keep an eye on bookings and upcoming activity.'|t %}
-{% else %}
-  {% set hero_body = 'Create your first event and start taking RSVPs or selling tickets.'|t %}
-{% endif %}
-
+{% set has_focus_event = focus_event is iterable and focus_event.title|default('') is not empty %}
+{% set focus_links = has_focus_event ? focus_event.links|default({}) : {} %}
+{% set focus_metrics = has_focus_event ? focus_event.metrics|default([]) : [] %}
+{% set focus_actions = has_focus_event ? focus_event.quick_actions|default([]) : [] %}
+{% set metric_rows = focus_metrics is iterable and focus_metrics|length > 0 ? focus_metrics : kpis %}
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
+
 {% set hero_primary_url = NULL %}
 {% set hero_primary_label = NULL %}
-{% if events_empty and empty_state.url is defined and empty_state.url %}
+{% if has_focus_event and focus_links.manage is defined and focus_links.manage %}
+  {% set hero_primary_url = focus_links.manage %}
+  {% set hero_primary_label = 'Manage event'|t %}
+{% elseif events_empty and empty_state.url is defined and empty_state.url %}
   {% set hero_primary_url = empty_state.url %}
   {% set hero_primary_label = empty_state.action_label|default('Create event'|t) %}
 {% elseif not events_empty and empty_state.url is defined and empty_state.url %}
@@ -55,88 +47,73 @@
 {% set kpi_board_modifiers = ['total', 'in', 'ready', 'capacity', 'remain', 'blocked'] %}
 
 <section class="mel-live-operations mel-vendor-dashboard" data-mel-vendor-dashboard>
-  {% if onboarding_panel is defined and onboarding_panel %}
-    <div class="mel-vendor-dashboard__onboarding">{{ onboarding_panel }}</div>
-  {% endif %}
-
-  {% set quick_bar_actions = [] %}
-  {% if actions is iterable %}
-    {% for action in actions %}
-      {% if quick_bar_actions|length < 4 and action.url is defined and action.url and action.action_label is defined and action.action_label %}
-        {% set quick_bar_actions = quick_bar_actions|merge([action]) %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-
-  {% if quick_bar_actions|length > 0 %}
-    <nav class="mel-live-ops__quick-bar" aria-label="{{ 'Priority actions'|t }}">
-      <div class="mel-live-ops__quick-inner" role="toolbar">
-        {% for action in quick_bar_actions %}
-          {% set sev = action.severity|default('info') %}
-          {% set qa_variant = (sev == 'error' or sev == 'warning' or sev == 'success') ? 'primary' : 'lavender' %}
-          <a
-            class="mel-live-ops__action mel-live-ops__action--{{ qa_variant }}{% if loop.first %} mel-live-ops__action--featured{% endif %}"
-            href="{{ action.url }}"
-            data-icon="search"
-          >
-            <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
-            <span class="mel-live-ops__action-label">{{ action.action_label }}</span>
-          </a>
-        {% endfor %}
+  {% if priority_action %}
+    {% set priority_sev = priority_action.severity|default('info') %}
+    {% set priority_chip = priority_sev == 'error' or priority_sev == 'warning' ? 'warn' : (priority_sev == 'success' ? 'success' : 'info') %}
+    <section class="mel-vendor-dashboard__priority mel-vendor-dashboard__priority--{{ priority_chip }}" aria-labelledby="mel-dash-priority-title">
+      <div>
+        <p class="mel-live-ops__eyebrow">{{ 'Priority attention'|t }}</p>
+        <h2 id="mel-dash-priority-title" class="mel-vendor-dashboard__priority-title">{{ priority_action.title|default('Review next step'|t) }}</h2>
+        {% if priority_action.message is defined and priority_action.message %}
+          <p class="mel-vendor-dashboard__priority-message">{{ priority_action.message }}</p>
+        {% endif %}
       </div>
-    </nav>
+      {% if priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
+        <a class="mel-btn mel-btn--primary mel-vendor-dashboard__priority-action" href="{{ priority_action.url }}">{{ priority_action.action_label }}</a>
+      {% endif %}
+    </section>
   {% endif %}
 
-  <section class="mel-live-ops__hero" aria-labelledby="mel-dash-hero-title">
+  <section class="mel-live-ops__hero mel-vendor-dashboard__event-hero" aria-labelledby="mel-dash-hero-title">
     <div class="mel-live-ops__hero-surface">
-      <div class="mel-live-ops__hero-layout">
+      <div class="mel-live-ops__hero-layout mel-vendor-dashboard__event-hero-layout">
         <div class="mel-live-ops__hero-primary">
-          <p class="mel-live-ops__eyebrow">{{ 'Organiser console'|t }}</p>
+          <p class="mel-live-ops__eyebrow">{{ 'Current event'|t }}</p>
           <h1 id="mel-dash-hero-title" class="mel-live-ops__hero-title">
-            {% if vendor.label is defined and vendor.label %}
-              {{ 'Welcome back, @name'|t({'@name': vendor.label}) }}
+            {% if has_focus_event %}
+              {{ focus_event.title }}
             {% else %}
-              {{ 'Welcome to your organiser dashboard'|t }}
+              {{ empty_state.title|default('Welcome to your organiser dashboard'|t) }}
             {% endif %}
           </h1>
-          <p class="mel-live-ops__hero-venue">{{ hero_body }}</p>
+          <p class="mel-live-ops__hero-venue">
+            {% if has_focus_event %}
+              {{ focus_event.operation_summary|default(model.hero_shell_hint|default('Your event is ready for review.'|t)) }}
+            {% else %}
+              {{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}
+            {% endif %}
+          </p>
 
-          {% if launch_pro_status is defined and launch_pro_status %}
-            {{ launch_pro_status }}
-          {% elseif is_pro|default(false) %}
-            <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Subscription'|t }}">
-              <span class="mel-live-ops__chip mel-live-ops__chip--success">{{ 'PRO PLAN ✓ Active'|t }}</span>
-              <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ path('myeventlane_pro.manage') }}">{{ 'Manage'|t }}</a>
-            </div>
-          {% elseif show_pro_prompt|default(false) %}
-            <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Subscription'|t }}">
-              <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ 'FREE PLAN'|t }}</span>
-              {% if pro_upgrade_url %}
-                <a class="mel-live-ops__chip mel-live-ops__chip--live" href="{{ pro_upgrade_url }}">{{ 'Upgrade to Pro'|t }}</a>
-              {% else %}
-                <a class="mel-live-ops__chip mel-live-ops__chip--live" href="{{ path('myeventlane_pro.overview') }}">{{ 'Upgrade to Pro'|t }}</a>
+          {% if has_focus_event %}
+            <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Event state'|t }}">
+              {% if focus_event.status_label is defined and focus_event.status_label %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ focus_event.status_label }}</span>
+              {% endif %}
+              {% if focus_event.booking_state_label is defined and focus_event.booking_state_label %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ focus_event.booking_state_label }}</span>
+              {% endif %}
+              {% if focus_event.date_label is defined and focus_event.date_label %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ focus_event.date_label }}</span>
               {% endif %}
             </div>
+            {% if focus_event.attendee_summary is defined and focus_event.attendee_summary %}
+              <p class="mel-vendor-dashboard__event-summary">{{ focus_event.attendee_summary }}</p>
+            {% endif %}
           {% endif %}
         </div>
 
         <div class="mel-live-ops__hero-aside">
-          {% if readiness.score is defined and readiness.score is not same as(null) and readiness.score is not same as('') %}
-            {% set rscore = readiness.score + 0 %}
-            <div class="mel-live-ops__progress-shell" style="--mel-ops-progress: {{ rscore > 100 ? 100 : (rscore < 0 ? 0 : rscore) }};">
-              <div class="mel-live-ops__progress-ring" role="progressbar" aria-valuenow="{{ rscore }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ 'Account readiness'|t }}">
-                <span class="mel-live-ops__progress-ring-label">
-                  <span class="mel-live-ops__progress-percent">{{ readiness.score }}%</span>
-                  <span class="mel-live-ops__progress-caption">{{ 'readiness'|t }}</span>
-                </span>
-              </div>
-              <div class="mel-live-ops__progress-track" aria-hidden="true">
-                <span class="mel-live-ops__progress-fill" style="width: {{ rscore > 100 ? 100 : (rscore < 0 ? 0 : rscore) }}%;"></span>
-              </div>
-              <div class="mel-live-ops__hero-summary">
-                <p class="mel-live-ops__summary-line">{{ 'Setup progress'|t }}</p>
-                <p class="mel-live-ops__summary-muted">{{ 'Based on payouts, branding, ticketing, and event publishing.'|t }}</p>
-              </div>
+          {% if has_focus_event %}
+            {% set img = focus_event.image|default({}) %}
+            {% set img_url = img.url|default('') %}
+            {% set img_alt = img.alt|default(focus_event.title|default('Event image'|t)) %}
+            {% set img_ph = img.is_placeholder|default(false) %}
+            <div class="mel-vendor-dashboard__event-media{% if img_ph %} mel-vendor-dashboard__event-media--placeholder{% endif %}">
+              {% if img_url %}
+                <img src="{{ img_url }}" alt="{{ img_ph ? '' : img_alt|e('html_attr') }}" loading="lazy"/>
+              {% else %}
+                <span class="mel-vendor-dashboard__event-media-fallback" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</span>
+              {% endif %}
             </div>
           {% endif %}
 
@@ -153,134 +130,95 @@
     </div>
   </section>
 
-  <div class="mel-live-ops__split">
-    <div class="mel-live-ops__stack">
-      {% if operational_readiness_items is iterable and operational_readiness_items|length > 0 %}
-        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-operational-readiness-title">
-          <div class="mel-live-ops__timeline-head">
-            <h2 class="mel-live-ops__panel-title" id="mel-dash-operational-readiness-title">{{ operational_readiness.heading|default('Operational readiness'|t) }}</h2>
-            <p class="mel-live-ops__panel-intro">{{ operational_readiness.intro|default('A calm snapshot of publishing, bookings, payouts, attendees, and discovery.'|t) }}</p>
-          </div>
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for item in operational_readiness_items %}
-              {% set sev = item.severity|default('info') %}
-              {% set chip_mod =
-                sev == 'success' ? 'success' :
-                (sev == 'warning' or sev == 'error') ? 'warn' :
-                (sev == 'neutral' ? 'calm' : 'info')
-              %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
-                <div class="mel-live-ops__timeline-body">
-                  <div class="mel-live-ops__timeline-headline">
-                    <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
-                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
-                  </div>
-                  {% if item.message|default('') is not empty %}
-                    <p class="mel-live-ops__muted">{{ item.message }}</p>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-          {% if first_event_guidance is iterable and first_event_guidance|length > 0 %}
-            <div class="mel-live-ops__timeline-feed" role="list" aria-label="{{ 'First event guidance'|t }}">
-              {% for item in first_event_guidance %}
-                <article class="mel-live-ops__timeline-card" role="listitem">
-                  <div class="mel-live-ops__timeline-avatar" aria-hidden="true">•</div>
-                  <div class="mel-live-ops__timeline-body">
-                    <p class="mel-live-ops__timeline-name">{{ item.message|default('') }}</p>
-                  </div>
-                </article>
-              {% endfor %}
-            </div>
+  <section class="mel-live-ops__metrics mel-vendor-dashboard__metric-strip" aria-labelledby="mel-dash-kpis-title">
+    <h2 id="mel-dash-kpis-title" class="mel-live-ops__panel-title">{{ 'Quick metrics'|t }}</h2>
+    <p class="mel-live-ops__panel-intro">
+      {% if has_focus_event %}
+        {{ 'Lightweight signals for the current event.'|t }}
+      {% else %}
+        {{ 'Metrics will appear after your first RSVP, ticket sale, or event view.'|t }}
+      {% endif %}
+    </p>
+    {% if metric_rows is iterable and metric_rows|length > 0 %}
+      <div class="mel-live-ops__metric-board mel-vendor-dashboard__metric-board" role="list">
+        {% for metric in metric_rows|slice(0, 5) %}
+          {% set stat_mod = kpi_board_modifiers[loop.index0 % kpi_board_modifiers|length] %}
+          {% set metric_inner %}
+            <span class="mel-live-ops__stat-label">{{ metric.label|default('') }}</span>
+            <span class="mel-live-ops__stat-value">{{ metric.value|default('-') }}</span>
+            {% if metric.context is defined and metric.context %}
+              <span class="mel-live-ops__stat-note">{{ metric.context }}</span>
+            {% endif %}
+          {% endset %}
+          {% if metric.url is defined and metric.url %}
+            <a class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem" href="{{ metric.url }}">{{ metric_inner }}</a>
+          {% else %}
+            <article class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem">{{ metric_inner }}</article>
           {% endif %}
-        </section>
-      {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </section>
 
-      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
-        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-lifecycle-guidance-title">
-          <div class="mel-live-ops__timeline-head">
-            <h2 class="mel-live-ops__panel-title" id="mel-dash-lifecycle-guidance-title">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
-            <p class="mel-live-ops__panel-intro">{{ lifecycle_guidance.intro|default('Helpful context based on the organiser and event signals already shown here.'|t) }}</p>
-          </div>
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for item in lifecycle_guidance_items %}
-              {% set sev = item.severity|default('info') %}
-              {% set chip_mod =
-                sev == 'success' ? 'success' :
-                (sev == 'warning' or sev == 'error') ? 'warn' :
-                (sev == 'neutral' ? 'calm' : 'info')
-              %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
-                <div class="mel-live-ops__timeline-body">
-                  <div class="mel-live-ops__timeline-headline">
-                    <span class="mel-live-ops__timeline-name">{{ item.stage|default('') }}</span>
-                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
-                  </div>
-                  {% if item.message|default('') is not empty %}
-                    <p class="mel-live-ops__muted">{{ item.message }}</p>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-        </section>
-      {% endif %}
+  {% if focus_actions is iterable and focus_actions|length > 0 %}
+    <nav class="mel-live-ops__quick-bar mel-vendor-dashboard__quick-actions" aria-label="{{ 'Quick actions'|t }}">
+      <div class="mel-live-ops__quick-inner" role="toolbar">
+        {% for action in focus_actions %}
+          <a class="mel-live-ops__action mel-live-ops__action--{{ loop.first ? 'primary' : 'lavender' }}{% if loop.first %} mel-live-ops__action--featured{% endif %}" href="{{ action.url }}" data-icon="{{ action.icon|default('search')|e('html_attr') }}">
+            <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
+            <span class="mel-live-ops__action-label">{{ action.label }}</span>
+          </a>
+        {% endfor %}
+      </div>
+    </nav>
+  {% elseif hero_primary_url and hero_primary_label %}
+    <nav class="mel-live-ops__quick-bar mel-vendor-dashboard__quick-actions" aria-label="{{ 'Quick actions'|t }}">
+      <div class="mel-live-ops__quick-inner" role="toolbar">
+        <a class="mel-live-ops__action mel-live-ops__action--primary mel-live-ops__action--featured" href="{{ hero_primary_url }}" data-icon="settings">
+          <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
+          <span class="mel-live-ops__action-label">{{ hero_primary_label }}</span>
+        </a>
+      </div>
+    </nav>
+  {% endif %}
 
-      <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-actions-title">
-        <div class="mel-live-ops__timeline-head">
-          <h2 class="mel-live-ops__panel-title" id="mel-dash-actions-title">{{ 'What to do next'|t }}</h2>
-          <p class="mel-live-ops__panel-intro">{{ 'Small setup steps now help publishing and payouts go smoothly.'|t }}</p>
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--activity">
+    <summary>{{ 'Recent activity'|t }}</summary>
+    <div class="mel-live-ops__panel mel-vendor-dashboard__panel">
+      {% if activity_items is iterable and activity_items|length > 0 %}
+        <div class="mel-live-ops__timeline-feed" role="list">
+          {% for item in activity_items|slice(0, 6) %}
+            {% set row_type = item.type|default('info') %}
+            {% set row_chip = row_type == 'success' ? 'success' : (row_type == 'warning' or row_type == 'error' ? 'warn' : 'info') %}
+            <article class="mel-live-ops__timeline-card" role="listitem">
+              <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ row_type == 'success' ? '+' : 'i' }}</div>
+              <div class="mel-live-ops__timeline-body">
+                <p class="mel-live-ops__timeline-name">{{ item.message|default('') }}</p>
+                {% if item.url is defined and item.url %}
+                  <a class="mel-live-ops__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}</a>
+                {% endif %}
+              </div>
+              <span class="mel-live-ops__chip mel-live-ops__chip--{{ row_chip }}">{{ row_type == 'success' ? ('Activity'|t) : ('Update'|t) }}</span>
+            </article>
+          {% endfor %}
         </div>
-        {% if actions is iterable and actions|length > 0 %}
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for action in actions %}
-              {% set sev = action.severity|default('info') %}
-              {% set chip_mod = (sev == 'error' or sev == 'warning') ? 'warn' : (sev == 'success' ? 'success' : 'info') %}
-              {% set sev_label =
-                sev == 'error' ? ('Needs attention'|t) :
-                (sev == 'warning' ? ('Review needed'|t) :
-                (sev == 'success' ? ('On track'|t) : ('FYI'|t)))
-              %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                {% set avatar_glyph = (sev == 'error') ? '!' : (sev == 'warning' ? '!' : '•') %}
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ avatar_glyph }}</div>
-                <div class="mel-live-ops__timeline-body">
-                  <div class="mel-live-ops__timeline-headline">
-                    <span class="mel-live-ops__timeline-name">{{ action.title|default('') }}</span>
-                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev_label }}</span>
-                  </div>
-                  {% if action.message is defined and action.message %}
-                    <p class="mel-live-ops__muted">{{ action.message }}</p>
-                  {% endif %}
-                  {% if action.url is defined and action.url and action.action_label is defined and action.action_label %}
-                    <div class="mel-live-ops__stack">
-                      <a class="mel-btn mel-btn--secondary" href="{{ action.url }}">{{ action.action_label }}</a>
-                    </div>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-        {% else %}
-          <p class="mel-live-ops__muted">{{ 'Nothing urgent right now. Your key setup and event tasks look clear.'|t }}</p>
-        {% endif %}
-      </section>
+      {% else %}
+        <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
+      {% endif %}
     </div>
+  </details>
 
-    <div class="mel-live-ops__stack">
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--setup">
+    <summary>{{ 'Review event setup'|t }}</summary>
+    <div class="mel-vendor-dashboard__details-grid">
+      {% if onboarding_panel is defined and onboarding_panel %}
+        <div class="mel-vendor-dashboard__onboarding">{{ onboarding_panel }}</div>
+      {% endif %}
+
       <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-readiness-title">
         <div class="mel-live-ops__timeline-head">
-          <h2 class="mel-live-ops__panel-title" id="mel-dash-readiness-title">{{ 'Readiness'|t }}</h2>
-          <p class="mel-live-ops__panel-intro">
-            {% if readiness.score is defined %}
-              {{ '@pct% complete'|t({'@pct': readiness.score}) }}
-            {% else %}
-              {{ 'Tracks organiser readiness across key setup milestones.'|t }}
-            {% endif %}
-          </p>
+          <h2 class="mel-live-ops__panel-title" id="mel-dash-readiness-title">{{ 'Readiness details'|t }}</h2>
+          <p class="mel-live-ops__panel-intro">{{ 'Setup checks from the existing readiness system.'|t }}</p>
         </div>
         {% if readiness_items is iterable and readiness_items|length > 0 %}
           <div class="mel-live-ops__timeline-feed" role="list">
@@ -288,15 +226,9 @@
               {% set done = item.complete|default(false) %}
               {% set sev = item.severity|default('neutral') %}
               {% set chip_mod = done ? 'success' : ((sev == 'warning') ? 'warn' : 'info') %}
-              {% set status_label %}
-                {% if done %}
-                  {{ readiness.row_complete_label|default('Complete'|t) }}
-                {% else %}
-                  {{ readiness.row_incomplete_label|default('Action required'|t) }}
-                {% endif %}
-              {% endset %}
+              {% set status_label = done ? readiness.row_complete_label|default('Complete'|t) : readiness.row_incomplete_label|default('Action required'|t) %}
               <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{% if done %}✓{% else %}!{% endif %}</div>
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{% if done %}+{% else %}!{% endif %}</div>
                 <div class="mel-live-ops__timeline-body">
                   {% if item.url is defined and item.url %}
                     <a class="mel-live-ops__readiness-link" href="{{ item.url }}">
@@ -313,231 +245,266 @@
               </article>
             {% endfor %}
           </div>
-        {% elseif dashboard_vendor_id %}
-          <p class="mel-live-ops__muted">{{ 'Your setup looks good — readiness checks are clear for your organiser account.'|t }}</p>
-        {% else %}
-          <p class="mel-live-ops__muted">{{ 'Readiness checks will appear here once your account is set up.'|t }}</p>
         {% endif %}
       </section>
-    </div>
-  </div>
 
-  <section class="mel-live-ops__metrics mel-vendor-dashboard__metric-intro" aria-labelledby="mel-dash-kpis-title">
-    <h2 id="mel-dash-kpis-title" class="mel-live-ops__panel-title">{{ 'Performance snapshot'|t }}</h2>
-    <p class="mel-live-ops__panel-intro">{{ 'Based on published events you manage.'|t }}</p>
-    {% if kpis is iterable and kpis|length > 0 %}
-      <div class="mel-live-ops__metric-board" role="list">
-        {% for kpi in kpis %}
-          {% set stat_mod = kpi_board_modifiers[loop.index0 % kpi_board_modifiers|length] %}
-          {% set kpi_contract = kpi.mel_data_presentation_contract|default('') %}
-          {% set kpi_inner %}
-            <span class="mel-live-ops__stat-icon" aria-hidden="true"></span>
-            <span class="mel-live-ops__stat-label">{{ kpi.label|default('') }}</span>
-            <span class="mel-live-ops__stat-value">{{ kpi.value|default('—') }}</span>
-            {% if kpi.context is defined and kpi.context %}
-              <span class="mel-live-ops__stat-note">{{ kpi.context }}</span>
-            {% endif %}
-          {% endset %}
-          {% if kpi.url is defined and kpi.url %}
-            <a
-              class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}"
-              role="listitem"
-              href="{{ kpi.url }}"
-              {% if kpi_contract %} data-mel-presentation-contract="{{ kpi_contract }}" data-mel-component-contract="{{ kpi.mel_component_contract|default('') }}"{% endif %}
-            >
-              {{ kpi_inner }}
-            </a>
-          {% else %}
-            <article
-              class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}"
-              role="listitem"
-              {% if kpi_contract %} data-mel-presentation-contract="{{ kpi_contract }}" data-mel-component-contract="{{ kpi.mel_component_contract|default('') }}"{% endif %}
-            >
-              {{ kpi_inner }}
-            </article>
-          {% endif %}
-        {% endfor %}
-      </div>
-    {% elseif dashboard_vendor_id %}
-      <p class="mel-live-ops__muted">{{ 'Performance data will appear after your first RSVP, ticket sale, or event view.'|t }}</p>
-    {% else %}
-      <p class="mel-live-ops__muted">{{ 'Metrics will appear here when available.'|t }}</p>
-    {% endif %}
-  </section>
-
-  {% if analytics_summary.available is defined and analytics_summary.available and analytics_items is iterable and analytics_items|length > 0 %}
-    <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-analytics-summary-title">
-      <div class="mel-live-ops__timeline-head">
-        <h2 class="mel-live-ops__panel-title" id="mel-dash-analytics-summary-title">{{ 'Analytics'|t }}</h2>
-        <p class="mel-live-ops__panel-intro">{{ 'Signals from visitors and engagement.'|t }}</p>
-      </div>
-      <div class="mel-live-ops__timeline-feed" role="list">
-        {% for row in analytics_items %}
-          <article class="mel-live-ops__timeline-card" role="listitem">
-            <div class="mel-live-ops__timeline-avatar" aria-hidden="true">∗</div>
-            <div class="mel-live-ops__timeline-body">
-              <p class="mel-live-ops__timeline-name">{{ row }}</p>
-            </div>
-          </article>
-        {% endfor %}
-      </div>
-    </section>
-  {% endif %}
-
-  {% if growth_cards is defined and growth_cards|length > 0 %}
-    <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-growth-title">
-      <div class="mel-live-ops__timeline-head">
-        <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Growth suggestions'|t }}</h2>
-        <p class="mel-live-ops__panel-intro">{{ 'Timely, relevant steps to help you optimise outcomes.'|t }}</p>
-      </div>
-      <ul class="mel-vendor-dashboard__growth-feed" role="list">
-        {% for card in growth_cards %}
-          <li>
-            <article
-              class="mel-growth-card {{ card.card_class|default('') }}"
-              role="listitem"
-              data-insight-key="{{ card.key }}"
-              {% if card.event_id is defined and card.event_id %}data-event-id="{{ card.event_id }}"{% endif %}
-            >
-              <div class="mel-growth-card__body">
-                <h3 class="mel-growth-card__title">{{ card.title }}</h3>
-                <p class="mel-growth-card__message">{{ card.message }}</p>
-                <div class="mel-growth-card__actions">
-                  {% if card.cta_track_url %}
-                    <a href="{{ card.cta_track_url }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
-                  {% elseif card.cta_route %}
-                    <a href="{{ path(card.cta_route, card.cta_params|default({})) }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+      {% if operational_readiness_items is iterable and operational_readiness_items|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-operational-readiness-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-operational-readiness-title">{{ operational_readiness.heading|default('Operational readiness'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ operational_readiness.intro|default('Publishing, bookings, payouts, attendees, and discovery.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in operational_readiness_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod = sev == 'success' ? 'success' : (sev == 'warning' or sev == 'error' ? 'warn' : (sev == 'neutral' ? 'calm' : 'info')) %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '+' : 'i' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                  </div>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
                   {% endif %}
                 </div>
-              </div>
-              {% if card.dismissible %}
-                <button type="button" class="mel-growth-card__dismiss" data-mel-growth-dismiss aria-label="{{ 'Dismiss suggestion'|t }}">{{ 'Dismiss'|t }}</button>
-              {% endif %}
-            </article>
-          </li>
-        {% endfor %}
-      </ul>
-    </section>
-  {% endif %}
-
-  <section class="mel-vendor-dashboard__events-scope" aria-labelledby="mel-dash-events-title">
-    <div class="mel-live-ops__attendees-head">
-      <h2 id="mel-dash-events-title" class="mel-live-ops__panel-title">{{ 'Your events'|t }}</h2>
-      <p class="mel-live-ops__panel-intro">{{ 'Jump into ticketing, RSVP, analytics, or the event workspace.'|t }}</p>
-    </div>
-
-    {% if model_events is iterable and model_events|length > 0 %}
-      <div class="mel-vendor-dashboard__event-grid">
-        {% for ev in model_events|slice(0, 6) %}
-          {% set links = ev.links|default({}) %}
-          {% set et = ev.event_type|default('unknown') %}
-          {% if et == 'paid' %}
-            {% set type_label = 'Paid tickets'|t %}
-          {% elseif et == 'rsvp' %}
-            {% set type_label = 'RSVP'|t %}
-          {% elseif et == 'both' %}
-            {% set type_label = 'Tickets & RSVP'|t %}
-          {% else %}
-            {% set type_label = 'Setup needed'|t %}
+              </article>
+            {% endfor %}
+          </div>
+          {% if first_event_guidance is iterable and first_event_guidance|length > 0 %}
+            <div class="mel-live-ops__timeline-feed" role="list" aria-label="{{ 'First event guidance'|t }}">
+              {% for item in first_event_guidance %}
+                <article class="mel-live-ops__timeline-card" role="listitem">
+                  <div class="mel-live-ops__timeline-avatar" aria-hidden="true">i</div>
+                  <div class="mel-live-ops__timeline-body">
+                    <p class="mel-live-ops__timeline-name">{{ item.message|default('') }}</p>
+                  </div>
+                </article>
+              {% endfor %}
+            </div>
           {% endif %}
-          <article class="mel-live-ops__attendee-row mel-vendor-dashboard__event-row">
-            <div class="mel-live-ops__attendee-meta">
-              <div class="mel-live-ops__attendee-ident">
-                {% set img = ev.image|default({}) %}
-                {% set img_url = img.url|default('') %}
-                {% set img_alt = img.alt|default('') %}
-                {% set img_ph = img.is_placeholder|default(false) %}
-                {% if img_url %}
-                  <div class="mel-event-card-thumb{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
-                    <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_alt|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+        </section>
+      {% endif %}
+
+      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-lifecycle-guidance-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-lifecycle-guidance-title">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ lifecycle_guidance.intro|default('Context from the lifecycle system.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in lifecycle_guidance_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod = sev == 'success' ? 'success' : (sev == 'warning' or sev == 'error' ? 'warn' : (sev == 'neutral' ? 'calm' : 'info')) %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '+' : 'i' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.stage|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
                   </div>
-                {% else %}
-                  <div class="mel-event-card-thumb mel-event-card-thumb--fallback">
-                    <span class="mel-event-card-thumb__fallback-label" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</span>
-                  </div>
-                {% endif %}
-                <div>
-                  <span class="mel-live-ops__attendee-name">{{ ev.title|default('') }}</span>
-                  {% if ev.date_label is defined and ev.date_label %}
-                    <span class="mel-live-ops__attendee-email">{{ ev.date_label }}</span>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
                   {% endif %}
-                  <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Status'|t }}">
-                    {% if ev.status_label is defined and ev.status_label %}
-                      <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ ev.status_label }}</span>
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+
+      {% if secondary_actions is iterable and secondary_actions|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-secondary-actions-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-secondary-actions-title">{{ 'Other recommendations'|t }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ 'Additional action queue items kept out of the primary alert.'|t }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for action in secondary_actions %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">i</div>
+                <div class="mel-live-ops__timeline-body">
+                  <p class="mel-live-ops__timeline-name">{{ action.title|default('') }}</p>
+                  {% if action.message is defined and action.message %}
+                    <p class="mel-live-ops__muted">{{ action.message }}</p>
+                  {% endif %}
+                  {% if action.url is defined and action.url and action.action_label is defined and action.action_label %}
+                    <a class="mel-live-ops__readiness-link" href="{{ action.url }}">{{ action.action_label }}</a>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+    </div>
+  </details>
+
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--events">
+    <summary>{{ 'All events and secondary guidance'|t }}</summary>
+    <div class="mel-vendor-dashboard__details-grid">
+      <section class="mel-vendor-dashboard__events-scope" aria-labelledby="mel-dash-events-title">
+        <div class="mel-live-ops__timeline-head">
+          <h2 id="mel-dash-events-title" class="mel-live-ops__panel-title">{{ 'Your events'|t }}</h2>
+          <p class="mel-live-ops__panel-intro">{{ 'Jump into ticketing, RSVP, analytics, or the event workspace.'|t }}</p>
+        </div>
+
+        {% if model_events is iterable and model_events|length > 0 %}
+          <div class="mel-vendor-dashboard__event-grid">
+            {% for ev in model_events|slice(0, 6) %}
+              {% set links = ev.links|default({}) %}
+              {% set et = ev.event_type|default('unknown') %}
+              {% set type_label = et == 'paid' ? 'Paid tickets'|t : (et == 'rsvp' ? 'RSVP'|t : (et == 'both' ? 'Tickets & RSVP'|t : 'Setup needed'|t)) %}
+              <article class="mel-live-ops__attendee-row mel-vendor-dashboard__event-row">
+                <div class="mel-live-ops__attendee-meta">
+                  <div class="mel-live-ops__attendee-ident">
+                    {% set img = ev.image|default({}) %}
+                    {% set img_url = img.url|default('') %}
+                    {% set img_alt = img.alt|default('') %}
+                    {% set img_ph = img.is_placeholder|default(false) %}
+                    {% if img_url %}
+                      <div class="mel-event-card-thumb{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
+                        <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_ph ? '' : img_alt|e('html_attr') }}" loading="lazy" width="56" height="56"/>
+                      </div>
+                    {% else %}
+                      <div class="mel-event-card-thumb mel-event-card-thumb--fallback">
+                        <span class="mel-event-card-thumb__fallback-label" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</span>
+                      </div>
                     {% endif %}
-                    <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ type_label }}</span>
-                  </div>
-                  {% set issues = ev.presentation_issues|default([]) %}
-                  {% if issues is iterable and issues|length > 0 %}
-                    <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Setup issues'|t }}">
-                      {% for issue in issues %}
-                        {% set isev = issue.severity|default('warning') %}
-                        {% set issue_chip = isev == 'error' ? 'warn' : 'warn' %}
-                        <span class="mel-live-ops__chip mel-live-ops__chip--{{ issue_chip }}">{{ issue.label|default('') }}</span>
-                      {% endfor %}
+                    <div>
+                      <span class="mel-live-ops__attendee-name">{{ ev.title|default('') }}</span>
+                      {% if ev.date_label is defined and ev.date_label %}
+                        <span class="mel-live-ops__attendee-email">{{ ev.date_label }}</span>
+                      {% endif %}
+                      <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Status'|t }}">
+                        {% if ev.status_label is defined and ev.status_label %}
+                          <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ ev.status_label }}</span>
+                        {% endif %}
+                        <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ type_label }}</span>
+                      </div>
+                      {% if ev.metric_label is defined and ev.metric_label %}
+                        <p class="mel-live-ops__attendee-ticket">{{ ev.metric_label }}</p>
+                      {% endif %}
+                      {% if ev.revenue_label is defined and ev.revenue_label %}
+                        <p class="mel-live-ops__ticket-code-line">{{ 'Revenue: @r'|t({'@r': ev.revenue_label}) }}</p>
+                      {% endif %}
                     </div>
+                  </div>
+                </div>
+                <div class="mel-live-ops__attendee-side">
+                  {% if links.manage is defined and links.manage %}
+                    <a class="mel-live-ops__hero-cta mel-btn mel-btn--primary mel-btn--sm" href="{{ links.manage }}">{{ 'Manage'|t }}</a>
                   {% endif %}
-                  {% if ev.metric_label is defined and ev.metric_label %}
-                    <p class="mel-live-ops__attendee-ticket">{{ ev.metric_label }}</p>
+                  {% if links.edit is defined and links.edit %}
+                    <a class="mel-btn mel-btn--secondary mel-btn--sm" href="{{ links.edit }}">{{ 'Edit'|t }}</a>
                   {% endif %}
-                  {% if ev.revenue_label is defined and ev.revenue_label %}
-                    <p class="mel-live-ops__ticket-code-line">{{ 'Revenue: @r'|t({'@r': ev.revenue_label}) }}</p>
+                  {% if links.attendees is defined and links.attendees %}
+                    <a class="mel-btn mel-btn--secondary mel-btn--sm" href="{{ links.attendees }}">{{ 'Attendees'|t }}</a>
                   {% endif %}
-                  {% if ev.capacity_label is defined and ev.capacity_label %}
-                    <p class="mel-live-ops__ticket-code-line">{{ 'Capacity: @c'|t({'@c': ev.capacity_label}) }}</p>
+                  {% if links.analytics is defined and links.analytics %}
+                    <a class="mel-btn mel-btn--ghost mel-btn--sm" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
+                  {% endif %}
+                  {% set removal = ev.removal|default(null) %}
+                  {% if removal %}
+                    <button type="button" class="mel-btn mel-btn--sm mel-event-card-remove-open" data-mel-open-dialog="{{ removal.dialog_id|e('html_attr') }}" aria-haspopup="dialog">
+                      {{ removal.danger_label|default('Archive'|t) }}
+                    </button>
+                    {% include '@myeventlane_vendor_theme/components/mel-event-card-removal-dialog.html.twig' with { removal: removal } only %}
                   {% endif %}
                 </div>
-              </div>
-            </div>
-            <div class="mel-live-ops__attendee-side">
-              {% if links.manage is defined and links.manage %}
-                <a class="mel-live-ops__hero-cta mel-btn mel-btn--primary mel-btn--sm" href="{{ links.manage }}">{{ 'Manage'|t }}</a>
-              {% endif %}
-              {% if links.edit is defined and links.edit %}
-                <a class="mel-btn mel-btn--secondary mel-btn--sm" href="{{ links.edit }}">{{ 'Edit'|t }}</a>
-              {% endif %}
-              {% if links.tickets is defined and links.tickets %}
-                <a class="mel-btn mel-btn--secondary mel-btn--sm" href="{{ links.tickets }}">{{ 'Tickets'|t }}</a>
-              {% endif %}
-              {% if links.analytics is defined and links.analytics %}
-                <a class="mel-btn mel-btn--ghost mel-btn--sm" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
-              {% endif %}
-              {% set removal = ev.removal|default(null) %}
-              {% if removal %}
-                <button type="button" class="mel-btn mel-btn--sm mel-event-card-remove-open" data-mel-open-dialog="{{ removal.dialog_id|e('html_attr') }}" aria-haspopup="dialog">
-                  {{ removal.danger_label|default('Archive'|t) }}
-                </button>
-                {% include '@myeventlane_vendor_theme/components/mel-event-card-removal-dialog.html.twig' with { removal: removal } only %}
-              {% endif %}
-            </div>
-          </article>
-        {% endfor %}
-      </div>
-    {% else %}
-      <div class="mel-live-ops__panel mel-vendor-dashboard__panel mel-vendor-dashboard__events-empty">
-        <p class="mel-live-ops__panel-title mel-vendor-dashboard__events-empty-title">{{ empty_state.title|default('Welcome to your organiser dashboard'|t) }}</p>
-        <p class="mel-live-ops__panel-intro mel-vendor-dashboard__events-empty-intro">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
-        {# Hero primary already shows create/view when URL exists; avoid duplicate primary CTAs. #}
-        {% if hero_primary_url is empty and empty_state.url is defined and empty_state.url and empty_state.action_label is defined and empty_state.action_label %}
-          <p class="mel-vendor-dashboard__events-empty-actions"><a class="mel-btn mel-btn--primary" href="{{ empty_state.url }}">{{ empty_state.action_label }}</a></p>
+              </article>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="mel-live-ops__panel mel-vendor-dashboard__panel mel-vendor-dashboard__events-empty">
+            <p class="mel-live-ops__panel-title mel-vendor-dashboard__events-empty-title">{{ empty_state.title|default('Welcome to your organiser dashboard'|t) }}</p>
+            <p class="mel-live-ops__panel-intro mel-vendor-dashboard__events-empty-intro">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
+          </div>
         {% endif %}
+      </section>
+
+      {% if analytics_summary.available is defined and analytics_summary.available and analytics_items is iterable and analytics_items|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-analytics-summary-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-analytics-summary-title">{{ 'Analytics summary'|t }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ 'Detailed charts remain on analytics pages.'|t }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for row in analytics_items %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">i</div>
+                <div class="mel-live-ops__timeline-body">
+                  <p class="mel-live-ops__timeline-name">{{ row }}</p>
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+
+      {% if growth_cards is defined and growth_cards|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-growth-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Promotion guidance'|t }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ 'Suggestions remain secondary to the current event.'|t }}</p>
+          </div>
+          <ul class="mel-vendor-dashboard__growth-feed" role="list">
+            {% for card in growth_cards %}
+              <li>
+                <article class="mel-growth-card {{ card.card_class|default('') }}" role="listitem" data-insight-key="{{ card.key }}"{% if card.event_id is defined and card.event_id %} data-event-id="{{ card.event_id }}"{% endif %}>
+                  <div class="mel-growth-card__body">
+                    <h3 class="mel-growth-card__title">{{ card.title }}</h3>
+                    <p class="mel-growth-card__message">{{ card.message }}</p>
+                    <div class="mel-growth-card__actions">
+                      {% if card.cta_track_url %}
+                        <a href="{{ card.cta_track_url }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                      {% elseif card.cta_route %}
+                        <a href="{{ path(card.cta_route, card.cta_params|default({})) }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                      {% endif %}
+                    </div>
+                  </div>
+                  {% if card.dismissible %}
+                    <button type="button" class="mel-growth-card__dismiss" data-mel-growth-dismiss aria-label="{{ 'Dismiss suggestion'|t }}">{{ 'Dismiss'|t }}</button>
+                  {% endif %}
+                </article>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+    </div>
+  </details>
+
+  <footer class="mel-vendor-dashboard__footer-surfaces" aria-label="{{ 'Secondary dashboard surfaces'|t }}">
+    {% if launch_pro_status is defined and launch_pro_status %}
+      <div class="mel-vendor-dashboard__micro-surface">{{ launch_pro_status }}</div>
+    {% elseif is_pro|default(false) %}
+      <div class="mel-vendor-dashboard__micro-surface">
+        <span class="mel-live-ops__chip mel-live-ops__chip--success">{{ 'PRO PLAN active'|t }}</span>
+        <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ path('myeventlane_pro.manage') }}">{{ 'Manage'|t }}</a>
+      </div>
+    {% elseif show_pro_prompt|default(false) %}
+      <div class="mel-vendor-dashboard__micro-surface">
+        <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ 'FREE PLAN'|t }}</span>
+        <a class="mel-live-ops__chip mel-live-ops__chip--live" href="{{ pro_upgrade_url|default(path('myeventlane_pro.overview')) }}">{{ 'Upgrade to Pro'|t }}</a>
       </div>
     {% endif %}
-  </section>
 
-  {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
-    <div class="mel-vendor-dashboard__billing-strip mel-vendor-dashboard__billing-strip--below-events">{{ mel_contribution_billing_strip }}</div>
-  {% endif %}
+    {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
+      <div class="mel-vendor-dashboard__billing-strip mel-vendor-dashboard__billing-strip--below-events">{{ mel_contribution_billing_strip }}</div>
+    {% endif %}
 
-  {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
-    <div class="mel-vendor-dashboard__boost-slot mel-vendor-dashboard__boost-slot--below-events">
-      {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
-        event: {
-          title: mel_top_boost_opportunity.title,
-          image: mel_top_boost_opportunity.image|default(null),
-        },
-        performance: mel_top_boost_opportunity.performance,
-      } only %}
-    </div>
-  {% endif %}
+    {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
+      <div class="mel-vendor-dashboard__boost-slot mel-vendor-dashboard__boost-slot--below-events">
+        {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
+          event: {
+            title: mel_top_boost_opportunity.title,
+            image: mel_top_boost_opportunity.image|default(null),
+          },
+          performance: mel_top_boost_opportunity.performance,
+        } only %}
+      </div>
+    {% endif %}
+  </footer>
 </section>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -13,12 +13,14 @@
 {% set first_event_guidance = operational_readiness.first_event_guidance|default([]) %}
 {% set lifecycle_guidance = model.lifecycle_guidance|default({}) %}
 {% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
+{% set organiser_overview = model.organiser_overview|default([]) %}
 {% set kpis = model.kpis|default([]) %}
 {% set actions = model.action_queue|default([]) %}
 {% set priority_action = model.priority_action|default(actions|first|default(null)) %}
 {% set secondary_actions = model.secondary_actions|default(actions|slice(1)) %}
 {% set model_events = model.events|default([]) %}
 {% set focus_event = model.current_event|default(model_events|first|default({})) %}
+{% set upcoming_events = model.upcoming_events|default([]) %}
 {% set empty_state = model.empty_state|default({}) %}
 {% set analytics_summary = model.analytics_summary|default({}) %}
 {% set analytics_items = analytics_summary.items|default([]) %}
@@ -130,6 +132,33 @@
     </div>
   </section>
 
+  {% if organiser_overview is iterable and organiser_overview|length > 0 %}
+    <section class="mel-vendor-dashboard__overview-strip" aria-labelledby="mel-dash-overview-title">
+      <div class="mel-vendor-dashboard__section-head">
+        <div>
+          <p class="mel-live-ops__eyebrow">{{ 'Mission control'|t }}</p>
+          <h2 id="mel-dash-overview-title" class="mel-live-ops__panel-title">{{ 'Organiser overview'|t }}</h2>
+        </div>
+        {% if model_events is iterable and model_events|length > 0 %}
+          <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ 'Across your events'|t }}</span>
+        {% endif %}
+      </div>
+      <div class="mel-vendor-dashboard__overview-items" role="list">
+        {% for item in organiser_overview|slice(0, 6) %}
+          {% set overview_sev = item.severity|default('neutral') %}
+          {% set overview_chip = overview_sev == 'success' ? 'success' : (overview_sev == 'warning' or overview_sev == 'error' ? 'warn' : 'calm') %}
+          <article class="mel-vendor-dashboard__overview-item mel-vendor-dashboard__overview-item--{{ overview_chip }}" role="listitem">
+            <span class="mel-vendor-dashboard__overview-label">{{ item.label|default('') }}</span>
+            <strong class="mel-vendor-dashboard__overview-value">{{ item.value|default('0') }}</strong>
+            {% if item.context is defined and item.context %}
+              <span class="mel-vendor-dashboard__overview-context">{{ item.context }}</span>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+
   <section class="mel-live-ops__metrics mel-vendor-dashboard__metric-strip" aria-labelledby="mel-dash-kpis-title">
     <h2 id="mel-dash-kpis-title" class="mel-live-ops__panel-title">{{ 'Quick metrics'|t }}</h2>
     <p class="mel-live-ops__panel-intro">
@@ -182,31 +211,75 @@
     </nav>
   {% endif %}
 
-  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--activity">
-    <summary>{{ 'Recent activity'|t }}</summary>
-    <div class="mel-live-ops__panel mel-vendor-dashboard__panel">
-      {% if activity_items is iterable and activity_items|length > 0 %}
-        <div class="mel-live-ops__timeline-feed" role="list">
-          {% for item in activity_items|slice(0, 6) %}
-            {% set row_type = item.type|default('info') %}
-            {% set row_chip = row_type == 'success' ? 'success' : (row_type == 'warning' or row_type == 'error' ? 'warn' : 'info') %}
-            <article class="mel-live-ops__timeline-card" role="listitem">
-              <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ row_type == 'success' ? '+' : 'i' }}</div>
-              <div class="mel-live-ops__timeline-body">
-                <p class="mel-live-ops__timeline-name">{{ item.message|default('') }}</p>
-                {% if item.url is defined and item.url %}
-                  <a class="mel-live-ops__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}</a>
-                {% endif %}
-              </div>
-              <span class="mel-live-ops__chip mel-live-ops__chip--{{ row_chip }}">{{ row_type == 'success' ? ('Activity'|t) : ('Update'|t) }}</span>
-            </article>
-          {% endfor %}
-        </div>
-      {% else %}
-        <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
-      {% endif %}
+  <section class="mel-vendor-dashboard__activity-stream" aria-labelledby="mel-dash-activity-title">
+    <div class="mel-vendor-dashboard__section-head">
+      <div>
+        <p class="mel-live-ops__eyebrow">{{ 'Operational activity'|t }}</p>
+        <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent signals'|t }}</h2>
+      </div>
+      <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ 'Sparse updates'|t }}</span>
     </div>
-  </details>
+    {% if activity_items is iterable and activity_items|length > 0 %}
+      <div class="mel-vendor-dashboard__activity-list" role="list">
+        {% for item in activity_items|slice(0, 4) %}
+          {% set row_type = item.type|default('info') %}
+          {% set row_chip = row_type == 'success' ? 'success' : (row_type == 'warning' or row_type == 'error' ? 'warn' : 'info') %}
+          <article class="mel-vendor-dashboard__activity-item" role="listitem">
+            <span class="mel-live-ops__chip mel-live-ops__chip--{{ row_chip }}">{{ row_type == 'success' ? ('Signal'|t) : ('Update'|t) }}</span>
+            <p class="mel-vendor-dashboard__activity-message">{{ item.message|default('') }}</p>
+            {% if item.url is defined and item.url %}
+              <a class="mel-live-ops__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}</a>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
+    {% endif %}
+  </section>
+
+  {% if upcoming_events is iterable and upcoming_events|length > 0 %}
+    <section class="mel-vendor-dashboard__upcoming-strip" aria-labelledby="mel-dash-upcoming-title">
+      <div class="mel-vendor-dashboard__section-head">
+        <div>
+          <p class="mel-live-ops__eyebrow">{{ 'Upcoming events'|t }}</p>
+          <h2 id="mel-dash-upcoming-title" class="mel-live-ops__panel-title">{{ 'Next in view'|t }}</h2>
+        </div>
+        {% if empty_state.url is defined and empty_state.url %}
+          <a class="mel-live-ops__readiness-link" href="{{ empty_state.url }}">{{ 'View all events'|t }}</a>
+        {% endif %}
+      </div>
+      <div class="mel-vendor-dashboard__upcoming-row" role="list">
+        {% for ev in upcoming_events %}
+          {% set links = ev.links|default({}) %}
+          {% set status = ev.status|default('upcoming') %}
+          {% set status_chip = status == 'draft' ? 'warn' : 'lavender' %}
+          <article class="mel-vendor-dashboard__upcoming-card" role="listitem">
+            <div>
+              <h3 class="mel-vendor-dashboard__upcoming-title">{{ ev.title|default('Untitled event'|t) }}</h3>
+              {% if ev.date_label is defined and ev.date_label %}
+                <p class="mel-vendor-dashboard__upcoming-date">{{ ev.date_label }}</p>
+              {% endif %}
+            </div>
+            <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Event state'|t }}">
+              {% if ev.status_label is defined and ev.status_label %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--{{ status_chip }}">{{ ev.status_label }}</span>
+              {% endif %}
+              {% if ev.booking_state_label is defined and ev.booking_state_label %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ ev.booking_state_label }}</span>
+              {% endif %}
+            </div>
+            {% if ev.metric_label is defined and ev.metric_label %}
+              <p class="mel-vendor-dashboard__upcoming-meta">{{ ev.metric_label }}</p>
+            {% endif %}
+            {% if links.manage is defined and links.manage %}
+              <a class="mel-live-ops__readiness-link" href="{{ links.manage }}">{{ 'Open event'|t }}</a>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
 
   <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--setup">
     <summary>{{ 'Review event setup'|t }}</summary>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -86,12 +86,12 @@
     <div class="mel-live-ops__hero-surface">
       <div class="mel-live-ops__hero-layout">
         <div class="mel-live-ops__hero-primary">
-          <p class="mel-live-ops__eyebrow">{{ 'Vendor Console'|t }}</p>
+          <p class="mel-live-ops__eyebrow">{{ 'Organiser console'|t }}</p>
           <h1 id="mel-dash-hero-title" class="mel-live-ops__hero-title">
             {% if vendor.label is defined and vendor.label %}
               {{ 'Welcome back, @name'|t({'@name': vendor.label}) }}
             {% else %}
-              {{ 'Welcome to your Vendor Console'|t }}
+              {{ 'Welcome to your organiser dashboard'|t }}
             {% endif %}
           </h1>
           <p class="mel-live-ops__hero-venue">{{ hero_body }}</p>
@@ -152,8 +152,8 @@
     <div class="mel-live-ops__stack">
       <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-actions-title">
         <div class="mel-live-ops__timeline-head">
-          <h2 class="mel-live-ops__panel-title" id="mel-dash-actions-title">{{ 'What needs attention now'|t }}</h2>
-          <p class="mel-live-ops__panel-intro">{{ 'Fix blockers early so launches stay smooth.'|t }}</p>
+          <h2 class="mel-live-ops__panel-title" id="mel-dash-actions-title">{{ 'What to do next'|t }}</h2>
+          <p class="mel-live-ops__panel-intro">{{ 'Small setup steps now help publishing and payouts go smoothly.'|t }}</p>
         </div>
         {% if actions is iterable and actions|length > 0 %}
           <div class="mel-live-ops__timeline-feed" role="list">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -20,6 +20,8 @@
 {% set operational_readiness = model.operational_readiness|default({}) %}
 {% set operational_readiness_items = operational_readiness.items|default([]) %}
 {% set first_event_guidance = operational_readiness.first_event_guidance|default([]) %}
+{% set lifecycle_guidance = model.lifecycle_guidance|default({}) %}
+{% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
 {% set kpis = model.kpis|default([]) %}
 {% set actions = model.action_queue|default([]) %}
 {% set model_events = model.events|default([]) %}
@@ -193,6 +195,37 @@
               {% endfor %}
             </div>
           {% endif %}
+        </section>
+      {% endif %}
+
+      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-lifecycle-guidance-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-lifecycle-guidance-title">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ lifecycle_guidance.intro|default('Helpful context based on the organiser and event signals already shown here.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in lifecycle_guidance_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod =
+                sev == 'success' ? 'success' :
+                (sev == 'warning' or sev == 'error') ? 'warn' :
+                (sev == 'neutral' ? 'calm' : 'info')
+              %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.stage|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                  </div>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
         </section>
       {% endif %}
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -17,6 +17,9 @@
 {% set vendor = model.vendor|default({}) %}
 {% set readiness = model.readiness|default({}) %}
 {% set readiness_items = readiness.items|default([]) %}
+{% set operational_readiness = model.operational_readiness|default({}) %}
+{% set operational_readiness_items = operational_readiness.items|default([]) %}
+{% set first_event_guidance = operational_readiness.first_event_guidance|default([]) %}
 {% set kpis = model.kpis|default([]) %}
 {% set actions = model.action_queue|default([]) %}
 {% set model_events = model.events|default([]) %}
@@ -150,6 +153,49 @@
 
   <div class="mel-live-ops__split">
     <div class="mel-live-ops__stack">
+      {% if operational_readiness_items is iterable and operational_readiness_items|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-operational-readiness-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-operational-readiness-title">{{ operational_readiness.heading|default('Operational readiness'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ operational_readiness.intro|default('A calm snapshot of publishing, bookings, payouts, attendees, and discovery.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in operational_readiness_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod =
+                sev == 'success' ? 'success' :
+                (sev == 'warning' or sev == 'error') ? 'warn' :
+                (sev == 'neutral' ? 'calm' : 'info')
+              %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                  </div>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+          {% if first_event_guidance is iterable and first_event_guidance|length > 0 %}
+            <div class="mel-live-ops__timeline-feed" role="list" aria-label="{{ 'First event guidance'|t }}">
+              {% for item in first_event_guidance %}
+                <article class="mel-live-ops__timeline-card" role="listitem">
+                  <div class="mel-live-ops__timeline-avatar" aria-hidden="true">•</div>
+                  <div class="mel-live-ops__timeline-body">
+                    <p class="mel-live-ops__timeline-name">{{ item.message|default('') }}</p>
+                  </div>
+                </article>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </section>
+      {% endif %}
+
       <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-actions-title">
         <div class="mel-live-ops__timeline-head">
           <h2 class="mel-live-ops__panel-title" id="mel-dash-actions-title">{{ 'What to do next'|t }}</h2>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
@@ -4,7 +4,7 @@
  * Left navigation sidebar for MyEventLane Vendor Console.
  */
 #}
-<nav class="mel-sidebar mel-vendor-console__nav" aria-label="{{ 'Vendor navigation'|t }}">
+<nav class="mel-sidebar mel-vendor-console__nav" aria-label="{{ 'Organiser navigation'|t }}">
   {% if page.is_admin and page.admin_portal_url %}
     <div class="mel-sidebar__admin-link">
       <a href="{{ page.admin_portal_url }}" class="mel-sidebar__link mel-sidebar__link--admin" target="_blank" rel="noopener noreferrer">
@@ -14,7 +14,7 @@
   {% endif %}
 
   <div class="mel-sidebar__brand">
-    <a href="{{ page.vendor_shell_brand_url|default(path('myeventlane_vendor.console.dashboard')) }}" class="mel-sidebar__logo" aria-label="{{ 'Vendor dashboard'|t }}">
+    <a href="{{ page.vendor_shell_brand_url|default(path('myeventlane_vendor.console.dashboard')) }}" class="mel-sidebar__logo" aria-label="{{ 'Organiser dashboard'|t }}">
       <span class="mel-sidebar__logo-mark">M</span>
       <span class="mel-sidebar__logo-text">MyEventLane</span>
     </a>
@@ -92,7 +92,7 @@
         </div>
         <div class="mel-sidebar__user-info">
           <div class="mel-sidebar__user-name">{{ page.user_name }}</div>
-          <div class="mel-sidebar__user-role">{{ page.user_role|default('Vendor'|t) }}</div>
+          <div class="mel-sidebar__user-role">{{ page.user_role|default('Organiser'|t) }}</div>
         </div>
       </div>
     {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
@@ -37,14 +37,23 @@
             <span class="mel-sidebar__link-label">{{ item.label }}</span>
           </a>
         {% else %}
+          {# Items that need an event context use a clearer disabled reason; #}
+          {# others fall back to the calmer 'Available soon' wording. #}
+          {% set event_scoped_keys = ['orders', 'checkin', 'check_in', 'ticket_holders', 'event_editor'] %}
+          {% set disabled_reason = item.key in event_scoped_keys
+            ? 'Open this from an event'|t
+            : 'Available soon'|t %}
+          {% set disabled_badge = item.key in event_scoped_keys
+            ? 'Event-only'|t
+            : 'Soon'|t %}
           <span class="mel-sidebar__link mel-vendor-console__nav-item mel-sidebar__link--disabled"
                 aria-disabled="true"
-                title="{{ 'Coming soon'|t }}">
+                title="{{ disabled_reason }}">
             <span class="mel-sidebar__link-icon" aria-hidden="true">
               {% include '@myeventlane_vendor_theme/components/sidebar-icon.html.twig' with { icon: item.icon|default('dashboard') } only %}
             </span>
             <span class="mel-sidebar__link-label">{{ item.label }}</span>
-            <span class="mel-sidebar__link-badge">{{ 'Soon'|t }}</span>
+            <span class="mel-sidebar__link-badge">{{ disabled_badge }}</span>
           </span>
         {% endif %}
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -14,7 +14,7 @@
 <div class="mel-sidebar-overlay" data-sidebar-overlay style="pointer-events:none;"></div>
 
 <div class="mel-vendor-console mel-vendor-shell{% if page.wizard_sidebar_active %} mel-vendor-shell--wizard-sidebar{% endif %}">
-  <aside id="mel-vendor-sidebar" class="mel-vendor-shell__sidebar mel-vendor-sidebar mel-vendor-console__sidebar" role="navigation" aria-label="{{ 'Vendor navigation'|t }}" data-sidebar>
+  <aside id="mel-vendor-sidebar" class="mel-vendor-shell__sidebar mel-vendor-sidebar mel-vendor-console__sidebar" role="navigation" aria-label="{{ 'Organiser navigation'|t }}" data-sidebar>
     {% include '@myeventlane_vendor_theme/includes/sidebar.html.twig' with { page: page } %}
   </aside>
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -107,6 +107,39 @@
         </section>
       {% endif %}
 
+      {% set ops_readiness = model.operational_readiness|default({}) %}
+      {% set ops_readiness_items = ops_readiness.items|default([]) %}
+      {% if ops_readiness_items is iterable and ops_readiness_items|length > 0 %}
+        <section class="mel-live-ops__panel" aria-labelledby="mel-ws-operational-readiness-heading">
+          <div class="mel-live-ops__timeline-head">
+            <h2 id="mel-ws-operational-readiness-heading" class="mel-live-ops__panel-title">{{ ops_readiness.heading|default('Operational readiness'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ ops_readiness.intro|default('What is ready, what attendees can see, and what still needs setup.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in ops_readiness_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod =
+                sev == 'success' ? 'success' :
+                (sev == 'warning' or sev == 'error') ? 'warn' :
+                (sev == 'neutral' ? 'calm' : 'info')
+              %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                  </div>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+
       <section class="mel-live-ops__panel" aria-labelledby="mel-ws-readiness-heading">
         <div class="mel-live-ops__timeline-head">
           <h2 id="mel-ws-readiness-heading" class="mel-live-ops__panel-title">{{ 'Readiness'|t }}</h2>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -140,6 +140,39 @@
         </section>
       {% endif %}
 
+      {% set lifecycle_guidance = model.lifecycle_guidance|default({}) %}
+      {% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
+      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
+        <section class="mel-live-ops__panel" aria-labelledby="mel-ws-lifecycle-guidance-heading">
+          <div class="mel-live-ops__timeline-head">
+            <h2 id="mel-ws-lifecycle-guidance-heading" class="mel-live-ops__panel-title">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ lifecycle_guidance.intro|default('Contextual notes that explain this event state without adding new rules or alerts.'|t) }}</p>
+          </div>
+          <div class="mel-live-ops__timeline-feed" role="list">
+            {% for item in lifecycle_guidance_items %}
+              {% set sev = item.severity|default('info') %}
+              {% set chip_mod =
+                sev == 'success' ? 'success' :
+                (sev == 'warning' or sev == 'error') ? 'warn' :
+                (sev == 'neutral' ? 'calm' : 'info')
+              %}
+              <article class="mel-live-ops__timeline-card" role="listitem">
+                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
+                <div class="mel-live-ops__timeline-body">
+                  <div class="mel-live-ops__timeline-headline">
+                    <span class="mel-live-ops__timeline-name">{{ item.stage|default('') }}</span>
+                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                  </div>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+
       <section class="mel-live-ops__panel" aria-labelledby="mel-ws-readiness-heading">
         <div class="mel-live-ops__timeline-head">
           <h2 id="mel-ws-readiness-heading" class="mel-live-ops__panel-title">{{ 'Readiness'|t }}</h2>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/studio/studio.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/studio/studio.html.twig
@@ -76,7 +76,7 @@
           </a>
 
           <button class="mel-btn mel-btn-primary">
-            Boost Event
+            {{ 'Promote event'|t }}
           </button>
 
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly copy/IA updates, but it also adds new dashboard/workspace summary payload builders in `MelReadinessHelper` and wires them into view models/templates; incorrect signal derivation could mislead organisers even though no enforcement logic changes.
> 
> **Overview**
> Aligns organiser/customer-facing terminology and trust copy across the product (e.g. **“vendor” → “organiser”**, **“escalation” → “support request”**, “Boost” → “Promote event”), including route titles, hub/sidebar navigation ordering, checkout/attendee wording, Help Assistant fallbacks, AI prompt text, and transactional email templates.
> 
> Adds **presentation-only operational readiness and lifecycle summary builders** to `MelReadinessHelper` and surfaces them in the organiser dashboard (`VendorDashboardViewModelBuilder`), event studio publish readiness warnings, and the vendor event operations page (new `empty_guidance` injected into `mel-venue-operations.html.twig`).
> 
> Improves empty states in multiple Drupal Views (Help Centre listings, vendor events, vendor RSVPs) with custom accessible `role="status"` messages and guidance when filters return no results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33c5d74df195025d9e11296209d3510579ac5c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->