### PR TITLE
Bugfix/my tickets confirmed translation

### DIFF
--- a/docs/issuance-pipeline.md
+++ b/docs/issuance-pipeline.md
@@ -13,7 +13,7 @@ Intended flow:
 3. **`TicketIssuer`** — Creates one **`myeventlane_ticket`** row per unit quantity for eligible order items (variation-backed, event-resolvable).
 4. **QR payloads** — Built from ticket entities via **`TicketQrPayload`** and **`QrCodeGenerator`** (also surfaced through **`UniversalTicketViewModelBuilder`**).
 5. **PDFs** — Generated through **`TicketPdfGenerator`** (`myeventlane_tickets.ticket_pdf_generator`), using the canonical view model for issued tickets. Legacy paths (order item, attendee, RSVP) remain for compatibility and are **not** part of the paid-order issuance slice; they are isolated in compatibility adapters (see [legacy-pdf-compatibility.md](./legacy-pdf-compatibility.md)).
-6. **Wallet** — The **`myeventlane_wallet`** module is currently **scaffold/stub** (builders and routes exist; pass generation is not production-complete). **`UniversalTicketViewModelBuilder`** exposes wallet **action URLs** that reference existing routes; **no** full wallet convergence was done in this commit. Future wallet generation must **derive from issued ticket entities**, not raw order items.
+6. **Wallet** — **`myeventlane_wallet`** routes remain **`/wallet/apple/{order_item_id}`** and **`/wallet/google/{order_item_id}`** for compatibility. Internally, wallet generation **resolves issued `myeventlane_ticket` rows** for that order item, enforces the same access semantics as ticket PDFs, and builds Apple scaffold bytes from **`UniversalTicketViewModelBuilder`** (which uses **`TicketQrPayload`**). When no issued ticket exists, **legacy placeholder** behaviour is preserved (no issuance from wallet). See [wallet-operational-convergence.md](./wallet-operational-convergence.md).
 7. **Notifications** — Order confirmation PDFs at send time are merged by **`MessagingManager`** → **`OrderConfirmationAttachmentResolver`** → **`TicketPdfGenerator::getPdfContentForTicket()`** per ticket row for the order. Ticket-ready email uses **`TicketMailer`**, which attaches PDFs from **`TicketPdfGenerator`** for assigned tickets.
 
 ```mermaid
@@ -97,4 +97,5 @@ Performed in a full environment (e.g. DDEV) with real mail and checkout:
 ## Related documentation
 
 - [operational-surface-convergence.md](./operational-surface-convergence.md) — My Tickets and PDF rendering convergence onto **`UniversalTicketViewModelBuilder`**.
+- [wallet-operational-convergence.md](./wallet-operational-convergence.md) — Wallet routes, inward ticket resolution, and QR authority alignment.
 - [legacy-pdf-compatibility.md](./legacy-pdf-compatibility.md) — **Governance:** operational authority vs legacy PDF adapters, inward-only delegation, frozen contracts, forbidden patterns (Commit 5+).

--- a/docs/legacy-pdf-compatibility.md
+++ b/docs/legacy-pdf-compatibility.md
@@ -72,7 +72,7 @@ Treat the following as **regression-sensitive contracts**, not implementation de
 | **QR payload structure and signing** | Payload formats and HMAC behavior are scanner- and history-sensitive. |
 | **Route structure** | Ticket PDF download URLs and public entry points must remain stable. |
 | **Attachment filenames and MIME** | Order confirmation and mail attachments must preserve expected names and `application/pdf` semantics. |
-| **Guest access behavior** | Anonymous or guest flows must not lose access to entitled artifacts where they currently have it. |
+| **Guest access behavior** | Anonymous or guest flows must not lose access to entitled artifacts where they currently have it. Wallet inward resolution follows the same ownership semantics as ticket PDFs (see [wallet-operational-convergence.md](./wallet-operational-convergence.md)). |
 | **Customer-visible PDF layout** | No **material** visual or layout regressions in production PDFs without explicit design sign-off. |
 
 **Allowed to evolve** behind the same contracts: internal field extraction, normalization delegation, render array shaping, and duplication reduction **that does not change** the frozen outputs above.

--- a/docs/operational-surface-convergence.md
+++ b/docs/operational-surface-convergence.md
@@ -10,6 +10,10 @@ Builder-driven rendering matters because operational ticket state is broader tha
 
 This removes duplicated operational shaping from `MyTicketsController`, Twig preprocessing, and template-only arrays. The checkout flow controller now delegates My Tickets order presentation to `MyTicketsOrderViewModelBuilder`, which loads issued `myeventlane_ticket` rows for already customer-scoped orders and normalizes each ticket through `UniversalTicketViewModelBuilder`. Legacy order-item rendering remains only as a compatibility fallback for orders that do not yet have issued ticket entities.
 
+## Wallet (Phase 2C)
+
+Wallet download routes remain order-item keyed for historical URL stability. **`WalletTicketResolver`** maps each **`order_item_id`** route parameter inward to issued **`myeventlane_ticket`** rows before **`PkPassBuilder`** (and future Google Wallet JWT code) runs. QR strings and entitlement metadata continue to flow through **`UniversalTicketViewModelBuilder`** → **`TicketQrPayload`** so wallet artifacts stay in the same operational spine as PDFs and scanners. See [wallet-operational-convergence.md](./wallet-operational-convergence.md).
+
 ## Ticket PDFs
 
 PDF rendering for issued tickets now derives operational entitlement data from the canonical `myeventlane_tickets.universal_ticket_view_model_builder` service, eliminating duplicated normalization in the PDF pipeline.
@@ -52,3 +56,5 @@ Now the canonical path is: `UniversalTicketViewModelBuilder::build()` → normal
 Paid-order **ticket row issuance** is owned by **`TicketIssuer`** on **`ORDER_PAID`** (see **`OrderPaidSubscriber`** in `myeventlane_tickets`). **`event_attendee`** creation on order placement is a separate roster concern and is **not** duplicate issuance.
 
 Canonical order-confirmation PDF merging is documented in [issuance-pipeline.md](./issuance-pipeline.md).
+
+Wallet operational convergence (Phase 2C) is documented in [wallet-operational-convergence.md](./wallet-operational-convergence.md).

--- a/docs/wallet-operational-convergence.md
+++ b/docs/wallet-operational-convergence.md
@@ -1,0 +1,49 @@
+# Wallet operational convergence (Phase 2C)
+
+This document is the **governance contract** for how MyEventLane generates wallet artifacts after Phase 2C. It complements [issuance-pipeline.md](./issuance-pipeline.md) and [operational-surface-convergence.md](./operational-surface-convergence.md).
+
+## Canonical authority
+
+- **`myeventlane_ticket`** entities are the **operational entitlement authority** for wallet bytes and wallet-adjacent metadata (alongside PDFs and scanner-facing QR).
+- **Commerce order items** remain **purchase context** and **route compatibility keys** only. They must not be used as a parallel source of operational truth when issued tickets exist.
+
+## Canonical lifecycle (inward-only)
+
+Paid Commerce flow (unchanged):
+
+1. `ORDER_PAID` → `TicketIssuer::issueForOrder()` → issued `myeventlane_ticket` rows.
+2. Customer surfaces (My Tickets, PDFs) already normalize through `UniversalTicketViewModelBuilder` and `TicketQrPayload`.
+
+Wallet flow (Phase 2C):
+
+1. Stable public routes: `/wallet/apple/{order_item_id}` and `/wallet/google/{order_item_id}`.
+2. **`WalletTicketResolver`** loads issued tickets for that order item ID and selects the operational row (deterministic lowest ID, or unique holder-email match when multiple rows exist for quantity > 1).
+3. **`WalletDownloadAccessChecker`** enforces the same entitlement ownership semantics as ticket PDF download (including guest checkout continuity for `uid` 0 orders matched by purchaser email).
+4. **`PkPassBuilder`** (and future Google JWT work) consumes the **issued `Ticket` entity** and derives QR text from the **universal view model**, which in turn uses **`TicketQrPayload`** — no parallel QR shaping.
+
+If **no** issued ticket exists for the order item, builders keep the **legacy placeholder** behaviour (empty Apple scaffold, frozen Google placeholder URL). **No silent issuance** and **no issuance state mutation** occur from wallet routes.
+
+## Frozen external contracts
+
+The following must remain stable unless explicitly re-scoped with scanner and customer sign-off:
+
+- Wallet **path patterns** and **route names** (`myeventlane_wallet.apple`, `myeventlane_wallet.google`).
+- **QR payload formats** (`mel:v1:` and `mel:v1:json:`), signing, and ticket codes (owned by `TicketQrPayload` and ticket issuance).
+- **Guest continuity** for orders purchased as `uid` 0 with email-based access for signed-in purchasers.
+- **Google Wallet save URL** placeholder until JWT integration is implemented.
+
+## Forbidden patterns
+
+- Deriving wallet QR strings directly from Commerce order items, checkout paragraphs, or attendee rows when an issued ticket exists.
+- Duplicating entitlement normalization outside `UniversalTicketViewModelBuilder` / `TicketCapabilityManager`.
+- Duplicating QR construction outside `TicketQrPayload` (wallet code must not reimplement `mel:v1` signing or JSON payload shaping).
+- Exposing internal numeric ticket IDs in public URLs (routes remain order-item keyed for compatibility).
+
+## Residual intentional boundaries
+
+- **Multi-ticket order items (quantity > 1)** still share one wallet URL per order item; resolver picks a single deterministic row. Holder-email disambiguation applies when exactly one row matches the active account email. This matches the historical limitation of order-item-keyed wallet links documented in Phase 2B.
+- **Production `.pkpass` zip signing** remains future work; Phase 2C only guarantees **canonical operational payload scaffolding** inside the generated artifact path used by tests and local verification.
+
+## Related tests
+
+Kernel regressions live in `IssuancePipelineConvergenceTest` (wallet + issuance fixture). Unit coverage for guest legacy access lives in `WalletDownloadAccessCheckerTest`.

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
@@ -81,6 +81,7 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_tickets.universal_ticket_view_model_builder'
       - '@myeventlane_core.ticket_label_resolver'
+      - '@string_translation'
 
   logger.channel.myeventlane_checkout_flow:
     parent: logger.channel_base

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
@@ -7,6 +7,8 @@ namespace Drupal\myeventlane_checkout_flow\Service;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\TicketLabelResolver;
 use Drupal\myeventlane_tickets\Entity\Ticket;
@@ -18,6 +20,8 @@ use Drupal\paragraphs\ParagraphInterface;
  * Builds My Tickets order view models from canonical ticket models.
  */
 final class MyTicketsOrderViewModelBuilder {
+
+  use StringTranslationTrait;
 
   /**
    * Order workflow states that represent a finished purchase for My Tickets.
@@ -35,7 +39,10 @@ final class MyTicketsOrderViewModelBuilder {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly UniversalTicketViewModelBuilder $ticketViewModelBuilder,
     private readonly TicketLabelResolver $ticketLabelResolver,
-  ) {}
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
 
   /**
    * Builds My Tickets order view models in input order.
@@ -138,7 +145,7 @@ final class MyTicketsOrderViewModelBuilder {
 
     $stateId = $order->getState()->getId();
     $stateCustomer = in_array($stateId, self::COMPLETED_ORDER_STATES, TRUE)
-      ? 'Confirmed'
+      ? (string) $this->t('Confirmed')
       : (string) $order->getState()->getLabel();
 
     return [

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
@@ -280,6 +280,7 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $this->container->get('myeventlane_tickets.universal_ticket_view_model_builder'),
       $this->container->get('myeventlane_core.ticket_label_resolver'),
+      $this->container->get('string_translation'),
     );
   }
 

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/IssuancePipelineConvergenceTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/IssuancePipelineConvergenceTest.php
@@ -26,6 +26,7 @@ use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Canonical issuance, idempotency, and PDF-from-ticket continuity.
@@ -65,6 +66,7 @@ final class IssuancePipelineConvergenceTest extends KernelTestBase {
     'mel_ticket',
     'myeventlane_vendor',
     'myeventlane_tickets',
+    'myeventlane_wallet',
   ];
 
   private Node $event;
@@ -325,6 +327,175 @@ final class IssuancePipelineConvergenceTest extends KernelTestBase {
       }
     }
     $this->assertSame(2, $pdf_count);
+  }
+
+  /**
+   * Wallet inward resolution maps the Commerce order item route key to issued tickets.
+   */
+  public function testWalletResolverLinksIssuedTicketToOrderItem(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $items = array_values($order->getItems());
+    $this->assertNotEmpty($items);
+    $item = $items[0];
+    /** @var \Drupal\myeventlane_wallet\Service\WalletTicketResolver $resolver */
+    $resolver = $this->container->get('myeventlane_wallet.ticket_resolver');
+    $resolved = $resolver->resolvePrimaryTicketForOrderItem($item, $this->customer);
+    $this->assertInstanceOf(Ticket::class, $resolved);
+    $this->assertSame((int) $item->id(), (int) $resolved->get('order_item_id')->target_id);
+  }
+
+  /**
+   * Apple Wallet scaffold bytes reuse the universal view model QR (TicketQrPayload).
+   */
+  public function testPkpassScaffoldUsesSingleQrSource(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertNotEmpty($tickets);
+    $ticket = $tickets[0];
+    $expected = $this->container->get('myeventlane_tickets.ticket_qr_payload')->buildForTicket($ticket);
+    /** @var \Drupal\myeventlane_wallet\Service\PkPassBuilder $builder */
+    $builder = $this->container->get('myeventlane_wallet.pkpass_builder');
+    $path = $builder->generate($item, $ticket);
+    $payload = json_decode((string) file_get_contents($path), TRUE);
+    $this->assertIsArray($payload);
+    $this->assertSame($expected, $payload['qr_payload']);
+  }
+
+  /**
+   * When no issued ticket exists, wallet builders keep the legacy empty placeholder.
+   */
+  public function testWalletOrderItemWithoutTicketUsesLegacyPkpassPlaceholder(): void {
+    $order = $this->loadOrder();
+    $item = array_values($order->getItems())[0];
+    /** @var \Drupal\myeventlane_wallet\Service\PkPassBuilder $builder */
+    $builder = $this->container->get('myeventlane_wallet.pkpass_builder');
+    $path = $builder->generate($item, NULL);
+    $this->assertSame('', (string) file_get_contents($path));
+  }
+
+  /**
+   * Multiple tickets on one order item resolve by unique holder email when possible.
+   */
+  public function testWalletResolverPicksHolderWhenUniquelyMatches(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertCount(2, $tickets);
+    $tickets[0]->set('holder_email', 'alpha@example.test');
+    $tickets[0]->save();
+    $tickets[1]->set('holder_email', 'beta@example.test');
+    $tickets[1]->save();
+
+    $beta = User::create([
+      'name' => 'beta_viewer',
+      'mail' => 'beta@example.test',
+      'status' => 1,
+    ]);
+    $beta->save();
+
+    /** @var \Drupal\myeventlane_wallet\Service\WalletTicketResolver $resolver */
+    $resolver = $this->container->get('myeventlane_wallet.ticket_resolver');
+    $picked = $resolver->resolvePrimaryTicketForOrderItem($item, $beta);
+    $this->assertSame((int) $tickets[1]->id(), (int) $picked->id());
+  }
+
+  /**
+   * Merch entitlements keep structured mel:v1 JSON QR contracts in wallet scaffolds.
+   */
+  public function testMerchEntitlementWalletScaffoldPreservesStructuredQr(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $ticket = $tickets[0];
+    $ticket->set('entitlement_type', Ticket::ENTITLEMENT_MERCH);
+    $ticket->save();
+
+    /** @var \Drupal\myeventlane_wallet\Service\PkPassBuilder $builder */
+    $builder = $this->container->get('myeventlane_wallet.pkpass_builder');
+    $path = $builder->generate($item, $ticket);
+    $payload = json_decode((string) file_get_contents($path), TRUE);
+    $this->assertIsArray($payload);
+    $this->assertStringStartsWith('mel:v1:json:', (string) $payload['qr_payload']);
+  }
+
+  /**
+   * Parking entitlements keep structured mel:v1 JSON QR contracts in wallet scaffolds.
+   */
+  public function testParkingEntitlementWalletScaffoldPreservesStructuredQr(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $ticket = $tickets[0];
+    $ticket->set('entitlement_type', Ticket::ENTITLEMENT_PARKING);
+    $ticket->save();
+
+    /** @var \Drupal\myeventlane_wallet\Service\PkPassBuilder $builder */
+    $builder = $this->container->get('myeventlane_wallet.pkpass_builder');
+    $path = $builder->generate($item, $ticket);
+    $payload = json_decode((string) file_get_contents($path), TRUE);
+    $this->assertIsArray($payload);
+    $this->assertStringStartsWith('mel:v1:json:', (string) $payload['qr_payload']);
+  }
+
+  /**
+   * Multi-use entitlements surface structured QR metadata without duplicate shaping.
+   */
+  public function testMultiUseEntitlementWalletScaffoldUsesStructuredQr(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $ticket = $tickets[0];
+    $ticket->set('entitlement_type', Ticket::ENTITLEMENT_DRINK);
+    $ticket->set('redemption_limit', 3);
+    $ticket->save();
+
+    /** @var \Drupal\myeventlane_wallet\Service\PkPassBuilder $builder */
+    $builder = $this->container->get('myeventlane_wallet.pkpass_builder');
+    $path = $builder->generate($item, $ticket);
+    $payload = json_decode((string) file_get_contents($path), TRUE);
+    $this->assertIsArray($payload);
+    $this->assertStringStartsWith('mel:v1:json:', (string) $payload['qr_payload']);
+  }
+
+  /**
+   * Wallet download access follows purchaser ownership for issued tickets.
+   */
+  public function testWalletAccessCheckerAllowsPurchaser(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $ticket = $this->loadTicketsForOrder((int) $order->id())[0];
+    /** @var \Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker $access */
+    $access = $this->container->get('myeventlane_wallet.download_access');
+    $access->assertAuthorized($item, $ticket, $this->customer);
+    $this->addToAssertionCount(1);
+  }
+
+  /**
+   * Wallet download access denies cross-customer ticket use.
+   */
+  public function testWalletAccessCheckerDeniesOtherCustomer(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $item = array_values($order->getItems())[0];
+    $ticket = $this->loadTicketsForOrder((int) $order->id())[0];
+    $stranger = User::create([
+      'name' => 'stranger_wallet',
+      'mail' => 'stranger-wallet@example.test',
+      'status' => 1,
+    ]);
+    $stranger->save();
+    /** @var \Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker $access */
+    $access = $this->container->get('myeventlane_wallet.download_access');
+    $this->expectException(AccessDeniedHttpException::class);
+    $access->assertAuthorized($item, $ticket, $stranger);
   }
 
   private function issuer(): TicketIssuer {

--- a/web/modules/custom/myeventlane_wallet/myeventlane_wallet.services.yml
+++ b/web/modules/custom/myeventlane_wallet/myeventlane_wallet.services.yml
@@ -1,7 +1,17 @@
 services:
+  myeventlane_wallet.download_access:
+    class: Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker
+    arguments: ['@config.factory']
+
+  myeventlane_wallet.ticket_resolver:
+    class: Drupal\myeventlane_wallet\Service\WalletTicketResolver
+    arguments: ['@entity_type.manager']
+
   myeventlane_wallet.pkpass_builder:
     class: Drupal\myeventlane_wallet\Service\PkPassBuilder
-    arguments: ['@file_system', '@config.factory', '@myeventlane_wallet.wallet_signer']
+    arguments:
+      - '@file_system'
+      - '@myeventlane_tickets.universal_ticket_view_model_builder'
 
   myeventlane_wallet.wallet_signer:
     class: Drupal\myeventlane_wallet\Service\WalletSigner
@@ -10,9 +20,3 @@ services:
   myeventlane_wallet.google_wallet_builder:
     class: Drupal\myeventlane_wallet\Service\GoogleWalletBuilder
     arguments: ['@config.factory', '@renderer']
-
-
-
-
-
-

--- a/web/modules/custom/myeventlane_wallet/src/Controller/WalletAppleController.php
+++ b/web/modules/custom/myeventlane_wallet/src/Controller/WalletAppleController.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_wallet\Controller;
 
-use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\myeventlane_wallet\Service\PkPassBuilder;
+use Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker;
+use Drupal\myeventlane_wallet\Service\WalletTicketResolver;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -20,12 +20,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class WalletAppleController extends ControllerBase {
 
-  /**
-   * Constructs WalletAppleController.
-   */
   public function __construct(
     private readonly PkPassBuilder $pkpassBuilder,
     private readonly FileSystemInterface $fileSystem,
+    private readonly WalletTicketResolver $walletTicketResolver,
+    private readonly WalletDownloadAccessChecker $walletDownloadAccessChecker,
   ) {}
 
   /**
@@ -35,38 +34,18 @@ final class WalletAppleController extends ControllerBase {
     $instance = new self(
       $container->get('myeventlane_wallet.pkpass_builder'),
       $container->get('file_system'),
+      $container->get('myeventlane_wallet.ticket_resolver'),
+      $container->get('myeventlane_wallet.download_access'),
     );
     $instance->entityTypeManager = $container->get('entity_type.manager');
     return $instance;
   }
 
   /**
-   * Ensures the current user can download for the given order item.
-   *
-   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-   */
-  private function assertOrderItemDownloadAccess(OrderItemInterface $order_item): void {
-    $account = $this->currentUser();
-
-    if (!$account->isAuthenticated()) {
-      throw new AccessDeniedHttpException();
-    }
-
-    if ($account->hasPermission('administer myeventlane wallet') || $account->hasPermission('administer commerce_order')) {
-      return;
-    }
-
-    $order = $order_item->getOrder();
-    if (!$order || (int) $order->getCustomerId() !== (int) $account->id()) {
-      throw new AccessDeniedHttpException();
-    }
-  }
-
-  /**
    * Downloads an Apple Wallet pass for an order item.
    *
    * @param string $order_item_id
-   *   The order item ID.
+   *   The order item ID (route compatibility key).
    *
    * @return \Symfony\Component\HttpFoundation\Response
    *   The pass file response.
@@ -84,9 +63,10 @@ final class WalletAppleController extends ControllerBase {
       throw new NotFoundHttpException();
     }
 
-    $this->assertOrderItemDownloadAccess($item);
+    $ticket = $this->walletTicketResolver->resolvePrimaryTicketForOrderItem($item, $this->currentUser());
+    $this->walletDownloadAccessChecker->assertAuthorized($item, $ticket, $this->currentUser());
 
-    $passPath = $this->pkpassBuilder->generate($item);
+    $passPath = $this->pkpassBuilder->generate($item, $ticket);
     $realPath = $this->fileSystem->realpath($passPath) ?: $passPath;
 
     if (!is_file($realPath) || !is_readable($realPath)) {
@@ -96,7 +76,6 @@ final class WalletAppleController extends ControllerBase {
     $response = new BinaryFileResponse($realPath);
     $response->headers->set('Content-Type', 'application/vnd.apple.pkpass');
     $response->setContentDisposition('attachment', 'ticket.pkpass');
-    // Passes are typically generated in a temp directory.
     $response->deleteFileAfterSend(TRUE);
 
     return $response;

--- a/web/modules/custom/myeventlane_wallet/src/Controller/WalletGoogleController.php
+++ b/web/modules/custom/myeventlane_wallet/src/Controller/WalletGoogleController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_wallet\Controller;
 
-use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\myeventlane_wallet\Service\GoogleWalletBuilder;
+use Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker;
+use Drupal\myeventlane_wallet\Service\WalletTicketResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -18,11 +18,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class WalletGoogleController extends ControllerBase {
 
-  /**
-   * Constructs WalletGoogleController.
-   */
   public function __construct(
     private readonly GoogleWalletBuilder $googleBuilder,
+    private readonly WalletTicketResolver $walletTicketResolver,
+    private readonly WalletDownloadAccessChecker $walletDownloadAccessChecker,
   ) {}
 
   /**
@@ -31,39 +30,18 @@ final class WalletGoogleController extends ControllerBase {
   public static function create(ContainerInterface $container): self {
     $instance = new self(
       $container->get('myeventlane_wallet.google_wallet_builder'),
+      $container->get('myeventlane_wallet.ticket_resolver'),
+      $container->get('myeventlane_wallet.download_access'),
     );
     $instance->entityTypeManager = $container->get('entity_type.manager');
     return $instance;
   }
 
   /**
-   * Ensures the current user can generate wallet links for an order item.
-   *
-   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-   */
-  private function assertOrderItemWalletAccess(OrderItemInterface $order_item): void {
-    $account = $this->currentUser();
-
-    if (!$account->isAuthenticated()) {
-      throw new AccessDeniedHttpException();
-    }
-
-    if ($account->hasPermission('administer myeventlane wallet')
-      || $account->hasPermission('administer commerce_order')) {
-      return;
-    }
-
-    $order = $order_item->getOrder();
-    if (!$order || (int) $order->getCustomerId() !== (int) $account->id()) {
-      throw new AccessDeniedHttpException();
-    }
-  }
-
-  /**
    * Returns a Google Wallet save link for an order item.
    *
    * @param string $order_item_id
-   *   The order item ID.
+   *   The order item ID (route compatibility key).
    *
    * @return array
    *   A render array with the wallet link.
@@ -81,9 +59,10 @@ final class WalletGoogleController extends ControllerBase {
       throw new NotFoundHttpException();
     }
 
-    $this->assertOrderItemWalletAccess($item);
+    $ticket = $this->walletTicketResolver->resolvePrimaryTicketForOrderItem($item, $this->currentUser());
+    $this->walletDownloadAccessChecker->assertAuthorized($item, $ticket, $this->currentUser());
 
-    $url = $this->googleBuilder->generateSaveLink($item);
+    $url = $this->googleBuilder->generateSaveLink($item, $ticket);
 
     $parts = parse_url($url) ?: [];
     $scheme = $parts['scheme'] ?? '';

--- a/web/modules/custom/myeventlane_wallet/src/Service/GoogleWalletBuilder.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/GoogleWalletBuilder.php
@@ -7,31 +7,39 @@ namespace Drupal\myeventlane_wallet\Service;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use InvalidArgumentException;
 
 /**
  * Builds Google Wallet pass links.
+ *
+ * Save URLs remain the frozen placeholder contract; issued tickets are accepted so
+ * future JWT work can derive from canonical ticket rows without changing routes.
  */
 final class GoogleWalletBuilder {
 
-  /**
-   * Constructs GoogleWalletBuilder.
-   */
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
     private readonly RendererInterface $renderer,
   ) {}
 
   /**
-   * Generates a Google Wallet save link for an order item.
+   * Generates a Google Wallet save link for an order item route.
    *
-   * @param \Drupal\commerce_order\Entity\OrderItemInterface $orderItem
-   *   The order item.
+   * @param \Drupal\myeventlane_tickets\Entity\Ticket|null $ticket
+   *   Issued ticket when inward resolution succeeded; NULL for legacy mode.
    *
    * @return string
    *   The Google Wallet save URL.
    */
-  public function generateSaveLink(OrderItemInterface $orderItem): string {
-    // @todo Implement actual Google Wallet JWT generation.
+  public function generateSaveLink(OrderItemInterface $orderItem, ?Ticket $ticket = NULL): string {
+    if ($ticket instanceof Ticket
+      && !$ticket->get('order_item_id')->isEmpty()
+      && (int) $ticket->get('order_item_id')->target_id !== (int) $orderItem->id()) {
+      throw new InvalidArgumentException('Ticket order item mismatch for wallet link generation.');
+    }
+
+    // @todo Implement actual Google Wallet JWT generation from canonical ticket context.
     return 'https://pay.google.com/gp/v/save/placeholder';
   }
 

--- a/web/modules/custom/myeventlane_wallet/src/Service/PkPassBuilder.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/PkPassBuilder.php
@@ -5,41 +5,60 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_wallet\Service;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Drupal\myeventlane_tickets\Service\UniversalTicketViewModelBuilder;
+use JsonException;
 
 /**
  * Builds Apple Wallet .pkpass files.
+ *
+ * Issued tickets drive operational scaffold content through the universal ticket
+ * view model (QR payloads originate from TicketQrPayload inside that builder).
  */
 final class PkPassBuilder {
 
-  /**
-   * Constructs PkPassBuilder.
-   */
   public function __construct(
     private readonly FileSystemInterface $fileSystem,
-    private readonly ConfigFactoryInterface $configFactory,
-    private readonly WalletSigner $walletSigner,
+    private readonly UniversalTicketViewModelBuilder $ticketViewModelBuilder,
   ) {}
 
   /**
-   * Generates a .pkpass file for an order item.
+   * Generates a .pkpass file path for the given order item route.
    *
-   * @param \Drupal\commerce_order\Entity\OrderItemInterface $orderItem
-   *   The order item.
+   * @param \Drupal\myeventlane_tickets\Entity\Ticket|null $ticket
+   *   Issued entitlement row when present; NULL preserves legacy placeholder
+   *   behaviour without operational ticket assumptions.
    *
    * @return string
    *   Path to the generated .pkpass file.
    */
-  public function generate(OrderItemInterface $orderItem): string {
-    // @todo Implement actual pass generation.
-    // For now, return a placeholder path.
+  public function generate(OrderItemInterface $orderItem, ?Ticket $ticket = NULL): string {
     $tempDir = $this->fileSystem->getTempDirectory();
     $passPath = $tempDir . '/ticket_' . $orderItem->id() . '.pkpass';
 
-    // Create placeholder file for now.
-    file_put_contents($passPath, '');
+    if (!$ticket instanceof Ticket) {
+      // Legacy compatibility: empty artifact until issuance exists for the line.
+      file_put_contents($passPath, '');
+      return $passPath;
+    }
 
+    $model = $this->ticketViewModelBuilder->build($ticket);
+    try {
+      $scaffold = json_encode([
+        'mel_wallet_scaffold' => 1,
+        'ticket_code' => (string) ($model['ticket']['code'] ?? ''),
+        'qr_payload' => (string) ($model['qr']['payload'] ?? ''),
+        'entitlement_type' => (string) ($model['ticket']['entitlement_type'] ?? ''),
+        'event_label' => (string) ($model['event']['label'] ?? ''),
+      ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+    catch (JsonException) {
+      file_put_contents($passPath, '');
+      return $passPath;
+    }
+
+    file_put_contents($passPath, $scaffold);
     return $passPath;
   }
 

--- a/web/modules/custom/myeventlane_wallet/src/Service/WalletDownloadAccessChecker.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/WalletDownloadAccessChecker.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_wallet\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Server-side access for wallet routes aligned with ticket PDF entitlement rules.
+ *
+ * When a canonical issued ticket is resolved, access follows the same rules as
+ * ticket PDF download for that row. Legacy routes without issued tickets keep
+ * order-scoped checks only (compatibility), without issuing or mutating tickets.
+ */
+final class WalletDownloadAccessChecker {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * Asserts the account may request wallet artifacts for this order item route.
+   *
+   * @param \Drupal\myeventlane_tickets\Entity\Ticket|null $ticket
+   *   Issued ticket from inward-only resolution, or NULL for legacy mode.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+   *   When PDF/wallet expiry window has elapsed (matches ticket PDF behaviour).
+   */
+  public function assertAuthorized(OrderItemInterface $order_item, ?Ticket $ticket, AccountInterface $account): void {
+    if ($account->hasPermission('administer myeventlane wallet') || $account->hasPermission('administer commerce_order')) {
+      return;
+    }
+
+    if ($ticket instanceof Ticket) {
+      if ((int) $ticket->get('order_item_id')->target_id !== (int) $order_item->id()) {
+        throw new AccessDeniedHttpException();
+      }
+      if (!$this->canAccessTicket($ticket, $account)) {
+        throw new AccessDeniedHttpException();
+      }
+      if ($this->isExpired((int) $ticket->getCreatedTime())) {
+        throw new NotFoundHttpException();
+      }
+      return;
+    }
+
+    $order = $order_item->getOrder();
+    if (!$order instanceof OrderInterface || !$this->orderBelongsToAccount($order, $account)) {
+      throw new AccessDeniedHttpException();
+    }
+
+    if ($this->isExpired((int) $order_item->getCreatedTime())) {
+      throw new NotFoundHttpException();
+    }
+  }
+
+  /**
+   * Whether the account may access wallet data for this issued ticket.
+   */
+  public function canAccessTicket(Ticket $ticket, AccountInterface $account): bool {
+    if ($account->hasPermission('administer myeventlane tickets')) {
+      return TRUE;
+    }
+
+    $purchaser_uid = (int) $ticket->get('purchaser_uid')->target_id;
+    if ($purchaser_uid === (int) $account->id()) {
+      return TRUE;
+    }
+
+    if ($account->isAuthenticated() && $purchaser_uid === 0 && !$ticket->get('order_id')->isEmpty()) {
+      $order = $ticket->get('order_id')->entity;
+      if ($order instanceof OrderInterface && $this->orderBelongsToAccount($order, $account)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Whether the commerce order is visible to the account (including guest).
+   */
+  public function orderBelongsToAccount(OrderInterface $order, AccountInterface $account): bool {
+    if ((int) $order->getCustomerId() === (int) $account->id()) {
+      return TRUE;
+    }
+    if ($account->isAuthenticated() && (int) $order->getCustomerId() === 0) {
+      $order_email = strtolower(trim((string) $order->getEmail()));
+      $user_email = strtolower(trim((string) $account->getEmail()));
+      if ($order_email !== '' && $user_email !== '' && $order_email === $user_email) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Returns TRUE when configured ticket PDF expiry has elapsed.
+   */
+  public function isExpired(int $created_timestamp): bool {
+    $days = (int) ($this->configFactory->get('myeventlane_tickets.settings')->get('pdf_expiry_days') ?? 0);
+    if ($days <= 0 || $created_timestamp <= 0) {
+      return FALSE;
+    }
+    $expires_at = $created_timestamp + ($days * 86400);
+    return time() > $expires_at;
+  }
+
+}

--- a/web/modules/custom/myeventlane_wallet/src/Service/WalletTicketResolver.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/WalletTicketResolver.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_wallet\Service;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+
+/**
+ * Resolves issued ticket entities for wallet routes keyed by order item ID.
+ *
+ * Order items remain a compatibility route surface only; issued
+ * myeventlane_ticket rows are the operational authority for wallet artifacts.
+ */
+final class WalletTicketResolver {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Loads issued tickets for an order item and picks the operational row.
+   *
+   * When multiple ticket rows exist for one order item (quantity > 1), prefers
+   * the single row whose holder email matches the active account email when
+   * exactly one such row exists; otherwise uses the lowest ticket ID for a
+   * deterministic choice. This mirrors inward-only compatibility used on PDF
+   * surfaces without changing public wallet URLs.
+   *
+   * @return \Drupal\myeventlane_tickets\Entity\Ticket|null
+   *   An issued ticket, or NULL when none exist (legacy compatibility path).
+   */
+  public function resolvePrimaryTicketForOrderItem(OrderItemInterface $order_item, AccountInterface $account): ?Ticket {
+    $storage = $this->entityTypeManager->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_item_id', (int) $order_item->id())
+      ->sort('id')
+      ->execute();
+    if (!$ids) {
+      return NULL;
+    }
+
+    /** @var \Drupal\myeventlane_tickets\Entity\Ticket[] $tickets */
+    $tickets = $storage->loadMultiple($ids);
+    $list = array_values($tickets);
+    usort($list, static function (Ticket $a, Ticket $b): int {
+      return ((int) $a->id()) <=> ((int) $b->id());
+    });
+
+    if (count($list) === 1) {
+      return $list[0];
+    }
+
+    $account_email = strtolower(trim((string) $account->getEmail()));
+    if ($account_email === '') {
+      return $list[0];
+    }
+
+    $matches = [];
+    foreach ($list as $ticket) {
+      if ($ticket->get('holder_email')->isEmpty()) {
+        continue;
+      }
+      $holder = strtolower(trim((string) $ticket->get('holder_email')->value));
+      if ($holder !== '' && $holder === $account_email) {
+        $matches[] = $ticket;
+      }
+    }
+
+    if (count($matches) === 1) {
+      return $matches[0];
+    }
+
+    return $list[0];
+  }
+
+}

--- a/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletDownloadAccessCheckerTest.php
+++ b/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletDownloadAccessCheckerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_wallet\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_wallet\Service\WalletDownloadAccessChecker;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @group myeventlane_wallet
+ */
+final class WalletDownloadAccessCheckerTest extends UnitTestCase {
+
+  public function testLegacyPathAllowsGuestOrderForAnonymousUser(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCustomerId')->willReturn(0);
+
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('getOrder')->willReturn($order);
+    $order_item->method('getCreatedTime')->willReturn(time());
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('isAuthenticated')->willReturn(FALSE);
+    $account->method('id')->willReturn('0');
+    $account->method('hasPermission')->willReturn(FALSE);
+
+    $this->checker()->assertAuthorized($order_item, NULL, $account);
+  }
+
+  public function testLegacyPathAllowsGuestOrderEmailMatch(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCustomerId')->willReturn(0);
+    $order->method('getEmail')->willReturn('guest@example.test');
+
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('getOrder')->willReturn($order);
+    $order_item->method('getCreatedTime')->willReturn(time());
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('isAuthenticated')->willReturn(TRUE);
+    $account->method('id')->willReturn('99');
+    $account->method('getEmail')->willReturn('guest@example.test');
+    $account->method('hasPermission')->willReturn(FALSE);
+
+    $this->checker()->assertAuthorized($order_item, NULL, $account);
+  }
+
+  public function testLegacyPathDeniesMismatchedGuestEmail(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCustomerId')->willReturn(0);
+    $order->method('getEmail')->willReturn('guest@example.test');
+
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('getOrder')->willReturn($order);
+    $order_item->method('getCreatedTime')->willReturn(time());
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('isAuthenticated')->willReturn(TRUE);
+    $account->method('id')->willReturn('99');
+    $account->method('getEmail')->willReturn('other@example.test');
+    $account->method('hasPermission')->willReturn(FALSE);
+
+    $this->expectException(AccessDeniedHttpException::class);
+    $this->checker()->assertAuthorized($order_item, NULL, $account);
+  }
+
+  public function testPdfExpiryWindowMarksOldArtifactsExpired(): void {
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')
+      ->willReturnCallback(static function (string $key, mixed $default = NULL): mixed {
+        if ($key === 'pdf_expiry_days') {
+          return 1;
+        }
+        return $default;
+      });
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')
+      ->with('myeventlane_tickets.settings')
+      ->willReturn($settings);
+
+    $checker = new WalletDownloadAccessChecker($factory);
+    $this->assertTrue($checker->isExpired(time() - 3 * 86400));
+    $this->assertFalse($checker->isExpired(time()));
+  }
+
+  private function checker(int $pdf_expiry_days = 0): WalletDownloadAccessChecker {
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')
+      ->willReturnCallback(static function (string $key, mixed $default = NULL) use ($pdf_expiry_days): mixed {
+        if ($key === 'pdf_expiry_days') {
+          return $pdf_expiry_days;
+        }
+        return $default;
+      });
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')
+      ->with('myeventlane_tickets.settings')
+      ->willReturn($settings);
+
+    return new WalletDownloadAccessChecker($factory);
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes wallet download/link flows and authorization logic to resolve issued `myeventlane_ticket` entities behind order-item-keyed routes; mistakes here could affect entitlement access (including guest continuity) or incorrectly deny/allow downloads.
> 
> **Overview**
> Wallet routes remain order-item keyed, but now **resolve inward to issued `myeventlane_ticket` rows** via new `WalletTicketResolver`, and enforce **PDF-aligned entitlement/expiry access rules** via new `WalletDownloadAccessChecker` before generating Apple/Google wallet artifacts.
> 
> `PkPassBuilder` and `GoogleWalletBuilder` now accept an optional `Ticket` (legacy placeholder behavior preserved when no issued ticket exists), and Apple `.pkpass` scaffolds derive QR payloads from `UniversalTicketViewModelBuilder` to keep a single QR authority.
> 
> My Tickets’ customer-facing “Confirmed” state is now translatable (`StringTranslationTrait`), and docs/tests were expanded to codify the wallet operational-convergence contract and regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9273ad3b7b12e3be998ac5b1dbfeddc8574d0f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->