### PR TITLE
refactor(tickets): converge operational observability

### DIFF
--- a/docs/issuance-pipeline.md
+++ b/docs/issuance-pipeline.md
@@ -67,13 +67,19 @@ A vestigial **`OrderPaidSubscriber`** under **`myeventlane_commerce`** (logging 
 
 **`TicketIssuer::issueForOrder()`** performs an **order-scoped, deterministic** guard: if **any** `myeventlane_ticket` row already exists for the order ID, issuance **aborts** with an **info** log. It does **not** partially issue, reconcile, or mutate existing ticket rows.
 
+**`TicketIssuer::countExpectedIssuanceUnits()`** and **`TicketIssuer::isOrderItemEligibleForTicketIssuance()`** expose the same eligibility rules for **read-only** diagnostics (no issuance side effects).
+
+## Operational observability (Phase 2D)
+
+Read-only integrity diagnostics for paid orders are centralized in **`OperationalIntegrityInspector`** (`myeventlane_tickets.operational_integrity_inspector`). It inspects issuance alignment, artifact readiness, recovery markers, compatibility surfaces, and guest/purchaser continuity **without** generating PDFs, wallet artifacts, or QR output for persistence. See [operational-observability.md](./operational-observability.md).
+
 ## Service locator cleanup (RSVP)
 
 **`RsvpMailer`** no longer uses `\Drupal::service('myeventlane_tickets.pdf_generator')` for RSVP PDF attachments; it receives **`@?myeventlane_tickets.ticket_pdf_generator`** via constructor injection.
 
 ## Tests
 
-Kernel coverage: **`IssuancePipelineConvergenceTest`** (`myeventlane_tickets`).
+Kernel coverage: **`IssuancePipelineConvergenceTest`** (`myeventlane_tickets`), **`OperationalIntegrityInspectorTest`** (read-only diagnostics).
 
 - Issuance creates one ticket entity per unit quantity.
 - **Regression:** calling **`issueForOrder()`** twice on the same order does **not** create additional ticket rows.
@@ -97,5 +103,6 @@ Performed in a full environment (e.g. DDEV) with real mail and checkout:
 ## Related documentation
 
 - [operational-surface-convergence.md](./operational-surface-convergence.md) — My Tickets and PDF rendering convergence onto **`UniversalTicketViewModelBuilder`**.
+- [operational-observability.md](./operational-observability.md) — read-only operational diagnostics authority and anti-patterns.
 - [wallet-operational-convergence.md](./wallet-operational-convergence.md) — Wallet routes, inward ticket resolution, and QR authority alignment.
 - [legacy-pdf-compatibility.md](./legacy-pdf-compatibility.md) — **Governance:** operational authority vs legacy PDF adapters, inward-only delegation, frozen contracts, forbidden patterns (Commit 5+).

--- a/docs/operational-observability.md
+++ b/docs/operational-observability.md
@@ -1,0 +1,75 @@
+# Operational observability (diagnostics spine)
+
+## Diagnostics authority
+
+Operational integrity diagnostics are implemented by **`OperationalIntegrityInspector`** (`myeventlane_tickets.operational_integrity_inspector`) in `web/modules/custom/myeventlane_tickets/src/Service/OperationalIntegrityInspector.php`.
+
+This service is the **single read-only diagnostics layer** for:
+
+- issuance visibility (counts, alignment, orphan links, idempotent guard signals)
+- artifact readiness (canonical PDF preconditions, wallet route scaffolds, QR payload operability, attachment continuity)
+- recovery visibility (state marker, late-tickets-after-confirmation heuristic, mismatch flags)
+- compatibility signals (canonical vs legacy surfaces, mixed paths)
+- guest and purchaser continuity checks on stored entities (no live session required)
+
+It **observes** existing operational state only. It does not issue tickets, generate PDFs or wallet bytes, alter recovery state, enqueue work, or expose signing secrets.
+
+**Services consulted (read-only):** `TicketIssuer` (expected counts and line eligibility), `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()` (same rules as `getPdfContentForTicket()` without rendering bytes), `UniversalTicketViewModelBuilder::build()` (structural operability, no model payload emitted), `TicketQrPayload::buildForTicket()` (operability only; output not returned), `TicketCapabilityManager::getEntitlementType()`, optional `WalletTicketResolver`, optional message sink with `findSentOrderConfirmationsForOrder()` (same shape as `MessageStorage`). Attachment continuity follows **`OrderConfirmationAttachmentResolver`** merge preconditions (holder fields per ticket) without invoking merge.
+
+## Read-only guarantees
+
+- No entity save, delete, or state `set`/`delete` from this service.
+- No calls to `TicketIssuer::issueForOrder()` or attachment merge send paths.
+- QR diagnostics use **`TicketQrPayload::buildForTicket()`** for operability checks; structured output arrays **must not** include raw payload strings, HMAC segments, or signing material (callers should consume boolean or enum-style status fields only).
+- Do not embed purchaser email addresses or holder emails in diagnostics arrays; use counts and machine-safe status tokens only.
+
+## Operational integrity domains
+
+Normalized `inspectOrder(OrderInterface $order)` returns:
+
+| Key | Role |
+| --- | --- |
+| `issuance` | Expected vs issued counts, alignment status, idempotent replay skip signal, partial-issuance guard anomaly, orphan ticket / orphan eligible order item counts |
+| `artifacts` | Canonical PDF readiness (holder preconditions via `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()`), wallet route scaffold (order item link present), QR operability (`TicketQrPayload`), attachment continuity (holder coverage for merge rules) |
+| `recovery` | `OrderPaidConfirmationPdfRecoverySubscriber` state key via `recoveryStateKey()`, optional message sink for sent confirmation timestamps, mismatch when recovery appears required but completion state missing |
+| `compatibility` | Order-item PDF legacy surface availability, wallet resolution surface (`WalletTicketResolver`), ticket PDF path from `UniversalTicketViewModelBuilder` probe |
+| `guest_continuity` | Purchaser UID alignment with order customer, guest checkout pattern checks (no PII in output) |
+
+Status values are **machine strings** (for example `valid`, `invalid`, `missing`, `canonical`, `legacy`, `mixed`, `recovered`, `pending`, `skipped`, `orphaned`, `unknown`) suitable for logs and automated checks—not UI copy.
+
+## Canonical vs compatibility visibility
+
+- **Canonical** paths are inferred when issued **`myeventlane_ticket`** rows satisfy universal view model build checks and canonical PDF preconditions.
+- **Legacy** surfaces remain visible where Commerce order-item PDF adapters or wallet routes operate without issued rows (compatibility only).
+- **Mixed** indicates heterogeneous rows (for example some tickets holder-ready, some not) or mixed wallet resolution outcomes across line items.
+
+## Recovery visibility
+
+Recovery completion is read from **`State` API** using the same key as **`OrderPaidConfirmationPdfRecoverySubscriber::recoveryStateKey()`**.
+
+When **`myeventlane_messaging.message_storage`** is available, late-ticket detection mirrors the subscriber’s comparison of earliest sent `order_confirmation` against minimum ticket `created` timestamp for the same recipient channel. Optional test doubles may implement only `findSentOrderConfirmationsForOrder()` for kernel isolation.
+
+## Structured logging
+
+`logger.channel.myeventlane_tickets` receives **warnings only** for:
+
+- orphan ticket or orphan eligible order item counts
+- issuance count anomalies and partial issuance under the idempotent guard
+- stray ticket rows with zero expected issuable units (duplicate-prevention context)
+- recovery mismatch (heuristic requirement without completion marker)
+
+Callers must avoid invoking diagnostics on hot per-request paths to prevent noise.
+
+## Anti-patterns (forbidden)
+
+- Using diagnostics to **issue tickets**, **generate PDFs**, **build wallet passes**, or **mutate recovery state**
+- Duplicating QR signing, payload shaping, or entitlement normalization outside **`TicketQrPayload`**, **`UniversalTicketViewModelBuilder`**, **`TicketCapabilityManager`**, and **`TicketIssuer`**
+- Treating compatibility adapters (`OrderItemPdfCompatibilityAdapter`, etc.) as operational authorities for entitlement truth
+- Embedding UI strings, translated labels, or marketing copy inside diagnostics payloads
+- Exposing purchaser email, entitlement secrets, raw HMAC material, or full QR payload strings through diagnostics APIs
+- Adding public routes, controllers, or admin pages for this phase (callers must enforce access before invoking the service)
+
+## Related documentation
+
+- [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
+- [operational-surface-convergence.md](./operational-surface-convergence.md) — wallet and PDF convergence context

--- a/docs/operational-surface-convergence.md
+++ b/docs/operational-surface-convergence.md
@@ -58,3 +58,7 @@ Paid-order **ticket row issuance** is owned by **`TicketIssuer`** on **`ORDER_PA
 Canonical order-confirmation PDF merging is documented in [issuance-pipeline.md](./issuance-pipeline.md).
 
 Wallet operational convergence (Phase 2C) is documented in [wallet-operational-convergence.md](./wallet-operational-convergence.md).
+
+## Operational observability (Phase 2D)
+
+**`OperationalIntegrityInspector`** (`myeventlane_tickets.operational_integrity_inspector`) provides deterministic, read-only diagnostics over the same operational spine (issued tickets, view model, PDF preconditions, wallet resolver, recovery state). It does not change customer routes, PDF routes, wallet URLs, or scanner contracts. Details and forbidden patterns: [operational-observability.md](./operational-observability.md).

--- a/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidConfirmationPdfRecoverySubscriber.php
+++ b/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidConfirmationPdfRecoverySubscriber.php
@@ -22,7 +22,19 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 final class OrderPaidConfirmationPdfRecoverySubscriber implements EventSubscriberInterface {
 
+  /**
+   * State API key prefix; order id is appended without separator ambiguity.
+   *
+   * @see self::recoveryStateKey()
+   */
   private const STATE_PREFIX = 'myeventlane_messaging.oc_pdf_recovery_done.';
+
+  /**
+   * Stable state key for PDF recovery completion marker for one order.
+   */
+  public static function recoveryStateKey(int $orderId): string {
+    return self::STATE_PREFIX . $orderId;
+  }
 
   public function __construct(
     private readonly OrderConfirmationQueueBuilder $orderConfirmationQueue,
@@ -56,7 +68,7 @@ final class OrderPaidConfirmationPdfRecoverySubscriber implements EventSubscribe
       return;
     }
 
-    if ($this->state->get(self::STATE_PREFIX . $orderId, FALSE)) {
+    if ($this->state->get(self::recoveryStateKey($orderId), FALSE)) {
       return;
     }
 
@@ -102,7 +114,7 @@ final class OrderPaidConfirmationPdfRecoverySubscriber implements EventSubscribe
 
     $messageId = $this->orderConfirmationQueue->queue($order, trim($mail), TRUE);
     if ($messageId) {
-      $this->state->set(self::STATE_PREFIX . $orderId, (int) time());
+      $this->state->set(self::recoveryStateKey($orderId), (int) time());
       $this->logger->info('ORDER_PAID: queued ticket PDF recovery order_confirmation resend for order @order_id message_id=@mid', [
         '@order_id' => (string) $orderId,
         '@mid' => $messageId,

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -153,3 +153,17 @@ services:
     arguments:
       - '@myeventlane_tickets.ticket_mailer'
       - '@logger.channel.myeventlane_tickets'
+
+  myeventlane_tickets.operational_integrity_inspector:
+    class: Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_tickets.ticket_issuer'
+      - '@myeventlane_tickets.universal_ticket_view_model_builder'
+      - '@myeventlane_tickets.ticket_pdf_generator'
+      - '@myeventlane_tickets.ticket_qr_payload'
+      - '@mel_ticket_capability.manager'
+      - '@state'
+      - '@logger.channel.myeventlane_tickets'
+      - '@?myeventlane_wallet.ticket_resolver'
+      - '@?myeventlane_messaging.message_storage'

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalIntegrityInspector.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalIntegrityInspector.php
@@ -1,0 +1,739 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\Core\State\StateInterface;
+use Drupal\myeventlane_messaging\EventSubscriber\OrderPaidConfirmationPdfRecoverySubscriber;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\myeventlane_tickets\Ticket\TicketPdfGenerator;
+use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
+use Drupal\myeventlane_wallet\Service\WalletTicketResolver;
+use Drupal\user\UserInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Read-only operational diagnostics for issuance, artifacts, and recovery.
+ *
+ * Does not mutate entities, queues, messages, or state. Callers must enforce
+ * access control before invoking on sensitive orders.
+ *
+ * @see \Drupal\myeventlane_messaging\EventSubscriber\OrderPaidConfirmationPdfRecoverySubscriber::recoveryStateKey()
+ */
+final class OperationalIntegrityInspector {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly TicketIssuer $ticketIssuer,
+    private readonly UniversalTicketViewModelBuilder $universalTicketViewModelBuilder,
+    private readonly TicketPdfGenerator $ticketPdfGenerator,
+    private readonly TicketQrPayload $ticketQrPayload,
+    private readonly TicketCapabilityManager $ticketCapabilityManager,
+    private readonly StateInterface $state,
+    private readonly LoggerInterface $logger,
+    private readonly ?WalletTicketResolver $walletTicketResolver = NULL,
+    private readonly ?object $messageStorage = NULL,
+  ) {}
+
+  /**
+   * Builds deterministic diagnostics for one Commerce order.
+   *
+   * @return array{
+   *   issuance: array<string, mixed>,
+   *   artifacts: array<string, mixed>,
+   *   recovery: array<string, mixed>,
+   *   compatibility: array<string, mixed>,
+   *   guest_continuity: array<string, mixed>
+   * }
+   */
+  public function inspectOrder(OrderInterface $order): array {
+    $orderId = (int) $order->id();
+    if ($orderId < 1) {
+      return $this->emptyDiagnostics('invalid');
+    }
+
+    $tickets = $this->loadTicketsForOrder($orderId);
+    $expected = $this->ticketIssuer->countExpectedIssuanceUnits($order);
+    $issued = count($tickets);
+
+    $orderItemIds = $this->orderItemIdSet($order);
+    $orphanTickets = $this->countOrphanTicketLinks($tickets, $orderItemIds);
+    $orphanEligibleItems = $this->countOrphanEligibleOrderItems($order, $tickets);
+
+    $issuance = $this->buildIssuanceDomain(
+      $orderId,
+      $expected,
+      $issued,
+      $orphanTickets,
+      $orphanEligibleItems,
+    );
+
+    $artifacts = $this->buildArtifactsDomain($order, $tickets);
+    $recovery = $this->buildRecoveryDomain($order, $tickets);
+    $compatibility = $this->buildCompatibilityDomain($order, $tickets, $artifacts);
+    $guest_continuity = $this->buildGuestContinuityDomain($order, $tickets);
+
+    $this->maybeLogAnomalies(
+      $orderId,
+      $issuance,
+      $recovery,
+    );
+
+    return [
+      'issuance' => $issuance,
+      'artifacts' => $artifacts,
+      'recovery' => $recovery,
+      'compatibility' => $compatibility,
+      'guest_continuity' => $guest_continuity,
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function emptyDiagnostics(string $order_status): array {
+    return [
+      'issuance' => [
+        'order_operational_status' => $order_status,
+        'expected_quantity' => 0,
+        'issued_ticket_count' => 0,
+        'quantity_alignment_status' => 'missing',
+        'idempotent_replay_would_skip' => FALSE,
+        'partial_issuance_blocked_by_idempotent_guard' => FALSE,
+        'orphan_ticket_count' => 0,
+        'orphan_eligible_order_item_count' => 0,
+      ],
+      'artifacts' => [
+        'canonical_pdf_readiness' => 'missing',
+        'wallet_route_scaffold' => 'missing',
+        'qr_payload_operational' => 'missing',
+        'attachment_continuity' => 'missing',
+      ],
+      'recovery' => [
+        'completion_state' => 'missing',
+        'recovery_completed_recorded' => FALSE,
+        'late_tickets_after_confirmation' => 'unknown',
+        'recovery_requirement_signal' => 'unknown',
+        'recovery_mismatch' => FALSE,
+      ],
+      'compatibility' => [
+        'ticket_pdf_operational_path' => 'pending',
+        'order_item_pdf_surface' => 'missing',
+        'wallet_resolution_surface' => 'pending',
+      ],
+      'guest_continuity' => [
+        'guest_access_compatible' => FALSE,
+        'entitlement_ownership_valid' => FALSE,
+        'purchaser_identity_continuity_valid' => FALSE,
+        'continuity_status' => 'invalid',
+      ],
+    ];
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   */
+  private function buildIssuanceDomain(
+    int $orderId,
+    int $expected,
+    int $issued,
+    int $orphanTickets,
+    int $orphanEligibleItems,
+  ): array {
+    $alignment = $this->quantityAlignmentStatus($expected, $issued);
+    $idempotentSkip = $issued > 0;
+    $partialBlocked = $issued > 0 && $issued < $expected;
+
+    return [
+      'order_operational_status' => 'valid',
+      'expected_quantity' => $expected,
+      'issued_ticket_count' => $issued,
+      'quantity_alignment_status' => $alignment,
+      'idempotent_replay_would_skip' => $idempotentSkip,
+      'partial_issuance_blocked_by_idempotent_guard' => $partialBlocked,
+      'orphan_ticket_count' => $orphanTickets,
+      'orphan_eligible_order_item_count' => $orphanEligibleItems,
+    ];
+  }
+
+  private function quantityAlignmentStatus(int $expected, int $issued): string {
+    if ($expected < 1 && $issued < 1) {
+      return 'pending';
+    }
+    if ($expected < 1 && $issued > 0) {
+      return 'invalid';
+    }
+    if ($expected > 0 && $issued < 1) {
+      return 'missing';
+    }
+    return $issued === $expected ? 'valid' : 'invalid';
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   */
+  private function buildArtifactsDomain(OrderInterface $order, array $tickets): array {
+    if ($tickets === []) {
+      return [
+        'canonical_pdf_readiness' => 'missing',
+        'wallet_route_scaffold' => 'missing',
+        'qr_payload_operational' => 'missing',
+        'attachment_continuity' => 'missing',
+      ];
+    }
+
+    $pdfReady = 0;
+    $pdfPending = 0;
+    $walletReady = 0;
+    $walletPending = 0;
+    $qrValid = 0;
+    $qrInvalid = 0;
+    $holderReady = 0;
+
+    foreach ($tickets as $ticket) {
+      $this->ticketCapabilityManager->getEntitlementType($ticket);
+      if ($this->ticketPdfGenerator->canonicalPdfPreconditionsSatisfied($ticket)) {
+        $pdfReady++;
+        $holderReady++;
+      }
+      else {
+        $pdfPending++;
+      }
+
+      if ($this->walletScaffoldPossible($ticket)) {
+        $walletReady++;
+      }
+      else {
+        $walletPending++;
+      }
+
+      if ($this->qrOperationalForTicket($ticket)) {
+        $qrValid++;
+      }
+      else {
+        $qrInvalid++;
+      }
+    }
+
+    $total = count($tickets);
+
+    return [
+      'canonical_pdf_readiness' => $this->aggregateReadiness($pdfReady, $pdfPending, $total),
+      'wallet_route_scaffold' => $this->aggregateReadiness($walletReady, $walletPending, $total),
+      'qr_payload_operational' => $this->aggregateReadiness($qrValid, $qrInvalid, $total),
+      'attachment_continuity' => $this->attachmentContinuityStatus($holderReady, $total),
+    ];
+  }
+
+  private function walletScaffoldPossible(Ticket $ticket): bool {
+    return $this->readTargetId($ticket, 'order_item_id') > 0;
+  }
+
+  private function qrOperationalForTicket(Ticket $ticket): bool {
+    try {
+      $payload = $this->ticketQrPayload->buildForTicket($ticket);
+      return trim($payload) !== '';
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   */
+  private function buildRecoveryDomain(OrderInterface $order, array $tickets): array {
+    $orderId = (int) $order->id();
+    $stateKey = OrderPaidConfirmationPdfRecoverySubscriber::recoveryStateKey($orderId);
+    $completedRaw = $this->state->get($stateKey, FALSE);
+    $completed = $completedRaw !== FALSE && $completedRaw !== NULL && $completedRaw !== '';
+
+    $late = 'unknown';
+    $signal = 'unknown';
+    $mismatch = FALSE;
+
+    if ($this->messageStorageSupportsRecovery() && $tickets !== []) {
+      $recipient = $this->orderRecipientMail($order);
+      if ($recipient !== '') {
+        $minCreated = $this->minTicketCreatedTimestamp($tickets);
+        $sentRows = $this->messageStorage->findSentOrderConfirmationsForOrder($orderId, $recipient);
+        $earliestSent = $this->earliestSentTimestamp($sentRows);
+        if ($earliestSent !== NULL && $earliestSent > 0 && $minCreated !== NULL && $minCreated > $earliestSent) {
+          $late = 'true';
+        }
+        else {
+          $late = 'false';
+        }
+
+        $eligible = $this->orderHasVariationLineItemsEligibleForTickets($order);
+        if ($eligible && $minCreated !== NULL && $earliestSent !== NULL && $earliestSent > 0 && $minCreated > $earliestSent) {
+          $signal = 'pending';
+        }
+        else {
+          $signal = 'none';
+        }
+      }
+      else {
+        $late = 'false';
+        $signal = 'skipped';
+      }
+    }
+    elseif ($tickets === []) {
+      $late = 'false';
+      $signal = 'none';
+    }
+
+    if ($completed) {
+      $signal = 'recovered';
+      $mismatch = FALSE;
+    }
+    elseif ($signal === 'pending' && !$completed) {
+      $mismatch = TRUE;
+    }
+
+    return [
+      'completion_state' => $completed ? 'recovered' : 'missing',
+      'recovery_completed_recorded' => $completed,
+      'late_tickets_after_confirmation' => $late,
+      'recovery_requirement_signal' => $signal,
+      'recovery_mismatch' => $mismatch,
+    ];
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCompatibilityDomain(OrderInterface $order, array $tickets, array $artifacts): array {
+    $orderItemSurface = $this->orderItemPdfSurfaceStatus($order);
+    $walletSurface = $this->walletResolutionSurface($order, $tickets);
+    $canonicalReadiness = $artifacts['canonical_pdf_readiness'] ?? 'missing';
+    $pdfPath = $this->ticketPdfPathStatus($tickets, $canonicalReadiness);
+
+    return [
+      'ticket_pdf_operational_path' => $pdfPath,
+      'order_item_pdf_surface' => $orderItemSurface,
+      'wallet_resolution_surface' => $walletSurface,
+    ];
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   */
+  private function buildGuestContinuityDomain(OrderInterface $order, array $tickets): array {
+    $customerId = (int) $order->getCustomerId();
+    $ownership = TRUE;
+    $purchaserContinuity = TRUE;
+
+    foreach ($tickets as $ticket) {
+      $purchaserUid = $this->readTargetId($ticket, 'purchaser_uid');
+      if ($purchaserUid !== $customerId) {
+        $ownership = FALSE;
+      }
+      if ($customerId > 0 && $purchaserUid !== $customerId) {
+        $purchaserContinuity = FALSE;
+      }
+      if ($customerId === 0 && $purchaserUid !== 0) {
+        $purchaserContinuity = FALSE;
+      }
+    }
+
+    $guestAccess = $this->guestAccessPatternValid($order, $tickets, $customerId);
+
+    $continuity = ($ownership && $purchaserContinuity && $guestAccess) ? 'valid' : 'invalid';
+
+    return [
+      'guest_access_compatible' => $guestAccess,
+      'entitlement_ownership_valid' => $ownership,
+      'purchaser_identity_continuity_valid' => $purchaserContinuity,
+      'continuity_status' => $continuity,
+    ];
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function guestAccessPatternValid(OrderInterface $order, array $tickets, int $customerId): bool {
+    if ($tickets === []) {
+      return TRUE;
+    }
+    if ($customerId > 0) {
+      return TRUE;
+    }
+    foreach ($tickets as $ticket) {
+      if ((int) $ticket->getOwnerId() !== 0) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param array<string, mixed> $issuance
+   * @param array<string, mixed> $recovery
+   */
+  private function maybeLogAnomalies(int $orderId, array $issuance, array $recovery): void {
+    $orphanTickets = (int) ($issuance['orphan_ticket_count'] ?? 0);
+    $orphanItems = (int) ($issuance['orphan_eligible_order_item_count'] ?? 0);
+    if ($orphanTickets > 0 || $orphanItems > 0) {
+      $this->logger->warning('OperationalIntegrityInspector: orphan operational state for order @order_id orphan_tickets=@ot orphan_items=@oi', [
+        '@order_id' => (string) $orderId,
+        '@ot' => (string) $orphanTickets,
+        '@oi' => (string) $orphanItems,
+        'order_id' => $orderId,
+        'orphan_ticket_count' => $orphanTickets,
+        'orphan_eligible_order_item_count' => $orphanItems,
+      ]);
+    }
+
+    $expected = (int) ($issuance['expected_quantity'] ?? 0);
+    $issued = (int) ($issuance['issued_ticket_count'] ?? 0);
+    if ($issued > $expected && $expected >= 0) {
+      $this->logger->warning('OperationalIntegrityInspector: issuance count anomaly (possible duplicate guard context) order @order_id expected=@e issued=@i', [
+        '@order_id' => (string) $orderId,
+        '@e' => (string) $expected,
+        '@i' => (string) $issued,
+        'order_id' => $orderId,
+        'expected_quantity' => $expected,
+        'issued_ticket_count' => $issued,
+      ]);
+    }
+
+    $partial = (bool) ($issuance['partial_issuance_blocked_by_idempotent_guard'] ?? FALSE);
+    if ($partial) {
+      $this->logger->warning('OperationalIntegrityInspector: partial issuance with idempotent guard active order @order_id expected=@e issued=@i', [
+        '@order_id' => (string) $orderId,
+        '@e' => (string) $expected,
+        '@i' => (string) $issued,
+        'order_id' => $orderId,
+        'expected_quantity' => $expected,
+        'issued_ticket_count' => $issued,
+      ]);
+    }
+
+    if ($issued > 0 && $expected === 0) {
+      $this->logger->warning('OperationalIntegrityInspector: duplicate_issuance_prevention_detection stray_ticket_rows order @order_id issued=@i', [
+        '@order_id' => (string) $orderId,
+        '@i' => (string) $issued,
+        'order_id' => $orderId,
+        'issued_ticket_count' => $issued,
+      ]);
+    }
+
+    if (!empty($recovery['recovery_mismatch'])) {
+      $this->logger->warning('OperationalIntegrityInspector: recovery mismatch detected order @order_id', [
+        '@order_id' => (string) $orderId,
+        'order_id' => $orderId,
+      ]);
+    }
+  }
+
+  /**
+   * @return list<Ticket>
+   */
+  private function loadTicketsForOrder(int $orderId): array {
+    if (!$this->entityTypeManager->hasDefinition('myeventlane_ticket')) {
+      return [];
+    }
+    $storage = $this->entityTypeManager->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_id', $orderId)
+      ->sort('id')
+      ->execute();
+    if (!$ids || !is_array($ids)) {
+      return [];
+    }
+    $loaded = $storage->loadMultiple($ids);
+    $list = [];
+    foreach ($loaded as $entity) {
+      if ($entity instanceof Ticket) {
+        $list[] = $entity;
+      }
+    }
+    return $list;
+  }
+
+  /**
+   * @return array<int, true>
+   */
+  private function orderItemIdSet(OrderInterface $order): array {
+    $set = [];
+    foreach ($order->getItems() as $item) {
+      if ($item instanceof OrderItemInterface) {
+        $set[(int) $item->id()] = TRUE;
+      }
+    }
+    return $set;
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function countOrphanTicketLinks(array $tickets, array $orderItemIds): int {
+    $orphan = 0;
+    foreach ($tickets as $ticket) {
+      $oi = $this->readTargetId($ticket, 'order_item_id');
+      if ($oi < 1 || !isset($orderItemIds[$oi])) {
+        $orphan++;
+      }
+    }
+    return $orphan;
+  }
+
+  /**
+   * Eligible variation line items with fewer linked tickets than quantity.
+   *
+   * @param list<Ticket> $tickets
+   */
+  private function countOrphanEligibleOrderItems(OrderInterface $order, array $tickets): int {
+    $byItem = [];
+    foreach ($tickets as $ticket) {
+      $oi = $this->readTargetId($ticket, 'order_item_id');
+      if ($oi > 0) {
+        $byItem[$oi] = ($byItem[$oi] ?? 0) + 1;
+      }
+    }
+
+    $orphan = 0;
+    foreach ($order->getItems() as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+      $purchased = $item->getPurchasedEntity();
+      if (!$purchased || $purchased->getEntityTypeId() !== 'commerce_product_variation') {
+        continue;
+      }
+      if (!$this->ticketIssuer->isOrderItemEligibleForTicketIssuance($item)) {
+        continue;
+      }
+      $qty = max(0, (int) $item->getQuantity());
+      $have = (int) ($byItem[(int) $item->id()] ?? 0);
+      if ($have < $qty) {
+        $orphan++;
+      }
+    }
+    return $orphan;
+  }
+
+  /**
+   * True when the order has at least one variation line item TicketIssuer would attempt.
+   */
+  private function orderHasVariationLineItemsEligibleForTickets(OrderInterface $order): bool {
+    return $this->ticketIssuer->countExpectedIssuanceUnits($order) > 0;
+  }
+
+  private function orderRecipientMail(OrderInterface $order): string {
+    $mail = $order->getEmail();
+    if (!$mail) {
+      $customer = $order->getCustomer();
+      $mail = $customer ? $customer->getEmail() : NULL;
+    }
+    return $mail ? trim((string) $mail) : '';
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function minTicketCreatedTimestamp(array $tickets): ?int {
+    $min = NULL;
+    foreach ($tickets as $ticket) {
+      $c = $this->ticketCreated($ticket);
+      if ($c !== NULL && ($min === NULL || $c < $min)) {
+        $min = $c;
+      }
+    }
+    return $min;
+  }
+
+  private function ticketCreated(Ticket $ticket): ?int {
+    if (!$ticket->hasField('created') || $ticket->get('created')->isEmpty()) {
+      return NULL;
+    }
+    $created = (int) $ticket->get('created')->value;
+    return $created > 0 ? $created : NULL;
+  }
+
+  /**
+   * @param object[] $rows
+   */
+  private function earliestSentTimestamp(array $rows): ?int {
+    $min = NULL;
+    foreach ($rows as $row) {
+      $s = isset($row->sent) ? (int) $row->sent : 0;
+      if ($s > 0 && ($min === NULL || $s < $min)) {
+        $min = $s;
+      }
+    }
+    return $min;
+  }
+
+  private function orderItemPdfSurfaceStatus(OrderInterface $order): string {
+    foreach ($order->getItems() as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+      $purchased = $item->getPurchasedEntity();
+      if ($purchased && $purchased->getEntityTypeId() === 'commerce_product_variation') {
+        return 'legacy';
+      }
+    }
+    return 'missing';
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function walletResolutionSurface(OrderInterface $order, array $tickets): string {
+    if (!$this->walletTicketResolver instanceof WalletTicketResolver) {
+      return 'unknown';
+    }
+    if ($tickets === []) {
+      return 'legacy';
+    }
+    $account = $this->resolveOrderAccount($order);
+    $canonical = 0;
+    $legacy = 0;
+    foreach ($order->getItems() as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+      $purchased = $item->getPurchasedEntity();
+      if (!$purchased || $purchased->getEntityTypeId() !== 'commerce_product_variation') {
+        continue;
+      }
+      $count = $this->countTicketsForOrderItem($tickets, (int) $item->id());
+      if ($count < 1) {
+        $legacy++;
+        continue;
+      }
+      $resolved = $this->walletTicketResolver->resolvePrimaryTicketForOrderItem($item, $account);
+      $canonical += $resolved instanceof Ticket ? 1 : 0;
+    }
+    if ($canonical > 0 && $legacy > 0) {
+      return 'mixed';
+    }
+    return $canonical > 0 ? 'canonical' : 'legacy';
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function countTicketsForOrderItem(array $tickets, int $orderItemId): int {
+    $n = 0;
+    foreach ($tickets as $ticket) {
+      if ($this->readTargetId($ticket, 'order_item_id') === $orderItemId) {
+        $n++;
+      }
+    }
+    return $n;
+  }
+
+  private function resolveOrderAccount(OrderInterface $order): AccountInterface {
+    $uid = (int) $order->getCustomerId();
+    if ($uid > 0) {
+      $user = $this->entityTypeManager->getStorage('user')->load($uid);
+      if ($user instanceof UserInterface) {
+        return $user;
+      }
+    }
+    return new AnonymousUserSession();
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   */
+  private function ticketPdfPathStatus(array $tickets, string $canonicalReadiness): string {
+    if ($tickets === []) {
+      return 'pending';
+    }
+    $viewModelOk = 0;
+    $viewModelBad = 0;
+    foreach ($tickets as $ticket) {
+      if ($this->viewModelBuilds($ticket)) {
+        $viewModelOk++;
+      }
+      else {
+        $viewModelBad++;
+      }
+    }
+    if ($viewModelOk > 0 && $viewModelBad > 0) {
+      return 'mixed';
+    }
+    if ($canonicalReadiness === 'mixed') {
+      return 'mixed';
+    }
+    if ($viewModelOk === count($tickets)) {
+      return 'canonical';
+    }
+    if ($viewModelBad === count($tickets)) {
+      return 'invalid';
+    }
+    return 'legacy';
+  }
+
+  private function viewModelBuilds(Ticket $ticket): bool {
+    try {
+      $model = $this->universalTicketViewModelBuilder->build($ticket);
+      return isset($model['ticket']['code']) && $model['ticket']['code'] !== '';
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  private function aggregateReadiness(int $ready, int $notReady, int $total): string {
+    if ($total < 1) {
+      return 'missing';
+    }
+    if ($ready === $total) {
+      return 'valid';
+    }
+    if ($notReady === $total) {
+      return $ready > 0 ? 'invalid' : 'pending';
+    }
+    return 'mixed';
+  }
+
+  private function attachmentContinuityStatus(int $holderReady, int $total): string {
+    if ($total < 1) {
+      return 'missing';
+    }
+    if ($holderReady === $total) {
+      return 'valid';
+    }
+    if ($holderReady < 1) {
+      return 'pending';
+    }
+    return 'mixed';
+  }
+
+  private function readTargetId(Ticket $ticket, string $field): int {
+    if (!$ticket->hasField($field) || $ticket->get($field)->isEmpty()) {
+      return 0;
+    }
+    return (int) $ticket->get($field)->target_id;
+  }
+
+  private function messageStorageSupportsRecovery(): bool {
+    return is_object($this->messageStorage)
+      && method_exists($this->messageStorage, 'findSentOrderConfirmationsForOrder');
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
@@ -24,6 +24,51 @@ final class TicketIssuer {
   ) {}
 
   /**
+   * Read-only count of ticket rows that issuance would create for this order.
+   *
+   * Mirrors {@see self::issueForOrder()} line-item rules excluding the
+   * idempotent early return when tickets already exist.
+   */
+  public function countExpectedIssuanceUnits(OrderInterface $order): int {
+    $total = 0;
+    foreach ($order->getItems() as $order_item) {
+      if (!$order_item instanceof OrderItemInterface) {
+        continue;
+      }
+
+      $purchased_entity = $order_item->getPurchasedEntity();
+      if (!$purchased_entity || $purchased_entity->getEntityTypeId() !== 'commerce_product_variation') {
+        continue;
+      }
+
+      if (!$this->resolveEventFromOrderItem($order_item)) {
+        continue;
+      }
+
+      $qty = (int) $order_item->getQuantity();
+      if ($qty < 1) {
+        continue;
+      }
+
+      $total += $qty;
+    }
+
+    return $total;
+  }
+
+  /**
+   * True when this line item would contribute rows in {@see self::issueForOrder()}.
+   */
+  public function isOrderItemEligibleForTicketIssuance(OrderItemInterface $order_item): bool {
+    $purchased_entity = $order_item->getPurchasedEntity();
+    if (!$purchased_entity || $purchased_entity->getEntityTypeId() !== 'commerce_product_variation') {
+      return FALSE;
+    }
+
+    return $this->resolveEventFromOrderItem($order_item) !== NULL;
+  }
+
+  /**
    * Issues tickets for a paid order.
    *
    * One order item quantity = N ticket entities.

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketPdfGenerator.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketPdfGenerator.php
@@ -81,6 +81,13 @@ final class TicketPdfGenerator {
   }
 
   /**
+   * Read-only: whether holder fields satisfy canonical PDF generation rules.
+   */
+  public function canonicalPdfPreconditionsSatisfied(Ticket $ticket): bool {
+    return !$ticket->get('holder_name')->isEmpty() && !$ticket->get('holder_email')->isEmpty();
+  }
+
+  /**
    * Gets PDF content as bytes for a ticket (for email attachments).
    *
    * When the canonical view model builder is available, all operational
@@ -93,10 +100,7 @@ final class TicketPdfGenerator {
    *   If ticket holder details are not assigned.
    */
   public function getPdfContentForTicket(Ticket $ticket): array {
-    if (
-      $ticket->get('holder_name')->isEmpty() ||
-      $ticket->get('holder_email')->isEmpty()
-    ) {
+    if (!$this->canonicalPdfPreconditionsSatisfied($ticket)) {
       throw new \LogicException('Ticket holder details must be assigned before PDF generation.');
     }
 

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalIntegrityInspectorTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalIntegrityInspectorTest.php
@@ -1,0 +1,506 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel;
+
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_order\Entity\OrderItem;
+use Drupal\commerce_order\Entity\OrderItemType;
+use Drupal\commerce_order\Entity\OrderType;
+use Drupal\commerce_price\Entity\Currency;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_messaging\EventSubscriber\OrderPaidConfirmationPdfRecoverySubscriber;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector
+ *
+ * @group myeventlane_tickets
+ */
+#[RunTestsInSeparateProcesses]
+final class OperationalIntegrityInspectorTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'link',
+    'path',
+    'path_alias',
+    'views',
+    'address',
+    'node',
+    'options',
+    'datetime',
+    'datetime_range',
+    'commerce',
+    'commerce_number_pattern',
+    'commerce_price',
+    'commerce_order',
+    'commerce_product',
+    'commerce_store',
+    'entity_reference_revisions',
+    'paragraphs',
+    'profile',
+    'state_machine',
+    'mel_ticket',
+    'myeventlane_vendor',
+    'myeventlane_tickets',
+    'myeventlane_wallet',
+  ];
+
+  private Node $event;
+
+  private User $customer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    foreach (array_keys($container->getDefinitions()) as $service_id) {
+      if (str_starts_with($service_id, 'myeventlane_vendor.') && $service_id !== 'myeventlane_vendor.event_access_checker') {
+        $container->removeDefinition($service_id);
+      }
+    }
+
+    $container->register('myeventlane_vendor.event_access_checker', EventVendorAccessChecker::class);
+    $container->register('myeventlane_onboarding.manager', \stdClass::class);
+    $container->register('myeventlane_core.vendor_follow', \stdClass::class);
+    $container->register('myeventlane_event_studio.save', \stdClass::class);
+    $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
+    $container->register('myeventlane_core.domain_detector', \stdClass::class);
+    $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
+    $container->register('myeventlane_boost.manager', \stdClass::class);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('commerce_currency');
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_order');
+    $this->installEntitySchema('commerce_order_item');
+    $this->installEntitySchema('myeventlane_ticket');
+    $this->installConfig(['commerce_store', 'commerce_product', 'commerce_order']);
+
+    NodeType::create([
+      'type' => 'event',
+      'name' => 'Event',
+    ])->save();
+    $this->createEventFields();
+    $this->ensureProductEventField();
+
+    if (!OrderItemType::load('default')) {
+      OrderItemType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'purchasableEntityType' => 'commerce_product_variation',
+        'orderType' => 'default',
+      ])->save();
+    }
+    if (!OrderType::load('default')) {
+      OrderType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'workflow' => 'order_default',
+      ])->save();
+    }
+    if (!Currency::load('AUD')) {
+      Currency::create([
+        'currencyCode' => 'AUD',
+        'name' => 'Australian Dollar',
+        'numericCode' => '036',
+        'symbol' => '$',
+        'fractionDigits' => 2,
+      ])->save();
+    }
+
+    $store_type_storage = $this->container->get('entity_type.manager')->getStorage('commerce_store_type');
+    if (!$store_type_storage->load('online')) {
+      $store_type_storage->create(['id' => 'online', 'label' => 'Online'])->save();
+    }
+    $store = Store::create([
+      'type' => 'online',
+      'name' => 'Inspector Store',
+      'mail' => 'store@example.test',
+      'default_currency' => 'AUD',
+      'status' => 1,
+    ]);
+    $store->save();
+
+    $this->customer = User::create([
+      'name' => 'inspector_customer',
+      'mail' => 'inspector@example.test',
+      'status' => 1,
+    ]);
+    $this->customer->save();
+
+    $this->event = Node::create([
+      'type' => 'event',
+      'title' => 'Inspector Event',
+      'uid' => $this->customer->id(),
+      'status' => 1,
+      'field_event_start' => '2026-08-01T10:00:00',
+      'field_event_end' => '2026-08-01T12:00:00',
+      'field_venue_name' => 'Hall A',
+      'field_event_vendor' => $this->customer->id(),
+    ]);
+    $this->event->save();
+
+    $product = Product::create([
+      'type' => 'default',
+      'title' => 'Inspector Product',
+      'stores' => [$store],
+      'field_event' => $this->event->id(),
+    ]);
+    $product->save();
+
+    $variation = ProductVariation::create([
+      'type' => 'default',
+      'sku' => 'INSPECTOR-SKU',
+      'title' => 'GA',
+      'product_id' => $product->id(),
+      'price' => new Price('25.00', 'AUD'),
+      'status' => 1,
+    ]);
+    $variation->save();
+
+    $order = Order::create([
+      'type' => 'default',
+      'store_id' => $store->id(),
+      'state' => 'completed',
+      'uid' => $this->customer->id(),
+      'mail' => 'inspector@example.test',
+      'placed' => time(),
+    ]);
+    $order->save();
+
+    $item = OrderItem::create([
+      'type' => 'default',
+      'purchased_entity' => $variation,
+      'quantity' => 2,
+      'unit_price' => new Price('25.00', 'AUD'),
+      'order_id' => $order->id(),
+    ]);
+    $item->save();
+    $order->addItem($item);
+    $order->save();
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testCanonicalIssuanceValid(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('valid', $diag['issuance']['quantity_alignment_status']);
+    $this->assertSame(2, $diag['issuance']['expected_quantity']);
+    $this->assertSame(2, $diag['issuance']['issued_ticket_count']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testDuplicateIssuancePreventionObservable(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $this->issuer()->issueForOrder($order);
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertTrue($diag['issuance']['idempotent_replay_would_skip']);
+    $this->assertSame(2, $diag['issuance']['issued_ticket_count']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testOrphanTicketDetection(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertNotEmpty($tickets);
+    $tickets[0]->set('order_item_id', NULL);
+    $tickets[0]->save();
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertGreaterThanOrEqual(1, $diag['issuance']['orphan_ticket_count']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testOrphanEligibleOrderItemDetection(): void {
+    $order = $this->loadOrder();
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame(2, $diag['issuance']['expected_quantity']);
+    $this->assertSame(0, $diag['issuance']['issued_ticket_count']);
+    $this->assertGreaterThanOrEqual(1, $diag['issuance']['orphan_eligible_order_item_count']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testCanonicalArtifactDetection(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    foreach ($this->loadTicketsForOrder((int) $order->id()) as $ticket) {
+      $ticket->set('holder_name', 'Pat');
+      $ticket->set('holder_email', 'pat@example.test');
+      $ticket->save();
+    }
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('valid', $diag['artifacts']['canonical_pdf_readiness']);
+    $this->assertSame('valid', $diag['artifacts']['attachment_continuity']);
+    $this->assertSame('valid', $diag['artifacts']['qr_payload_operational']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testWalletContinuityDetection(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('valid', $diag['artifacts']['wallet_route_scaffold']);
+    $this->assertSame('canonical', $diag['compatibility']['wallet_resolution_surface']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testLegacyCompatibilitySurface(): void {
+    $order = $this->loadOrder();
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('legacy', $diag['compatibility']['order_item_pdf_surface']);
+    $this->assertSame('legacy', $diag['compatibility']['wallet_resolution_surface']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testMixedCompatibilityDetection(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $tickets[0]->set('holder_name', 'A');
+    $tickets[0]->set('holder_email', 'a@example.test');
+    $tickets[0]->save();
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('mixed', $diag['artifacts']['canonical_pdf_readiness']);
+    $this->assertSame('mixed', $diag['artifacts']['attachment_continuity']);
+    $this->assertContains($diag['compatibility']['ticket_pdf_operational_path'], ['canonical', 'mixed']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testGuestContinuityValid(): void {
+    $order = $this->loadOrder();
+    $order->setCustomerId(0);
+    $order->save();
+    $this->issuer()->issueForOrder($order);
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertTrue($diag['guest_continuity']['guest_access_compatible']);
+    $this->assertTrue($diag['guest_continuity']['entitlement_ownership_valid']);
+    $this->assertSame('valid', $diag['guest_continuity']['continuity_status']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testGuestContinuityInvalid(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $tickets[0]->set('purchaser_uid', 0);
+    $tickets[0]->save();
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertFalse($diag['guest_continuity']['entitlement_ownership_valid']);
+    $this->assertSame('invalid', $diag['guest_continuity']['continuity_status']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testRecoveryVisibility(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $key = OrderPaidConfirmationPdfRecoverySubscriber::recoveryStateKey((int) $order->id());
+    $this->container->get('state')->set($key, time());
+    $diag = $this->inspector()->inspectOrder($order);
+    $this->assertSame('recovered', $diag['recovery']['completion_state']);
+    $this->assertTrue($diag['recovery']['recovery_completed_recorded']);
+    $this->assertFalse($diag['recovery']['recovery_mismatch']);
+  }
+
+  /**
+   * @covers ::inspectOrder
+   */
+  public function testRecoveryMismatchWithStubSink(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    foreach ($tickets as $ticket) {
+      $ticket->set('created', 5000000);
+      $ticket->save();
+    }
+    $sent = new \stdClass();
+    $sent->sent = 1000;
+    $stub = new class([$sent]) {
+      /**
+       * @param object[] $rows
+       */
+      public function __construct(private readonly array $rows) {}
+      /**
+       * @return object[]
+       */
+      public function findSentOrderConfirmationsForOrder(int $orderId, string $recipient): array {
+        return $this->rows;
+      }
+    };
+    $inspector = $this->buildInspectorWithMessageSink($stub);
+    $diag = $inspector->inspectOrder($order);
+    $this->assertTrue($diag['recovery']['recovery_mismatch']);
+    $this->assertSame('pending', $diag['recovery']['recovery_requirement_signal']);
+  }
+
+  private function issuer(): TicketIssuer {
+    return $this->container->get('myeventlane_tickets.ticket_issuer');
+  }
+
+  private function inspector(): OperationalIntegrityInspector {
+    return $this->container->get('myeventlane_tickets.operational_integrity_inspector');
+  }
+
+  private function buildInspectorWithMessageSink(object $sink): OperationalIntegrityInspector {
+    return new OperationalIntegrityInspector(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('myeventlane_tickets.ticket_issuer'),
+      $this->container->get('myeventlane_tickets.universal_ticket_view_model_builder'),
+      $this->container->get('myeventlane_tickets.ticket_pdf_generator'),
+      $this->container->get('myeventlane_tickets.ticket_qr_payload'),
+      $this->container->get('mel_ticket_capability.manager'),
+      $this->container->get('state'),
+      $this->container->get('logger.channel.myeventlane_tickets'),
+      $this->container->get('myeventlane_wallet.ticket_resolver'),
+      $sink,
+    );
+  }
+
+  private function loadOrder(): Order {
+    $storage = $this->container->get('entity_type.manager')->getStorage('commerce_order');
+    $ids = $storage->getQuery()->accessCheck(FALSE)->sort('order_id')->execute();
+    $this->assertNotEmpty($ids);
+    $order = $storage->load(reset($ids));
+    $this->assertInstanceOf(Order::class, $order);
+    return $order;
+  }
+
+  /**
+   * @return array<int, \Drupal\myeventlane_tickets\Entity\Ticket>
+   */
+  private function loadTicketsForOrder(int $order_id): array {
+    $storage = $this->container->get('entity_type.manager')->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_id', $order_id)
+      ->sort('id')
+      ->execute();
+    if (!$ids) {
+      return [];
+    }
+    $loaded = $storage->loadMultiple($ids);
+    return array_values($loaded);
+  }
+
+  /**
+   * @return array<string, array{type: string, settings: array<string, mixed>}>
+   */
+  private function eventFieldDefinitions(): array {
+    return [
+      'field_event_start' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_event_end' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_venue_name' => [
+        'type' => 'string',
+        'settings' => ['max_length' => 255],
+      ],
+      'field_event_vendor' => [
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'user'],
+      ],
+    ];
+  }
+
+  private function createEventFields(): void {
+    foreach ($this->eventFieldDefinitions() as $field_name => $definition) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'type' => $definition['type'],
+        'settings' => $definition['settings'],
+      ])->save();
+
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'bundle' => 'event',
+        'label' => $field_name,
+      ])->save();
+    }
+  }
+
+  private function ensureProductEventField(): void {
+    if (FieldStorageConfig::loadByName('commerce_product', 'field_event')) {
+      return;
+    }
+    FieldStorageConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'bundle' => 'default',
+      'label' => 'Event',
+    ])->save();
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new read-only diagnostics service that inspects ticket issuance/artifact/recovery state and emits warning logs, which could affect operational logging/noise and is easy to accidentally call on hot paths. Also introduces new public helper methods on core ticket/messaging services that may be depended on by other modules.
> 
> **Overview**
> Adds **Phase 2D operational observability** via a new `OperationalIntegrityInspector` service (registered as `myeventlane_tickets.operational_integrity_inspector`) that inspects a paid order for issuance alignment, artifact readiness (PDF holder preconditions, QR operability, wallet scaffold), recovery completion/mismatch, compatibility surface signals, and guest/purchaser continuity, and logs warnings for anomalies.
> 
> Exposes supporting read-only helpers: `TicketIssuer::countExpectedIssuanceUnits()` / `isOrderItemEligibleForTicketIssuance()`, `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()`, and a stable `OrderPaidConfirmationPdfRecoverySubscriber::recoveryStateKey()` used by both the subscriber and inspector.
> 
> Adds kernel coverage in `OperationalIntegrityInspectorTest` and new documentation in `docs/operational-observability.md` plus updates to existing issuance/convergence docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4577d88650fabc06ae4a08c17d26d1a5ec2bca8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->