### PR TITLE
Fix MEL homepage event grids and footer links

### DIFF
--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -1,0 +1,23 @@
+myeventlane_front.about:
+  path: '/about'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\MarketingPageController::about'
+    _title: 'About MyEventLane'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.story:
+  path: '/story'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\MarketingPageController::story'
+    _title: 'MyEventLane Story'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.blog:
+  path: '/blog'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\MarketingPageController::blog'
+    _title: 'MyEventLane Blog'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/myeventlane_front/src/Controller/MarketingPageController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/MarketingPageController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Public marketing pages linked from the site footer.
+ */
+final class MarketingPageController extends ControllerBase {
+
+  /**
+   * Builds the About MyEventLane page.
+   */
+  public function about(): array {
+    return $this->buildPage(
+      $this->t('About MyEventLane'),
+      $this->t('MyEventLane helps people discover local events and gives organisers a straightforward way to publish, promote, and manage them.'),
+      [
+        $this->t('Find events by category, date, and ticket type.'),
+        $this->t('Host free RSVP or ticketed events with clear organiser tools.'),
+        $this->t('Keep community trust, support, and secure payments close to every event journey.'),
+      ],
+    );
+  }
+
+  /**
+   * Builds the MyEventLane Story page.
+   */
+  public function story(): array {
+    return $this->buildPage(
+      $this->t('MyEventLane Story'),
+      $this->t('MyEventLane is built around a simple idea: local events should be easier to find, easier to host, and easier to trust.'),
+      [
+        $this->t('We are shaping MyEventLane for community organisers, creative teams, venues, and attendees who want one reliable place to connect.'),
+        $this->t('The platform is continuing to grow with better discovery, stronger organiser workflows, and practical support content.'),
+      ],
+    );
+  }
+
+  /**
+   * Builds the Blog placeholder page.
+   */
+  public function blog(): array {
+    return $this->buildPage(
+      $this->t('MyEventLane Blog'),
+      $this->t('The MyEventLane blog is being set up.'),
+      [
+        $this->t('Check back for organiser guides, platform updates, and event discovery stories.'),
+      ],
+    );
+  }
+
+  /**
+   * Builds a shared marketing page render array.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $title
+   *   Page title.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $intro
+   *   Introductory copy.
+   * @param array<int, \Drupal\Core\StringTranslation\TranslatableMarkup> $points
+   *   Supporting bullet points.
+   *
+   * @return array
+   *   Render array.
+   */
+  private function buildPage(TranslatableMarkup $title, TranslatableMarkup $intro, array $points): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-container', 'mel-marketing-page'],
+      ],
+      'content' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-marketing-page__body'],
+        ],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h1',
+          '#value' => $title,
+        ],
+        'intro' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $intro,
+        ],
+        'points' => [
+          '#theme' => 'item_list',
+          '#items' => $points,
+        ],
+      ],
+      '#cache' => [
+        'max-age' => 3600,
+      ],
+    ];
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -62,6 +62,7 @@ front:
   dependencies:
     - core/drupal
     - core/once
+    - myeventlane_theme/global-styling
 
 # Help Centre search (/help/search) — compiled into dist/main.scss via Vite.
 help_search:

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1124,24 +1124,15 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     $variables['directory'] = base_path() . $theme_path;
   }
 
-  // Footer: dynamic categories (only if > 3 published events) + organiser detection.
+  // Footer: list every category without count queries on each page request.
   $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
   $tree = $term_storage->loadTree('categories', 0, 10, TRUE);
   $categories = [];
   foreach ($tree as $term) {
-    $count = \Drupal::entityQuery('node')
-      ->condition('type', 'event')
-      ->condition('status', 1)
-      ->condition('field_category', $term->id())
-      ->accessCheck(FALSE)
-      ->count()
-      ->execute();
-    if ($count > 3) {
-      $categories[] = [
-        'title' => $term->label(),
-        'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $term->id()])->toString(),
-      ];
-    }
+    $categories[] = [
+      'title' => $term->label(),
+      'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $term->id()])->toString(),
+    ];
   }
   $variables['mel_footer_categories'] = $categories;
   $variables['mel_is_organiser'] = \Drupal::currentUser()->hasPermission('access vendor dashboard');

--- a/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
@@ -15,7 +15,13 @@
 
       <div class="mel-footer__col">
         <h4>{{ 'Find events'|t }}</h4>
-        {{ drupal_menu('footer-find') }}
+        <ul class="menu mel-footer__links">
+          <li><a href="{{ path('view.upcoming_events.page_events') }}">{{ 'All events'|t }}</a></li>
+          <li><a href="{{ path('view.upcoming_events.page_events') }}">{{ 'Nearby events'|t }}</a></li>
+          <li><a href="{{ path('view.upcoming_events.page_today') }}">{{ 'Today'|t }}</a></li>
+          <li><a href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a></li>
+          <li><a href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free & RSVP'|t }}</a></li>
+        </ul>
         {% if mel_footer_categories %}
           <ul class="mel-footer__dynamic">
             {% for item in mel_footer_categories %}
@@ -27,7 +33,13 @@
 
       <div class="mel-footer__col">
         <h4>{{ 'Host events'|t }}</h4>
-        {{ drupal_menu('footer-host') }}
+        <ul class="menu mel-footer__links">
+          <li><a href="{{ path('myeventlane_vendor.create_event_gateway') }}">{{ 'Create event'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_help_centre.organisers_index') }}">{{ 'How to create an event'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_help_centre.organisers_index') }}">{{ 'Set up tickets and RSVPs'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_help_centre.vendors_index') }}">{{ 'Managing your events'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_vendor.organisers') }}">{{ 'Event organisers'|t }}</a></li>
+        </ul>
         {% if mel_is_organiser %}
           <ul class="mel-footer__dynamic">
             <li><a href="{{ path('myeventlane_vendor.console.dashboard') }}">{{ 'Vendor dashboard'|t }}</a></li>
@@ -38,7 +50,12 @@
 
       <div class="mel-footer__col mel-footer__col--wide">
         <h4>{{ 'About MyEventLane'|t }}</h4>
-        {{ drupal_menu('footer-about') }}
+        <ul class="menu mel-footer__links">
+          <li><a href="{{ path('myeventlane_front.about') }}">{{ 'About MyEventLane'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_front.story') }}">{{ 'MyEventLane Story'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_front.blog') }}">{{ 'Blog'|t }}</a></li>
+          <li><a href="{{ path('myeventlane_public_trust.page') }}">{{ 'Trust & transparency'|t }}</a></li>
+        </ul>
         <div class="mel-footer__trust">
           <span>{{ 'Community-first platform'|t }}</span>
           <span>{{ 'Secure payments via Stripe'|t }}</span>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events--discover.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events--discover.html.twig
@@ -5,8 +5,7 @@
  */
 #}
 {% if rows %}
-  {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
-  <div class="mel-event-grid mel-grid mel-grid--events" data-loaded="false" role="list" aria-label="{{ 'Discover events'|t }}">
+  <div class="mel-event-grid mel-grid mel-grid--events" role="list" aria-label="{{ 'Discover events'|t }}">
     {% for row in rows %}
       <div role="listitem">{{ row.content }}</div>
     {% endfor %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events--embed_discover.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events--embed_discover.html.twig
@@ -5,8 +5,7 @@
  */
 #}
 {% if rows %}
-  {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
-  <div class="mel-event-grid mel-grid mel-grid--events" data-loaded="false">
+  <div class="mel-event-grid mel-grid mel-grid--events">
     {% for row in rows %}
       {{- row.content -}}
     {% endfor %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-home-events.html.twig
@@ -7,8 +7,7 @@
  */
 #}
 {% if rows %}
-  {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
-  <div class="mel-event-grid mel-grid mel-grid--events" data-loaded="false">
+  <div class="mel-event-grid mel-grid mel-grid--events">
     {% for row in rows %}
       {{- row.content -}}
     {% endfor %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Render MEL homepage event grids without the skeleton-gated hidden state so non-featured event sections are visible even if the skeleton handoff fails.
- Replace undefined footer menu placeholders with explicit public Find events, Host events, and About MyEventLane links.
- List all footer categories without per-category event-count queries and add public About/Story/Blog placeholder routes.

## Testing
- `git diff --check HEAD~1..HEAD`
- Static validation script confirmed footer route references/labels, homepage grid templates no longer use `data-loaded="false"`, and footer categories no longer run count queries.
- `php -l web/modules/custom/myeventlane_front/src/Controller/MarketingPageController.php`
- `php -l web/themes/custom/myeventlane_theme/myeventlane_theme.theme`
- Symfony YAML parse: `myeventlane_front.routing.yml`, `myeventlane_theme.libraries.yml`
- Twig parser syntax checks: changed footer and homepage view templates
- `php composer.phar validate --no-check-publish`

## Environment note
- Full Drupal runtime validation (`drush cache:rebuild`) is blocked in this cloud image because no default database connection is configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://myeventlane.slack.com/archives/C0B2R8Y8Q8M/p1778456600386049?thread_ts=1778456600.386049&cid=C0B2R8Y8Q8M)

<div><a href="https://cursor.com/agents/bc-2dbcb61d-ef1f-51c6-a98d-6442ec92e2c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbcb61d-ef1f-51c6-a98d-6442ec92e2c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

