### PR TITLE
fix(wallet): block anonymous uid 0 matching guest orders

### DIFF
--- a/web/modules/custom/myeventlane_wallet/src/Service/WalletDownloadAccessChecker.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/WalletDownloadAccessChecker.php
@@ -72,7 +72,8 @@ final class WalletDownloadAccessChecker {
     }
 
     $purchaser_uid = (int) $ticket->get('purchaser_uid')->target_id;
-    if ($purchaser_uid === (int) $account->id()) {
+    // Anonymous accounts share uid 0 with guest-checkout purchasers; never match on id alone.
+    if ($purchaser_uid > 0 && $purchaser_uid === (int) $account->id()) {
       return TRUE;
     }
 
@@ -90,10 +91,13 @@ final class WalletDownloadAccessChecker {
    * Whether the commerce order is visible to the account (including guest).
    */
   public function orderBelongsToAccount(OrderInterface $order, AccountInterface $account): bool {
-    if ((int) $order->getCustomerId() === (int) $account->id()) {
+    $customer_id = (int) $order->getCustomerId();
+    $account_id = (int) $account->id();
+    // Guest orders use customer uid 0; anonymous users are also uid 0 — require a real uid match.
+    if ($customer_id > 0 && $customer_id === $account_id) {
       return TRUE;
     }
-    if ($account->isAuthenticated() && (int) $order->getCustomerId() === 0) {
+    if ($account->isAuthenticated() && $customer_id === 0) {
       $order_email = strtolower(trim((string) $order->getEmail()));
       $user_email = strtolower(trim((string) $account->getEmail()));
       if ($order_email !== '' && $user_email !== '' && $order_email === $user_email) {

--- a/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletDownloadAccessCheckerTest.php
+++ b/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletDownloadAccessCheckerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 final class WalletDownloadAccessCheckerTest extends UnitTestCase {
 
-  public function testLegacyPathAllowsGuestOrderForAnonymousUser(): void {
+  public function testLegacyPathDeniesGuestOrderForAnonymousUser(): void {
     $order = $this->createMock(OrderInterface::class);
     $order->method('getCustomerId')->willReturn(0);
 
@@ -31,6 +31,7 @@ final class WalletDownloadAccessCheckerTest extends UnitTestCase {
     $account->method('id')->willReturn('0');
     $account->method('hasPermission')->willReturn(FALSE);
 
+    $this->expectException(AccessDeniedHttpException::class);
     $this->checker()->assertAuthorized($order_item, NULL, $account);
   }
 


### PR DESCRIPTION
Guest Commerce orders and tickets use customer/purchaser uid 0, which matched every anonymous Drupal session (uid 0), allowing wallet downloads without proof of purchase.

Require a positive uid for purchaser/customer id equality; guest orders still authorize authenticated users via email match in orderBelongsToAccount.

Update unit test to expect access denied for anonymous + guest order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes server-side authorization logic for wallet artifacts; mistakes could either block legitimate access or reintroduce an access-control bypass for guest purchases.
> 
> **Overview**
> Prevents anonymous users (uid `0`) from being authorized to download wallet artifacts for guest-checkout tickets/orders by requiring a *positive* `purchaser_uid`/`customer_id` before treating it as an ID match.
> 
> Guest orders are still accessible for authenticated users via the existing email-match path, and the unit test is updated to assert `AccessDeniedHttpException` for anonymous + guest order on the legacy route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c0e6f26d4c3d093615c7c2bd2b2813c5234be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->