### PR TITLE
Cursor/autocomplete form data e9516

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.attendee_extra_field.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.attendee_extra_field.default.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.attendee_extra_field.field_attendee_extra_field
+    - field.field.paragraph.attendee_extra_field.field_question_applicability
     - field.field.paragraph.attendee_extra_field.field_question_help
     - field.field.paragraph.attendee_extra_field.field_question_label
     - field.field.paragraph.attendee_extra_field.field_question_machine_name
     - field.field.paragraph.attendee_extra_field.field_question_options
     - field.field.paragraph.attendee_extra_field.field_question_required
+    - field.field.paragraph.attendee_extra_field.field_question_status
+    - field.field.paragraph.attendee_extra_field.field_question_ticket_types
     - field.field.paragraph.attendee_extra_field.field_question_type
     - paragraphs.paragraphs_type.attendee_extra_field
 id: paragraph.attendee_extra_field.default
@@ -64,4 +67,7 @@ content:
 hidden:
   created: true
   field_attendee_extra_field: true
+  field_question_applicability: true
+  field_question_status: true
+  field_question_ticket_types: true
   status: true

--- a/config/sync/core.entity_view_display.paragraph.attendee_extra_field.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.attendee_extra_field.default.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.attendee_extra_field.field_attendee_extra_field
+    - field.field.paragraph.attendee_extra_field.field_question_applicability
     - field.field.paragraph.attendee_extra_field.field_question_help
     - field.field.paragraph.attendee_extra_field.field_question_label
     - field.field.paragraph.attendee_extra_field.field_question_machine_name
     - field.field.paragraph.attendee_extra_field.field_question_options
     - field.field.paragraph.attendee_extra_field.field_question_required
+    - field.field.paragraph.attendee_extra_field.field_question_status
+    - field.field.paragraph.attendee_extra_field.field_question_ticket_types
     - field.field.paragraph.attendee_extra_field.field_question_type
     - paragraphs.paragraphs_type.attendee_extra_field
   module:
@@ -45,7 +48,10 @@ content:
     region: content
 hidden:
   field_attendee_extra_field: true
+  field_question_applicability: true
   field_question_help: true
   field_question_machine_name: true
   field_question_options: true
+  field_question_status: true
+  field_question_ticket_types: true
   search_api_excerpt: true

--- a/config/sync/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
+++ b/config/sync/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
@@ -1,0 +1,23 @@
+uuid: 19d4a4bf-4921-4e10-9f4d-81601847f4c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_applicability
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question applicability'
+description: 'Controls whether this question applies to every ticket holder, selected ticket types, or a future per-order flow.'
+required: false
+translatable: false
+default_value:
+  -
+    value: per_ticket
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.paragraph.attendee_extra_field.field_question_status.yml
+++ b/config/sync/field.field.paragraph.attendee_extra_field.field_question_status.yml
@@ -1,0 +1,23 @@
+uuid: e0f2dc79-8e6b-4fc7-afc6-7917a0fa65b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_status
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question status'
+description: 'Whether this checkout question should render for new checkout sessions.'
+required: false
+translatable: false
+default_value:
+  -
+    value: active
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
+++ b/config/sync/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
@@ -1,0 +1,21 @@
+uuid: 9e007639-c895-4e1f-beba-00765537e67c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_ticket_types
+    - paragraphs.paragraphs_type.attendee_extra_field
+id: paragraph.attendee_extra_field.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Ticket types'
+description: 'For per-ticket-type questions, select the ticket types that should receive this question.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:mel_ticket_type'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.storage.paragraph.field_question_applicability.yml
+++ b/config/sync/field.storage.paragraph.field_question_applicability.yml
@@ -1,0 +1,30 @@
+uuid: ae7e8817-3839-48ac-b9d3-9a2205ccdcfe
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: per_ticket
+      label: 'Per ticket'
+    -
+      value: per_ticket_type
+      label: 'Per ticket type'
+    -
+      value: per_order
+      label: 'Per order'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_question_status.yml
+++ b/config/sync/field.storage.paragraph.field_question_status.yml
@@ -1,0 +1,27 @@
+uuid: 0731ed44-4c31-4634-a78c-15558e4a785f
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: active
+      label: Active
+    -
+      value: archived
+      label: Archived
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_question_ticket_types.yml
+++ b/config/sync/field.storage.paragraph.field_question_ticket_types.yml
@@ -1,0 +1,22 @@
+uuid: 371480e2-4edd-425a-8bca-f22431b79574
+langcode: en
+status: true
+dependencies:
+  module:
+    - mel_ticket
+    - paragraphs
+id: paragraph.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: mel_ticket_type
+module: core
+locked: false
+cardinality: -1
+translatable: false
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_question_type.yml
+++ b/config/sync/field.storage.paragraph.field_question_type.yml
@@ -30,6 +30,9 @@ settings:
       value: email
       label: Email
     -
+      value: number
+      label: Number
+    -
       value: tel
       label: 'Phone number'
   allowed_values_function: ''

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/TicketHolderParagraphPane.php
@@ -393,6 +393,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       $type = $question->hasField('field_question_type')
         ? (string) ($question->get('field_question_type')->value ?? 'text')
         : 'text';
+      $required = $this->questionIsRequired($question);
       $field_name = "extra_{$itemIndex}_{$delta}_{$q_index}";
 
       // Normalize: always read from field_attendee_extra_field.
@@ -424,11 +425,11 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => ['' => $this->t('- Select -')] + ($options ?: ['_' => $this->t('No options')]),
             '#default_value' => $default,
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
-            '#description' => (string) $this->t('Required.'),
+            '#description' => $this->questionRequirementDescription($required),
           ];
           break;
 
@@ -437,7 +438,7 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#type' => 'checkbox',
             '#title' => $label,
             '#default_value' => (bool) $default,
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
@@ -457,11 +458,13 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $decoded,
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
-            '#description' => (string) $this->t('Select all that apply. Required.'),
+            '#description' => $required
+              ? (string) $this->t('Select all that apply. Required.')
+              : (string) $this->t('Select all that apply. Optional.'),
           ];
           break;
 
@@ -472,11 +475,11 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#options' => $options ?: ['_' => $this->t('Option')],
             '#default_value' => $default,
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
-            '#description' => (string) $this->t('Required.'),
+            '#description' => $this->questionRequirementDescription($required),
           ];
           break;
 
@@ -486,11 +489,25 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#title' => $label,
             '#rows' => 3,
             '#default_value' => $default,
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
-            '#description' => (string) $this->t('Required.'),
+            '#description' => $this->questionRequirementDescription($required),
+          ];
+          break;
+
+        case 'number':
+          $fieldset[$field_name] = [
+            '#type' => 'number',
+            '#title' => $label,
+            '#default_value' => is_numeric($default) ? $default : '',
+            '#required' => $required,
+            '#attributes' => [
+              'class' => ['mel-attendee-question-field'],
+              'inputmode' => 'decimal',
+            ],
+            '#description' => $this->questionRequirementDescription($required),
           ];
           break;
 
@@ -499,11 +516,11 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
             '#type' => 'textfield',
             '#title' => $label,
             '#default_value' => is_scalar($default) || $default === NULL ? (string) ($default ?? '') : '',
-            '#required' => TRUE,
+            '#required' => $required,
             '#attributes' => [
               'class' => ['mel-attendee-question-field'],
             ],
-            '#description' => (string) $this->t('Required.'),
+            '#description' => $this->questionRequirementDescription($required),
           ];
           break;
       }
@@ -753,9 +770,22 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
       if (!$question instanceof ParagraphInterface) {
         continue;
       }
-
       $field_key = "extra_{$itemIndex}_{$delta}_{$q_index}";
-      if (array_key_exists($field_key, $entry) && !$this->isEmptySubmittedAnswer($entry[$field_key])) {
+      $submitted_value = $entry[$field_key] ?? NULL;
+      if ($this->questionType($question) === 'number'
+        && !$this->isEmptySubmittedAnswer($submitted_value)
+        && !is_numeric($submitted_value)) {
+        $form_state->setErrorByName(
+          "{$this->getPluginId()}][order_items][$itemIndex][$delta][$field_key",
+          $this->t('Enter a valid number.')
+        );
+        continue;
+      }
+      if (!$this->questionIsRequired($question)) {
+        continue;
+      }
+
+      if (array_key_exists($field_key, $entry) && !$this->isEmptySubmittedAnswer($submitted_value)) {
         continue;
       }
 
@@ -791,6 +821,21 @@ final class TicketHolderParagraphPane extends CheckoutPaneBase {
     }
 
     return is_string($value) ? trim($value) === '' : FALSE;
+  }
+
+  private function questionIsRequired(ParagraphInterface $question): bool {
+    return $question->hasField('field_question_required')
+      && !empty($question->get('field_question_required')->value);
+  }
+
+  private function questionType(ParagraphInterface $question): string {
+    return $question->hasField('field_question_type')
+      ? (string) ($question->get('field_question_type')->value ?? 'textfield')
+      : 'textfield';
+  }
+
+  private function questionRequirementDescription(bool $required): string {
+    return $required ? (string) $this->t('Required.') : (string) $this->t('Optional.');
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Service/CheckoutAttendeeSchemaService.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Service/CheckoutAttendeeSchemaService.php
@@ -9,6 +9,7 @@ use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_checkout_paragraph\CheckoutAttendeeSchemaInspectorInterface;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\node\NodeInterface;
@@ -110,6 +111,7 @@ final class CheckoutAttendeeSchemaService implements CheckoutAttendeeSchemaInspe
     }
 
     $tier_templates = [];
+    $tier = NULL;
     $variation = $order_item->getPurchasedEntity();
     if ($variation instanceof ProductVariationInterface && $event instanceof NodeInterface) {
       $tier = $this->ticketAvailability->resolveTierForVariation($event, $variation);
@@ -121,6 +123,9 @@ final class CheckoutAttendeeSchemaService implements CheckoutAttendeeSchemaInspe
         $tier_templates = $tier->get('field_attendee_questions')->referencedEntities();
       }
     }
+
+    $event_templates = $this->filterQuestionTemplatesForOrderItem($event_templates, $tier, FALSE);
+    $tier_templates = $this->filterQuestionTemplatesForOrderItem($tier_templates, $tier, TRUE);
 
     return $this->mergeQuestionTemplateParagraphs($event_templates, $tier_templates);
   }
@@ -169,6 +174,78 @@ final class CheckoutAttendeeSchemaService implements CheckoutAttendeeSchemaInspe
       return 'id:' . (string) $paragraph->id();
     }
     return 'tmp:' . spl_object_id($paragraph);
+  }
+
+  /**
+   * @param \Drupal\paragraphs\ParagraphInterface[] $templates
+   *
+   * @return \Drupal\paragraphs\ParagraphInterface[]
+   */
+  private function filterQuestionTemplatesForOrderItem(array $templates, ?TicketTypeInterface $tier, bool $tierScoped): array {
+    $out = [];
+    foreach ($templates as $template) {
+      if (!$template instanceof ParagraphInterface) {
+        continue;
+      }
+      if (!$this->questionTemplateIsActive($template)) {
+        continue;
+      }
+      $applicability = $this->questionTemplateApplicability($template);
+      if ($applicability === 'per_order') {
+        $this->logger->notice('Skipping per-order attendee question @id in checkout; per-order answer storage is not enabled.', [
+          '@id' => (string) $template->id(),
+        ]);
+        continue;
+      }
+      if ($applicability === 'per_ticket_type') {
+        if (!$tier instanceof TicketTypeInterface) {
+          continue;
+        }
+        $ticket_ids = $this->questionTemplateTicketTypeIds($template);
+        if ($ticket_ids !== [] && !in_array((int) $tier->id(), $ticket_ids, TRUE)) {
+          continue;
+        }
+        if ($ticket_ids === [] && !$tierScoped) {
+          continue;
+        }
+      }
+      $out[] = $template;
+    }
+    return $out;
+  }
+
+  private function questionTemplateIsActive(ParagraphInterface $paragraph): bool {
+    if ($paragraph->hasField('field_question_status') && !$paragraph->get('field_question_status')->isEmpty()) {
+      return (string) $paragraph->get('field_question_status')->value !== 'archived';
+    }
+    return TRUE;
+  }
+
+  private function questionTemplateApplicability(ParagraphInterface $paragraph): string {
+    if ($paragraph->hasField('field_question_applicability') && !$paragraph->get('field_question_applicability')->isEmpty()) {
+      $value = (string) $paragraph->get('field_question_applicability')->value;
+      if (in_array($value, ['per_ticket', 'per_ticket_type', 'per_order'], TRUE)) {
+        return $value;
+      }
+    }
+    return 'per_ticket';
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function questionTemplateTicketTypeIds(ParagraphInterface $paragraph): array {
+    if (!$paragraph->hasField('field_question_ticket_types') || $paragraph->get('field_question_ticket_types')->isEmpty()) {
+      return [];
+    }
+    $ids = [];
+    foreach ($paragraph->get('field_question_ticket_types')->getValue() as $item) {
+      $target_id = isset($item['target_id']) ? (int) $item['target_id'] : 0;
+      if ($target_id > 0) {
+        $ids[] = $target_id;
+      }
+    }
+    return array_values(array_unique($ids));
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Support/AttendeeHolderMissingEvaluator.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Support/AttendeeHolderMissingEvaluator.php
@@ -79,6 +79,9 @@ final class AttendeeHolderMissingEvaluator {
       if (!$question instanceof ParagraphInterface) {
         continue;
       }
+      if (!static::questionIsRequired($question)) {
+        continue;
+      }
       $answered = TRUE;
       if ($question->hasField('field_attendee_extra_field')) {
         $answered = !$question->get('field_attendee_extra_field')->isEmpty()
@@ -103,7 +106,7 @@ final class AttendeeHolderMissingEvaluator {
   private static function questionLabels(array $questions): array {
     $out = [];
     foreach ($questions as $q) {
-      if ($q instanceof ParagraphInterface) {
+      if ($q instanceof ParagraphInterface && static::questionIsRequired($q)) {
         $out[] = static::questionFingerprint($q, 0, 0, 0);
       }
     }
@@ -133,6 +136,11 @@ final class AttendeeHolderMissingEvaluator {
       return TRUE;
     }
     return is_string($value) ? trim((string) $value) === '' : FALSE;
+  }
+
+  private static function questionIsRequired(ParagraphInterface $question): bool {
+    return $question->hasField('field_question_required')
+      && !empty($question->get('field_question_required')->value);
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/ParagraphQuestionMapper.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/ParagraphQuestionMapper.php
@@ -19,6 +19,16 @@ class ParagraphQuestionMapper {
     }
 
     foreach ($event->get('field_attendee_questions')->referencedEntities() as $para) {
+      if ($para->hasField('field_question_status')
+        && !$para->get('field_question_status')->isEmpty()
+        && (string) $para->get('field_question_status')->value === 'archived') {
+        continue;
+      }
+      if ($para->hasField('field_question_applicability')
+        && !$para->get('field_question_applicability')->isEmpty()
+        && (string) $para->get('field_question_applicability')->value !== 'per_ticket') {
+        continue;
+      }
       $machine = $para->get('field_question_machine_name')->value ?? strtolower(preg_replace('/\s+/', '_', $para->label()));
       $type = $para->get('field_question_type')->value ?? 'textfield';
       $required = (bool) ($para->get('field_question_required')->value ?? FALSE);
@@ -65,6 +75,16 @@ class ParagraphQuestionMapper {
         case 'textarea':
           $elements[$machine] = [
             '#type' => 'textarea',
+            '#title' => $title,
+            '#required' => $required,
+            '#default_value' => $defaults[$machine] ?? '',
+            '#description' => $help,
+          ];
+          break;
+
+        case 'number':
+          $elements[$machine] = [
+            '#type' => 'number',
             '#title' => $title,
             '#required' => $required,
             '#default_value' => $defaults[$machine] ?? '',

--- a/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeQuestionCaptureService.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeQuestionCaptureService.php
@@ -37,7 +37,8 @@ final class EventAttendeeQuestionCaptureService {
     foreach ($event->get('field_attendee_questions')->referencedEntities() as $paragraph) {
       if ($paragraph instanceof EntityInterface
         && $paragraph->getEntityTypeId() === 'paragraph'
-        && $paragraph->bundle() === 'attendee_extra_field') {
+        && $paragraph->bundle() === 'attendee_extra_field'
+        && $this->templateIsActiveForRsvp($paragraph)) {
         $out[] = $paragraph;
       }
     }
@@ -113,6 +114,12 @@ final class EventAttendeeQuestionCaptureService {
         ],
         'email' => [
           '#type' => 'email',
+          '#title' => $label,
+          '#required' => $required,
+          '#description' => $description,
+        ],
+        'number' => [
+          '#type' => 'number',
           '#title' => $label,
           '#required' => $required,
           '#description' => $description,
@@ -267,6 +274,19 @@ final class EventAttendeeQuestionCaptureService {
     }
     $usedKeys[$candidate] = TRUE;
     return $candidate;
+  }
+
+  private function templateIsActiveForRsvp(EntityInterface $paragraph): bool {
+    if ($paragraph->hasField('field_question_status')
+      && !$paragraph->get('field_question_status')->isEmpty()
+      && (string) $paragraph->get('field_question_status')->value === 'archived') {
+      return FALSE;
+    }
+    if ($paragraph->hasField('field_question_applicability') && !$paragraph->get('field_question_applicability')->isEmpty()) {
+      $applicability = (string) $paragraph->get('field_question_applicability')->value;
+      return $applicability === 'per_ticket';
+    }
+    return TRUE;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -223,6 +223,138 @@
 }
 
 /* -------------------------------------------------------------------------- */
+/* Operational checkout questions                                              */
+/* -------------------------------------------------------------------------- */
+
+.mel-event-studio .mel-event-studio-questions {
+  max-width: 100%;
+}
+
+.mel-event-studio .mel-event-studio-questions__notice {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border: 1px solid #fed7aa;
+  border-radius: 10px;
+  background: #fff7ed;
+  color: #9a3412;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.mel-event-studio .mel-event-studio-questions__manager {
+  overflow-x: auto;
+}
+
+.mel-event-studio .mel-event-studio-questions__table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: separate;
+  border-spacing: 0 10px;
+}
+
+.mel-event-studio .mel-event-studio-questions__table th {
+  color: #64748b;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mel-event-studio .mel-event-studio-questions__table td {
+  vertical-align: top;
+  padding: 12px;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.mel-event-studio .mel-event-studio-questions__table td:first-child {
+  border-left: 1px solid #e2e8f0;
+  border-radius: 12px 0 0 12px;
+}
+
+.mel-event-studio .mel-event-studio-questions__table td:last-child {
+  border-right: 1px solid #e2e8f0;
+  border-radius: 0 12px 12px 0;
+}
+
+.mel-event-studio .mel-event-studio-questions__weight {
+  max-width: 72px;
+  margin-bottom: 8px;
+}
+
+.mel-event-studio .mel-event-studio-questions__label {
+  min-width: 180px;
+}
+
+.mel-event-studio .mel-event-studio-questions__preview {
+  max-width: 180px;
+  margin: 8px 0 0;
+  color: #64748b;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.mel-event-studio .mel-event-studio-questions__add {
+  margin-top: 20px;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+@media (max-width: 760px) {
+  .mel-event-studio .mel-event-studio-questions__manager {
+    overflow-x: visible;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table {
+    min-width: 0;
+    border-spacing: 0;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table thead {
+    display: none;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table,
+  .mel-event-studio .mel-event-studio-questions__table tbody,
+  .mel-event-studio .mel-event-studio-questions__table tr,
+  .mel-event-studio .mel-event-studio-questions__table td {
+    display: block;
+    width: 100%;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table tr {
+    margin-bottom: 16px;
+    padding: 14px;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    background: #fff;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table td,
+  .mel-event-studio .mel-event-studio-questions__table td:first-child,
+  .mel-event-studio .mel-event-studio-questions__table td:last-child {
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table td + td {
+    margin-top: 12px;
+  }
+
+  .mel-event-studio .mel-event-studio-questions__table input,
+  .mel-event-studio .mel-event-studio-questions__table select,
+  .mel-event-studio .mel-event-studio-questions__table textarea,
+  .mel-event-studio .mel-event-studio-questions__add input,
+  .mel-event-studio .mel-event-studio-questions__add select,
+  .mel-event-studio .mel-event-studio-questions__add textarea {
+    max-width: 100%;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
 /* Sidebar nav (#mel-wizard-nav)                                               */
 /* -------------------------------------------------------------------------- */
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -113,6 +113,12 @@ services:
       - '@database'
       - '@logger.channel.myeventlane_event_studio'
 
+  myeventlane_event_studio.question_template_manager:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager
+    arguments:
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_event_studio'
+
   myeventlane_event_studio.governance_builder:
     class: Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder
     arguments:
@@ -203,6 +209,9 @@ services:
       - '@myeventlane_vendor.event_access_checker'
       - '@myeventlane_vendor.current_vendor_resolver'
       - '@myeventlane_event_studio.autosave'
+      - '@plugin.manager.myeventlane_event_studio_section'
+      - '@form_builder'
+      - '@myeventlane_event_studio.entity_autocomplete_mel_normalizer'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -9,11 +9,15 @@ use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolver;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
@@ -37,6 +41,9 @@ final class EventStudioAutosaveController {
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
     private readonly CurrentVendorResolver $currentVendorResolver,
     private readonly EventStudioAutosaveService $autosaveService,
+    private readonly EventStudioSectionManager $sectionManager,
+    private readonly FormBuilderInterface $formBuilder,
+    private readonly EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer,
   ) {}
 
   public function handle(Request $request): JsonResponse {
@@ -79,6 +86,11 @@ final class EventStudioAutosaveController {
     }
 
     $section = $this->normalizeSection($params['mel_studio_section'] ?? 'section');
+    $section_error = $this->validateAutosaveSection($section, $node);
+    if ($section_error instanceof JsonResponse) {
+      return $section_error;
+    }
+
     $base_changed = $this->parsePositiveInt($params['mel_studio_changed'] ?? NULL);
     $base_revision_id = $this->parsePositiveInt($params['mel_studio_revision'] ?? NULL);
     if ($this->autosaveService->isStaleSubmission($node, $base_changed, $base_revision_id)) {
@@ -93,6 +105,7 @@ final class EventStudioAutosaveController {
     if (!is_array($mel)) {
       $mel = [];
     }
+    $mel = $this->normalizeMelForSection($section, $node, $mel);
 
     $decoded_event_highlights = NULL;
     $event_highlights_items_state = NULL;
@@ -217,6 +230,80 @@ final class EventStudioAutosaveController {
       return 'section';
     }
     return preg_replace('/[^a-z0-9_:-]+/i', '_', $section) ?: 'section';
+  }
+
+  private function validateAutosaveSection(string $section, NodeInterface $node): ?JsonResponse {
+    $plugin = $this->sectionManager->section($section);
+    if (!$plugin instanceof EventStudioSectionInterface) {
+      $this->logger->warning('Event Studio autosave rejected for unsupported section @section nid=@nid uid=@uid.', [
+        '@section' => $section,
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $this->currentUser->id(),
+      ]);
+      return new JsonResponse([
+        'ok' => FALSE,
+        'errors' => ['This Studio section does not support autosave.'],
+      ], 422);
+    }
+
+    if (!$plugin->isWritable()
+      || $plugin->sectionState() === EventStudioSectionInterface::STATE_READONLY
+      || $plugin->sectionState() === EventStudioSectionInterface::STATE_DEFERRED
+      || $plugin->sectionState() === EventStudioSectionInterface::STATE_COMING_SOON) {
+      $this->logger->warning('Event Studio autosave rejected for non-writable section @section nid=@nid uid=@uid state=@state.', [
+        '@section' => $section,
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $this->currentUser->id(),
+        '@state' => $plugin->sectionState(),
+      ]);
+      return new JsonResponse([
+        'ok' => FALSE,
+        'errors' => ['This Studio section is readonly and cannot be autosaved.'],
+      ], 403);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @param array<string, mixed> $mel
+   *
+   * @return array<string, mixed>
+   */
+  private function normalizeMelForSection(string $section, NodeInterface $node, array $mel): array {
+    $plugin = $this->sectionManager->section($section);
+    if (!$plugin instanceof EventStudioSectionInterface) {
+      return $mel;
+    }
+    $target = $plugin->renderTarget();
+    if (!str_starts_with($target, 'form:')) {
+      return $mel;
+    }
+    $form_class = substr($target, 5);
+    if ($form_class === '' || !class_exists($form_class)) {
+      return $mel;
+    }
+
+    try {
+      $form = $this->formBuilder->getForm($form_class, $node);
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Event Studio autosave could not inspect section form @section for autocomplete normalization: @message', [
+        '@section' => $section,
+        '@message' => $e->getMessage(),
+      ]);
+      return $mel;
+    }
+
+    if (!isset($form['mel']) || !is_array($form['mel'])) {
+      return $mel;
+    }
+
+    return $this->entityAutocompleteMelNormalizer->normalizeValuesForForm($form['mel'], $mel, [
+      'section' => $section,
+      'event_id' => (int) $node->id(),
+      'uid' => (int) $this->currentUser->id(),
+    ]);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -4,58 +4,439 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Form;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Isolated Event Studio form for checkout question settings.
+ * Operational Event Studio form for checkout question templates.
  */
-final class EventCheckoutQuestionsForm extends EventStudioBaseForm {
+final class EventCheckoutQuestionsForm extends FormBase {
+
+  protected EntityTypeManagerInterface $studioEntityTypeManager;
+
+  protected AccountProxyInterface $studioCurrentUser;
+
+  protected EventVendorAccessChecker $studioEventVendorAccessChecker;
+
+  protected EventStudioAutosaveService $studioAutosaveService;
+
+  protected EventStudioQuestionTemplateManager $studioQuestionTemplateManager;
+
+  protected LoggerInterface $studioLogger;
+
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    AccountProxyInterface $currentUserProxy,
+    EventVendorAccessChecker $eventVendorAccessChecker,
+    EventStudioAutosaveService $autosaveService,
+    EventStudioQuestionTemplateManager $questionTemplateManager,
+    LoggerInterface $logger,
+  ) {
+    $this->studioEntityTypeManager = $entityTypeManager;
+    $this->studioCurrentUser = $currentUserProxy;
+    $this->studioEventVendorAccessChecker = $eventVendorAccessChecker;
+    $this->studioAutosaveService = $autosaveService;
+    $this->studioQuestionTemplateManager = $questionTemplateManager;
+    $this->studioLogger = $logger;
+  }
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('myeventlane_event_studio.autosave'),
+      $container->get('myeventlane_event_studio.question_template_manager'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+    );
+  }
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_checkout_questions_form';
   }
 
-  protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.workspace_questions';
-  }
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    $event = $this->getRouteEvent($node);
+    $this->assertCanManageEvent($event);
 
-  protected function getPreviousRouteName(): ?string {
-    return NULL;
-  }
+    $form['#tree'] = TRUE;
+    $form['#attributes']['class'][] = 'mel-event-studio-questions';
+    $form['#attributes']['data-mel-event-studio-form'] = '1';
+    $form['#attributes']['data-mel-event-studio-section'] = 'questions';
 
-  protected function getCurrentStepId(): string {
-    return 'questions';
-  }
-
-  protected function getContinueButtonLabel() {
-    return $this->t('Save checkout questions');
-  }
-
-  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
-    $this->messenger()->addStatus($this->t('Checkout question settings saved.'));
-    $form_state->setRedirect('myeventlane_event_studio.workspace_questions', ['node' => $saved->id()]);
-  }
-
-  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
-    $form['mel']['collect_attendee_questions'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Collect extra attendee details'),
-      '#description' => $this->t('Gather information per guest beyond name and email. Detailed question-library editing remains service-backed and will not use nested entity widgets here.'),
-      '#default_value' => !empty($melDefaults['collect_attendee_questions']),
-      '#mel_option_card' => TRUE,
+    $form['event_id'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->id(),
+    ];
+    $form['nid'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->id(),
+    ];
+    $form['mel_studio_section'] = [
+      '#type' => 'hidden',
+      '#value' => 'questions',
+    ];
+    $form['mel_studio_changed'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->getChangedTime(),
+    ];
+    $form['mel_studio_revision'] = [
+      '#type' => 'hidden',
+      '#value' => (string) (int) $event->getRevisionId(),
     ];
 
-    $form['mel']['attendee_questions_editor'] = [
+    $form['intro'] = [
       '#type' => 'container',
-      '#tree' => TRUE,
-      'items_state' => [
-        '#type' => 'hidden',
-        '#default_value' => is_string(($melDefaults['attendee_questions_editor']['items_state'] ?? NULL))
-          ? $melDefaults['attendee_questions_editor']['items_state']
-          : '[]',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-event-studio-questions__intro']],
+      'title' => [
+        '#markup' => '<h3 class="mel-es-card__title">' . $this->t('Checkout questions') . '</h3>',
+      ],
+      'copy' => [
+        '#markup' => '<p class="mel-es-card__hint">' . $this->t('Manage governed attendee question templates. Checkout still stores answers on attendee records; this screen never exposes attendee answers.') . '</p>',
+      ],
+      'per_order_notice' => [
+        '#markup' => '<p class="mel-event-studio-questions__notice">' . $this->t('Per-order questions are planned but not checkout-rendered in this slice. Use per-ticket or per-ticket-type questions for active checkout capture.') . '</p>',
       ],
     ];
+
+    $ticket_options = $this->studioQuestionTemplateManager->ticketOptions($event);
+    $form['questions_card'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-event-studio-questions__manager']],
+    ];
+    $form['questions_card']['questions'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Label'),
+        $this->t('Type'),
+        $this->t('Applies To'),
+        $this->t('Required'),
+        $this->t('Status'),
+        $this->t('Actions'),
+      ],
+      '#empty' => $this->t('No checkout questions yet. Add a question below.'),
+      '#attributes' => ['class' => ['mel-event-studio-questions__table']],
+    ];
+
+    foreach ($this->studioQuestionTemplateManager->loadRows($event) as $row) {
+      $row_id = (int) $row['id'];
+      $form['questions_card']['questions'][$row_id] = $this->buildQuestionRow($row, $ticket_options);
+    }
+
+    $form['questions_card']['new_question'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Add question'),
+      '#open' => TRUE,
+      '#attributes' => ['class' => ['mel-event-studio-questions__add']],
+    ] + $this->buildQuestionEditor([
+      'id' => 0,
+      'weight' => count($this->studioQuestionTemplateManager->loadRows($event)),
+      'label' => '',
+      'type' => 'textfield',
+      'required' => FALSE,
+      'status' => EventStudioQuestionTemplateManager::STATUS_ACTIVE,
+      'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET,
+      'ticket_type_ids' => [],
+      'options' => '',
+      'machine_name' => '',
+    ], $ticket_options, TRUE);
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Save checkout questions'),
+        '#button_type' => 'primary',
+      ],
+    ];
+
+    return $form;
+  }
+
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $form_state->setErrorByName('', $this->t('The event could not be loaded.'));
+      return;
+    }
+    $this->assertCanManageEvent($event);
+
+    $base_changed = (int) ($form_state->getValue('mel_studio_changed') ?? 0);
+    $base_revision_id = (int) ($form_state->getValue('mel_studio_revision') ?? 0);
+    if ($this->studioAutosaveService->isStaleSubmission($event, $base_changed, $base_revision_id)) {
+      $form_state->setErrorByName('', $this->t('This section was updated elsewhere. Refresh to continue editing safely.'));
+      return;
+    }
+
+    $existing_rows = $this->submittedExistingRows($form_state);
+    $new_row = $this->submittedNewRow($form_state);
+    foreach ($this->studioQuestionTemplateManager->validateRows($event, $existing_rows, $new_row) as $error) {
+      $form_state->setErrorByName('questions', $error);
+    }
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $this->messenger()->addError($this->t('The event could not be loaded.'));
+      return;
+    }
+    $this->assertCanManageEvent($event);
+
+    $errors = $this->studioQuestionTemplateManager->saveRows(
+      $event,
+      $this->submittedExistingRows($form_state),
+      $this->submittedNewRow($form_state)
+    );
+    if ($errors !== []) {
+      foreach ($errors as $error) {
+        $this->messenger()->addError($error);
+      }
+      return;
+    }
+
+    $this->studioAutosaveService->clearDraft($event, 'questions');
+    $this->messenger()->addStatus($this->t('Checkout questions saved.'));
+    $form_state->setRebuild(TRUE);
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<int, string> $ticketOptions
+   */
+  private function buildQuestionRow(array $row, array $ticketOptions): array {
+    $editor = $this->buildQuestionEditor($row, $ticketOptions, FALSE);
+    $preview = $this->buildPreviewText($row);
+
+    return [
+      'label' => [
+        'id' => [
+          '#type' => 'hidden',
+          '#value' => (string) (int) $row['id'],
+        ],
+        'weight' => [
+          '#type' => 'number',
+          '#title' => $this->t('Order'),
+          '#title_display' => 'invisible',
+          '#default_value' => (int) $row['weight'],
+          '#min' => 0,
+          '#step' => 1,
+          '#attributes' => ['class' => ['mel-event-studio-questions__weight']],
+        ],
+        'label' => $editor['label'],
+      ],
+      'type' => [
+        'type' => $editor['type'],
+        'options' => $editor['options'],
+      ],
+      'applicability' => [
+        'applicability' => $editor['applicability'],
+        'ticket_type_ids' => $editor['ticket_type_ids'],
+      ],
+      'required' => [
+        'required' => $editor['required'],
+      ],
+      'status' => [
+        'status' => $editor['status'],
+      ],
+      'actions' => [
+        'machine_name' => $editor['machine_name'],
+        'preview' => [
+          '#markup' => '<p class="mel-event-studio-questions__preview">' . $preview . '</p>',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<int, string> $ticketOptions
+   *
+   * @return array<string, mixed>
+   */
+  private function buildQuestionEditor(array $row, array $ticketOptions, bool $isNew): array {
+    $prefix = $isNew ? 'new_question' : 'questions';
+    return [
+      'label' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Label'),
+        '#title_display' => $isNew ? 'before' : 'invisible',
+        '#default_value' => (string) ($row['label'] ?? ''),
+        '#maxlength' => 255,
+        '#attributes' => ['class' => ['mel-event-studio-questions__label']],
+      ],
+      'type' => [
+        '#type' => 'select',
+        '#title' => $this->t('Type'),
+        '#title_display' => $isNew ? 'before' : 'invisible',
+        '#options' => $this->studioQuestionTemplateManager->typeOptions(),
+        '#default_value' => (string) ($row['type'] ?? 'textfield'),
+      ],
+      'options' => [
+        '#type' => 'textarea',
+        '#title' => $this->t('Options'),
+        '#default_value' => (string) ($row['options'] ?? ''),
+        '#rows' => 3,
+        '#description' => $this->t('One option per line. Used only for select, checkbox, and radio questions.'),
+      ],
+      'applicability' => [
+        '#type' => 'select',
+        '#title' => $this->t('Applies to'),
+        '#title_display' => $isNew ? 'before' : 'invisible',
+        '#options' => $this->studioQuestionTemplateManager->applicabilityOptions(),
+        '#default_value' => (string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
+        '#description' => $isNew ? $this->t('Per-order questions are planned and are not available for active checkout capture yet.') : NULL,
+      ],
+      'ticket_type_ids' => [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Ticket types'),
+        '#options' => $ticketOptions,
+        '#default_value' => $row['ticket_type_ids'] ?? [],
+        '#description' => $ticketOptions === []
+          ? $this->t('Create ticket types before using per-ticket-type questions.')
+          : $this->t('Required when Applies to is Per ticket type.'),
+        '#states' => [
+          'visible' => [
+            ':input[name^="' . $prefix . '"][name$="[applicability]"]' => ['value' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE],
+          ],
+        ],
+      ],
+      'required' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Required'),
+        '#default_value' => !empty($row['required']),
+      ],
+      'status' => [
+        '#type' => 'select',
+        '#title' => $this->t('Status'),
+        '#title_display' => $isNew ? 'before' : 'invisible',
+        '#options' => $this->studioQuestionTemplateManager->statusOptions(),
+        '#default_value' => (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
+      ],
+      'machine_name' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Machine name'),
+        '#default_value' => (string) ($row['machine_name'] ?? ''),
+        '#maxlength' => 64,
+        '#description' => $this->t('Optional stable key. Leave blank to generate from the label.'),
+      ],
+      'weight' => [
+        '#type' => 'hidden',
+        '#value' => (string) (int) ($row['weight'] ?? 0),
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   */
+  private function buildPreviewText(array $row): string {
+    $status = (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE);
+    $required = !empty($row['required']) ? (string) $this->t('Required') : (string) $this->t('Optional');
+    if ($status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED) {
+      return (string) $this->t('Archived: hidden from new checkout sessions.');
+    }
+    return $required . '. ' . (string) $this->t('Answers are collected in checkout, not shown here.');
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function submittedExistingRows(FormStateInterface $form_state): array {
+    $rows = $form_state->getValue(['questions_card', 'questions']) ?? [];
+    if (!is_array($rows)) {
+      return [];
+    }
+    $out = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $flat = [
+        'id' => (int) ($row['label']['id'] ?? 0),
+        'weight' => (int) ($row['label']['weight'] ?? 0),
+        'label' => (string) ($row['label']['label'] ?? ''),
+        'type' => (string) ($row['type']['type'] ?? 'textfield'),
+        'options' => (string) ($row['type']['options'] ?? ''),
+        'applicability' => (string) ($row['applicability']['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
+        'ticket_type_ids' => $row['applicability']['ticket_type_ids'] ?? [],
+        'required' => !empty($row['required']['required']),
+        'status' => (string) ($row['status']['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
+        'machine_name' => (string) ($row['actions']['machine_name'] ?? ''),
+      ];
+      if ($flat['id'] > 0) {
+        $out[] = $flat;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function submittedNewRow(FormStateInterface $form_state): ?array {
+    $row = $form_state->getValue(['questions_card', 'new_question']) ?? NULL;
+    if (!is_array($row) || trim((string) ($row['label'] ?? '')) === '') {
+      return NULL;
+    }
+    return [
+      'id' => 0,
+      'weight' => (int) ($row['weight'] ?? 999),
+      'label' => (string) ($row['label'] ?? ''),
+      'type' => (string) ($row['type'] ?? 'textfield'),
+      'options' => (string) ($row['options'] ?? ''),
+      'applicability' => (string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
+      'ticket_type_ids' => $row['ticket_type_ids'] ?? [],
+      'required' => !empty($row['required']),
+      'status' => (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
+      'machine_name' => (string) ($row['machine_name'] ?? ''),
+    ];
+  }
+
+  private function getRouteEvent(?NodeInterface $parameterNode = NULL): NodeInterface {
+    if ($parameterNode instanceof NodeInterface && $parameterNode->bundle() === 'event') {
+      return $parameterNode;
+    }
+    $node = $this->getRouteMatch()->getParameter('node');
+    if ($node instanceof NodeInterface && $node->bundle() === 'event') {
+      return $node;
+    }
+    throw new NotFoundHttpException();
+  }
+
+  private function loadSubmittedEvent(FormStateInterface $form_state): ?NodeInterface {
+    $event_id = (int) ($form_state->getValue('event_id') ?? 0);
+    if ($event_id < 1) {
+      return NULL;
+    }
+    $event = $this->studioEntityTypeManager->getStorage('node')->load($event_id);
+    return $event instanceof NodeInterface && $event->bundle() === 'event' ? $event : NULL;
+  }
+
+  private function assertCanManageEvent(NodeInterface $event): void {
+    if ($this->studioCurrentUser->hasPermission('administer nodes')) {
+      return;
+    }
+    if (!$this->studioEventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $this->studioCurrentUser)) {
+      $this->studioLogger->warning('Event Studio questions access denied for event @nid uid @uid.', [
+        '@nid' => (string) $event->id(),
+        '@uid' => (string) $this->studioCurrentUser->id(),
+      ]);
+      throw new AccessDeniedHttpException();
+    }
+    if (!$event->access('update', $this->studioCurrentUser)) {
+      throw new AccessDeniedHttpException();
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline;
@@ -34,6 +35,7 @@ abstract class EventStudioBaseForm extends FormBase {
     protected EventStudioSaveService $saveService,
     protected EventStudioMelPayloadService $melPayloadService,
     protected EventStudioWizardMelBaseline $wizardMelBaseline,
+    protected EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer,
     protected EventVendorAccessChecker $eventVendorAccessChecker,
     protected EventStudioAutosaveService $autosaveService,
     RequestStack $request_stack,
@@ -53,6 +55,7 @@ abstract class EventStudioBaseForm extends FormBase {
       $container->get('myeventlane_event_studio.save'),
       $container->get('myeventlane_event_studio.mel_payload'),
       $container->get('myeventlane_event_studio.wizard_mel_baseline'),
+      $container->get('myeventlane_event_studio.entity_autocomplete_mel_normalizer'),
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('myeventlane_event_studio.autosave'),
       $container->get('request_stack'),
@@ -232,6 +235,11 @@ abstract class EventStudioBaseForm extends FormBase {
     ];
 
     $this->buildWizardStepContent($form, $form_state, $node, $melDefaults);
+    $this->entityAutocompleteMelNormalizer->normalizeDefaultValuesForForm($form['mel'], [
+      'section' => $this->getCurrentStepId(),
+      'event_id' => (int) $node->id(),
+      'uid' => (int) $this->currentUser->id(),
+    ]);
 
     $form['actions'] = [
       '#type' => 'actions',
@@ -328,6 +336,15 @@ abstract class EventStudioBaseForm extends FormBase {
    * Saves merged mel via EventStudioSaveService and redirects to the next route.
    */
   public function submitContinue(array &$form, FormStateInterface $form_state): void {
+    $submitted = $form_state->getValue('mel') ?? [];
+    if (is_array($submitted) && isset($form['mel']) && is_array($form['mel'])) {
+      $form_state->setValue('mel', $this->entityAutocompleteMelNormalizer->normalizeValuesForForm($form['mel'], $submitted, [
+        'section' => $this->getCurrentStepId(),
+        'event_id' => (int) ($form_state->getValue('nid') ?? 0),
+        'uid' => (int) $this->currentUser->id(),
+      ]));
+    }
+
     $result = $this->persistWizardMel($form_state, $this->isDraftWizardSave());
     if ($result === NULL) {
       return;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EntityAutocompleteMelNormalizer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EntityAutocompleteMelNormalizer.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
+use Drupal\Component\Utility\Tags;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\Element;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -42,6 +45,17 @@ final class EntityAutocompleteMelNormalizer {
       $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $value);
       if ($entity instanceof EntityInterface) {
         return $entity;
+      }
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return NULL;
+    }
+    if (is_string($value)) {
+      $entity_id = EntityAutocomplete::extractEntityIdFromAutocompleteInput($value);
+      if ($entity_id !== NULL) {
+        $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $entity_id);
+        if ($entity instanceof EntityInterface) {
+          return $entity;
+        }
       }
       $this->logDiscard($context_key, $entity_type_id, $value);
       return NULL;
@@ -90,6 +104,9 @@ final class EntityAutocompleteMelNormalizer {
       $this->logDiscard($context_key, $entity_type_id, $value);
       return [];
     }
+    if (is_string($value)) {
+      return $this->normalizeTagString($value, $entity_type_id, $context_key);
+    }
     if (!is_array($value)) {
       $this->logDiscard($context_key, $entity_type_id, $value);
       return [];
@@ -125,12 +142,267 @@ final class EntityAutocompleteMelNormalizer {
     return $out;
   }
 
+  /**
+   * Normalizes submitted/default values by reading entity_autocomplete elements.
+   *
+   * @param array<string, mixed> $form
+   *   A Form API element tree.
+   * @param array<string, mixed> $values
+   *   Submitted or restored values aligned to the same tree.
+   * @param array<string, scalar|null> $log_context
+   *   Optional operational context: section, event_id, uid.
+   *
+   * @return array<string, mixed>
+   *   Values with entity_autocomplete leaves normalized for safe replay.
+   */
+  public function normalizeValuesForForm(array $form, array $values, array $log_context = []): array {
+    $normalized = $values;
+    $this->normalizeValuesRecursive($form, $normalized, [], $log_context);
+    return $normalized;
+  }
+
+  /**
+   * Rewrites entity_autocomplete #default_value entries in a Form API tree.
+   *
+   * @param array<string, mixed> $form
+   * @param array<string, scalar|null> $log_context
+   *   Optional operational context: section, event_id, uid.
+   */
+  public function normalizeDefaultValuesForForm(array &$form, array $log_context = []): void {
+    $this->normalizeDefaultValuesRecursive($form, [], $log_context);
+  }
+
+  /**
+   * @param array<string, mixed> $element
+   * @param array<string, mixed> $values
+   * @param list<string> $path
+   * @param array<string, scalar|null> $log_context
+   */
+  private function normalizeValuesRecursive(array $element, array &$values, array $path, array $log_context): void {
+    foreach (Element::children($element) as $key) {
+      if (!isset($element[$key]) || !is_array($element[$key])) {
+        continue;
+      }
+      $child = $element[$key];
+      $child_path = [...$path, (string) $key];
+      if (($child['#type'] ?? NULL) === 'entity_autocomplete') {
+        if (!array_key_exists($key, $values)) {
+          continue;
+        }
+        $target_type = $child['#target_type'] ?? NULL;
+        if (!is_string($target_type) || $target_type === '') {
+          continue;
+        }
+        $context_key = 'mel.' . implode('.', $child_path);
+        $child_context = $log_context + [
+          'field_key' => implode('.', $child_path),
+          'payload_type' => is_object($values[$key]) ? get_debug_type($values[$key]) : gettype($values[$key]),
+        ];
+        $values[$key] = !empty($child['#tags'])
+          ? $this->normalizeTagsForReplay($values[$key], $target_type, $context_key, $child_context)
+          : $this->normalizeSingleForReplay($values[$key], $target_type, $context_key, $child_context);
+        continue;
+      }
+      if (array_key_exists($key, $values) && is_array($values[$key])) {
+        $this->normalizeValuesRecursive($child, $values[$key], $child_path, $log_context);
+      }
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $element
+   * @param list<string> $path
+   * @param array<string, scalar|null> $log_context
+   */
+  private function normalizeDefaultValuesRecursive(array &$element, array $path, array $log_context): void {
+    if (($element['#type'] ?? NULL) === 'entity_autocomplete' && array_key_exists('#default_value', $element)) {
+      $target_type = $element['#target_type'] ?? NULL;
+      if (is_string($target_type) && $target_type !== '') {
+        $context_key = 'mel.' . implode('.', $path);
+        $child_context = $log_context + [
+          'field_key' => implode('.', $path),
+          'payload_type' => is_object($element['#default_value']) ? get_debug_type($element['#default_value']) : gettype($element['#default_value']),
+        ];
+        $element['#default_value'] = !empty($element['#tags'])
+          ? $this->normalizeTagsForReplay($element['#default_value'], $target_type, $context_key, $child_context)
+          : $this->normalizeSingleForReplay($element['#default_value'], $target_type, $context_key, $child_context);
+      }
+    }
+
+    foreach (Element::children($element) as $key) {
+      if (!isset($element[$key]) || !is_array($element[$key])) {
+        continue;
+      }
+      $child_path = [...$path, (string) $key];
+      $this->normalizeDefaultValuesRecursive($element[$key], $child_path, $log_context);
+    }
+  }
+
+  /**
+   * @param array<string, scalar|null> $log_context
+   */
+  private function normalizeSingleForReplay(mixed $value, string $entity_type_id, string $context_key, array $log_context): ?EntityInterface {
+    $normalized = $this->normalizeSingleWithoutLogging($value, $entity_type_id);
+    if ($normalized instanceof EntityInterface || $value === NULL || $value === '') {
+      return $normalized;
+    }
+    $this->logReplayDiscard($context_key, $entity_type_id, $value, $log_context);
+    return NULL;
+  }
+
+  /**
+   * @param array<string, scalar|null> $log_context
+   *
+   * @return array<int, \Drupal\Core\Entity\EntityInterface>
+   */
+  private function normalizeTagsForReplay(mixed $value, string $entity_type_id, string $context_key, array $log_context): array {
+    $normalized = $this->normalizeTagsWithoutLogging($value, $entity_type_id);
+    if ($normalized !== [] || $value === NULL || $value === [] || $value === '') {
+      return $normalized;
+    }
+    $this->logReplayDiscard($context_key, $entity_type_id, $value, $log_context);
+    return [];
+  }
+
+  private function normalizeSingleWithoutLogging(mixed $value, string $entity_type_id): ?EntityInterface {
+    if ($value === NULL || $value === '') {
+      return NULL;
+    }
+    if (is_array($value)) {
+      $value = $this->extractSingleEntityValue($value);
+      if ($value === NULL || $value === '') {
+        return NULL;
+      }
+      if (is_array($value)) {
+        return NULL;
+      }
+    }
+    if ($value instanceof EntityInterface) {
+      return $value->getEntityTypeId() === $entity_type_id ? $value : NULL;
+    }
+    if (is_numeric($value)) {
+      $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $value);
+      return $entity instanceof EntityInterface ? $entity : NULL;
+    }
+    if (is_string($value)) {
+      $entity_id = EntityAutocomplete::extractEntityIdFromAutocompleteInput($value);
+      if ($entity_id !== NULL) {
+        $entity = $this->entityTypeManager->getStorage($entity_type_id)->load((int) $entity_id);
+        return $entity instanceof EntityInterface ? $entity : NULL;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @return array<int, \Drupal\Core\Entity\EntityInterface>
+   */
+  private function normalizeTagsWithoutLogging(mixed $value, string $entity_type_id): array {
+    if ($value === NULL || $value === [] || $value === '') {
+      return [];
+    }
+    if ($value instanceof EntityInterface) {
+      return $value->getEntityTypeId() === $entity_type_id ? [$value] : [];
+    }
+    if (is_string($value)) {
+      return $this->loadTagIds($this->extractTagIdsFromString($value), $entity_type_id);
+    }
+    if (!is_array($value)) {
+      return [];
+    }
+    $ids = [];
+    $entities = [];
+    foreach ($value as $item) {
+      if ($item instanceof EntityInterface) {
+        if ($item->getEntityTypeId() === $entity_type_id) {
+          $entities[] = $item;
+        }
+        continue;
+      }
+      if (is_numeric($item)) {
+        $ids[] = (int) $item;
+        continue;
+      }
+      if (is_array($item) && isset($item['target_id']) && is_numeric($item['target_id'])) {
+        $ids[] = (int) $item['target_id'];
+      }
+    }
+    return array_values([...$entities, ...$this->loadTagIds($ids, $entity_type_id)]);
+  }
+
+  /**
+   * @return array<int, \Drupal\Core\Entity\EntityInterface>
+   */
+  private function normalizeTagString(string $value, string $entity_type_id, string $context_key): array {
+    $ids = $this->extractTagIdsFromString($value);
+    if ($ids === [] && trim($value) !== '') {
+      $this->logDiscard($context_key, $entity_type_id, $value);
+      return [];
+    }
+    return $this->loadTagIds($ids, $entity_type_id);
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function extractTagIdsFromString(string $value): array {
+    $ids = [];
+    foreach (Tags::explode($value) as $part) {
+      $part = trim($part);
+      if ($part === '') {
+        continue;
+      }
+      if (is_numeric($part)) {
+        $ids[] = (int) $part;
+        continue;
+      }
+      $entity_id = EntityAutocomplete::extractEntityIdFromAutocompleteInput($part);
+      if ($entity_id !== NULL) {
+        $ids[] = (int) $entity_id;
+      }
+    }
+    return array_values(array_unique(array_filter($ids)));
+  }
+
+  /**
+   * @param list<int> $ids
+   *
+   * @return array<int, \Drupal\Core\Entity\EntityInterface>
+   */
+  private function loadTagIds(array $ids, string $entity_type_id): array {
+    $out = [];
+    foreach (array_values(array_unique(array_filter($ids))) as $id) {
+      $entity = $this->entityTypeManager->getStorage($entity_type_id)->load($id);
+      if ($entity instanceof EntityInterface) {
+        $out[] = $entity;
+      }
+    }
+    return $out;
+  }
+
   private function logDiscard(string $context_key, string $entity_type_id, mixed $value): void {
     $info = is_object($value) ? get_debug_type($value) : gettype($value);
     $this->logger->warning('Discarded invalid entity_autocomplete default for @key (expected entity type @type): @info', [
       '@key' => $context_key,
       '@type' => $entity_type_id,
       '@info' => $info,
+    ]);
+  }
+
+  /**
+   * @param array<string, scalar|null> $log_context
+   */
+  private function logReplayDiscard(string $context_key, string $entity_type_id, mixed $value, array $log_context): void {
+    $info = is_object($value) ? get_debug_type($value) : gettype($value);
+    $this->logger->warning('Discarded invalid entity_autocomplete replay value for @key (expected entity type @type): @info section=@section event=@event uid=@uid field=@field payload_type=@payload_type', [
+      '@key' => $context_key,
+      '@type' => $entity_type_id,
+      '@info' => $info,
+      '@section' => (string) ($log_context['section'] ?? 'unknown'),
+      '@event' => (string) ($log_context['event_id'] ?? 'unknown'),
+      '@uid' => (string) ($log_context['uid'] ?? 'unknown'),
+      '@field' => (string) ($log_context['field_key'] ?? $context_key),
+      '@payload_type' => (string) ($log_context['payload_type'] ?? $info),
     ]);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -299,6 +299,7 @@ final class EventStudioMelPayloadService {
       'checkboxes',
       'radios',
       'email',
+      'number',
       'tel',
     ];
     $out = [];
@@ -325,6 +326,17 @@ final class EventStudioMelPayloadService {
         'required' => !empty($row['required']),
         'save_to_library' => !empty($row['save_to_library']),
       ];
+      $status = trim((string) ($row['status'] ?? ''));
+      if ($status !== '') {
+        $item['status'] = $status;
+      }
+      $applicability = trim((string) ($row['applicability'] ?? ''));
+      if ($applicability !== '') {
+        $item['applicability'] = $applicability;
+      }
+      if (isset($row['ticket_type_ids']) && is_array($row['ticket_type_ids'])) {
+        $item['ticket_type_ids'] = $row['ticket_type_ids'];
+      }
       $machine = trim((string) ($row['machine_name'] ?? ''));
       if ($machine !== '') {
         $item['machine_name'] = $machine;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs\ParagraphInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Operational manager for Event Studio checkout question templates.
+ */
+final class EventStudioQuestionTemplateManager {
+
+  use StringTranslationTrait;
+
+  public const STATUS_ACTIVE = 'active';
+  public const STATUS_ARCHIVED = 'archived';
+
+  public const APPLIES_PER_TICKET = 'per_ticket';
+  public const APPLIES_PER_TICKET_TYPE = 'per_ticket_type';
+  public const APPLIES_PER_ORDER = 'per_order';
+
+  /**
+   * @var array<string, string>
+   */
+  private const TYPE_MAP = [
+    'text' => 'textfield',
+    'textfield' => 'textfield',
+    'textarea' => 'textarea',
+    'select' => 'select',
+    'checkbox' => 'checkboxes',
+    'checkboxes' => 'checkboxes',
+    'radio' => 'radios',
+    'radios' => 'radios',
+    'email' => 'email',
+    'number' => 'number',
+    'tel' => 'tel',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Studio-governed field types exposed to vendors.
+   *
+   * @return array<string, string>
+   */
+  public function typeOptions(): array {
+    return [
+      'textfield' => (string) $this->t('Text'),
+      'textarea' => (string) $this->t('Long text'),
+      'select' => (string) $this->t('Select'),
+      'checkboxes' => (string) $this->t('Checkbox'),
+      'radios' => (string) $this->t('Radio'),
+      'email' => (string) $this->t('Email'),
+      'number' => (string) $this->t('Number'),
+    ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function applicabilityOptions(): array {
+    return [
+      self::APPLIES_PER_TICKET => (string) $this->t('Per ticket'),
+      self::APPLIES_PER_TICKET_TYPE => (string) $this->t('Per ticket type'),
+      self::APPLIES_PER_ORDER => (string) $this->t('Per order'),
+    ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function statusOptions(): array {
+    return [
+      self::STATUS_ACTIVE => (string) $this->t('Active'),
+      self::STATUS_ARCHIVED => (string) $this->t('Archived'),
+    ];
+  }
+
+  /**
+   * @return array<int, string>
+   */
+  public function ticketOptions(NodeInterface $event): array {
+    $options = [];
+    foreach ($this->loadEventTickets($event) as $ticket) {
+      $options[(int) $ticket->id()] = $ticket->label();
+    }
+    return $options;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function loadRows(NodeInterface $event): array {
+    if (!$event->hasField('field_attendee_questions') || $event->get('field_attendee_questions')->isEmpty()) {
+      return [];
+    }
+
+    $rows = [];
+    foreach ($event->get('field_attendee_questions')->referencedEntities() as $delta => $paragraph) {
+      if (!$paragraph instanceof ParagraphInterface || $paragraph->bundle() !== 'attendee_extra_field') {
+        continue;
+      }
+      $rows[] = $this->rowFromParagraph($paragraph, (int) $delta);
+    }
+    return $rows;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   */
+  public function validateRow(NodeInterface $event, array $row, string $context = 'question'): ?string {
+    $label = trim((string) ($row['label'] ?? ''));
+    if ($label === '') {
+      return (string) $this->t('Each question needs a label.');
+    }
+
+    $type = $this->normalizeType((string) ($row['type'] ?? ''));
+    if ($type === 'tel' || !array_key_exists($type, $this->typeOptions())) {
+      return (string) $this->t('@question uses an unsupported type.', ['@question' => $context]);
+    }
+
+    $status = $this->normalizeStatus((string) ($row['status'] ?? self::STATUS_ACTIVE));
+    $applicability = $this->normalizeApplicability((string) ($row['applicability'] ?? self::APPLIES_PER_TICKET));
+
+    $options = $this->normalizeOptions((string) ($row['options'] ?? ''));
+    if (in_array($type, ['select', 'checkboxes', 'radios'], TRUE) && $options === []) {
+      return (string) $this->t('@question needs at least one option.', ['@question' => $context]);
+    }
+    if (!in_array($type, ['select', 'checkboxes', 'radios'], TRUE) && $options !== []) {
+      return (string) $this->t('@question has options, but options are only supported for select, checkbox, and radio questions.', ['@question' => $context]);
+    }
+
+    $ticket_ids = $this->normalizeTicketTypeIds($row['ticket_type_ids'] ?? []);
+    if ($applicability === self::APPLIES_PER_TICKET_TYPE) {
+      if ($ticket_ids === []) {
+        return (string) $this->t('@question must select at least one ticket type.', ['@question' => $context]);
+      }
+      $valid_ticket_ids = array_keys($this->ticketOptions($event));
+      foreach ($ticket_ids as $ticket_id) {
+        if (!in_array($ticket_id, $valid_ticket_ids, TRUE)) {
+          return (string) $this->t('@question references a ticket type that does not belong to this event.', ['@question' => $context]);
+        }
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $existingRows
+   * @param array<string, mixed>|null $newRow
+   *
+   * @return list<string>
+   */
+  public function validateRows(NodeInterface $event, array $existingRows, ?array $newRow = NULL): array {
+    $errors = [];
+    $seen = [];
+    foreach ($existingRows as $index => $row) {
+      if (!is_array($row)) {
+        $errors[] = (string) $this->t('Question row @row was invalid.', ['@row' => (string) ($index + 1)]);
+        continue;
+      }
+      $context = (string) $this->t('Question @row', ['@row' => (string) ($index + 1)]);
+      $error = $this->validateRow($event, $row, $context);
+      if ($error !== NULL) {
+        $errors[] = $error;
+        continue;
+      }
+      $status = $this->normalizeStatus((string) ($row['status'] ?? self::STATUS_ACTIVE));
+      $label_key = mb_strtolower(trim((string) ($row['label'] ?? '')));
+      if ($status === self::STATUS_ACTIVE && $label_key !== '') {
+        if (isset($seen[$label_key])) {
+          $errors[] = (string) $this->t('Active question labels must be unique: @label.', ['@label' => (string) $row['label']]);
+        }
+        $seen[$label_key] = TRUE;
+      }
+    }
+
+    if ($newRow !== NULL && trim((string) ($newRow['label'] ?? '')) !== '') {
+      $error = $this->validateRow($event, $newRow, (string) $this->t('New question'));
+      if ($error !== NULL) {
+        $errors[] = $error;
+      }
+      $status = $this->normalizeStatus((string) ($newRow['status'] ?? self::STATUS_ACTIVE));
+      $label_key = mb_strtolower(trim((string) ($newRow['label'] ?? '')));
+      if ($status === self::STATUS_ACTIVE && isset($seen[$label_key])) {
+        $errors[] = (string) $this->t('Active question labels must be unique: @label.', ['@label' => (string) $newRow['label']]);
+      }
+    }
+
+    return array_values(array_unique($errors));
+  }
+
+  /**
+   * @param list<array<string, mixed>> $existingRows
+   * @param array<string, mixed>|null $newRow
+   *
+   * @return list<string>
+   */
+  public function saveRows(NodeInterface $event, array $existingRows, ?array $newRow = NULL): array {
+    if (!$event->hasField('field_attendee_questions')) {
+      return [(string) $this->t('Attendee questions are not available on this event.')];
+    }
+
+    $errors = $this->validateRows($event, $existingRows, $newRow);
+    if ($errors !== []) {
+      return $errors;
+    }
+
+    $paragraphs = [];
+    try {
+      foreach ($existingRows as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
+        $paragraph = $this->loadManagedParagraph($event, (int) ($row['id'] ?? 0));
+        if (!$paragraph instanceof ParagraphInterface) {
+          continue;
+        }
+        $this->applyRowToParagraph($paragraph, $row);
+        $paragraph->save();
+        $paragraphs[] = [
+          'paragraph' => $paragraph,
+          'weight' => (int) ($row['weight'] ?? 0),
+        ];
+      }
+
+      if ($newRow !== NULL && trim((string) ($newRow['label'] ?? '')) !== '') {
+        $paragraph = Paragraph::create(['type' => 'attendee_extra_field']);
+        $this->applyRowToParagraph($paragraph, $newRow);
+        $paragraph->save();
+        $paragraphs[] = [
+          'paragraph' => $paragraph,
+          'weight' => (int) ($newRow['weight'] ?? 999),
+        ];
+      }
+
+      usort($paragraphs, static fn (array $a, array $b): int => ($a['weight'] <=> $b['weight']));
+      $references = [];
+      foreach ($paragraphs as $item) {
+        $paragraph = $item['paragraph'];
+        if (!$paragraph instanceof ParagraphInterface) {
+          continue;
+        }
+        $references[] = [
+          'target_id' => (int) $paragraph->id(),
+          'target_revision_id' => (int) $paragraph->getRevisionId(),
+        ];
+      }
+
+      $event->set('field_attendee_questions', $references);
+      if ($event->hasField('field_collect_per_ticket')) {
+        $has_active_checkout_question = FALSE;
+        foreach ($paragraphs as $item) {
+          $paragraph = $item['paragraph'];
+          if ($paragraph instanceof ParagraphInterface
+            && $this->paragraphStatus($paragraph) === self::STATUS_ACTIVE
+            && $this->paragraphApplicability($paragraph) !== self::APPLIES_PER_ORDER) {
+            $has_active_checkout_question = TRUE;
+            break;
+          }
+        }
+        $event->set('field_collect_per_ticket', $has_active_checkout_question);
+      }
+      $event->save();
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio question template save failed for event @nid: @message', [
+        '@nid' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return [(string) $this->t('Checkout questions could not be saved. Check the rows and try again.')];
+    }
+
+    return [];
+  }
+
+  public function normalizeType(string $type): string {
+    $type = trim($type);
+    return self::TYPE_MAP[$type] ?? 'textfield';
+  }
+
+  public function normalizeStatus(string $status): string {
+    return $status === self::STATUS_ARCHIVED ? self::STATUS_ARCHIVED : self::STATUS_ACTIVE;
+  }
+
+  public function normalizeApplicability(string $applicability): string {
+    return match ($applicability) {
+      self::APPLIES_PER_TICKET_TYPE => self::APPLIES_PER_TICKET_TYPE,
+      self::APPLIES_PER_ORDER => self::APPLIES_PER_ORDER,
+      default => self::APPLIES_PER_TICKET,
+    };
+  }
+
+  public function paragraphStatus(ParagraphInterface $paragraph): string {
+    if ($paragraph->hasField('field_question_status') && !$paragraph->get('field_question_status')->isEmpty()) {
+      return $this->normalizeStatus((string) $paragraph->get('field_question_status')->value);
+    }
+    return self::STATUS_ACTIVE;
+  }
+
+  public function paragraphApplicability(ParagraphInterface $paragraph): string {
+    if ($paragraph->hasField('field_question_applicability') && !$paragraph->get('field_question_applicability')->isEmpty()) {
+      return $this->normalizeApplicability((string) $paragraph->get('field_question_applicability')->value);
+    }
+    return self::APPLIES_PER_TICKET;
+  }
+
+  /**
+   * @return list<int>
+   */
+  public function paragraphTicketTypeIds(ParagraphInterface $paragraph): array {
+    if (!$paragraph->hasField('field_question_ticket_types') || $paragraph->get('field_question_ticket_types')->isEmpty()) {
+      return [];
+    }
+    $ids = [];
+    foreach ($paragraph->get('field_question_ticket_types')->getValue() as $item) {
+      $target_id = isset($item['target_id']) ? (int) $item['target_id'] : 0;
+      if ($target_id > 0) {
+        $ids[] = $target_id;
+      }
+    }
+    return array_values(array_unique($ids));
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function normalizeOptions(string $raw): array {
+    $lines = preg_split('/\R/', $raw) ?: [];
+    $options = [];
+    foreach ($lines as $line) {
+      $option = trim($line);
+      if ($option !== '') {
+        $options[] = $option;
+      }
+    }
+    return array_values(array_unique($options));
+  }
+
+  /**
+   * @return list<int>
+   */
+  public function normalizeTicketTypeIds(mixed $raw): array {
+    if (!is_array($raw)) {
+      return [];
+    }
+    $ids = [];
+    foreach ($raw as $key => $value) {
+      $candidate = is_numeric($value) ? (int) $value : (is_numeric($key) && $value ? (int) $key : 0);
+      if ($candidate > 0) {
+        $ids[] = $candidate;
+      }
+    }
+    return array_values(array_unique($ids));
+  }
+
+  /**
+   * @return list<\Drupal\mel_ticket\Entity\TicketTypeInterface>
+   */
+  private function loadEventTickets(NodeInterface $event): array {
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return [];
+    }
+    $tickets = [];
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $ticket) {
+      if ($ticket instanceof TicketTypeInterface && !$ticket->isArchived()) {
+        $tickets[] = $ticket;
+      }
+    }
+    return $tickets;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function rowFromParagraph(ParagraphInterface $paragraph, int $delta): array {
+    $type = $paragraph->hasField('field_question_type') && !$paragraph->get('field_question_type')->isEmpty()
+      ? $this->normalizeType((string) $paragraph->get('field_question_type')->value)
+      : 'textfield';
+    $status = $this->paragraphStatus($paragraph);
+    $applicability = $this->paragraphApplicability($paragraph);
+    $ticket_type_ids = $this->paragraphTicketTypeIds($paragraph);
+    $ticket_type_labels = [];
+    if ($paragraph->hasField('field_question_ticket_types')) {
+      foreach ($paragraph->get('field_question_ticket_types')->referencedEntities() as $ticket) {
+        if ($ticket instanceof TicketTypeInterface) {
+          $ticket_type_labels[] = $ticket->label();
+        }
+      }
+    }
+
+    return [
+      'id' => (int) $paragraph->id(),
+      'revision_id' => (int) $paragraph->getRevisionId(),
+      'weight' => $delta,
+      'label' => $paragraph->hasField('field_question_label') ? (string) ($paragraph->get('field_question_label')->value ?? '') : '',
+      'type' => $type,
+      'type_label' => $this->typeOptions()[$type] ?? $type,
+      'required' => $paragraph->hasField('field_question_required') && !empty($paragraph->get('field_question_required')->value),
+      'status' => $status,
+      'applicability' => $applicability,
+      'ticket_type_ids' => $ticket_type_ids,
+      'ticket_type_labels' => $ticket_type_labels,
+      'options' => $paragraph->hasField('field_question_options') ? (string) ($paragraph->get('field_question_options')->value ?? '') : '',
+      'machine_name' => $paragraph->hasField('field_question_machine_name') ? (string) ($paragraph->get('field_question_machine_name')->value ?? '') : '',
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   */
+  private function applyRowToParagraph(ParagraphInterface $paragraph, array $row): void {
+    $label = trim((string) ($row['label'] ?? ''));
+    $type = $this->normalizeType((string) ($row['type'] ?? 'textfield'));
+    $status = $this->normalizeStatus((string) ($row['status'] ?? self::STATUS_ACTIVE));
+    $applicability = $this->normalizeApplicability((string) ($row['applicability'] ?? self::APPLIES_PER_TICKET));
+
+    if ($paragraph->hasField('field_question_label')) {
+      $paragraph->set('field_question_label', $label);
+    }
+    if ($paragraph->hasField('field_question_type')) {
+      $paragraph->set('field_question_type', $type);
+    }
+    if ($paragraph->hasField('field_question_required')) {
+      $paragraph->set('field_question_required', !empty($row['required']) ? 1 : 0);
+    }
+    if ($paragraph->hasField('field_question_status')) {
+      $paragraph->set('field_question_status', $status);
+    }
+    if ($paragraph->hasField('field_question_applicability')) {
+      $paragraph->set('field_question_applicability', $applicability);
+    }
+    if ($paragraph->hasField('field_question_options')) {
+      $options = $this->normalizeOptions((string) ($row['options'] ?? ''));
+      $paragraph->set('field_question_options', $options === [] ? NULL : ['value' => implode("\n", $options)]);
+    }
+    if ($paragraph->hasField('field_question_machine_name')) {
+      $machine = trim((string) ($row['machine_name'] ?? ''));
+      $paragraph->set('field_question_machine_name', $machine !== '' ? $machine : $this->machineNameFromLabel($label));
+    }
+    if ($paragraph->hasField('field_question_ticket_types')) {
+      $ticket_ids = $this->normalizeTicketTypeIds($row['ticket_type_ids'] ?? []);
+      $paragraph->set('field_question_ticket_types', array_map(static fn (int $id): array => ['target_id' => $id], $ticket_ids));
+    }
+  }
+
+  private function loadManagedParagraph(NodeInterface $event, int $paragraphId): ?ParagraphInterface {
+    if ($paragraphId < 1 || !$event->hasField('field_attendee_questions')) {
+      return NULL;
+    }
+    foreach ($event->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+      if ($paragraph instanceof ParagraphInterface && (int) $paragraph->id() === $paragraphId) {
+        return $paragraph;
+      }
+    }
+    return NULL;
+  }
+
+  private function machineNameFromLabel(string $label): string {
+    $slug = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '_', $label));
+    $slug = trim((string) preg_replace('/_+/', '_', $slug), '_');
+    return $slug !== '' ? $slug : 'question_' . substr(hash('sha256', $label), 0, 10);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1070,6 +1070,24 @@ final class EventStudioSaveService {
         $paragraph->set($field_map['label'], $label);
         $paragraph->set($field_map['type'], $this->normalizeAttendeeQuestionTypeValue($type));
         $paragraph->set($field_map['required'], $required ? 1 : 0);
+        if ($paragraph->hasField('field_question_status')) {
+          $paragraph->set('field_question_status', $this->normalizeAttendeeQuestionStatusValue((string) ($question['status'] ?? 'active')));
+        }
+        if ($paragraph->hasField('field_question_applicability')) {
+          $paragraph->set('field_question_applicability', $this->normalizeAttendeeQuestionApplicabilityValue((string) ($question['applicability'] ?? 'per_ticket')));
+        }
+        if ($paragraph->hasField('field_question_ticket_types')) {
+          $ticket_type_references = [];
+          if (isset($question['ticket_type_ids']) && is_array($question['ticket_type_ids'])) {
+            foreach ($question['ticket_type_ids'] as $ticket_type_id) {
+              $ticket_type_id = (int) $ticket_type_id;
+              if ($ticket_type_id > 0) {
+                $ticket_type_references[] = ['target_id' => $ticket_type_id];
+              }
+            }
+          }
+          $paragraph->set('field_question_ticket_types', $ticket_type_references);
+        }
 
         $normalized_type = $this->normalizeAttendeeQuestionTypeValue($type);
         if ($paragraph->hasField('field_question_options')) {
@@ -1185,8 +1203,21 @@ final class EventStudioSaveService {
       'radio' => 'radios',
       'radios' => 'radios',
       'email' => 'email',
+      'number' => 'number',
       'tel' => 'tel',
       default => 'textfield',
+    };
+  }
+
+  private function normalizeAttendeeQuestionStatusValue(string $status): string {
+    return trim($status) === 'archived' ? 'archived' : 'active';
+  }
+
+  private function normalizeAttendeeQuestionApplicabilityValue(string $applicability): string {
+    return match (trim($applicability)) {
+      'per_ticket_type' => 'per_ticket_type',
+      'per_order' => 'per_order',
+      default => 'per_ticket',
     };
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWizardMelBaseline.php
@@ -48,7 +48,11 @@ final class EventStudioWizardMelBaseline {
       return [];
     }
 
-    $normalized = $this->normalizeBaselineMel($baseline);
+    $normalized = $this->entityAutocompleteMelNormalizer->normalizeValuesForForm($mel, $baseline, [
+      'section' => 'baseline',
+      'event_id' => (int) $node->id(),
+      'uid' => NULL,
+    ]);
     $this->baselineMelByNodeRevision[$cacheKey] = $normalized;
     return $normalized;
   }
@@ -75,38 +79,6 @@ final class EventStudioWizardMelBaseline {
       $out[$key] = $this->extractDefaultsRecursive($child);
     }
     return $out;
-  }
-
-  /**
-   * @param array<string, mixed> $mel
-   *
-   * @return array<string, mixed>
-   */
-  private function normalizeBaselineMel(array $mel): array {
-    $single = [
-      'venue_saved' => 'myeventlane_venue',
-      'field_product_target' => 'commerce_product',
-    ];
-    foreach ($single as $key => $entity_type_id) {
-      if (!array_key_exists($key, $mel)) {
-        continue;
-      }
-      $mel[$key] = $this->entityAutocompleteMelNormalizer->normalizeSingle($mel[$key], $entity_type_id, 'mel.' . $key);
-    }
-
-    $tags = [
-      'field_category' => 'taxonomy_term',
-      'field_tags' => 'taxonomy_term',
-      'field_accessibility' => 'taxonomy_term',
-    ];
-    foreach ($tags as $key => $entity_type_id) {
-      if (!array_key_exists($key, $mel)) {
-        continue;
-      }
-      $mel[$key] = $this->entityAutocompleteMelNormalizer->normalizeTags($mel[$key], $entity_type_id, 'mel.' . $key);
-    }
-
-    return $mel;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EntityAutocompleteMelNormalizerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EntityAutocompleteMelNormalizerTest.php
@@ -81,6 +81,102 @@ final class EntityAutocompleteMelNormalizerTest extends TestCase {
     ], 'commerce_product', 'mel.field_product_target'));
   }
 
+  /**
+   * @covers ::normalizeValuesForForm
+   */
+  public function testNormalizeValuesForFormUsesAutocompleteElementMetadata(): void {
+    $venue = $this->entity('myeventlane_venue');
+    $category = $this->entity('taxonomy_term');
+
+    $venueStorage = $this->createMock(EntityStorageInterface::class);
+    $venueStorage->expects($this->once())
+      ->method('load')
+      ->with(100)
+      ->willReturn($venue);
+
+    $termStorage = $this->createMock(EntityStorageInterface::class);
+    $termStorage->expects($this->once())
+      ->method('load')
+      ->with(200)
+      ->willReturn($category);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')
+      ->willReturnMap([
+        ['myeventlane_venue', $venueStorage],
+        ['taxonomy_term', $termStorage],
+      ]);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('warning');
+
+    $normalizer = new EntityAutocompleteMelNormalizer($entityTypeManager, $logger);
+    $form = [
+      'venue_saved' => [
+        '#type' => 'entity_autocomplete',
+        '#target_type' => 'myeventlane_venue',
+      ],
+      'field_category' => [
+        '#type' => 'entity_autocomplete',
+        '#target_type' => 'taxonomy_term',
+        '#tags' => TRUE,
+      ],
+    ];
+
+    $normalized = $normalizer->normalizeValuesForForm($form, [
+      'venue_saved' => 'Main Hall (100)',
+      'field_category' => 'Music (200)',
+    ]);
+
+    $this->assertSame($venue, $normalized['venue_saved']);
+    $this->assertSame([$category], $normalized['field_category']);
+  }
+
+  /**
+   * @covers ::normalizeDefaultValuesForForm
+   */
+  public function testNormalizeDefaultValuesForFormDropsMalformedAutocompleteDefaultsWithOperationalContext(): void {
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->expects($this->never())->method('getStorage');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        'Discarded invalid entity_autocomplete replay value for @key (expected entity type @type): @info section=@section event=@event uid=@uid field=@field payload_type=@payload_type',
+        [
+          '@key' => 'mel.venue_saved',
+          '@type' => 'myeventlane_venue',
+          '@info' => 'array',
+          '@section' => 'information',
+          '@event' => '123',
+          '@uid' => '456',
+          '@field' => 'venue_saved',
+          '@payload_type' => 'array',
+        ],
+      );
+
+    $normalizer = new EntityAutocompleteMelNormalizer($entityTypeManager, $logger);
+    $form = [
+      'venue_saved' => [
+        '#type' => 'entity_autocomplete',
+        '#target_type' => 'myeventlane_venue',
+        '#default_value' => [
+          ['target_id' => 100],
+          ['target_id' => 101],
+        ],
+      ],
+    ];
+
+    $normalizer->normalizeDefaultValuesForForm($form, [
+      'section' => 'information',
+      'event_id' => 123,
+      'uid' => 456,
+    ]);
+
+    $this->assertNull($form['venue_saved']['#default_value']);
+  }
+
   private function entity(string $entityTypeId): EntityInterface {
     $entity = $this->createMock(EntityInterface::class);
     $entity->method('getEntityTypeId')->willReturn($entityTypeId);

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+require_once dirname(__DIR__, 3) . '/src/Service/EventStudioQuestionTemplateManager.php';
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioQuestionTemplateManagerTest extends TestCase {
+
+  /**
+   * @covers ::normalizeType
+   */
+  public function testNormalizeTypeMapsGovernedAliases(): void {
+    $manager = $this->manager();
+
+    $this->assertSame('textfield', $manager->normalizeType('text'));
+    $this->assertSame('checkboxes', $manager->normalizeType('checkbox'));
+    $this->assertSame('radios', $manager->normalizeType('radio'));
+    $this->assertSame('number', $manager->normalizeType('number'));
+    $this->assertSame('textfield', $manager->normalizeType('made_up'));
+  }
+
+  /**
+   * @covers ::applicabilityOptions
+   */
+  public function testApplicabilityOptionsIncludePerOrderMetadataOption(): void {
+    $manager = $this->manager();
+
+    $this->assertArrayHasKey(EventStudioQuestionTemplateManager::APPLIES_PER_ORDER, $manager->applicabilityOptions());
+  }
+
+  /**
+   * @covers ::normalizeOptions
+   */
+  public function testNormalizeOptionsTrimsAndDeduplicatesLines(): void {
+    $manager = $this->manager();
+
+    $this->assertSame(['VIP', 'General'], $manager->normalizeOptions(" VIP \n\nGeneral\nVIP"));
+  }
+
+  /**
+   * @covers ::normalizeTicketTypeIds
+   */
+  public function testNormalizeTicketTypeIdsAcceptsCheckboxShapes(): void {
+    $manager = $this->manager();
+
+    $this->assertSame([10, 20], $manager->normalizeTicketTypeIds([
+      10 => '10',
+      20 => 20,
+      30 => 0,
+    ]));
+  }
+
+  private function manager(): EventStudioQuestionTemplateManager {
+    $manager = new EventStudioQuestionTemplateManager(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(LoggerInterface::class),
+    );
+    $manager->setStringTranslation($this->translator());
+    return $manager;
+  }
+
+  private function translator(): TranslationInterface {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    return $translator;
+  }
+
+}

--- a/web/modules/custom/myeventlane_schema/config/install/core.entity_form_display.paragraph.attendee_extra_field.default.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/core.entity_form_display.paragraph.attendee_extra_field.default.yml
@@ -2,11 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.attendee_extra_field.field_question_applicability
     - field.field.paragraph.attendee_extra_field.field_question_help
     - field.field.paragraph.attendee_extra_field.field_question_label
     - field.field.paragraph.attendee_extra_field.field_question_machine_name
     - field.field.paragraph.attendee_extra_field.field_question_options
     - field.field.paragraph.attendee_extra_field.field_question_required
+    - field.field.paragraph.attendee_extra_field.field_question_status
+    - field.field.paragraph.attendee_extra_field.field_question_ticket_types
     - field.field.paragraph.attendee_extra_field.field_question_type
     - paragraphs.paragraphs_type.attendee_extra_field
   module:
@@ -62,4 +65,7 @@ content:
     region: content
     settings: {  }
     third_party_settings: {}
-hidden: {  }
+hidden:
+  field_question_applicability: true
+  field_question_status: true
+  field_question_ticket_types: true

--- a/web/modules/custom/myeventlane_schema/config/install/core.entity_view_display.paragraph.attendee_extra_field.default.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/core.entity_view_display.paragraph.attendee_extra_field.default.yml
@@ -2,11 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.attendee_extra_field.field_question_applicability
     - field.field.paragraph.attendee_extra_field.field_question_help
     - field.field.paragraph.attendee_extra_field.field_question_label
     - field.field.paragraph.attendee_extra_field.field_question_machine_name
     - field.field.paragraph.attendee_extra_field.field_question_options
     - field.field.paragraph.attendee_extra_field.field_question_required
+    - field.field.paragraph.attendee_extra_field.field_question_status
+    - field.field.paragraph.attendee_extra_field.field_question_ticket_types
     - field.field.paragraph.attendee_extra_field.field_question_type
     - paragraphs.paragraphs_type.attendee_extra_field
 id: paragraph.attendee_extra_field.default
@@ -40,9 +43,12 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
 hidden:
+  field_question_applicability: true
   field_question_help: true
   field_question_machine_name: true
   field_question_options: true
+  field_question_status: true
+  field_question_ticket_types: true
 
 
 

--- a/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_applicability
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question applicability'
+description: 'Controls whether this question applies to every ticket holder, selected ticket types, or a future per-order flow.'
+required: false
+translatable: false
+default_value:
+  - value: per_ticket
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_status.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_status
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question status'
+description: 'Whether this checkout question should render for new checkout sessions.'
+required: false
+translatable: false
+default_value:
+  - value: active
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_ticket_types
+    - paragraphs.paragraphs_type.attendee_extra_field
+id: paragraph.attendee_extra_field.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Ticket types'
+description: 'For per-ticket-type questions, select the ticket types that should receive this question.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:mel_ticket_type'
+  handler_settings: {  }
+field_type: entity_reference

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_applicability.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_applicability.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    - { value: 'per_ticket', label: 'Per ticket' }
+    - { value: 'per_ticket_type', label: 'Per ticket type' }
+    - { value: 'per_order', label: 'Per order' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_status.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_status.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    - { value: 'active', label: 'Active' }
+    - { value: 'archived', label: 'Archived' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_ticket_types.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_ticket_types.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - mel_ticket
+    - paragraphs
+id: paragraph.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: mel_ticket_type
+module: core
+locked: false
+cardinality: -1
+translatable: false
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_type.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.paragraph.field_question_type.yml
@@ -16,6 +16,7 @@ settings:
     - { value: 'checkboxes', label: 'Checkboxes' }
     - { value: 'radios', label: 'Radio buttons' }
     - { value: 'email', label: 'Email' }
+    - { value: 'number', label: 'Number' }
     - { value: 'tel', label: 'Phone number' }
   allowed_values_function: ''
 module: options

--- a/web/modules/custom/myeventlane_schema/config/optional/core.entity_view_display.paragraph.attendee_extra_field.default.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/core.entity_view_display.paragraph.attendee_extra_field.default.yml
@@ -2,11 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.attendee_extra_field.field_question_applicability
     - field.field.paragraph.attendee_extra_field.field_question_help
     - field.field.paragraph.attendee_extra_field.field_question_label
     - field.field.paragraph.attendee_extra_field.field_question_machine_name
     - field.field.paragraph.attendee_extra_field.field_question_options
     - field.field.paragraph.attendee_extra_field.field_question_required
+    - field.field.paragraph.attendee_extra_field.field_question_status
+    - field.field.paragraph.attendee_extra_field.field_question_ticket_types
     - field.field.paragraph.attendee_extra_field.field_question_type
     - paragraphs.paragraphs_type.attendee_extra_field
 id: paragraph.attendee_extra_field.default
@@ -40,6 +43,9 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
 hidden:
+  field_question_applicability: true
   field_question_help: true
   field_question_machine_name: true
   field_question_options: true
+  field_question_status: true
+  field_question_ticket_types: true

--- a/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_applicability.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_applicability
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question applicability'
+description: 'Controls whether this question applies to every ticket holder, selected ticket types, or a future per-order flow.'
+required: false
+translatable: false
+default_value:
+  - value: per_ticket
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_status.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_status
+    - paragraphs.paragraphs_type.attendee_extra_field
+  module:
+    - options
+id: paragraph.attendee_extra_field.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Question status'
+description: 'Whether this checkout question should render for new checkout sessions.'
+required: false
+translatable: false
+default_value:
+  - value: active
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.field.paragraph.attendee_extra_field.field_question_ticket_types.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_question_ticket_types
+    - paragraphs.paragraphs_type.attendee_extra_field
+id: paragraph.attendee_extra_field.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+bundle: attendee_extra_field
+label: 'Ticket types'
+description: 'For per-ticket-type questions, select the ticket types that should receive this question.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:mel_ticket_type'
+  handler_settings: {  }
+field_type: entity_reference

--- a/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_applicability.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_applicability.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_applicability
+field_name: field_question_applicability
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    - { value: 'per_ticket', label: 'Per ticket' }
+    - { value: 'per_ticket_type', label: 'Per ticket type' }
+    - { value: 'per_order', label: 'Per order' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_status.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_status.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_question_status
+field_name: field_question_status
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    - { value: 'active', label: 'Active' }
+    - { value: 'archived', label: 'Archived' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_ticket_types.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_ticket_types.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - mel_ticket
+    - paragraphs
+id: paragraph.field_question_ticket_types
+field_name: field_question_ticket_types
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: mel_ticket_type
+module: core
+locked: false
+cardinality: -1
+translatable: false
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_type.yml
+++ b/web/modules/custom/myeventlane_schema/config/optional/field.storage.paragraph.field_question_type.yml
@@ -16,6 +16,7 @@ settings:
     - { value: 'checkboxes', label: 'Checkboxes' }
     - { value: 'radios', label: 'Radio buttons' }
     - { value: 'email', label: 'Email' }
+    - { value: 'number', label: 'Number' }
     - { value: 'tel', label: 'Phone number' }
   allowed_values_function: ''
 module: options

--- a/web/modules/custom/myeventlane_vendor/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/EventCheckoutQuestionsForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -20,6 +21,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly AccountProxyInterface $currentUserProxy,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
   ) {}
 
   /**
@@ -29,6 +31,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('current_user'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -92,6 +95,9 @@ final class EventCheckoutQuestionsForm extends FormBase {
       $type = $paragraph->get('field_question_type')->value ?? 'text';
       $label = $paragraph->get('field_question_label')->value ?? 'Unnamed Question';
       $required = (bool) ($paragraph->get('field_question_required')->value ?? FALSE);
+      $status = $paragraph->hasField('field_question_status') && !$paragraph->get('field_question_status')->isEmpty()
+        ? (string) $paragraph->get('field_question_status')->value
+        : 'active';
       $apply_to = $this->t('All guests');
 
       $rows[$delta] = [
@@ -100,12 +106,13 @@ final class EventCheckoutQuestionsForm extends FormBase {
         'required' => ['#markup' => $required ? $this->t('Yes') : $this->t('No')],
         'apply_to' => ['#markup' => $apply_to],
         'operations' => [
-          'delete' => [
+          'archive' => [
             '#type' => 'submit',
-            '#value' => $this->t('Delete'),
+            '#value' => $status === 'archived' ? $this->t('Archived') : $this->t('Archive'),
             '#submit' => ['::deleteQuestion'],
-            '#name' => 'delete_question_' . $paragraph->id(),
+            '#name' => 'archive_question_' . $paragraph->id(),
             '#paragraph_id' => $paragraph->id(),
+            '#disabled' => $status === 'archived',
             '#attributes' => ['class' => ['button', 'button--small', 'button--danger']],
           ],
         ],
@@ -152,10 +159,16 @@ final class EventCheckoutQuestionsForm extends FormBase {
     $paragraph_storage = $this->entityTypeManager->getStorage('paragraph');
     $paragraph = $paragraph_storage->create([
       'type' => 'attendee_extra_field',
-      'field_question_type' => 'text',
+      'field_question_type' => 'textfield',
       'field_question_label' => 'New Question',
       'field_question_required' => FALSE,
     ]);
+    if ($paragraph->hasField('field_question_status')) {
+      $paragraph->set('field_question_status', 'active');
+    }
+    if ($paragraph->hasField('field_question_applicability')) {
+      $paragraph->set('field_question_applicability', 'per_ticket');
+    }
     $paragraph->save();
 
     $questions = $event->hasField('field_attendee_questions') ? $event->get('field_attendee_questions')->getValue() : [];
@@ -171,7 +184,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
   }
 
   /**
-   * Submit handler to delete a question.
+   * Submit handler to archive a question without deleting historical answers.
    */
   public function deleteQuestion(array &$form, FormStateInterface $form_state): void {
     $event = $form_state->get('event') ?? $form['#event'] ?? NULL;
@@ -192,17 +205,13 @@ final class EventCheckoutQuestionsForm extends FormBase {
       return;
     }
 
-    if ($event->hasField('field_attendee_questions') && !$event->get('field_attendee_questions')->isEmpty()) {
-      $questions = $event->get('field_attendee_questions')->getValue();
-      $questions = array_filter($questions, static function (array $item) use ($paragraph_id) {
-        return ($item['target_id'] ?? NULL) !== $paragraph_id;
-      });
-      $event->set('field_attendee_questions', array_values($questions));
+    if ($paragraph instanceof ParagraphInterface && $paragraph->hasField('field_question_status')) {
+      $paragraph->set('field_question_status', 'archived');
+      $paragraph->save();
       $event->save();
     }
 
-    $paragraph->delete();
-    $this->messenger()->addStatus($this->t('Question deleted.'));
+    $this->messenger()->addStatus($this->t('Question archived.'));
     $form_state->setRebuild();
   }
 
@@ -220,7 +229,8 @@ final class EventCheckoutQuestionsForm extends FormBase {
     if ($this->currentUserProxy->hasPermission('administer nodes')) {
       return TRUE;
     }
-    return $event->getOwnerId() === $this->currentUserProxy->id();
+    return $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $this->currentUserProxy)
+      && $event->access('update', $this->currentUserProxy);
   }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to new config fields and updated filtering/validation that changes which attendee questions render/validate in checkout/RSVP, plus new autosave normalization logic that touches form submission paths.
> 
> **Overview**
> Adds new attendee-question metadata fields (**`field_question_status`**, **`field_question_applicability`**, **`field_question_ticket_types`**) and extends `field_question_type` with **`number`**, updating Drupal config and storage accordingly.
> 
> Updates checkout/RSVP question rendering and validation to respect *required vs optional*, support `number` inputs (with numeric validation), and to **skip archived questions** and questions not applicable to the current ticket/tier; per-order questions are explicitly ignored at checkout.
> 
> Introduces an Event Studio “Checkout questions” manager UI backed by a new `EventStudioQuestionTemplateManager` service, adds styling for the new table-based editor, and switches vendor-side deletion to **archiving** templates.
> 
> Hardens Event Studio autosave and wizard flows by validating section writability and normalizing `entity_autocomplete` values/defaults based on form metadata to prevent invalid replay/default payloads (with expanded unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cf5220e0310e4e4d29eb054de5c31440896f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->