### PR TITLE
Cursor/brand preview 74938

### DIFF
--- a/docs/offline-reconciliation-operational-continuity.md
+++ b/docs/offline-reconciliation-operational-continuity.md
@@ -68,11 +68,16 @@ Normalized scalar fields (machine-oriented):
 - Duplicating timing, session, zone, or scanner result-token semantics outside the canonical managers
 - Exposing `replay_token`, site HMAC material, or continuity fingerprints on customer surfaces
 
+## Operational escalation and resolution governance (Phase 3A, Commit 4)
+
+Escalation, resolution, and suppression **governance projections** for staff (SLA acknowledgement windows, severity→escalation routing, suppression rule visibility) are documented in [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md). Those projections **must not** become alternate continuity authority, must not mutate persisted continuity blobs, and must not execute reconciliation.
+
 ## Related documentation
 
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)
 - [device-gate-identity-convergence.md](./device-gate-identity-convergence.md)
 - [operational-observability.md](./operational-observability.md)
+- [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [zone-access-topology-convergence.md](./zone-access-topology-convergence.md)
 - [session-multiuse-entitlement-convergence.md](./session-multiuse-entitlement-convergence.md)

--- a/docs/operational-escalation-resolution-governance.md
+++ b/docs/operational-escalation-resolution-governance.md
@@ -1,0 +1,73 @@
+# Operational escalation and resolution governance (Phase 3A, Commit 4)
+
+## Purpose
+
+Converge **canonical escalation governance**, **resolution lifecycle governance**, **suppression rules**, **SLA acknowledgement semantics**, and **audit-safe projections** for staff operational coordination. This layer is **observational and coordinative**: it does not issue tickets, mutate entitlements, execute reconciliation, enqueue work, auto-resolve incidents, or expose QR or replay material.
+
+## Authority boundaries
+
+| Authority | Owns |
+| --- | --- |
+| **Entitlement authority** | Issued ticket rows, entitlement truth, capability maps (`EntitlementCapabilityRegistry`, `TicketCapabilityManager`). |
+| **Scanner authority** | Scan orchestration and public JSON contracts (`ScannerOperationManager`). |
+| **Continuity authority** | Continuity / reconciliation metadata normalization (`OperationalContinuityPolicyManager`). |
+| **Diagnostics authority** | `OperationalIntegrityInspector` read models. |
+| **Incident authority** (future persistence) | Incident records when introduced; this phase does **not** add incident entities or mutation APIs. |
+| **Workflow authority** | Business workflows outside this document. |
+| **Operational workspace authority** | Staff shell composition (`OperationalWorkspaceBuilder`, `VenueOperationsController`). |
+| **Escalation governance** (`OperationalEscalationPolicyManager`) | Normalization of escalation + severity tokens, severity→escalation routing table, SLA acknowledgement windows for **projections**. |
+| **Resolution governance** (`OperationalResolutionGovernanceManager`) | Resolution state normalization, suppression validation rules, declarative transition matrix, acknowledgement timing projection. |
+| **Escalation audit projection** (`OperationalEscalationAuditProjector`) | Audit-safe summaries and workspace card shapes derived from managers only. |
+
+Escalation and resolution governance are **not** authoritative ticket truth and must not be consulted by scanner or issuance paths.
+
+## Canonical tokens
+
+### Escalation levels
+
+`none`, `review`, `elevated`, `urgent`, `executive`
+
+### Severity levels
+
+`low`, `warning`, `moderate`, `elevated`, `severe`, `critical`
+
+### Resolution states
+
+`unresolved`, `acknowledged`, `under_review`, `monitoring`, `resolved`, `suppressed`
+
+## Suppression semantics
+
+- Suppression **requires** an explicit non-empty **reason** string at validation time.
+- Suppression governance **never** deletes operational or incident history; it only governs whether a suppression **intent** is structurally valid.
+- Suppression must **not** remove incidents from audit views, mutate entitlement state, erase scanner evidence, or erase redemption evidence.
+
+## SLA semantics
+
+SLA material is expressed as **acknowledgement seconds** per escalation tier (for example urgent tiers expect shorter acknowledgement windows). Values feed **deadline projections** from a request-time anchor; they are not timers or daemons.
+
+## Workspace integration
+
+- Route: `/admin/mel/operations` (unchanged).
+- Route access remains `view mel venue operations workspace` via `OperationalWorkspaceAccessChecker`.
+- **Escalation governance cards**, **SLA indicators**, **resolution governance cards**, **suppression visibility**, **ownership indicators**, and **escalation audit visibility** render only when the account holds **`govern mel operational escalations`** (restricted). The builder attaches governance **sections**; Twig renders normalized card rows only.
+
+Forbidden in the workspace: mutation buttons, “repair now”, “retry issuance”, reconciliation execution, entitlement editing, websocket clients.
+
+## Twig and SCSS rules
+
+- Twig renders **pre-shaped** `sections` / `meta` only — no severity math, SLA math, suppression decisions, or lifecycle transitions in templates.
+- SCSS extends the existing operational workspace stylesheet with **soft severity tones** for governance sections; no full redesign.
+
+## Forbidden patterns
+
+- Mutating ticket entities, redemption logs, or recovery state from governance services.
+- Regenerating QR payloads or exposing replay tokens through governance projections.
+- Automated escalation, auto-suppression, auto-resolution, queues, or realtime systems inside this phase.
+- Duplicating scanner evaluation, continuity fingerprints, or entitlement maps inside governance managers (rollup inputs must remain inspector/workspace merged summaries only).
+
+## Related documents
+
+- [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
+- [operational-observability.md](./operational-observability.md)
+- [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md)
+- [issuance-pipeline.md](./issuance-pipeline.md)

--- a/docs/operational-observability.md
+++ b/docs/operational-observability.md
@@ -81,9 +81,14 @@ Callers must avoid invoking diagnostics on hot per-request paths to prevent nois
 
 Staff operational convergence now has a **canonical read-only shell** (`VenueOperationsController` + `OperationalWorkspaceBuilder`) that merges inspector diagnostics for sampled orders tied to an optional event query parameter. See [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md) for route, access, and visibility boundaries.
 
+## Escalation and resolution governance (Phase 3A, Commit 4)
+
+Staff may view **escalation governance**, **SLA acknowledgement projections**, **resolution lifecycle framing**, **suppression rule visibility**, and **audit-safe history summaries** in the same workspace when they hold **`govern mel operational escalations`**. Normalization and routing live in `OperationalEscalationPolicyManager` and `OperationalResolutionGovernanceManager`; card shapes are composed only through `OperationalEscalationAuditProjector`. This layer **does not** change inspector semantics, ticket entities, redemption logs, QR contracts, or continuity authority — see [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md).
+
 ## Related documentation
 
 - [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md) — continuity / reconciliation metadata authority
+- [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md) — escalation, resolution, suppression governance projections
 - [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue gate policy, offline scaffolding, replay metadata
 - [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — capability registry delegation

--- a/docs/venue-operations-workspace-convergence.md
+++ b/docs/venue-operations-workspace-convergence.md
@@ -11,11 +11,14 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 | Component | Responsibility |
 | --- | --- |
 | `OperationalWorkspaceAccessChecker` (`myeventlane_tickets.operational_workspace_access`) | Route access only: anonymous denied; requires `view mel venue operations workspace` (restricted permission). |
-| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). |
+| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). When the account has `govern mel operational escalations`, appends **governance sections** produced exclusively by `OperationalEscalationAuditProjector` (escalation, SLA, resolution, suppression, audit visibility). |
+| `OperationalEscalationPolicyManager` (`myeventlane_tickets.operational_escalation_policy_manager`) | Normalizes escalation and severity tokens, maps severity to escalation tiers, and defines SLA acknowledgement semantics for projections (not scanner authority). |
+| `OperationalResolutionGovernanceManager` (`myeventlane_tickets.operational_resolution_governance_manager`) | Resolution state normalization, suppression validation (explicit reason required), lifecycle transition matrix, acknowledgement timing projection. |
+| `OperationalEscalationAuditProjector` (`myeventlane_tickets.operational_escalation_audit_projector`) | Audit-safe escalation/resolution/suppression summaries for the workspace; no secrets or QR material. |
 | `VenueOperationsController` | Resolves optional `?event={nid}` (event bundle only), invokes the builder, returns a themed render array with cache tags/contexts. |
 | `venue_operations_workspace` Twig template | Renders pre-shaped `sections` and `meta` only — **no policy branching, no calculations**. |
 
-**Composition note:** `OperationalIntegrityInspector` already orchestrates `TicketCapabilityManager`, `TimedEntryPolicyManager`, `SessionEntitlementPolicyManager`, `ZoneAccessPolicyManager`, `DeviceOperationIdentityManager`, `OperationalContinuityPolicyManager`, and `OccupancyPolicyManager` for `inspectOrder()` output. The workspace builder **reuses** that spine and adds only **type-catalog** rows via `EntitlementCapabilityRegistry` + `VenueOperationPolicyManager::describeEntitlementGateSemantics()` so policy is not evaluated twice for the same ticket rows.
+**Composition note:** `OperationalIntegrityInspector` already orchestrates `TicketCapabilityManager`, `TimedEntryPolicyManager`, `SessionEntitlementPolicyManager`, `ZoneAccessPolicyManager`, `DeviceOperationIdentityManager`, `OperationalContinuityPolicyManager`, and `OccupancyPolicyManager` for `inspectOrder()` output. The workspace builder **reuses** that spine and adds only **type-catalog** rows via `EntitlementCapabilityRegistry` + `VenueOperationPolicyManager::describeEntitlementGateSemantics()` so policy is not evaluated twice for the same ticket rows. **Governance note (Phase 3A Commit 4):** governed severity is **projected** from merged rollup machine strings via `OperationalEscalationPolicyManager::projectSeverityFromOperationalRollup()` — not a second scanner or continuity evaluation.
 
 ## Read model boundaries
 
@@ -36,9 +39,11 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 - Returning `replay_token`, HMAC segments, QR payload bytes, or raw continuity fingerprints to themed output.
 - Vendor routes reusing the workspace theme or builder without the staff permission and admin routing guarantees.
 - Introducing websocket clients, polling JS, or charting libraries for this shell.
+- Controllers or Twig computing escalation, SLA deadlines, suppression outcomes, or resolution transitions outside the governance managers / audit projector.
 
 ## Related documents
 
 - [operational-observability.md](./operational-observability.md)
+- [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -435,6 +435,22 @@
   border: 1px solid var(--mel-studio-border);
 }
 
+.mel-cover-preview__placeholder {
+  display: block;
+  width: 100%;
+  max-width: 22rem;
+  height: auto;
+  max-height: 7.5rem;
+  margin: 0 auto 0.35rem;
+  object-fit: contain;
+  border-radius: calc(var(--mel-studio-radius) - 2px);
+}
+
+/* Gin and some resets weaken [hidden]; keep empty-state fully off when a hero exists. */
+.mel-cover-preview__empty[hidden] {
+  display: none !important;
+}
+
 .mel-cover-preview__empty-text {
   font-size: 0.875rem;
   color: var(--mel-studio-muted);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -2160,36 +2160,34 @@
   }
 
   function bindCoverFilePreview(form) {
-    var media = form.querySelector('.mel-identity-media');
-    if (!media) {
-      return;
-    }
-    once('mel-cover-file', 'input[type="file"]', media).forEach(function (input) {
-      input.addEventListener('change', function () {
-        var f = input.files && input.files[0];
-        if (!f || !f.type || f.type.indexOf('image/') !== 0) {
-          return;
-        }
-        var r = new FileReader();
-        r.onload = function () {
-          var img = document.getElementById('mel-cover-preview-img');
-          var empty = document.getElementById('mel-cover-preview-empty');
-          var prevImg = document.getElementById('mel-preview-card-img');
-          var ph = document.getElementById('mel-preview-card-placeholder');
-          if (img && empty) {
-            img.src = r.result;
-            img.removeAttribute('hidden');
-            empty.setAttribute('hidden', 'hidden');
+    form.querySelectorAll('.mel-identity-media').forEach(function (media) {
+      once('mel-cover-file', 'input[type="file"]', media).forEach(function (input) {
+        input.addEventListener('change', function () {
+          var f = input.files && input.files[0];
+          if (!f || !f.type || f.type.indexOf('image/') !== 0) {
+            return;
           }
-          if (prevImg && ph) {
-            prevImg.src = r.result;
-            prevImg.alt = val(form, 'mel[field_event_image_alt]') || '';
-            prevImg.removeAttribute('hidden');
-            ph.setAttribute('hidden', 'hidden');
-          }
-          scheduleApplyLivePreview(form, false);
-        };
-        r.readAsDataURL(f);
+          var r = new FileReader();
+          r.onload = function () {
+            var img = document.getElementById('mel-cover-preview-img');
+            var empty = document.getElementById('mel-cover-preview-empty');
+            var prevImg = document.getElementById('mel-preview-card-img');
+            var ph = document.getElementById('mel-preview-card-placeholder');
+            if (img && empty) {
+              img.src = r.result;
+              img.removeAttribute('hidden');
+              empty.setAttribute('hidden', 'hidden');
+            }
+            if (prevImg && ph) {
+              prevImg.src = r.result;
+              prevImg.alt = val(form, 'mel[field_event_image_alt]') || '';
+              prevImg.removeAttribute('hidden');
+              ph.setAttribute('hidden', 'hidden');
+            }
+            scheduleApplyLivePreview(form, false);
+          };
+          r.readAsDataURL(f);
+        });
       });
     });
   }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.7
+  version: 1.8
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -11,6 +11,16 @@ use Drupal\Core\Template\Attribute;
 use Drupal\myeventlane_event_studio\EventStudioMelOptionCards;
 
 /**
+ * Returns a root-relative URL for the default MEL hero placeholder graphic.
+ */
+function myeventlane_event_studio_hero_placeholder_url(): string {
+  $theme_path = \Drupal::service('extension.list.theme')->getPath('myeventlane_theme');
+  $request = \Drupal::request();
+  $base = $request ? $request->getBasePath() : '';
+  return $base . '/' . $theme_path . '/images/mel/placeholders/mel-placeholder-default.svg';
+}
+
+/**
  * Implements hook_theme().
  *
  * Render-element theme on the form root so the template outputs a real <form>
@@ -374,4 +384,5 @@ function myeventlane_event_studio_preprocess_mel_event_studio(&$variables): void
 
   $variables['mel_advanced_ticket_manager_url'] = $element['#mel_advanced_ticket_manager_url'] ?? NULL;
   $variables['mel_studio_governance'] = $element['#mel_studio_governance'] ?? ['enabled' => FALSE];
+  $variables['mel_hero_placeholder_url'] = myeventlane_event_studio_hero_placeholder_url();
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -4,13 +4,85 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Form;
 
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\file\FileInterface;
+use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
+use Drupal\myeventlane_event_studio\Service\EventStudioAiAssistBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline;
+use Drupal\myeventlane_location\Service\LocationProviderManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Isolated Event Studio form for event branding.
  */
 final class EventBrandingForm extends EventStudioBaseForm {
+
+  public function __construct(
+    EntityFieldManagerInterface $entityFieldManager,
+    EntityTypeManagerInterface $entityTypeManager,
+    AccountProxyInterface $currentUser,
+    EventStudioSaveService $saveService,
+    EventStudioMelPayloadService $melPayloadService,
+    EventStudioWizardMelBaseline $wizardMelBaseline,
+    EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer,
+    EventVendorAccessChecker $eventVendorAccessChecker,
+    EventStudioAutosaveService $autosaveService,
+    EventStudioAiAssistBuilder $aiAssistBuilder,
+    RequestStack $request_stack,
+    LoggerInterface $logger,
+    ?LocationProviderManager $eventStudioLocationProvider,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+  ) {
+    parent::__construct(
+      $entityFieldManager,
+      $entityTypeManager,
+      $currentUser,
+      $saveService,
+      $melPayloadService,
+      $wizardMelBaseline,
+      $entityAutocompleteMelNormalizer,
+      $eventVendorAccessChecker,
+      $autosaveService,
+      $aiAssistBuilder,
+      $request_stack,
+      $logger,
+      $eventStudioLocationProvider,
+    );
+  }
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('myeventlane_event_studio.save'),
+      $container->get('myeventlane_event_studio.mel_payload'),
+      $container->get('myeventlane_event_studio.wizard_mel_baseline'),
+      $container->get('myeventlane_event_studio.entity_autocomplete_mel_normalizer'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('myeventlane_event_studio.autosave'),
+      $container->get('myeventlane_event_studio.ai_assist_builder'),
+      $container->get('request_stack'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+      $container->has('myeventlane_location.provider_manager')
+        ? $container->get('myeventlane_location.provider_manager')
+        : NULL,
+      $container->get('file_url_generator'),
+    );
+  }
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_branding_form';
@@ -37,7 +109,77 @@ final class EventBrandingForm extends EventStudioBaseForm {
     $form_state->setRedirect('myeventlane_event_studio.workspace_branding', ['node' => $saved->id()]);
   }
 
+  /**
+   * Resolves a usable image URL for the hero preview from mel baseline fids.
+   */
+  private function getHeroPreviewUrlFromMelDefaults(array $melDefaults): ?string {
+    $raw = $melDefaults['field_event_image'] ?? [];
+    if (!is_array($raw)) {
+      return NULL;
+    }
+    $fid = 0;
+    foreach ($raw as $item) {
+      $fid = (int) $item;
+      if ($fid > 0) {
+        break;
+      }
+    }
+    if ($fid < 1) {
+      return NULL;
+    }
+    $file = $this->entityTypeManager->getStorage('file')->load($fid);
+    if (!$file instanceof FileInterface) {
+      return NULL;
+    }
+    $uri = $file->getFileUri();
+    if ($uri === '') {
+      return NULL;
+    }
+    return $this->fileUrlGenerator->generateString($uri);
+  }
+
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    // Never put hero preview markup in #prefix on managed_file: core's
+    // ManagedFile::processManagedFile() replaces #prefix/#suffix with the AJAX
+    // wrapper (see web/core/modules/file/src/Element/ManagedFile.php).
+    $placeholder_src = Html::escape(myeventlane_event_studio_hero_placeholder_url());
+
+    $heroPreviewUrl = $this->getHeroPreviewUrlFromMelDefaults($melDefaults);
+    $hero_alt = Html::escape(trim((string) ($melDefaults['field_event_image_alt'] ?? '')));
+
+    if ($heroPreviewUrl !== NULL && $heroPreviewUrl !== '') {
+      $preview_src = Html::escape($heroPreviewUrl);
+      $preview_img_markup = '<img class="mel-cover-preview__img" id="mel-cover-preview-img" src="' . $preview_src . '" alt="' . $hero_alt . '" width="1200" height="630" loading="lazy" />';
+      $empty_wrapper_attrs = ' id="mel-cover-preview-empty" class="mel-cover-preview__empty" hidden';
+    }
+    else {
+      $preview_img_markup = '<img class="mel-cover-preview__img" id="mel-cover-preview-img" src="" alt="" width="1200" height="630" loading="lazy" hidden />';
+      $empty_wrapper_attrs = ' id="mel-cover-preview-empty" class="mel-cover-preview__empty"';
+    }
+
+    $form['mel']['branding_hero_shell'] = [
+      '#type' => 'markup',
+      '#markup' => Markup::create(
+        '<section class="mel-es-field-group mel-es-field-group--branding" aria-labelledby="mel-es-branding-title">'
+        . '<header class="mel-es-field-group__header">'
+        . '<h3 class="mel-es-field-group__title" id="mel-es-branding-title">' . Html::escape((string) $this->t('Branding')) . '</h3>'
+        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Shape how your event appears across MyEventLane and social sharing.')) . '</p>'
+        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('You can change visuals later. Accessibility text helps everyone understand the image.')) . '</p>'
+        . '</header>'
+        . '<div class="mel-es-field-group__body">'
+        . '<div class="mel-identity-media mel-identity-media--compact">'
+        . '<div class="mel-cover-preview" id="mel-cover-preview" data-mel-cover-preview>'
+        . $preview_img_markup
+        . '<div' . $empty_wrapper_attrs . '>'
+        . '<img class="mel-cover-preview__placeholder" src="' . $placeholder_src . '" width="800" height="450" loading="lazy" decoding="async" alt="" />'
+        . '<span class="mel-cover-preview__empty-icon" aria-hidden="true"></span>'
+        . '<span class="mel-cover-preview__empty-text">' . Html::escape((string) $this->t('No cover image yet — upload a hero image so attendees recognise your event.')) . '</span>'
+        . '</div></div>'
+        . '<div class="mel-identity-media__fields mel-builder-fields mel-builder-fields--stack">'
+      ),
+      '#weight' => -10,
+    ];
+
     $form['mel']['field_event_image'] = [
       '#type' => 'managed_file',
       '#title' => $this->t('Hero image'),
@@ -49,7 +191,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#default_value' => $melDefaults['field_event_image'] ?? [],
       '#attributes' => ['class' => ['mel-input-file']],
       '#description' => $this->t('Optional, but recommended. A clear image helps attendees recognise your event.'),
-      '#prefix' => '<section class="mel-es-field-group mel-es-field-group--branding" aria-labelledby="mel-es-branding-title"><header class="mel-es-field-group__header"><h3 class="mel-es-field-group__title" id="mel-es-branding-title">' . $this->t('Branding') . '</h3><p class="mel-es-field-group__hint">' . $this->t('Shape how your event appears across MyEventLane and social sharing.') . '</p><p class="mel-es-field-group__reassurance">' . $this->t('You can change visuals later. Accessibility text helps everyone understand the image.') . '</p></header><div class="mel-es-field-group__body">',
+      '#weight' => 0,
     ];
 
     $form['mel']['field_event_image_alt'] = [
@@ -58,7 +200,8 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#default_value' => $melDefaults['field_event_image_alt'] ?? '',
       '#description' => $this->t('Briefly describe the image for screen readers.'),
       '#attributes' => ['class' => ['mel-input']],
-      '#suffix' => '</div></section>',
+      '#suffix' => '</div></div></div></section>',
+      '#weight' => 1,
     ];
 
     $form['unavailable'] = [

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -483,6 +483,7 @@
                     <div class="mel-cover-preview" id="mel-cover-preview" data-mel-cover-preview>
                       <img class="mel-cover-preview__img" id="mel-cover-preview-img" src="" alt="" width="1200" height="630" loading="lazy" hidden />
                       <div class="mel-cover-preview__empty" id="mel-cover-preview-empty">
+                        <img class="mel-cover-preview__placeholder" src="{{ mel_hero_placeholder_url|e('html_attr') }}" width="800" height="450" loading="lazy" decoding="async" alt="" />
                         <span class="mel-cover-preview__empty-icon" aria-hidden="true"></span>
                         <span class="mel-cover-preview__empty-text">{{ 'No cover yet — events with images get better placement in discovery.'|t }}</span>
                       </div>

--- a/web/modules/custom/myeventlane_tickets/css/venue-operations-workspace.css
+++ b/web/modules/custom/myeventlane_tickets/css/venue-operations-workspace.css
@@ -87,3 +87,41 @@
   color: #1f2328;
   word-break: break-word;
 }
+
+.mel-ops-workspace__meta--governance {
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  color: #4a5563;
+}
+
+/* Soft severity / governance tones (governance sections only). */
+.mel-ops-workspace__section--tone-low .mel-ops-workspace__section-title {
+  border-bottom-color: #c5ccd6;
+}
+
+.mel-ops-workspace__section--tone-warning .mel-ops-workspace__section-title {
+  border-bottom-color: #d9b26b;
+}
+
+.mel-ops-workspace__section--tone-moderate .mel-ops-workspace__section-title,
+.mel-ops-workspace__section--tone-elevated .mel-ops-workspace__section-title {
+  border-bottom-color: #c49a6c;
+}
+
+.mel-ops-workspace__section--tone-severe .mel-ops-workspace__section-title,
+.mel-ops-workspace__section--tone-critical .mel-ops-workspace__section-title {
+  border-bottom-color: #c96b6b;
+}
+
+.mel-ops-workspace__section--tone-warning .mel-ops-card,
+.mel-ops-workspace__section--tone-moderate .mel-ops-card,
+.mel-ops-workspace__section--tone-elevated .mel-ops-card,
+.mel-ops-workspace__section--tone-severe .mel-ops-card,
+.mel-ops-workspace__section--tone-critical .mel-ops-card {
+  border-left: 3px solid #d9b26b;
+}
+
+.mel-ops-workspace__section--tone-severe .mel-ops-card,
+.mel-ops-workspace__section--tone-critical .mel-ops-card {
+  border-left-color: #c96b6b;
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_tickets\Service;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -41,6 +42,8 @@ final class OperationalWorkspaceBuilder {
     private readonly VenueOperationPolicyManager $venueOperationPolicyManager,
     private readonly OperationalIntegrityInspector $operationalIntegrityInspector,
     private readonly EntitlementCapabilityRegistry $entitlementCapabilityRegistry,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly OperationalEscalationAuditProjector $operationalEscalationAuditProjector,
   ) {}
 
   /**
@@ -55,7 +58,9 @@ final class OperationalWorkspaceBuilder {
    */
   public function build(?NodeInterface $event): array {
     $cache_tags = ['config:myeventlane_tickets.settings'];
-    $cache_contexts = ['user.permissions'];
+    $cache_contexts = ['user.permissions', 'user'];
+
+    $governance_enabled = $this->currentUser->hasPermission('govern mel operational escalations');
 
     $meta = [
       'built_at' => $this->time->getRequestTime(),
@@ -64,6 +69,7 @@ final class OperationalWorkspaceBuilder {
       'event_title' => $event?->getTitle(),
       'sampled_orders' => 0,
       'sampled_tickets' => 0,
+      'governance_projection_enabled' => $governance_enabled,
     ];
 
     if ($event) {
@@ -81,6 +87,16 @@ final class OperationalWorkspaceBuilder {
       $this->buildScannerOperationsSection($merged),
       $entitlement_catalog,
     ];
+
+    if ($governance_enabled) {
+      $governance = $this->operationalEscalationAuditProjector->buildWorkspaceGovernanceSections(
+        $merged,
+        (int) $meta['built_at']
+      );
+      foreach ($governance as $gov_section) {
+        $sections[] = $gov_section;
+      }
+    }
 
     $sections = $this->stripSensitiveRecursive($sections);
 

--- a/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
+++ b/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
@@ -12,10 +12,13 @@
     {% else %}
       <p class="mel-ops-workspace__meta">{{ 'Event'|t }}: {{ meta.event_title }} <span class="mel-ops-workspace__id">({{ meta.event_id }})</span></p>
     {% endif %}
+    {% if meta.governance_projection_enabled is defined and meta.governance_projection_enabled %}
+      <p class="mel-ops-workspace__meta mel-ops-workspace__meta--governance">{{ 'Escalation and resolution governance projections are enabled for your account (read-only).'|t }}</p>
+    {% endif %}
   </header>
 
   {% for section in sections %}
-    <section class="mel-ops-workspace__section" data-ops-section="{{ section.id }}">
+    <section class="mel-ops-workspace__section{% if section.section_tone is defined %} mel-ops-workspace__section--tone-{{ section.section_tone }}{% endif %}" data-ops-section="{{ section.id }}">
       <h2 class="mel-ops-workspace__section-title">{{ section.title }}</h2>
       <div class="mel-ops-workspace__cards">
         {% for card in section.cards %}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEscalationGovernanceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEscalationGovernanceKernelTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_tickets\Service\OperationalEscalationAuditProjector;
+use Drupal\myeventlane_tickets\Service\OperationalEscalationPolicyManager;
+use Drupal\myeventlane_tickets\Service\OperationalResolutionGovernanceManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Service\OperationalEscalationPolicyManager
+ *
+ * @group myeventlane_tickets
+ */
+#[RunTestsInSeparateProcesses]
+final class OperationalEscalationGovernanceKernelTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'node',
+    'options',
+    'datetime',
+    'datetime_range',
+    'commerce',
+    'commerce_price',
+    'commerce_order',
+    'commerce_product',
+    'entity_reference_revisions',
+    'paragraphs',
+    'mel_ticket',
+    'myeventlane_vendor',
+    'myeventlane_tickets',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    foreach (array_keys($container->getDefinitions()) as $service_id) {
+      if (str_starts_with($service_id, 'myeventlane_vendor.') && $service_id !== 'myeventlane_vendor.event_access_checker') {
+        $container->removeDefinition($service_id);
+      }
+    }
+
+    $container->register('myeventlane_vendor.event_access_checker', EventVendorAccessChecker::class);
+    $container->register('myeventlane_onboarding.manager', \stdClass::class);
+    $container->register('myeventlane_core.vendor_follow', \stdClass::class);
+    $container->register('myeventlane_event_studio.save', \stdClass::class);
+    $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
+    $container->register('myeventlane_core.domain_detector', \stdClass::class);
+    $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
+    $container->register('myeventlane_boost.manager', \stdClass::class);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installConfig(['user']);
+  }
+
+  public function testEscalationNormalization(): void {
+    $m = $this->escalationManager();
+    $this->assertSame('none', $m->normalizeEscalation(''));
+    $this->assertSame('review', $m->normalizeEscalation('review'));
+    $this->assertSame('none', $m->normalizeEscalation('unknown_level'));
+  }
+
+  public function testSeverityNormalization(): void {
+    $m = $this->escalationManager();
+    $this->assertSame('low', $m->normalizeSeverity(''));
+    $this->assertSame('severe', $m->normalizeSeverity('severe'));
+    $this->assertSame('low', $m->normalizeSeverity('not-a-severity'));
+  }
+
+  public function testSlaProjectionNormalization(): void {
+    $m = $this->escalationManager();
+    $sla = $m->slaSemanticsForEscalation('urgent');
+    $this->assertSame(1800, $sla['acknowledgement_seconds']);
+    $resolution = $this->resolutionManager();
+    $timing = $resolution->projectAcknowledgementTiming('severe', 1_700_000_000);
+    $this->assertSame(1_700_000_000 + 1800, $timing['acknowledgement_deadline_unix']);
+  }
+
+  public function testSeverityRollupProjection(): void {
+    $m = $this->escalationManager();
+    $merged = [
+      'issuance' => ['worst_quantity_alignment_status' => 'invalid'],
+      'recovery' => ['recovery_mismatch_observed' => FALSE],
+      'artifacts' => [
+        'canonical_pdf_readiness' => 'valid',
+        'qr_payload_operational' => 'valid',
+        'attachment_continuity' => 'valid',
+      ],
+      'guest_continuity' => ['continuity_statuses_observed' => ['valid']],
+    ];
+    $this->assertSame('severe', $m->projectSeverityFromOperationalRollup($merged));
+  }
+
+  public function testResolutionGovernanceTransitions(): void {
+    $r = $this->resolutionManager();
+    $this->assertTrue($r->lifecycleTransitionAllowed('monitoring', 'resolved'));
+    $this->assertFalse($r->lifecycleTransitionAllowed('unresolved', 'suppressed'));
+    $this->assertSame('under_review', $r->projectResolutionStateFromRollup([
+      'recovery' => ['recovery_mismatch_observed' => TRUE],
+    ]));
+  }
+
+  public function testSuppressionGovernance(): void {
+    $r = $this->resolutionManager();
+    $invalid = $r->validateSuppression([]);
+    $this->assertFalse($invalid['valid']);
+    $valid = $r->validateSuppression(['reason' => 'Coordinated maintenance window']);
+    $this->assertTrue($valid['valid']);
+  }
+
+  public function testAuditHistoryProjections(): void {
+    $r = $this->resolutionManager();
+    $timeline = $r->projectResolutionAuditTimeline([
+      ['state' => 'acknowledged', 'recorded_at' => 100, 'note' => 'staff visibility'],
+    ]);
+    $this->assertSame('acknowledged', $timeline[0]['resolution_state']);
+    $this->assertSame(100, $timeline[0]['recorded_at_unix']);
+  }
+
+  public function testAuditProjectorNoSecretLeakage(): void {
+    $projector = $this->auditProjector();
+    $sections = $projector->buildWorkspaceGovernanceSections([], 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('replay_token', $blob);
+    $this->assertStringNotContainsString('qr_payload', $blob);
+    $this->assertStringNotContainsString('@', $blob);
+  }
+
+  private function escalationManager(): OperationalEscalationPolicyManager {
+    return $this->container->get('myeventlane_tickets.operational_escalation_policy_manager');
+  }
+
+  private function resolutionManager(): OperationalResolutionGovernanceManager {
+    return $this->container->get('myeventlane_tickets.operational_resolution_governance_manager');
+  }
+
+  private function auditProjector(): OperationalEscalationAuditProjector {
+    return $this->container->get('myeventlane_tickets.operational_escalation_audit_projector');
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
@@ -18,6 +18,8 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\myeventlane_tickets\Service\OperationalEscalationAuditProjector;
 use Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector;
 use Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder;
 use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
@@ -284,6 +286,85 @@ final class OperationalWorkspaceConvergenceKernelTest extends KernelTestBase {
     $this->assertContains('Drupal\myeventlane_tickets\Service\EntitlementCapabilityRegistry', $types);
   }
 
+  public function testBuilderUsesGovernanceProjector(): void {
+    $ref = new ReflectionClass(OperationalWorkspaceBuilder::class);
+    $params = $ref->getConstructor()?->getParameters() ?? [];
+    $types = [];
+    foreach ($params as $p) {
+      $t = $p->getType();
+      if ($t instanceof \ReflectionNamedType) {
+        $types[] = $t->getName();
+      }
+    }
+    $this->assertContains(OperationalEscalationAuditProjector::class, $types);
+  }
+
+  public function testGovernanceSectionsIncludedForStaffWithEscalationPermission(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertNotEmpty($tickets);
+    foreach ($tickets as $ticket) {
+      $ticket->set('event_id', $this->event->id());
+      $ticket->save();
+    }
+
+    $staff = User::create([
+      'name' => 'workspace_staff_gov',
+      'mail' => 'staff-gov-ws@example.test',
+      'status' => 1,
+    ]);
+    $staff->addRole('mel_ws_staff');
+    $staff->save();
+    $staff = User::load($staff->id());
+    $this->assertNotFalse($staff);
+
+    /** @var \Drupal\Core\Session\AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($staff);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $this->assertTrue($workspace['meta']['governance_projection_enabled']);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertContains('escalation_governance', $ids);
+    $this->assertContains('resolution_governance', $ids);
+    $this->assertContains('suppression_governance', $ids);
+    $this->assertContains('escalation_audit', $ids);
+
+    $switcher->switchBack();
+  }
+
+  public function testGovernanceSectionsOmittedWithoutEscalationPermission(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    foreach ($tickets as $ticket) {
+      $ticket->set('event_id', $this->event->id());
+      $ticket->save();
+    }
+
+    $viewer = User::create([
+      'name' => 'workspace_ops_view',
+      'mail' => 'ops-view-ws@example.test',
+      'status' => 1,
+    ]);
+    $viewer->addRole('mel_ws_ops_view');
+    $viewer->save();
+    $viewer = User::load($viewer->id());
+    $this->assertNotFalse($viewer);
+
+    /** @var \Drupal\Core\Session\AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($viewer);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $this->assertFalse($workspace['meta']['governance_projection_enabled']);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertNotContains('escalation_governance', $ids);
+
+    $switcher->switchBack();
+  }
+
   public function testGlobalCatalogSectionPresentWithoutEvent(): void {
     $workspace = $this->workspaceBuilder()->build(NULL);
     $ids = array_column($workspace['sections'], 'id');
@@ -302,7 +383,18 @@ final class OperationalWorkspaceConvergenceKernelTest extends KernelTestBase {
       Role::create([
         'id' => 'mel_ws_staff',
         'label' => 'MEL workspace staff',
-      ])->grantPermission('view mel venue operations workspace')->save();
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->grantPermission('govern mel operational escalations')
+        ->save();
+    }
+    if (!Role::load('mel_ws_ops_view')) {
+      Role::create([
+        'id' => 'mel_ws_ops_view',
+        'label' => 'MEL workspace view only',
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->save();
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds permission-gated governance projections into the staff ops workspace and extends caching/context behavior, which could affect what privileged users see. Event Studio branding UI changes alter managed file markup and preview behavior, with moderate risk of regressions in form/AJAX rendering.
> 
> **Overview**
> Adds a new **operational escalation/resolution governance** documentation set and links it from existing continuity/observability/workspace docs, explicitly framing the layer as *read-only projections* (SLA acknowledgement windows, suppression visibility, audit-safe summaries).
> 
> Updates the staff `/admin/mel/operations` workspace to optionally append governance sections when the viewer has `govern mel operational escalations`, including new template support for per-section severity tones and a header indicator; adds SCSS for soft severity styling and kernel tests to verify permission-gated inclusion and no secret leakage.
> 
> Improves Event Studio branding hero preview by introducing a theme-based placeholder graphic, fixing empty-state hiding via CSS, making the JS preview binding work with multiple `.mel-identity-media` containers, and rebuilding the branding step markup in `EventBrandingForm` to render an initial preview from saved file IDs without relying on `managed_file` `#prefix/#suffix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5cdadf67ff4c0636c1ca8557c0ec3c0a31c3785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->