### PR TITLE
Cursor/preg split check 19b9c

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -553,6 +553,20 @@
     return (el.value || '').trim();
   }
 
+  function melHeroAltValue(form) {
+    return (
+      val(form, 'mel[field_event_image_alt]') ||
+      val(form, 'mel[field_event_image][0][alt]') ||
+      ''
+    );
+  }
+
+  function melHeroAltFieldName(form) {
+    return form.querySelector('[name="mel[field_event_image][0][alt]"]')
+      ? 'mel[field_event_image][0][alt]'
+      : 'mel[field_event_image_alt]';
+  }
+
   /** Category: multi-select uses mel[field_category][]; autocomplete uses mel[field_category]. */
   function categoryFieldHasValue(form) {
     var multi = form.querySelector('select[name="mel[field_category][]"]');
@@ -2092,6 +2106,7 @@
   function melHeroImageFidsPresent(form) {
     var inp =
       form.querySelector('input[name="mel[field_event_image][fids]"]') ||
+      form.querySelector('input[name="mel[field_event_image][0][fids]"]') ||
       form.querySelector('input[name*="field_event_image"][name*="fids"]');
     if (!inp) {
       return false;

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -16,6 +16,7 @@ use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolver;
@@ -350,10 +351,11 @@ final class EventStudioAutosaveController {
       }
     }
 
-    $image_fids = $mel['field_event_image'] ?? [];
-    $image_fid = 0;
-    if (is_array($image_fids) && $image_fids !== []) {
-      $image_fid = (int) reset($image_fids);
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel);
+    $image_fid = $hero['fid'];
+    $image_alt = $hero['alt'];
+    if ($image_alt === '') {
+      $image_alt = trim((string) ($params['field_event_image_alt'] ?? ''));
     }
 
     $payload = [
@@ -362,7 +364,7 @@ final class EventStudioAutosaveController {
       'body' => $mel['body'] ?? $params['basics']['body'] ?? $params['body'] ?? '',
       'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? $params['field_event_intro'] ?? '')),
       'field_event_image' => $image_fid,
-      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? $params['field_event_image_alt'] ?? '')),
+      'field_event_image_alt' => $image_alt,
       'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? $params['field_contact_email'] ?? '')),
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? $params['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? $params['field_category'] ?? ''),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -88,7 +88,11 @@ final class EventStudioMelPayloadService {
       return 0;
     }
     if (is_string($fids)) {
-      foreach (preg_split('/\s+/', trim($fids)) ?: [] as $part) {
+      $parts = preg_split('/\s+/', trim($fids));
+      if (!is_array($parts)) {
+        return 0;
+      }
+      foreach ($parts as $part) {
         if ($part === '') {
           continue;
         }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -22,6 +22,86 @@ final class EventStudioMelPayloadService {
   ) {}
 
   /**
+   * Normalizes hero fid + alt from `mel` or baseline fragments.
+   *
+   * Supports legacy `managed_file` values (`mel[field_event_image]` fid list),
+   * optional `mel[field_event_image_alt]`, and image / image_widget_crop widgets
+   * (`mel[field_event_image][0][fids]`, `…[0][alt]`).
+   *
+   * @param array<string, mixed> $fragment
+   *   Partial or full mel array containing `field_event_image` / `field_event_image_alt`.
+   *
+   * @return array{fid: int, alt: string}
+   */
+  public static function normalizeHeroFromMelFragment(array $fragment): array {
+    $alt = trim((string) ($fragment['field_event_image_alt'] ?? ''));
+    $raw = $fragment['field_event_image'] ?? NULL;
+    if (!is_array($raw)) {
+      return ['fid' => 0, 'alt' => $alt];
+    }
+
+    if (isset($raw[0]) && is_array($raw[0])) {
+      $delta = $raw[0];
+      $fid = self::firstPositiveIntFromFidsValue($delta['fids'] ?? NULL);
+      if ($fid < 1 && isset($delta['target_id'])) {
+        $fid = max(0, (int) $delta['target_id']);
+      }
+      $delta_alt = trim((string) ($delta['alt'] ?? ''));
+      if ($delta_alt !== '') {
+        $alt = $delta_alt;
+      }
+      return ['fid' => $fid, 'alt' => $alt];
+    }
+
+    if (array_key_exists('fids', $raw)) {
+      return ['fid' => self::firstPositiveIntFromFidsValue($raw['fids']), 'alt' => $alt];
+    }
+
+    $fid = 0;
+    foreach ($raw as $value) {
+      if (is_array($value)) {
+        continue;
+      }
+      if (is_numeric($value)) {
+        $candidate = (int) $value;
+        if ($candidate > 0) {
+          $fid = $candidate;
+          break;
+        }
+      }
+    }
+
+    return ['fid' => $fid, 'alt' => $alt];
+  }
+
+  private static function firstPositiveIntFromFidsValue(mixed $fids): int {
+    if ($fids === NULL || $fids === '') {
+      return 0;
+    }
+    if (is_array($fids)) {
+      foreach ($fids as $value) {
+        $candidate = (int) $value;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+      return 0;
+    }
+    if (is_string($fids)) {
+      foreach (preg_split('/\s+/', trim($fids)) ?: [] as $part) {
+        if ($part === '') {
+          continue;
+        }
+        $candidate = (int) $part;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+    }
+    return 0;
+  }
+
+  /**
    * @return array<string, mixed>
    */
   public function buildFromFormState(FormStateInterface $form_state, EntityTypeManagerInterface $entityTypeManager): array {
@@ -71,19 +151,15 @@ final class EventStudioMelPayloadService {
     $has_attendee_questions = $attendee_questions !== [];
     $collect_per_ticket = !empty($mel['collect_attendee_questions']) || $has_attendee_questions;
 
-    $image_fids = $mel['field_event_image'] ?? [];
-    $image_fid = 0;
-    if (is_array($image_fids) && $image_fids !== []) {
-      $image_fid = (int) reset($image_fids);
-    }
+    $hero = self::normalizeHeroFromMelFragment($mel);
 
     $payload = [
       'title' => $mel['title'] ?? '',
       'summary' => $mel['summary'] ?? '',
       'body' => $mel['body'] ?? '',
       'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? '')),
-      'field_event_image' => $image_fid,
-      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? '')),
+      'field_event_image' => $hero['fid'],
+      'field_event_image_alt' => $hero['alt'],
       'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? '')),
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? ''),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how Event Studio extracts and saves the event hero image `fid` and alt text across autosave and form submissions, which can affect persisted event branding data if the normalization misses an edge case.
> 
> **Overview**
> Improves Event Studio hero image handling to support multiple Drupal widget shapes (legacy `managed_file` and newer image/image_crop deltas).
> 
> Backend payload building now normalizes hero `fid` + alt via `EventStudioMelPayloadService::normalizeHeroFromMelFragment()` (used by both `EventStudioMelPayloadService` and `EventStudioAutosaveController`), and falls back to request params for alt when missing.
> 
> Frontend updates add helpers to read alt from either field name and extend `melHeroImageFidsPresent()` to detect `mel[field_event_image][0][fids]`, keeping preview/empty-state logic consistent when the widget structure differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837f717d472a05b1a306afeb385eb1f2766bd63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->