### PR TITLE
Studio publish

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -878,12 +878,31 @@ final class TicketTierLifecycleService {
             return ['ok' => FALSE, 'messages' => ['Ticket data could not be matched to this event. Reload the page and try again.']];
           }
           $variation = $existing_variations[$variation_id];
+          $row['title'] = $this->resolveManagerRowTitle($row, $variation);
+          if ($row['title'] === '') {
+            $this->loggerFactory->get('myeventlane_event')->warning(
+              'persistTicketManagerRows: rejected existing ticket row @vid without a name for event @nid.',
+              [
+                '@vid' => (string) $variation_id,
+                '@nid' => (string) $nid,
+              ],
+            );
+            return ['ok' => FALSE, 'messages' => ['Ticket name is required.']];
+          }
         }
         else {
+          $title = trim((string) ($row['title'] ?? ''));
+          if ($title === '') {
+            $this->loggerFactory->get('myeventlane_event')->warning(
+              'persistTicketManagerRows: rejected new ticket row without a name for event @nid.',
+              ['@nid' => (string) $nid],
+            );
+            return ['ok' => FALSE, 'messages' => ['Ticket name is required.']];
+          }
           $variation = ProductVariation::create([
             'type' => 'ticket_variation',
-            'sku' => $this->generateTicketManagerSku($event, (string) ($row['title'] ?? 'ticket')),
-            'title' => '',
+            'sku' => $this->generateTicketManagerSku($event, $title),
+            'title' => $title,
             'price' => new Price('0.00', (string) ($row['currency'] ?? 'AUD')),
             'status' => 1,
             'product_id' => $product->id(),
@@ -1613,7 +1632,7 @@ final class TicketTierLifecycleService {
    * @param array<string, mixed> $values
    */
   private function applyManagerRowToVariation(ProductVariationInterface $variation, array $values, NodeInterface $event): void {
-    $variation->setTitle(trim((string) ($values['title'] ?? '')));
+    $variation->setTitle($this->resolveManagerRowTitle($values, $variation));
     $variation->setPrice(new Price($this->normalizeManagerPriceNumber($values['price'] ?? '0'), (string) ($values['currency'] ?? 'AUD')));
 
     if ($variation->hasField('field_best_value')) {
@@ -1647,6 +1666,25 @@ final class TicketTierLifecycleService {
     $variationForDefault = $variation->id() !== NULL ? $variation : NULL;
     $active = $this->managerRowIsActive($values, $variationForDefault);
     $this->applyManagerRowActiveToVariation($variation, $active);
+  }
+
+  /**
+   * Keeps existing ticket names when a nested manager submission omits the text input.
+   *
+   * @param array<string, mixed> $values
+   */
+  public function resolveManagerRowTitle(array $values, ?ProductVariationInterface $variation = NULL): string {
+    $title = trim((string) ($values['title'] ?? ''));
+    if ($title !== '') {
+      return $title;
+    }
+    if ($variation instanceof ProductVariationInterface) {
+      $existing = trim((string) $variation->getTitle());
+      if ($existing !== '') {
+        return $existing;
+      }
+    }
+    return '';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -83,6 +83,11 @@
     };
   }
 
+  function publishUrlFor(button) {
+    const topbarButton = document.querySelector('[data-mel-publish-action]');
+    return button.dataset.melPublishUrl || topbarButton?.dataset.melPublishUrl || studioSettings().publishUrl;
+  }
+
   function setPublishButtonState(button, state) {
     if (!button) {
       return;
@@ -109,6 +114,20 @@
     else {
       button.textContent = Drupal.t('Publish');
     }
+  }
+
+  function updatePublishPanels(shell, published) {
+    shell.querySelectorAll('[data-mel-publish-panel="draft"], .mel-publish-action-card__draft').forEach((panel) => {
+      panel.hidden = !!published;
+      panel.setAttribute('aria-hidden', published ? 'true' : 'false');
+    });
+    shell.querySelectorAll('[data-mel-publish-panel="live"], .mel-publish-action-card__live').forEach((panel) => {
+      panel.hidden = !published;
+      panel.setAttribute('aria-hidden', published ? 'false' : 'true');
+    });
+    shell.querySelectorAll('[name="mel[status]"]').forEach((input) => {
+      input.value = published ? '1' : '0';
+    });
   }
 
   function setText(root, selector, text) {
@@ -148,6 +167,9 @@
     }
     if (button && result.revisionId) {
       button.dataset.melNodeRevision = String(result.revisionId);
+    }
+    if (button) {
+      setPublishButtonState(button, result.published ? 'published' : 'idle');
     }
   }
 
@@ -317,7 +339,7 @@
           if (button.disabled) {
             return;
           }
-          const publishUrl = button.dataset.melPublishUrl || studioSettings().publishUrl;
+          const publishUrl = publishUrlFor(button);
           if (!publishUrl) {
             renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish action is unavailable. Refresh and try again.')]);
             setPublishButtonState(button, 'cannot_publish');
@@ -355,11 +377,83 @@
             }
             renderPublishFeedback(shell, result.message || Drupal.t('Published successfully'), []);
             setPublishButtonState(button, 'published');
+            updatePublishPanels(shell, true);
           }
           catch (error) {
             console.error('Event Studio publish failed.', error);
             renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish failed. Check your connection and try again.')]);
             setPublishButtonState(button, 'cannot_publish');
+          }
+        });
+      });
+
+      once('mel-event-studio-shell-unpublish', '[data-mel-unpublish-action]', context).forEach((button) => {
+        const shell = button.closest('[data-mel-studio-shell]');
+        if (!shell) {
+          return;
+        }
+        button.addEventListener('click', async (event) => {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          event.stopPropagation();
+          if (button.disabled) {
+            return;
+          }
+          const publishUrl = publishUrlFor(button);
+          if (!publishUrl) {
+            renderPublishFeedback(shell, Drupal.t('Cannot unpublish yet'), [Drupal.t('Unpublish action is unavailable. Refresh and try again.')]);
+            return;
+          }
+          const metadata = {
+            ...publishMetadata(shell, button),
+            action: 'unpublish',
+          };
+          if (metadata.dirty) {
+            renderPublishFeedback(shell, Drupal.t('Cannot unpublish yet'), [Drupal.t('Save this section before changing publish state.')]);
+            return;
+          }
+          const originalLabel = button.textContent;
+          button.disabled = true;
+          button.setAttribute('aria-disabled', 'true');
+          button.textContent = Drupal.t('Unpublishing...');
+          hidePublishFeedback(shell);
+          try {
+            const token = await getCsrfToken();
+            const response = await fetch(publishUrl, {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': token,
+              },
+              body: JSON.stringify(metadata),
+            });
+            const result = await response.json().catch(() => ({}));
+            updateTopbar(shell, result);
+            updateReadiness(shell, result.readiness);
+            if (!response.ok || !result.ok) {
+              const messages = result.messages && result.messages.length
+                ? result.messages
+                : [Drupal.t('Unpublish could not complete.')];
+              renderPublishFeedback(shell, result.message || Drupal.t('Cannot unpublish yet'), messages, result.restoreUrl);
+              button.disabled = false;
+              button.removeAttribute('aria-disabled');
+              button.textContent = originalLabel || Drupal.t('Unpublish');
+              return;
+            }
+            renderPublishFeedback(shell, result.message || Drupal.t('Unpublished successfully'), []);
+            updatePublishPanels(shell, false);
+            sectionForms(shell).forEach((form) => setFormPublishState(form, 'clean'));
+            button.disabled = false;
+            button.removeAttribute('aria-disabled');
+            button.textContent = originalLabel || Drupal.t('Unpublish');
+          }
+          catch (error) {
+            console.error('Event Studio unpublish failed.', error);
+            renderPublishFeedback(shell, Drupal.t('Cannot unpublish yet'), [Drupal.t('Unpublish failed. Check your connection and try again.')]);
+            button.disabled = false;
+            button.removeAttribute('aria-disabled');
+            button.textContent = originalLabel || Drupal.t('Unpublish');
           }
         });
       });

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -70,10 +70,13 @@ final class EventStudioPublishController {
       return $this->blockedResponse(
         409,
         'unsaved_changes',
-        [(string) $this->t('Save this section before publishing.')],
+        [(string) $this->t('Save this section before changing publish state.')],
         $node,
       );
     }
+
+    $action = (string) ($data['action'] ?? 'publish');
+    $publishing = $action !== 'unpublish';
 
     $baseChanged = $this->parsePositiveInt($data['changed'] ?? $data['mel_studio_changed'] ?? NULL);
     $baseRevisionId = $this->parsePositiveInt($data['revision_id'] ?? $data['mel_studio_revision'] ?? NULL);
@@ -91,12 +94,16 @@ final class EventStudioPublishController {
       return $this->blockedResponse(
         409,
         'autosave_draft',
-        [(string) $this->t('An autosaved draft is waiting in @section. Restore or save it before publishing.', [
+        [(string) $this->t('An autosaved draft is waiting in @section. Restore or save it before changing publish state.', [
           '@section' => $this->sectionManager->sectionTitle($draftSection),
         ])],
         $node,
         $draftSection,
       );
+    }
+
+    if (!$publishing) {
+      return $this->setPublishedState($node, FALSE);
     }
 
     $readiness = $this->eventReadiness->evaluate($node, $account);
@@ -112,8 +119,18 @@ final class EventStudioPublishController {
       );
     }
 
+    return $this->setPublishedState($node, TRUE);
+  }
+
+  private function setPublishedState(NodeInterface $node, bool $published): JsonResponse {
+    $account = $this->currentUser;
     try {
-      $this->saveService->setNodePublishedState($node, $account, TRUE, 'Event Studio shell publish action.');
+      $this->saveService->setNodePublishedState(
+        $node,
+        $account,
+        $published,
+        $published ? 'Event Studio shell publish action.' : 'Event Studio shell unpublish action.',
+      );
     }
     catch (\InvalidArgumentException $e) {
       $this->logger->notice('Event Studio publish blocked for event @nid uid=@uid: @message', [
@@ -152,8 +169,8 @@ final class EventStudioPublishController {
       200,
       $node,
       $readiness,
-      (string) $this->t('Published successfully'),
-      'published',
+      $published ? (string) $this->t('Published successfully') : (string) $this->t('Unpublished successfully'),
+      $published ? 'published' : 'draft',
       [],
     );
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -1528,6 +1528,7 @@ final class EventStudioForm extends FormBase {
       $ticket_rows = $this->getEmbeddedTicketManagerTicketRows($form_state);
       $active_count = 0;
       $best_value_count = 0;
+      $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
       foreach ($ticket_rows as $row_key => $row) {
         if (!is_array($row) || !empty($row['more']['delete'])) {
           continue;
@@ -1540,7 +1541,10 @@ final class EventStudioForm extends FormBase {
           $best_value_count++;
         }
         $prefix = 'mel][tickets_section][tickets][tickets][' . $row_key;
-        $this->validateEmbeddedTicketManagerRow($form_state, $row, $prefix);
+        $vid = $this->ticketTierLifecycle->managerSubmittedVariationId($row_key, $row);
+        $loaded = $vid > 0 ? $variation_storage->load($vid) : NULL;
+        $variation = $loaded instanceof ProductVariationInterface ? $loaded : NULL;
+        $this->validateEmbeddedTicketManagerRow($form_state, $row, $prefix, $variation);
       }
       if ($active_count > 1 && $best_value_count > 1) {
         $form_state->setErrorByName('mel][tickets_section][tickets][tickets', $this->t('Only one ticket can be marked as best value.'));
@@ -1551,7 +1555,6 @@ final class EventStudioForm extends FormBase {
 
       $needs_active_paid = FALSE;
       $sellable_paid = 0;
-      $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
       foreach ($ticket_rows as $row_key => $row) {
         if (!is_array($row) || !empty($row['more']['delete'])) {
           continue;
@@ -2002,8 +2005,8 @@ final class EventStudioForm extends FormBase {
   /**
    * @param array<string, mixed> $values
    */
-  private function validateEmbeddedTicketManagerRow(FormStateInterface $form_state, array $values, string $prefix): void {
-    if (trim((string) ($values['title'] ?? '')) === '') {
+  private function validateEmbeddedTicketManagerRow(FormStateInterface $form_state, array $values, string $prefix, ?ProductVariationInterface $variation = NULL): void {
+    if ($this->ticketTierLifecycle->resolveManagerRowTitle($values, $variation) === '') {
       $form_state->setErrorByName($prefix . '][title', $this->t('Ticket name is required.'));
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -168,7 +168,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       '#type' => 'actions',
       'submit' => [
         '#type' => 'submit',
-        '#value' => $this->t('Save tickets'),
+        '#value' => $this->t('Save and sync tickets'),
         '#button_type' => 'primary',
       ],
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -78,24 +78,80 @@ class EventStudioPublishForm extends EventStudioBaseForm {
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
     $form_state->set('mel_was_published_snapshot', $node->isPublished());
     $published = !empty($melDefaults['status']);
-    $draft_hidden = $published ? ' hidden' : '';
-    $live_hidden = $published ? '' : ' hidden';
+    $form['mel']['publish_action_card'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-publish-action-card'],
+        'role' => 'region',
+        'aria-labelledby' => 'mel-publish-action-title-wizard',
+        'data-mel-publish-card' => '1',
+      ],
+      'draft' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-publish-action-card__panel', 'mel-publish-action-card__draft'],
+          'data-mel-publish-panel' => 'draft',
+        ] + ($published ? ['hidden' => 'hidden'] : []),
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Publish event'),
+          '#attributes' => [
+            'id' => 'mel-publish-action-title-wizard',
+            'class' => ['mel-publish-action-card__title'],
+          ],
+        ],
+        'description' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('After publishing, your public page can show RSVPs or tickets you\'ve turned on.'),
+          '#attributes' => ['class' => ['mel-publish-action-card__desc']],
+        ],
+        'publish_now' => [
+          '#type' => 'html_tag',
+          '#tag' => 'button',
+          '#value' => $this->t('Publish now'),
+          '#attributes' => [
+            'type' => 'button',
+            'class' => ['mel-btn', 'mel-btn--primary'],
+            'id' => 'mel-publish-now',
+          ],
+        ],
+      ],
+      'live' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-publish-action-card__panel', 'mel-publish-action-card__live'],
+          'data-mel-publish-panel' => 'live',
+        ] + ($published ? [] : ['hidden' => 'hidden']),
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Your event is live'),
+          '#attributes' => ['class' => ['mel-publish-action-card__title']],
+        ],
+        'description' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Updates publish when you save.'),
+          '#attributes' => ['class' => ['mel-publish-action-card__desc']],
+        ],
+        'unpublish' => [
+          '#type' => 'html_tag',
+          '#tag' => 'button',
+          '#value' => $this->t('Unpublish'),
+          '#attributes' => [
+            'type' => 'button',
+            'class' => ['mel-btn', 'mel-btn--ghost'],
+            'id' => 'mel-revert-draft',
+            'data-mel-unpublish-action' => '',
+          ],
+        ],
+      ],
+    ];
     $form['mel']['status'] = [
       '#type' => 'hidden',
       '#default_value' => $published ? '1' : '0',
-      '#prefix' =>
-        '<div class="mel-publish-action-card" role="region" aria-labelledby="mel-publish-action-title-wizard" data-mel-publish-card="1">' .
-        '<div class="mel-publish-action-card__panel mel-publish-action-card__draft"' . $draft_hidden . ' data-mel-publish-panel="draft">' .
-        '<h3 id="mel-publish-action-title-wizard" class="mel-publish-action-card__title">' . $this->t('Publish event') . '</h3>' .
-        '<p class="mel-publish-action-card__desc">' . $this->t('After publishing, your public page can show RSVPs or tickets you\'ve turned on.') . '</p>' .
-        '<button type="button" class="mel-btn mel-btn--primary" id="mel-publish-now">' . $this->t('Publish now') . '</button>' .
-        '</div>' .
-        '<div class="mel-publish-action-card__panel mel-publish-action-card__live"' . $live_hidden . ' data-mel-publish-panel="live">' .
-        '<h3 class="mel-publish-action-card__title">' . $this->t('Your event is live') . '</h3>' .
-        '<p class="mel-publish-action-card__desc">' . $this->t('Updates publish when you save.') . '</p>' .
-        '<button type="button" class="mel-btn mel-btn--ghost" id="mel-revert-draft">' . $this->t('Unpublish') . '</button>' .
-        '</div>',
-      '#suffix' => '</div>',
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -412,9 +412,14 @@ final class EventStudioSaveService {
       }
     }
     $node->setPublished($published);
-    if ($published && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()
-        && (string) $node->get('moderation_state')->value === 'draft') {
-      $node->set('moderation_state', 'published');
+    if ($node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()) {
+      $moderationState = (string) $node->get('moderation_state')->value;
+      if ($published && $moderationState !== 'published') {
+        $node->set('moderation_state', 'published');
+      }
+      if (!$published && $moderationState === 'published') {
+        $node->set('moderation_state', 'archived');
+      }
     }
     EventNodeRevisionSave::prepare($node, $revision_log);
     if ($node->getEntityType()->isRevisionable()) {

--- a/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
@@ -539,6 +539,7 @@ final class EventTicketManagerForm extends FormBase {
     $rows = $form_state->getValue('tickets') ?? [];
     $best_value_count = 0;
     $active_count = 0;
+    $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
     if (is_array($rows)) {
       foreach ($rows as $row_key => $row) {
         if (!is_array($row) || !empty($row['more']['delete'])) {
@@ -551,7 +552,10 @@ final class EventTicketManagerForm extends FormBase {
         if (!empty($row['best_value'])) {
           $best_value_count++;
         }
-        $this->validateTicketValues($form_state, $row, 'tickets][' . $row_key);
+        $vid = $this->ticketTierLifecycle->managerSubmittedVariationId($row_key, $row);
+        $loaded_variation = $vid > 0 ? $variation_storage->load($vid) : NULL;
+        $variation = $loaded_variation instanceof ProductVariationInterface ? $loaded_variation : NULL;
+        $this->validateTicketValues($form_state, $row, 'tickets][' . $row_key, $variation);
       }
     }
 
@@ -562,7 +566,6 @@ final class EventTicketManagerForm extends FormBase {
     if (in_array($event_type, ['paid', 'both'], TRUE)) {
       $needs_active_paid = FALSE;
       $sellable_paid = 0;
-      $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
       foreach ($rows as $row_key => $row) {
         if (!is_array($row) || !empty($row['more']['delete'])) {
           continue;
@@ -596,8 +599,8 @@ final class EventTicketManagerForm extends FormBase {
    * @param array<string, mixed> $values
    *   Submitted ticket values.
    */
-  private function validateTicketValues(FormStateInterface $form_state, array $values, string $prefix): void {
-    if (trim((string) ($values['title'] ?? '')) === '') {
+  private function validateTicketValues(FormStateInterface $form_state, array $values, string $prefix, ?ProductVariationInterface $variation = NULL): void {
+    if ($this->ticketTierLifecycle->resolveManagerRowTitle($values, $variation) === '') {
       $form_state->setErrorByName($prefix . '][title', $this->t('Ticket name is required.'));
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new publish-state transitions (including unpublish/archiving moderation state) and updates client/server publish flows, which can impact event visibility and workflow behavior. Also tightens ticket-tier validation/persistence, which could reject previously-accepted submissions if titles are missing.
> 
> **Overview**
> Enables **unpublish** from Event Studio by extending the shell UI, publish wizard card, and `EventStudioPublishController` to accept an `action` (`publish`/`unpublish`) and toggle published state accordingly, updating the UI panels/status in-place.
> 
> Updates `EventStudioSaveService::setNodePublishedState()` to handle both directions of moderation state changes (publish forces `published`; unpublish moves `published` -> `archived`).
> 
> Hardens ticket manager behavior so ticket names are always required while also preserving existing names when nested ticket manager submissions omit the title field (`resolveManagerRowTitle()`), and wires that logic into both embedded Studio ticket validation and the vendor ticket manager form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f22a208dfb6820da1174182baa871eae0d96ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->