### PR TITLE
Fix/event studio guest cues locale

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -1817,6 +1817,10 @@
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
 }
 
+.mel-event-studio-sidebar-overlay {
+  display: none;
+}
+
 .mel-event-studio-readiness-strip {
   display: flex;
   align-items: center;
@@ -2353,6 +2357,8 @@
   .mel-event-studio-workspace {
     grid-template-columns: minmax(0, 1fr) !important;
     gap: 16px;
+    position: relative;
+    overflow: visible;
   }
 
   .mel-event-studio-sidebar-toggle {
@@ -2363,6 +2369,7 @@
 
   .mel-event-studio-sidebar-overlay {
     appearance: none;
+    display: block;
     position: fixed;
     inset: 0;
     z-index: 1000;
@@ -2400,6 +2407,15 @@
   .mel-event-studio-section {
     max-width: 100%;
     box-sizing: border-box;
+  }
+
+  .mel-event-studio-workspace__main {
+    grid-column: 1;
+    position: relative;
+    width: 100%;
+    min-width: 0;
+    overflow: visible;
+    transform: none;
   }
 
   .mel-event-studio-section__header,
@@ -2482,6 +2498,12 @@
     overflow-x: clip;
   }
 
+  .mel-event-studio-workspace {
+    grid-template-columns: minmax(0, 1fr) !important;
+    position: relative;
+    overflow: visible;
+  }
+
   .mel-event-studio-sidebar-toggle {
     display: inline-flex !important;
     align-items: center;
@@ -2494,6 +2516,7 @@
 
   .mel-event-studio-sidebar-overlay {
     appearance: none;
+    display: block;
     position: fixed;
     inset: 0;
     z-index: 1000;
@@ -2529,6 +2552,16 @@
 
   .mel-event-studio-sidebar__inner {
     min-height: 100%;
+  }
+
+  .mel-event-studio-workspace__main {
+    grid-column: 1;
+    position: relative;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    overflow: visible;
+    transform: none;
   }
 
   .mel-event-studio-topbar {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -310,6 +310,7 @@
             overlay.hidden = false;
           }
         };
+        closeSidebar();
         button.addEventListener('click', () => {
           if (shell.classList.contains('is-sidebar-open')) {
             closeSidebar();

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -5629,18 +5629,23 @@
     return words / sentences.length;
   }
 
-  function melAiChangeSummary(original, suggestion, promptType) {
+  function melAiChangeSummaryItems(original, suggestion, promptType) {
     var originalText = (original || '').trim();
     var suggestionText = (suggestion || '').trim();
     var originalLength = originalText.length;
     var suggestionLength = suggestionText.length;
     var changes = [];
-    var hasChange = function (label) {
-      return changes.indexOf(label) !== -1;
+    var hasChange = function (code) {
+      return changes.some(function (change) {
+        return change.code === code;
+      });
     };
-    var addChange = function (label) {
-      if (label && !hasChange(label) && changes.length < 4) {
-        changes.push(label);
+    var addChange = function (code, label) {
+      if (code && label && !hasChange(code) && changes.length < 4) {
+        changes.push({
+          code: code,
+          label: label,
+        });
       }
     };
 
@@ -5651,41 +5656,47 @@
     if (originalLength > 0 && suggestionLength < originalLength) {
       var percent = Math.round((1 - (suggestionLength / originalLength)) * 100);
       if (percent >= 5) {
-        addChange(Drupal.t('Shortened by @percent%', { '@percent': String(percent) }));
+        addChange('shortened', Drupal.t('Shortened by @percent%', { '@percent': String(percent) }));
       }
     }
     else if (originalLength > 0 && suggestionLength > originalLength) {
       var longerPercent = Math.round(((suggestionLength / originalLength) - 1) * 100);
       if (longerPercent >= 8) {
-        addChange(Drupal.t('Added @percent% more detail', { '@percent': String(longerPercent) }));
+        addChange('added_detail', Drupal.t('Added @percent% more detail', { '@percent': String(longerPercent) }));
       }
     }
 
     if (originalText && melAiAverageSentenceLength(suggestionText) < melAiAverageSentenceLength(originalText)) {
-      addChange(Drupal.t('Simplified sentence structure'));
+      addChange('simplified_sentence_structure', Drupal.t('Simplified sentence structure'));
     }
 
     if (promptType === 'more_welcoming' || promptType === 'community_friendly' || promptType === 'friendly' || promptType === 'lgbtqia' || promptType === 'family') {
-      addChange(Drupal.t('Made tone more welcoming'));
+      addChange('welcoming_tone', Drupal.t('Made tone more welcoming'));
     }
     if (promptType === 'attendee_clarity' || promptType === 'minimal' || promptType === 'shorter' || promptType === 'social_short') {
-      addChange(Drupal.t('Improved readability for mobile'));
+      addChange('mobile_readability', Drupal.t('Improved readability for mobile'));
     }
     if (promptType === 'workshop' || promptType === 'activist' || /\b(join|book|rsvp|reserve|discover|learn|experience|bring|come)\b/i.test(suggestionText)) {
-      addChange(Drupal.t('Clarified the attendee action'));
+      addChange('attendee_action', Drupal.t('Clarified the attendee action'));
     }
     if (/\b(accessible|accessibility|step-free|quiet|caption|interpreter|sensory|wheelchair|inclusive|welcoming)\b/i.test(suggestionText)
       && !/\b(accessible|accessibility|step-free|quiet|caption|interpreter|sensory|wheelchair|inclusive|welcoming)\b/i.test(originalText)) {
-      addChange(Drupal.t('Added accessibility-minded wording'));
+      addChange('accessibility_wording', Drupal.t('Added accessibility-minded wording'));
     }
     if (!changes.length && originalText && melAiSentenceCount(suggestionText) <= melAiSentenceCount(originalText)) {
-      addChange(Drupal.t('Made the copy easier to scan'));
+      addChange('easier_to_scan', Drupal.t('Made the copy easier to scan'));
     }
     if (!changes.length) {
-      addChange(Drupal.t('Shaped the copy for guests'));
+      addChange('guest_copy_shaping', Drupal.t('Shaped the copy for guests'));
     }
 
     return changes;
+  }
+
+  function melAiChangeSummary(original, suggestion, promptType) {
+    return melAiChangeSummaryItems(original, suggestion, promptType).map(function (change) {
+      return change.label;
+    });
   }
 
   function melAiRenderChanges(assist, text) {
@@ -5713,7 +5724,7 @@
   }
 
   function melAiGuestCueSummary(original, suggestion, promptType) {
-    var changes = melAiChangeSummary(original, suggestion, promptType);
+    var changes = melAiChangeSummaryItems(original, suggestion, promptType);
     var cues = [];
     var addCue = function (label) {
       if (label && cues.indexOf(label) === -1 && cues.length < 3) {
@@ -5721,17 +5732,17 @@
       }
     };
     changes.forEach(function (change) {
-      if (/short|scan|mobile/i.test(change)) {
+      if (change.code === 'shortened' || change.code === 'mobile_readability') {
         addCue(Drupal.t('Shorter for mobile'));
       }
-      else if (/welcoming|tone|community/i.test(change)) {
+      else if (change.code === 'welcoming_tone') {
         addCue(Drupal.t('More welcoming'));
       }
-      else if (/simplified|readability|clarity|easier/i.test(change)) {
+      else if (change.code === 'simplified_sentence_structure' || change.code === 'easier_to_scan') {
         addCue(Drupal.t('Easy to scan'));
       }
-      else if (/action|accessibility/i.test(change)) {
-        addCue(change);
+      else if (change.code === 'attendee_action' || change.code === 'accessibility_wording') {
+        addCue(change.label);
       }
     });
     if (!cues.length) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX and copy-assist changes; main risk is unintended mobile layout/sidebar behavior or changed guest cue labels across locales.
> 
> **Overview**
> Improves the mobile Event Studio shell by ensuring the sidebar starts closed and adding responsive layout tweaks so the sidebar overlay and main column behave correctly on small screens.
> 
> Refactors AI assist change summaries to return structured `{code,label}` items and updates guest cue generation to key off stable codes rather than matching translated strings, preventing locale-dependent cue logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a95d16d61258dc9c8c8ce1658cbbe2f54a6e333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->