### PR TITLE
Cursor/2026 05 11 ngik fe3f1

### DIFF
--- a/config/sync/block.block.front_featured_events.yml
+++ b/config/sync/block.block.front_featured_events.yml
@@ -1,6 +1,6 @@
 uuid: 2cc53d11-d71b-4eed-a198-bacf79ac6acb
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - views.view.front_featured_events
@@ -11,13 +11,13 @@ dependencies:
     - myeventlane_theme
 id: front_featured_events
 theme: myeventlane_theme
-region: header_left
+region: homepage_featured
 weight: 0
 provider: null
 plugin: 'views_block:front_featured_events-block_featured'
 settings:
   id: 'views_block:front_featured_events-block_featured'
-  label: ''
+  label: 'Featured events'
   label_display: '0'
   provider: views
   views_label: ''

--- a/config/sync/block.block.myeventlane_theme_homeheromyeventlane.yml
+++ b/config/sync/block.block.myeventlane_theme_homeheromyeventlane.yml
@@ -9,7 +9,7 @@ dependencies:
     - myeventlane_theme
 id: myeventlane_theme_homeheromyeventlane
 theme: myeventlane_theme
-region: hero
+region: homepage_hero
 weight: 0
 provider: null
 plugin: myeventlane_home_hero
@@ -22,4 +22,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "<front>\r\n"
+    pages: '<front>'

--- a/config/sync/block.block.myeventlane_theme_homepage_blog.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_blog.yml
@@ -1,0 +1,30 @@
+uuid: e034a4c9-6fe3-42dd-aca1-f71bef9817c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.mel_blog
+  module:
+    - system
+    - views
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_blog
+theme: myeventlane_theme
+region: homepage_blog
+weight: 0
+provider: null
+plugin: 'views_block:mel_blog-homepage_preview'
+settings:
+  id: 'views_block:mel_blog-homepage_preview'
+  label: 'Homepage blog guides'
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: null
+  exposed: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/block.block.myeventlane_theme_homepage_categories.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_categories.yml
@@ -1,0 +1,25 @@
+uuid: ab70d546-3179-4b67-8308-351bbec13721
+langcode: en
+status: false
+dependencies:
+  module:
+    - myeventlane_blocks
+    - system
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_categories
+theme: myeventlane_theme
+region: homepage_categories
+weight: 0
+provider: null
+plugin: myeventlane_category_pills
+settings:
+  id: myeventlane_category_pills
+  label: 'Homepage categories'
+  label_display: '0'
+  provider: myeventlane_blocks
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/block.block.myeventlane_theme_homepage_latest.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_latest.yml
@@ -1,0 +1,30 @@
+uuid: fb69d82b-0435-4f31-99f0-fb7c7c849d2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.upcoming_events
+  module:
+    - system
+    - views
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_latest
+theme: myeventlane_theme
+region: homepage_latest
+weight: 0
+provider: null
+plugin: 'views_block:upcoming_events-homepage_latest'
+settings:
+  id: 'views_block:upcoming_events-homepage_latest'
+  label: 'Homepage latest events'
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: null
+  exposed: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/block.block.myeventlane_theme_homepage_tonight.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_tonight.yml
@@ -1,0 +1,30 @@
+uuid: 6f3a640b-9098-4ec8-99f0-6f22f614b462
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.upcoming_events
+  module:
+    - system
+    - views
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_tonight
+theme: myeventlane_theme
+region: homepage_tonight
+weight: 0
+provider: null
+plugin: 'views_block:upcoming_events-homepage_tonight'
+settings:
+  id: 'views_block:upcoming_events-homepage_tonight'
+  label: 'Homepage tonight events'
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: null
+  exposed: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/core.entity_form_display.node.blog_post.default.yml
+++ b/config/sync/core.entity_form_display.node.blog_post.default.yml
@@ -1,0 +1,127 @@
+uuid: a85a4676-9a39-4be3-b955-3dc5466257f2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_hero_image
+    - field.field.node.blog_post.field_excerpt
+    - field.field.node.blog_post.field_publish_date
+    - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_tags
+    - node.type.blog_post
+  module:
+    - content_moderation
+    - datetime
+    - path
+    - text
+id: node.blog_post.default
+targetEntityType: node
+bundle: blog_post
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: true
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_blog_hero_image:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_excerpt:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_publish_date:
+    type: datetime_default
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_seo_description:
+    type: string_textarea
+    weight: 6
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 10
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_view_display.node.blog_post.default.yml
+++ b/config/sync/core.entity_view_display.node.blog_post.default.yml
@@ -1,0 +1,61 @@
+uuid: 75cf00d3-456f-465a-b490-4e9a92fbc71d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_hero_image
+    - field.field.node.blog_post.field_excerpt
+    - field.field.node.blog_post.field_publish_date
+    - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_tags
+    - node.type.blog_post
+  module:
+    - text
+    - user
+id: node.blog_post.default
+targetEntityType: node
+bundle: blog_post
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_blog_hero_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: -10
+    region: content
+  field_excerpt:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: -5
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_publish_date: true
+  field_seo_description: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.blog_post.teaser.yml
+++ b/config/sync/core.entity_view_display.node.blog_post.teaser.yml
@@ -1,0 +1,48 @@
+uuid: bef21611-9cb9-482d-ac99-186bb96f9a4a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_hero_image
+    - field.field.node.blog_post.field_excerpt
+    - field.field.node.blog_post.field_publish_date
+    - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_tags
+    - node.type.blog_post
+  module:
+    - user
+id: node.blog_post.teaser
+targetEntityType: node
+bundle: blog_post
+mode: teaser
+content:
+  field_blog_hero_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: thumbnail
+      link: false
+    third_party_settings: {  }
+    weight: -10
+    region: content
+  field_excerpt:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: -5
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  body: true
+  field_publish_date: true
+  field_seo_description: true
+  field_tags: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.node.blog_post.body.yml
+++ b/config/sync/field.field.node.blog_post.body.yml
@@ -1,0 +1,24 @@
+uuid: a66b9434-cc39-4477-ac7b-422551bc363e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.blog_post
+  module:
+    - text
+id: node.blog_post.body
+field_name: body
+entity_type: node
+bundle: blog_post
+label: Body
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/sync/field.field.node.blog_post.field_blog_hero_image.yml
+++ b/config/sync/field.field.node.blog_post.field_blog_hero_image.yml
@@ -1,0 +1,24 @@
+uuid: 0ecc9bed-4482-48ec-bcba-844540f5b433
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blog_hero_image
+    - media.type.image
+    - node.type.blog_post
+id: node.blog_post.field_blog_hero_image
+field_name: field_blog_hero_image
+entity_type: node
+bundle: blog_post
+label: 'Hero image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+field_type: entity_reference

--- a/config/sync/field.field.node.blog_post.field_excerpt.yml
+++ b/config/sync/field.field.node.blog_post.field_excerpt.yml
@@ -1,0 +1,19 @@
+uuid: fa1dcc76-f1a8-4546-a82d-15aa726b0353
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_excerpt
+    - node.type.blog_post
+id: node.blog_post.field_excerpt
+field_name: field_excerpt
+entity_type: node
+bundle: blog_post
+label: Excerpt
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.blog_post.field_publish_date.yml
+++ b/config/sync/field.field.node.blog_post.field_publish_date.yml
@@ -1,0 +1,21 @@
+uuid: c0444199-0c4c-49b1-85bc-66aa13bbb1c7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publish_date
+    - node.type.blog_post
+  module:
+    - datetime
+id: node.blog_post.field_publish_date
+field_name: field_publish_date
+entity_type: node
+bundle: blog_post
+label: 'Publish date'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.blog_post.field_seo_description.yml
+++ b/config/sync/field.field.node.blog_post.field_seo_description.yml
@@ -1,0 +1,19 @@
+uuid: 17714fb9-769a-43d2-b7a3-dc7621b957c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_seo_description
+    - node.type.blog_post
+id: node.blog_post.field_seo_description
+field_name: field_seo_description
+entity_type: node
+bundle: blog_post
+label: 'SEO description'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.blog_post.field_tags.yml
+++ b/config/sync/field.field.node.blog_post.field_tags.yml
@@ -1,0 +1,24 @@
+uuid: 96cdd0fd-e656-4c11-9736-767623822567
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.blog_post
+    - taxonomy.vocabulary.tags
+id: node.blog_post.field_tags
+field_name: field_tags
+entity_type: node
+bundle: blog_post
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_blog_hero_image.yml
+++ b/config/sync/field.storage.node.field_blog_hero_image.yml
@@ -1,0 +1,20 @@
+uuid: ccb13841-6efc-4bfe-9534-5dfdcb9b2183
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_blog_hero_image
+field_name: field_blog_hero_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_excerpt.yml
+++ b/config/sync/field.storage.node.field_excerpt.yml
@@ -1,0 +1,19 @@
+uuid: 91ec9f42-8f86-4d5d-b619-94a7790d22df
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_excerpt
+field_name: field_excerpt
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_publish_date.yml
+++ b/config/sync/field.storage.node.field_publish_date.yml
@@ -1,0 +1,20 @@
+uuid: 133e7db8-67d9-4e31-a9a4-33ce638b06db
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_publish_date
+field_name: field_publish_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_seo_description.yml
+++ b/config/sync/field.storage.node.field_seo_description.yml
@@ -1,0 +1,19 @@
+uuid: 498aa7f1-0af4-44d0-9fae-54691bb2f29f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_seo_description
+field_name: field_seo_description
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.blog_post.yml
+++ b/config/sync/node.type.blog_post.yml
@@ -1,0 +1,11 @@
+uuid: 267d387b-0dbd-41f9-89fc-9823f9c224c4
+langcode: en
+status: true
+dependencies: {  }
+name: 'Blog post'
+type: blog_post
+description: 'Marketing, organiser education, and public guide content.'
+help: null
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/sync/pathauto.pattern.blog_posts.yml
+++ b/config/sync/pathauto.pattern.blog_posts.yml
@@ -1,0 +1,22 @@
+uuid: 87b4c137-0367-4dd0-a168-dc06d926b279
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: blog_posts
+label: 'Blog post paths'
+type: 'canonical_entities:node'
+pattern: 'blog/[node:title]'
+selection_criteria:
+  03edc280-39e1-4de1-92c4-ec6172f17c2b:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: eadedac2-6d44-40b6-9db5-9bb77b82259c
+    context_mapping:
+      node: node
+    bundles:
+      blog_post: blog_post
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/config/sync/pathauto.settings.yml
+++ b/config/sync/pathauto.settings.yml
@@ -4,6 +4,7 @@ enabled_entity_types:
   - myeventlane_vendor
   - profile
   - user
+  - node
 punctuation:
   double_quotes: 0
   quotes: 0

--- a/config/sync/search_api.index.mel_content.yml
+++ b/config/sync/search_api.index.mel_content.yml
@@ -132,7 +132,7 @@ field_settings:
         - anonymous
       view_mode:
         'entity:node':
-          article: teaser
+          blog_post: teaser
           event: teaser
           page: teaser
   status:
@@ -177,7 +177,7 @@ datasource_settings:
     bundles:
       default: false
       selected:
-        - article
+        - blog_post
         - event
         - help_article
         - help_landing_page

--- a/config/sync/system.menu.footer-about.yml
+++ b/config/sync/system.menu.footer-about.yml
@@ -1,0 +1,8 @@
+uuid: 2521859f-51d3-4032-a7d1-f325f6bd066a
+langcode: en
+status: true
+dependencies: {  }
+id: footer-about
+label: 'Footer - About'
+description: 'Footer navigation menu.'
+locked: false

--- a/config/sync/system.menu.footer-community.yml
+++ b/config/sync/system.menu.footer-community.yml
@@ -1,0 +1,8 @@
+uuid: 76624a45-d3cf-4fd3-910a-0ce8cb74aafd
+langcode: en
+status: true
+dependencies: {  }
+id: footer-community
+label: 'Footer - Community'
+description: 'Footer navigation menu.'
+locked: false

--- a/config/sync/system.menu.footer-find.yml
+++ b/config/sync/system.menu.footer-find.yml
@@ -1,0 +1,8 @@
+uuid: 5ac7b370-6a3a-4e54-b8cb-80c35d233c83
+langcode: en
+status: true
+dependencies: {  }
+id: footer-find
+label: 'Footer - Find events'
+description: 'Footer navigation menu.'
+locked: false

--- a/config/sync/system.menu.footer-host.yml
+++ b/config/sync/system.menu.footer-host.yml
@@ -1,0 +1,8 @@
+uuid: a2bb4b7e-ff72-4e94-96c5-47369f20ca91
+langcode: en
+status: true
+dependencies: {  }
+id: footer-host
+label: 'Footer - Host events'
+description: 'Footer navigation menu.'
+locked: false

--- a/config/sync/views.view.mel_blog.yml
+++ b/config/sync/views.view.mel_blog.yml
@@ -1,0 +1,290 @@
+uuid: b3823699-5ad5-494f-8dc7-13403fb53c42
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.storage.node.field_publish_date
+    - node.type.blog_post
+    - taxonomy.vocabulary.tags
+  module:
+    - datetime
+    - node
+    - taxonomy
+    - user
+id: mel_blog
+label: 'MEL Blog'
+module: views
+description: 'Public blog and organiser guides.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Blog
+      fields: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 12
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No guides yet</h3><p class="mel-empty-state__what">Organiser guides are coming soon. Start by browsing events or creating your first listing.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/create-event">Create an event</a> <a class="mel-link" href="/events">Explore events</a></p></div>'
+            format: full_html
+          tokenize: false
+      sorts:
+        field_publish_date_value:
+          id: field_publish_date_value
+          table: node__field_publish_date
+          field: field_publish_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            blog_post: blog_post
+          group: 1
+          expose:
+            operator: ''
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: tid_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: tid_op
+            identifier: tags
+            required: false
+            remember: false
+            multiple: true
+          is_grouped: false
+          vid: tags
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  homepage_preview:
+    id: homepage_preview
+    display_title: 'Homepage preview'
+    display_plugin: block
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No guides yet</h3><p class="mel-empty-state__what">Helpful organiser guides are coming soon.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/create-event">Create event</a> <a class="mel-link" href="/events">Explore events</a></p></div>'
+            format: full_html
+          tokenize: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            blog_post: blog_post
+          group: 1
+          expose:
+            operator: ''
+      defaults:
+        empty: false
+        pager: false
+        filters: false
+      display_extenders: {  }
+      block_description: 'Homepage: Blog guides'
+      block_category: MyEventLane
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_blog:
+    id: page_blog
+    display_title: 'Blog page'
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: blog
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -3,19 +3,24 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.event.teaser_tonight
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_product_target
+    - field.field.node.event.field_promoted
     - field.storage.node.field_category
     - field.storage.node.field_event_end
-    - field.field.node.event.field_product_target
     - field.storage.node.field_event_state
     - field.storage.node.field_event_type
     - field.storage.node.field_product_target
+    - field.storage.node.field_promoted
     - node.type.event
     - system.menu.main
     - taxonomy.vocabulary.categories
   module:
     - datetime
+    - myeventlane_views
     - node
+    - options
     - taxonomy
     - user
 id: upcoming_events
@@ -101,7 +106,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="mel-event-grid-empty"><div class="mel-event-grid-empty-icon">📅</div><h3 class="mel-event-grid-empty-title">No upcoming events</h3><p class="mel-event-grid-empty-text">Check back soon—or explore other ways to find something to do.</p><p class="mel-event-grid-empty-next"><a href="/events/this-weekend">This weekend</a> · <a href="/events/free">Free events</a> · <a href="/">Browse categories on the homepage</a></p></div>'
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No upcoming events yet</h3><p class="mel-empty-state__what">Check back soon, browse this weekend, or explore free events.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events/this-weekend">Browse this weekend</a> <a class="mel-link" href="/events/free">See free events</a></p></div>'
             format: full_html
           tokenize: false
       sorts:
@@ -403,7 +408,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -658,6 +662,557 @@ display:
         filters: false
       display_extenders: {  }
       block_description: 'Upcoming Events'
+      block_category: MyEventLane
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  homepage_latest:
+    id: homepage_latest
+    display_title: 'Homepage latest'
+    display_plugin: block
+    position: 8
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 12
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No upcoming events yet</h3><p class="mel-empty-state__what">Check back soon, browse this weekend, or explore free events.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events/this-weekend">Browse this weekend</a> <a class="mel-link" href="/events/free">See free events</a></p></div>'
+            format: full_html
+          tokenize: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_category
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: Category
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: category
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+          vid: categories
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      defaults:
+        empty: false
+        pager: false
+        row: false
+        filters: false
+      display_extenders: {  }
+      block_description: 'Homepage: Upcoming events'
+      block_category: MyEventLane
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  homepage_tonight:
+    id: homepage_tonight
+    display_title: 'Homepage tonight'
+    display_plugin: block
+    position: 9
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 6
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">Nothing listed for tonight yet</h3><p class="mel-empty-state__what">Explore upcoming events or check back as hosts publish new plans.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Explore events</a> <a class="mel-link" href="/events/this-weekend">Browse this weekend</a></p></div>'
+            format: full_html
+          tokenize: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: between
+          value:
+            min: today
+            max: 'tomorrow midnight'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_category
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: Category
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: category
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+          vid: categories
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser_tonight
+      defaults:
+        empty: false
+        pager: false
+        row: false
+        filters: false
+      display_extenders: {  }
+      block_description: 'Homepage: On tonight'
       block_category: MyEventLane
     cache_metadata:
       max-age: -1
@@ -1582,6 +2137,411 @@ display:
         filters: false
       display_extenders: {  }
       path: events/free
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_popular:
+    id: page_popular
+    display_title: 'Popular events'
+    display_plugin: page
+    position: 9
+    display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 12
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No popular events yet</h3><p class="mel-empty-state__what">Browse upcoming events while organisers boost new experiences.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Explore events</a></p></div>'
+            format: full_html
+          tokenize: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_event_type:
+          id: field_event_type
+          table: node__field_event_type
+          field: field_event_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_type
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_event_type_op
+            label: 'Ticket type'
+            description: ''
+            use_operator: false
+            operator: field_event_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: event_type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          reduce_duplicates: false
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_category
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Category
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: category
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+          vid: categories
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_promoted_value:
+          id: field_promoted_value
+          table: node__field_promoted
+          field: field_promoted_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_promoted
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      defaults:
+        empty: false
+        pager: false
+        row: false
+        filters: false
+      display_description: 'Boosted and popular public event discovery route.'
+      display_extenders: {  }
+      path: events/popular
+      menu:
+        type: normal
+        title: 'Popular events'
+        description: 'Browse all upcoming events'
+        weight: 0
+        enabled: false
+        menu_name: main
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/docs/event-commerce-acceptance-audit.md
+++ b/docs/event-commerce-acceptance-audit.md
@@ -1,0 +1,158 @@
+# Event Commerce Acceptance Audit
+
+Status: acceptance audit  
+Scope: Event Commerce resolver, classification registry, purchasable classifications, and mixed-cart governance foundation  
+Date: 2026-05-11
+
+## Objective
+
+This audit validates that the event-commerce governance foundation is operationally passive. The reviewed layer may resolve existing relationships, classify existing purchasables from explicit metadata, and expose read-only groupings. It must not mutate carts, orders, checkout, products, ticket lifecycle, RSVP state, Stripe behavior, payment routing, capacities, or fulfilment state.
+
+No merchandise UI, add-on forms, fulfilment implementation, checkout panes, order processors, Stripe logic, Studio sections, entity fields, or workflows were added as part of this audit.
+
+## Audited Components
+
+- `web/modules/custom/myeventlane_event/src/Service/EventCommerceResolver.php`
+- `web/modules/custom/myeventlane_event/src/Service/EventCommerceClassificationRegistry.php`
+- `web/modules/custom/myeventlane_event/src/Value/EventCommercePurchasableType.php`
+- `web/modules/custom/myeventlane_event/myeventlane_event.services.yml`
+- `docs/event-commerce-boundaries.md`
+- `docs/event-commerce-classifications.md`
+- `docs/mixed-cart-governance.md`
+- `web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php`
+- `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml`
+- `web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml`
+- `web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php`
+- `web/modules/custom/myeventlane_commerce/src/EventSubscriber/OrderCompletedSubscriber.php`
+- `web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php`
+- `web/modules/custom/myeventlane_tickets/src/EventSubscriber/OrderPaidSubscriber.php`
+- `web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php`
+- `web/modules/custom/myeventlane_commerce/src/Service/StripeConnectPaymentService.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php`
+
+## Boundary Findings
+
+`EventCommerceResolver` is read-only. It resolves the canonical ticket product from `field_product_target`, event-linked products from `field_event`, ticket product variations, event relationships from order items, and normalized relationship groups. It uses entity queries and entity loads only. It does not call `save()`, `delete()`, `addOrderItem()`, `submitForm()`, Stripe APIs, payment services, checkout services, cart services, capacity services, or ticket issuer services.
+
+`EventCommerceClassificationRegistry` is read-only. It returns canonical metadata from `EventCommercePurchasableType`, normalizes known classification IDs, and classifies products or variations only from explicit bundle maps supplied by owning domains. It does not infer bundle behavior and does not persist state.
+
+`EventCommercePurchasableType` is a metadata contract only. It defines canonical classification constants and metadata such as domain, attendance access, and fulfilment requirement. It creates no fields, no products, no variations, no order items, no checkout panes, and no Stripe side effects.
+
+Service-boundary search found the resolver and classification registry defined only in `myeventlane_event.services.yml`. They are not injected into checkout processors, order refresh processors, payment gateways, Stripe services, ticket issuance subscribers, RSVP services, Studio services, readiness services, or vendor publishing gates.
+
+## Mutation Checks
+
+Searches inside resolver/classification paths found no operational mutation calls:
+
+- No `save()` or `delete()`.
+- No `addOrderItem()` or Commerce cart manager usage.
+- No `submitForm()` or checkout pane implementation.
+- No order refresh, checkout flow, payment gateway, or Stripe calls.
+- No ticket issuer, attendee creation, QR generation, or email dispatch calls.
+- No capacity mutation or lifecycle archive/publish calls.
+
+The only array mutations in the resolver are in-memory grouping helpers used to normalize return values. They do not write entities or session/cart state.
+
+## Operational Flow Audit
+
+### RSVP Event Flow
+
+RSVP runtime remains owned by the existing RSVP and attendee modules. Public RSVP forms, RSVP confirmation, RSVP thank-you handling, RSVP dashboard/listing routes, and RSVP mailer paths do not inject or call the event-commerce resolver or classification registry.
+
+No classification logic affects RSVP creation, save, publish, frontend rendering, submission, confirmation, or dashboard visibility.
+
+### Paid Ticket Flow
+
+Paid ticket creation, editing, archiving, and Commerce projection remain owned by `TicketTierLifecycleService`, `TicketTypeManager`, and existing ticket forms/controllers. The resolver/classification layer is not called by ticket lifecycle code.
+
+Ticket selection and add-to-cart remain owned by `TicketSelectionForm`, which uses Commerce cart services directly and continues to set `field_target_event` on ticket order items. The new governance layer does not add or remove cart items.
+
+Ticket issuance remains owned by `TicketIssuer` through `OrderPaidSubscriber`. Issuance still runs from Commerce order paid events and creates ticket entities from order items with purchasable Commerce product variations and event relationships. The governance layer does not call the issuer and does not alter issuer behavior.
+
+Residual guard: current issuance is not classification-driven. Before any future non-ticket event-linked purchasable is made orderable, issuance must continue to be constrained to ticket-owned order item semantics so add-ons, merchandise, donations, upgrades, and future bundles cannot issue attendance access.
+
+### Mixed Event States
+
+Draft, published, unpublished, archived ticket, RSVP, paid, and hybrid readiness remain evaluated by existing event type, ticket lifecycle, and readiness code. `EventReadinessService` uses `TicketTypeManager`, `VendorPublishRequirementsGate`, and `PaidPublishStripeGate`; it does not use classification services.
+
+Archived tickets remain excluded by ticket lifecycle/readiness checks. The resolver does not publish, unpublish, archive, detach, attach, or sync ticket rows.
+
+### Checkout Flow
+
+Checkout remains Drupal Commerce-native. The checkout flow is still `MelEventCheckoutFlow`, extending Commerce checkout panes, with existing panes and services. The governance layer does not define checkout panes, checkout flows, order processors, order refresh processors, or cart forms.
+
+Cart item creation, quantity handling, and removal remain Commerce/cart-owned. Ticket add-to-cart remains in `TicketSelectionForm`; update/remove flows remain Commerce cart UI behavior.
+
+### Ticket Issuance
+
+Attendance access remains ticket-domain-owned. `OrderPaidSubscriber` calls `TicketIssuer::issueForOrder()` on the existing Commerce order paid event. `TicketIssuer` generates ticket rows, ownership, ticket code, order linkage, order item linkage, purchased entity linkage, and MEL ticket type linkage without using classification services.
+
+`OrderCompletedSubscriber` continues to create attendee records from ticket holder paragraphs on order placement and separates RSVP versus paid records by price/source. It does not call the classification layer.
+
+### Stripe Flow
+
+Stripe Connect behavior remains unchanged. `StripeConnect` still delegates payment intent creation to the existing Stripe gateway parent after merging parameters from `StripeConnectPaymentService`. `StripeConnectPaymentService` still uses existing order item classifier logic, store Stripe fields, and order item price/bundle checks.
+
+No event-commerce classification metadata is passed to Stripe metadata. No resolver or classification registry service is injected into Stripe gateway, Stripe validation, vendor onboarding, payout routing, or Connect publish gates.
+
+### Studio And Readiness
+
+Event Studio readiness remains operationally unchanged. Tickets are active readiness participants; merchandise, add-ons, fulfilment, orders, and analytics sections are metadata/deferred operational sections and do not add Commerce mutation forms in this phase.
+
+Autosave and publish remain owned by existing Studio save/readiness services and vendor access checks. The commerce governance resolver is not injected into Studio save, autosave, readiness, section manager, or controller services.
+
+### Access Flow
+
+Studio access remains enforced server-side by `EventStudioAccess` and vendor access services. The governance layer does not change route access requirements or vendor/customer isolation.
+
+## Database And Config Safety
+
+No schema or update-path changes were introduced by the governance layer. `ddev drush updb -y` reported no pending updates.
+
+`ddev drush config:status` reported no differences between the active database configuration and `config/sync`, confirming the audit did not create hidden config mutations or config drift.
+
+Searches of `config/sync` found no references to `EventCommerceResolver`, `EventCommerceClassificationRegistry`, or event-commerce classification services.
+
+## Required Assertions
+
+- EventCommerceResolver is read-only: verified.
+- Classification registry does not mutate runtime state: verified.
+- Checkout still Commerce-native: verified.
+- Ticket issuance still ticket-domain-owned: verified.
+- RSVP flow unchanged by classification layer: verified.
+- Stripe flow unchanged by classification layer: verified.
+- Readiness unchanged operationally: verified.
+- No new save boundaries introduced by resolver/classification paths: verified.
+- No new Commerce mutations introduced by resolver/classification paths: verified.
+- No order-item behavior changes introduced by resolver/classification paths: verified.
+
+## Verification Commands
+
+- `ddev exec php -l web/modules/custom/myeventlane_event/src/Service/EventCommerceResolver.php`: pass.
+- `ddev exec php -l web/modules/custom/myeventlane_event/src/Service/EventCommerceClassificationRegistry.php`: pass.
+- `ddev exec php -l web/modules/custom/myeventlane_event/src/Value/EventCommercePurchasableType.php`: pass.
+- `composer validate`: pass.
+- `ddev drush status`: Drupal 11.3.8 bootstrapped successfully at `https://myeventlane.ddev.site`.
+- `ddev drush cr`: pass.
+- `ddev drush updb -y`: pass, no pending updates.
+- `ddev drush config:status`: pass, no active/sync differences.
+
+`git diff --check` and real browser validation are recorded below after the final audit pass.
+
+## Browser Validation
+
+Browser validation against DDEV was started at `https://myeventlane.ddev.site`. Final route/action results are pending and must be recorded before this audit is treated as complete.
+
+## Residual Risks
+
+The current governance layer is passive because it is not wired into operational mutation paths. Future event-linked purchasables must not rely on this absence as a safety mechanism. Before merchandise, add-ons, donations, upgrades, or future bundles become orderable alongside tickets, the owning domain must enforce explicit order item boundaries and ticket issuance exclusions.
+
+`TicketIssuer` currently resolves attendance access from Commerce variation/order item event relationships, not from `EventCommercePurchasableType` metadata. That is acceptable for the current shipped ticket-only paid flow, but future non-ticket event-linked products must be guarded so they cannot satisfy ticket issuance conditions accidentally.
+
+The audit did not change Stripe architecture and did not validate live Stripe payment settlement beyond existing DDEV/browser checkout smoke limits.
+
+## Future Guarded Extension Notes
+
+Future commerce expansion may only proceed after the acceptance audit remains green and the owning domains provide explicit contracts for bundle IDs, classification maps, access rules, persistence, order item semantics, readiness behavior, and test coverage.
+
+Merchandise, add-ons, fulfilment, mixed-cart tooling, checkout extensions, order processors, and Stripe changes must be implemented in their owning domains. Event Studio may surface operational views and empty states, but must not become the transactional implementation.

--- a/docs/event-commerce-boundaries.md
+++ b/docs/event-commerce-boundaries.md
@@ -1,0 +1,185 @@
+# Event Commerce Boundaries
+
+Status: internal governance  
+Scope: event, ticket, Commerce product, and fulfilment ownership
+
+## Principle
+
+Event Studio may surface Commerce operations, but it must not become the Commerce implementation. Money-moving behavior, checkout, carts, Stripe Connect, ticket issuance, and fulfilment state transitions stay with their owning domains.
+
+No future merchandise, add-on, fulfilment, scanning, POS, or analytics feature may bypass Studio for operational UI, and no Studio section may bypass Commerce or ticket domain services for business logic.
+
+## Domain Ownership
+
+| Domain | Owns | Must Not Own |
+| --- | --- | --- |
+| Event | Visibility, branding, publishing, schedule, operational readiness | Product SKU behavior, ticket issuance, shipping states |
+| Ticket | Attendance access, ticket lifecycle, capacities, sales windows | Merchandise, fulfilment products, Stripe charge model |
+| Commerce product | Merchandise, add-ons, purchasable upgrades, fulfilment products | Event publish state, ticket scan state |
+| Fulfilment | Shipping, pickup, redemption, inventory fulfilment states | Checkout payment state, ticket lifecycle source of truth |
+
+Tickets are not merchandise. Merchandise is not fulfilment. Add-ons are not ticket entities. Future code must preserve separate ownership even when these purchasables share one Commerce cart.
+
+## Purchasable Classifications
+
+Canonical event-commerce classifications live in `web/modules/custom/myeventlane_event/src/Value/EventCommercePurchasableType.php` and are exposed through `web/modules/custom/myeventlane_event/src/Service/EventCommerceClassificationRegistry.php`.
+
+Current classifications:
+
+| Classification | Domain | Meaning |
+| --- | --- | --- |
+| `ticket` | Ticket | Attendance access purchasable governed by ticket lifecycle and capacity rules. |
+| `addon` | Commerce product | Optional event-linked purchasable such as parking, meals, shuttle, camping, or VIP extras. |
+| `merchandise` | Commerce product | Physical or digital product sold alongside an event without becoming a ticket. |
+| `donation` | Commerce product | Voluntary purchasable that remains a separate Commerce order item boundary. |
+| `upgrade` | Commerce product | Purchasable enhancement that must not replace ticket lifecycle logic. |
+| `bundle_future` | Commerce product | Reserved classification for a future governed bundle architecture. |
+
+Classifications are metadata contracts. They do not create fields, products, variations, fulfilment records, carts, checkout panes, or Stripe side effects.
+
+## Existing Canonical Services
+
+| Concern | Service or file |
+| --- | --- |
+| Ticket product sync | `web/modules/custom/myeventlane_event/src/Service/EventProductManager.php` |
+| Ticket tier lifecycle | `web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php` |
+| Booking mode resolution | `web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php` |
+| Event Commerce resolution | `web/modules/custom/myeventlane_event/src/Service/EventCommerceResolver.php` |
+| Event Commerce classifications | `web/modules/custom/myeventlane_event/src/Service/EventCommerceClassificationRegistry.php` |
+| Ticket availability | `web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php` |
+| Order item classification | `web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php` |
+| Ticket issuance | `web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php` |
+| Vendor ownership | `web/modules/custom/myeventlane_checkout_flow/src/Service/VendorOwnershipResolver.php` |
+
+## EventCommerceResolver Contract
+
+`EventCommerceResolver` is read-only. It may:
+
+- Resolve the event ticket product from `field_product_target`.
+- Resolve products that reference an event through `field_event`.
+- Resolve ticket product variations for display or validation.
+- Resolve the event represented by an order item using the same order as ticket issuance: variation `field_event`, product `field_event`, then order item `field_target_event`.
+- Resolve unique events across mixed order items.
+- Classify or map existing event-to-Commerce relationships when the owning domain supplies the product bundles and semantics.
+- Expose grouped read-only relationships by canonical purchasable classification.
+- Treat the event `field_product_target` product and its purchasables as `ticket`.
+
+It must not:
+
+- Create or update products.
+- Mutate carts.
+- Change checkout.
+- Trigger Stripe or payment side effects.
+- Alter orders.
+- Issue tickets.
+- Change Stripe or Connect behavior.
+- Create fulfilment records.
+- Infer future product bundle names without an owning domain supplying them.
+
+## Event-Linked Product Model
+
+The canonical relationship model is:
+
+- Events may reference their canonical ticket product through `field_product_target`.
+- Commerce products may reference their event through `field_event`.
+- Commerce order items may reference the event through `field_target_event` where the order item type owns that relationship.
+- Relationship services resolve links. Product arrays must not be serialized onto event nodes.
+
+Future merchandise and add-on work should prefer event-linked Commerce products and resolver-backed read models over duplicated entity references or hardcoded ids.
+
+## Add-ons And Donations
+
+Add-ons are optional purchasables. They must remain Commerce products or variations linked operationally to events and must not mutate ticket definitions, capacities, attendance access, or ticket issuance.
+
+Donations remain Commerce purchasables. They must keep clean order item boundaries and must not become special-case ticket logic.
+
+## Mixed Cart Governance
+
+MEL must support mixed event carts through Drupal Commerce-native carts, checkout, order items, and payments. A cart may contain:
+
+- `2` VIP tickets.
+- `1` parking add-on.
+- `1` T-shirt.
+- `$10` donation.
+
+This must remain one cart, one checkout, and one payment flow. Do not fork checkout systems or introduce a parallel payment path for merchandise, add-ons, donations, or upgrades.
+
+## Studio Allowed Touches
+
+Event Studio may:
+
+- Show operational Commerce sections.
+- Link to explicit Studio routes for tickets, merchandise, add-ons, orders, and fulfilment.
+- Display empty states before a domain is implemented.
+- Call read-only resolvers for existing event-linked entities.
+- Delegate saves to owning domain services.
+
+Event Studio must not:
+
+- Duplicate product sync.
+- Duplicate ticket issuance.
+- Build parallel checkout flows.
+- Mutate carts or orders.
+- Read raw payment state for UI decisions.
+- Change platform fees, application fees, Connect accounts, payout behavior, or webhook semantics.
+
+## Fulfilment Boundary
+
+Fulfilment is not implemented in this phase. Future fulfilment work must define:
+
+- Inventory ownership.
+- Shipping and pickup state machines.
+- Redemption rules.
+- Refund and cancellation interactions.
+- Customer-visible vs vendor-only state.
+- Audit logs for state transitions.
+
+Until then, fulfilment sections remain governed placeholders.
+
+Future fulfilment extensions may support shipping, event pickup, QR redemption, or digital fulfilment. They must not hardcode ticket assumptions into fulfilment state.
+
+## Readiness Preparation
+
+Commerce and fulfilment readiness may be added only through future provider contracts after the owning domains have stable persisted data, access boundaries, and verification paths. This phase does not activate merchandise, fulfilment, or inventory readiness providers.
+
+Future provider examples:
+
+- Merchandise readiness.
+- Fulfilment readiness.
+- Inventory readiness.
+
+These providers must remain read-only during evaluation and must avoid heavy queries on workspace load.
+
+## Studio Access And Performance
+
+Future Commerce Studio sections must:
+
+- Reuse `EventStudioAccess` and `EventVendorAccessChecker`.
+- Preserve the `administer nodes` override.
+- Preserve vendor-team access checks.
+- Block customers and anonymous users server-side.
+- Avoid exposing raw Commerce admin routes in Studio.
+- Lazy-load expensive data.
+- Paginate operational lists.
+- Isolate autosave boundaries.
+- Avoid rendering large Commerce entity trees inline.
+
+Future merchandise and add-on operational tables must use Studio operational table standards: operational actions, inline validation, isolated saves, responsive overflow handling, and mobile-safe layouts.
+
+## Analytics Boundary
+
+Future analytics must keep metrics separate:
+
+- Attendance metrics.
+- Revenue metrics.
+- Merchandise metrics.
+- Operational metrics.
+- Conversion metrics.
+
+Do not create giant mixed analytics queries. Use domain-specific pre-aggregation, pagination, caching, or queues when needed.
+
+## Stripe And Checkout Safety
+
+Commerce expansion must follow `docs/universal-ticket-extension.md`, `docs/event-commerce-classifications.md`, `docs/mixed-cart-governance.md`, and `.cursor/rules/mel-stripe-connect-safety.mdc`.
+
+Changes to charge model, account type, application fees, payout behavior, webhook semantics, or connected-vendor handling require explicit product and technical sign-off before implementation.

--- a/docs/event-studio-architecture.md
+++ b/docs/event-studio-architecture.md
@@ -1,0 +1,133 @@
+# Event Studio Architecture
+
+Status: internal governance  
+Scope: canonical vendor event operations platform
+
+## Purpose
+
+Event Studio is the canonical MEL surface for event operations. Future event operations systems must extend Studio instead of creating parallel Drupal admin, vendor console, or one-off controller surfaces.
+
+Studio owns the operational shell: routing into event workspaces, section navigation, autosave boundaries, publish readiness presentation, and domain delegation. It does not own every business rule. Tickets, Commerce products, fulfilment, access control, payments, and analytics remain with their domain services.
+
+Event Commerce expansion follows the same rule. Event Studio remains the operational orchestration layer, while Drupal Commerce remains the transactional engine for carts, checkout, order items, payments, and product pricing.
+
+## Runtime Shape
+
+The primary implementation lives in `web/modules/custom/myeventlane_event_studio`.
+
+Key code owners:
+
+| Concern | Owner |
+| --- | --- |
+| Studio shell controller | `web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php` |
+| Section registry | `web/modules/custom/myeventlane_event_studio/src/EventStudioSectionManager.php` |
+| Section plugins | `web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection` |
+| Event access | `web/modules/custom/myeventlane_event_studio/src/Access/EventStudioAccess.php` |
+| Autosave | `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioAutosaveService.php` |
+| Save and publish orchestration | `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php` |
+| Publish readiness evaluation | `web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php` |
+
+Explicit named routes in `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml` are part of the operational contract. The section plugin system does not replace route YAML with a dynamic route engine.
+
+`EventReadinessService` remains the authoritative readiness orchestrator in this phase. Provider contracts exist for future domains, but Studio does not yet use container-tagged provider orchestration for publish gates or readiness display.
+
+## Section Model
+
+Studio sections are governed by `EventStudioSection` plugins. A section plugin describes:
+
+- Stable section id.
+- Explicit route name.
+- Route fragment used by URLs and autosave keys.
+- Navigation group and weight.
+- Icon metadata.
+- Access policy metadata.
+- Rendering target.
+- Readiness participation.
+- Operational domain area.
+- Deferred-placeholder status.
+
+The plugin registry provides shell metadata. It does not authorize bypassing route access, entity access, or vendor parity checks.
+
+The shell must evaluate section access before rendering a requested section. Sidebar visibility, direct URL access, and section rendering are expected to use the same plugin access result.
+
+## Access
+
+Every Studio route must use server-side access enforcement. Required standards:
+
+- Deny anonymous users.
+- Deny customers without vendor workspace parity.
+- Reuse `EventVendorAccessChecker` through `EventStudioAccess`.
+- Preserve admin override through `administer nodes`.
+- Preserve entity update access on editable event routes.
+- Do not rely on sidebar hiding, Twig conditions, or client-side checks.
+
+Section plugins can add section-level metadata and future section-level access checks, but route access remains explicit and deterministic.
+
+The default section plugin access policy is `event_update`. It must preserve vendor workspace parity, entity update access, and the admin override. New access policies require code and documentation review before use.
+
+## Autosave And Save
+
+Autosave is section-scoped and uses private tempstore. Autosave keys depend on stable section ids and route fragments, so new sections must keep identifiers stable after release.
+
+Canonical event persistence remains with `EventStudioSaveService`. Section UI must delegate to domain services instead of duplicating ticket, Commerce, fulfilment, or analytics business logic.
+
+## Boundaries
+
+Studio owns:
+
+- Operational workspace shell.
+- Section navigation.
+- Autosave boundaries.
+- Publish readiness display.
+- Future readiness provider contracts.
+- Empty states and operational UX standards.
+- Delegation into domain services.
+
+Studio does not own:
+
+- Stripe or Connect charge model.
+- Commerce checkout or cart mutation.
+- Ticket issuance.
+- Merchandise product creation.
+- Fulfilment state machines.
+- Scanning device flows.
+- Large analytics queries.
+- Dynamic readiness provider orchestration before the owning domains exist.
+
+## Commerce Expansion
+
+Studio may reserve and surface Commerce-oriented sections, including merchandise, add-ons, discounts, orders, and fulfilment. Deferred sections must remain placeholders until their owning domain services, access rules, persistence model, and verification paths exist.
+
+Commerce sections must not embed raw Commerce admin widgets or create parallel admin routes inside Studio. They must use governed Studio patterns for operational tables, inline validation, isolated saves, responsive overflow handling, and mobile-safe layouts.
+
+The current Commerce expansion foundation is read-only:
+
+- `EventCommerceResolver` resolves event-linked Commerce relationships.
+- `EventCommerceClassificationRegistry` exposes canonical purchasable classification metadata.
+- Mixed carts remain Drupal Commerce-native with one cart, one checkout, and one payment flow.
+- Merchandise, add-ons, donations, and upgrades remain separate purchasable classifications and must not collapse into ticket entities.
+- Fulfilment remains a future domain with extension points only.
+
+Future Commerce sections must reuse `EventStudioAccess`, preserve the `administer nodes` override, preserve vendor-team access, and block customers server-side.
+
+## Performance Rules
+
+Future sections must:
+
+- Lazy-load expensive datasets.
+- Paginate operational lists.
+- Avoid building giant render trees on workspace load.
+- Isolate autosave payloads by section.
+- Keep analytics and reporting queries out of initial shell rendering.
+- Attach cache contexts and tags explicitly when output depends on route, user, permissions, event, or vendor state.
+
+## Related Docs
+
+- `docs/event-studio-section-contracts.md`
+- `docs/event-commerce-boundaries.md`
+- `docs/event-commerce-classifications.md`
+- `docs/mixed-cart-governance.md`
+- `docs/readiness-provider-architecture.md`
+- `docs/operational-readiness-governance.md`
+- `docs/universal-ticket-extension.md`
+- `docs/vendor-console-v2-access-matrix.md`

--- a/docs/event-studio-section-contracts.md
+++ b/docs/event-studio-section-contracts.md
@@ -1,0 +1,127 @@
+# Event Studio Section Contracts
+
+Status: internal governance  
+Scope: section registration, navigation, rendering, access, readiness, and operational UX
+
+## Contract
+
+Every Event Studio section must have two explicit pieces:
+
+1. A named route in `web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml`.
+2. An `EventStudioSection` plugin in `web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection`.
+
+Routes stay explicit for auditability and operational debugging. Plugins govern metadata and shell behavior.
+
+## Plugin Metadata
+
+Each section plugin must define:
+
+| Metadata | Rule |
+| --- | --- |
+| `id` | Stable machine id used by autosave and readiness references. |
+| `title` | Human-readable section title. |
+| `group` | Sidebar group such as Manage Event, Commerce, or Operations. |
+| `routeName` | Existing explicit route name. |
+| `routeFragment` | Stable URL/autosave fragment when different from id. |
+| `weight` | Navigation order inside the group. |
+| `icon` | Optional shell icon metadata. |
+| `accessPolicy` | Access contract identifier. |
+| `renderTarget` | Rendering contract, such as controller or future form/controller target. |
+| `readinessParticipant` | Whether the section contributes readiness signals. |
+| `operationalArea` | Event, ticket, commerce product, fulfilment, operations, or analytics. |
+| `deferred` | True for reserved placeholders without full feature implementation. |
+
+## Current Section Inventory
+
+| Section | Route | Domain |
+| --- | --- | --- |
+| `overview` | `myeventlane_event_studio.workspace` | event |
+| `information` | `myeventlane_event_studio.workspace_information` | event |
+| `branding` | `myeventlane_event_studio.workspace_branding` | event |
+| `content` | `myeventlane_event_studio.workspace_content` | event |
+| `tickets` | `myeventlane_event_studio.workspace_tickets` | ticket |
+| `questions` | `myeventlane_event_studio.workspace_questions` | commerce |
+| `capacity` | `myeventlane_event_studio.workspace_capacity` | ticket |
+| `merchandise` | `myeventlane_event_studio.workspace_merchandise` | commerce product |
+| `addons` | `myeventlane_event_studio.workspace_addons` | commerce product |
+| `promotions` | `myeventlane_event_studio.workspace_promotions` | event |
+| `attendees` | `myeventlane_event_studio.workspace_attendees` | operations |
+| `fulfilment` | `myeventlane_event_studio.workspace_fulfilment` | fulfilment |
+| `orders` | `myeventlane_event_studio.workspace_orders` | commerce |
+| `analytics` | `myeventlane_event_studio.workspace_analytics` | analytics |
+| `settings` | `myeventlane_event_studio.workspace_settings` | event |
+
+## Rendering Rules
+
+The Studio controller may continue to render existing section forms while the shell is being stabilized. New domain sections must not add large business logic directly to `EventStudioController`.
+
+Future render targets must declare:
+
+- The owning controller, form, or component builder.
+- The save/autosave boundary.
+- The domain service responsible for persistence.
+- Cache contexts and tags.
+- Empty-state behavior for zero-data states.
+
+## Access Rules
+
+Every new section route must:
+
+- Use `EventStudioAccess`.
+- Require event update access when editing event operations.
+- Preserve vendor team permission checks.
+- Preserve admin override.
+- Deny anonymous users and customers server-side.
+
+Section plugins may expose access metadata, but they must not replace route access.
+
+The default plugin access policy is `event_update`. It must:
+
+- Deny anonymous users.
+- Preserve the `administer nodes` override.
+- Require vendor workspace parity through `EventVendorAccessChecker`.
+- Require event entity update access.
+- Add user and permission cache contexts when access depends on account state.
+
+The Studio controller must deny direct section rendering when plugin access is denied. A section hidden from navigation must not be reachable by direct URL unless a reviewed access policy explicitly allows it.
+
+## UX Rules
+
+Sections must use shared Studio patterns for:
+
+- Empty states.
+- Readiness cards.
+- Operational tables.
+- Sticky action bars.
+- Mobile drawers.
+- Save indicators.
+- Inline validation.
+
+Raw placeholder render arrays are not allowed for new sections. Use `EventStudioEmptyStateBuilder` until a governed section UI exists.
+
+Deferred sections must remain operational placeholders. They may reserve navigation, route, and metadata contracts, but they must not add hidden product, fulfilment, scanning, POS, or analytics behavior before the owning domain exists.
+
+## Anti-Patterns
+
+Do not:
+
+- Add dynamic `/studio/{section}` routes.
+- Hide unauthorized sections only in Twig.
+- Duplicate ticket lifecycle logic in Studio.
+- Resolve Commerce products inside random forms or controllers.
+- Add expensive analytics queries to workspace load.
+- Add section-specific autosave protocols.
+- Add readiness conditionals directly in Twig or JavaScript.
+- Add plugin access policies without route-layer parity and entity-access review.
+
+## Change Protocol
+
+Adding a new section requires:
+
+1. Explicit route YAML.
+2. `EventStudioSection` plugin metadata.
+3. Server-side access review.
+4. Domain owner confirmation.
+5. Empty state or full governed rendering target.
+6. Performance and cache review.
+7. Readiness-provider contract review when the section affects publish readiness.

--- a/docs/readiness-provider-architecture.md
+++ b/docs/readiness-provider-architecture.md
@@ -1,0 +1,133 @@
+# Readiness Provider Architecture
+
+Status: internal governance  
+Scope: current readiness behavior and future provider migration
+
+## Current Rule
+
+`EventReadinessService` is production infrastructure. It remains the canonical server-side publish readiness evaluator in this phase.
+
+The current service lives at `web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php` and returns `EventReadinessResult`. It is used by Studio display and publish/save enforcement paths.
+
+This phase adds provider contracts only. It does not split the working readiness system into tagged providers yet.
+
+Do not register readiness providers as active services for publish gating in this phase. The provider model is a future extension contract, not the current execution path.
+
+## Enforcement Versus Presentation
+
+Readiness has two distinct roles:
+
+| Role | Meaning |
+| --- | --- |
+| Enforcement | Blocks publish or unsafe operations. Must live in PHP services and domain gates. |
+| Presentation | Explains state to vendors. May summarize domain signals but must not invent enforcement logic. |
+
+Twig and JavaScript may render readiness output. They must not duplicate readiness decisions.
+
+## Future Provider Contract
+
+Future providers implement `EventReadinessProviderInterface` and return `EventReadinessProviderResult`.
+
+Provider metadata must include:
+
+- Stable provider id.
+- Owning domain.
+- Related Studio section id, when applicable.
+- Blocking errors.
+- Warnings.
+- Completed items.
+
+Available contract primitives:
+
+| Primitive | Purpose |
+| --- | --- |
+| `EventReadinessProviderInterface` | Future provider API for one domain-owned readiness evaluator. |
+| `AbstractEventReadinessProvider` | Shared metadata and typed result construction for future providers. |
+| `EventReadinessProviderResult` | Provider-level result DTO for future aggregation. |
+| `ReadinessIssue` | Typed issue object for future provider outputs. |
+| `ReadinessSeverity` | Severity enum for blocking errors, warnings, and completed signals. |
+
+Future discovery convention:
+
+- Provider services should use a stable service tag such as `myeventlane_event_studio.readiness_provider`.
+- Tags should include provider id, domain, section id, and weight when provider orchestration is approved.
+- Service discovery must not become the publish readiness source of truth until the migration has domain tests and a rollback path.
+
+Potential future providers:
+
+- Branding readiness provider.
+- Ticket readiness provider.
+- Commerce readiness provider.
+- Fulfilment readiness provider.
+- Scanning readiness provider.
+- Analytics readiness provider.
+
+## Migration Sequence
+
+Do not create partial providers before their domains exist. A domain is ready for a readiness provider only when it has:
+
+1. A domain owner service.
+2. Stable persisted data.
+3. Access boundaries.
+4. Tests or verification paths.
+5. A Studio section contract.
+6. Clear enforcement versus presentation rules.
+
+After that, `EventReadinessService` can become an aggregator over tagged providers in a controlled refactor. That migration is explicitly outside the current governance foundation.
+
+## Provider Rules
+
+Providers must:
+
+- Evaluate one domain only.
+- Fail loudly with logging when required data cannot be inspected.
+- Return deterministic messages.
+- Avoid heavy queries on workspace load.
+- Add cacheability metadata when exposed through render builders.
+- Avoid leaking staff-only diagnostics to vendors.
+
+Providers must not:
+
+- Mutate event, ticket, Commerce, or fulfilment state.
+- Call Stripe or remote APIs during page render.
+- Duplicate another provider's responsibility.
+- Hide blocking failures as warnings.
+- Depend on client-side state for server-side decisions.
+
+## Section Participation
+
+Sections declare readiness participation through `EventStudioSection` metadata. That metadata is not itself readiness logic. It tells the shell and future aggregators which sections may contribute readiness signals.
+
+Examples:
+
+| Section | Readiness role |
+| --- | --- |
+| `information` | Title, schedule, booking mode basics |
+| `branding` | Required event image and public presentation readiness |
+| `tickets` | Paid ticket presence, ticket capacity, ticket lifecycle validity |
+| `settings` | Publish requirements and final review |
+| `merchandise` | Future Commerce product readiness only after merchandise exists |
+| `fulfilment` | Future shipping, pickup, redemption, or inventory readiness only after fulfilment exists |
+
+## Testing Expectations
+
+When provider aggregation is implemented later, tests must cover:
+
+- Provider ordering.
+- Duplicate message handling.
+- Blocking versus warning behavior.
+- Section links.
+- Vendor access boundaries.
+- Staff-only diagnostics exclusion.
+- Published and draft event behavior.
+
+Until then, tests should continue to verify the current `EventReadinessService` behavior and publish gates.
+
+## Related Files
+
+- `web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php`
+- `web/modules/custom/myeventlane_event_studio/src/DTO/EventReadinessResult.php`
+- `web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderInterface.php`
+- `web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderResult.php`
+- `docs/operational-readiness-governance.md`
+- `docs/event-studio-section-contracts.md`

--- a/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
@@ -22,3 +22,126 @@ entity.myeventlane_onboarding_state.collection:
   route_name: entity.myeventlane_onboarding_state.collection
   parent: myeventlane_core.config
   weight: 5
+
+# Public footer discovery links. These are static menu links so footer IA is
+# deployable with code/config rather than database-only menu-link content.
+myeventlane_core.footer_find_events.all_events:
+  title: 'All events'
+  route_name: view.upcoming_events.page_events
+  menu_name: footer-find
+  weight: 0
+
+myeventlane_core.footer_find_events.today:
+  title: 'Today'
+  route_name: view.upcoming_events.page_today
+  menu_name: footer-find
+  weight: 1
+
+myeventlane_core.footer_find_events.this_weekend:
+  title: 'This weekend'
+  route_name: view.upcoming_events.page_this_weekend
+  menu_name: footer-find
+  weight: 2
+
+myeventlane_core.footer_find_events.free:
+  title: 'Free events'
+  route_name: view.upcoming_events.page_free
+  menu_name: footer-find
+  weight: 3
+
+myeventlane_core.footer_find_events.popular:
+  title: 'Popular events'
+  route_name: view.upcoming_events.page_popular
+  menu_name: footer-find
+  weight: 4
+
+myeventlane_core.footer_find_events.blog:
+  title: 'Blog & guides'
+  route_name: view.mel_blog.page_blog
+  menu_name: footer-find
+  weight: 5
+
+myeventlane_core.footer_host.create_event:
+  title: 'Create event'
+  route_name: myeventlane_vendor.create_event_gateway
+  menu_name: footer-host
+  weight: 0
+
+myeventlane_core.footer_host.help_centre:
+  title: 'Help centre'
+  route_name: myeventlane_help_centre.home
+  menu_name: footer-host
+  weight: 1
+
+myeventlane_core.footer_host.sell_more_tickets:
+  title: 'How to sell more tickets'
+  url: 'internal:/blog/how-to-sell-more-tickets'
+  menu_name: footer-host
+  weight: 2
+
+myeventlane_core.footer_host.promote_event:
+  title: 'Promote your event'
+  url: 'internal:/blog/event-promotion-tips'
+  menu_name: footer-host
+  weight: 3
+
+myeventlane_core.footer_host.setup_guide:
+  title: 'Event setup guide'
+  url: 'internal:/blog/event-setup-guide'
+  menu_name: footer-host
+  weight: 4
+
+myeventlane_core.footer_about.about:
+  title: 'About MyEventLane'
+  url: 'internal:/about'
+  menu_name: footer-about
+  weight: 0
+
+myeventlane_core.footer_about.story:
+  title: 'Our story'
+  url: 'internal:/our-story'
+  menu_name: footer-about
+  weight: 1
+
+myeventlane_core.footer_about.blog:
+  title: 'Blog'
+  route_name: view.mel_blog.page_blog
+  menu_name: footer-about
+  weight: 2
+
+myeventlane_core.footer_about.contact:
+  title: 'Contact'
+  url: 'internal:/contact'
+  menu_name: footer-about
+  weight: 3
+
+myeventlane_core.footer_about.privacy:
+  title: 'Privacy policy'
+  url: 'internal:/privacy'
+  menu_name: footer-about
+  weight: 4
+
+myeventlane_core.footer_about.terms:
+  title: 'Terms'
+  url: 'internal:/terms'
+  menu_name: footer-about
+  weight: 5
+
+myeventlane_core.footer_community.instagram:
+  title: 'Instagram'
+  url: 'https://www.instagram.com/myeventlane'
+  menu_name: footer-community
+  weight: 0
+
+myeventlane_core.footer_community.facebook:
+  title: 'Facebook'
+  url: 'https://www.facebook.com/myeventlane'
+  menu_name: footer-community
+  weight: 1
+
+myeventlane_core.footer_community.linkedin:
+  title: 'LinkedIn'
+  url: 'https://www.linkedin.com/company/myeventlane'
+  menu_name: footer-community
+  weight: 2
+

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -969,9 +969,17 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       $stores = $product_entity->getStores();
       if ($stores !== [] && \Drupal::hasService('myeventlane_checkout_flow.order_pricing_breakdown')) {
         $store_entity = reset($stores);
-        /** @var \Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder $gst_breakdown */
-        $gst_breakdown = \Drupal::service('myeventlane_checkout_flow.order_pricing_breakdown');
-        $variables['mel_show_price_includes_gst_note'] = $gst_breakdown->eventPaidListingShouldShowIncludesGstNote($store_entity);
+        try {
+          /** @var \Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder $gst_breakdown */
+          $gst_breakdown = \Drupal::service('myeventlane_checkout_flow.order_pricing_breakdown');
+          $variables['mel_show_price_includes_gst_note'] = $gst_breakdown->eventPaidListingShouldShowIncludesGstNote($store_entity);
+        }
+        catch (\Throwable $e) {
+          \Drupal::logger('myeventlane_event')->warning('Unable to resolve GST display note for event @nid during node preprocess: @message', [
+            '@nid' => (string) $node->id(),
+            '@message' => $e->getMessage(),
+          ]);
+        }
       }
     }
   }

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -83,6 +83,9 @@ services:
   myeventlane_event.commerce_classification_registry:
     class: Drupal\myeventlane_event\Service\EventCommerceClassificationRegistry
 
+  myeventlane_event.operational_type_registry:
+    class: Drupal\myeventlane_event\Service\EventOperationalTypeRegistry
+
   myeventlane_event.event_mode_manager:
     class: Drupal\myeventlane_event\Service\EventModeManager
     arguments:
@@ -108,6 +111,7 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_event.ticket_type_manager'
       - '@logger.factory'
+      - '@myeventlane_vendor.event_access_checker'
 
   myeventlane_event.booking_flow_resolver:
     class: Drupal\myeventlane_event\Service\BookingFlowResolver

--- a/web/modules/custom/myeventlane_event/src/Service/EventOperationalTypeRegistry.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventOperationalTypeRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\myeventlane_event\Value\EventOperationalType;
+use Drupal\node\NodeInterface;
+
+/**
+ * Resolves operational event type metadata without changing event storage.
+ */
+final class EventOperationalTypeRegistry {
+
+  /**
+   * Returns all operational type definitions.
+   *
+   * @return array<string, array<string, mixed>>
+   */
+  public function definitions(): array {
+    return EventOperationalType::definitions();
+  }
+
+  /**
+   * Resolves the operational type id for an event.
+   */
+  public function resolve(NodeInterface $event): string {
+    if ($event->bundle() !== 'event' || !$event->hasField('field_event_type') || $event->get('field_event_type')->isEmpty()) {
+      return '';
+    }
+    return EventOperationalType::fromFieldEventType((string) $event->get('field_event_type')->value);
+  }
+
+  /**
+   * Returns metadata for an operational type id.
+   *
+   * @return array<string, mixed>
+   */
+  public function definition(string $operational_type): array {
+    return $this->definitions()[$operational_type] ?? [];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -15,6 +15,7 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use InvalidArgumentException;
 
@@ -36,6 +37,7 @@ final class TicketTierLifecycleService {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TicketTypeManager $ticketTypeManager,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
   ) {}
 
   /**
@@ -201,7 +203,10 @@ final class TicketTierLifecycleService {
       ? []
       : $event->get('field_ticket_types')->getValue();
     $ids = [];
-    foreach ($refs as $row) {
+      foreach ($refs as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
       if (!empty($row['target_id'])) {
         $ids[] = (int) $row['target_id'];
       }
@@ -236,7 +241,7 @@ final class TicketTierLifecycleService {
         : $event->get('field_ticket_types')->getValue();
       $filtered = array_values(array_filter(
         $refs,
-        static fn (array $item): bool => (int) ($item['target_id'] ?? 0) !== $ticketId
+        static fn (mixed $item): bool => !is_array($item) || (int) ($item['target_id'] ?? 0) !== $ticketId
       ));
       if ($filtered !== $refs) {
         $event->set('field_ticket_types', $filtered);
@@ -271,6 +276,9 @@ final class TicketTierLifecycleService {
     $current = [];
     if (!$event->get('field_ticket_types')->isEmpty()) {
       foreach ($event->get('field_ticket_types')->getValue() as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
         if (!empty($row['target_id'])) {
           $current[] = (int) $row['target_id'];
         }
@@ -404,6 +412,12 @@ final class TicketTierLifecycleService {
     if (array_key_exists('field_is_best_value', $values)) {
       $payload['field_is_best_value'] = !empty($values['field_is_best_value']) ? 1 : 0;
     }
+    if (array_key_exists('sale_start', $values)) {
+      $payload['sale_start'] = $this->normalizeTicketDateValue($values['sale_start']);
+    }
+    if (array_key_exists('sale_end', $values)) {
+      $payload['sale_end'] = $this->normalizeTicketDateValue($values['sale_end']);
+    }
 
     if (in_array($kind, ['paid', 'rsvp'], TRUE)) {
       $payload['capacity'] = $this->normalizeOptionalPositiveInteger(
@@ -453,8 +467,7 @@ final class TicketTierLifecycleService {
     AccountInterface $account,
     array $values,
   ): array {
-    if ((int) $ticket->get('vendor_id')->target_id !== (int) $account->id()
-      && !$account->hasPermission('administer mel_ticket_type entities')) {
+    if (!$this->accountCanManageTicketForEvent($event, $ticket, $account)) {
       throw new InvalidArgumentException('Ticket not found on this event.');
     }
 
@@ -523,6 +536,12 @@ final class TicketTierLifecycleService {
     }
     if (array_key_exists('field_is_best_value', $values)) {
       $payload['field_is_best_value'] = !empty($values['field_is_best_value']) ? 1 : 0;
+    }
+    if (array_key_exists('sale_start', $values)) {
+      $payload['sale_start'] = $this->normalizeTicketDateValue($values['sale_start']);
+    }
+    if (array_key_exists('sale_end', $values)) {
+      $payload['sale_end'] = $this->normalizeTicketDateValue($values['sale_end']);
     }
 
     if (array_key_exists('hidden_label', $values)) {
@@ -1106,11 +1125,20 @@ final class TicketTierLifecycleService {
     if (!$this->ticketBelongsToEvent($event, $ticketId)) {
       return NULL;
     }
-    if ((int) $entity->get('vendor_id')->target_id !== (int) $account->id()
-      && !$account->hasPermission('administer mel_ticket_type entities')) {
+    if (!$this->accountCanManageTicketForEvent($event, $entity, $account)) {
       return NULL;
     }
     return $entity;
+  }
+
+  private function accountCanManageTicketForEvent(NodeInterface $event, TicketTypeInterface $ticket, AccountInterface $account): bool {
+    if ($account->hasPermission('administer mel_ticket_type entities')) {
+      return TRUE;
+    }
+    if ((int) $ticket->get('vendor_id')->target_id === (int) $account->id()) {
+      return TRUE;
+    }
+    return $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account);
   }
 
   private function clearTicketEventReference(NodeInterface $event, int $ticketId): bool {
@@ -1421,6 +1449,24 @@ final class TicketTierLifecycleService {
       throw new InvalidArgumentException($message);
     }
     return (int) $raw;
+  }
+
+  private function normalizeTicketDateValue(mixed $value): ?string {
+    if ($value instanceof DrupalDateTime) {
+      return $value->format('Y-m-d\TH:i:s');
+    }
+    if (is_array($value) && isset($value['date'], $value['time'])) {
+      $raw = trim((string) $value['date'] . ' ' . (string) $value['time']);
+      if ($raw === '') {
+        return NULL;
+      }
+      return (new DrupalDateTime($raw))->format('Y-m-d\TH:i:s');
+    }
+    $raw = trim((string) $value);
+    if ($raw === '') {
+      return NULL;
+    }
+    return (new DrupalDateTime($raw))->format('Y-m-d\TH:i:s');
   }
 
   private function resolveEventKind(NodeInterface $event): string {

--- a/web/modules/custom/myeventlane_event/src/Value/EventOperationalType.php
+++ b/web/modules/custom/myeventlane_event/src/Value/EventOperationalType.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Value;
+
+/**
+ * Defines future-facing operational event type identifiers.
+ *
+ * These constants are metadata contracts only. They do not change existing
+ * field_event_type storage values or booking behavior.
+ */
+final class EventOperationalType {
+
+  public const RSVP = 'rsvp';
+  public const TICKETED = 'ticketed';
+  public const HYBRID = 'hybrid';
+  public const SEATED = 'seated';
+  public const FESTIVAL = 'festival';
+  public const DIGITAL = 'digital';
+  public const EXTERNAL = 'external';
+
+  /**
+   * Returns canonical metadata for future Studio decisions.
+   *
+   * @return array<string, array<string, mixed>>
+   */
+  public static function definitions(): array {
+    return [
+      self::RSVP => [
+        'label' => 'RSVP event',
+        'commerce_required' => FALSE,
+        'attendance_access' => TRUE,
+        'seating_required' => FALSE,
+      ],
+      self::TICKETED => [
+        'label' => 'Ticketed event',
+        'commerce_required' => TRUE,
+        'attendance_access' => TRUE,
+        'seating_required' => FALSE,
+      ],
+      self::HYBRID => [
+        'label' => 'Hybrid event',
+        'commerce_required' => TRUE,
+        'attendance_access' => TRUE,
+        'seating_required' => FALSE,
+      ],
+      self::SEATED => [
+        'label' => 'Seated event',
+        'commerce_required' => TRUE,
+        'attendance_access' => TRUE,
+        'seating_required' => TRUE,
+      ],
+      self::FESTIVAL => [
+        'label' => 'Festival',
+        'commerce_required' => TRUE,
+        'attendance_access' => TRUE,
+        'seating_required' => FALSE,
+      ],
+      self::DIGITAL => [
+        'label' => 'Digital event',
+        'commerce_required' => FALSE,
+        'attendance_access' => TRUE,
+        'seating_required' => FALSE,
+      ],
+      self::EXTERNAL => [
+        'label' => 'External booking event',
+        'commerce_required' => FALSE,
+        'attendance_access' => FALSE,
+        'seating_required' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * Maps current field_event_type values onto operational type identifiers.
+   */
+  public static function fromFieldEventType(string $field_event_type): string {
+    return match ($field_event_type) {
+      'paid' => self::TICKETED,
+      'both' => self::HYBRID,
+      'rsvp' => self::RSVP,
+      'external' => self::EXTERNAL,
+      default => $field_event_type,
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -1192,3 +1192,493 @@
 .mel-event-studio .mel-es-workspace__main .fieldset {
   margin-bottom: 1.2rem;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Canonical operational Studio shell                                          */
+/* -------------------------------------------------------------------------- */
+
+.mel-event-studio--workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: 100%;
+}
+
+.mel-event-studio-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 18px;
+  min-height: 76px;
+  padding: 14px 20px;
+  border: 1px solid #e8e8ef;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.mel-event-studio-topbar__eyebrow,
+.mel-event-studio-sidebar__heading {
+  margin: 0 0 4px;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mel-event-studio-topbar__title {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.mel-event-studio-topbar__meta,
+.mel-event-studio-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
+}
+
+.mel-event-studio-topbar__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.mel-event-studio-topbar__state,
+.mel-event-studio-topbar__saved,
+.mel-event-studio-topbar__autosave {
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.mel-event-studio-topbar__autosave.is-unsaved,
+.mel-event-studio-topbar__autosave.has-draft {
+  color: #92400e;
+  font-weight: 700;
+}
+
+.mel-event-studio-topbar__autosave.is-saving {
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.mel-event-studio-topbar__autosave.is-saved {
+  color: #166534;
+  font-weight: 700;
+}
+
+.mel-event-studio-topbar__autosave.is-error {
+  color: #991b1b;
+  font-weight: 700;
+  white-space: normal;
+}
+
+.mel-event-studio-topbar__autosave a {
+  color: inherit;
+}
+
+.mel-event-studio-sidebar-toggle {
+  display: none;
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid #e8e8ef;
+  border-radius: 999px;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 700;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio-readiness-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 14px;
+  border: 1px solid #e8e8ef;
+  border-radius: 14px;
+  background: #fff;
+  color: #475569;
+}
+
+.mel-event-studio-readiness-strip__summary,
+.mel-event-studio-readiness-strip__counts {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.mel-event-studio-readiness-strip__counts span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.mel-event-studio-readiness-strip.is-ready {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.mel-event-studio-readiness-strip.needs-attention {
+  border-color: #fecaca;
+  background: #fff7f7;
+  color: #991b1b;
+}
+
+.mel-event-studio-workspace {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  align-items: start;
+  gap: 24px;
+}
+
+.mel-event-studio-sidebar {
+  position: sticky;
+  top: 96px;
+  align-self: start;
+}
+
+.mel-event-studio-sidebar__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border: 1px solid #e8e8ef;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio-sidebar__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-event-studio-sidebar__link {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 12px;
+  border-radius: 12px;
+  color: #334155;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.mel-event-studio-sidebar__link:hover,
+.mel-event-studio-sidebar__link:focus,
+.mel-event-studio-sidebar__link.is-active {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.mel-event-studio-sidebar__link.is-active {
+  box-shadow: inset 3px 0 0 #ec4899;
+}
+
+.mel-event-studio-workspace__main {
+  min-width: 0;
+}
+
+.mel-event-studio-section {
+  border: 1px solid #e8e8ef;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+}
+
+.mel-event-studio-section__header {
+  padding: 22px 24px 0;
+}
+
+.mel-event-studio-section__title {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.mel-event-studio-section__body {
+  padding: 20px 24px 24px;
+}
+
+.mel-event-studio-section__form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.mel-event-studio-section__placeholder {
+  max-width: 680px;
+  color: #475569;
+  line-height: 1.55;
+}
+
+.mel-readiness-card {
+  padding: 18px;
+  border: 1px solid #e8e8ef;
+  border-radius: 16px;
+  background: #f8fafc;
+}
+
+.mel-readiness-card.is-ready {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.mel-readiness-card.needs-attention {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.mel-readiness-card__title {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.mel-readiness-card__summary {
+  margin: 0 0 14px;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.mel-readiness-card__heading {
+  margin: 16px 0 8px;
+  color: #0f172a;
+  font-size: 0.86rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mel-readiness-card__list {
+  margin-bottom: 0;
+}
+
+.mel-readiness-card__list--errors {
+  color: #991b1b;
+}
+
+.mel-readiness-card__list--warnings {
+  color: #92400e;
+}
+
+.mel-readiness-card__list--completed {
+  color: #166534;
+}
+
+.mel-event-studio-operational-tickets {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.mel-event-studio-ticket-intro {
+  max-width: 760px;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.mel-event-studio-ticket-table {
+  width: 100%;
+  max-width: 100%;
+}
+
+.mel-event-studio-ticket-table th {
+  color: #475569;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mel-event-studio-ticket-table td {
+  vertical-align: top;
+}
+
+.mel-event-studio-ticket-table .form-item {
+  margin-bottom: 0.75rem;
+}
+
+.mel-event-studio-ticket-add {
+  border: 1px solid #e8e8ef;
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: #f8fafc;
+}
+
+@media (max-width: 960px) {
+  .mel-event-studio-topbar {
+    grid-template-columns: minmax(0, 1fr);
+    position: sticky;
+    top: 0;
+  }
+
+  .mel-event-studio-topbar__meta,
+  .mel-event-studio-topbar__actions {
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+
+  .mel-event-studio-readiness-strip {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .mel-event-studio-readiness-strip__counts {
+    max-width: 100%;
+  }
+
+  .mel-event-studio-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+
+  .mel-event-studio-sidebar {
+    position: static;
+  }
+
+  .mel-event-studio-section__header {
+    padding: 18px 18px 0;
+  }
+
+  .mel-event-studio-section__body {
+    padding: 18px;
+  }
+
+  .mel-event-studio .mel-event-studio__footer-actions,
+  .mel-event-studio .form-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 15;
+    margin: 18px -24px -24px;
+    padding: 12px 24px;
+    border-top: 1px solid #e8e8ef;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.08);
+  }
+}
+
+@media (max-width: 760px) {
+  .mel-event-studio-sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mel-event-studio--workspace::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 24;
+    background: rgba(15, 23, 42, 0.28);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 160ms ease;
+  }
+
+  .mel-event-studio--workspace.is-sidebar-open::before {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .mel-event-studio-sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 25;
+    width: min(86vw, 340px);
+    padding: 16px;
+    overflow-y: auto;
+    transform: translateX(-105%);
+    transition: transform 180ms ease;
+  }
+
+  .mel-event-studio--workspace.is-sidebar-open .mel-event-studio-sidebar {
+    transform: translateX(0);
+  }
+
+  .mel-event-studio-sidebar__inner {
+    min-height: 100%;
+  }
+
+  .mel-event-studio-topbar {
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 14px;
+  }
+
+  .mel-event-studio-topbar__actions .mel-btn {
+    flex: 1 1 140px;
+  }
+
+  .mel-event-studio-readiness-strip__summary,
+  .mel-event-studio-readiness-strip__counts {
+    width: 100%;
+  }
+
+  .mel-event-studio-readiness-strip__counts span {
+    flex: 1 1 120px;
+    justify-content: center;
+  }
+
+  .mel-event-studio-ticket-table,
+  .mel-event-studio-ticket-table thead,
+  .mel-event-studio-ticket-table tbody,
+  .mel-event-studio-ticket-table th,
+  .mel-event-studio-ticket-table td,
+  .mel-event-studio-ticket-table tr {
+    display: block;
+  }
+
+  .mel-event-studio-ticket-table thead {
+    display: none;
+  }
+
+  .mel-event-studio-ticket-table tr {
+    margin-bottom: 16px;
+    padding: 14px;
+    border: 1px solid #e8e8ef;
+    border-radius: 14px;
+    background: #fff;
+  }
+
+  .mel-event-studio-ticket-table td {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .mel-event-studio-ticket-table input,
+  .mel-event-studio-ticket-table select,
+  .mel-event-studio-ticket-table textarea {
+    max-width: 100%;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -1,0 +1,114 @@
+(function (Drupal, drupalSettings, once) {
+  'use strict';
+
+  const tokenPromise = fetch('/session/token', { credentials: 'same-origin' }).then((response) => response.text());
+  const stateClasses = ['is-unsaved', 'is-saving', 'is-saved', 'is-error', 'has-draft'];
+
+  function setStatus(status, message, state) {
+    if (!status) {
+      return;
+    }
+    stateClasses.forEach((className) => status.classList.remove(className));
+    if (state) {
+      status.classList.add(state);
+    }
+    status.textContent = message;
+  }
+
+  Drupal.behaviors.melEventStudioShellAutosave = {
+    attach(context) {
+      once('mel-event-studio-sidebar-toggle', '[data-mel-studio-sidebar-toggle]', context).forEach((button) => {
+        const shell = button.closest('[data-mel-studio-shell]');
+        if (!shell) {
+          return;
+        }
+        button.addEventListener('click', () => {
+          const isOpen = shell.classList.toggle('is-sidebar-open');
+          button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+        shell.addEventListener('click', (event) => {
+          if (event.target !== shell || !shell.classList.contains('is-sidebar-open')) {
+            return;
+          }
+          shell.classList.remove('is-sidebar-open');
+          button.setAttribute('aria-expanded', 'false');
+        });
+        shell.querySelectorAll('.mel-event-studio-sidebar__link').forEach((link) => {
+          link.addEventListener('click', () => {
+            shell.classList.remove('is-sidebar-open');
+            button.setAttribute('aria-expanded', 'false');
+          });
+        });
+      });
+
+      once('mel-event-studio-shell-autosave', 'form[data-mel-event-studio-form="1"]', context).forEach((form) => {
+        if (form.matches('.mel-event-studio-operational-tickets')) {
+          return;
+        }
+        let timer = null;
+        let dirty = false;
+        const status = document.getElementById('mel-studio-form-state');
+        const delay = Number(drupalSettings.myeventlaneEventStudio?.autosaveDelay || 12000);
+        const autosaveUrl = drupalSettings.myeventlaneEventStudio?.autosaveUrl;
+        if (!autosaveUrl) {
+          return;
+        }
+        if (drupalSettings.myeventlaneEventStudio?.draftAvailable) {
+          status?.classList.add('has-draft');
+        }
+
+        const schedule = () => {
+          window.clearTimeout(timer);
+          dirty = true;
+          setStatus(status, Drupal.t('Unsaved changes'), 'is-unsaved');
+          timer = window.setTimeout(async () => {
+            const data = new FormData(form);
+            data.set('mel_autosave_ts', String(Date.now()));
+            setStatus(status, Drupal.t('Saving...'), 'is-saving');
+            try {
+              const token = await tokenPromise;
+              const response = await fetch(autosaveUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'X-CSRF-Token': token },
+                body: data,
+              });
+              const result = await response.json().catch(() => ({}));
+              if (response.status === 409) {
+                dirty = true;
+                setStatus(
+                  status,
+                  result.message || Drupal.t('This section was updated elsewhere. Refresh to continue editing safely.'),
+                  'is-error',
+                );
+                return;
+              }
+              if (!response.ok || !result.ok) {
+                throw new Error(`Autosave failed with ${response.status}`);
+              }
+              dirty = false;
+              setStatus(status, Drupal.t('Saved just now'), 'is-saved');
+            }
+            catch (error) {
+              setStatus(status, Drupal.t('Draft could not be saved. Retry by editing again.'), 'is-error');
+            }
+          }, delay);
+        };
+
+        form.addEventListener('input', schedule);
+        form.addEventListener('change', schedule);
+        form.addEventListener('submit', () => {
+          dirty = false;
+          window.clearTimeout(timer);
+        });
+        window.addEventListener('beforeunload', (event) => {
+          if (!dirty) {
+            return;
+          }
+          event.preventDefault();
+          event.returnValue = '';
+        });
+      });
+    },
+  };
+})(Drupal, drupalSettings, once);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -5489,6 +5489,10 @@
           true,
         );
 
+        if (form.closest('[data-mel-studio-shell]')) {
+          return;
+        }
+
         var timeoutId = null;
         var url = Drupal.url('vendor/events/autosave');
 
@@ -5507,14 +5511,18 @@
               var body = new FormData(form);
               var autosaveTs = Date.now();
               body.append('mel_autosave_ts', String(autosaveTs));
-              fetch(url, {
-                method: 'POST',
-                body: body,
-                credentials: 'same-origin',
-                headers: {
-                  Accept: 'application/json',
-                },
-              })
+              melGetCsrfToken()
+                .then(function (token) {
+                  return fetch(url, {
+                    method: 'POST',
+                    body: body,
+                    credentials: 'same-origin',
+                    headers: {
+                      Accept: 'application/json',
+                      'X-CSRF-Token': token,
+                    },
+                  });
+                })
                 .then(function (response) {
                   return response.json().then(function (data) {
                     return { ok: response.ok, status: response.status, data: data };

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.4
+  version: 1.6
   css:
     theme:
       css/mel-event-studio.css: {}
@@ -15,9 +15,15 @@ mel_event_studio:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
+  version: 1.1
   css:
     theme:
       css/mel-event-studio-nav.css: {}
       css/mel-event-studio-shell.css: { weight: 200 }
+  js:
+    js/mel-event-studio-shell.js: {}
   dependencies:
     - core/drupal
+    - core/drupalSettings
+    - core/once
+    - myeventlane_location/address_autocomplete

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.links.task.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.links.task.yml
@@ -1,0 +1,5 @@
+myeventlane_event_studio.workspace:
+  route_name: myeventlane_event_studio.workspace
+  base_route: entity.node.canonical
+  title: 'Event Studio'
+  weight: 20

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -30,6 +30,47 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-wizard-nav',
     ],
+    'mel_event_studio_workspace' => [
+      'variables' => [
+        'node' => NULL,
+        'sections' => [],
+        'current_section' => 'overview',
+        'current_section_label' => '',
+        'section_content' => NULL,
+        'topbar' => [],
+        'readiness' => [],
+      ],
+      'template' => 'mel-event-studio-workspace',
+    ],
+    'mel_event_studio_sidebar' => [
+      'variables' => [
+        'sections' => [],
+        'current_section' => 'overview',
+      ],
+      'template' => 'mel-event-studio-sidebar',
+    ],
+    'mel_event_studio_topbar' => [
+      'variables' => [
+        'topbar' => [],
+      ],
+      'template' => 'mel-event-studio-topbar',
+    ],
+    'mel_event_studio_section' => [
+      'variables' => [
+        'label' => '',
+        'content' => NULL,
+      ],
+      'template' => 'mel-event-studio-section',
+    ],
+    'mel_event_studio_empty_state' => [
+      'variables' => [
+        'title' => '',
+        'body' => '',
+        'prompt' => '',
+        'guidance' => [],
+      ],
+      'template' => 'mel-event-studio-empty-state',
+    ],
     'mel_event_studio_wizard_preview' => [
       'variables' => [
         'node' => NULL,
@@ -120,6 +161,21 @@ function _myeventlane_event_studio_is_event_studio_route(?string $route_name = N
     'myeventlane_event_studio.edit_description',
     'myeventlane_event_studio.edit_preview',
     'myeventlane_event_studio.edit_publish',
+    'myeventlane_event_studio.workspace',
+    'myeventlane_event_studio.workspace_information',
+    'myeventlane_event_studio.workspace_branding',
+    'myeventlane_event_studio.workspace_content',
+    'myeventlane_event_studio.workspace_tickets',
+    'myeventlane_event_studio.workspace_questions',
+    'myeventlane_event_studio.workspace_capacity',
+    'myeventlane_event_studio.workspace_merchandise',
+    'myeventlane_event_studio.workspace_addons',
+    'myeventlane_event_studio.workspace_promotions',
+    'myeventlane_event_studio.workspace_attendees',
+    'myeventlane_event_studio.workspace_fulfilment',
+    'myeventlane_event_studio.workspace_orders',
+    'myeventlane_event_studio.workspace_analytics',
+    'myeventlane_event_studio.workspace_settings',
   ];
   return in_array($route_name, $routes, TRUE);
 }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -14,6 +14,231 @@ myeventlane_event_studio.edit:
     _title_callback: myeventlane_event_studio.controller:editTitle
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace:
+  path: '/vendor/events/{node}/studio'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'overview'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_information:
+  path: '/vendor/events/{node}/studio/information'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'information'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_branding:
+  path: '/vendor/events/{node}/studio/branding'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'branding'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_content:
+  path: '/vendor/events/{node}/studio/content'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'content'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_tickets:
+  path: '/vendor/events/{node}/studio/tickets'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'tickets'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_questions:
+  path: '/vendor/events/{node}/studio/questions'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'questions'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_capacity:
+  path: '/vendor/events/{node}/studio/capacity'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'capacity'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_merchandise:
+  path: '/vendor/events/{node}/studio/merchandise'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'merchandise'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_addons:
+  path: '/vendor/events/{node}/studio/addons'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'addons'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_add_ons:
+  path: '/vendor/events/{node}/studio/add-ons'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'addons'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_promotions:
+  path: '/vendor/events/{node}/studio/promotions'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'promotions'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_attendees:
+  path: '/vendor/events/{node}/studio/attendees'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'attendees'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_fulfilment:
+  path: '/vendor/events/{node}/studio/fulfilment'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'fulfilment'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_orders:
+  path: '/vendor/events/{node}/studio/orders'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'orders'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_analytics:
+  path: '/vendor/events/{node}/studio/analytics'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'analytics'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_settings:
+  path: '/vendor/events/{node}/studio/settings'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'settings'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+
   options:
     parameters:
@@ -27,6 +252,7 @@ myeventlane_event_studio.edit_basic:
     _title: 'Basic info'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -39,6 +265,7 @@ myeventlane_event_studio.edit_datetime:
     _title: 'Date & location'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -51,6 +278,7 @@ myeventlane_event_studio.edit_tickets:
     _title: 'Tickets'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -63,6 +291,7 @@ myeventlane_event_studio.edit_description:
     _title: 'Description'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -75,6 +304,7 @@ myeventlane_event_studio.edit_preview:
     _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioPreviewController::title'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -87,6 +317,7 @@ myeventlane_event_studio.edit_publish:
     _title: 'Publish'
   requirements:
     _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       node:
@@ -100,6 +331,7 @@ myeventlane_event_studio.autosave:
   requirements:
     _permission: 'access content'
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _csrf_request_header_token: 'TRUE'
 
 myeventlane_event_studio.governance_refresh:
   path: '/vendor/events/{node}/studio/governance-refresh'
@@ -143,6 +375,7 @@ myeventlane_event_studio.ai_generate:
   methods: [POST]
   requirements:
     _permission: 'access content'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     _csrf_request_header_token: 'TRUE'
 
 myeventlane_event_studio.ai_rewrite:
@@ -152,6 +385,7 @@ myeventlane_event_studio.ai_rewrite:
   methods: [POST]
   requirements:
     _permission: 'access content'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     _csrf_request_header_token: 'TRUE'
 
 myeventlane_event_studio.ticket_link_suggestions:
@@ -161,4 +395,5 @@ myeventlane_event_studio.ticket_link_suggestions:
   methods: [POST]
   requirements:
     _permission: 'access content'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     _csrf_request_header_token: 'TRUE'

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -7,6 +7,11 @@ services:
       - '@logger.channel.myeventlane_event_studio'
       - '@request_stack'
       - '@myeventlane_vendor.event_access_checker'
+      - '@date.formatter'
+      - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.autosave'
+      - '@plugin.manager.myeventlane_event_studio_section'
+      - '@myeventlane_event_studio.empty_state_builder'
     tags:
       - { name: controller.service_arguments }
 
@@ -45,9 +50,28 @@ services:
     tags:
       - { name: event_subscriber }
 
+  Drupal\myeventlane_event_studio\Access\EventStudioAccess:
+    arguments:
+      - '@myeventlane_vendor.current_vendor_resolver'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_event_studio'
+
   logger.channel.myeventlane_event_studio:
     parent: logger.channel_base
     arguments: ['myeventlane_event_studio']
+
+  plugin.manager.myeventlane_event_studio_section:
+    class: Drupal\myeventlane_event_studio\EventStudioSectionManager
+    arguments:
+      - '@container.namespaces'
+      - '@module_handler'
+      - '@cache.discovery'
+
+  myeventlane_event_studio.empty_state_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder
+    arguments:
+      - '@string_translation'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper
@@ -117,7 +141,22 @@ services:
       - '@myeventlane_event_studio.highlight_helper'
       - '@myeventlane_vendor.paid_publish_stripe_gate'
       - '@myeventlane_vendor.publish_requirements_gate'
+      - '@myeventlane_event_studio.readiness'
       - '@?myeventlane_questions.template_cloner'
+
+  myeventlane_event_studio.readiness:
+    class: Drupal\myeventlane_event_studio\Service\EventReadinessService
+    arguments:
+      - '@myeventlane_event.ticket_type_manager'
+      - '@myeventlane_vendor.publish_requirements_gate'
+      - '@myeventlane_vendor.paid_publish_stripe_gate'
+      - '@string_translation'
+
+  myeventlane_event_studio.autosave:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService
+    arguments:
+      - '@tempstore.private'
+      - '@logger.channel.myeventlane_event_studio'
 
   myeventlane_event_studio.governance_refresh_controller:
     class: Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceRefreshController
@@ -148,9 +187,10 @@ services:
       - '@current_user'
       - '@entity_type.manager'
       - '@myeventlane_event_studio.highlight_helper'
-      - '@tempstore.private'
       - '@logger.channel.myeventlane_event_studio'
       - '@access_manager'
       - '@myeventlane_vendor.event_access_checker'
+      - '@myeventlane_vendor.current_vendor_resolver'
+      - '@myeventlane_event_studio.autosave'
     tags:
       - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/src/Access/EventStudioAccess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Access/EventStudioAccess.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_vendor\Service\CurrentVendorResolver;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access checker for the canonical vendor Event Studio workspace.
+ */
+final class EventStudioAccess implements ContainerInjectionInterface {
+
+  public function __construct(
+    private readonly CurrentVendorResolver $currentVendorResolver,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_vendor.current_vendor_resolver'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('entity_type.manager'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+    );
+  }
+
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResult {
+    $event = $route_match->getParameter('node') ?? $route_match->getParameter('event');
+    if (is_numeric($event)) {
+      $event = $this->entityTypeManager->getStorage('node')->load((int) $event);
+    }
+    if (!$event instanceof NodeInterface || $event->bundle() !== 'event') {
+      return AccessResult::forbidden()
+        ->addCacheContexts(['route']);
+    }
+
+    if ($account->isAnonymous()) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user.roles']);
+    }
+
+    if ($account->hasPermission('administer nodes')) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user.permissions']);
+    }
+
+    $vendor = $this->currentVendorResolver->resolveFromEvent($event)
+      ?? $this->currentVendorResolver->resolveFromUser($account);
+    if ($vendor === NULL) {
+      $this->logger->warning('Event Studio access denied: no vendor context for event_id=@eid uid=@uid', [
+        '@eid' => (string) $event->id(),
+        '@uid' => (string) $account->id(),
+      ]);
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user']);
+    }
+
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheableDependency($vendor)
+        ->addCacheContexts(['user']);
+    }
+
+    $entity_access = $event->access('update', $account, TRUE);
+    if (!$entity_access->isAllowed()) {
+      return $entity_access
+        ->andIf(AccessResult::forbidden())
+        ->addCacheableDependency($vendor)
+        ->addCacheContexts(['user']);
+    }
+
+    return AccessResult::allowed()
+      ->addCacheableDependency($event)
+      ->addCacheableDependency($vendor)
+      ->addCacheContexts(['user']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Attribute/EventStudioSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Attribute/EventStudioSection.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+
+/**
+ * Defines an Event Studio section plugin.
+ *
+ * Routes remain explicit YAML. This attribute describes operational metadata
+ * used by the Studio shell, navigation, readiness contracts, and governance.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class EventStudioSection extends Plugin {
+
+  public function __construct(
+    string $id,
+    public readonly string $title,
+    public readonly string $group,
+    public readonly string $routeName,
+    public readonly int $weight = 0,
+    public readonly string $icon = '',
+    public readonly string $routeFragment = '',
+    public readonly string $accessPolicy = 'event_update',
+    public readonly string $renderTarget = 'controller',
+    public readonly bool $readinessParticipant = FALSE,
+    public readonly string $operationalArea = 'event',
+    public readonly bool $deferred = FALSE,
+    ?string $deriver = NULL,
+  ) {
+    parent::__construct($id, $deriver);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAiController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAiController.php
@@ -67,7 +67,7 @@ final class EventStudioAiController implements ContainerInjectionInterface {
       'audience' => $audience,
     ], $uid, NULL);
 
-    \Drupal::logger('myeventlane_ai')->notice('AI result ok=@ok', [
+    $this->logger->notice('Event Studio AI result ok=@ok', [
       '@ok' => !empty($response['ok']) ? '1' : '0',
     ]);
 
@@ -121,7 +121,7 @@ final class EventStudioAiController implements ContainerInjectionInterface {
 
     $response = $this->aiGenerator->rewriteEventContentReliable($payload, $uid, NULL);
 
-    \Drupal::logger('myeventlane_ai')->notice('AI rewrite ok=@ok', [
+    $this->logger->notice('Event Studio AI rewrite ok=@ok', [
       '@ok' => !empty($response['ok']) ? '1' : '0',
     ]);
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -10,10 +10,11 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_vendor\Service\CurrentVendorResolver;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -31,10 +32,11 @@ final class EventStudioAutosaveController {
     private readonly AccountProxyInterface $currentUser,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly EventHighlightHelper $eventHighlightHelper,
-    private readonly PrivateTempStoreFactory $privateTempStoreFactory,
     private readonly LoggerInterface $logger,
     private readonly AccessManagerInterface $accessManager,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly CurrentVendorResolver $currentVendorResolver,
+    private readonly EventStudioAutosaveService $autosaveService,
   ) {}
 
   public function handle(Request $request): JsonResponse {
@@ -51,50 +53,40 @@ final class EventStudioAutosaveController {
     $params = $request->request->all();
 
     $storage = $this->entityTypeManager->getStorage('node');
-    $node = NULL;
-    if (!empty($params['nid'])) {
-      $loaded = $storage->load((int) $params['nid']);
-      if (!$loaded instanceof NodeInterface || $loaded->bundle() !== 'event') {
-        return new JsonResponse(['ok' => FALSE, 'message' => 'Not found'], 404);
-      }
-
-      if (!$account->hasPermission('administer nodes')) {
-        if (!$loaded->access('update', $account)) {
-          $this->logger->warning('Event Studio autosave denied: node update nid=@nid uid=@uid', [
-            '@nid' => (string) $loaded->id(),
-            '@uid' => (string) $account->id(),
-          ]);
-          throw new AccessDeniedHttpException();
-        }
-        if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($loaded, $account)) {
-          $this->logger->warning('Event Studio autosave denied: workspace parity nid=@nid uid=@uid', [
-            '@nid' => (string) $loaded->id(),
-            '@uid' => (string) $account->id(),
-          ]);
-          throw new AccessDeniedHttpException();
-        }
-      }
-      $node = $loaded;
-    }
-    else {
+    if (empty($params['nid'])) {
       if (!$this->accessManager->checkNamedRoute('myeventlane_event_studio.create', [], $account, TRUE)->isAllowed()) {
         $this->logger->warning('Event Studio autosave denied: create route access uid=@uid', [
           '@uid' => (string) $account->id(),
         ]);
         throw new AccessDeniedHttpException();
       }
+      return new JsonResponse([
+        'ok' => FALSE,
+        'errors' => ['Open the Event Studio draft before autosaving.'],
+      ], 422);
     }
 
+    $loaded = $storage->load((int) $params['nid']);
+    if (!$loaded instanceof NodeInterface || $loaded->bundle() !== 'event') {
+      return new JsonResponse(['ok' => FALSE, 'message' => 'Not found'], 404);
+    }
+    $this->assertCanAutosaveEvent($loaded);
+    $node = $loaded;
+
     $incoming_autosave_ts = $this->parseAutosaveTimestamp($params);
-    if ($node !== NULL && $incoming_autosave_ts !== NULL) {
-      $store = $this->privateTempStoreFactory->get('myeventlane_event_studio_autosave');
-      $stored_ts = $store->get('node.' . $node->id());
-      if ($stored_ts !== NULL && is_numeric($stored_ts) && $incoming_autosave_ts < (float) $stored_ts) {
-        return new JsonResponse([
-          'ok' => FALSE,
-          'latest_ts' => (float) $stored_ts,
-        ], 409);
-      }
+    if ($incoming_autosave_ts === NULL) {
+      $incoming_autosave_ts = (float) round(microtime(TRUE) * 1000);
+    }
+
+    $section = $this->normalizeSection($params['mel_studio_section'] ?? 'section');
+    $base_changed = $this->parsePositiveInt($params['mel_studio_changed'] ?? NULL);
+    $base_revision_id = $this->parsePositiveInt($params['mel_studio_revision'] ?? NULL);
+    if ($this->autosaveService->isStaleSubmission($node, $base_changed, $base_revision_id)) {
+      $this->autosaveService->clearDraft($node, $section);
+      return new JsonResponse([
+        'ok' => FALSE,
+        'message' => 'This section was updated elsewhere. Refresh to continue editing safely.',
+      ], 409);
     }
 
     $mel = $params['mel'] ?? [];
@@ -121,24 +113,49 @@ final class EventStudioAutosaveController {
       $event_highlights_items_state = is_array($eh) ? trim((string) ($eh['items_state'] ?? '')) : '';
     }
 
-    $payload = $this->payloadFromRequestParams($params, $decoded_event_highlights, $event_highlights_items_state);
-    $result = $this->saveService->save($payload, $node, $account, TRUE);
-    if ($result['errors'] !== []) {
-      return new JsonResponse(['ok' => FALSE, 'errors' => $result['errors']], 422);
+    if ($decoded_event_highlights !== NULL) {
+      $mel['event_highlights'] = [
+        'items_state' => $event_highlights_items_state ?? '',
+        'decoded' => $decoded_event_highlights,
+      ];
     }
-
-    $saved_node = $result['node'];
-    // Always key tempstore by the node returned from save() (nid exists after first create).
-    if ($saved_node !== NULL && $incoming_autosave_ts !== NULL) {
-      $store = $this->privateTempStoreFactory->get('myeventlane_event_studio_autosave');
-      $store->set('node.' . $saved_node->id(), (float) $incoming_autosave_ts);
-    }
+    $this->autosaveService->storeDraft($node, $section, $mel, $incoming_autosave_ts, $base_changed, $base_revision_id);
 
     return new JsonResponse([
       'ok' => TRUE,
-      'nid' => $saved_node?->id(),
-      'governance_urls' => $saved_node instanceof NodeInterface ? $this->buildGovernanceUrls($saved_node) : [],
+      'nid' => $node->id(),
+      'section' => $section,
+      'message' => 'Saved just now',
+      'restore_available' => TRUE,
+      'changed' => $node->getChangedTime(),
+      'revision_id' => (int) $node->getRevisionId(),
+      'governance_urls' => $this->buildGovernanceUrls($node),
     ]);
+  }
+
+  private function assertCanAutosaveEvent(NodeInterface $event): void {
+    $account = $this->currentUser;
+    if ($account->hasPermission('administer nodes')) {
+      return;
+    }
+
+    $vendor = $this->currentVendorResolver->resolveFromEvent($event)
+      ?? $this->currentVendorResolver->resolveFromUser($account);
+    if ($vendor === NULL) {
+      $this->logger->warning('Event Studio autosave denied: no vendor context nid=@nid uid=@uid', [
+        '@nid' => (string) $event->id(),
+        '@uid' => (string) $account->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+
+    if (!$event->access('update', $account) || !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      $this->logger->warning('Event Studio autosave denied: edit access nid=@nid uid=@uid', [
+        '@nid' => (string) $event->id(),
+        '@uid' => (string) $account->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
   }
 
   /**
@@ -184,6 +201,22 @@ final class EventStudioAutosaveController {
       return (float) $params['mel_autosave_ts'];
     }
     return NULL;
+  }
+
+  private function parsePositiveInt(mixed $value): int {
+    if (!is_numeric($value)) {
+      return 0;
+    }
+    $parsed = (int) $value;
+    return $parsed > 0 ? $parsed : 0;
+  }
+
+  private function normalizeSection(mixed $value): string {
+    $section = trim((string) $value);
+    if ($section === '') {
+      return 'section';
+    }
+    return preg_replace('/[^a-z0-9_:-]+/i', '_', $section) ?: 'section';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -5,9 +5,22 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
-use Drupal\myeventlane_event_studio\Form\EventStudioForm;
+use Drupal\myeventlane_event_studio\EventStudioSectionManager;
+use Drupal\myeventlane_event_studio\Form\EventBrandingForm;
+use Drupal\myeventlane_event_studio\Form\EventCheckoutQuestionsForm;
+use Drupal\myeventlane_event_studio\Form\EventContentForm;
+use Drupal\myeventlane_event_studio\Form\EventInformationForm;
+use Drupal\myeventlane_event_studio\Form\EventStudioOperationalTicketsForm;
+use Drupal\myeventlane_event_studio\Form\EventStudioTicketsForm;
+use Drupal\myeventlane_event_studio\Form\EventPromotionForm;
+use Drupal\myeventlane_event_studio\Form\EventSettingsForm;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
+use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService;
 use Drupal\node\NodeInterface;
@@ -29,6 +42,11 @@ final class EventStudioController extends ControllerBase {
     private readonly LoggerInterface $logger,
     private readonly RequestStack $requestStack,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly DateFormatterInterface $dateFormatter,
+    private readonly EventReadinessService $eventReadiness,
+    private readonly EventStudioAutosaveService $autosaveService,
+    private readonly EventStudioSectionManager $sectionManager,
+    private readonly EventStudioEmptyStateBuilder $emptyStateBuilder,
   ) {
     // ControllerBase / EntityTypeManagerTrait already declare protected $entityTypeManager.
     $this->entityTypeManager = $entity_type_manager;
@@ -41,6 +59,11 @@ final class EventStudioController extends ControllerBase {
       $container->get('logger.factory')->get('myeventlane_event_studio'),
       $container->get('request_stack'),
       $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('date.formatter'),
+      $container->get('myeventlane_event_studio.readiness'),
+      $container->get('myeventlane_event_studio.autosave'),
+      $container->get('plugin.manager.myeventlane_event_studio_section'),
+      $container->get('myeventlane_event_studio.empty_state_builder'),
     );
   }
 
@@ -63,27 +86,10 @@ final class EventStudioController extends ControllerBase {
       if ($request !== NULL && $request->query->count() > 0) {
         $url_options['query'] = $request->query->all();
       }
-      return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.edit', $route_params, $url_options)->toString());
+      return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace', $route_params, $url_options)->toString());
     }
 
-    try {
-      $storage = $this->entityTypeManager()->getStorage('node');
-      /** @var \Drupal\node\NodeInterface $node */
-      $node = $storage->create([
-        'type' => 'event',
-        'title' => $this->t('Untitled event'),
-        'uid' => $uid,
-        'status' => 0,
-      ]);
-      $node->save();
-    }
-    catch (\Throwable $e) {
-      $this->logger->error('Event Studio create: failed to persist draft event uid=@uid @message', [
-        '@uid' => (string) $uid,
-        '@message' => $e->getMessage(),
-      ]);
-      throw $e;
-    }
+    $node = $this->eventStudioCreate->createDraftEventForUser($uid);
 
     $new_id = (int) $node->id();
     $url_options = [];
@@ -95,10 +101,10 @@ final class EventStudioController extends ControllerBase {
       '@uid' => (string) $uid,
     ]);
 
-    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.edit', ['node' => $new_id], $url_options)->toString());
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $new_id], $url_options)->toString());
   }
 
-  public function buildEdit(NodeInterface $node): array {
+  public function buildEdit(NodeInterface $node): RedirectResponse {
     if ($node->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
@@ -111,13 +117,78 @@ final class EventStudioController extends ControllerBase {
       '@eid' => (string) $node->id(),
       '@uid' => (string) $this->currentUser()->id(),
     ]);
-    $form = $this->formBuilder()->getForm(EventStudioForm::class, $node);
-    $form['#theme_wrappers'] = [];
-    $form['#theme'] = 'mel_event_studio';
-    $form['#mel_studio_mode'] = 'edit';
-    $form['#attached']['library'] ??= [];
-    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio';
-    return $form;
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $node->id()])->toString());
+  }
+
+  public function redirectEventToTicketsWorkspace(NodeInterface $event): RedirectResponse {
+    if ($event->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event->id()])->toString());
+  }
+
+  /**
+   * Builds the canonical operational Event Studio shell.
+   *
+   * @return array<string, mixed>
+   */
+  public function workspace(NodeInterface $node, string $section = 'overview'): array {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    $account = $this->currentUser();
+    if (!$account->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+      throw new AccessDeniedHttpException();
+    }
+
+    if (!$this->sectionManager->hasSection($section)) {
+      throw new NotFoundHttpException();
+    }
+    if (!$this->sectionManager->sectionAccess($section, $node, $account)->isAllowed()) {
+      throw new AccessDeniedHttpException();
+    }
+
+    $this->logger->notice('Vendor Event Studio workspace: event_id=@eid section=@section uid=@uid', [
+      '@eid' => (string) $node->id(),
+      '@section' => $section,
+      '@uid' => (string) $account->id(),
+    ]);
+
+    $readiness = $this->eventReadiness->evaluate($node, $account);
+
+    return [
+      '#theme' => 'mel_event_studio_workspace',
+      '#node' => $node,
+      '#sections' => $this->sectionManager->buildNavigation($node, $account, $section),
+      '#current_section' => $section,
+      '#current_section_label' => $this->sectionManager->sectionTitle($section),
+      '#section_content' => $this->buildSectionContent($node, $section, $readiness),
+      '#topbar' => $this->buildTopbar($node, $readiness, $section),
+      '#readiness' => $this->buildReadinessSummary($readiness),
+      '#attached' => [
+        'library' => ['myeventlane_event_studio/mel_event_studio_shell_only'],
+        'drupalSettings' => [
+          'myeventlaneEventStudio' => [
+            'autosaveUrl' => Url::fromRoute('myeventlane_event_studio.autosave')->toString(),
+            'autosaveDelay' => 12000,
+            'currentSection' => $section,
+            'draftAvailable' => $this->autosaveService->hasDraft($node, $section),
+          ],
+        ],
+      ],
+      '#cache' => [
+        'tags' => $node->getCacheTags(),
+        'contexts' => ['route', 'user', 'user.permissions'],
+      ],
+    ];
+  }
+
+  public function workspaceTitle(NodeInterface $node): string {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    return (string) $this->t('@title Studio', ['@title' => $node->label()]);
   }
 
   public function editTitle(NodeInterface $node): string {
@@ -125,6 +196,177 @@ final class EventStudioController extends ControllerBase {
       throw new NotFoundHttpException();
     }
     return (string) $this->t('Edit event — @title', ['@title' => $node->getTitle()]);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildTopbar(NodeInterface $node, EventReadinessResult $readiness, string $section): array {
+    $state = $node->isPublished()
+      ? $this->t('Published')
+      : $this->operationalState($readiness);
+
+    return [
+      'title' => $node->label(),
+      'status' => $node->isPublished() ? $this->t('Published') : $this->t('Draft'),
+      'state' => $state,
+      'last_saved' => $node->getChangedTime() > 0 ? $this->t('Last saved @time', [
+        '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
+      ]) : $this->t('Not saved yet'),
+      'restore_draft' => $this->autosaveService->hasDraft($node, $section),
+      'restore_url' => Url::fromRoute($this->sectionManager->sectionRouteName($section), [
+        'node' => $node->id(),
+      ], [
+        'query' => ['restore_draft' => '1'],
+      ])->toString(),
+      'preview_url' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString(),
+      'publish_url' => Url::fromRoute('myeventlane_event_studio.workspace_settings', ['node' => $node->id()])->toString(),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildSectionContent(NodeInterface $node, string $section, EventReadinessResult $readiness): array {
+    return match ($section) {
+      'information' => $this->formBuilder()->getForm(EventInformationForm::class, $node),
+      'branding' => $this->formBuilder()->getForm(EventBrandingForm::class, $node),
+      'content' => $this->formBuilder()->getForm(EventContentForm::class, $node),
+      'tickets' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-studio-section__form-stack']],
+        'mode' => $this->formBuilder()->getForm(EventStudioTicketsForm::class, $node),
+        'operational' => $this->formBuilder()->getForm(EventStudioOperationalTicketsForm::class, $node),
+      ],
+      'questions' => $this->formBuilder()->getForm(EventCheckoutQuestionsForm::class, $node),
+      'promotions' => $this->formBuilder()->getForm(EventPromotionForm::class, $node),
+      'settings' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-studio-section__form-stack']],
+        'readiness' => $this->buildReadinessCard($readiness),
+        'settings' => $this->formBuilder()->getForm(EventSettingsForm::class, $node),
+      ],
+      'overview' => $this->buildOverviewSection($node, $readiness),
+      default => $this->buildDeferredSection($section),
+    };
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildOverviewSection(NodeInterface $node, EventReadinessResult $readiness): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-studio-section__placeholder']],
+      'summary' => [
+        '#markup' => '<p>' . $this->t('Use the sidebar to manage one operational area at a time. Event information, content, tickets, and publishing now load as independent Studio sections.') . '</p>',
+      ],
+      'actions' => [
+        '#theme' => 'item_list',
+        '#items' => [
+          $this->t('Review event information before publishing.'),
+          $this->t('Manage tickets through the existing MEL ticket lifecycle path.'),
+          $this->t('Use Settings to review readiness and publish without leaving Studio.'),
+        ],
+      ],
+      'readiness' => $this->buildReadinessCard($readiness),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildDeferredSection(string $section): array {
+    $label = $this->sectionManager->sectionTitle($section);
+    return $this->emptyStateBuilder->deferredSection($label);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildReadinessCard(EventReadinessResult $result): array {
+    $build = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-readiness-card', $result->ready ? 'is-ready' : 'needs-attention']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $result->ready ? $this->t('Ready to publish') : $this->t('Needs attention'),
+        '#attributes' => ['class' => ['mel-readiness-card__title']],
+      ],
+      'summary' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $result->ready
+          ? $this->t('No publish blockers detected. Review warnings before going live.')
+          : $this->t('Resolve the blocking items before publishing.'),
+        '#attributes' => ['class' => ['mel-readiness-card__summary']],
+      ],
+    ];
+
+    if ($result->errors !== []) {
+      $build['errors_title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h4',
+        '#value' => $this->t('Blocking errors'),
+        '#attributes' => ['class' => ['mel-readiness-card__heading']],
+      ];
+      $build['errors'] = [
+        '#theme' => 'item_list',
+        '#items' => $result->errors,
+        '#attributes' => ['class' => ['mel-readiness-card__list', 'mel-readiness-card__list--errors']],
+      ];
+    }
+
+    if ($result->warnings !== []) {
+      $build['warnings_title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h4',
+        '#value' => $this->t('Warnings'),
+        '#attributes' => ['class' => ['mel-readiness-card__heading']],
+      ];
+      $build['warnings'] = [
+        '#theme' => 'item_list',
+        '#items' => $result->warnings,
+        '#attributes' => ['class' => ['mel-readiness-card__list', 'mel-readiness-card__list--warnings']],
+      ];
+    }
+
+    if ($result->completed !== []) {
+      $build['completed_title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h4',
+        '#value' => $this->t('Complete'),
+        '#attributes' => ['class' => ['mel-readiness-card__heading']],
+      ];
+      $build['completed'] = [
+        '#theme' => 'item_list',
+        '#items' => $result->completed,
+        '#attributes' => ['class' => ['mel-readiness-card__list', 'mel-readiness-card__list--completed']],
+      ];
+    }
+
+    return $build;
+  }
+
+  /**
+   * @return array{ready: bool, errors: list<string>, warnings: list<string>, completed: list<string>, state: string}
+   */
+  private function buildReadinessSummary(EventReadinessResult $result): array {
+    return [
+      'ready' => $result->ready,
+      'errors' => $result->errors,
+      'warnings' => $result->warnings,
+      'completed' => $result->completed,
+      'state' => $this->operationalState($result),
+    ];
+  }
+
+  private function operationalState(EventReadinessResult $result): string {
+    if (!$result->ready) {
+      return (string) $this->t('Needs Attention');
+    }
+    return (string) $this->t('Ready');
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioTicketSuggestionsController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioTicketSuggestionsController.php
@@ -8,6 +8,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_event_studio\Service\EventStudioTicketLinkSuggestionService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,6 +25,7 @@ final class EventStudioTicketSuggestionsController implements ContainerInjection
       $container->get('myeventlane_event_studio.ticket_link_suggestion'),
       $container->get('entity_type.manager'),
       $container->get('current_user'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -31,6 +33,7 @@ final class EventStudioTicketSuggestionsController implements ContainerInjection
     private readonly EventStudioTicketLinkSuggestionService $suggestionService,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly AccountProxyInterface $currentUser,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
   ) {}
 
   public function suggest(Request $request): JsonResponse {
@@ -57,24 +60,24 @@ final class EventStudioTicketSuggestionsController implements ContainerInjection
     }
 
     $nid = isset($data['nid']) ? (int) $data['nid'] : 0;
-    $nidForService = NULL;
-    if ($nid > 0) {
-      $storage = $this->entityTypeManager->getStorage('node');
-      $loaded = $storage->load($nid);
-      if (!$loaded instanceof NodeInterface || $loaded->bundle() !== 'event') {
-        return new JsonResponse(['ok' => FALSE, 'error' => 'Not found'], 404);
-      }
-      if (!$loaded->access('update', $this->currentUser)) {
-        throw new AccessDeniedHttpException();
-      }
-      $nidForService = $nid;
+    if ($nid < 1) {
+      return new JsonResponse(['ok' => FALSE, 'error' => 'Event context is required.'], 400);
+    }
+    $storage = $this->entityTypeManager->getStorage('node');
+    $loaded = $storage->load($nid);
+    if (!$loaded instanceof NodeInterface || $loaded->bundle() !== 'event') {
+      return new JsonResponse(['ok' => FALSE, 'error' => 'Not found'], 404);
+    }
+    if (!$this->currentUser->hasPermission('administer nodes')
+      && (!$loaded->access('update', $this->currentUser) || !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($loaded, $this->currentUser))) {
+      throw new AccessDeniedHttpException();
     }
 
     $strings = $this->suggestionService->suggest(
       $this->currentUser,
       $eventTitle,
       $tierTitles,
-      $nidForService,
+      $nid,
     );
 
     return new JsonResponse([

--- a/web/modules/custom/myeventlane_event_studio/src/DTO/EventReadinessResult.php
+++ b/web/modules/custom/myeventlane_event_studio/src/DTO/EventReadinessResult.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\DTO;
+
+/**
+ * Publish readiness result for Event Studio.
+ */
+final class EventReadinessResult {
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   * @param list<string> $completed
+   */
+  public function __construct(
+    public readonly bool $ready,
+    public readonly array $errors,
+    public readonly array $warnings,
+    public readonly array $completed = [],
+  ) {}
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   * @param list<string> $completed
+   */
+  public static function create(array $errors = [], array $warnings = [], array $completed = []): self {
+    return new self($errors === [], $errors, $warnings, $completed);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioSectionManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioSectionManager.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Discovers and orders governed Event Studio section plugins.
+ */
+final class EventStudioSectionManager extends DefaultPluginManager {
+
+  /**
+   * Constructs the section plugin manager.
+   */
+  public function __construct(\Traversable $namespaces, ModuleHandlerInterface $module_handler, CacheBackendInterface $cache_backend) {
+    parent::__construct(
+      'Plugin/EventStudioSection',
+      $namespaces,
+      $module_handler,
+      EventStudioSectionInterface::class,
+      EventStudioSection::class,
+    );
+    $this->alterInfo('myeventlane_event_studio_section_info');
+    $this->setCacheBackend($cache_backend, 'myeventlane_event_studio_sections');
+  }
+
+  /**
+   * Returns a section plugin instance, or NULL when it is unknown.
+   */
+  public function section(string $section_id): ?EventStudioSectionInterface {
+    try {
+      $instance = $this->createInstance($section_id);
+    }
+    catch (PluginException) {
+      return NULL;
+    }
+    return $instance instanceof EventStudioSectionInterface ? $instance : NULL;
+  }
+
+  /**
+   * Returns TRUE when a section exists.
+   */
+  public function hasSection(string $section_id): bool {
+    return isset($this->getDefinitions()[$section_id]);
+  }
+
+  /**
+   * Returns active sections keyed by section id.
+   *
+   * @return array<string, \Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface>
+   */
+  public function activeSections(NodeInterface $event, AccountInterface $account): array {
+    $sections = [];
+    foreach (array_keys($this->getDefinitions()) as $section_id) {
+      $section = $this->section((string) $section_id);
+      if (!$section instanceof EventStudioSectionInterface) {
+        continue;
+      }
+      if (!$this->sectionAccess((string) $section_id, $event, $account)->isAllowed()) {
+        continue;
+      }
+      $sections[(string) $section_id] = $section;
+    }
+    uasort($sections, static function (EventStudioSectionInterface $a, EventStudioSectionInterface $b): int {
+      return [$a->groupWeight(), $a->weight(), $a->title()] <=> [$b->groupWeight(), $b->weight(), $b->title()];
+    });
+    return $sections;
+  }
+
+  /**
+   * Evaluates direct access to a section plugin.
+   */
+  public function sectionAccess(string $section_id, NodeInterface $event, AccountInterface $account): AccessResultInterface {
+    $section = $this->section($section_id);
+    if (!$section instanceof EventStudioSectionInterface) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['route']);
+    }
+
+    return $section->access($event, $account);
+  }
+
+  /**
+   * Builds grouped sidebar links for active sections.
+   *
+   * @return array<string, array<int, array<string, mixed>>>
+   */
+  public function buildNavigation(NodeInterface $event, AccountInterface $account, string $current_section): array {
+    $groups = [];
+    foreach ($this->activeSections($event, $account) as $section_id => $section) {
+      $group = $section->group();
+      $groups[$group] ??= [];
+      $groups[$group][] = [
+        'id' => $section_id,
+        'label' => $section->title(),
+        'icon' => $section->icon(),
+        'route_fragment' => $section->routeFragment(),
+        'operational_area' => $section->operationalArea(),
+        'deferred' => $section->isDeferred(),
+        'url' => Url::fromRoute($section->routeName(), ['node' => $event->id()])->toString(),
+        'active' => $section_id === $current_section,
+      ];
+    }
+    return $groups;
+  }
+
+  /**
+   * Returns a section title, or a generic label when unavailable.
+   */
+  public function sectionTitle(string $section_id): string {
+    return $this->section($section_id)?->title() ?? 'Section';
+  }
+
+  /**
+   * Returns a section route, falling back to the overview route.
+   */
+  public function sectionRouteName(string $section_id): string {
+    return $this->section($section_id)?->routeName() ?? 'myeventlane_event_studio.workspace';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -13,7 +13,10 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -48,6 +51,53 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     'myeventlane_event_studio.edit_publish',
   ];
 
+  /**
+   * Remaining vendor operational edit surfaces that now terminate in Studio.
+   *
+   * @var list<string>
+   */
+  private const VENDOR_LEGACY_OPERATION_ROUTES = [
+    'myeventlane_vendor.manage_event.edit',
+    'myeventlane_vendor.manage_event.design',
+    'myeventlane_vendor.manage_event.content',
+    'myeventlane_vendor.manage_event.tickets',
+    'myeventlane_vendor.manage_event.checkout_questions',
+    'myeventlane_vendor.manage_event.series',
+    'myeventlane_vendor.manage_event.promote',
+    'myeventlane_vendor.manage_event.payments',
+    'myeventlane_vendor.manage_event.comms',
+    'myeventlane_vendor.manage_event.advanced',
+    'myeventlane_vendor.console.event_workspace',
+    'myeventlane_vendor.console.event_overview',
+    'myeventlane_vendor.console.event_editor',
+    'myeventlane_vendor.console.event_orders',
+    'myeventlane_vendor.console.event_order_view',
+    'myeventlane_vendor.console.event_tickets',
+    'myeventlane_vendor.console.event_rsvps',
+    'myeventlane_vendor.console.event_analytics',
+    'myeventlane_vendor.console.event_settings',
+    'myeventlane_vendor.console.event_unpublish',
+    'myeventlane_vendor.console.event_promotion',
+    'myeventlane_vendor.console.event_publish',
+    'myeventlane_vendor_comms.branding',
+    'myeventlane_event_attendees.vendor_list',
+    'myeventlane_event_attendees.legacy_vendor_event_attendees_path',
+    'myeventlane_event_attendees.waitlist_manage',
+    'myeventlane_tickets.event_tickets_types',
+    'entity.mel_event_ticket_settings.edit_form',
+    'myeventlane_tickets.event_tickets_settings',
+    'myeventlane_tickets.event_tickets_groups',
+    'myeventlane_tickets.event_tickets_groups_add',
+    'myeventlane_tickets.event_tickets_groups_edit',
+    'myeventlane_tickets.event_tickets_access_codes',
+    'myeventlane_tickets.event_tickets_access_codes_add',
+    'myeventlane_tickets.event_tickets_access_codes_edit',
+    'myeventlane_tickets.event_tickets_widgets',
+    'myeventlane_tickets.event_tickets_widgets_add',
+    'myeventlane_tickets.event_tickets_widgets_edit',
+    'myeventlane_tickets.event_ticket_type_edit',
+  ];
+
   public function __construct(
     private readonly AccountProxyInterface $currentUser,
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -55,7 +105,11 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
   ) {}
 
   public static function getSubscribedEvents(): array {
-    return [KernelEvents::REQUEST => ['onKernelRequest', 40]];
+    return [
+      KernelEvents::REQUEST => ['onKernelRequest', 31],
+      KernelEvents::EXCEPTION => ['onKernelException', 0],
+      KernelEvents::RESPONSE => ['onKernelResponse', 0],
+    ];
   }
 
   public function onKernelRequest(RequestEvent $event): void {
@@ -67,36 +121,133 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
       return;
     }
-    $route = (string) ($request->attributes->get('_route') ?? '');
-    $redirect_routes = array_merge(self::WIZARD_STEP_ROUTES, self::STUDIO_LEGACY_STEP_ROUTES);
-    if (!in_array($route, $redirect_routes, TRUE)) {
+    $response = $this->redirectResponseForLegacyRequest($request);
+    if ($response instanceof RedirectResponse) {
+      $event->setResponse($response);
+    }
+  }
+
+  public function onKernelException(ExceptionEvent $event): void {
+    if (!$event->isMainRequest() || !$event->getThrowable() instanceof AccessDeniedHttpException) {
       return;
+    }
+
+    $request = $event->getRequest();
+    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
+      return;
+    }
+    $response = $this->redirectResponseForLegacyRequest($request);
+    if ($response instanceof RedirectResponse) {
+      $event->setResponse($response);
+    }
+  }
+
+  public function onKernelResponse(ResponseEvent $event): void {
+    if (!$event->isMainRequest() || $event->getResponse()->getStatusCode() !== 403) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
+      return;
+    }
+    $response = $this->redirectResponseForLegacyRequest($request);
+    if ($response instanceof RedirectResponse) {
+      $event->setResponse($response);
+    }
+  }
+
+  private function redirectResponseForLegacyRequest(Request $request): ?RedirectResponse {
+    $route = (string) ($request->attributes->get('_route') ?? '');
+    $redirect_routes = array_merge(self::WIZARD_STEP_ROUTES, self::STUDIO_LEGACY_STEP_ROUTES, self::VENDOR_LEGACY_OPERATION_ROUTES);
+    if (!in_array($route, $redirect_routes, TRUE)) {
+      return NULL;
     }
 
     if ($this->currentUser->hasPermission('administer nodes')) {
-      return;
+      return NULL;
     }
     if ((int) $this->currentUser->id() === 1) {
-      return;
+      return NULL;
     }
 
     if ($this->currentUser->isAnonymous()) {
-      return;
+      return NULL;
     }
 
     $node = $this->resolveEventNode($request);
     if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
-      return;
+      return NULL;
     }
 
-    $url = Url::fromRoute('myeventlane_event_studio.edit', ['node' => $node->id()])->toString();
-    $this->logger->notice('Vendor legacy wizard redirect: from_route=@from to_route=myeventlane_event_studio.edit event_id=@eid studio_selected=1 uid=@uid', [
+    $to_route = $this->sectionRouteForLegacyRoute($route);
+    $url = Url::fromRoute($to_route, ['node' => $node->id()])->toString();
+    $this->logger->notice('Vendor legacy wizard redirect: from_route=@from to_route=@to event_id=@eid studio_selected=1 uid=@uid', [
       '@from' => $route,
+      '@to' => $to_route,
       '@eid' => (string) $node->id(),
       '@uid' => (string) $this->currentUser->id(),
     ]);
 
-    $event->setResponse(new RedirectResponse($url, 302));
+    return new RedirectResponse($url, 302);
+  }
+
+  private function sectionRouteForLegacyRoute(string $route): string {
+    return match ($route) {
+      'myeventlane_event.wizard.basics',
+      'myeventlane_event.wizard.when_where',
+      'myeventlane_event_studio.edit_basic',
+      'myeventlane_event_studio.edit_datetime' => 'myeventlane_event_studio.workspace_information',
+      'myeventlane_vendor.console.event_workspace',
+      'myeventlane_vendor.console.event_overview' => 'myeventlane_event_studio.workspace',
+      'myeventlane_event.wizard.tickets',
+      'myeventlane_event_studio.edit_tickets',
+      'myeventlane_vendor.manage_event.tickets',
+      'myeventlane_vendor.console.event_tickets',
+      'myeventlane_tickets.event_tickets_types',
+      'entity.mel_event_ticket_settings.edit_form',
+      'myeventlane_tickets.event_tickets_settings',
+      'myeventlane_tickets.event_tickets_groups',
+      'myeventlane_tickets.event_tickets_groups_add',
+      'myeventlane_tickets.event_tickets_groups_edit',
+      'myeventlane_tickets.event_tickets_access_codes',
+      'myeventlane_tickets.event_tickets_access_codes_add',
+      'myeventlane_tickets.event_tickets_access_codes_edit',
+      'myeventlane_tickets.event_tickets_widgets',
+      'myeventlane_tickets.event_tickets_widgets_add',
+      'myeventlane_tickets.event_tickets_widgets_edit',
+      'myeventlane_tickets.event_ticket_type_edit' => 'myeventlane_event_studio.workspace_tickets',
+      'myeventlane_event.wizard.details',
+      'myeventlane_event.wizard.review',
+      'myeventlane_event_studio.edit_description',
+      'myeventlane_event_studio.edit_preview',
+      'myeventlane_vendor.manage_event.content' => 'myeventlane_event_studio.workspace_content',
+      'myeventlane_vendor.manage_event.edit',
+      'myeventlane_vendor.console.event_editor' => 'myeventlane_event_studio.workspace_information',
+      'myeventlane_vendor.manage_event.design',
+      'myeventlane_vendor_comms.branding' => 'myeventlane_event_studio.workspace_branding',
+      'myeventlane_vendor.manage_event.checkout_questions' => 'myeventlane_event_studio.workspace_questions',
+      'myeventlane_vendor.manage_event.series',
+      'myeventlane_event_attendees.vendor_list',
+      'myeventlane_event_attendees.legacy_vendor_event_attendees_path',
+      'myeventlane_event_attendees.waitlist_manage',
+      'myeventlane_vendor.console.event_rsvps' => 'myeventlane_event_studio.workspace_attendees',
+      'myeventlane_vendor.manage_event.promote',
+      'myeventlane_vendor.console.event_promotion' => 'myeventlane_event_studio.workspace_promotions',
+      'myeventlane_vendor.console.event_orders',
+      'myeventlane_vendor.console.event_order_view' => 'myeventlane_event_studio.workspace_orders',
+      'myeventlane_vendor.console.event_analytics' => 'myeventlane_event_studio.workspace_analytics',
+      'myeventlane_event.wizard.publish',
+      'myeventlane_event.wizard.success',
+      'myeventlane_event_studio.edit_publish',
+      'myeventlane_vendor.manage_event.payments',
+      'myeventlane_vendor.manage_event.comms',
+      'myeventlane_vendor.manage_event.advanced',
+      'myeventlane_vendor.console.event_settings',
+      'myeventlane_vendor.console.event_unpublish',
+      'myeventlane_vendor.console.event_publish' => 'myeventlane_event_studio.workspace_settings',
+      default => 'myeventlane_event_studio.workspace',
+    };
   }
 
   /**
@@ -113,6 +264,12 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
         if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
           return $loaded;
         }
+      }
+    }
+    if (preg_match('#^/vendor/events?/(\d+)(?:/|$)#', $request->getPathInfo(), $matches) === 1) {
+      $loaded = $this->entityTypeManager->getStorage('node')->load((int) $matches[1]);
+      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+        return $loaded;
       }
     }
     return NULL;

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorMelTicketTypeEditRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorMelTicketTypeEditRedirectSubscriber.php
@@ -73,7 +73,7 @@ final class VendorMelTicketTypeEditRedirectSubscriber implements EventSubscriber
       throw new AccessDeniedHttpException('Edit ticket types in Event Studio.');
     }
 
-    $url = Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event_nid])->toString();
+    $url = Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event_nid])->toString();
     $this->logger->notice('Vendor mel_ticket_type edit redirect: tid=@tid event_id=@eid uid=@uid', [
       '@tid' => (string) $ticket->id(),
       '@eid' => (string) $event_nid,

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for event branding.
+ */
+final class EventBrandingForm extends EventStudioBaseForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_branding_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_branding';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'branding';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save branding');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Branding saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_branding', ['node' => $saved->id()]);
+  }
+
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['mel']['field_event_image'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('Hero image'),
+      '#upload_location' => 'public://events',
+      '#upload_validators' => [
+        'FileExtension' => ['extensions' => 'png gif jpg jpeg webp'],
+        'FileSizeLimit' => ['fileLimit' => 5 * 1024 * 1024],
+      ],
+      '#default_value' => $melDefaults['field_event_image'] ?? [],
+      '#attributes' => ['class' => ['mel-input-file']],
+    ];
+
+    $form['mel']['field_event_image_alt'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Image alt text'),
+      '#default_value' => $melDefaults['field_event_image_alt'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['unavailable'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-studio-section__placeholder']],
+      'copy' => [
+        '#markup' => '<p>' . $this->t('Additional branding controls will appear here when their event fields are configured. No parallel branding storage is created.') . '</p>',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for checkout question settings.
+ */
+final class EventCheckoutQuestionsForm extends EventStudioBaseForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_checkout_questions_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_questions';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'questions';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save checkout questions');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Checkout question settings saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_questions', ['node' => $saved->id()]);
+  }
+
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['mel']['collect_attendee_questions'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Collect extra attendee details'),
+      '#description' => $this->t('Gather information per guest beyond name and email. Detailed question-library editing remains service-backed and will not use nested entity widgets here.'),
+      '#default_value' => !empty($melDefaults['collect_attendee_questions']),
+      '#mel_option_card' => TRUE,
+    ];
+
+    $form['mel']['attendee_questions_editor'] = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+      'items_state' => [
+        '#type' => 'hidden',
+        '#default_value' => is_string(($melDefaults['attendee_questions_editor']['items_state'] ?? NULL))
+          ? $melDefaults['attendee_questions_editor']['items_state']
+          : '[]',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventContentForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventContentForm.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for public event content.
+ */
+final class EventContentForm extends EventStudioDescriptionForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_content_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_content';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'content';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save content');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Content saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_content', ['node' => $saved->id()]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for event information.
+ */
+final class EventInformationForm extends EventStudioBaseForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_information_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_information';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'information';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save information');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Event information saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_information', ['node' => $saved->id()]);
+  }
+
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['mel']['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Event title'),
+      '#default_value' => $melDefaults['title'] ?? $node->label(),
+      '#required' => TRUE,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['summary'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Summary'),
+      '#default_value' => $melDefaults['summary'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['start_date'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('Start'),
+      '#default_value' => $melDefaults['start_date'] ?? NULL,
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['end_date'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('End'),
+      '#default_value' => $melDefaults['end_date'] ?? NULL,
+      '#date_increment' => 15,
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['field_category'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Categories'),
+      '#target_type' => 'taxonomy_term',
+      '#tags' => TRUE,
+      '#selection_handler' => 'default',
+      '#selection_settings' => [
+        'target_bundles' => ['categories' => 'categories'],
+      ],
+      '#default_value' => $melDefaults['field_category'] ?? [],
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
+    $form['mel']['venue_mode'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Location'),
+      '#options' => [
+        'saved' => $this->t('Use saved venue'),
+        'create' => $this->t('Create new venue'),
+        'one_off' => $this->t('One-off address'),
+      ],
+      '#default_value' => $melDefaults['venue_mode'] ?? 'one_off',
+    ];
+
+    $form['mel']['venue_saved'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Search your venues'),
+      '#target_type' => 'myeventlane_venue',
+      '#default_value' => $melDefaults['venue_saved'] ?? NULL,
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'saved'],
+        ],
+      ],
+    ];
+
+    $form['mel']['venue_create_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Venue name'),
+      '#default_value' => $melDefaults['venue_create_name'] ?? '',
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'create'],
+        ],
+      ],
+    ];
+
+    $form['mel']['location_search'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search address'),
+      '#attributes' => [
+        'class' => ['mel-location-search', 'mel-input'],
+        'data-mel-location' => 'true',
+      ],
+      '#states' => [
+        'visible' => [
+          'or' => [
+            [':input[name="mel[venue_mode]"]' => ['value' => 'one_off']],
+            [':input[name="mel[venue_mode]"]' => ['value' => 'create']],
+          ],
+        ],
+      ],
+    ];
+
+    $form['mel']['field_location'] = [
+      '#type' => 'hidden',
+      '#default_value' => is_string($melDefaults['field_location'] ?? NULL) ? $melDefaults['field_location'] : '',
+    ];
+
+    $form['mel']['field_location_latitude'] = [
+      '#type' => 'hidden',
+      '#default_value' => $melDefaults['field_location_latitude'] ?? '',
+    ];
+
+    $form['mel']['field_location_longitude'] = [
+      '#type' => 'hidden',
+      '#default_value' => $melDefaults['field_location_longitude'] ?? '',
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventPromotionForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventPromotionForm.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for promotion section convergence.
+ */
+final class EventPromotionForm extends EventStudioBaseForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_promotion_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_promotions';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'promotions';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save promotions');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Promotion settings saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_promotions', ['node' => $saved->id()]);
+  }
+
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['notice'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-studio-section__placeholder']],
+      'copy' => [
+        '#markup' => '<p>' . $this->t('Promotion tools now live inside Event Studio. Existing communications services remain the source of truth; this section intentionally does not create a parallel promotion system.') . '</p>',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Isolated Event Studio form for publish/settings controls.
+ */
+final class EventSettingsForm extends EventStudioPublishForm {
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_settings_form';
+  }
+
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_settings';
+  }
+
+  protected function getPreviousRouteName(): ?string {
+    return NULL;
+  }
+
+  protected function getCurrentStepId(): string {
+    return 'settings';
+  }
+
+  protected function getContinueButtonLabel() {
+    return $this->t('Save settings');
+  }
+
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($saved->isPublished() ? $this->t('Event settings saved.') : $this->t('Event saved as draft.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_settings', ['node' => $saved->id()]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
@@ -10,14 +10,17 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Shared route-based Event Studio wizard (save + redirect per step).
@@ -31,8 +34,13 @@ abstract class EventStudioBaseForm extends FormBase {
     protected EventStudioSaveService $saveService,
     protected EventStudioMelPayloadService $melPayloadService,
     protected EventStudioWizardMelBaseline $wizardMelBaseline,
+    protected EventVendorAccessChecker $eventVendorAccessChecker,
+    protected EventStudioAutosaveService $autosaveService,
+    RequestStack $request_stack,
     protected LoggerInterface $logger,
-  ) {}
+  ) {
+    $this->requestStack = $request_stack;
+  }
 
   /**
    * {@inheritdoc}
@@ -45,6 +53,9 @@ abstract class EventStudioBaseForm extends FormBase {
       $container->get('myeventlane_event_studio.save'),
       $container->get('myeventlane_event_studio.mel_payload'),
       $container->get('myeventlane_event_studio.wizard_mel_baseline'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('myeventlane_event_studio.autosave'),
+      $container->get('request_stack'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
   }
@@ -79,7 +90,8 @@ abstract class EventStudioBaseForm extends FormBase {
     if ($node->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
-    if ((int) $node->getOwnerId() !== (int) $this->currentUser->id() && !$this->currentUser->hasPermission('administer nodes')) {
+    if (!$this->currentUser->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $this->currentUser)) {
       throw new AccessDeniedHttpException();
     }
   }
@@ -176,11 +188,24 @@ abstract class EventStudioBaseForm extends FormBase {
     $form['#attributes']['class'][] = 'mel-event-studio-wizard-form';
     $form['#attributes']['data-mel-event-studio-wizard'] = '1';
     $form['#attributes']['data-mel-event-studio-form'] = '1';
+    $form['#attributes']['data-mel-event-studio-section'] = $this->getCurrentStepId();
     $form['#tree'] = TRUE;
 
     $form['nid'] = [
       '#type' => 'hidden',
       '#default_value' => (string) (int) $node->id(),
+    ];
+    $form['mel_studio_section'] = [
+      '#type' => 'hidden',
+      '#default_value' => $this->getCurrentStepId(),
+    ];
+    $form['mel_studio_changed'] = [
+      '#type' => 'hidden',
+      '#default_value' => (string) $node->getChangedTime(),
+    ];
+    $form['mel_studio_revision'] = [
+      '#type' => 'hidden',
+      '#default_value' => (string) (int) $node->getRevisionId(),
     ];
 
     $form['wizard_nav'] = [
@@ -190,6 +215,15 @@ abstract class EventStudioBaseForm extends FormBase {
     ];
 
     $melDefaults = $this->wizardMelBaseline->getBaselineMel($node);
+    $draft = $this->autosaveService->getDraft($node, $this->getCurrentStepId());
+    $request = $this->requestStack->getCurrentRequest();
+    if ($draft !== NULL && $request !== NULL && $request->query->getBoolean('restore_draft')) {
+      $draftMel = $draft['mel'] ?? [];
+      if (is_array($draftMel)) {
+        $melDefaults = $this->mergeMel($melDefaults, $draftMel);
+        $this->messenger()->addStatus($this->t('Restored your autosaved draft for this section. Save when you are ready to keep it.'));
+      }
+    }
 
     $form['mel'] = [
       '#type' => 'container',
@@ -271,6 +305,26 @@ abstract class EventStudioBaseForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {}
 
   /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid < 1) {
+      return;
+    }
+    $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
+    if (!$loaded instanceof NodeInterface || $loaded->bundle() !== 'event') {
+      return;
+    }
+
+    $baseChanged = (int) ($form_state->getValue('mel_studio_changed') ?? 0);
+    $baseRevisionId = (int) ($form_state->getValue('mel_studio_revision') ?? 0);
+    if ($this->autosaveService->isStaleSubmission($loaded, $baseChanged, $baseRevisionId)) {
+      $form_state->setErrorByName('', $this->t('This section was updated elsewhere. Refresh to continue editing safely.'));
+    }
+  }
+
+  /**
    * Saves merged mel via EventStudioSaveService and redirects to the next route.
    */
   public function submitContinue(array &$form, FormStateInterface $form_state): void {
@@ -291,6 +345,7 @@ abstract class EventStudioBaseForm extends FormBase {
       return;
     }
 
+    $this->autosaveService->clearDraft($saved, $this->getCurrentStepId());
     $this->onWizardStepSaveSuccess($saved, $form_state);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBasicForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBasicForm.php
@@ -23,7 +23,7 @@ final class EventStudioBasicForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.edit_datetime';
+    return 'myeventlane_event_studio.workspace_information';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDateForm.php
@@ -39,14 +39,14 @@ final class EventStudioDateForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.edit_tickets';
+    return 'myeventlane_event_studio.workspace_tickets';
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getPreviousRouteName(): ?string {
-    return 'myeventlane_event_studio.edit_basic';
+    return 'myeventlane_event_studio.workspace_information';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
@@ -10,7 +10,7 @@ use Drupal\node\NodeInterface;
 /**
  * Wizard step: description, discovery, and policies.
  */
-final class EventStudioDescriptionForm extends EventStudioBaseForm {
+class EventStudioDescriptionForm extends EventStudioBaseForm {
 
   /**
    * {@inheritdoc}
@@ -23,14 +23,14 @@ final class EventStudioDescriptionForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.edit_preview';
+    return 'myeventlane_event_studio.workspace_settings';
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getPreviousRouteName(): ?string {
-    return 'myeventlane_event_studio.edit_tickets';
+    return 'myeventlane_event_studio.workspace_tickets';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Operational Event Studio ticket table backed by mel_ticket_type entities.
+ */
+final class EventStudioOperationalTicketsForm extends FormBase {
+
+  private EntityTypeManagerInterface $studioEntityTypeManager;
+
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly TicketTierLifecycleService $ticketTierLifecycle,
+    private readonly EventStudioAutosaveService $autosaveService,
+    private readonly LoggerInterface $logger,
+  ) {
+    $this->studioEntityTypeManager = $entity_type_manager;
+  }
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('myeventlane_event.ticket_tier_lifecycle'),
+      $container->get('myeventlane_event_studio.autosave'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_operational_tickets';
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    $event = $this->getRouteEvent($node);
+    $this->assertCanManageEvent($event);
+
+    $form['#tree'] = TRUE;
+    $form['#attributes']['class'][] = 'mel-event-studio-operational-tickets';
+    $form['event_id'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->id(),
+    ];
+    $form['mel_studio_changed'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->getChangedTime(),
+    ];
+    $form['mel_studio_revision'] = [
+      '#type' => 'hidden',
+      '#value' => (string) (int) $event->getRevisionId(),
+    ];
+
+    $form['intro'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-studio-ticket-intro']],
+      'copy' => [
+        '#markup' => '<p>' . $this->t('Manage ticket rows independently. Saves here update MEL ticket types and let the existing lifecycle service sync Commerce projections.') . '</p>',
+      ],
+    ];
+
+    $form['tickets'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Ticket Name'),
+        $this->t('Price'),
+        $this->t('Capacity'),
+        $this->t('Sales Window'),
+        $this->t('Visibility'),
+        $this->t('Status'),
+        $this->t('Actions'),
+      ],
+      '#empty' => $this->t('No tickets yet. Add a row below and save tickets.'),
+      '#attributes' => ['class' => ['mel-event-studio-ticket-table']],
+    ];
+
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
+      $ticket_id = (int) $ticket->id();
+      $form['tickets'][$ticket_id] = $this->buildExistingTicketRow($ticket);
+    }
+
+    $form['new_ticket'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Add ticket'),
+      '#open' => TRUE,
+      '#attributes' => ['class' => ['mel-event-studio-ticket-add']],
+      'ticket_kind' => [
+        '#type' => 'select',
+        '#title' => $this->t('Type'),
+        '#options' => [
+          'paid' => $this->t('Paid'),
+          'rsvp' => $this->t('RSVP'),
+          'external' => $this->t('External'),
+        ],
+        '#default_value' => 'paid',
+      ],
+      'title' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Ticket name'),
+        '#maxlength' => 255,
+      ],
+      'price_amount' => [
+        '#type' => 'number',
+        '#title' => $this->t('Price'),
+        '#min' => 0,
+        '#step' => 0.01,
+        '#states' => [
+          'visible' => [
+            ':input[name="new_ticket[ticket_kind]"]' => ['value' => 'paid'],
+          ],
+        ],
+      ],
+      'capacity' => [
+        '#type' => 'number',
+        '#title' => $this->t('Capacity'),
+        '#min' => 1,
+        '#step' => 1,
+        '#description' => $this->t('Leave empty for unlimited.'),
+      ],
+      'external_uri' => [
+        '#type' => 'url',
+        '#title' => $this->t('External URL'),
+        '#states' => [
+          'visible' => [
+            ':input[name="new_ticket[ticket_kind]"]' => ['value' => 'external'],
+          ],
+        ],
+      ],
+      'visibility_mode' => [
+        '#type' => 'select',
+        '#title' => $this->t('Visibility'),
+        '#options' => $this->visibilityOptions(),
+        '#default_value' => 'public',
+      ],
+      'status' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Active'),
+        '#default_value' => TRUE,
+      ],
+      'field_is_best_value' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Best value'),
+        '#description' => $this->t('Use when there is more than one paid or RSVP ticket.'),
+      ],
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Save tickets'),
+        '#button_type' => 'primary',
+      ],
+    ];
+
+    return $form;
+  }
+
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $form_state->setErrorByName('', $this->t('The event could not be loaded.'));
+      return;
+    }
+    $baseChanged = (int) ($form_state->getValue('mel_studio_changed') ?? 0);
+    $baseRevisionId = (int) ($form_state->getValue('mel_studio_revision') ?? 0);
+    if ($this->autosaveService->isStaleSubmission($event, $baseChanged, $baseRevisionId)) {
+      $form_state->setErrorByName('', $this->t('This section was updated elsewhere. Refresh to continue editing safely.'));
+      return;
+    }
+
+    foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
+      if (!empty($row['archive'])) {
+        continue;
+      }
+      $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser());
+      if (!$ticket instanceof TicketTypeInterface) {
+        $form_state->setErrorByName('tickets][' . $ticket_id, $this->t('Ticket data could not be matched to this event. Reload and try again.'));
+        continue;
+      }
+      try {
+        $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser(), $row);
+      }
+      catch (\InvalidArgumentException $e) {
+        $form_state->setErrorByName('tickets][' . $ticket_id, $e->getMessage());
+      }
+    }
+
+    $new = $form_state->getValue('new_ticket');
+    if (is_array($new) && trim((string) ($new['title'] ?? '')) !== '') {
+      try {
+        $this->ticketTierLifecycle->buildTicketValuesFromInput($event, $this->currentUser(), $new);
+      }
+      catch (\InvalidArgumentException $e) {
+        $form_state->setErrorByName('new_ticket', $e->getMessage());
+      }
+    }
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $this->messenger()->addError($this->t('The event could not be loaded.'));
+      return;
+    }
+    $this->assertCanManageEvent($event);
+
+    try {
+      foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
+        $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser());
+        if (!$ticket instanceof TicketTypeInterface) {
+          continue;
+        }
+        if (!empty($row['archive'])) {
+          $this->ticketTierLifecycle->archiveTicketOnEvent($event, $ticket);
+          continue;
+        }
+        $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser(), $row);
+        $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
+      }
+
+      $new = $form_state->getValue('new_ticket');
+      if (is_array($new) && trim((string) ($new['title'] ?? '')) !== '') {
+        $values = $this->ticketTierLifecycle->buildTicketValuesFromInput($event, $this->currentUser(), $new);
+        $this->ticketTierLifecycle->createAttachAndSync($event, $values);
+      }
+
+      $this->ticketTierLifecycle->reconcileEventTicketReferences($event);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio operational ticket save failed for event @nid: @message', [
+        '@nid' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('Tickets could not be saved. Check the rows and try again.'));
+      return;
+    }
+
+    $this->messenger()->addStatus($this->t('Tickets saved and synced.'));
+    $form_state->setRebuild(TRUE);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildExistingTicketRow(TicketTypeInterface $ticket): array {
+    $kind = $ticket->getTicketKind();
+    $price = $ticket->toPriceValue();
+    $status = $ticket->isPublished() ? $this->t('Active') : $this->t('Inactive');
+    if ($ticket->isArchived()) {
+      $status = $this->t('Archived');
+    }
+
+    return [
+      'title' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Ticket Name'),
+        '#title_display' => 'invisible',
+        '#default_value' => $ticket->getTitle(),
+        '#maxlength' => 255,
+      ],
+      'price_amount' => [
+        '#type' => 'number',
+        '#title' => $this->t('Price'),
+        '#title_display' => 'invisible',
+        '#min' => 0,
+        '#step' => 0.01,
+        '#default_value' => $price?->getNumber() ?? '',
+        '#disabled' => $kind !== 'paid',
+      ],
+      'capacity' => [
+        '#type' => 'number',
+        '#title' => $this->t('Capacity'),
+        '#title_display' => 'invisible',
+        '#min' => 1,
+        '#step' => 1,
+        '#default_value' => $ticket->get('capacity')->isEmpty() ? '' : (string) $ticket->get('capacity')->value,
+      ],
+      'sales_window' => [
+        'sale_start' => [
+          '#type' => 'datetime',
+          '#title' => $this->t('Sales start'),
+          '#default_value' => $this->dateFieldDefault($ticket, 'sale_start'),
+        ],
+        'sale_end' => [
+          '#type' => 'datetime',
+          '#title' => $this->t('Sales end'),
+          '#default_value' => $this->dateFieldDefault($ticket, 'sale_end'),
+        ],
+      ],
+      'visibility_mode' => [
+        '#type' => 'select',
+        '#title' => $this->t('Visibility'),
+        '#title_display' => 'invisible',
+        '#options' => $this->visibilityOptions(),
+        '#default_value' => $ticket->hasField('visibility_mode') && !$ticket->get('visibility_mode')->isEmpty()
+          ? (string) $ticket->get('visibility_mode')->value
+          : 'public',
+      ],
+      'status' => [
+        '#type' => 'container',
+        'published' => [
+          '#type' => 'checkbox',
+          '#title' => $status,
+          '#default_value' => $ticket->isPublished(),
+          '#disabled' => $ticket->isArchived(),
+        ],
+        'best_value' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Best value'),
+          '#default_value' => $ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket(),
+          '#disabled' => $ticket->isArchived() || !$ticket->hasField('field_is_best_value'),
+        ],
+      ],
+      'actions' => [
+        'ticket_kind' => [
+          '#type' => 'hidden',
+          '#value' => $kind,
+        ],
+        'archive' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Archive'),
+          '#disabled' => $ticket->isArchived(),
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<int, array<string, mixed>>
+   */
+  private function submittedExistingTicketRows(FormStateInterface $form_state): array {
+    $rows = $form_state->getValue('tickets') ?? [];
+    if (!is_array($rows)) {
+      return [];
+    }
+    $out = [];
+    foreach ($rows as $ticket_id => $row) {
+      if (!is_array($row) || !is_numeric($ticket_id)) {
+        continue;
+      }
+      $row['id'] = (int) $ticket_id;
+      $row['price_amount'] = $row['price_amount'] ?? '';
+      $row['status'] = !empty($row['status']['published']) ? 1 : 0;
+      $row['field_is_best_value'] = !empty($row['status']['best_value']) ? 1 : 0;
+      if (isset($row['sales_window']) && is_array($row['sales_window'])) {
+        $row['sale_start'] = $row['sales_window']['sale_start'] ?? NULL;
+        $row['sale_end'] = $row['sales_window']['sale_end'] ?? NULL;
+      }
+      $out[(int) $ticket_id] = $row;
+    }
+    return $out;
+  }
+
+  private function dateFieldDefault(TicketTypeInterface $ticket, string $field_name): ?DrupalDateTime {
+    if (!$ticket->hasField($field_name) || $ticket->get($field_name)->isEmpty()) {
+      return NULL;
+    }
+    $value = (string) $ticket->get($field_name)->value;
+    return $value !== '' ? new DrupalDateTime($value) : NULL;
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  private function visibilityOptions(): array {
+    return [
+      'public' => (string) $this->t('Public'),
+      'hidden' => (string) $this->t('Hidden'),
+      'access_code' => (string) $this->t('Access code'),
+      'group_only' => (string) $this->t('Group / partner only'),
+    ];
+  }
+
+  private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {
+    if ($node instanceof NodeInterface) {
+      return $node;
+    }
+    $route_node = $this->getRouteMatch()->getParameter('node');
+    if ($route_node instanceof NodeInterface) {
+      return $route_node;
+    }
+    throw new NotFoundHttpException();
+  }
+
+  private function loadSubmittedEvent(FormStateInterface $form_state): ?NodeInterface {
+    $event_id = (int) ($form_state->getValue('event_id') ?? 0);
+    if ($event_id < 1) {
+      return NULL;
+    }
+    $event = $this->studioEntityTypeManager->getStorage('node')->load($event_id);
+    return $event instanceof NodeInterface && $event->bundle() === 'event' ? $event : NULL;
+  }
+
+  private function assertCanManageEvent(NodeInterface $event): void {
+    if ($event->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    if (!$this->currentUser->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $this->currentUser)) {
+      throw new AccessDeniedHttpException();
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -11,7 +11,7 @@ use Drupal\node\NodeInterface;
 /**
  * Wizard step: publishing (live / draft).
  */
-final class EventStudioPublishForm extends EventStudioBaseForm {
+class EventStudioPublishForm extends EventStudioBaseForm {
 
   /**
    * {@inheritdoc}
@@ -31,7 +31,7 @@ final class EventStudioPublishForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   protected function getPreviousRouteName(): ?string {
-    return 'myeventlane_event_studio.edit_preview';
+    return 'myeventlane_event_studio.workspace_content';
   }
 
   /**
@@ -65,7 +65,7 @@ final class EventStudioPublishForm extends EventStudioBaseForm {
     $just_went_live = $saved->isPublished() && !$snapshot;
     if ($just_went_live) {
       $this->messenger()->addStatus($this->t('Your event is live'));
-      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_event_studio.edit', ['node' => $saved->id()], ['query' => ['mel_celebrate' => '1']]));
+      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $saved->id()], ['query' => ['mel_celebrate' => '1']]));
       return;
     }
     $this->messenger()->addStatus($this->t('Event saved.'));

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
@@ -23,14 +23,14 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.edit_description';
+    return 'myeventlane_event_studio.workspace_content';
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getPreviousRouteName(): ?string {
-    return 'myeventlane_event_studio.edit_datetime';
+    return 'myeventlane_event_studio.workspace_information';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AddonsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AddonsSection.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Add-ons section metadata.
+ */
+#[EventStudioSection(
+  id: 'addons',
+  title: 'Add-ons',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_addons',
+  weight: 140,
+  icon: 'addons',
+  routeFragment: 'addons',
+  operationalArea: 'commerce_product',
+  deferred: TRUE,
+)]
+final class AddonsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AnalyticsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AnalyticsSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Analytics section metadata.
+ */
+#[EventStudioSection(
+  id: 'analytics',
+  title: 'Analytics',
+  group: 'Operations',
+  routeName: 'myeventlane_event_studio.workspace_analytics',
+  weight: 230,
+  icon: 'analytics',
+  operationalArea: 'analytics',
+  deferred: TRUE,
+)]
+final class AnalyticsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Attendees section metadata.
+ */
+#[EventStudioSection(
+  id: 'attendees',
+  title: 'Attendees',
+  group: 'Operations',
+  routeName: 'myeventlane_event_studio.workspace_attendees',
+  weight: 200,
+  icon: 'attendees',
+  operationalArea: 'operations',
+  deferred: TRUE,
+)]
+final class AttendeesSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/BrandingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/BrandingSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Branding section metadata.
+ */
+#[EventStudioSection(
+  id: 'branding',
+  title: 'Branding',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace_branding',
+  weight: 20,
+  icon: 'branding',
+  readinessParticipant: TRUE,
+  operationalArea: 'event',
+)]
+final class BrandingSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/CapacitySection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/CapacitySection.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Capacity section metadata.
+ */
+#[EventStudioSection(
+  id: 'capacity',
+  title: 'Capacity',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_capacity',
+  weight: 120,
+  icon: 'capacity',
+  readinessParticipant: TRUE,
+  operationalArea: 'ticket',
+  deferred: TRUE,
+)]
+final class CapacitySection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Content section metadata.
+ */
+#[EventStudioSection(
+  id: 'content',
+  title: 'Content',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace_content',
+  weight: 30,
+  icon: 'content',
+  readinessParticipant: TRUE,
+  operationalArea: 'event',
+)]
+final class ContentSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionBase.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionBase.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base implementation for Event Studio section metadata plugins.
+ */
+abstract class EventStudioSectionBase extends PluginBase implements EventStudioSectionInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Constructs the Event Studio section plugin base.
+   *
+   * @param array<string, mixed> $configuration
+   *   Plugin configuration.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $checker = $container->get('myeventlane_vendor.event_access_checker');
+    if (!$checker instanceof EventVendorAccessChecker) {
+      throw new InvalidPluginDefinitionException((string) $plugin_id, 'Event Studio section plugins require the EventVendorAccessChecker service.');
+    }
+
+    return new static(
+      $configuration,
+      (string) $plugin_id,
+      $plugin_definition,
+      $checker,
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function title(): string {
+    return (string) new TranslatableMarkup((string) $this->pluginDefinition['title']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function group(): string {
+    return (string) new TranslatableMarkup((string) $this->pluginDefinition['group']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function routeName(): string {
+    return (string) $this->pluginDefinition['routeName'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function routeFragment(): string {
+    $fragment = (string) ($this->pluginDefinition['routeFragment'] ?? '');
+    return $fragment !== '' ? $fragment : (string) $this->getPluginId();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function weight(): int {
+    return (int) ($this->pluginDefinition['weight'] ?? 0);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function groupWeight(): int {
+    return match ((string) $this->pluginDefinition['group']) {
+      'Manage Event' => 0,
+      'Commerce' => 100,
+      'Operations' => 200,
+      default => 500,
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function icon(): string {
+    return (string) ($this->pluginDefinition['icon'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function accessPolicy(): string {
+    return (string) ($this->pluginDefinition['accessPolicy'] ?? 'event_update');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderTarget(): string {
+    return (string) ($this->pluginDefinition['renderTarget'] ?? 'controller');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function participatesInReadiness(): bool {
+    return (bool) ($this->pluginDefinition['readinessParticipant'] ?? FALSE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function operationalArea(): string {
+    return (string) ($this->pluginDefinition['operationalArea'] ?? 'event');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isDeferred(): bool {
+    return (bool) ($this->pluginDefinition['deferred'] ?? FALSE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(NodeInterface $event, AccountInterface $account): AccessResultInterface {
+    if ($event->bundle() !== 'event') {
+      return AccessResult::forbidden()->addCacheContexts(['route']);
+    }
+
+    if ($account->isAnonymous()) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user.roles']);
+    }
+
+    if ($account->hasPermission('administer nodes')) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user.permissions']);
+    }
+
+    if ($this->accessPolicy() !== 'event_update') {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user', 'user.permissions']);
+    }
+
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user', 'user.permissions']);
+    }
+
+    $entity_access = $event->access('update', $account, TRUE);
+    if (!$entity_access->isAllowed()) {
+      return $entity_access
+        ->andIf(AccessResult::forbidden())
+        ->addCacheableDependency($event)
+        ->addCacheContexts(['user', 'user.permissions']);
+    }
+
+    return AccessResult::allowed()
+      ->andIf($entity_access)
+      ->addCacheableDependency($event)
+      ->addCacheContexts(['user', 'user.permissions']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionInterface.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Defines the contract for Event Studio operational sections.
+ */
+interface EventStudioSectionInterface extends PluginInspectionInterface {
+
+  /**
+   * Returns the human-readable section title.
+   */
+  public function title(): string;
+
+  /**
+   * Returns the navigation group label.
+   */
+  public function group(): string;
+
+  /**
+   * Returns the explicit route name owned by this section.
+   */
+  public function routeName(): string;
+
+  /**
+   * Returns the stable route fragment used in paths and autosave keys.
+   */
+  public function routeFragment(): string;
+
+  /**
+   * Returns the navigation weight.
+   */
+  public function weight(): int;
+
+  /**
+   * Returns the group ordering weight.
+   */
+  public function groupWeight(): int;
+
+  /**
+   * Returns the optional icon identifier.
+   */
+  public function icon(): string;
+
+  /**
+   * Returns the section access policy identifier.
+   */
+  public function accessPolicy(): string;
+
+  /**
+   * Returns the rendering target contract identifier.
+   */
+  public function renderTarget(): string;
+
+  /**
+   * Returns TRUE when this section participates in readiness.
+   */
+  public function participatesInReadiness(): bool;
+
+  /**
+   * Returns the operational domain area for governance reporting.
+   */
+  public function operationalArea(): string;
+
+  /**
+   * Returns TRUE when the section is intentionally placeholder-only.
+   */
+  public function isDeferred(): bool;
+
+  /**
+   * Evaluates section-level access.
+   */
+  public function access(NodeInterface $event, AccountInterface $account): AccessResultInterface;
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Fulfilment section metadata.
+ */
+#[EventStudioSection(
+  id: 'fulfilment',
+  title: 'Fulfilment',
+  group: 'Operations',
+  routeName: 'myeventlane_event_studio.workspace_fulfilment',
+  weight: 210,
+  icon: 'fulfilment',
+  operationalArea: 'fulfilment',
+  deferred: TRUE,
+)]
+final class FulfilmentSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/InformationSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/InformationSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Event information section metadata.
+ */
+#[EventStudioSection(
+  id: 'information',
+  title: 'Event Information',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace_information',
+  weight: 10,
+  icon: 'information',
+  readinessParticipant: TRUE,
+  operationalArea: 'event',
+)]
+final class InformationSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MerchandiseSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MerchandiseSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Merchandise section metadata.
+ */
+#[EventStudioSection(
+  id: 'merchandise',
+  title: 'Merchandise',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_merchandise',
+  weight: 130,
+  icon: 'merchandise',
+  operationalArea: 'commerce_product',
+  deferred: TRUE,
+)]
+final class MerchandiseSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OrdersSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OrdersSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Orders section metadata.
+ */
+#[EventStudioSection(
+  id: 'orders',
+  title: 'Orders',
+  group: 'Operations',
+  routeName: 'myeventlane_event_studio.workspace_orders',
+  weight: 220,
+  icon: 'orders',
+  operationalArea: 'commerce',
+  deferred: TRUE,
+)]
+final class OrdersSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OverviewSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OverviewSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Overview section metadata.
+ */
+#[EventStudioSection(
+  id: 'overview',
+  title: 'Overview',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace',
+  weight: 0,
+  icon: 'overview',
+  readinessParticipant: TRUE,
+  operationalArea: 'event',
+)]
+final class OverviewSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/PromotionsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/PromotionsSection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Promotions section metadata.
+ */
+#[EventStudioSection(
+  id: 'promotions',
+  title: 'Promotions',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace_promotions',
+  weight: 40,
+  icon: 'promotions',
+  operationalArea: 'event',
+)]
+final class PromotionsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/QuestionsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/QuestionsSection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Checkout questions section metadata.
+ */
+#[EventStudioSection(
+  id: 'questions',
+  title: 'Checkout Questions',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_questions',
+  weight: 110,
+  icon: 'questions',
+  operationalArea: 'commerce',
+)]
+final class QuestionsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/SettingsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/SettingsSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Settings section metadata.
+ */
+#[EventStudioSection(
+  id: 'settings',
+  title: 'Settings',
+  group: 'Manage Event',
+  routeName: 'myeventlane_event_studio.workspace_settings',
+  weight: 50,
+  icon: 'settings',
+  readinessParticipant: TRUE,
+  operationalArea: 'event',
+)]
+final class SettingsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/TicketsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/TicketsSection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Ticketing section metadata.
+ */
+#[EventStudioSection(
+  id: 'tickets',
+  title: 'Tickets',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_tickets',
+  weight: 100,
+  icon: 'tickets',
+  readinessParticipant: TRUE,
+  operationalArea: 'ticket',
+)]
+final class TicketsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Readiness/AbstractEventReadinessProvider.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Readiness/AbstractEventReadinessProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Readiness;
+
+/**
+ * Base contract for future domain-owned readiness providers.
+ *
+ * Providers are not wired into EventReadinessService in this phase. This base
+ * class only standardizes metadata and result construction for future domains.
+ */
+abstract class AbstractEventReadinessProvider implements EventReadinessProviderInterface {
+
+  public function __construct(
+    private readonly string $providerId,
+    private readonly string $domain,
+    private readonly ?string $sectionId = NULL,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id(): string {
+    return $this->providerId;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function domain(): string {
+    return $this->domain;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sectionId(): ?string {
+    return $this->sectionId;
+  }
+
+  /**
+   * Creates a provider result from typed readiness issues.
+   *
+   * @param list<\Drupal\myeventlane_event_studio\Readiness\ReadinessIssue> $issues
+   *   Typed readiness issues owned by this provider.
+   */
+  protected function resultFromIssues(array $issues): EventReadinessProviderResult {
+    return EventReadinessProviderResult::fromIssues(
+      $this->id(),
+      $this->domain(),
+      $issues,
+      $this->sectionId(),
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderInterface.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Readiness;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Future contract for domain-owned Event Studio readiness providers.
+ *
+ * Implementations are intentionally not wired into EventReadinessService yet.
+ * The production readiness service remains the source of truth until provider
+ * migration is scheduled with matching domain tests.
+ */
+interface EventReadinessProviderInterface {
+
+  /**
+   * Returns the stable provider identifier.
+   */
+  public function id(): string;
+
+  /**
+   * Returns the owning operational domain.
+   */
+  public function domain(): string;
+
+  /**
+   * Returns the section id this provider primarily supports, if any.
+   */
+  public function sectionId(): ?string;
+
+  /**
+   * Evaluates this provider's readiness signals for an event.
+   */
+  public function evaluate(NodeInterface $event, AccountInterface $account): EventReadinessProviderResult;
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderResult.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Readiness/EventReadinessProviderResult.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Readiness;
+
+/**
+ * Value object returned by future readiness providers.
+ */
+final class EventReadinessProviderResult {
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   * @param list<string> $completed
+   * @param list<\Drupal\myeventlane_event_studio\Readiness\ReadinessIssue> $issues
+   */
+  public function __construct(
+    public readonly string $providerId,
+    public readonly string $domain,
+    public readonly array $errors = [],
+    public readonly array $warnings = [],
+    public readonly array $completed = [],
+    public readonly ?string $sectionId = NULL,
+    public readonly array $issues = [],
+  ) {}
+
+  /**
+   * Creates a provider result from readiness item lists.
+   *
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   * @param list<string> $completed
+   */
+  public static function create(string $provider_id, string $domain, array $errors = [], array $warnings = [], array $completed = [], ?string $section_id = NULL): self {
+    return new self(
+      $provider_id,
+      $domain,
+      array_values(array_unique($errors)),
+      array_values(array_unique($warnings)),
+      array_values(array_unique($completed)),
+      $section_id,
+    );
+  }
+
+  /**
+   * Creates a provider result from typed readiness issues.
+   *
+   * @param list<\Drupal\myeventlane_event_studio\Readiness\ReadinessIssue> $issues
+   */
+  public static function fromIssues(string $provider_id, string $domain, array $issues, ?string $section_id = NULL): self {
+    $errors = [];
+    $warnings = [];
+    $completed = [];
+    $typed_issues = [];
+
+    foreach ($issues as $issue) {
+      if (!$issue instanceof ReadinessIssue) {
+        continue;
+      }
+      $typed_issues[] = $issue;
+      switch ($issue->severity) {
+        case ReadinessSeverity::Error:
+          $errors[] = $issue->message;
+          break;
+
+        case ReadinessSeverity::Warning:
+          $warnings[] = $issue->message;
+          break;
+
+        case ReadinessSeverity::Completed:
+          $completed[] = $issue->message;
+          break;
+      }
+    }
+
+    return new self(
+      $provider_id,
+      $domain,
+      array_values(array_unique($errors)),
+      array_values(array_unique($warnings)),
+      array_values(array_unique($completed)),
+      $section_id,
+      $typed_issues,
+    );
+  }
+
+  /**
+   * Returns TRUE when the provider has no blocking errors.
+   */
+  public function isReady(): bool {
+    return $this->errors === [];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Readiness/ReadinessIssue.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Readiness/ReadinessIssue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Readiness;
+
+/**
+ * Describes one future readiness signal without changing current orchestration.
+ */
+final class ReadinessIssue {
+
+  public function __construct(
+    public readonly ReadinessSeverity $severity,
+    public readonly string $message,
+    public readonly string $code = '',
+    public readonly ?string $sectionId = NULL,
+  ) {}
+
+  /**
+   * Creates a blocking readiness issue.
+   */
+  public static function error(string $message, string $code = '', ?string $section_id = NULL): self {
+    return new self(ReadinessSeverity::Error, $message, $code, $section_id);
+  }
+
+  /**
+   * Creates a non-blocking readiness warning.
+   */
+  public static function warning(string $message, string $code = '', ?string $section_id = NULL): self {
+    return new self(ReadinessSeverity::Warning, $message, $code, $section_id);
+  }
+
+  /**
+   * Creates a completed readiness signal.
+   */
+  public static function completed(string $message, string $code = '', ?string $section_id = NULL): self {
+    return new self(ReadinessSeverity::Completed, $message, $code, $section_id);
+  }
+
+  /**
+   * Returns TRUE when this issue blocks publishing.
+   */
+  public function isBlocking(): bool {
+    return $this->severity->isBlocking();
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Readiness/ReadinessSeverity.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Readiness/ReadinessSeverity.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Readiness;
+
+/**
+ * Defines severity levels for future domain-owned readiness providers.
+ */
+enum ReadinessSeverity: string {
+
+  case Error = 'error';
+  case Warning = 'warning';
+  case Completed = 'completed';
+
+  /**
+   * Returns TRUE when this severity blocks publishing.
+   */
+  public function isBlocking(): bool {
+    return $this === self::Error;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_event\Service\TicketTypeManager;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
+use Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate;
+use Drupal\node\NodeInterface;
+
+/**
+ * Evaluates whether an event is ready to publish without changing state.
+ */
+final class EventReadinessService {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly TicketTypeManager $ticketTypeManager,
+    private readonly VendorPublishRequirementsGate $publishRequirementsGate,
+    private readonly PaidPublishStripeGate $paidPublishStripeGate,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  public function evaluate(NodeInterface $event, AccountInterface $account): EventReadinessResult {
+    if ($event->bundle() !== 'event') {
+      return EventReadinessResult::create([(string) $this->t('Invalid event.')]);
+    }
+
+    $errors = [];
+    $warnings = [];
+    $completed = [];
+
+    $title = trim($event->label());
+    if ($title === '' || strcasecmp($title, 'Untitled event') === 0) {
+      $errors[] = (string) $this->t('Add an event title.');
+    }
+    else {
+      $completed[] = (string) $this->t('Event title added.');
+    }
+
+    if ($this->validateDates($event, $errors)) {
+      $completed[] = (string) $this->t('Event dates complete.');
+    }
+
+    $event_type = $this->eventType($event);
+    if (!in_array($event_type, ['rsvp', 'paid', 'both', 'external'], TRUE)) {
+      $errors[] = (string) $this->t('Choose how attendees will join this event.');
+    }
+    else {
+      $completed[] = (string) $this->t('Booking mode selected.');
+    }
+
+    if ($event_type === 'external') {
+      if (!$event->hasField('field_external_url') || $event->get('field_external_url')->isEmpty()) {
+        $errors[] = (string) $this->t('Add the external booking URL.');
+      }
+      else {
+        $completed[] = (string) $this->t('External booking URL added.');
+      }
+    }
+
+    if (in_array($event_type, ['paid', 'both'], TRUE)) {
+      if ($this->validatePaidTickets($event, $errors)) {
+        $completed[] = (string) $this->t('Ticketing configured.');
+      }
+      $stripe = $this->paidPublishStripeGate->validatePaidPublishAllowed($account, (int) $event->id());
+      if ($stripe !== NULL) {
+        $errors[] = $stripe;
+      }
+      else {
+        $completed[] = (string) $this->t('Payment onboarding complete.');
+      }
+    }
+
+    $denials = $this->publishRequirementsGate->getLivePublishDenialReasons($account);
+    foreach ($denials as $reason) {
+      $errors[] = $reason;
+    }
+    if ($denials === []) {
+      $completed[] = (string) $this->t('Vendor publish requirements complete.');
+    }
+
+    if (!$event->hasField('field_event_image') || $event->get('field_event_image')->isEmpty()) {
+      $errors[] = (string) $this->t('Add a banner image.');
+    }
+    else {
+      $completed[] = (string) $this->t('Branding image added.');
+    }
+
+    if ($this->validateCapacities($event, $errors, $warnings)) {
+      $completed[] = (string) $this->t('Capacity settings valid.');
+    }
+
+    $errors = array_values(array_unique($errors));
+    $warnings = array_values(array_unique($warnings));
+    $completed = array_values(array_unique($completed));
+    return EventReadinessResult::create($errors, $warnings, $completed);
+  }
+
+  /**
+   * @param list<string> $errors
+   */
+  private function validateDates(NodeInterface $event, array &$errors): bool {
+    if (!$event->hasField('field_event_start') || $event->get('field_event_start')->isEmpty()) {
+      $errors[] = (string) $this->t('Add a start date.');
+      return FALSE;
+    }
+    if (!$event->hasField('field_event_end') || $event->get('field_event_end')->isEmpty()) {
+      $errors[] = (string) $this->t('Add an end date.');
+      return FALSE;
+    }
+
+    try {
+      $start = new DrupalDateTime((string) $event->get('field_event_start')->value);
+      $end = new DrupalDateTime((string) $event->get('field_event_end')->value);
+      if ($end->getTimestamp() <= $start->getTimestamp()) {
+        $errors[] = (string) $this->t('End date must be after the start date.');
+        return FALSE;
+      }
+    }
+    catch (\Throwable) {
+      $errors[] = (string) $this->t('Event dates are invalid.');
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param list<string> $errors
+   */
+  private function validatePaidTickets(NodeInterface $event, array &$errors): bool {
+    $has_active_paid = FALSE;
+    foreach ($this->ticketTypeManager->loadEventTicketTypesForDisplay($event) as $ticket) {
+      if (!$ticket instanceof TicketTypeInterface || $ticket->isArchived() || !$ticket->isPublished()) {
+        continue;
+      }
+      if ($ticket->getTicketKind() !== 'paid') {
+        continue;
+      }
+      $price = $ticket->toPriceValue();
+      if ($price !== NULL && (float) $price->getNumber() > 0) {
+        $has_active_paid = TRUE;
+        break;
+      }
+    }
+    if (!$has_active_paid) {
+      $errors[] = (string) $this->t('Add at least one active paid ticket.');
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   */
+  private function validateCapacities(NodeInterface $event, array &$errors, array &$warnings): bool {
+    $valid = TRUE;
+    foreach (['field_capacity', 'field_event_capacity_total'] as $field_name) {
+      if ($event->hasField($field_name) && !$event->get($field_name)->isEmpty() && (int) $event->get($field_name)->value < 0) {
+        $errors[] = (string) $this->t('Event capacity cannot be negative.');
+        $valid = FALSE;
+      }
+    }
+
+    foreach ($this->ticketTypeManager->loadEventTicketTypesForDisplay($event) as $ticket) {
+      if (!$ticket instanceof TicketTypeInterface || $ticket->isArchived()) {
+        continue;
+      }
+      if ($ticket->hasField('capacity') && !$ticket->get('capacity')->isEmpty() && (int) $ticket->get('capacity')->value < 1) {
+        $errors[] = (string) $this->t('Ticket capacity must be empty or at least 1.');
+        $valid = FALSE;
+      }
+      if ($ticket->getTicketKind() === 'paid' && !$ticket->isPublished()) {
+        $warnings[] = (string) $this->t('Inactive paid tickets will not be available at checkout.');
+      }
+    }
+    return $valid;
+  }
+
+  private function eventType(NodeInterface $event): string {
+    if (!$event->hasField('field_event_type') || $event->get('field_event_type')->isEmpty()) {
+      return '';
+    }
+    return (string) $event->get('field_event_type')->value;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioAutosaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioAutosaveService.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Stores bounded Event Studio section drafts without mutating event entities.
+ */
+final class EventStudioAutosaveService {
+
+  private const STORE = 'myeventlane_event_studio_autosave';
+
+  public function __construct(
+    private readonly PrivateTempStoreFactory $privateTempStoreFactory,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $mel
+   */
+  public function storeDraft(NodeInterface $event, string $section, array $mel, float $autosaveTimestamp, int $baseChanged, int $baseRevisionId): void {
+    $this->privateTempStoreFactory
+      ->get(self::STORE)
+      ->set($this->key($event, $section), [
+        'event_id' => (int) $event->id(),
+        'section' => $section,
+        'mel' => $mel,
+        'autosave_ts' => $autosaveTimestamp,
+        'base_changed' => $baseChanged,
+        'base_revision_id' => $baseRevisionId,
+        'stored_at' => time(),
+      ]);
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  public function getDraft(NodeInterface $event, string $section): ?array {
+    $draft = $this->privateTempStoreFactory
+      ->get(self::STORE)
+      ->get($this->key($event, $section));
+
+    if (!is_array($draft)) {
+      return NULL;
+    }
+
+    if ($this->draftIsOlderThanEntity($event, $draft)) {
+      $this->clearDraft($event, $section);
+      $this->logger->notice('Event Studio autosave draft invalidated after newer entity save: event_id=@nid section=@section', [
+        '@nid' => (string) $event->id(),
+        '@section' => $section,
+      ]);
+      return NULL;
+    }
+
+    return $draft;
+  }
+
+  public function hasDraft(NodeInterface $event, string $section): bool {
+    return $this->getDraft($event, $section) !== NULL;
+  }
+
+  public function clearDraft(NodeInterface $event, string $section): void {
+    $this->privateTempStoreFactory
+      ->get(self::STORE)
+      ->delete($this->key($event, $section));
+  }
+
+  public function isStaleSubmission(NodeInterface $event, int $baseChanged, int $baseRevisionId): bool {
+    if ($baseChanged > 0 && $event->getChangedTime() > $baseChanged) {
+      return TRUE;
+    }
+
+    if ($baseRevisionId > 0 && (int) $event->getRevisionId() !== $baseRevisionId) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * @param array<string, mixed> $draft
+   */
+  private function draftIsOlderThanEntity(NodeInterface $event, array $draft): bool {
+    $baseChanged = (int) ($draft['base_changed'] ?? 0);
+    $baseRevisionId = (int) ($draft['base_revision_id'] ?? 0);
+
+    return $this->isStaleSubmission($event, $baseChanged, $baseRevisionId);
+  }
+
+  private function key(NodeInterface $event, string $section): string {
+    $safeSection = preg_replace('/[^a-z0-9_:-]+/i', '_', $section) ?: 'section';
+    return 'node.' . (int) $event->id() . '.' . $safeSection;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Builds consistent empty states for Event Studio operational sections.
+ */
+final class EventStudioEmptyStateBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(TranslationInterface $string_translation) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds an Event Studio empty-state render array.
+   *
+   * @param list<string> $guidance
+   *   Optional guidance items shown below the main copy.
+   *
+   * @return array<string, mixed>
+   */
+  public function build(string $title, string $body, string $prompt = '', array $guidance = []): array {
+    return [
+      '#theme' => 'mel_event_studio_empty_state',
+      '#title' => $title,
+      '#body' => $body,
+      '#prompt' => $prompt,
+      '#guidance' => $guidance,
+    ];
+  }
+
+  /**
+   * Builds a deferred section empty state from a section label.
+   *
+   * @return array<string, mixed>
+   */
+  public function deferredSection(string $section_label): array {
+    return $this->build(
+      (string) $this->t('No @section workspace yet', ['@section' => $section_label]),
+      (string) $this->t('@section is reserved for a governed Studio extension. It must register a section contract before adding operational UI.', [
+        '@section' => $section_label,
+      ]),
+      (string) $this->t('Keep this section empty until the owning domain service and access contract exist.'),
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -40,6 +40,7 @@ final class EventStudioSaveService {
     private readonly EventHighlightHelper $eventHighlightHelper,
     private readonly PaidPublishStripeGate $paidPublishStripeGate,
     private readonly VendorPublishRequirementsGate $publishRequirementsGate,
+    private readonly EventReadinessService $eventReadiness,
     private readonly ?QuestionTemplateCloner $questionTemplateCloner = NULL,
   ) {}
 
@@ -288,6 +289,13 @@ final class EventStudioSaveService {
       return ['node' => NULL, 'errors' => $attendee_errors];
     }
 
+    if (!$draft && $willPublish) {
+      $readiness = $this->eventReadiness->evaluate($node, $account);
+      if (!$readiness->ready) {
+        return ['node' => NULL, 'errors' => $readiness->errors];
+      }
+    }
+
     EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio draft.' : 'Event Studio save.');
     try {
       $node->save();
@@ -397,6 +405,10 @@ final class EventStudioSaveService {
         if ($stripeMsg !== NULL) {
           throw new \InvalidArgumentException($stripeMsg);
         }
+      }
+      $readiness = $this->eventReadiness->evaluate($node, $account);
+      if (!$readiness->ready) {
+        throw new \InvalidArgumentException(implode(' ', $readiness->errors));
       }
     }
     $node->setPublished($published);

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-empty-state.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-empty-state.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Reusable Event Studio empty state.
+ */
+#}
+<div class="mel-event-studio-empty-state">
+  <h3 class="mel-event-studio-empty-state__title">{{ title }}</h3>
+  <p class="mel-event-studio-empty-state__body">{{ body }}</p>
+
+  {% if prompt %}
+    <p class="mel-event-studio-empty-state__prompt">{{ prompt }}</p>
+  {% endif %}
+
+  {% if guidance %}
+    <ul class="mel-event-studio-empty-state__guidance">
+      {% for item in guidance %}
+        <li>{{ item }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-section.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-section.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Canonical Event Studio section wrapper.
+ */
+#}
+<section class="mel-event-studio-section" aria-labelledby="mel-event-studio-section-title">
+  <header class="mel-event-studio-section__header">
+    <h2 class="mel-event-studio-section__title" id="mel-event-studio-section-title">{{ label }}</h2>
+  </header>
+  <div class="mel-event-studio-section__body">
+    {{ content }}
+  </div>
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Canonical Event Studio sidebar navigation.
+ */
+#}
+<aside class="mel-event-studio-sidebar" id="mel-event-studio-sidebar" aria-label="{{ 'Event Studio sections'|t }}">
+  <div class="mel-event-studio-sidebar__inner">
+    {% for group, items in sections %}
+      <nav class="mel-event-studio-sidebar__group" aria-labelledby="mel-studio-nav-{{ loop.index }}">
+        <h2 class="mel-event-studio-sidebar__heading" id="mel-studio-nav-{{ loop.index }}">{{ group }}</h2>
+        <ul class="mel-event-studio-sidebar__list">
+          {% for item in items %}
+            <li class="mel-event-studio-sidebar__item">
+              <a
+                class="mel-event-studio-sidebar__link{% if item.active %} is-active{% endif %}"
+                href="{{ item.url }}"
+                {% if item.active %}aria-current="page"{% endif %}
+              >{{ item.label }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    {% endfor %}
+  </div>
+</aside>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Canonical Event Studio top bar.
+ */
+#}
+<header class="mel-event-studio-topbar" role="banner">
+  <div class="mel-event-studio-topbar__event">
+    <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Studio'|t }}</p>
+    <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
+  </div>
+  <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
+    <span class="mel-event-studio-topbar__badge">{{ topbar.status }}</span>
+    <span class="mel-event-studio-topbar__state">{{ topbar.state }}</span>
+    <span class="mel-event-studio-topbar__saved">{{ topbar.last_saved }}</span>
+    <span class="mel-event-studio-topbar__autosave{% if topbar.restore_draft %} has-draft{% endif %}" id="mel-studio-form-state" role="status">
+      {% if topbar.restore_draft %}
+        <a href="{{ topbar.restore_url }}">{{ 'Restore draft available'|t }}</a>
+      {% endif %}
+    </span>
+  </div>
+  <div class="mel-event-studio-topbar__actions">
+    <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'Preview'|t }}</a>
+    <a class="mel-btn mel-btn--primary" href="{{ topbar.publish_url }}">{{ 'Publish'|t }}</a>
+  </div>
+</header>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Canonical Event Studio operational workspace shell.
+ */
+#}
+<div class="mel-event-studio mel-event-studio--workspace" data-mel-studio-shell="1">
+  {{ include('@myeventlane_event_studio/mel-event-studio-topbar.html.twig', {
+    topbar: topbar
+  }, with_context = false) }}
+
+  <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}">
+    <div class="mel-event-studio-readiness-strip__summary">
+      <strong>{{ readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t }}</strong>
+      <span>{{ readiness.state }}</span>
+    </div>
+    <div class="mel-event-studio-readiness-strip__counts">
+      <span>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
+      <span>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
+      <span>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
+    </div>
+  </section>
+
+  <button
+    class="mel-event-studio-sidebar-toggle"
+    type="button"
+    aria-controls="mel-event-studio-sidebar"
+    aria-expanded="false"
+    data-mel-studio-sidebar-toggle
+  >{{ 'Sections'|t }}</button>
+
+  <div class="mel-event-studio-workspace">
+    {{ include('@myeventlane_event_studio/mel-event-studio-sidebar.html.twig', {
+      sections: sections,
+      current_section: current_section
+    }, with_context = false) }}
+
+    <main class="mel-event-studio-workspace__main" id="mel-event-studio-section" tabindex="-1">
+      {{ include('@myeventlane_event_studio/mel-event-studio-section.html.twig', {
+        label: current_section_label,
+        content: section_content
+      }, with_context = false) }}
+    </main>
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_front/myeventlane_front.module
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.module
@@ -14,6 +14,11 @@ function myeventlane_front_theme($existing, $type, $theme, $path): array {
     'myeventlane_home_hero' => [
       'variables' => [
         'pills' => NULL,
+        'featured_events' => NULL,
+        'hero_image_url' => NULL,
+        'hero_image_url_mobile' => NULL,
+        'hero_hide_on_mobile' => FALSE,
+        'hero_alt' => '',
       ],
       'template' => 'myeventlane-home-hero',
       'path' => $path . '/templates',

--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -1,0 +1,7 @@
+myeventlane_front.about:
+  path: '/about'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectAbout'
+    _title: 'About MyEventLane'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -14,10 +14,42 @@ myeventlane_front.story:
   requirements:
     _permission: 'access content'
 
+myeventlane_front.blog:
+  path: '/blog'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToBlog'
+    _title: 'Blog'
+  requirements:
+    _permission: 'access content'
+
 myeventlane_front.contact:
   path: '/contact'
   defaults:
     _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToHelp'
     _title: 'Contact'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.privacy:
+  path: '/privacy'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToPrivacy'
+    _title: 'Privacy policy'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.terms:
+  path: '/terms'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToTerms'
+    _title: 'Terms'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.cookies:
+  path: '/cookies'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToCookies'
+    _title: 'Cookies'
   requirements:
     _permission: 'access content'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -1,7 +1,23 @@
 myeventlane_front.about:
   path: '/about'
   defaults:
-    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectAbout'
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToHelp'
     _title: 'About MyEventLane'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.story:
+  path: '/our-story'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToHelp'
+    _title: 'Our story'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.contact:
+  path: '/contact'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToHelp'
+    _title: 'Contact'
   requirements:
     _permission: 'access content'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -1,0 +1,7 @@
+services:
+  myeventlane_front.featured_events_render_builder:
+    class: Drupal\myeventlane_front\Service\FeaturedEventsRenderBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@views.executable'
+      - '@logger.factory'

--- a/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\LocalRedirectResponse;
+
+/**
+ * Redirects legacy About links to the current public help hub.
+ */
+final class LegacyAboutController extends ControllerBase {
+
+  /**
+   * Redirects the retired /about entry point.
+   */
+  public function redirectAbout(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/help', 301);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
@@ -8,14 +8,14 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\LocalRedirectResponse;
 
 /**
- * Redirects legacy About links to the current public help hub.
+ * Redirects legacy front-page content routes to the current public help hub.
  */
 final class LegacyAboutController extends ControllerBase {
 
   /**
-   * Redirects the retired /about entry point.
+   * Redirects retired footer entry points.
    */
-  public function redirectAbout(): LocalRedirectResponse {
+  public function redirectToHelp(): LocalRedirectResponse {
     return new LocalRedirectResponse('/help', 301);
   }
 

--- a/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
@@ -19,4 +19,32 @@ final class LegacyAboutController extends ControllerBase {
     return new LocalRedirectResponse('/help', 301);
   }
 
+  /**
+   * Redirects retired blog entry points.
+   */
+  public function redirectToBlog(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/blog', 301);
+  }
+
+  /**
+   * Redirects retired privacy entry points.
+   */
+  public function redirectToPrivacy(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/privacy', 301);
+  }
+
+  /**
+   * Redirects retired terms entry points.
+   */
+  public function redirectToTerms(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/terms', 301);
+  }
+
+  /**
+   * Redirects retired cookie policy entry points.
+   */
+  public function redirectToCookies(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/cookies', 301);
+  }
+
 }

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\myeventlane_front\Service\FeaturedEventsRenderBuilder;
 use Drupal\myeventlane_page_visuals\Service\PageVisualResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -31,6 +32,7 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
     $plugin_id,
     $plugin_definition,
     private readonly BlockManagerInterface $blockManager,
+    private readonly FeaturedEventsRenderBuilder $featuredEventsRenderBuilder,
     private readonly PageVisualResolver $pageVisualResolver,
     private readonly RouteMatchInterface $routeMatch,
   ) {
@@ -46,6 +48,7 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
       $plugin_id,
       $plugin_definition,
       $container->get('plugin.manager.block'),
+      $container->get('myeventlane_front.featured_events_render_builder'),
       $container->get('myeventlane.page_visual_resolver'),
       $container->get('current_route_match'),
     );
@@ -57,7 +60,7 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
   public function build(): array {
     $pills = [];
     try {
-      $instance = $this->blockManager->createInstance('views_block:front_category_pills-pill', []);
+      $instance = $this->blockManager->createInstance('myeventlane_category_pills', []);
       $pills = $instance->build();
       $pills['#cache']['contexts'][] = 'url.path';
     }
@@ -86,10 +89,16 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
     $build = [
       '#theme' => 'myeventlane_home_hero',
       '#pills' => $pills,
+      '#featured_events' => $this->featuredEventsRenderBuilder->build(),
       '#hero_image_url' => $hero_image_url,
       '#hero_image_url_mobile' => $hero_image_url_mobile,
       '#hero_hide_on_mobile' => $hero_hide_on_mobile,
       '#hero_alt' => $hero_alt,
+      '#attached' => [
+        'library' => [
+          'myeventlane_theme/home-hero-rotator',
+        ],
+      ],
       '#cache' => [
         'contexts' => array_unique($cache_contexts),
         'tags' => array_unique($cache_tags),

--- a/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\views\ViewExecutableFactory;
+
+/**
+ * Builds the canonical homepage featured events render array.
+ */
+final class FeaturedEventsRenderBuilder {
+
+  private const VIEW_ID = 'front_featured_events';
+  private const DISPLAY_ID = 'block_featured';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly ViewExecutableFactory $viewExecutableFactory,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * Builds the existing featured events View display.
+   *
+   * @return array
+   *   A render array for front_featured_events:block_featured, or an empty
+   *   cacheable render array if the View cannot be built.
+   */
+  public function build(): array {
+    try {
+      $storage = $this->entityTypeManager
+        ->getStorage('view')
+        ->load(self::VIEW_ID);
+
+      if ($storage === NULL) {
+        $this->loggerFactory->get('myeventlane_front')->error('Homepage featured View "@view" was not found.', [
+          '@view' => self::VIEW_ID,
+        ]);
+
+        return $this->emptyBuild();
+      }
+
+      $view = $this->viewExecutableFactory->get($storage);
+      if (!$view->access(self::DISPLAY_ID)) {
+        return $this->emptyBuild();
+      }
+
+      return $view->buildRenderable(self::DISPLAY_ID);
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_front')->error('Could not build homepage featured events: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+
+      return $this->emptyBuild();
+    }
+  }
+
+  /**
+   * Returns cacheable empty output for failure or denied access.
+   */
+  private function emptyBuild(): array {
+    return [
+      '#markup' => '',
+      '#cache' => [
+        'contexts' => ['user.permissions'],
+        'tags' => ['config:views.view.' . self::VIEW_ID],
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig
+++ b/web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig
@@ -11,47 +11,73 @@
  */
 #}
 
-<section class="mel-home-hero" aria-label="Find events">
-  <div class="mel-home-hero__art{% if hero_hide_on_mobile|default(false) %} mel-home-hero__art--hide-mobile{% endif %}" aria-hidden="true">
-    {% if hero_image_url %}
-      {% if hero_image_url_mobile|default(null) and not hero_hide_on_mobile|default(false) %}
-        <picture>
-          <source media="(max-width: 767px)" srcset="{{ hero_image_url_mobile }}">
-          <img
-            class="mel-home-hero__art-img"
-            src="{{ hero_image_url }}"
-            alt="{{ hero_alt }}"
-            loading="eager"
-          />
-        </picture>
-      {% else %}
-        <img
-          class="mel-home-hero__art-img"
-          src="{{ hero_image_url }}"
-          alt="{{ hero_alt }}"
-          loading="eager"
-        />
-      {% endif %}
-    {% else %}
-      <div class="mel-home-hero__art-img mel-home-hero__art-img--placeholder"></div>
-    {% endif %}
-  </div>
-
+<section class="mel-home-hero" aria-labelledby="mel-home-hero-title">
   <div class="mel-home-hero__inner">
-    <h1 class="mel-home-hero__title">Find events near you</h1>
+    <div class="mel-home-hero__content">
+      <p class="mel-home-hero__eyebrow">{{ 'MyEventLane'|t }}</p>
+      <h1 id="mel-home-hero-title" class="mel-home-hero__title">{{ 'Your lane to great events.'|t }}</h1>
+      <p class="mel-home-hero__text">
+        {{ 'Find workshops, gigs, markets, festivals, and community moments worth leaving the house for.'|t }}
+      </p>
 
-    <form class="mel-home-hero__search" role="search" action="#" method="get">
-      <label class="visually-hidden" for="mel-home-search">Search events</label>
-      <input id="mel-home-search" name="q" type="search" placeholder="Search events" />
-      <button type="submit" aria-label="Search">
-        <span aria-hidden="true">🔍</span>
-      </button>
-    </form>
+      <form class="mel-home-hero__search" role="search" action="{{ path('view.upcoming_events.page_events') }}" method="get">
+        <label class="visually-hidden" for="mel-home-search">{{ 'Search events'|t }}</label>
+        <input
+          id="mel-home-search"
+          name="q"
+          type="search"
+          placeholder="{{ 'Search events, organisers, or places'|t }}"
+        />
+        <button type="submit">{{ 'Search'|t }}</button>
+      </form>
 
-    {% if pills %}
-      <div class="mel-home-hero__pills">
-        {{ pills }}
+      <div class="mel-home-hero__actions" role="group" aria-label="{{ 'Homepage actions'|t }}">
+        <a class="mel-btn mel-btn--primary mel-home-hero__primary" href="{{ path('view.upcoming_events.page_events') }}">
+          {{ 'Explore events'|t }}
+        </a>
+        <a class="mel-link mel-home-hero__secondary" href="{{ path('myeventlane_vendor.create_event_gateway') }}">
+          {{ 'Create event'|t }}
+        </a>
       </div>
-    {% endif %}
+
+      {% if pills %}
+        <div class="mel-home-hero__pills" aria-label="{{ 'Popular categories'|t }}">
+          {{ pills }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="mel-home-hero__art{% if hero_hide_on_mobile|default(false) %} mel-home-hero__art--hide-mobile{% endif %}">
+      <div class="mel-home-hero__art-frame">
+        {% if featured_events %}
+          <div class="mel-home-hero__feature-rotator" data-mel-home-hero-rotator aria-label="{{ 'Featured event highlights'|t }}">
+            {{ featured_events }}
+          </div>
+        {% elseif hero_image_url %}
+          {% if hero_image_url_mobile|default(null) and not hero_hide_on_mobile|default(false) %}
+            <picture aria-hidden="true">
+              <source media="(max-width: 767px)" srcset="{{ hero_image_url_mobile }}">
+              <img
+                class="mel-home-hero__art-img"
+                src="{{ hero_image_url }}"
+                alt=""
+                loading="eager"
+                decoding="async"
+              />
+            </picture>
+          {% else %}
+            <img
+              class="mel-home-hero__art-img"
+              src="{{ hero_image_url }}"
+              alt=""
+              loading="eager"
+              decoding="async"
+            />
+          {% endif %}
+        {% else %}
+          <div class="mel-home-hero__art-img mel-home-hero__art-img--placeholder" aria-hidden="true"></div>
+        {% endif %}
+      </div>
+    </div>
   </div>
 </section>

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.routing.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.routing.yml
@@ -59,10 +59,10 @@ myeventlane_tickets.event_tickets_types:
 myeventlane_tickets.event_tickets_settings:
   path: '/vendor/events/{event}/tickets/settings'
   defaults:
-    _controller: '\Drupal\myeventlane_tickets\Controller\EventTicketsController::settings'
+    _controller: 'myeventlane_event_studio.controller:redirectEventToTicketsWorkspace'
     _title: 'Ticket settings'
   requirements:
-    _custom_access: 'myeventlane_tickets.access.event_tickets:access'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
   options:
     parameters:
       event:

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventStudioCreateService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventStudioCreateService.php
@@ -11,7 +11,9 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -63,6 +65,37 @@ final class VendorEventStudioCreateService {
       ]);
       return NULL;
     }
+  }
+
+  /**
+   * Creates the minimal draft event scaffold used by the canonical Studio flow.
+   */
+  public function createDraftEventForUser(int $uid): NodeInterface {
+    if ($uid <= 0) {
+      throw new \InvalidArgumentException('A valid user id is required to create a draft event.');
+    }
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('node');
+      /** @var \Drupal\node\NodeInterface $node */
+      $node = $storage->create([
+        'type' => 'event',
+        'title' => $this->t('Untitled event'),
+        'uid' => $uid,
+        'status' => 0,
+      ]);
+      EventNodeRevisionSave::prepare($node, 'Event Studio draft created.');
+      $node->save();
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('VendorEventStudioCreateService: failed to persist draft event uid=@uid @message', [
+        '@uid' => (string) $uid,
+        '@message' => $e->getMessage(),
+      ]);
+      throw $e;
+    }
+
+    return $node;
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/js/home-hero-rotator.js
+++ b/web/themes/custom/myeventlane_theme/js/home-hero-rotator.js
@@ -1,0 +1,216 @@
+/**
+ * @file
+ * Lightweight homepage hero featured-event rotator.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  var ROTATION_DELAY = 6200;
+  var ITEM_SELECTOR = [
+    '.mel-featured-carousel__slide',
+    '.mel-featured-carousel__item',
+    '.mel-featured-home-grid__item',
+  ].join(',');
+  var FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]',
+  ].join(',');
+
+  function setFocusableState(item, isActive) {
+    item.querySelectorAll(FOCUSABLE_SELECTOR).forEach(function (element) {
+      if (isActive) {
+        if (element.hasAttribute('data-mel-original-tabindex')) {
+          var original = element.getAttribute('data-mel-original-tabindex');
+          element.removeAttribute('data-mel-original-tabindex');
+          if (original === '') {
+            element.removeAttribute('tabindex');
+          }
+          else {
+            element.setAttribute('tabindex', original);
+          }
+        }
+        return;
+      }
+
+      if (!element.hasAttribute('data-mel-original-tabindex')) {
+        element.setAttribute('data-mel-original-tabindex', element.getAttribute('tabindex') || '');
+      }
+      element.setAttribute('tabindex', '-1');
+    });
+  }
+
+  function activate(items, index) {
+    items.forEach(function (item, itemIndex) {
+      var isActive = itemIndex === index;
+      item.classList.toggle('is-active', isActive);
+      item.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      setFocusableState(item, isActive);
+    });
+  }
+
+  function clampIndex(index, length) {
+    return (index + length) % length;
+  }
+
+  function enhanceFeaturedCarousel(carousel) {
+    if (carousel.closest('[data-mel-home-hero-rotator]')) {
+      return;
+    }
+
+    var track = carousel.querySelector('.mel-featured-carousel__track');
+    var items = Array.prototype.slice.call(carousel.querySelectorAll('[data-mel-featured-slide]'));
+    if (!track || items.length === 0) {
+      return;
+    }
+
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var dots = Array.prototype.slice.call(carousel.querySelectorAll('[data-mel-featured-dot]'));
+    var prev = carousel.querySelector('[data-mel-featured-prev]');
+    var next = carousel.querySelector('[data-mel-featured-next]');
+    var activeIndex = 0;
+    var timer = null;
+
+    function update(index, shouldScroll) {
+      activeIndex = clampIndex(index, items.length);
+      items.forEach(function (item, itemIndex) {
+        var isActive = itemIndex === activeIndex;
+        item.classList.toggle('is-active', isActive);
+        item.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+        setFocusableState(item, isActive);
+      });
+      dots.forEach(function (dot, dotIndex) {
+        var isActive = dotIndex === activeIndex;
+        dot.classList.toggle('is-active', isActive);
+        dot.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+
+      if (shouldScroll !== false) {
+        track.scrollTo({
+          left: items[activeIndex].offsetLeft,
+          behavior: reducedMotion ? 'auto' : 'smooth',
+        });
+      }
+    }
+
+    function stop() {
+      if (timer) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    }
+
+    function start() {
+      stop();
+      if (reducedMotion || items.length < 2) {
+        return;
+      }
+      timer = window.setInterval(function () {
+        update(activeIndex + 1);
+      }, ROTATION_DELAY);
+    }
+
+    carousel.classList.add('is-enhanced');
+    update(0, false);
+
+    if (prev) {
+      prev.addEventListener('click', function () {
+        stop();
+        update(activeIndex - 1);
+        start();
+      });
+    }
+
+    if (next) {
+      next.addEventListener('click', function () {
+        stop();
+        update(activeIndex + 1);
+        start();
+      });
+    }
+
+    dots.forEach(function (dot) {
+      dot.addEventListener('click', function () {
+        var index = parseInt(dot.getAttribute('data-mel-featured-dot'), 10);
+        if (Number.isNaN(index)) {
+          return;
+        }
+        stop();
+        update(index);
+        start();
+      });
+    });
+
+    track.addEventListener('scroll', function () {
+      window.clearTimeout(track.melFeaturedScrollTimer);
+      track.melFeaturedScrollTimer = window.setTimeout(function () {
+        var nearestIndex = activeIndex;
+        var nearestDistance = Infinity;
+        items.forEach(function (item, index) {
+          var distance = Math.abs(item.offsetLeft - track.scrollLeft);
+          if (distance < nearestDistance) {
+            nearestDistance = distance;
+            nearestIndex = index;
+          }
+        });
+        update(nearestIndex, false);
+      }, 120);
+    }, { passive: true });
+
+    carousel.addEventListener('mouseenter', stop);
+    carousel.addEventListener('mouseleave', start);
+    carousel.addEventListener('focusin', stop);
+    carousel.addEventListener('focusout', start);
+
+    start();
+  }
+
+  Drupal.behaviors.melHomeHeroRotator = {
+    attach: function (context) {
+      once('melFeaturedCarousel', '[data-mel-featured-carousel]', context).forEach(enhanceFeaturedCarousel);
+
+      once('melHomeHeroRotator', '[data-mel-home-hero-rotator]', context).forEach(function (rotator) {
+        var items = Array.prototype.slice.call(rotator.querySelectorAll(ITEM_SELECTOR));
+        if (items.length === 0) {
+          return;
+        }
+
+        var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        var activeIndex = 0;
+        var timer = null;
+
+        rotator.classList.add('is-enhanced');
+        activate(items, activeIndex);
+
+        if (reducedMotion || items.length < 2) {
+          return;
+        }
+
+        function stop() {
+          if (timer) {
+            window.clearInterval(timer);
+            timer = null;
+          }
+        }
+
+        function start() {
+          stop();
+          timer = window.setInterval(function () {
+            activeIndex = (activeIndex + 1) % items.length;
+            activate(items, activeIndex);
+          }, ROTATION_DELAY);
+        }
+
+        rotator.addEventListener('mouseenter', stop);
+        rotator.addEventListener('mouseleave', start);
+        rotator.addEventListener('focusin', stop);
+        rotator.addEventListener('focusout', start);
+
+        start();
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
@@ -15,6 +15,16 @@ regions:
   pre_content: 'Pre-content'
   highlighted: Highlighted
   content: Content
+  homepage_hero: 'Homepage Hero'
+  homepage_featured: 'Homepage Featured'
+  homepage_categories: 'Homepage Categories'
+  homepage_latest: 'Homepage Latest'
+  homepage_tonight: 'Homepage Tonight'
+  homepage_nearby: 'Homepage Nearby'
+  homepage_online: 'Homepage Online'
+  homepage_host_cta: 'Homepage Host CTA'
+  homepage_blog: 'Homepage Blog'
+  homepage_newsletter: 'Homepage Newsletter'
   host_cta: 'Home: Host CTA'
   bottom_cta: 'Home: Bottom CTA'
   below_content: 'Below content'

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -23,6 +23,13 @@ skeleton:
     - core/drupal
     - core/once
 
+home-hero-rotator:
+  js:
+    js/home-hero-rotator.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Branded 403/404 (standalone CSS; source SCSS in mel_maintenance/scss/errors.scss).
 mel-error-pages:
   version: VERSION
@@ -62,6 +69,7 @@ front:
   dependencies:
     - core/drupal
     - core/once
+    - myeventlane_theme/home-hero-rotator
 
 # Help Centre search (/help/search) — compiled into dist/main.scss via Vite.
 help_search:

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -94,7 +94,7 @@
 }
 
 .mel-event-card--standard .mel-event-card__image {
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 4 / 3;
 }
 
 .mel-event-card--standard .mel-event-card__image img,
@@ -347,10 +347,10 @@
 }
 
 .mel-event-card__title {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
   line-height: 1.25;
-  margin: 0 0 10px;
+  margin: 0 0 8px;
   color: mel.$mel-ds-color-text;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -360,8 +360,8 @@
 }
 
 .mel-event-card__when {
-  margin: 0 0 6px;
-  font-size: 15px;
+  margin: 0 0 5px;
+  font-size: 14px;
   font-weight: 600;
   line-height: 1.35;
   color: mel.$mel-ds-color-text;
@@ -392,7 +392,7 @@
 
 .mel-event-card__status {
   margin: 0;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 700;
   line-height: 1.3;
   color: mel.$mel-ds-color-text;
@@ -438,9 +438,9 @@
   align-items: center;
   justify-content: center;
   min-height: 44px;
-  padding: 0 16px;
-  border-radius: 12px;
-  font-size: 14px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 13px;
   font-weight: 700;
   line-height: 1.2;
   color: mel.$mel-ds-color-text;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_footer.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_footer.scss
@@ -1,10 +1,9 @@
 // ==========================================================================
 // Footer Component
 // ==========================================================================
-// Condensed 3-column layout (Find events, Host events, About) + compact legal row.
+// Four-column discovery footer + compact legal row.
 // No glow, newsletter, CTA, or gradient bands.
 
-@use 'sass:color';
 @use '../tokens/colors';
 @use '../tokens/spacing';
 @use '../tokens/typography';
@@ -12,74 +11,95 @@
 @use '../tokens/breakpoints';
 
 .mel-footer {
-  padding: spacing.mel-space(4) 0;
-  background: colors.$mel-color-bg;
-  border-top: 1px solid rgba(242, 109, 91, 0.15);
+  padding: spacing.mel-space(7) 0 0;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(242, 109, 91, 0.08), transparent 26rem),
+    colors.$mel-color-bg;
+  border-top: 1px solid rgba(242, 109, 91, 0.14);
 }
 
 .mel-footer__container {
-  max-width: 1100px;
+  max-width: 1240px;
   margin: 0 auto;
   padding: 0 spacing.mel-space(5);
   display: flex;
   flex-direction: column;
-  gap: spacing.mel-space(3);
+  gap: spacing.mel-space(6);
 }
 
 /* NAVIGATION GRID */
 
 .mel-footer__nav {
   display: grid;
-  grid-template-columns: 1fr 1fr 1.4fr;
-  gap: 48px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(28px, 4vw, 52px);
   align-items: start;
 }
 
+.mel-footer__col {
+  min-width: 0;
+}
+
 .mel-footer__col h4 {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: typography.$mel-font-semibold;
-  margin-bottom: 14px;
-  letter-spacing: 0.2px;
+  margin: 0 0 16px;
+  letter-spacing: 0.01em;
   color: colors.$mel-color-navy;
 }
 
-.mel-footer .menu {
+.mel-footer .menu,
+.mel-footer .menu-level-0,
+.mel-footer nav ul {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
-.mel-footer .menu li {
+.mel-footer .menu li,
+.mel-footer .menu-item,
+.mel-footer nav li {
+  display: block;
   margin: 0;
 }
 
-.mel-footer .menu a {
-  font-size: 13px;
+.mel-footer .menu a,
+.mel-footer .menu-item a,
+.mel-footer nav a {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-height: 28px;
+  font-size: 14px;
   line-height: 1.5;
   color: colors.$mel-color-text;
   text-decoration: none;
   transition: color 0.15s ease;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
-.mel-footer .menu a:hover {
+.mel-footer .menu a:hover,
+.mel-footer .menu-item a:hover,
+.mel-footer nav a:hover {
   color: colors.$mel-color-primary;
 }
 
 /* DYNAMIC SECTIONS (categories, organiser links) — same styling as primary menu links */
 
 .mel-footer__dynamic {
-  margin-top: 14px;
-  padding-top: 10px;
+  margin-top: 16px;
+  padding-top: 14px;
   border-top: 1px solid rgba(0, 0, 0, 0.05);
   list-style: none;
   padding-left: 0;
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .mel-footer__dynamic li {
@@ -87,7 +107,7 @@
 }
 
 .mel-footer__dynamic a {
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.5;
   color: colors.$mel-color-text;
   text-decoration: none;
@@ -101,12 +121,12 @@
 /* TRUST BADGES (About column) */
 
 .mel-footer__trust {
-  margin-top: 16px;
-  font-size: 12.5px;
+  margin-top: 18px;
+  font-size: 13px;
   color: colors.$mel-color-text-muted;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 /* ==============================
@@ -117,12 +137,12 @@
   width: 100%;
   background: linear-gradient(180deg, #232b3a 0%, #1f2633 100%);
   border-top: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 20px 0;
-  margin-top: spacing.mel-space(3);
+  padding: 24px 0;
+  margin-top: spacing.mel-space(7);
 }
 
 .mel-footer__base-inner {
-  max-width: 1100px;
+  max-width: 1240px;
   margin: 0 auto;
   padding: 0 spacing.mel-space(5);
   display: flex;
@@ -139,7 +159,9 @@
 
 .mel-footer__meta {
   display: flex;
-  gap: 20px;
+  flex-wrap: wrap;
+  gap: 12px 22px;
+  align-items: center;
   font-size: 12.5px;
   color: rgba(255, 255, 255, 0.7);
 }
@@ -155,15 +177,26 @@
 }
 
 .mel-footer__create-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: radii.$mel-radius-pill;
+  background: rgba(255, 255, 255, 0.08);
   font-size: 13px;
   font-weight: typography.$mel-font-semibold;
-  color: colors.$mel-color-primary;
+  color: #ffffff;
   text-decoration: none;
-  transition: color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
 
 .mel-footer__create-link:hover {
-  color: color.adjust(colors.$mel-color-primary, $lightness: 8%);
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
 }
 
 /* RESPONSIVE */
@@ -171,11 +204,7 @@
 @include breakpoints.mel-break(md, max) {
   .mel-footer__nav {
     grid-template-columns: 1fr 1fr;
-    gap: spacing.mel-space(3);
-  }
-
-  .mel-footer__col--wide {
-    grid-column: span 2;
+    gap: spacing.mel-space(5) spacing.mel-space(4);
   }
 
   .mel-footer__base-inner {
@@ -186,8 +215,22 @@
 }
 
 @include breakpoints.mel-break(sm, max) {
+  .mel-footer {
+    padding-top: spacing.mel-space(6);
+  }
+
+  .mel-footer__container,
+  .mel-footer__base-inner {
+    padding-inline: spacing.mel-space(4);
+  }
+
   .mel-footer__nav {
     grid-template-columns: 1fr;
+    gap: spacing.mel-space(5);
+  }
+
+  .mel-footer__col h4 {
+    margin-bottom: 10px;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -1,31 +1,357 @@
 // ==========================================================================
 // Home Hero Component
 // ==========================================================================
-// Homepage hero with brand, search, and popular tags.
-// BEM: .hero, .mel-home-hero
-//
-// Hero artwork is delivered via <img>/<picture> in hero.twig (runtime URLs or
-// text-free abstract SVG). Do not point CSS backgrounds at the event
-// placeholder asset — it is for listing/event shells only.
+// Homepage hero with brand, search, category pills, and Page Visuals art.
 
+@use '../base/mel-ds-tokens' as mel;
 @use '../tokens/breakpoints';
 
-// Hide hero art on mobile when hero_hide_on_mobile is set (Page Visuals).
+.mel-home-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2rem, 5vw, 4.75rem) 24px clamp(1.5rem, 4vw, 3rem);
+  background:
+    radial-gradient(circle at 12% 18%, color-mix(in srgb, mel.$mel-ds-color-primary 20%, transparent), transparent 34rem),
+    radial-gradient(circle at 88% 10%, rgba(255, 210, 147, 0.36), transparent 28rem),
+    radial-gradient(circle at 72% 84%, rgba(186, 230, 210, 0.34), transparent 30rem),
+    linear-gradient(135deg, #fff7f2 0%, #f7f1ff 52%, #eefaf4 100%);
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(rgba(41, 50, 65, 0.08) 1px, transparent 1px);
+    background-size: 18px 18px;
+    mask-image: linear-gradient(90deg, #000 0%, transparent 76%);
+    pointer-events: none;
+  }
+}
+
+.mel-home-hero__inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 28px;
+  width: min(100%, 1240px);
+  margin: 0 auto;
+
+  @include breakpoints.mel-break(lg) {
+    grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr);
+    align-items: center;
+    gap: 48px;
+  }
+}
+
+.mel-home-hero__content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.mel-home-hero__eyebrow {
+  margin: 0 0 10px;
+  color: mel.$mel-ds-color-primary;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mel-home-hero__title {
+  max-width: 11ch;
+  margin: 0;
+  color: mel.$mel-ds-color-text;
+  font-family: mel.$mel-ds-font-main;
+  font-size: clamp(2.75rem, 8vw, 5.6rem);
+  font-weight: 850;
+  letter-spacing: -0.055em;
+  line-height: 0.94;
+}
+
+.mel-home-hero__text {
+  max-width: 42rem;
+  margin: 18px 0 0;
+  color: color-mix(in srgb, mel.$mel-ds-color-text 74%, #fff 26%);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.58;
+}
+
+.mel-home-hero__search {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  width: min(100%, 720px);
+  margin-top: 24px;
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.68);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 18px 54px rgba(98, 81, 130, 0.14);
+
+  @supports (backdrop-filter: blur(1px)) {
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+  }
+
+  @include breakpoints.mel-break(sm) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+}
+
+.mel-home-hero__search input {
+  min-width: 0;
+  min-height: 48px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: mel.$mel-ds-color-text;
+  font: inherit;
+
+  &::placeholder {
+    color: mel.$mel-ds-color-muted;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px color-mix(in srgb, mel.$mel-ds-color-primary 28%, transparent);
+  }
+}
+
+.mel-home-hero__search button {
+  min-height: 48px;
+  padding: 0 22px;
+  border: 0;
+  border-radius: 999px;
+  background: mel.$mel-ds-color-primary;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 800;
+  box-shadow: 0 10px 28px color-mix(in srgb, mel.$mel-ds-color-primary 32%, transparent);
+
+  &:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px #fff,
+      0 0 0 5px color-mix(in srgb, mel.$mel-ds-color-primary 38%, transparent);
+  }
+}
+
+.mel-home-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px 18px;
+  margin-top: 18px;
+}
+
+.mel-home-hero__secondary {
+  font-weight: 700;
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-home-hero__pills {
+  width: min(100%, 760px);
+  margin-top: 22px;
+}
+
+.mel-home-hero__pills .mel-category-pills,
+.mel-home-hero__pills .mel-category-strip,
+.mel-home-hero__pills ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-home-hero__pills a,
+.mel-home-hero__pills .mel-pill,
+.mel-home-hero__pills .mel-category-pill {
+  min-height: 40px;
+  border-radius: 999px;
+  box-shadow: 0 8px 20px rgba(74, 63, 104, 0.12);
+  text-decoration: none;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 26px rgba(74, 63, 104, 0.16);
+  }
+
+  &:focus-visible {
+    outline: 3px solid color-mix(in srgb, mel.$mel-ds-color-primary 38%, transparent);
+    outline-offset: 3px;
+  }
+}
+
+.mel-home-hero__art {
+  min-width: 0;
+
+  @include breakpoints.mel-break(lg, max) {
+    order: -1;
+  }
+}
+
 .mel-home-hero__art--hide-mobile {
   @include breakpoints.mel-break(md, max) {
     display: none;
   }
 }
 
+.mel-home-hero__art-frame {
+  position: relative;
+  min-height: clamp(220px, 34vw, 420px);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: clamp(24px, 4vw, 38px);
+  overflow: hidden;
+  background:
+    linear-gradient(145deg, rgba(242, 109, 91, 0.22), rgba(124, 131, 253, 0.24));
+  box-shadow:
+    0 22px 64px rgba(54, 45, 77, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+
+  picture {
+    display: block;
+    height: 100%;
+  }
+}
+
+.mel-home-hero__feature-rotator {
+  position: relative;
+  min-height: clamp(260px, 34vw, 430px);
+  isolation: isolate;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel,
+.mel-home-hero__feature-rotator .mel-featured-home-carousel,
+.mel-home-hero__feature-rotator .mel-featured-carousel__track,
+.mel-home-hero__feature-rotator .mel-featured-home-carousel__track {
+  height: 100%;
+  min-height: inherit;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel {
+  overflow: hidden;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel::before,
+.mel-home-hero__feature-rotator .mel-featured-carousel::after {
+  display: none;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel__track {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  scroll-snap-type: none;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel__item {
+  grid-area: 1 / 1;
+  min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(18px, 0, 0) scale(0.985);
+  transition:
+    opacity 0.55s ease,
+    transform 0.55s ease;
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel__item:first-child,
+.mel-home-hero__feature-rotator .mel-featured-carousel__item.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.mel-home-hero__feature-rotator.is-enhanced .mel-featured-carousel__item:first-child:not(.is-active) {
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(-18px, 0, 0) scale(0.985);
+}
+
+.mel-home-hero__feature-rotator .mel-event-card--featured,
+.mel-home-hero__feature-rotator .mel-event-hero-card {
+  min-height: clamp(260px, 34vw, 430px);
+  border-radius: clamp(24px, 4vw, 38px);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow:
+    0 18px 48px rgba(31, 38, 51, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.mel-home-hero__feature-rotator .mel-event-hero-card__overlay {
+  background:
+    linear-gradient(90deg, rgba(13, 18, 28, 0.7) 0%, rgba(13, 18, 28, 0.28) 52%, rgba(13, 18, 28, 0.08) 100%),
+    linear-gradient(0deg, rgba(13, 18, 28, 0.72) 0%, transparent 58%);
+}
+
+.mel-home-hero__feature-rotator .mel-featured-carousel__controls {
+  display: none;
+}
+
+.mel-home-hero__feature-rotator .mel-event-hero-card__content,
+.mel-home-hero__feature-rotator .mel-event-card__body {
+  width: min(100%, 390px);
+  padding: clamp(20px, 3vw, 30px);
+}
+
+.mel-home-hero__feature-rotator .mel-event-hero-card__title,
+.mel-home-hero__feature-rotator .mel-event-card__title {
+  font-size: clamp(1.45rem, 3vw, 2.35rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.mel-home-hero__feature-rotator .mel-event-hero-card__when,
+.mel-home-hero__feature-rotator .mel-event-hero-card__where,
+.mel-home-hero__feature-rotator .mel-event-card__when,
+.mel-home-hero__feature-rotator .mel-event-card__location {
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-home-hero__feature-rotator .mel-featured-carousel__item {
+    transition: none;
+    transform: none;
+  }
+}
+
+.mel-home-hero__art-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: clamp(220px, 34vw, 420px);
+  object-fit: cover;
+}
+
+.mel-home-hero__art-img--placeholder {
+  background:
+    radial-gradient(circle at 26% 30%, rgba(255, 255, 255, 0.58), transparent 22%),
+    radial-gradient(circle at 70% 22%, rgba(246, 196, 122, 0.52), transparent 28%),
+    radial-gradient(circle at 68% 74%, rgba(124, 131, 253, 0.42), transparent 30%),
+    linear-gradient(135deg, rgba(242, 109, 91, 0.32), rgba(255, 255, 255, 0.2));
+}
+
+// Fallback legacy hero component used when no homepage hero block is placed.
 .hero {
-  // Semi-transparent tint that blends into the page-shell gradient.
-  // NOT opaque — the body/page radials show through, creating continuity.
   background: var(--mel-gradient-hero);
   padding: clamp(1.5rem, 4vw, 3.25rem) 1.5rem;
   position: relative;
   overflow: hidden;
 
-  // Soft radial depth — reinforces the gradient in the hero zone
   &::before {
     content: '';
     position: absolute;
@@ -42,198 +368,5 @@
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: 0;
-
-    @include breakpoints.mel-break(md, max) {
-      gap: 0;
-    }
-  }
-
-  // Text overlays the image (desktop)
-  &__text {
-    @include breakpoints.mel-break(md) {
-      position: relative;
-      z-index: 1;
-    }
-  }
-
-  &__headline {
-    font-size: clamp(2rem, 4.5vw, 2.75rem);
-    font-weight: 700;
-    color: var(--mel-ink);
-    margin: 0 0 1rem;
-    line-height: 1.15;
-    max-width: 22ch;
-  }
-
-  &__supporting {
-    max-width: 36rem;
-    margin: 0 0 1.75rem;
-    line-height: 1.6;
-    font-size: clamp(1rem, 2.2vw, 1.125rem);
-    color: var(--mel-muted);
-  }
-
-  &__ctas {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1rem;
-    align-items: center;
-    margin-bottom: 0.5rem;
-
-    @include breakpoints.mel-break(md) {
-      position: relative;
-      z-index: 1;
-    }
-  }
-
-  &__cta {
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &__tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    align-items: center;
-    margin-top: 2rem;
-
-    @include breakpoints.mel-break(md) {
-      position: relative;
-      z-index: 1;
-      margin-top: 2.25rem;
-    }
-  }
-
-  &__tags-label {
-    font-size: 0.875rem;
-    color: var(--mel-muted);
-    margin-right: 0.25rem;
-  }
-
-  &__tag {
-    display: inline-flex;
-    align-items: center;
-    height: 32px;
-    padding: 0 12px;
-    font-size: 0.875rem;
-    font-weight: 600;
-    border-radius: 999px;
-    border: none;
-    color: var(--mel-ink);
-    text-decoration: none;
-    transition: all 0.15s ease;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    background: var(--mel-lilac);
-    color: var(--mel-navy);
-
-    // Mel colours - rotate through palette (child 1 = label, 2+ = pills)
-    &:nth-child(2) { background: var(--mel-coral); color: #fff; }
-    &:nth-child(3) { background: var(--mel-blue); color: #fff; }
-    &:nth-child(4) { background: var(--mel-lilac); color: var(--mel-navy); }
-    &:nth-child(5) { background: var(--mel-peach); color: var(--mel-navy); }
-    &:nth-child(6) { background: var(--mel-mint); color: var(--mel-navy); }
-    &:nth-child(7) { background: var(--mel-orange); color: #fff; }
-    &:nth-child(8) { background: var(--mel-sky); color: var(--mel-navy); }
-    &:nth-child(9) { background: var(--mel-butter); color: var(--mel-navy); }
-    &:nth-child(10) { background: var(--mel-coral); color: #fff; }
-    &:nth-child(11) { background: var(--mel-blue); color: #fff; }
-    &:nth-child(12) { background: var(--mel-lilac); color: var(--mel-navy); }
-
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-    }
-
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--mel-surface), 0 0 0 5px var(--mel-focus);
-    }
-  }
-
-  &__visual {
-    min-height: 280px;
-
-    // Mobile: show art above content
-    @include breakpoints.mel-break(md, max) {
-      order: 0;
-      min-height: 200px;
-      margin-top: 0;
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-    }
-
-    // Desktop: image under the copy; text stays readable above
-    @include breakpoints.mel-break(md) {
-      position: absolute;
-      top: 5px;
-      left: 0;
-      right: 0;
-      width: 100%;
-      min-height: 280px;
-      z-index: 0;
-    }
-  }
-
-  &__visual-inner {
-    width: 100%;
-    height: 100%;
-    min-height: 280px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    picture {
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-
-    @include breakpoints.mel-break(md, max) {
-      min-height: 200px;
-      max-width: min(100%, 420px);
-      margin: 0 auto;
-    }
-
-    @include breakpoints.mel-break(md) {
-      width: 100%;
-      min-height: 280px;
-      align-items: flex-start;
-      justify-content: flex-end;
-    }
-  }
-
-  &__visual-img {
-    width: 100%;
-    height: auto;
-    max-height: 320px;
-    object-fit: contain;
-    object-position: center top;
-    display: block;
-    filter: drop-shadow(0 18px 40px rgba(110, 90, 160, 0.12));
-
-    @include breakpoints.mel-break(md) {
-      max-height: none;
-      max-width: min(560px, 52vw);
-      min-height: 280px;
-      object-fit: contain;
-      object-position: right top;
-      margin-left: auto;
-    }
-
-    &--fallback {
-      border-radius: clamp(20px, 4vw, 28px);
-    }
-  }
-
-  &__content {
-    // Mobile: content below the art
-    @include breakpoints.mel-break(md, max) {
-      order: 1;
-    }
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_grid.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_grid.scss
@@ -8,7 +8,23 @@
 
 .mel-grid--events,
 .mel-grid.mel-grid--events {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  grid-template-columns: 1fr;
+  gap: spacing.mel-space(4);
+}
+
+@include breakpoints.mel-break(md) {
+  .mel-grid--events,
+  .mel-grid.mel-grid--events {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@include breakpoints.mel-break(lg) {
+  .mel-grid--events,
+  .mel-grid.mel-grid--events {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: spacing.mel-space(4);
+  }
 }
 
 .mel-grid--featured,

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
@@ -1,5 +1,5 @@
 // ==========================================================================
-// MEL discovery — upcoming events / browse grids (1 → 2 → 3 columns)
+// MEL discovery — upcoming events / browse grids (1 -> 2 -> 4 columns)
 // ==========================================================================
 // Contexts:
 // - `.mel-discovery` — upcoming_events Views wrappers (see views-view--upcoming-events*.twig)
@@ -14,7 +14,7 @@
   min-width: 0;
 }
 
-// Shared grid: explicit columns (layout/_grid.scss uses auto-fit minmax — subtler than this).
+// Shared grid: explicit columns for scannable discovery density.
 .mel-discovery .mel-event-grid.mel-grid--events,
 .mel-home-discover .mel-event-grid.mel-grid--events {
   display: grid;
@@ -33,13 +33,13 @@
   .mel-discovery .mel-event-grid.mel-grid--events,
   .mel-home-discover .mel-event-grid.mel-grid--events {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: mel.$mel-ds-space-lg;
+    gap: mel.$mel-ds-space-md;
   }
 }
 
 @include breakpoints.mel-break(lg) {
   .mel-discovery .mel-event-grid.mel-grid--events,
   .mel-home-discover .mel-event-grid.mel-grid--events {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -1,77 +1,465 @@
 // ==========================================================================
-// MEL homepage — v2 conversion layout (scoped to .mel-page--home)
+// MEL homepage visual system (scoped to .mel-page--home)
 // ==========================================================================
 
 @use '../base/mel-ds-tokens' as mel;
 @use '../tokens/breakpoints';
 
-// ---------------------------------------------------------------------------
-// Category strip — homepage block (`myeventlane_category_pills`)
-// ---------------------------------------------------------------------------
-
-.mel-section--categories .mel-category-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.mel-page--home {
+  background:
+    radial-gradient(circle at 8% 10%, rgba(242, 109, 91, 0.05), transparent 30rem),
+    radial-gradient(circle at 92% 38%, rgba(124, 131, 253, 0.06), transparent 32rem);
 }
 
-.mel-section--categories .mel-category-strip .mel-category-pill {
-  border-radius: 999px;
-  padding: 6px 12px;
-  background: #efe9ff;
-  font-size: 14px;
-  font-weight: 600;
+.mel-page--home .mel-section {
+  padding-block: clamp(1.25rem, 3.5vw, 2.45rem);
+}
+
+.mel-page--home .mel-section__header {
+  margin-bottom: 18px;
+}
+
+.mel-page--home .mel-section__title {
+  letter-spacing: -0.025em;
+}
+
+.mel-page--home .mel-section__link,
+.mel-page--home .mel-section__header a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  color: mel.$mel-ds-color-primary;
   text-decoration: none;
-  color: inherit;
-  transition:
-    background 0.2s ease,
-    transform 0.2s ease;
+}
 
-  &:hover {
-    background: #e2d9ff;
-    transform: translateY(-1px);
-  }
+.mel-page--home .mel-section__link:focus-visible,
+.mel-page--home .mel-section__header a:focus-visible {
+  outline: 3px solid color-mix(in srgb, mel.$mel-ds-color-primary 36%, transparent);
+  outline-offset: 3px;
+  border-radius: 999px;
 }
 
 // ---------------------------------------------------------------------------
-// Featured — marketplace hero rail (homepage only)
+// Category strip - homepage block (`myeventlane_category_pills`)
+// ---------------------------------------------------------------------------
+
+.mel-page--home .mel-section--categories {
+  display: none;
+}
+
+// ---------------------------------------------------------------------------
+// Featured - premium editorial carousel from the existing featured View.
 // ---------------------------------------------------------------------------
 
 .mel-page--home .mel-section--featured {
-  margin-top: 0;
-  margin-bottom: 0;
+  padding-top: clamp(1.1rem, 3vw, 2rem);
+  padding-bottom: clamp(1.35rem, 3.5vw, 2.4rem);
 }
 
-// ---------------------------------------------------------------------------
-// Discover / Free — tighter marketplace density (homepage listings)
-// ---------------------------------------------------------------------------
+.mel-page--home .mel-section--featured .mel-container {
+  max-width: 1240px;
+}
 
-.mel-page--home .mel-section--discover .mel-grid.mel-grid--events,
-.mel-page--home .mel-section--free .mel-grid.mel-grid--events,
-.mel-page--home .mel-section--time .mel-grid.mel-grid--events {
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+.mel-page--home .mel-featured-home-carousel {
+  overflow: hidden;
+}
+
+.mel-page--home .mel-featured-home-carousel::before,
+.mel-page--home .mel-featured-home-carousel::after {
+  display: none;
+}
+
+.mel-page--home .mel-featured-home-carousel__track {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0;
+  margin: 0;
+  padding: 6px 0 18px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-padding-inline: 0;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid color-mix(in srgb, mel.$mel-ds-color-primary 45%, transparent);
+    outline-offset: 4px;
+    border-radius: 28px;
+  }
+}
+
+.mel-page--home .mel-featured-home-carousel__item {
+  flex: 0 0 100%;
+  min-width: 0;
+  scroll-snap-align: start;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card-article,
+.mel-page--home .mel-featured-home-carousel .mel-event-card {
+  display: block;
+  height: 100%;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured,
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card {
+  width: 100%;
+  min-height: clamp(360px, 42vw, 520px);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: clamp(24px, 3vw, 34px);
+  overflow: hidden;
+  background: #1f2633;
+  box-shadow: 0 26px 70px rgba(31, 38, 51, 0.2);
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card {
+  color: #fff;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__overlay {
+  background:
+    linear-gradient(90deg, rgba(13, 18, 28, 0.78) 0%, rgba(13, 18, 28, 0.32) 52%, rgba(13, 18, 28, 0.06) 100%),
+    linear-gradient(0deg, rgba(13, 18, 28, 0.8) 0%, transparent 62%);
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__title {
+  max-width: 11ch;
+  font-size: clamp(2.2rem, 5.2vw, 4.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__when,
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__where,
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__status,
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__status-note {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-hero-card__cta-chip {
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.24);
+}
+
+.mel-page--home .mel-featured-carousel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 12px;
+  margin-top: 14px;
+}
 
-  @media (width <= 768px) {
-    grid-template-columns: 1fr;
+.mel-page--home .mel-featured-carousel__button,
+.mel-page--home .mel-featured-carousel__dot {
+  border: 0;
+  cursor: pointer;
+}
+
+.mel-page--home .mel-featured-carousel__button {
+  display: inline-grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 10%, transparent);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  color: mel.$mel-ds-color-text;
+  font-size: 24px;
+  line-height: 1;
+  box-shadow: 0 10px 28px rgba(55, 45, 82, 0.1);
+}
+
+.mel-page--home .mel-featured-carousel__dots {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mel-page--home .mel-featured-carousel__dot {
+  width: 9px;
+  height: 9px;
+  padding: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, mel.$mel-ds-color-text 22%, transparent);
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease,
+    width 0.2s ease;
+}
+
+.mel-page--home .mel-featured-carousel__dot.is-active {
+  width: 24px;
+  background: mel.$mel-ds-color-primary;
+}
+
+.mel-page--home .mel-featured-carousel__button:focus-visible,
+.mel-page--home .mel-featured-carousel__dot:focus-visible {
+  outline: 3px solid color-mix(in srgb, mel.$mel-ds-color-primary 36%, transparent);
+  outline-offset: 3px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .mel-page--home .mel-featured-carousel__button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 34px rgba(55, 45, 82, 0.14);
+  }
+
+  .mel-page--home .mel-featured-carousel__dot:hover {
+    transform: scale(1.12);
+  }
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__link {
+  position: relative;
+  min-height: inherit;
+  color: #fff;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__image {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background:
+    linear-gradient(90deg, rgba(13, 18, 28, 0.78) 0%, rgba(13, 18, 28, 0.32) 48%, rgba(13, 18, 28, 0.12) 100%),
+    linear-gradient(0deg, rgba(13, 18, 28, 0.78) 0%, transparent 58%);
+  pointer-events: none;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__image .mel-event-card__image-element,
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: clamp(360px, 42vw, 520px);
+  object-fit: cover;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__image-badge {
+  z-index: 4;
+  top: 22px;
+  left: 22px;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__body {
+  position: relative;
+  z-index: 3;
+  justify-content: flex-end;
+  width: min(100%, 560px);
+  min-height: clamp(360px, 42vw, 520px);
+  padding: clamp(24px, 5vw, 48px);
+  color: #fff;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__title {
+  min-height: 0;
+  margin-bottom: 12px;
+  color: #fff;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__when,
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__location,
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__status,
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__status-secondary {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__location-slot {
+  min-height: 0;
+  margin-bottom: 12px;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__cta-row {
+  margin-top: 8px;
+}
+
+.mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__cta-chip {
+  background: mel.$mel-ds-color-primary;
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.22);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured:hover,
+  .mel-page--home .mel-featured-home-carousel .mel-event-hero-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 30px 76px rgba(31, 38, 51, 0.24);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-page--home .mel-featured-home-carousel__track {
+    scroll-behavior: auto;
+  }
+
+  .mel-page--home .mel-featured-carousel__dot {
+    transition: none;
+  }
+}
+
+@media (width <= 640px) {
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured,
+  .mel-page--home .mel-featured-home-carousel .mel-event-hero-card,
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__image .mel-event-card__image-element,
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__placeholder,
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__body {
+    min-height: clamp(300px, 88vw, 360px);
+  }
+
+  .mel-page--home .mel-featured-home-carousel .mel-event-card--featured .mel-event-card__body {
+    padding: 22px;
   }
 }
 
 // ---------------------------------------------------------------------------
-// On tonight — urgency band
+// Discovery - dense marketplace grid across homepage rails.
 // ---------------------------------------------------------------------------
 
-.mel-page--home .mel-section--tonight-urgent {
-  position: relative;
-  padding-left: mel.$mel-ds-space-lg;
-  border-radius: mel.$mel-ds-radius-md;
-  background: color-mix(in srgb, mel.$mel-ds-color-accent 8%, mel.$mel-ds-color-surface);
-  box-shadow: inset 4px 0 0 color-mix(in srgb, mel.$mel-ds-color-accent 70%, transparent);
+.mel-page--home .mel-section--latest {
+  padding-top: clamp(1rem, 2.6vw, 1.9rem);
 }
 
-// ---------------------------------------------------------------------------
-// Card CTAs — clearer affordance on hover (full card is still one link)
-// ---------------------------------------------------------------------------
+.mel-page--home .mel-section--tonight {
+  position: relative;
+  overflow: hidden;
+}
+
+.mel-page--home .mel-section--tonight::before {
+  content: '';
+  position: absolute;
+  inset: 10% 0 auto auto;
+  width: min(34vw, 360px);
+  height: min(34vw, 360px);
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(124, 131, 253, 0.12), transparent 68%);
+  pointer-events: none;
+}
+
+.mel-page--home .mel-section--discover .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--latest .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--nearby .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--online .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--tonight .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--free .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--time .mel-grid.mel-grid--events {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+
+  @media (width <= 1024px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (width <= 640px) {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}
+
+.mel-page--home .mel-home-event-grid > * {
+  min-width: 0;
+}
+
+.mel-page--home .mel-card-reason--tonight {
+  width: fit-content;
+  margin: 0 0 8px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, mel.$mel-ds-color-primary 14%, #fff);
+  color: mel.$mel-ds-color-primary;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card,
+.mel-page--home .mel-section--latest .mel-event-card,
+.mel-page--home .mel-section--nearby .mel-event-card,
+.mel-page--home .mel-section--online .mel-event-card,
+.mel-page--home .mel-section--tonight .mel-event-card {
+  height: 100%;
+  border-radius: 18px;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__image,
+.mel-page--home .mel-section--latest .mel-event-card__image,
+.mel-page--home .mel-section--nearby .mel-event-card__image,
+.mel-page--home .mel-section--online .mel-event-card__image,
+.mel-page--home .mel-section--tonight .mel-event-card__image {
+  aspect-ratio: 4 / 3;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__body,
+.mel-page--home .mel-section--latest .mel-event-card__body,
+.mel-page--home .mel-section--nearby .mel-event-card__body,
+.mel-page--home .mel-section--online .mel-event-card__body,
+.mel-page--home .mel-section--tonight .mel-event-card__body {
+  padding: 12px 13px 13px;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__title,
+.mel-page--home .mel-section--latest .mel-event-card__title,
+.mel-page--home .mel-section--nearby .mel-event-card__title,
+.mel-page--home .mel-section--online .mel-event-card__title,
+.mel-page--home .mel-section--tonight .mel-event-card__title {
+  margin-bottom: 8px;
+  font-size: 16px;
+  line-height: 1.22;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__when,
+.mel-page--home .mel-section--latest .mel-event-card__when,
+.mel-page--home .mel-section--nearby .mel-event-card__when,
+.mel-page--home .mel-section--online .mel-event-card__when,
+.mel-page--home .mel-section--tonight .mel-event-card__when,
+.mel-page--home .mel-section--discover .mel-event-card__status,
+.mel-page--home .mel-section--latest .mel-event-card__status,
+.mel-page--home .mel-section--nearby .mel-event-card__status,
+.mel-page--home .mel-section--online .mel-event-card__status,
+.mel-page--home .mel-section--tonight .mel-event-card__status {
+  font-size: 13px;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__location-slot,
+.mel-page--home .mel-section--latest .mel-event-card__location-slot,
+.mel-page--home .mel-section--nearby .mel-event-card__location-slot,
+.mel-page--home .mel-section--online .mel-event-card__location-slot,
+.mel-page--home .mel-section--tonight .mel-event-card__location-slot {
+  min-height: 1.2em;
+  margin-bottom: 6px;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__location,
+.mel-page--home .mel-section--latest .mel-event-card__location,
+.mel-page--home .mel-section--nearby .mel-event-card__location,
+.mel-page--home .mel-section--online .mel-event-card__location,
+.mel-page--home .mel-section--tonight .mel-event-card__location {
+  font-size: 12px;
+}
+
+.mel-page--home .mel-section--discover .mel-event-card__cta-chip,
+.mel-page--home .mel-section--latest .mel-event-card__cta-chip,
+.mel-page--home .mel-section--nearby .mel-event-card__cta-chip,
+.mel-page--home .mel-section--online .mel-event-card__cta-chip,
+.mel-page--home .mel-section--tonight .mel-event-card__cta-chip {
+  min-height: 44px;
+  padding-inline: 12px;
+  border-radius: 999px;
+  font-size: 12px;
+}
 
 @media (hover: hover) and (pointer: fine) {
   .mel-page--home .mel-event-card:hover .mel-event-card__cta-chip {
@@ -79,13 +467,46 @@
     border-color: color-mix(in srgb, mel.$mel-ds-color-primary 40%, transparent);
     color: mel.$mel-ds-color-text;
   }
+}
 
-  .mel-page--home .mel-event-card--featured:hover .mel-event-card__cta-chip {
-    background: mel.$mel-ds-color-primary;
-    color: #fff;
-    border-color: transparent;
-    box-shadow: 0 4px 14px color-mix(in srgb, mel.$mel-ds-color-primary 35%, transparent);
+// ---------------------------------------------------------------------------
+// Blog preview - editorial, lightweight, no homepage exposed filters.
+// ---------------------------------------------------------------------------
+
+.mel-page--home .mel-blog-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+
+  @media (width <= 900px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  @media (width <= 640px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mel-page--home .mel-blog-preview-grid__item {
+  min-width: 0;
+}
+
+.mel-page--home .mel-section--blog .views-exposed-form,
+.mel-page--home .mel-section--blog form.views-exposed-form {
+  display: none;
+}
+
+.mel-page--home .mel-section--blog article,
+.mel-page--home .mel-blog-preview-grid__item > * {
+  height: 100%;
+}
+
+.mel-page--home .mel-section--blog .node {
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: 0 12px 36px rgba(55, 45, 82, 0.08);
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +522,7 @@
   flex-direction: column;
   gap: mel.$mel-ds-space-xl;
   padding: mel.$mel-ds-space-2xl mel.$mel-ds-space-lg;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
   border-radius: mel.$mel-ds-radius-lg;
   background: linear-gradient(
     135deg,
@@ -108,7 +530,6 @@
     color-mix(in srgb, mel.$mel-ds-color-primary 10%, mel.$mel-ds-color-bg) 100%
   );
   box-shadow: mel.$mel-ds-shadow-soft;
-  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
 
   @include breakpoints.mel-break(md) {
     flex-direction: row;
@@ -119,66 +540,27 @@
 }
 
 .mel-host-cta__title {
+  margin: 0 0 mel.$mel-ds-space-sm;
+  color: mel.$mel-ds-color-text;
   font-family: mel.$mel-ds-font-main;
   font-size: mel.$mel-ds-font-h2;
   font-weight: 700;
-  margin: 0 0 mel.$mel-ds-space-sm;
-  color: mel.$mel-ds-color-text;
   line-height: 1.2;
 }
 
 .mel-host-cta__text {
+  max-width: 36rem;
+  margin: 0;
+  color: mel.$mel-ds-color-text;
   font-family: mel.$mel-ds-font-main;
   font-size: mel.$mel-ds-font-body;
   line-height: 1.55;
-  color: mel.$mel-ds-color-text;
-  margin: 0;
-  max-width: 36rem;
   opacity: 0.92;
 }
 
 .mel-host-cta__actions {
   display: flex;
+  flex-shrink: 0;
   flex-wrap: wrap;
   gap: mel.$mel-ds-space-sm mel.$mel-ds-space-md;
-  flex-shrink: 0;
-}
-
-// ---------------------------------------------------------------------------
-// Final CTA band
-// ---------------------------------------------------------------------------
-
-.mel-section--final-cta {
-  margin-bottom: mel.$mel-ds-space-xl;
-}
-
-.mel-final-cta {
-  text-align: center;
-  padding: mel.$mel-ds-space-2xl mel.$mel-ds-space-lg;
-  border-radius: mel.$mel-ds-radius-md;
-  background: mel.$mel-ds-color-surface;
-  box-shadow: mel.$mel-ds-shadow-soft;
-  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 10%, transparent);
-  max-width: 720px;
-  margin: 0 auto;
-}
-
-.mel-final-cta__title {
-  font-family: mel.$mel-ds-font-main;
-  font-size: mel.$mel-ds-font-h3;
-  font-weight: 700;
-  margin: 0 0 mel.$mel-ds-space-sm;
-  color: mel.$mel-ds-color-text;
-}
-
-.mel-final-cta__text {
-  font-family: mel.$mel-ds-font-main;
-  font-size: mel.$mel-ds-font-small;
-  line-height: 1.55;
-  color: mel.$mel-ds-color-muted;
-  margin: 0 0 mel.$mel-ds-space-lg;
-}
-
-.mel-final-cta__btn {
-  min-width: 200px;
 }

--- a/web/themes/custom/myeventlane_theme/templates/account/mel-account-empty-state.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/account/mel-account-empty-state.html.twig
@@ -5,13 +5,10 @@
  */
 #}
 <div class="mel-account-empty-state mel-my-account__empty">
-  {% if title %}
-    <h2 class="mel-account-empty-state__title">{{ title }}</h2>
-  {% endif %}
-  {% if message %}
-    <p class="mel-account-empty-state__text">{{ message }}</p>
-  {% endif %}
-  {% if primary_url and primary_label %}
-    <a href="{{ primary_url }}" class="mel-button mel-button--primary">{{ primary_label }}</a>
-  {% endif %}
+  {% include '@myeventlane_theme/components/empty-state.html.twig' with {
+    title: title|default(''),
+    text: message|default(''),
+    cta_primary_url: primary_url|default(''),
+    cta_primary_label: primary_label|default('')
+  } %}
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/components/empty-state.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/empty-state.html.twig
@@ -1,0 +1,35 @@
+{#
+/**
+ * @file
+ * Reusable MEL empty state.
+ *
+ * Variables:
+ * - title: Empty state heading.
+ * - text: Supporting copy.
+ * - cta_primary_url: Optional primary CTA URL.
+ * - cta_primary_label: Optional primary CTA label.
+ * - cta_secondary_url: Optional secondary CTA URL.
+ * - cta_secondary_label: Optional secondary CTA label.
+ */
+#}
+<div class="mel-empty-state mel-empty-state--governed">
+  {% if title %}
+    <h3 class="mel-empty-state__heading">{{ title }}</h3>
+  {% endif %}
+
+  {% if text %}
+    <p class="mel-empty-state__what">{{ text }}</p>
+  {% endif %}
+
+  {% if (cta_primary_url and cta_primary_label) or (cta_secondary_url and cta_secondary_label) %}
+    <p class="mel-empty-state__cta">
+      {% if cta_primary_url and cta_primary_label %}
+        <a class="mel-btn mel-btn--cta" href="{{ cta_primary_url }}">{{ cta_primary_label }}</a>
+      {% endif %}
+
+      {% if cta_secondary_url and cta_secondary_label %}
+        <a class="mel-link" href="{{ cta_secondary_url }}">{{ cta_secondary_label }}</a>
+      {% endif %}
+    </p>
+  {% endif %}
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
@@ -2,7 +2,7 @@
 /**
  * @file
  * Main site footer.
- * Condensed 3-column layout (Find events, Host events, About) + compact legal row.
+ * Menu-backed discovery footer for public marketplace pages.
  */
 #}
 
@@ -11,7 +11,7 @@
 
   <div class="mel-footer__container">
 
-    <div class="mel-footer__nav">
+    <nav class="mel-footer__nav" aria-label="{{ 'Footer navigation'|t }}">
 
       <div class="mel-footer__col">
         <h4>{{ 'Find events'|t }}</h4>
@@ -36,7 +36,7 @@
         {% endif %}
       </div>
 
-      <div class="mel-footer__col mel-footer__col--wide">
+      <div class="mel-footer__col">
         <h4>{{ 'About MyEventLane'|t }}</h4>
         {{ drupal_menu('footer-about') }}
         <div class="mel-footer__trust">
@@ -46,7 +46,12 @@
         </div>
       </div>
 
-    </div>
+      <div class="mel-footer__col">
+        <h4>{{ 'Community'|t }}</h4>
+        {{ drupal_menu('footer-community') }}
+      </div>
+
+    </nav>
 
   </div>
 

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -1,137 +1,125 @@
 {#
 /**
  * @file
- * MEL homepage — code-driven discovery.
+ * MEL homepage — region-driven discovery.
  */
 #}
 {% extends "page.html.twig" %}
 
 {% block hero %}
-  {% set popular_tags = popular_tags|default([]) %}
-  {% include '@myeventlane_theme/components/hero/hero.twig' with { popular_tags: popular_tags } %}
+  {% if page.homepage_hero %}
+    <div class="mel-region-homepage-hero">
+      {{ page.homepage_hero }}
+    </div>
+  {% elseif page.hero %}
+    <div class="mel-region-hero">
+      {{ page.hero }}
+    </div>
+  {% else %}
+    {% set popular_tags = popular_tags|default([]) %}
+    {% include '@myeventlane_theme/components/hero/hero.twig' with { popular_tags: popular_tags } %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
   {{ attach_library('myeventlane_theme/front') }}
 
-  {% set mel_home_featured_markup %}
-    {{ drupal_view('front_featured_events', 'block_featured') }}
-  {% endset %}
-
-  {% set mel_home_discover_markup %}
-    {{ drupal_view('mel_home_events', 'embed_discover') }}
-  {% endset %}
-
-  {% set mel_home_free_markup %}
-    {{ drupal_view('mel_home_events', 'under_20') }}
-  {% endset %}
-
-  {% set mel_home_tonight_markup %}
-    {{ drupal_view('mel_home_events', 'tonight') }}
-  {% endset %}
-
-  {% set mel_home_categories_markup %}
-    {{ drupal_block('myeventlane_category_pills') }}
-  {% endset %}
-
   <div class="mel-page mel-page--home">
 
-    {% if mel_home_featured_markup|trim %}
+    {% if page.homepage_featured %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--featured',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
         header_extra_class: 'mel-section__header--featured',
         title: 'Featured events'|t,
-        subtitle: 'Hand-picked events worth your evening.'|t,
+        subtitle: 'The can’t-miss pick at the top of the lane.'|t,
         link_url: path('view.upcoming_events.page_events'),
         link_text: 'Browse marketplace'|t,
         link_class: 'mel-link',
-        content: mel_home_featured_markup
+        content: page.homepage_featured
       } %}
     {% endif %}
 
-    {% if mel_home_discover_markup|trim %}
+    {% if page.homepage_latest %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--discover',
+        section_class: 'mel-section--latest mel-section--discover',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Find something you’ll love'|t,
-        subtitle: 'Browse what’s happening near you.'|t,
+        title: 'Upcoming events'|t,
+        subtitle: 'What’s coming up across MyEventLane.'|t,
         link_url: path('view.upcoming_events.page_events'),
         link_text: 'See all'|t,
         content_wrapper_class: 'mel-section__discover-view',
-        content: mel_home_discover_markup
+        content: page.homepage_latest
       } %}
     {% endif %}
 
-    {% if mel_home_tonight_markup|trim %}
-      {% set mel_home_tonight_section_content %}
-        <div class="mel-section__discover-view">
-          {{ mel_home_tonight_markup }}
-        </div>
-        <div class="mel-section__content-footer">
-          <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-section__link">{{ 'See all upcoming events →'|t }}</a>
-        </div>
-      {% endset %}
+    {% if page.homepage_tonight %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--time mel-section--tonight-urgent',
+        section_class: 'mel-section--tonight mel-section--discover',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Going out tonight?'|t,
-        subtitle: 'These events are happening soon — don’t miss out.'|t,
-        content: mel_home_tonight_section_content
+        title: 'On tonight'|t,
+        subtitle: 'Last-minute plans and events already warming up.'|t,
+        link_url: path('view.upcoming_events.page_today'),
+        link_text: 'See today'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_tonight
       } %}
     {% endif %}
 
-    {% if mel_home_free_markup|trim %}
+    {% if page.homepage_nearby %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--free',
+        section_class: 'mel-section--nearby',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Free & RSVP'|t,
-        subtitle: 'Low-friction ways to join in.'|t,
-        link_url: path('view.upcoming_events.page_free'),
-        link_text: 'See all'|t,
-        content: mel_home_free_markup
+        title: 'Nearby events'|t,
+        subtitle: 'Find experiences close to you.'|t,
+        link_url: '/events/nearby',
+        link_text: 'Explore nearby'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_nearby
       } %}
     {% endif %}
 
-    {% if mel_home_categories_markup|trim %}
-      <section class="mel-section mel-section--categories" aria-labelledby="mel-home-categories-title">
-        <div class="mel-container mel-container--wide">
-          <div class="mel-section__header">
-            <div class="mel-section__intro">
-              <h2 id="mel-home-categories-title" class="mel-section__title">{{ 'Browse by category'|t }}</h2>
-              <p class="mel-section__subtitle">{{ 'Pick a lane — we’ll show matching events.'|t }}</p>
-            </div>
-          </div>
-
-          <div class="mel-section__content">
-            <div class="mel-category-strip">
-              {{ mel_home_categories_markup }}
-            </div>
-          </div>
-        </div>
-      </section>
+    {% if page.homepage_online %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--online',
+        section_width_class: 'mel-section--wide',
+        container_class: 'mel-container mel-container--wide',
+        title: 'Online events'|t,
+        subtitle: 'Join from wherever you are.'|t,
+        link_url: '/events/online',
+        link_text: 'See online events'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_online
+      } %}
     {% endif %}
 
-    <section class="mel-section mel-section--host mel-section--full" aria-labelledby="mel-host-cta-title">
-      <div class="mel-container mel-container--wide">
-        <div class="mel-host-cta">
-          <div class="mel-host-cta__copy">
-            <h2 id="mel-host-cta-title" class="mel-host-cta__title">{{ 'Ready to host your next event?'|t }}</h2>
-            <p class="mel-host-cta__text">
-              {{ 'List for free, sell tickets with transparent fees, and grow your community on MyEventLane.'|t }}
-            </p>
-          </div>
-          <div class="mel-host-cta__actions">
-            <a class="mel-btn mel-btn--cta" href="{{ path('myeventlane_vendor.create_event_gateway') }}">{{ 'Create Event'|t }}</a>
-            <a class="mel-btn mel-btn-secondary" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Host help'|t }}</a>
-          </div>
-        </div>
-      </div>
-    </section>
+    {% if page.homepage_blog %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--blog',
+        section_width_class: 'mel-section--wide',
+        container_class: 'mel-container mel-container--wide',
+        title: 'Guides for better nights out'|t,
+        subtitle: 'Lightweight ideas for discovering, hosting, and growing events.'|t,
+        link_url: '/blog',
+        link_text: 'Read more'|t,
+        content_wrapper_class: 'mel-section__blog-view',
+        content: page.homepage_blog
+      } %}
+    {% endif %}
+
+    {% if page.homepage_host_cta %}
+      {{ page.homepage_host_cta }}
+    {% else %}
+      {% include '@myeventlane_theme/includes/mel-host-cta-default.html.twig' %}
+    {% endif %}
+
+    {% if page.homepage_newsletter %}
+      {{ page.homepage_newsletter }}
+    {% endif %}
 
   </div>
 {% endblock %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-featured-events--block-featured.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-featured-events--block-featured.html.twig
@@ -1,19 +1,32 @@
 {#
 /**
  * @file
- * Featured events — full-bleed hero slider (homepage block_featured).
+ * Featured events — homepage featured card grid.
  */
 #}
 {% if rows %}
-  <div class="mel-featured-hero">
-
-    <div class="mel-featured-hero__track">
+  <div class="mel-featured-carousel mel-featured-home-carousel" data-mel-featured-carousel aria-label="{{ 'Featured events'|t }}">
+    <div class="mel-featured-carousel__track mel-featured-home-carousel__track" tabindex="0">
       {% for row in rows %}
-        <div class="mel-featured-hero__slide">
+        <div class="mel-featured-carousel__item mel-featured-home-carousel__item{% if loop.first %} is-active{% endif %}" data-mel-featured-slide>
           {{ row.content }}
         </div>
       {% endfor %}
     </div>
-
+    {% if rows|length > 1 %}
+      <div class="mel-featured-carousel__controls" aria-label="{{ 'Featured event carousel controls'|t }}">
+        <button class="mel-featured-carousel__button mel-featured-carousel__button--prev" type="button" data-mel-featured-prev aria-label="{{ 'Show previous featured event'|t }}">
+          <span aria-hidden="true">‹</span>
+        </button>
+        <div class="mel-featured-carousel__dots" role="tablist" aria-label="{{ 'Featured event slides'|t }}">
+          {% for row in rows %}
+            <button class="mel-featured-carousel__dot{% if loop.first %} is-active{% endif %}" type="button" data-mel-featured-dot="{{ loop.index0 }}" role="tab" aria-selected="{{ loop.first ? 'true' : 'false' }}" aria-label="{{ 'Show featured event @number'|t({'@number': loop.index}) }}"></button>
+          {% endfor %}
+        </div>
+        <button class="mel-featured-carousel__button mel-featured-carousel__button--next" type="button" data-mel-featured-next aria-label="{{ 'Show next featured event'|t }}">
+          <span aria-hidden="true">›</span>
+        </button>
+      </div>
+    {% endif %}
   </div>
 {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Homepage blog/guide preview grid.
+ */
+#}
+{% if rows %}
+  <div class="mel-blog-preview-grid">
+    {% for row in rows %}
+      <div class="mel-blog-preview-grid__item">
+        {{ row.content }}
+      </div>
+    {% endfor %}
+  </div>
+{% else %}
+  {% include '@myeventlane_theme/components/empty-state.html.twig' with {
+    title: 'No guides yet'|t,
+    text: 'Helpful organiser guides are coming soon.'|t,
+    cta_primary_url: '/create-event',
+    cta_primary_label: 'Create event'|t,
+    cta_secondary_url: '/events',
+    cta_secondary_label: 'Explore events'|t
+  } %}
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-latest.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-latest.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Homepage latest events grid.
+ */
+#}
+{% if rows %}
+  {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
+  <div class="mel-event-grid mel-grid mel-grid--events mel-home-event-grid" data-loaded="false">
+    {% for row in rows %}
+      {{- row.content -}}
+    {% endfor %}
+  </div>
+{% else %}
+  {% include '@myeventlane_theme/components/empty-state.html.twig' with {
+    title: 'No upcoming events yet'|t,
+    text: 'Check back soon or explore the marketplace for more events.'|t,
+    cta_primary_url: '/events',
+    cta_primary_label: 'Explore events'|t,
+    cta_secondary_url: '/create-event',
+    cta_secondary_label: 'Create event'|t
+  } %}
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-tonight.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-tonight.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Homepage tonight events grid.
+ */
+#}
+{% if rows %}
+  {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
+  <div class="mel-event-grid mel-grid mel-grid--events mel-home-event-grid mel-home-event-grid--tonight" data-loaded="false">
+    {% for row in rows %}
+      {{- row.content -}}
+    {% endfor %}
+  </div>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to new Drupal config (content type, views, menus) plus significant changes to Event Studio routing/access control and autosave behavior, which could impact vendor editing flows and permissions.
> 
> **Overview**
> Enables a new public blog/guides capability by adding a `blog_post` content type (fields, form/view displays), a `mel_blog` view with `/blog` page + homepage preview block, and pathauto support for node aliases (`blog/[node:title]`).
> 
> Updates homepage composition by activating/moving the featured events and hero blocks into new homepage regions, and adding new homepage blocks for *latest events*, *tonight*, and *blog guides*.
> 
> Expands public discovery/navigation by adding new footer menus and deployable footer links, and extends `upcoming_events` with new homepage blocks, a `/events/popular` route (promoted filter), and adjusted empty states/filters.
> 
> Introduces the canonical Event Studio workspace shell (`/vendor/events/{node}/studio` + section routes) with a section plugin framework, new shell-only library (CSS/JS), stricter route access via `EventStudioAccess`, and an updated autosave implementation that stores per-section drafts in private tempstore with CSRF header enforcement and stale-submission conflict handling.
> 
> Adds minor safety/hardening in event rendering and ticket lifecycle: wraps GST note resolution in `try/catch`, adds an operational event type registry, improves ticket reference handling robustness, adds `sale_start`/`sale_end` normalization, and broadens ticket management permission checks via vendor workspace parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e451e918e05d86b0627ed86a8ea2210cbf8b21c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->