### PR TITLE
Cursor/govern escalations 3d116

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -2053,6 +2053,52 @@
     host.innerHTML = chips.join('');
   }
 
+  /**
+   * Finds the anchor for an uploaded image inside Drupal managed_file markup.
+   *
+   * @param {Element|null} root
+   * @return {HTMLAnchorElement|null}
+   */
+  function melFindManagedFileImageLink(root) {
+    if (!root || !root.querySelectorAll) {
+      return null;
+    }
+    var candidates = root.querySelectorAll('.form-managed-file a[href]');
+    var i;
+    for (i = 0; i < candidates.length; i++) {
+      var a = candidates[i];
+      var href = a.getAttribute('href') || '';
+      if (!href || href.indexOf('javascript:') === 0) {
+        continue;
+      }
+      if (
+        href.indexOf('/files/') !== -1 ||
+        href.indexOf('/system/files') !== -1 ||
+        href.indexOf('files/') !== -1 ||
+        /\.(png|jpe?g|gif|webp|svg)(\?|#|$)/i.test(href)
+      ) {
+        return a;
+      }
+    }
+    return candidates.length ? candidates[0] : null;
+  }
+
+  /**
+   * True when managed_file has non-empty fids for mel[field_event_image].
+   *
+   * @param {HTMLFormElement} form
+   * @return {boolean}
+   */
+  function melHeroImageFidsPresent(form) {
+    var inp =
+      form.querySelector('input[name="mel[field_event_image][fids]"]') ||
+      form.querySelector('input[name*="field_event_image"][name*="fids"]');
+    if (!inp) {
+      return false;
+    }
+    return String(inp.value || '').trim() !== '';
+  }
+
   function syncCoverPreview(form) {
     var wrap = document.getElementById('mel-cover-preview');
     var img = document.getElementById('mel-cover-preview-img');
@@ -2063,11 +2109,20 @@
 
     var mediaRoot = form.querySelector('.mel-identity-media');
     var link =
-      (mediaRoot && mediaRoot.querySelector('.form-managed-file a[href*="files/"]')) ||
-      form.querySelector('.form-managed-file a[href*="files/"]');
+      (mediaRoot && melFindManagedFileImageLink(mediaRoot)) || melFindManagedFileImageLink(form);
     if (link && link.href) {
       img.src = link.href;
       img.removeAttribute('hidden');
+      empty.setAttribute('hidden', 'hidden');
+      return;
+    }
+
+    // Fids or SSR preview: do not show the empty-state placeholder while a file
+    // is still attached, even if Gin/theme omitted a matching file link.
+    if (melHeroImageFidsPresent(form) || (img.getAttribute('src') || '').trim() !== '') {
+      if ((img.getAttribute('src') || '').trim() !== '') {
+        img.removeAttribute('hidden');
+      }
       empty.setAttribute('hidden', 'hidden');
       return;
     }
@@ -2085,12 +2140,17 @@
     }
     var mediaRoot = form.querySelector('.mel-identity-media');
     var link =
-      (mediaRoot && mediaRoot.querySelector('.form-managed-file a[href*="files/"]')) ||
-      form.querySelector('.form-managed-file a[href*="files/"]');
+      (mediaRoot && melFindManagedFileImageLink(mediaRoot)) || melFindManagedFileImageLink(form);
     if (link && link.href) {
       img.src = link.href;
       img.alt = val(form, 'mel[field_event_image_alt]') || '';
       img.removeAttribute('hidden');
+      ph.setAttribute('hidden', 'hidden');
+    } else if (hasCoverFile(form)) {
+      if ((img.getAttribute('src') || '').trim() !== '') {
+        img.alt = val(form, 'mel[field_event_image_alt]') || '';
+        img.removeAttribute('hidden');
+      }
       ph.setAttribute('hidden', 'hidden');
     } else {
       img.removeAttribute('src');
@@ -2648,9 +2708,12 @@
   }
 
   function hasCoverFile(form) {
+    var media = form.querySelector('.mel-identity-media');
     return !!(
-      form.querySelector('.mel-identity-media .form-managed-file a[href*="files/"]') ||
-      form.querySelector('input[name="mel[field_event_image][]"]')?.value
+      (media && melFindManagedFileImageLink(media)) ||
+      melFindManagedFileImageLink(form) ||
+      form.querySelector('input[name="mel[field_event_image][]"]')?.value ||
+      melHeroImageFidsPresent(form)
     );
   }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.6
+  version: 1.7
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
@@ -30,6 +30,11 @@ view mel venue operations workspace:
   description: 'Access the read-only staff venue operations workspace at /admin/mel/operations.'
   restrict access: true
 
+govern mel operational escalations:
+  title: 'Govern MyEventLane operational escalations'
+  description: 'View escalation, SLA, resolution, and suppression governance projections in the venue operations workspace.'
+  restrict access: true
+
 
 
 

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -233,6 +233,23 @@ services:
       - '@myeventlane_tickets.ticket_mailer'
       - '@logger.channel.myeventlane_tickets'
 
+  myeventlane_tickets.operational_escalation_policy_manager:
+    class: Drupal\myeventlane_tickets\Service\OperationalEscalationPolicyManager
+    arguments:
+      - '@logger.channel.myeventlane_tickets'
+
+  myeventlane_tickets.operational_resolution_governance_manager:
+    class: Drupal\myeventlane_tickets\Service\OperationalResolutionGovernanceManager
+    arguments:
+      - '@myeventlane_tickets.operational_escalation_policy_manager'
+      - '@logger.channel.myeventlane_tickets'
+
+  myeventlane_tickets.operational_escalation_audit_projector:
+    class: Drupal\myeventlane_tickets\Service\OperationalEscalationAuditProjector
+    arguments:
+      - '@myeventlane_tickets.operational_escalation_policy_manager'
+      - '@myeventlane_tickets.operational_resolution_governance_manager'
+
   myeventlane_tickets.operational_workspace_builder:
     class: Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder
     arguments:
@@ -241,6 +258,8 @@ services:
       - '@myeventlane_tickets.venue_operation_policy_manager'
       - '@myeventlane_tickets.operational_integrity_inspector'
       - '@myeventlane_tickets.entitlement_capability_registry'
+      - '@current_user'
+      - '@myeventlane_tickets.operational_escalation_audit_projector'
 
   myeventlane_tickets.operational_workspace_access:
     class: Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalEscalationAuditProjector.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalEscalationAuditProjector.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+/**
+ * Audit-safe projections for escalation, resolution, and suppression visibility.
+ *
+ * Emits Twig-safe card arrays only; no secrets, replay tokens, or QR material.
+ */
+final class OperationalEscalationAuditProjector {
+
+  public function __construct(
+    private readonly OperationalEscalationPolicyManager $escalationPolicyManager,
+    private readonly OperationalResolutionGovernanceManager $resolutionGovernanceManager,
+  ) {}
+
+  /**
+   * Builds governance sections for the venue operations workspace.
+   *
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildWorkspaceGovernanceSections(array $merged, int $requestTime): array {
+    $severity = $this->escalationPolicyManager->projectSeverityFromOperationalRollup($merged);
+    $escalation = $this->escalationPolicyManager->mapSeverityToEscalation($severity);
+    $routing = $this->escalationPolicyManager->describeSeverityRouting($severity);
+    $sla = $this->escalationPolicyManager->slaSemanticsForEscalation($escalation);
+    $timing = $this->resolutionGovernanceManager->projectAcknowledgementTiming($severity, $requestTime);
+    $resolution = $this->resolutionGovernanceManager->projectResolutionStateFromRollup($merged);
+
+    $sectionTone = $severity;
+
+    $escalation_history = $this->projectEscalationHistory($merged, $severity, $escalation, $requestTime);
+    $resolution_history = $this->projectResolutionHistory($resolution, $requestTime);
+    $suppression_audit = $this->projectSuppressionAudit(NULL);
+
+    $ownership = 'Venue operations staff (workspace projection; non-binding ownership label).';
+
+    return [
+      [
+        'id' => 'escalation_governance',
+        'title' => 'Escalation governance',
+        'section_tone' => $sectionTone,
+        'cards' => [
+          [
+            'label' => 'Governed severity (rollup projection)',
+            'value' => $severity,
+          ],
+          [
+            'label' => 'Mapped escalation tier',
+            'value' => $escalation,
+          ],
+          [
+            'label' => 'Severity routing',
+            'value' => (string) ($routing['routing_descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'Escalation descriptor',
+            'value' => (string) ($this->escalationPolicyManager->describeEscalation($escalation)['escalation_descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'SLA acknowledgement window (seconds)',
+            'value' => (string) (int) ($sla['acknowledgement_seconds'] ?? 0),
+          ],
+          [
+            'label' => 'SLA descriptor',
+            'value' => (string) ($sla['sla_descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'Acknowledgement deadline (unix)',
+            'value' => (string) (int) ($timing['acknowledgement_deadline_unix'] ?? 0),
+          ],
+        ],
+      ],
+      [
+        'id' => 'resolution_governance',
+        'title' => 'Resolution governance',
+        'section_tone' => $sectionTone,
+        'cards' => [
+          [
+            'label' => 'Projected resolution state (observational)',
+            'value' => $resolution,
+          ],
+          [
+            'label' => 'Operational ownership indicator',
+            'value' => $ownership,
+          ],
+          [
+            'label' => 'Closure note',
+            'value' => 'Resolved and suppressed are terminal governance states except explicit staff re-opens per transition matrix.',
+          ],
+          [
+            'label' => 'Transition probe (monitoring → resolved)',
+            'value' => $this->resolutionGovernanceManager->lifecycleTransitionAllowed('monitoring', 'resolved') ? 'allowed' : 'denied',
+          ],
+          [
+            'label' => 'Transition probe (unresolved → suppressed)',
+            'value' => $this->resolutionGovernanceManager->lifecycleTransitionAllowed('unresolved', 'suppressed') ? 'allowed' : 'denied',
+          ],
+        ],
+      ],
+      [
+        'id' => 'suppression_governance',
+        'title' => 'Suppression governance',
+        'section_tone' => $sectionTone,
+        'cards' => [
+          [
+            'label' => 'Active suppression (projection)',
+            'value' => $suppression_audit['active'] ? 'yes' : 'no',
+          ],
+          [
+            'label' => 'Suppression audit visibility',
+            'value' => (string) ($suppression_audit['visibility_descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'Invalid suppression rehearsal (no reason)',
+            'value' => ($this->resolutionGovernanceManager->validateSuppression([])['valid'] ?? FALSE) ? 'valid' : 'rejected',
+          ],
+        ],
+      ],
+      [
+        'id' => 'escalation_audit',
+        'title' => 'Escalation audit visibility',
+        'section_tone' => $sectionTone,
+        'cards' => $this->flattenAuditCards($escalation_history, $resolution_history),
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, string>>
+   */
+  public function projectEscalationHistory(array $merged, string $severity, string $escalation, int $requestTime): array {
+    $scope = $merged === [] ? 'global' : 'event_sample';
+    return [[
+      'summary' => sprintf(
+        'Observation anchor %d: scope=%s; governed_severity=%s; escalation=%s.',
+        $requestTime,
+        $scope,
+        $severity,
+        $escalation
+      ),
+    ]];
+  }
+
+  /**
+   * @return list<array<string, string>>
+   */
+  public function projectResolutionHistory(string $projectedState, int $requestTime): array {
+    return [[
+      'summary' => sprintf(
+        'Resolution projection at %d: state=%s (read-only governance; no incident store mutation).',
+        $requestTime,
+        $projectedState
+      ),
+    ]];
+  }
+
+  /**
+   * @param array<string, mixed>|null $suppression
+   *
+   * @return array<string, mixed>
+   */
+  public function projectSuppressionAudit(?array $suppression): array {
+    if ($suppression === NULL || $suppression === []) {
+      return [
+        'active' => FALSE,
+        'visibility_descriptor' => 'No suppression payload supplied; historical incidents remain auditable elsewhere.',
+      ];
+    }
+    return [
+      'active' => TRUE,
+      'visibility_descriptor' => 'Suppression metadata present; audit history must remain append-only.',
+    ];
+  }
+
+  /**
+   * @param list<array<string, string>> $escalationRows
+   * @param list<array<string, string>> $resolutionRows
+   *
+   * @return list<array<string, string>>
+   */
+  private function flattenAuditCards(array $escalationRows, array $resolutionRows): array {
+    $cards = [];
+    foreach ($escalationRows as $row) {
+      $cards[] = [
+        'label' => 'Escalation history',
+        'value' => (string) ($row['summary'] ?? ''),
+      ];
+    }
+    foreach ($resolutionRows as $row) {
+      $cards[] = [
+        'label' => 'Resolution history',
+        'value' => (string) ($row['summary'] ?? ''),
+      ];
+    }
+    return $cards !== [] ? $cards : [
+      [
+        'label' => 'Audit visibility',
+        'value' => 'No audit rows projected for this window.',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalEscalationPolicyManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalEscalationPolicyManager.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+
+/**
+ * Canonical escalation and severity normalization for operational governance.
+ *
+ * This manager is **not** ticket truth, scanner authority, or continuity authority.
+ * It normalizes declared governance tokens, maps severity to escalation tiers,
+ * and exposes SLA acknowledgement semantics for staff projections only.
+ */
+final class OperationalEscalationPolicyManager {
+
+  /**
+   * Canonical escalation levels (ordered least to most acute).
+   *
+   * @var list<string>
+   */
+  public const ESCALATION_LEVELS = [
+    'none',
+    'review',
+    'elevated',
+    'urgent',
+    'executive',
+  ];
+
+  /**
+   * Canonical severity levels (ordered least to most acute).
+   *
+   * @var list<string>
+   */
+  public const SEVERITY_LEVELS = [
+    'low',
+    'warning',
+    'moderate',
+    'elevated',
+    'severe',
+    'critical',
+  ];
+
+  /**
+   * Rank map for max-severity selection.
+   *
+   * @var array<string, int>
+   */
+  private const SEVERITY_RANK = [
+    'low' => 0,
+    'warning' => 1,
+    'moderate' => 2,
+    'elevated' => 3,
+    'severe' => 4,
+    'critical' => 5,
+  ];
+
+  public function __construct(
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Normalizes a declared escalation level string.
+   */
+  public function normalizeEscalation(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return 'none';
+    }
+    if (!in_array($token, self::ESCALATION_LEVELS, TRUE)) {
+      $this->logger->warning('OperationalEscalationPolicyManager: unknown escalation token @token normalized to none.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return 'none';
+    }
+    return $token;
+  }
+
+  /**
+   * Normalizes a declared severity string.
+   */
+  public function normalizeSeverity(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return 'low';
+    }
+    if (!in_array($token, self::SEVERITY_LEVELS, TRUE)) {
+      $this->logger->warning('OperationalEscalationPolicyManager: unknown severity token @token normalized to low.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return 'low';
+    }
+    return $token;
+  }
+
+  /**
+   * Stable human-facing descriptor for an escalation level (machine strings).
+   *
+   * @return array<string, string>
+   */
+  public function describeEscalation(string $level): array {
+    $normalized = $this->normalizeEscalation($level);
+    $labels = [
+      'none' => 'No formal escalation path selected.',
+      'review' => 'Operational review visibility; coordinate within standard staffing.',
+      'elevated' => 'Elevated coordination; prioritize venue operations response.',
+      'urgent' => 'Urgent coordination; leadership visibility expected.',
+      'executive' => 'Executive visibility; minimal interpretation; maximum coordination clarity.',
+    ];
+    return [
+      'escalation_level' => $normalized,
+      'escalation_descriptor' => $labels[$normalized] ?? $labels['none'],
+    ];
+  }
+
+  /**
+   * Severity routing semantics (which escalation tier severity maps into).
+   *
+   * @return array<string, string>
+   */
+  public function describeSeverityRouting(string $severity): array {
+    $normalized = $this->normalizeSeverity($severity);
+    $target = $this->mapSeverityToEscalation($normalized);
+    return [
+      'severity' => $normalized,
+      'routes_to_escalation' => $target,
+      'routing_descriptor' => sprintf('Governed default routes severity %s to escalation %s.', $normalized, $target),
+    ];
+  }
+
+  /**
+   * Maps canonical severity to canonical escalation tier.
+   */
+  public function mapSeverityToEscalation(string $severity): string {
+    $s = $this->normalizeSeverity($severity);
+    return match ($s) {
+      'low' => 'none',
+      'warning' => 'review',
+      'moderate' => 'elevated',
+      'elevated' => 'elevated',
+      'severe' => 'urgent',
+      'critical' => 'executive',
+      default => 'none',
+    };
+  }
+
+  /**
+   * SLA semantics: acknowledgement window in seconds for an escalation tier.
+   *
+   * @return array<string, mixed>
+   */
+  public function slaSemanticsForEscalation(string $escalation): array {
+    $level = $this->normalizeEscalation($escalation);
+    $seconds = match ($level) {
+      'none' => 86400,
+      'review' => 7200,
+      'elevated' => 3600,
+      'urgent' => 1800,
+      'executive' => 900,
+      default => 86400,
+    };
+    return [
+      'escalation_level' => $level,
+      'acknowledgement_seconds' => $seconds,
+      'sla_descriptor' => sprintf(
+        'Acknowledgement expectation: %d seconds from observation anchor for escalation %s.',
+        $seconds,
+        $level
+      ),
+    ];
+  }
+
+  /**
+   * Projects governed severity from merged operational rollup keys only.
+   *
+   * Uses aggregated inspector machine strings already merged by the workspace
+   * builder — not per-ticket scanner evaluation and not entitlement mutation.
+   *
+   * @param array<string, mixed> $merged
+   */
+  public function projectSeverityFromOperationalRollup(array $merged): string {
+    if ($merged === []) {
+      return 'low';
+    }
+    $candidates = ['low'];
+    $issuance = is_array($merged['issuance'] ?? NULL) ? $merged['issuance'] : [];
+    $worst = (string) ($issuance['worst_quantity_alignment_status'] ?? '');
+    if ($worst === 'invalid') {
+      $candidates[] = 'severe';
+    }
+    elseif (in_array($worst, ['missing', 'pending'], TRUE)) {
+      $candidates[] = 'moderate';
+    }
+
+    $recovery = is_array($merged['recovery'] ?? NULL) ? $merged['recovery'] : [];
+    if (!empty($recovery['recovery_mismatch_observed'])) {
+      $candidates[] = 'elevated';
+    }
+
+    $artifacts = is_array($merged['artifacts'] ?? NULL) ? $merged['artifacts'] : [];
+    foreach (['canonical_pdf_readiness', 'qr_payload_operational', 'attachment_continuity'] as $key) {
+      $v = (string) ($artifacts[$key] ?? '');
+      if ($v === 'missing') {
+        $candidates[] = 'warning';
+      }
+      elseif ($v === 'mixed') {
+        $candidates[] = 'moderate';
+      }
+    }
+
+    $guest = is_array($merged['guest_continuity'] ?? NULL) ? $merged['guest_continuity'] : [];
+    foreach ($guest['continuity_statuses_observed'] ?? [] as $st) {
+      if ((string) $st === 'invalid') {
+        $candidates[] = 'moderate';
+      }
+    }
+
+    return $this->maxSeverityToken($candidates);
+  }
+
+  /**
+   * @param list<string> $tokens
+   */
+  private function maxSeverityToken(array $tokens): string {
+    $best = 'low';
+    $bestRank = -1;
+    foreach ($tokens as $t) {
+      $n = $this->normalizeSeverity($t);
+      $r = self::SEVERITY_RANK[$n] ?? 0;
+      if ($r > $bestRank) {
+        $bestRank = $r;
+        $best = $n;
+      }
+    }
+    return $best;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalResolutionGovernanceManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalResolutionGovernanceManager.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+
+/**
+ * Operational resolution and suppression governance (non-authoritative).
+ *
+ * Coordinates normalization of resolution lifecycle tokens, suppression rules,
+ * acknowledgement timing projections, and declarative transition rules.
+ * Does not mutate tickets, redemption logs, or incident persistence.
+ */
+final class OperationalResolutionGovernanceManager {
+
+  /**
+   * Canonical resolution states.
+   *
+   * @var list<string>
+   */
+  public const RESOLUTION_STATES = [
+    'unresolved',
+    'acknowledged',
+    'under_review',
+    'monitoring',
+    'resolved',
+    'suppressed',
+  ];
+
+  public function __construct(
+    private readonly OperationalEscalationPolicyManager $escalationPolicyManager,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Normalizes a resolution state token.
+   */
+  public function normalizeResolutionState(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return 'unresolved';
+    }
+    if (!in_array($token, self::RESOLUTION_STATES, TRUE)) {
+      $this->logger->warning('OperationalResolutionGovernanceManager: unknown resolution state @token normalized to unresolved.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return 'unresolved';
+    }
+    return $token;
+  }
+
+  /**
+   * Validates suppression intent without persisting or mutating incidents.
+   *
+   * Suppression MUST require an explicit non-empty reason string.
+   *
+   * @param array<string, mixed> $input
+   *
+   * @return array<string, mixed>
+   */
+  public function validateSuppression(array $input): array {
+    $reason = isset($input['reason']) ? trim((string) $input['reason']) : '';
+    if ($reason === '') {
+      return [
+        'valid' => FALSE,
+        'errors' => ['suppression_requires_explicit_reason'],
+      ];
+    }
+    return [
+      'valid' => TRUE,
+      'errors' => [],
+    ];
+  }
+
+  /**
+   * Declarative lifecycle closure: whether a transition is permitted.
+   */
+  public function lifecycleTransitionAllowed(string $from, string $to): bool {
+    $a = $this->normalizeResolutionState($from);
+    $b = $this->normalizeResolutionState($to);
+    if ($a === $b) {
+      return TRUE;
+    }
+    $matrix = [
+      'unresolved' => ['acknowledged', 'under_review', 'monitoring'],
+      'acknowledged' => ['under_review', 'monitoring', 'resolved', 'suppressed'],
+      'under_review' => ['monitoring', 'resolved', 'suppressed', 'acknowledged'],
+      'monitoring' => ['resolved', 'suppressed', 'under_review'],
+      'resolved' => [],
+      'suppressed' => ['monitoring', 'under_review'],
+    ];
+    return in_array($b, $matrix[$a] ?? [], TRUE);
+  }
+
+  /**
+   * Projects acknowledgement deadline from severity and anchor time.
+   *
+   * @return array<string, mixed>
+   */
+  public function projectAcknowledgementTiming(string $severity, int $openedRequestTime): array {
+    $normalized = $this->escalationPolicyManager->normalizeSeverity($severity);
+    $escalation = $this->escalationPolicyManager->mapSeverityToEscalation($normalized);
+    $sla = $this->escalationPolicyManager->slaSemanticsForEscalation($escalation);
+    $seconds = (int) ($sla['acknowledgement_seconds'] ?? 0);
+    $deadline = $openedRequestTime + $seconds;
+    return [
+      'severity' => $normalized,
+      'escalation_level' => $escalation,
+      'acknowledgement_deadline_unix' => $deadline,
+      'acknowledgement_seconds' => $seconds,
+      'sla_label' => (string) ($sla['sla_descriptor'] ?? ''),
+    ];
+  }
+
+  /**
+   * Projects an observational resolution state from merged rollup keys only.
+   *
+   * @param array<string, mixed> $merged
+   */
+  public function projectResolutionStateFromRollup(array $merged): string {
+    if ($merged === []) {
+      return 'unresolved';
+    }
+    $recovery = is_array($merged['recovery'] ?? NULL) ? $merged['recovery'] : [];
+    if (!empty($recovery['recovery_mismatch_observed'])) {
+      return 'under_review';
+    }
+    $issuance = is_array($merged['issuance'] ?? NULL) ? $merged['issuance'] : [];
+    $worst = (string) ($issuance['worst_quantity_alignment_status'] ?? '');
+    if (in_array($worst, ['invalid', 'missing'], TRUE)) {
+      return 'acknowledged';
+    }
+    $guest = is_array($merged['guest_continuity'] ?? NULL) ? $merged['guest_continuity'] : [];
+    foreach ($guest['continuity_statuses_observed'] ?? [] as $st) {
+      if ((string) $st === 'invalid') {
+        return 'monitoring';
+      }
+    }
+    return 'unresolved';
+  }
+
+  /**
+   * Builds a read-only audit timeline from normalized governance events.
+   *
+   * Each event must contain: state (string), recorded_at (int unix), note (string).
+   *
+   * @param list<array<string, mixed>> $events
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function projectResolutionAuditTimeline(array $events): array {
+    $out = [];
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $state = $this->normalizeResolutionState(isset($event['state']) ? (string) $event['state'] : NULL);
+      $at = (int) ($event['recorded_at'] ?? 0);
+      $note = trim((string) ($event['note'] ?? ''));
+      $out[] = [
+        'resolution_state' => $state,
+        'recorded_at_unix' => $at,
+        'audit_note' => $note !== '' ? $note : 'governance_event',
+      ];
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/VenueOperationPolicyManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/VenueOperationPolicyManager.php
@@ -209,7 +209,26 @@ final class VenueOperationPolicyManager {
   ): array {
     $composition = $this->evaluateTimedEntryForScan($ticket, $now, $parsed_qr_expires_at);
     if (!$composition['allow']) {
-      return $composition;
+      $policy = is_array($composition['policy'] ?? NULL) ? $composition['policy'] : [];
+      $timed = is_array($policy['timed_entry'] ?? NULL) ? $policy['timed_entry'] : [];
+      $session = is_array($policy['session_entitlement'] ?? NULL) ? $policy['session_entitlement'] : [];
+      $requested = $requested_zone_id !== NULL && trim($requested_zone_id) !== '' ? trim($requested_zone_id) : NULL;
+      $zone_skipped = $this->zoneAccessPolicyManager->evaluateZoneAccessForComposition(
+        $ticket,
+        $requested,
+        $timed,
+        $session,
+      );
+      return [
+        'allow' => FALSE,
+        'result_token' => (string) $composition['result_token'],
+        'message' => (string) $composition['message'],
+        'policy' => [
+          'timed_entry' => $timed,
+          'session_entitlement' => $session,
+          'zone_access' => $zone_skipped['policy'],
+        ],
+      ];
     }
 
     $timed = $composition['policy']['timed_entry'] ?? [];

--- a/web/modules/custom/myeventlane_tickets/src/Service/ZoneAccessPolicyManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/ZoneAccessPolicyManager.php
@@ -208,31 +208,6 @@ final class ZoneAccessPolicyManager {
   }
 
   /**
-   * Machine-only conflict codes for observability (read-only callers).
-   *
-   * When $requested_zone_id is set, evaluates that gate against policy.
-   * Structural issues (for example overlapping allow/deny lists) are always
-   * included when present.
-   *
-   * @return list<string>
-   */
-  public function detectZoneTopologyConflicts(Ticket $ticket, ?string $requested_zone_id): array {
-    $conflicts = $this->detectStructuralZoneConflicts($ticket);
-    $requested = $this->normalizeZoneId($requested_zone_id);
-    if ($requested === NULL) {
-      return array_values(array_unique($conflicts));
-    }
-    $now = $this->time->getCurrentTime();
-    $timed = $this->timedEntryPolicyManager->evaluate($ticket, $now, NULL);
-    $session = $this->sessionEntitlementPolicyManager->buildNormalizedPayload($ticket, $now, NULL, $timed);
-    $eval = $this->evaluateZoneAccessForComposition($ticket, $requested, $timed, $session);
-    if (!$eval['allow']) {
-      $conflicts[] = (string) ($eval['policy']['scanner']['reason'] ?? 'zone_operational_deny');
-    }
-    return array_values(array_unique($conflicts));
-  }
-
-  /**
    * Detects metadata inconsistencies without requiring a gate identifier.
    *
    * @return list<string>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new operational governance services and permissioning, and adjusts scan/zone denial policy payloads, which could affect staff workspace visibility and downstream consumers of policy arrays. Front-end changes are low risk but touch file preview behavior across themes.
> 
> **Overview**
> Adds *read-only operational governance projections* (severity→escalation mapping, SLA timing, resolution/suppression rules, and audit-safe card sections) via new services `OperationalEscalationPolicyManager`, `OperationalResolutionGovernanceManager`, and `OperationalEscalationAuditProjector`, plus a new restricted permission `govern mel operational escalations`.
> 
> Updates the venue operations workspace service wiring to include `current_user` and the new audit projector, and tweaks `VenueOperationPolicyManager::evaluateZoneAccessForScan()` to always include `zone_access` policy details even when earlier timed/session checks deny access; removes `ZoneAccessPolicyManager::detectZoneTopologyConflicts()`.
> 
> Improves Event Studio cover/preview image handling by reliably locating uploaded file links in `managed_file` markup and suppressing empty placeholders when `fids`/SSR preview indicate an image exists; bumps `mel_event_studio` library version to `1.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db52171b94bac149b8b21dc05a0df3611a9568c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->