### PR TITLE
feat(event-studio): improve moderation state handling and form metada…

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -130,6 +130,27 @@
     });
   }
 
+  function updateFormMetadata(shell, result) {
+    if (!result) {
+      return;
+    }
+    sectionForms(shell).forEach((form) => {
+      if (result.changed !== undefined && result.changed !== null) {
+        const changed = form.querySelector('[name="mel_studio_changed"]');
+        if (changed) {
+          changed.value = String(result.changed);
+        }
+      }
+      if (result.revisionId !== undefined && result.revisionId !== null) {
+        const revision = form.querySelector('[name="mel_studio_revision"]');
+        if (revision) {
+          revision.value = String(result.revisionId);
+        }
+      }
+      setFormPublishState(form, 'clean');
+    });
+  }
+
   function setText(root, selector, text) {
     const el = root.querySelector(selector);
     if (el) {
@@ -162,10 +183,10 @@
     setText(shell, '[data-mel-publish-state]', result.topbar.state || '');
     setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
     const button = shell.querySelector('[data-mel-publish-action]');
-    if (button && result.changed) {
+    if (button && result.changed !== undefined && result.changed !== null) {
       button.dataset.melNodeChanged = String(result.changed);
     }
-    if (button && result.revisionId) {
+    if (button && result.revisionId !== undefined && result.revisionId !== null) {
       button.dataset.melNodeRevision = String(result.revisionId);
     }
     if (button) {
@@ -378,11 +399,83 @@
             renderPublishFeedback(shell, result.message || Drupal.t('Published successfully'), []);
             setPublishButtonState(button, 'published');
             updatePublishPanels(shell, true);
+            updateFormMetadata(shell, result);
           }
           catch (error) {
             console.error('Event Studio publish failed.', error);
             renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish failed. Check your connection and try again.')]);
             setPublishButtonState(button, 'cannot_publish');
+          }
+        });
+      });
+
+      once('mel-event-studio-shell-card-publish', '[data-mel-card-publish-action]', context).forEach((button) => {
+        const shell = button.closest('[data-mel-studio-shell]');
+        if (!shell) {
+          return;
+        }
+        button.addEventListener('click', async (event) => {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          event.stopPropagation();
+          if (button.disabled) {
+            return;
+          }
+          const publishUrl = publishUrlFor(button);
+          if (!publishUrl) {
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish action is unavailable. Refresh and try again.')]);
+            return;
+          }
+          const metadata = {
+            ...publishMetadata(shell, button),
+            action: 'publish',
+          };
+          if (metadata.dirty) {
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Save this section before changing publish state.')]);
+            return;
+          }
+          const originalLabel = button.textContent;
+          button.disabled = true;
+          button.setAttribute('aria-disabled', 'true');
+          button.textContent = Drupal.t('Publishing...');
+          hidePublishFeedback(shell);
+          try {
+            const token = await getCsrfToken();
+            const response = await fetch(publishUrl, {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': token,
+              },
+              body: JSON.stringify(metadata),
+            });
+            const result = await response.json().catch(() => ({}));
+            updateTopbar(shell, result);
+            updateReadiness(shell, result.readiness);
+            if (!response.ok || !result.ok) {
+              const messages = result.messages && result.messages.length
+                ? result.messages
+                : (result.readiness && result.readiness.errors) || [Drupal.t('Publish could not complete.')];
+              renderPublishFeedback(shell, result.message || Drupal.t('Cannot publish yet'), messages, result.restoreUrl);
+              button.disabled = false;
+              button.removeAttribute('aria-disabled');
+              button.textContent = originalLabel || Drupal.t('Publish now');
+              return;
+            }
+            renderPublishFeedback(shell, result.message || Drupal.t('Published successfully'), []);
+            updatePublishPanels(shell, true);
+            updateFormMetadata(shell, result);
+            button.disabled = false;
+            button.removeAttribute('aria-disabled');
+            button.textContent = originalLabel || Drupal.t('Publish now');
+          }
+          catch (error) {
+            console.error('Event Studio publish failed.', error);
+            renderPublishFeedback(shell, Drupal.t('Cannot publish yet'), [Drupal.t('Publish failed. Check your connection and try again.')]);
+            button.disabled = false;
+            button.removeAttribute('aria-disabled');
+            button.textContent = originalLabel || Drupal.t('Publish now');
           }
         });
       });
@@ -443,7 +536,7 @@
             }
             renderPublishFeedback(shell, result.message || Drupal.t('Unpublished successfully'), []);
             updatePublishPanels(shell, false);
-            sectionForms(shell).forEach((form) => setFormPublishState(form, 'clean'));
+            updateFormMetadata(shell, result);
             button.disabled = false;
             button.removeAttribute('aria-disabled');
             button.textContent = originalLabel || Drupal.t('Unpublish');

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -115,6 +115,7 @@ class EventStudioPublishForm extends EventStudioBaseForm {
             'type' => 'button',
             'class' => ['mel-btn', 'mel-btn--primary'],
             'id' => 'mel-publish-now',
+            'data-mel-card-publish-action' => '',
           ],
         ],
       ],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -105,12 +105,17 @@ final class EventStudioSaveService {
       }
     }
 
-    // Editorial workflow: `draft` is not a published moderation state. Content Moderation's
-    // presave syncs the entity published flag to that state, undoing setPublished(TRUE).
-    // When the vendor intends to publish, transition to `published` so presave stays aligned.
-    if (!$draft && $willPublish && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()
-        && (string) $node->get('moderation_state')->value === 'draft') {
-      $node->set('moderation_state', 'published');
+    // Keep Content Moderation aligned with the requested published flag.
+    // Draft revisions are not default revisions in the editorial workflow, so
+    // unpublishing a live event must use the unpublished default state.
+    if (!$draft && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()) {
+      $moderationState = (string) $node->get('moderation_state')->value;
+      if ($willPublish && $moderationState !== 'published') {
+        $node->set('moderation_state', 'published');
+      }
+      if (!$willPublish && $moderationState === 'published') {
+        $node->set('moderation_state', 'archived');
+      }
     }
 
     if ($node->hasField('field_event_summary') && isset($payload['summary'])) {


### PR DESCRIPTION
…ta updates

- Enhanced the save logic in EventStudioSaveService to align moderation states with publish requests, ensuring proper transitions between 'published' and 'archived'.
- Added a new function in mel-event-studio-shell.js to update form metadata based on publish results, improving user feedback and state management.
- Updated EventStudioPublishForm to include a data attribute for publish actions, enhancing the button's functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches publish/unpublish behavior on both client and server, including Content Moderation state transitions, which can affect event visibility and revision workflow if misaligned. Changes are localized but impact a core vendor publishing path.
> 
> **Overview**
> Improves Event Studio publish/unpublish UX by syncing returned `changed`/`revisionId` back into all section forms (and treating `0` as valid), then resetting form publish state to *clean* after successful state changes.
> 
> Adds a dedicated publish handler for the wizard “Publish now” card button (wired via `data-mel-card-publish-action`) that uses the same publish endpoint, enforces no-dirty-forms, and restores button state/labels on success or failure.
> 
> Updates `EventStudioSaveService` to keep Content Moderation `moderation_state` aligned with the requested published flag, transitioning to `published` on publish and to `archived` on unpublish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88c689c4bd9a0b5a9fd51cd77584f63babefbbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->