### PR TITLE
Cursor/error review updates 12833

### DIFF
--- a/docs/entitlement-capability-convergence.md
+++ b/docs/entitlement-capability-convergence.md
@@ -16,7 +16,7 @@ It does **not** load entities for policy (callers pass normalized entitlement ty
 
 ## Delegation rules
 
-- **Delegate inward:** `TicketCapabilityManager`, `ScannerOperationManager`, `UniversalTicketViewModelBuilder`, `OperationalIntegrityInspector`, **`VenueOperationPolicyManager`**, wallet scaffolds, and PDF preprocessors **consume** registry output for entitlement-type policy. Venue gate descriptors, offline scaffolding metadata, and staff-side replay fingerprints are authored in **`VenueOperationPolicyManager`** and must not be duplicated in scanners, PDFs, or wallets.
+- **Delegate inward:** `TicketCapabilityManager`, `ScannerOperationManager`, `UniversalTicketViewModelBuilder`, `OperationalIntegrityInspector`, **`VenueOperationPolicyManager`** (which composes **`TimedEntryPolicyManager`** for operational clock policy), wallet scaffolds, and PDF preprocessors **consume** registry output for entitlement-type policy. Venue gate descriptors, offline scaffolding metadata, and staff-side replay fingerprints are authored in **`VenueOperationPolicyManager`**; entry windows and scanner timing states are authored in **`TimedEntryPolicyManager`** and must not be duplicated in scanners, PDFs, or wallets.
 - **Registry isolation:** the registry **must never** call scanners, PDF generators, wallet builders, view models, or mail paths.
 - **Entity authority unchanged:** `myeventlane_ticket` rows remain the entitlement authority for codes, limits, counts, status, and fulfilment fields. The registry describes **policy by entitlement type**, not per-row commerce configuration.
 
@@ -33,12 +33,12 @@ Scanner routing uses **`scanner_mode`**, which matches **`RedemptionLog`** actio
 | **Universal view model** | Adds `capabilities` (full map) and `fulfilment.mode` (registry `fulfilment_mode`). |
 | **PDF template builder** | Exposes `capabilities` alongside `view_model` for Twig. |
 | **Apple wallet scaffold** | JSON scaffold includes `capabilities` from the view model (QR payload contract unchanged). |
-| **Operational observability** | `artifacts.entitlement_capability_policy` lists deduplicated capability summaries per normalized entitlement type observed on the order; `artifacts.venue_operation_policy` lists deduplicated venue gate semantics and descriptors from **`VenueOperationPolicyManager`**. |
+| **Operational observability** | `artifacts.entitlement_capability_policy` lists deduplicated capability summaries per normalized entitlement type observed on the order; `artifacts.venue_operation_policy` lists deduplicated venue gate semantics and descriptors from **`VenueOperationPolicyManager`**; `artifacts.timed_entry_policy` lists per-ticket timing diagnostics from **`TimedEntryPolicyManager`**. |
 
 ## Anti-patterns (forbidden)
 
 - Entitlement `switch` / large `match` tables on entitlement type **outside** `EntitlementCapabilityRegistry` for operational policy (UI label `match` for human-readable copy in presenters is not policy).
-- Scanner-specific, wallet-specific, or PDF-specific **duplicated** interpretations of redeemability, multi-use, scanner action routing, **or venue gate / replay policy** (use `VenueOperationPolicyManager` for execution metadata).
+- Scanner-specific, wallet-specific, or PDF-specific **duplicated** interpretations of redeemability, multi-use, scanner action routing, **venue gate / replay policy**, or **operational timing windows** (use `VenueOperationPolicyManager` for execution metadata; use `TimedEntryPolicyManager` for clock policy).
 - Duplicate parallel capability arrays or entitlement-to-action maps outside the registry.
 - UI strings, translated labels, or marketing copy inside **`EntitlementCapabilityRegistry`** (machine tokens only).
 - Weakening redemption, fulfilment, or access checks by bypassing **`TicketCapabilityManager`** / scanner paths that already enforce entity state.
@@ -48,3 +48,5 @@ Scanner routing uses **`scanner_mode`**, which matches **`RedemptionLog`** actio
 - [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
 - [operational-surface-convergence.md](./operational-surface-convergence.md) — customer, PDF, and wallet surfaces
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue operations layer and replay scaffolding
+- [timed-entry-capacity-convergence.md](./timed-entry-capacity-convergence.md) — timed entry and capacity window authority
+

--- a/docs/issuance-pipeline.md
+++ b/docs/issuance-pipeline.md
@@ -73,7 +73,11 @@ A vestigial **`OrderPaidSubscriber`** under **`myeventlane_commerce`** (logging 
 
 ## Operational observability (Phase 2D)
 
-Read-only integrity diagnostics for paid orders are centralized in **`OperationalIntegrityInspector`** (`myeventlane_tickets.operational_integrity_inspector`). It inspects issuance alignment, artifact readiness, recovery markers, compatibility surfaces, and guest/purchaser continuity **without** generating PDFs, wallet artifacts, or QR output for persistence. See [operational-observability.md](./operational-observability.md).
+Read-only integrity diagnostics for paid orders are centralized in **`OperationalIntegrityInspector`** (`myeventlane_tickets.operational_integrity_inspector`). It inspects issuance alignment, artifact readiness, recovery markers, compatibility surfaces, guest/purchaser continuity, venue gate descriptors, and **timed entry diagnostics** (`artifacts.timed_entry_policy`) **without** generating PDFs, wallet artifacts, or QR output for persistence. See [operational-observability.md](./operational-observability.md) and [timed-entry-capacity-convergence.md](./timed-entry-capacity-convergence.md).
+
+## Timed entry and capacity windows (operational clock policy)
+
+Operational clock semantics (entry windows, grace, early/late states, session/capacity metadata) are centralized in **`TimedEntryPolicyManager`** (`myeventlane_tickets.timed_entry_policy_manager`). **`VenueOperationPolicyManager`** composes timed policy into descriptors and scan gates; **`ScannerOperationManager`** enforces the gate before mutations. QR payload contracts remain unchanged; structured QR `exp` continues to cap interpretation through the policy layer. Details: [timed-entry-capacity-convergence.md](./timed-entry-capacity-convergence.md).
 
 ## Entitlement capability convergence (Phase 2E)
 
@@ -85,7 +89,7 @@ Operational semantics for the seven ticket-backed entitlement types (admission, 
 
 ## Tests
 
-Kernel coverage: **`IssuancePipelineConvergenceTest`** (`myeventlane_tickets`), **`OperationalIntegrityInspectorTest`** (read-only diagnostics).
+Kernel coverage: **`IssuancePipelineConvergenceTest`** (`myeventlane_tickets`), **`OperationalIntegrityInspectorTest`** (read-only diagnostics), **`TimedEntryPolicyManagerTest`** (timing policy), and the existing **`VenueOperationPolicyManagerTest`**, **`TicketCheckinServiceTest`**, and **`UniversalTicketViewModelBuilderTest`** slices that cover scanner and view-model wiring.
 
 - Issuance creates one ticket entity per unit quantity.
 - **Regression:** calling **`issueForOrder()`** twice on the same order does **not** create additional ticket rows.

--- a/docs/offline-venue-operations-convergence.md
+++ b/docs/offline-venue-operations-convergence.md
@@ -11,16 +11,18 @@ This phase introduces a **single venue operation policy layer** for ticket-backe
 | Entitlement type policy (immutable maps) | `myeventlane_tickets.entitlement_capability_registry` | `EntitlementCapabilityRegistry` |
 | Entity-aware scan / expiry / redemption composition | `mel_ticket_capability.manager` | `TicketCapabilityManager` |
 | Venue gate policy, offline scaffolding metadata, replay fingerprints | `myeventlane_tickets.venue_operation_policy_manager` | `VenueOperationPolicyManager` |
+| Operational timing (entry windows, grace, session/capacity semantics) | `myeventlane_tickets.timed_entry_policy_manager` | `TimedEntryPolicyManager` |
 | Scanner orchestration (QR parse, mutations, audit) | `mel_scanner.operation_manager` | `ScannerOperationManager` |
 | Staff/API entry point | `myeventlane_tickets.ticket_checkin_service` | `TicketCheckinService` |
 
-`ScannerOperationManager` remains the **only** scanner orchestration implementation. It **must** route gate actions through `EntitlementCapabilityRegistry` and enrich `mel_redemption_log.metadata_json` using `VenueOperationPolicyManager` (nested key `venue_operation_integrity`).
+`ScannerOperationManager` remains the **only** scanner orchestration implementation. It **must** route gate actions through `EntitlementCapabilityRegistry`, apply **timed entry** decisions through **`VenueOperationPolicyManager`** (which delegates to **`TimedEntryPolicyManager`**), and enrich `mel_redemption_log.metadata_json` using `VenueOperationPolicyManager` (nested key `venue_operation_integrity`).
 
 ## Operational action authority
 
 - **Entitlement truth** lives on `myeventlane_ticket` entities (codes, limits, counts, status, fulfilment fields).
 - **Type-level policy** (scanner mode, multi-use semantics, fulfilment flags) comes from `EntitlementCapabilityRegistry`.
 - **Venue execution policy** (offline eligibility scaffold, conflict policy labels, deterministic operation envelopes) comes from `VenueOperationPolicyManager`.
+- **Operational timing policy** (entry windows, grace, late/early semantics, session/capacity window metadata, scanner timing state) comes from `TimedEntryPolicyManager`, composed by `VenueOperationPolicyManager` and enforced on the scan path before mutations.
 
 QR payload contracts, ticket codes, public scanner JSON shapes, and routes are **unchanged**.
 
@@ -54,11 +56,12 @@ This phase adds **non-authoritative scaffolding**:
 
 ## Observability
 
-`OperationalIntegrityInspector::inspectOrder()` adds `artifacts.venue_operation_policy`, keyed by normalized entitlement type, with machine-only gate semantics, descriptors, offline eligibility flags, replay state summaries, and conflict policy tokens. The inspector remains **read-only**.
+`OperationalIntegrityInspector::inspectOrder()` adds `artifacts.venue_operation_policy`, keyed by normalized entitlement type, with machine-only gate semantics, descriptors, offline eligibility flags, replay state summaries, and conflict policy tokens. It also adds **`artifacts.timed_entry_policy`** (per ticket id: policy snapshot + timing conflict codes from `TimedEntryPolicyManager`). The inspector remains **read-only**.
 
 ## Anti-patterns (forbidden)
 
 - Scanner-specific entitlement `switch` / parallel action maps outside `EntitlementCapabilityRegistry` and `VenueOperationPolicyManager`
+- Parallel timing / entry-window logic outside `TimedEntryPolicyManager` (scanners must not own clock policy)
 - Entitlement logic that bypasses `EntitlementCapabilityRegistry` for operational policy
 - A second replay-detection implementation that contradicts persisted ticket state checks
 - Offline-only entitlement rules that are not also enforced on the online scanner path
@@ -69,4 +72,5 @@ This phase adds **non-authoritative scaffolding**:
 
 - [entitlement-capability-convergence.md](./entitlement-capability-convergence.md)
 - [operational-observability.md](./operational-observability.md)
+- [timed-entry-capacity-convergence.md](./timed-entry-capacity-convergence.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)

--- a/docs/operational-observability.md
+++ b/docs/operational-observability.md
@@ -9,13 +9,14 @@ This service is the **single read-only diagnostics layer** for:
 - issuance visibility (counts, alignment, orphan links, idempotent guard signals)
 - artifact readiness (canonical PDF preconditions, wallet route scaffolds, QR payload operability, attachment continuity)
 - **venue operation policy** (`artifacts.venue_operation_policy` — gate semantics, offline eligibility scaffold, replay/conflict summaries from `VenueOperationPolicyManager`, keyed by normalized entitlement type)
+- **timed entry policy** (`artifacts.timed_entry_policy` — per-ticket timing snapshots and conflict codes from `TimedEntryPolicyManager`, read-only)
 - recovery visibility (state marker, late-tickets-after-confirmation heuristic, mismatch flags)
 - compatibility signals (canonical vs legacy surfaces, mixed paths)
 - guest and purchaser continuity checks on stored entities (no live session required)
 
 It **observes** existing operational state only. It does not issue tickets, generate PDFs or wallet bytes, alter recovery state, enqueue work, or expose signing secrets.
 
-**Services consulted (read-only):** `TicketIssuer` (expected counts and line eligibility), `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()` (same rules as `getPdfContentForTicket()` without rendering bytes), `UniversalTicketViewModelBuilder::build()` (structural operability, no model payload emitted), `TicketQrPayload::buildForTicket()` (operability only; output not returned), `TicketCapabilityManager::getEntitlementType()`, **`EntitlementCapabilityRegistry`** (machine-safe capability summaries in `artifacts.entitlement_capability_policy`), **`VenueOperationPolicyManager`** (machine-safe venue gate descriptors and replay/conflict scaffolding surfaced under `artifacts.venue_operation_policy`), optional `WalletTicketResolver`, optional message sink with `findSentOrderConfirmationsForOrder()` (same shape as `MessageStorage`). Attachment continuity follows **`OrderConfirmationAttachmentResolver`** merge preconditions (holder fields per ticket) without invoking merge.
+**Services consulted (read-only):** `TicketIssuer` (expected counts and line eligibility), `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()` (same rules as `getPdfContentForTicket()` without rendering bytes), `UniversalTicketViewModelBuilder::build()` (structural operability, no model payload emitted), `TicketQrPayload::buildForTicket()` (operability only; output not returned), `TicketCapabilityManager::getEntitlementType()`, **`EntitlementCapabilityRegistry`** (machine-safe capability summaries in `artifacts.entitlement_capability_policy`), **`VenueOperationPolicyManager`** (machine-safe venue gate descriptors and replay/conflict scaffolding surfaced under `artifacts.venue_operation_policy`), **`TimedEntryPolicyManager`** (timing snapshots and conflict lists under `artifacts.timed_entry_policy`), optional `WalletTicketResolver`, optional message sink with `findSentOrderConfirmationsForOrder()` (same shape as `MessageStorage`). Attachment continuity follows **`OrderConfirmationAttachmentResolver`** merge preconditions (holder fields per ticket) without invoking merge.
 
 ## Read-only guarantees
 
@@ -31,7 +32,7 @@ Normalized `inspectOrder(OrderInterface $order)` returns:
 | Key | Role |
 | --- | --- |
 | `issuance` | Expected vs issued counts, alignment status, idempotent replay skip signal, partial-issuance guard anomaly, orphan ticket / orphan eligible order item counts |
-| `artifacts` | Canonical PDF readiness (holder preconditions via `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()`), wallet route scaffold (order item link present), QR operability (`TicketQrPayload`), attachment continuity (holder coverage for merge rules), **`entitlement_capability_policy`** (deduplicated registry summaries per normalized entitlement type), **`venue_operation_policy`** (deduplicated venue gate semantics + descriptors from `VenueOperationPolicyManager`) |
+| `artifacts` | Canonical PDF readiness (holder preconditions via `TicketPdfGenerator::canonicalPdfPreconditionsSatisfied()`), wallet route scaffold (order item link present), QR operability (`TicketQrPayload`), attachment continuity (holder coverage for merge rules), **`entitlement_capability_policy`** (deduplicated registry summaries per normalized entitlement type), **`venue_operation_policy`** (deduplicated venue gate semantics + descriptors from `VenueOperationPolicyManager`), **`timed_entry_policy`** (per issued ticket id: `TimedEntryPolicyManager::evaluate()` snapshot plus `detectTimingConflicts()` codes) |
 | `recovery` | `OrderPaidConfirmationPdfRecoverySubscriber` state key via `recoveryStateKey()`, optional message sink for sent confirmation timestamps, mismatch when recovery appears required but completion state missing |
 | `compatibility` | Order-item PDF legacy surface availability, wallet resolution surface (`WalletTicketResolver`), ticket PDF path from `UniversalTicketViewModelBuilder` probe |
 | `guest_continuity` | Purchaser UID alignment with order customer, guest checkout pattern checks (no PII in output) |
@@ -64,7 +65,7 @@ Callers must avoid invoking diagnostics on hot per-request paths to prevent nois
 ## Anti-patterns (forbidden)
 
 - Using diagnostics to **issue tickets**, **generate PDFs**, **build wallet passes**, or **mutate recovery state**
-- Duplicating QR signing, payload shaping, entitlement normalization, **capability policy**, or **venue gate / replay scaffolding** outside **`TicketQrPayload`**, **`UniversalTicketViewModelBuilder`**, **`TicketCapabilityManager`**, **`TicketIssuer`**, **`EntitlementCapabilityRegistry`**, and **`VenueOperationPolicyManager`** (use the registry for immutable type maps; use the venue policy manager for gate execution metadata and staff-side integrity envelopes)
+- Duplicating QR signing, payload shaping, entitlement normalization, **capability policy**, **venue gate / replay scaffolding**, or **operational timing windows** outside **`TicketQrPayload`**, **`UniversalTicketViewModelBuilder`**, **`TicketCapabilityManager`**, **`TicketIssuer`**, **`EntitlementCapabilityRegistry`**, **`TimedEntryPolicyManager`**, and **`VenueOperationPolicyManager`** (use the registry for immutable type maps; use the venue policy manager for gate execution metadata and staff-side integrity envelopes; use the timed entry manager for clock policy)
 - Treating compatibility adapters (`OrderItemPdfCompatibilityAdapter`, etc.) as operational authorities for entitlement truth
 - Embedding UI strings, translated labels, or marketing copy inside diagnostics payloads
 - Exposing purchaser email, entitlement secrets, raw HMAC material, or full QR payload strings through diagnostics APIs
@@ -74,5 +75,6 @@ Callers must avoid invoking diagnostics on hot per-request paths to prevent nois
 
 - [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue gate policy, offline scaffolding, replay metadata
-- [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — capability registry and scanner delegation
+- [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — capability registry delegation
+- [timed-entry-capacity-convergence.md](./timed-entry-capacity-convergence.md) — operational timing authority and scanner convergence
 - [operational-surface-convergence.md](./operational-surface-convergence.md) — wallet and PDF convergence context

--- a/docs/timed-entry-capacity-convergence.md
+++ b/docs/timed-entry-capacity-convergence.md
@@ -1,0 +1,118 @@
+# Timed entry and capacity window convergence (Phase 2E)
+
+## Scope
+
+This phase adds **one canonical operational timing policy layer** for ticket-backed entitlements. It does **not** change QR signing contracts, ticket codes, wallet routes, PDF issuance authority, Commerce inventory, waitlists, or scanner JSON field names.
+
+## Canonical service
+
+| Responsibility | Service ID | Class |
+| --- | --- | --- |
+| Operational timing (entry windows, grace, session/capacity metadata, scanner timing state) | `myeventlane_tickets.timed_entry_policy_manager` | `TimedEntryPolicyManager` |
+
+## Policy flow (mandatory)
+
+Interpretation order for scanner timing:
+
+1. **`TimedEntryPolicyManager::evaluate()`** — sole authority for machine timing policy (no translated strings, no UI labels).
+2. **`VenueOperationPolicyManager`** — composes venue descriptors, scan gate resolution (`evaluateTimedEntryForScan()`), and staff integrity envelopes; delegates timing to `TimedEntryPolicyManager`.
+3. **`ScannerOperationManager`** — applies gate decisions from `VenueOperationPolicyManager` before operational mutation paths; does not implement parallel window rules.
+
+## Normalized policy shape
+
+`TimedEntryPolicyManager::evaluate()` returns:
+
+```php
+[
+  'entry_window' => [
+    'opens_at' => int|null,
+    'closes_at' => int|null,
+    'grace_seconds' => int,
+    'late_entry_allowed' => bool,
+    'early_entry_allowed' => bool,
+  ],
+  'session' => [
+    'session_key' => string|null,
+    'capacity_window' => string|null,
+  ],
+  'scanner' => [
+    'allowed_now' => bool,
+    'state' => 'allowed|early|late|expired|not_started',
+    'reason' => string, // machine token only
+  ],
+]
+```
+
+## Timing sources (no new entities)
+
+The policy manager may derive bounds from, in order of composition:
+
+- explicit Unix bounds in ticket `metadata_json` (see keys below)
+- ticket `collect_window` (daterange) for operational windows (for example parking, pickup, staggered sessions)
+- optional offsets from linked event `field_event_start` / `field_event_end` when metadata provides `entry_open_offset_seconds` / `entry_close_offset_seconds`
+- ticket `expires_at` and optional structured QR `exp` (passed into `evaluate()` as `parsed_qr_expires_at`) as **upper caps** on closing — QR contracts are unchanged; caps are interpretive only
+
+When no window sources exist, **`scanner.state` = `allowed`** with reason **`legacy_unrestricted`** (preserves pre-phase behaviour for typical admission rows).
+
+### Metadata keys (`metadata_json`)
+
+Supported containers (first match wins):
+
+- `mel_operational_timing` (preferred)
+- `operational_timing` (alias)
+
+Supported fields inside the container:
+
+| Field | Type | Role |
+| --- | --- | --- |
+| `entry_opens_at` | int (Unix) | Nominal entry open |
+| `entry_closes_at` | int (Unix) | Nominal entry close |
+| `entry_open_offset_seconds` | int | Added to event start (when event start present) |
+| `entry_close_offset_seconds` | int | Added to event end (or start if end missing) |
+| `grace_seconds` | int | Extends close when `late_entry_allowed` is true |
+| `late_entry_allowed` | bool | Default true when omitted |
+| `early_entry_allowed` | bool | Default false when omitted |
+| `session_key` | string | Workshop / session identifier (operational only) |
+| `capacity_window` | string | Capacity slot label (operational only) |
+
+Multiple sources combine using **strict intersection**: latest `opens_at` wins among defined opens; earliest `closes_at` wins among defined closes.
+
+## Scanner API compatibility
+
+Denied timing uses existing result tokens only:
+
+- **`expired`** when policy state is `expired` (including post-window and hard caps from ticket or QR expiry interpretation)
+- **`invalid`** when policy state is `not_started` (before nominal open without early allowance)
+
+Messages remain staff/scanner-facing English strings consistent with existing scanner responses; policy output itself stays machine-only.
+
+## Observability
+
+`OperationalIntegrityInspector::inspectOrder()` includes **`artifacts.timed_entry_policy`**, keyed by ticket id, with:
+
+- full `policy` array from `TimedEntryPolicyManager::evaluate()` at inspection time
+- `conflicts` from `TimedEntryPolicyManager::detectTimingConflicts()` (machine codes only)
+
+Read-only guarantees from [operational-observability.md](./operational-observability.md) still apply.
+
+## View model
+
+`UniversalTicketViewModelBuilder::build()` adds:
+
+- top-level **`timed_entry`** — same normalized policy array
+- **`scanner.timing_state`** and **`scanner.timing_allowed_now`** — timing semantics without altering existing `qr.payload` or wallet/PDF action contracts
+
+## Anti-patterns (forbidden)
+
+- Scanner-local timing rules, PDF-only windows, or wallet-only windows
+- UI-owned timing authority or translated strings inside `TimedEntryPolicyManager`
+- Duplicate grace-period or entry-window logic outside `TimedEntryPolicyManager`
+- Direct wall-clock comparisons on scanner paths that bypass `VenueOperationPolicyManager` / `TimedEntryPolicyManager`
+- Mutating ticket issuance or weakening replay protections to satisfy timing
+
+## Related documentation
+
+- [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue gate layer and scanner orchestration
+- [operational-observability.md](./operational-observability.md) — diagnostics domains
+- [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — registry delegation
+- [issuance-pipeline.md](./issuance-pipeline.md) — issuance and observability references

--- a/web/modules/custom/myeventlane_tickets/src/Service/ScannerOperationManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/ScannerOperationManager.php
@@ -107,13 +107,6 @@ final class ScannerOperationManager {
       return $result;
     }
 
-    if (isset($parsed['expires_at']) && (int) $parsed['expires_at'] <= $this->time->getCurrentTime()) {
-      $result = $this->result(FALSE, 'expired', 'Entitlement has expired.', (string) $ticket->get('ticket_code')->value);
-      $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
-      return $result;
-    }
-
     $status = (string) $ticket->get('status')->value;
     if ($status === Ticket::STATUS_VOID) {
       $result = $this->result(FALSE, 'void', 'Ticket is void and cannot be scanned.', (string) $ticket->get('ticket_code')->value);
@@ -134,6 +127,27 @@ final class ScannerOperationManager {
       $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
+
+    $parsed_qr_expires_at = isset($parsed['expires_at']) ? (int) $parsed['expires_at'] : NULL;
+    $timed_gate = $this->venueOperationPolicyManager->evaluateTimedEntryForScan(
+      $ticket,
+      $this->time->getCurrentTime(),
+      $parsed_qr_expires_at > 0 ? $parsed_qr_expires_at : NULL,
+    );
+    if (!$timed_gate['allow']) {
+      $result = $this->result(
+        FALSE,
+        (string) $timed_gate['result_token'],
+        (string) $timed_gate['message'],
+        (string) $ticket->get('ticket_code')->value,
+        0,
+        (int) $ticket->id(),
+      );
+      $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
+      return $result;
+    }
+
     if (!$this->capabilityManager->canBeScanned($ticket)) {
       $result_token = $this->capabilityManager->isExpired($ticket) ? 'expired' : 'redemption_limit_reached';
       $message = $result_token === 'expired' ? 'Entitlement has expired.' : 'Redemption limit has already been reached.';

--- a/web/modules/custom/myeventlane_tickets/src/Service/ScannerOperationManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/ScannerOperationManager.php
@@ -103,14 +103,14 @@ final class ScannerOperationManager {
     if ($ticket_event_id !== $route_event_id) {
       $result = $this->result(FALSE, 'wrong_event', 'Ticket is not valid for this event.', (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
 
     if (isset($parsed['expires_at']) && (int) $parsed['expires_at'] <= $this->time->getCurrentTime()) {
       $result = $this->result(FALSE, 'expired', 'Entitlement has expired.', (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
 
@@ -118,20 +118,20 @@ final class ScannerOperationManager {
     if ($status === Ticket::STATUS_VOID) {
       $result = $this->result(FALSE, 'void', 'Ticket is void and cannot be scanned.', (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
     if ($status === Ticket::STATUS_REFUNDED) {
       $result = $this->result(FALSE, 'refunded', 'Ticket was refunded and cannot be scanned.', (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
     if ($this->entitlementCapabilityRegistry->isAdmissionEntitlementType($this->capabilityManager->getEntitlementType($ticket)) && $status === Ticket::STATUS_CHECKED_IN) {
       $checked_in_at = $ticket->hasField('checked_in_at') ? (int) $ticket->get('checked_in_at')->value : 0;
       $result = $this->result(FALSE, 'already_checked_in', 'Ticket is already checked in.', (string) $ticket->get('ticket_code')->value, $checked_in_at, (int) $ticket->id());
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
     if (!$this->capabilityManager->canBeScanned($ticket)) {
@@ -139,7 +139,7 @@ final class ScannerOperationManager {
       $message = $result_token === 'expired' ? 'Entitlement has expired.' : 'Redemption limit has already been reached.';
       $result = $this->result(FALSE, $result_token, $message, (string) $ticket->get('ticket_code')->value, 0, (int) $ticket->id());
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, NULL, NULL, $mode);
+      $this->logRedemptionAudit($ticket, $this->resolveAction($ticket), $device_id, FALSE, $result['result'], $result['message'], $payload_sha256);
       return $result;
     }
 
@@ -178,7 +178,7 @@ final class ScannerOperationManager {
       $message = self::SUCCESS_MESSAGE_BY_ACTION[$action] ?? 'Scanned.';
       $result = $this->result(TRUE, $result_token, $message, (string) $ticket->get('ticket_code')->value, $now, (int) $ticket->id());
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $action, $device_id, TRUE, $result['result'], $result['message'], $payload_sha256, $redemption_before, $redemption_after, $mode);
+      $this->logRedemptionAudit($ticket, $action, $device_id, TRUE, $result['result'], $result['message'], $payload_sha256, $redemption_before, $redemption_after);
       return $result;
     }
     catch (\Throwable $e) {
@@ -190,7 +190,7 @@ final class ScannerOperationManager {
       ]);
       $result = $this->result(FALSE, 'error', "Scan couldn't be completed. Try again or use manual review.", (string) $ticket->get('ticket_code')->value);
       $this->checkinLogger->logResult($route_event_id, $ticket, $device_id, $mode, $result['result'], $result['message'], $normalized_input);
-      $this->logRedemptionAudit($ticket, $action, $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, $redemption_before, $redemption_before, $mode);
+      $this->logRedemptionAudit($ticket, $action, $device_id, FALSE, $result['result'], $result['message'], $payload_sha256, $redemption_before, $redemption_before);
       return $result;
     }
   }
@@ -215,9 +215,6 @@ final class ScannerOperationManager {
 
   /**
    * Logs one append-only redemption audit row.
-   *
-   * @param string $mode
-   *   Scan transport context forwarded to venue integrity metadata.
    */
   private function logRedemptionAudit(
     Ticket $ticket,
@@ -229,7 +226,6 @@ final class ScannerOperationManager {
     string $payload_sha256,
     ?int $redemption_count_before = NULL,
     ?int $redemption_count_after = NULL,
-    string $mode = 'online',
   ): void {
     if (!$this->entityTypeManager->hasDefinition('mel_redemption_log')) {
       return;
@@ -254,7 +250,6 @@ final class ScannerOperationManager {
         $before,
         $after,
         $payload_sha256,
-        $mode,
       );
       $values = [
         'ticket_id' => (int) $ticket->id(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new timed-entry gating step to the scanner check-in path, which can change when scans are accepted/denied and therefore impacts event entry operations. Also alters redemption-audit logging parameters, which could affect downstream observability/metadata consumers.
> 
> **Overview**
> Introduces **timed entry / capacity window policy** as a first-class operational concept, including a new `docs/timed-entry-capacity-convergence.md` and updates across existing convergence/observability docs to reference `TimedEntryPolicyManager` and the new `artifacts.timed_entry_policy` diagnostics surface.
> 
> Updates `ScannerOperationManager::process()` to enforce a **timed-entry scan gate** via `VenueOperationPolicyManager::evaluateTimedEntryForScan()` (using parsed QR `expires_at` as an upper cap), returning existing scanner result tokens (`expired`/`invalid`) when outside the allowed window.
> 
> Simplifies redemption audit logging by removing the forwarded scan `mode` parameter from `logRedemptionAudit()`/`buildIntegrityEnvelope()` call sites (audit rows still include the integrity envelope but no longer receive transport context from `ScannerOperationManager`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af9c81a73323f2f8a292a860326068c804862a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->