### PR TITLE
Studio publish

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -4,6 +4,10 @@
   let tokenPromise = null;
   const stateClasses = ['is-unsaved', 'is-saving', 'is-saved', 'is-error', 'has-draft'];
 
+  function studioSettings() {
+    return drupalSettings.myeventlaneEventStudio || {};
+  }
+
   function getCsrfToken() {
     if (!tokenPromise) {
       tokenPromise = fetch(Drupal.url('session/token'), { credentials: 'same-origin' })
@@ -39,6 +43,157 @@
     status.textContent = message;
   }
 
+  function setFormPublishState(form, state) {
+    if (!form) {
+      return;
+    }
+    form.dataset.melPublishState = state;
+  }
+
+  function sectionForms(shell) {
+    if (!shell) {
+      return [];
+    }
+    return Array.from(shell.querySelectorAll('form'));
+  }
+
+  function dirtyForms(shell) {
+    return sectionForms(shell).filter((form) => {
+      const state = form.dataset.melPublishState;
+      return state === 'dirty' || state === 'saving' || state === 'error';
+    });
+  }
+
+  function formValue(form, name) {
+    if (!form) {
+      return '';
+    }
+    const input = form.querySelector(`[name="${name}"]`);
+    return input ? input.value : '';
+  }
+
+  function publishMetadata(shell, button) {
+    const forms = sectionForms(shell);
+    const source = forms.find((form) => formValue(form, 'mel_studio_changed') || formValue(form, 'mel_studio_revision'));
+    return {
+      section: studioSettings().currentSection || button.dataset.melCurrentSection || '',
+      changed: formValue(source, 'mel_studio_changed') || button.dataset.melNodeChanged || studioSettings().nodeChanged || 0,
+      revision_id: formValue(source, 'mel_studio_revision') || button.dataset.melNodeRevision || studioSettings().nodeRevisionId || 0,
+      dirty: dirtyForms(shell).length > 0,
+    };
+  }
+
+  function setPublishButtonState(button, state) {
+    if (!button) {
+      return;
+    }
+    button.classList.remove('is-publishing', 'is-published', 'cannot-publish');
+    button.disabled = false;
+    button.removeAttribute('aria-disabled');
+    if (state === 'publishing') {
+      button.classList.add('is-publishing');
+      button.disabled = true;
+      button.setAttribute('aria-disabled', 'true');
+      button.textContent = Drupal.t('Publishing...');
+    }
+    else if (state === 'published') {
+      button.classList.add('is-published');
+      button.disabled = true;
+      button.setAttribute('aria-disabled', 'true');
+      button.textContent = Drupal.t('Published');
+    }
+    else if (state === 'cannot_publish') {
+      button.classList.add('cannot-publish');
+      button.textContent = Drupal.t('Cannot publish');
+    }
+    else {
+      button.textContent = Drupal.t('Publish');
+    }
+  }
+
+  function setText(root, selector, text) {
+    const el = root.querySelector(selector);
+    if (el) {
+      el.textContent = text;
+    }
+  }
+
+  function updateReadiness(shell, readiness) {
+    if (!readiness) {
+      return;
+    }
+    const strip = shell.querySelector('[data-mel-readiness-strip]');
+    if (!strip) {
+      return;
+    }
+    strip.classList.toggle('is-ready', !!readiness.ready);
+    strip.classList.toggle('needs-attention', !readiness.ready);
+    setText(strip, '[data-mel-readiness-title]', readiness.ready ? Drupal.t('Ready to publish') : Drupal.t('Needs attention'));
+    setText(strip, '[data-mel-readiness-state]', readiness.state || '');
+    setText(strip, '[data-mel-readiness-errors-count]', Drupal.formatPlural((readiness.errors || []).length, '1 blocker', '@count blocker(s)'));
+    setText(strip, '[data-mel-readiness-warnings-count]', Drupal.formatPlural((readiness.warnings || []).length, '1 warning', '@count warning(s)'));
+    setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
+  }
+
+  function updateTopbar(shell, result) {
+    if (!result || !result.topbar) {
+      return;
+    }
+    setText(shell, '[data-mel-publish-status]', result.topbar.status || '');
+    setText(shell, '[data-mel-publish-state]', result.topbar.state || '');
+    setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
+    const button = shell.querySelector('[data-mel-publish-action]');
+    if (button && result.changed) {
+      button.dataset.melNodeChanged = String(result.changed);
+    }
+    if (button && result.revisionId) {
+      button.dataset.melNodeRevision = String(result.revisionId);
+    }
+  }
+
+  function renderPublishFeedback(shell, title, messages, restoreUrl) {
+    const feedback = shell.querySelector('[data-mel-publish-feedback]');
+    if (!feedback) {
+      return;
+    }
+    const list = feedback.querySelector('[data-mel-publish-feedback-list]');
+    const heading = feedback.querySelector('[data-mel-publish-feedback-title]');
+    const restore = feedback.querySelector('[data-mel-publish-restore]');
+    if (heading) {
+      heading.textContent = title;
+    }
+    if (list) {
+      list.textContent = '';
+      (messages || []).forEach((message) => {
+        const item = document.createElement('li');
+        item.textContent = message;
+        list.appendChild(item);
+      });
+    }
+    if (restore) {
+      if (restoreUrl) {
+        restore.href = restoreUrl;
+        restore.hidden = false;
+      }
+      else {
+        restore.hidden = true;
+        restore.removeAttribute('href');
+      }
+    }
+    feedback.hidden = false;
+    if (typeof feedback.focus === 'function') {
+      feedback.setAttribute('tabindex', '-1');
+      feedback.focus({ preventScroll: true });
+    }
+  }
+
+  function hidePublishFeedback(shell) {
+    const feedback = shell.querySelector('[data-mel-publish-feedback]');
+    if (feedback) {
+      feedback.hidden = true;
+    }
+  }
+
   Drupal.behaviors.melEventStudioShellAutosave = {
     attach(context) {
       once('mel-event-studio-sidebar-toggle', '[data-mel-studio-sidebar-toggle]', context).forEach((button) => {
@@ -65,6 +220,13 @@
         });
       });
 
+      once('mel-event-studio-publish-form-state', '[data-mel-studio-shell] form', context).forEach((form) => {
+        setFormPublishState(form, 'clean');
+        form.addEventListener('input', () => setFormPublishState(form, 'dirty'), true);
+        form.addEventListener('change', () => setFormPublishState(form, 'dirty'), true);
+        form.addEventListener('submit', () => setFormPublishState(form, 'clean'));
+      });
+
       once('mel-event-studio-shell-autosave', 'form[data-mel-event-studio-form="1"]', context).forEach((form) => {
         if (form.matches('.mel-event-studio-operational-tickets')) {
           return;
@@ -72,19 +234,20 @@
         let timer = null;
         let dirty = false;
         const status = document.getElementById('mel-studio-form-state');
-        const delay = Number(drupalSettings.myeventlaneEventStudio?.autosaveDelay || 12000);
-        const autosaveUrl = drupalSettings.myeventlaneEventStudio?.autosaveUrl;
-        const currentSection = drupalSettings.myeventlaneEventStudio?.currentSection;
+        const delay = Number(studioSettings().autosaveDelay || 12000);
+        const autosaveUrl = studioSettings().autosaveUrl;
+        const currentSection = studioSettings().currentSection;
         if (!autosaveUrl) {
           return;
         }
-        if (drupalSettings.myeventlaneEventStudio?.draftAvailable) {
+        if (studioSettings().draftAvailable) {
           status?.classList.add('has-draft');
         }
 
         const schedule = () => {
           window.clearTimeout(timer);
           dirty = true;
+          setFormPublishState(form, 'dirty');
           setStatus(status, Drupal.t('Unsaved changes'), 'is-unsaved');
           timer = window.setTimeout(async () => {
             const data = new FormData(form);
@@ -92,6 +255,7 @@
             if (currentSection) {
               data.set('mel_studio_section', currentSection);
             }
+            setFormPublishState(form, 'saving');
             setStatus(status, Drupal.t('Saving...'), 'is-saving');
             try {
               const token = await getCsrfToken();
@@ -104,6 +268,7 @@
               const result = await response.json().catch(() => ({}));
               if (response.status === 409) {
                 dirty = true;
+                setFormPublishState(form, 'error');
                 setStatus(
                   status,
                   result.message || Drupal.t('This section was updated elsewhere. Refresh to continue editing safely.'),
@@ -115,10 +280,12 @@
                 throw new Error(`Autosave failed with ${response.status}`);
               }
               dirty = false;
+              setFormPublishState(form, 'clean');
               setStatus(status, Drupal.t('Saved just now'), 'is-saved');
             }
             catch (error) {
               console.error('Event Studio autosave failed.', error);
+              setFormPublishState(form, 'error');
               setStatus(status, Drupal.t('Draft could not be saved. Retry by editing again.'), 'is-error');
             }
           }, delay);
@@ -128,6 +295,7 @@
         form.addEventListener('change', schedule);
         form.addEventListener('submit', () => {
           dirty = false;
+          setFormPublishState(form, 'clean');
           window.clearTimeout(timer);
         });
         window.addEventListener('beforeunload', (event) => {
@@ -136,6 +304,63 @@
           }
           event.preventDefault();
           event.returnValue = '';
+        });
+      });
+
+      once('mel-event-studio-shell-publish', '[data-mel-publish-action]', context).forEach((button) => {
+        const shell = button.closest('[data-mel-studio-shell]');
+        if (!shell) {
+          return;
+        }
+        button.addEventListener('click', async (event) => {
+          event.preventDefault();
+          if (button.disabled) {
+            return;
+          }
+          const publishUrl = button.dataset.melPublishUrl || studioSettings().publishUrl;
+          if (!publishUrl) {
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish action is unavailable. Refresh and try again.')]);
+            setPublishButtonState(button, 'cannot_publish');
+            return;
+          }
+          const metadata = publishMetadata(shell, button);
+          if (metadata.dirty) {
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Save this section before publishing.')]);
+            setPublishButtonState(button, 'cannot_publish');
+            return;
+          }
+          setPublishButtonState(button, 'publishing');
+          hidePublishFeedback(shell);
+          try {
+            const token = await getCsrfToken();
+            const response = await fetch(publishUrl, {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': token,
+              },
+              body: JSON.stringify(metadata),
+            });
+            const result = await response.json().catch(() => ({}));
+            updateTopbar(shell, result);
+            updateReadiness(shell, result.readiness);
+            if (!response.ok || !result.ok) {
+              const messages = result.messages && result.messages.length
+                ? result.messages
+                : (result.readiness && result.readiness.errors) || [Drupal.t('Publish could not complete.')];
+              renderPublishFeedback(shell, result.message || Drupal.t('Cannot publish yet'), messages, result.restoreUrl);
+              setPublishButtonState(button, 'cannot_publish');
+              return;
+            }
+            renderPublishFeedback(shell, result.message || Drupal.t('Published successfully'), []);
+            setPublishButtonState(button, 'published');
+          }
+          catch (error) {
+            console.error('Event Studio publish failed.', error);
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish failed. Check your connection and try again.')]);
+            setPublishButtonState(button, 'cannot_publish');
+          }
         });
       });
     },

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -333,6 +333,21 @@ myeventlane_event_studio.autosave:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     _csrf_request_header_token: 'TRUE'
 
+myeventlane_event_studio.publish:
+  path: '/vendor/events/{node}/studio/publish'
+  defaults:
+    _controller: myeventlane_event_studio.publish_controller:publish
+  methods: [POST]
+  requirements:
+    _entity_access: 'node.update'
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    _csrf_request_header_token: 'TRUE'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
 myeventlane_event_studio.governance_refresh:
   path: '/vendor/events/{node}/studio/governance-refresh'
   defaults:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -194,3 +194,18 @@ services:
       - '@myeventlane_event_studio.autosave'
     tags:
       - { name: controller.service_arguments }
+
+  myeventlane_event_studio.publish_controller:
+    class: Drupal\myeventlane_event_studio\Controller\EventStudioPublishController
+    arguments:
+      - '@myeventlane_event_studio.save'
+      - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.autosave'
+      - '@plugin.manager.myeventlane_event_studio_section'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@current_user'
+      - '@date.formatter'
+      - '@logger.channel.myeventlane_event_studio'
+      - '@string_translation'
+    tags:
+      - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -174,6 +174,10 @@ final class EventStudioController extends ControllerBase {
             'autosaveDelay' => 12000,
             'currentSection' => $section,
             'draftAvailable' => $this->autosaveService->hasDraft($node, $section),
+            'publishUrl' => Url::fromRoute('myeventlane_event_studio.publish', ['node' => $node->id()])->toString(),
+            'nodeChanged' => $node->getChangedTime(),
+            'nodeRevisionId' => (int) $node->getRevisionId(),
+            'published' => $node->isPublished(),
           ],
         ],
       ],
@@ -220,7 +224,12 @@ final class EventStudioController extends ControllerBase {
         'query' => ['restore_draft' => '1'],
       ])->toString(),
       'preview_url' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString(),
-      'publish_url' => Url::fromRoute('myeventlane_event_studio.workspace_settings', ['node' => $node->id()])->toString(),
+      'publish_url' => Url::fromRoute('myeventlane_event_studio.publish', ['node' => $node->id()])->toString(),
+      'published' => $node->isPublished(),
+      'can_publish' => $readiness->ready,
+      'current_section' => $section,
+      'changed' => $node->getChangedTime(),
+      'revision_id' => (int) $node->getRevisionId(),
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Controller;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_event_studio\EventStudioSectionManager;
+use Drupal\myeventlane_event_studio\Service\EventReadinessService;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Shell-owned Event Studio publish operation.
+ */
+final class EventStudioPublishController {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EventStudioSaveService $saveService,
+    private readonly EventReadinessService $eventReadiness,
+    private readonly EventStudioAutosaveService $autosaveService,
+    private readonly EventStudioSectionManager $sectionManager,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly DateFormatterInterface $dateFormatter,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  public function publish(NodeInterface $node, Request $request): JsonResponse {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+
+    $account = $this->currentUser;
+    if ($account->isAnonymous()) {
+      $this->logger->warning('Event Studio publish denied: anonymous user for event @nid', [
+        '@nid' => (string) $node->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+
+    if (!$account->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+      $this->logger->warning('Event Studio publish denied: no vendor parity for event @nid uid=@uid', [
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $account->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+
+    $data = $this->requestPayload($request);
+    if (!empty($data['dirty'])) {
+      return $this->blockedResponse(
+        409,
+        'unsaved_changes',
+        [(string) $this->t('Save this section before publishing.')],
+        $node,
+      );
+    }
+
+    $baseChanged = $this->parsePositiveInt($data['changed'] ?? $data['mel_studio_changed'] ?? NULL);
+    $baseRevisionId = $this->parsePositiveInt($data['revision_id'] ?? $data['mel_studio_revision'] ?? NULL);
+    if ($this->autosaveService->isStaleSubmission($node, $baseChanged, $baseRevisionId)) {
+      return $this->blockedResponse(
+        409,
+        'stale_state',
+        [(string) $this->t('This event changed after this section loaded. Refresh to continue safely.')],
+        $node,
+      );
+    }
+
+    $draftSection = $this->firstAutosaveDraftSection($node);
+    if ($draftSection !== NULL) {
+      return $this->blockedResponse(
+        409,
+        'autosave_draft',
+        [(string) $this->t('An autosaved draft is waiting in @section. Restore or save it before publishing.', [
+          '@section' => $this->sectionManager->sectionTitle($draftSection),
+        ])],
+        $node,
+        $draftSection,
+      );
+    }
+
+    $readiness = $this->eventReadiness->evaluate($node, $account);
+    if (!$readiness->ready) {
+      return $this->readinessResponse(
+        FALSE,
+        422,
+        $node,
+        $readiness,
+        (string) $this->t('Cannot publish yet'),
+        'cannot_publish',
+        $readiness->errors,
+      );
+    }
+
+    try {
+      $this->saveService->setNodePublishedState($node, $account, TRUE, 'Event Studio shell publish action.');
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->logger->notice('Event Studio publish blocked for event @nid uid=@uid: @message', [
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $account->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $afterBlockReadiness = $this->eventReadiness->evaluate($node, $account);
+      return $this->readinessResponse(
+        FALSE,
+        422,
+        $node,
+        $afterBlockReadiness,
+        (string) $this->t('Cannot publish yet'),
+        'cannot_publish',
+        [$e->getMessage()],
+      );
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio publish failed for event @nid uid=@uid: @message', [
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $account->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return $this->blockedResponse(
+        500,
+        'publish_failed',
+        [(string) $this->t('Publish failed. Try again shortly.')],
+        $node,
+      );
+    }
+
+    $readiness = $this->eventReadiness->evaluate($node, $account);
+    return $this->readinessResponse(
+      TRUE,
+      200,
+      $node,
+      $readiness,
+      (string) $this->t('Published successfully'),
+      'published',
+      [],
+    );
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function requestPayload(Request $request): array {
+    $decoded = json_decode($request->getContent(), TRUE);
+    if (is_array($decoded)) {
+      return $decoded;
+    }
+    return $request->request->all();
+  }
+
+  private function parsePositiveInt(mixed $value): int {
+    if (!is_numeric($value)) {
+      return 0;
+    }
+    $parsed = (int) $value;
+    return $parsed > 0 ? $parsed : 0;
+  }
+
+  private function firstAutosaveDraftSection(NodeInterface $node): ?string {
+    foreach (array_keys($this->sectionManager->activeSections($node, $this->currentUser)) as $sectionId) {
+      if ($this->autosaveService->hasDraft($node, (string) $sectionId)) {
+        return (string) $sectionId;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @param list<string> $messages
+   */
+  private function blockedResponse(int $status, string $code, array $messages, NodeInterface $node, ?string $restoreSection = NULL): JsonResponse {
+    $readiness = $this->eventReadiness->evaluate($node, $this->currentUser);
+    return $this->readinessResponse(
+      FALSE,
+      $status,
+      $node,
+      $readiness,
+      (string) $this->t('Cannot publish yet'),
+      $code,
+      $messages,
+      $restoreSection,
+    );
+  }
+
+  /**
+   * @param list<string> $messages
+   */
+  private function readinessResponse(
+    bool $ok,
+    int $status,
+    NodeInterface $node,
+    EventReadinessResult $readiness,
+    string $message,
+    string $state,
+    array $messages,
+    ?string $restoreSection = NULL,
+  ): JsonResponse {
+    $payload = [
+      'ok' => $ok,
+      'state' => $state,
+      'message' => $message,
+      'messages' => $messages,
+      'published' => $node->isPublished(),
+      'topbar' => [
+        'status' => $node->isPublished() ? (string) $this->t('Published') : (string) $this->t('Draft'),
+        'state' => $node->isPublished() ? (string) $this->t('Published') : $this->operationalState($readiness),
+        'lastSaved' => $node->getChangedTime() > 0 ? (string) $this->t('Last saved @time', [
+          '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
+        ]) : (string) $this->t('Not saved yet'),
+      ],
+      'readiness' => [
+        'ready' => $readiness->ready,
+        'errors' => $readiness->errors,
+        'warnings' => $readiness->warnings,
+        'completed' => $readiness->completed,
+        'state' => $this->operationalState($readiness),
+      ],
+      'changed' => $node->getChangedTime(),
+      'revisionId' => (int) $node->getRevisionId(),
+    ];
+
+    if ($restoreSection !== NULL) {
+      $payload['restoreUrl'] = Url::fromRoute($this->sectionManager->sectionRouteName($restoreSection), [
+        'node' => $node->id(),
+      ], [
+        'query' => ['restore_draft' => '1'],
+      ])->toString();
+      $payload['restoreSection'] = $restoreSection;
+    }
+
+    return new JsonResponse($payload, $status);
+  }
+
+  private function operationalState(EventReadinessResult $result): string {
+    if (!$result->ready) {
+      return (string) $this->t('Needs Attention');
+    }
+    return (string) $this->t('Ready');
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -412,6 +412,10 @@ final class EventStudioSaveService {
       }
     }
     $node->setPublished($published);
+    if ($published && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()
+        && (string) $node->get('moderation_state')->value === 'draft') {
+      $node->set('moderation_state', 'published');
+    }
     EventNodeRevisionSave::prepare($node, $revision_log);
     if ($node->getEntityType()->isRevisionable()) {
       $node->setRevisionUserId((int) $account->id());

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -10,9 +10,9 @@
     <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
   </div>
   <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
-    <span class="mel-event-studio-topbar__badge">{{ topbar.status }}</span>
-    <span class="mel-event-studio-topbar__state">{{ topbar.state }}</span>
-    <span class="mel-event-studio-topbar__saved">{{ topbar.last_saved }}</span>
+    <span class="mel-event-studio-topbar__badge" data-mel-publish-status>{{ topbar.status }}</span>
+    <span class="mel-event-studio-topbar__state" data-mel-publish-state>{{ topbar.state }}</span>
+    <span class="mel-event-studio-topbar__saved" data-mel-publish-last-saved>{{ topbar.last_saved }}</span>
     <span class="mel-event-studio-topbar__autosave{% if topbar.restore_draft %} has-draft{% endif %}" id="mel-studio-form-state" role="status">
       {% if topbar.restore_draft %}
         <a href="{{ topbar.restore_url }}">{{ 'Restore draft available'|t }}</a>
@@ -21,6 +21,15 @@
   </div>
   <div class="mel-event-studio-topbar__actions">
     <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'Preview'|t }}</a>
-    <a class="mel-btn mel-btn--primary" href="{{ topbar.publish_url }}">{{ 'Publish'|t }}</a>
+    <button
+      class="mel-btn mel-btn--primary"
+      type="button"
+      data-mel-publish-action
+      data-mel-publish-url="{{ topbar.publish_url|e('html_attr') }}"
+      data-mel-current-section="{{ topbar.current_section|e('html_attr') }}"
+      data-mel-node-changed="{{ topbar.changed }}"
+      data-mel-node-revision="{{ topbar.revision_id }}"
+      {% if topbar.published %}disabled aria-disabled="true"{% endif %}
+    >{{ topbar.published ? 'Published'|t : 'Publish'|t }}</button>
   </div>
 </header>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -9,16 +9,22 @@
     topbar: topbar
   }, with_context = false) }}
 
-  <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}">
+  <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip>
     <div class="mel-event-studio-readiness-strip__summary">
-      <strong>{{ readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t }}</strong>
-      <span>{{ readiness.state }}</span>
+      <strong data-mel-readiness-title>{{ readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t }}</strong>
+      <span data-mel-readiness-state>{{ readiness.state }}</span>
     </div>
     <div class="mel-event-studio-readiness-strip__counts">
-      <span>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
-      <span>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
-      <span>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
+      <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
+      <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
+      <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
     </div>
+  </section>
+
+  <section class="mel-event-studio-publish-feedback" aria-live="polite" aria-atomic="true" data-mel-publish-feedback hidden>
+    <h2 class="mel-event-studio-publish-feedback__title" data-mel-publish-feedback-title>{{ 'Cannot publish yet'|t }}</h2>
+    <ul class="mel-event-studio-publish-feedback__list" data-mel-publish-feedback-list></ul>
+    <a class="mel-event-studio-publish-feedback__restore" href="#" data-mel-publish-restore hidden>{{ 'Restore draft'|t }}</a>
   </section>
 
   <button

--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -22,6 +22,14 @@ myeventlane_front.contact:
   requirements:
     _permission: 'access content'
 
+myeventlane_front.blog:
+  path: '/legacy-blog'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\LegacyAboutController::redirectToBlog'
+    _title: 'Blog'
+  requirements:
+    _permission: 'access content'
+
 myeventlane_front.privacy:
   path: '/privacy'
   defaults:

--- a/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/LegacyAboutController.php
@@ -20,6 +20,13 @@ final class LegacyAboutController extends ControllerBase {
   }
 
   /**
+   * Redirects the retired blog route name to the current blog page.
+   */
+  public function redirectToBlog(): LocalRedirectResponse {
+    return new LocalRedirectResponse('/blog', 301);
+  }
+
+  /**
    * Redirects retired policy entry points.
    */
   public function redirectToPolicies(): LocalRedirectResponse {

--- a/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/footer.html.twig
@@ -53,7 +53,7 @@
         <ul class="menu mel-footer__links">
           <li><a href="{{ path('myeventlane_front.about') }}">{{ 'About MyEventLane'|t }}</a></li>
           <li><a href="{{ path('myeventlane_front.story') }}">{{ 'MyEventLane Story'|t }}</a></li>
-          <li><a href="{{ path('myeventlane_front.blog') }}">{{ 'Blog'|t }}</a></li>
+          <li><a href="{{ path('view.mel_blog.page_blog') }}">{{ 'Blog'|t }}</a></li>
           <li><a href="{{ path('myeventlane_public_trust.page') }}">{{ 'Trust & transparency'|t }}</a></li>
         </ul>
         <div class="mel-footer__trust">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Event Studio publish API and client-side publish flow that changes how event nodes transition to published state, including moderation-state handling and concurrency checks. Risk is moderate because it touches publishing/business rules and access control paths, though scoped to vendor Event Studio routes.
> 
> **Overview**
> Enables publishing directly from the Event Studio shell via a new `POST /vendor/events/{node}/studio/publish` endpoint, returning JSON to refresh the topbar/readiness UI and providing user-facing blocker/restore-draft feedback.
> 
> Updates the shell JS and Twig templates to use a button-driven publish action (with disabled/“publishing” states), track per-form dirty/saving/error state to prevent publishing with unsaved changes, and dynamically update readiness/status after publish attempts.
> 
> Adjusts server-side publish behavior to guard against stale revisions, pending autosave drafts, and readiness failures, and ensures publishing also transitions `moderation_state` from `draft` to `published` when applicable. Separately, adds a legacy `/legacy-blog` redirect route and updates the footer Blog link to the views-based blog page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c649492ffba09d9b0f39fa097f8c9a05801edcb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->