### PR TITLE
Cursor/brand preview 74938

### DIFF
--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -1,0 +1,157 @@
+uuid: 2d61998e-a347-4eed-9918-682e921ab6b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.studio_branding
+    - crop.type.event_hero
+    - crop.type.focal_point
+    - field.field.node.event.body
+    - field.field.node.event.field_accessibility
+    - field.field.node.event.field_accessibility_contact
+    - field.field.node.event.field_accessibility_directions
+    - field.field.node.event.field_accessibility_entry
+    - field.field.node.event.field_accessibility_parking
+    - field.field.node.event.field_age_restriction
+    - field.field.node.event.field_attendee_questions
+    - field.field.node.event.field_cancel_reason
+    - field.field.node.event.field_cancelled_at
+    - field.field.node.event.field_capacity
+    - field.field.node.event.field_category
+    - field.field.node.event.field_collect_per_ticket
+    - field.field.node.event.field_contact_email
+    - field.field.node.event.field_contact_phone
+    - field.field.node.event.field_event_capacity_total
+    - field.field.node.event.field_event_end
+    - field.field.node.event.field_event_highlights
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_intro
+    - field.field.node.event.field_event_start
+    - field.field.node.event.field_event_state
+    - field.field.node.event.field_event_state_override
+    - field.field.node.event.field_event_store
+    - field.field.node.event.field_event_type
+    - field.field.node.event.field_event_vendor
+    - field.field.node.event.field_external_url
+    - field.field.node.event.field_featured
+    - field.field.node.event.field_is_series_template
+    - field.field.node.event.field_location
+    - field.field.node.event.field_location_latitude
+    - field.field.node.event.field_location_longitude
+    - field.field.node.event.field_location_place_id
+    - field.field.node.event.field_product_target
+    - field.field.node.event.field_promo_expires
+    - field.field.node.event.field_promoted
+    - field.field.node.event.field_refund_policy
+    - field.field.node.event.field_reviews_enabled
+    - field.field.node.event.field_sales_end
+    - field.field.node.event.field_sales_start
+    - field.field.node.event.field_series_instance_id
+    - field.field.node.event.field_series_parent
+    - field.field.node.event.field_series_rrule
+    - field.field.node.event.field_series_timezone
+    - field.field.node.event.field_tags
+    - field.field.node.event.field_ticket_types
+    - field.field.node.event.field_venue_address
+    - field.field.node.event.field_venue_name
+    - field.field.node.event.field_waitlist_capacity
+    - image.style.crop_thumbnail
+    - image.style.mel_crop_event_hero
+    - image.style.mel_crop_focal_point
+    - image.style.thumbnail
+    - node.type.event
+  module:
+    - crop
+    - focal_point
+    - image
+    - image_widget_crop
+id: node.event.studio_branding
+targetEntityType: node
+bundle: event
+mode: studio_branding
+content:
+  field_event_image:
+    type: image_widget_crop
+    weight: 0
+    region: content
+    settings:
+      show_crop_area: true
+      show_default_crop: true
+      warn_multiple_usages: false
+      crop_types_required: {  }
+      preview_image_style: thumbnail
+      crop_preview_image_style: mel_crop_event_hero
+      crop_list:
+        - event_hero
+        - focal_point
+      progress_indicator: throbber
+    third_party_settings: {  }
+hidden:
+  body: true
+  created: true
+  field_accessibility: true
+  field_accessibility_contact: true
+  field_accessibility_directions: true
+  field_accessibility_entry: true
+  field_accessibility_parking: true
+  field_age_policy: true
+  field_age_policy_note: true
+  field_age_restriction: true
+  field_attendee_questions: true
+  field_cancel_reason: true
+  field_cancelled_at: true
+  field_capacity: true
+  field_category: true
+  field_collect_per_ticket: true
+  field_contact_email: true
+  field_contact_phone: true
+  field_event_capacity_total: true
+  field_event_end: true
+  field_event_geo: true
+  field_event_highlights: true
+  field_event_intro: true
+  field_event_setup_complete: true
+  field_event_start: true
+  field_event_state: true
+  field_event_state_override: true
+  field_event_store: true
+  field_event_summary: true
+  field_event_type: true
+  field_event_vendor: true
+  field_external_url: true
+  field_featured: true
+  field_is_series_template: true
+  field_location: true
+  field_location_latitude: true
+  field_location_longitude: true
+  field_location_place_id: true
+  field_mel_sup_amt: true
+  field_mel_sup_chk: true
+  field_mel_sup_mode: true
+  field_mel_sup_oid: true
+  field_mel_sup_pct: true
+  field_product_target: true
+  field_promo_expires: true
+  field_promoted: true
+  field_refund_policy: true
+  field_reviews_enabled: true
+  field_sales_end: true
+  field_sales_start: true
+  field_series_instance_id: true
+  field_series_parent: true
+  field_series_rrule: true
+  field_series_timezone: true
+  field_tags: true
+  field_ticket_types: true
+  field_venue: true
+  field_venue_address: true
+  field_venue_name: true
+  field_waitlist_capacity: true
+  langcode: true
+  moderation_state: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  title: true
+  uid: true

--- a/config/sync/core.entity_form_mode.node.studio_branding.yml
+++ b/config/sync/core.entity_form_mode.node.studio_branding.yml
@@ -1,0 +1,11 @@
+uuid: e673e07e-cf13-4c8b-9d3e-865a5135b3c1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.studio_branding
+label: 'Studio branding'
+description: 'Event Studio — hero image with crop (vendor branding step).'
+targetEntityType: node
+cache: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -8,9 +8,11 @@ dependencies:
     - field.field.node.event.field_event_intro
     - field.field.node.event.field_location
     - field.field.node.event.field_venue_name
+    - image.style.mel_event_hero_featured
     - node.type.event
   module:
     - address
+    - focal_point
     - image
     - node
     - text
@@ -44,7 +46,7 @@ content:
     label: hidden
     settings:
       image_link: ''
-      image_style: large
+      image_style: mel_event_hero_featured
       image_loading:
         attribute: eager
     third_party_settings: {  }

--- a/config/sync/crop.type.event_hero.yml
+++ b/config/sync/crop.type.event_hero.yml
@@ -1,0 +1,12 @@
+uuid: 14cf33ec-dd08-4fec-a713-ef8586e2d88f
+langcode: en
+status: true
+dependencies: {  }
+id: event_hero
+label: 'Event hero (1200×630)'
+description: 'Fixed framing for event cover images in Event Studio branding (listings and social previews).'
+aspect_ratio: '1200:630'
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/config/sync/image.style.mel_crop_event_hero.yml
+++ b/config/sync/image.style.mel_crop_event_hero.yml
@@ -1,0 +1,17 @@
+uuid: 8a1c4f2e-9b3d-4e1a-a6f5-2d8e7c9b0a1f
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.event_hero
+  module:
+    - crop
+name: mel_crop_event_hero
+label: 'MEL crop — event hero (widget)'
+effects:
+  1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e:
+    uuid: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+    id: crop_crop
+    weight: 0
+    data:
+      crop_type: event_hero

--- a/config/sync/image.style.mel_crop_focal_point.yml
+++ b/config/sync/image.style.mel_crop_focal_point.yml
@@ -1,0 +1,19 @@
+uuid: 9b2d5e3f-0c4e-5f2b-b7a6-3e9f8d0c1b2a
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.focal_point
+  module:
+    - focal_point
+name: mel_crop_focal_point
+label: 'MEL crop — focal point (widget)'
+effects:
+  2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f:
+    uuid: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
+    id: focal_point_scale_and_crop
+    weight: 0
+    data:
+      width: 1200
+      height: 630
+      crop_type: focal_point

--- a/config/sync/image.style.mel_event_card_featured.yml
+++ b/config/sync/image.style.mel_event_card_featured.yml
@@ -1,15 +1,27 @@
 uuid: d8454f47-0878-472b-b78c-d2810a4e4295
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - crop.type.event_hero
+    - crop.type.focal_point
+  module:
+    - crop
+    - focal_point
 name: mel_event_card_featured
 label: 'MEL event card (featured)'
 effects:
+  5f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c:
+    uuid: 5f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c
+    id: crop_crop
+    weight: 0
+    data:
+      crop_type: event_hero
   c5d4f6d0-3a04-493b-a2d2-42ec2263ec4e:
     uuid: c5d4f6d0-3a04-493b-a2d2-42ec2263ec4e
-    id: image_scale_and_crop
-    weight: 0
+    id: focal_point_scale_and_crop
+    weight: 1
     data:
       width: 800
       height: 450
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.mel_event_card_standard.yml
+++ b/config/sync/image.style.mel_event_card_standard.yml
@@ -1,15 +1,27 @@
 uuid: cb3fea28-5909-4bc8-b00f-f4dbcfc49c6e
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - crop.type.event_hero
+    - crop.type.focal_point
+  module:
+    - crop
+    - focal_point
 name: mel_event_card_standard
 label: 'MEL event card (standard)'
 effects:
+  6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d:
+    uuid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
+    id: crop_crop
+    weight: 0
+    data:
+      crop_type: event_hero
   f8f903d0-7d66-40b8-a8b9-88845029b0b7:
     uuid: f8f903d0-7d66-40b8-a8b9-88845029b0b7
-    id: image_scale_and_crop
-    weight: 0
+    id: focal_point_scale_and_crop
+    weight: 1
     data:
       width: 400
       height: 500
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.mel_event_hero_featured.yml
+++ b/config/sync/image.style.mel_event_hero_featured.yml
@@ -1,0 +1,27 @@
+uuid: a3c4d5e6-7f8a-9b0c-1d2e-3f4a5b6c7d8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.event_hero
+    - crop.type.focal_point
+  module:
+    - crop
+    - focal_point
+name: mel_event_hero_featured
+label: 'MEL event hero (featured — event + book pages)'
+effects:
+  3d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a:
+    uuid: 3d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a
+    id: crop_crop
+    weight: 0
+    data:
+      crop_type: event_hero
+  4e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b:
+    uuid: 4e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1600
+      height: 900
+      crop_type: focal_point

--- a/docs/fulfillment-lifecycle-convergence.md
+++ b/docs/fulfillment-lifecycle-convergence.md
@@ -18,6 +18,8 @@ This layer **must not** issue tickets, change entitlements, change scanner outco
 
 **Inventory reservation governance** (Phase 4A Commit 2) consumes fulfillment operational signals and continuity semantics as **inputs** for reservation state normalization. Reservation governance does **not** duplicate fulfillment lifecycle logic; it projects reservation-specific vocabulary (`reserved`, `allocated`, `ready_for_collection`, etc.) for staff visibility. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
 
+**Operational entitlement capability convergence** (Phase 4A Commit 3) composes reservation governance outputs and fulfillment operational signals into unified capability types/states for merch pickup, hospitality access, redemption, parking, VIP, cloakroom, timed collection, and digital redemption visibility. See [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md).
+
 ## Canonical lifecycle states
 
 Normalized strings (single source in `FulfillmentLifecycleManager`): `pending`, `prepared`, `ready`, `partially_fulfilled`, `fulfilled`, `collected`, `consumed`, `expired`, `failed`, `cancelled`.
@@ -37,6 +39,7 @@ Do not add: inventory engines, warehouse orchestration, shipping execution, noti
 ## Related documentation
 
 - [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
+- [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md)
 - [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
 - [operational-coordination-state-convergence.md](./operational-coordination-state-convergence.md)
 - [operational-observability.md](./operational-observability.md)

--- a/docs/fulfillment-lifecycle-convergence.md
+++ b/docs/fulfillment-lifecycle-convergence.md
@@ -1,0 +1,43 @@
+# Fulfillment lifecycle convergence (Phase 4A)
+
+## Authority boundaries
+
+Fulfillment lifecycle visibility is a **read-only operational projection layer**. It **does not** own entitlement truth, scanner execution, redemption mutation, incident handling, or workspace mutation.
+
+| Authority | Role |
+| --- | --- |
+| Entitlement capability registry | Canonical capability semantics (`redeemable`, `multi_use`, `requires_fulfilment`, scanner action tokens). |
+| Scanner / check-in spine | Canonical admission validation, redemption execution, and consumption events. |
+| Operational integrity inspector | Staff-safe merged diagnostics (issuance, artifacts, recovery, guest continuity, fulfillment operational signals). |
+| Operational continuity / venue policy | Topology, timing, session, and continuity descriptors consumed as **signals**, not re-evaluated. |
+| Fulfillment lifecycle manager | Normalizes **lifecycle states**, **fulfillment types**, partial fulfillment, readiness/completion/degradation **descriptors** for display. |
+
+This layer **must not** issue tickets, change entitlements, change scanner outcomes, enqueue orchestration, send notifications, reserve inventory, or execute shipping.
+
+## Relationship to reservation governance
+
+**Inventory reservation governance** (Phase 4A Commit 2) consumes fulfillment operational signals and continuity semantics as **inputs** for reservation state normalization. Reservation governance does **not** duplicate fulfillment lifecycle logic; it projects reservation-specific vocabulary (`reserved`, `allocated`, `ready_for_collection`, etc.) for staff visibility. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
+
+## Canonical lifecycle states
+
+Normalized strings (single source in `FulfillmentLifecycleManager`): `pending`, `prepared`, `ready`, `partially_fulfilled`, `fulfilled`, `collected`, `consumed`, `expired`, `failed`, `cancelled`.
+
+Entity `fulfilment_status` maps into this vocabulary; admission **checked-in** rows map to `fulfilled` without duplicating scanner policy. Rollup-level issuance/recovery stress can surface as `failed` **visibility only**.
+
+## Canonical fulfillment types
+
+`admission`, `merch_pickup`, `hospitality`, `parking`, `vip_access`, `equipment`, `cloakroom` (reserved for future entitlement keys; currently unused), `multi_redeem`, `digital_access`.
+
+Types are derived from normalized entitlement types plus redemption limits (e.g. add-ons with `redemption_limit > 1` → `multi_redeem`).
+
+## Forbidden patterns
+
+Do not add: inventory engines, warehouse orchestration, shipping execution, notifications, realtime/WebSocket coordination, or duplicate scanner/entitlement/continuity policy stacks in Twig or ad-hoc controllers.
+
+## Related documentation
+
+- [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
+- [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
+- [operational-coordination-state-convergence.md](./operational-coordination-state-convergence.md)
+- [operational-observability.md](./operational-observability.md)
+- [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md)

--- a/docs/inventory-reservation-governance-convergence.md
+++ b/docs/inventory-reservation-governance-convergence.md
@@ -75,6 +75,7 @@ Do not expose: `replay_token`, `qr_payload`, device fingerprints, raw scanner pa
 ## Related documentation
 
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
+- [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md)
 - [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
 - [operational-coordination-state-convergence.md](./operational-coordination-state-convergence.md)
 - [operational-observability.md](./operational-observability.md)

--- a/docs/inventory-reservation-governance-convergence.md
+++ b/docs/inventory-reservation-governance-convergence.md
@@ -1,0 +1,81 @@
+# Inventory reservation governance convergence (Phase 4A, Commit 2)
+
+## Authority boundaries
+
+Inventory reservation governance is a **read-only normalization layer**. It **does not** own Commerce inventory, stock quantities, warehouse execution, shipping, dispatch, or realtime allocation.
+
+| Authority | Role |
+| --- | --- |
+| Commerce | Authoritative for purchasable inventory, order quantities, and inventory truth. |
+| Scanner / check-in spine | Authoritative for redemption execution, admission execution, and consumption execution. |
+| Fulfillment lifecycle (when present) | Authoritative for fulfillment lifecycle normalization consumed as signals. |
+| Operational integrity inspector | Staff-safe merged diagnostics including `fulfillment_operational_signals`. |
+| Operational continuity / venue policy | Topology, timing, session, and continuity descriptors consumed as **signals**, not re-evaluated. |
+| Entitlement capability registry | Canonical capability semantics (`redeemable`, `multi_use`, `requires_fulfilment`, collection support). |
+| Inventory reservation governance manager | Normalizes **reservation states**, **reservation types**, partial allocation, readiness/degradation/continuity **descriptors** for display. |
+
+This layer **must not** reserve stock, decrement inventory, mutate Commerce stock, orchestrate warehouse systems, trigger notifications, trigger dispatch, manage shipping, or allocate inventory in realtime.
+
+## Canonical reservation states
+
+Normalized strings (single source in `InventoryReservationGovernanceManager`): `unreserved`, `reserved`, `partially_reserved`, `allocated`, `prepared`, `ready_for_collection`, `degraded`, `exhausted`, `fulfilled`, `released`, `expired`, `cancelled`.
+
+Entity `fulfilment_status`, redemption counts/limits, issuance alignment, and continuity rollup stress map into this vocabulary for **visibility only**.
+
+## Canonical reservation types
+
+`merch`, `hospitality`, `food_drink`, `parking`, `vip_package`, `equipment`, `cloakroom` (reserved for future entitlement keys), `timed_pickup`, `digital_redemption`.
+
+Types are derived from normalized entitlement types, redemption limits, and timed-entry scanner state strings already materialized on inspector rows.
+
+## Allocation semantics
+
+Allocation summaries compose from:
+
+- reservation type and normalized reservation state,
+- redemption count / limit integers from `fulfillment_operational_signals`,
+- partial allocation flag when capabilities mark `redeemable` + `multi_use` and `0 < redemption_count < redemption_limit`.
+
+No stock decrement, warehouse slot assignment, or realtime allocation occurs in this layer.
+
+## Reservation lifecycle semantics
+
+Lifecycle ordering for audit continuity follows the canonical state list (low → progressed). Workspace audit timelines emit `lane_state`, `recorded_at_unix`, and `audit_note` strings only.
+
+## Degradation semantics
+
+Rollup-level issuance misalignment, recovery mismatch, invalid guest continuity, or non-valid canonical PDF readiness can surface **degraded** reservation visibility. Degradation descriptors are composed in PHP services; Twig renders pre-built strings only.
+
+## Continuity semantics
+
+Reservation continuity projections compose guest continuity statuses observed in merged rollups and per-ticket continuity mode strings from `artifacts.operational_continuity`. Continuity policy is **not** re-evaluated in reservation governance.
+
+## Partial allocation convergence
+
+When capabilities mark `redeemable` + `multi_use` and partial redemption counts apply, rows are labeled `partially_reserved` for reservation visibility. Exhausted (`redemption_count >= redemption_limit`) and fulfilled terminal states take precedence.
+
+## Workspace (`/admin/mel/operations`)
+
+Sections are gated by **`govern mel inventory reservations`** (separate from escalation, ownership, coordination, and fulfillment permissions). Twig renders **pre-built cards and timelines only**; all arithmetic and ordering happen in PHP services.
+
+Services:
+
+| Service ID | Class |
+| --- | --- |
+| `myeventlane_tickets.inventory_reservation_governance_manager` | `InventoryReservationGovernanceManager` |
+| `myeventlane_tickets.inventory_reservation_projection_builder` | `InventoryReservationProjectionBuilder` |
+| `myeventlane_tickets.inventory_reservation_audit_projector` | `InventoryReservationAuditProjector` |
+
+## Forbidden patterns
+
+Do not add: warehouse systems, stock orchestration, shipping execution, dispatch orchestration, notifications, websocket infrastructure, realtime reservation execution, or duplicate fulfillment/scanner/continuity/entitlement policy stacks in Twig or ad-hoc controllers.
+
+Do not expose: `replay_token`, `qr_payload`, device fingerprints, raw scanner payloads, or customer-sensitive identifiers in reservation audit projections.
+
+## Related documentation
+
+- [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
+- [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
+- [operational-coordination-state-convergence.md](./operational-coordination-state-convergence.md)
+- [operational-observability.md](./operational-observability.md)
+- [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md)

--- a/docs/offline-reconciliation-operational-continuity.md
+++ b/docs/offline-reconciliation-operational-continuity.md
@@ -76,6 +76,10 @@ Escalation, resolution, and suppression **governance projections** for staff (SL
 
 Reservation governance projections compose **continuity mode strings** and fulfillment operational signals from inspector rollups into reservation lifecycle visibility. They **must not** mutate continuity blobs, execute reconciliation, reserve stock, or decrement inventory. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
 
+## Operational entitlement capability convergence (Phase 4A, Commit 3)
+
+Capability convergence projections compose reservation governance outputs, fulfillment operational signals, and continuity mode strings into unified capability readiness/degradation visibility. They **must not** mutate continuity blobs, execute reconciliation, execute fulfillment, decrement inventory, or bypass scanner authority. See [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md).
+
 ## Related documentation
 
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)
@@ -83,6 +87,7 @@ Reservation governance projections compose **continuity mode strings** and fulfi
 - [operational-observability.md](./operational-observability.md)
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
 - [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
+- [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [zone-access-topology-convergence.md](./zone-access-topology-convergence.md)
 - [session-multiuse-entitlement-convergence.md](./session-multiuse-entitlement-convergence.md)

--- a/docs/offline-reconciliation-operational-continuity.md
+++ b/docs/offline-reconciliation-operational-continuity.md
@@ -72,12 +72,17 @@ Normalized scalar fields (machine-oriented):
 
 Escalation, resolution, and suppression **governance projections** for staff (SLA acknowledgement windows, severity→escalation routing, suppression rule visibility) are documented in [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md). Those projections **must not** become alternate continuity authority, must not mutate persisted continuity blobs, and must not execute reconciliation.
 
+## Inventory reservation governance (Phase 4A, Commit 2)
+
+Reservation governance projections compose **continuity mode strings** and fulfillment operational signals from inspector rollups into reservation lifecycle visibility. They **must not** mutate continuity blobs, execute reconciliation, reserve stock, or decrement inventory. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
+
 ## Related documentation
 
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)
 - [device-gate-identity-convergence.md](./device-gate-identity-convergence.md)
 - [operational-observability.md](./operational-observability.md)
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
+- [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [zone-access-topology-convergence.md](./zone-access-topology-convergence.md)
 - [session-multiuse-entitlement-convergence.md](./session-multiuse-entitlement-convergence.md)

--- a/docs/operational-coordination-state-convergence.md
+++ b/docs/operational-coordination-state-convergence.md
@@ -1,0 +1,96 @@
+# Operational coordination state convergence (Phase 3B, Commit 1)
+
+## Purpose
+
+Introduce a **single canonical operational coordination read-model** for staff at `/admin/mel/operations`. This layer expresses **venue operational readiness**, **operational degradation**, **recovery coordination**, **reconciliation readiness**, **venue confidence**, **incident saturation**, **operational posture**, and **coordination visibility** — all as **read-only governance semantics** composed from existing merged inspector rollups and existing escalation / resolution projections.
+
+This phase is **not** orchestration, automation, execution, dispatch, notifications, active failover, websocket coordination, or reconciliation execution.
+
+## Authority boundaries
+
+| Authority | Owns |
+| --- | --- |
+| **Entitlement authority** | Issued rows, capability truth, registry maps. |
+| **Scanner authority** | Scan orchestration and public JSON contracts (`ScannerOperationManager`). |
+| **Venue policy authority** | Gate semantics and venue composition (`VenueOperationPolicyManager` and delegates). |
+| **Operational continuity authority** | Continuity / reconciliation metadata (`OperationalContinuityPolicyManager`). |
+| **Incident authority** (when persisted) | Incident records — coordination layer **does not** mutate incidents. |
+| **Escalation governance** (`OperationalEscalationPolicyManager`) | Severity and escalation token normalization and governed severity **from rollups** (unchanged). |
+| **Resolution governance** (`OperationalResolutionGovernanceManager`) | Resolution lifecycle tokens and acknowledgement timing **for projections** (unchanged). |
+| **Coordination state** (`OperationalCoordinationStateManager`) | Normalization of coordination / posture / confidence / saturation tokens; **composition** of coordination semantics from rollup keys + governed severity + resolution projection only. |
+| **Coordination cards** (`OperationalCoordinationProjectionBuilder`) | Twig-safe workspace sections (labels/values pre-computed in PHP). |
+| **Coordination audit** (`OperationalCoordinationAuditProjector`) | Append-only style timelines and history summaries without secrets. |
+| **Operational workspace authority** (`OperationalWorkspaceBuilder`) | Merges inspector rollups, strips sensitive keys, attaches coordination sections **only** when permitted. |
+
+Coordination services **must not** be consulted by scanner, issuance, redemption, or continuity mutation paths.
+
+## Canonical tokens
+
+### Coordination states
+
+`nominal`, `elevated`, `degraded`, `constrained`, `recovery`, `reconciliation`, `saturated`, `restricted`
+
+### Operational postures
+
+`standard_operations`, `heightened_monitoring`, `incident_response`, `recovery_operations`, `reconciliation_operations`, `restricted_operations`
+
+### Venue confidence states
+
+`stable`, `caution`, `uncertain`, `degraded`, `critical`
+
+### Incident saturation states
+
+`clear`, `rising`, `elevated`, `saturated`
+
+Unknown external tokens normalize to safe defaults (**logged**): coordination → `nominal`, posture → `standard_operations`, confidence → `stable`, saturation → `clear`.
+
+## Posture normalization
+
+Operational posture is **derived** from the canonical coordination state, the projected resolution state, and governed severity — without introducing a second severity engine. Resolution lifecycle anchors may appear in coordination audit timelines **only** as normalized state strings and unix anchors (no store mutation).
+
+## Degradation semantics
+
+Degradation visibility is expressed as **rollup stress summaries**: counts and governed severity drawn from merged issuance, recovery, artifact readiness, and guest continuity observations already produced by `OperationalWorkspaceBuilder`. The coordination layer **does not** re-score scanner outcomes per ticket.
+
+## Recovery coordination semantics
+
+Recovery coordination summarizes **completion states observed** and **recovery mismatch** flags from merged recovery rollups. It describes coordination visibility only; it does not trigger recovery execution or subscriber work.
+
+## Reconciliation coordination semantics
+
+Reconciliation readiness summarizes **artifact readiness machine strings** (for example QR operability and attachment continuity) from merged rollups. It does **not** expose QR payloads, signing material, or replay continuity tokens.
+
+## Confidence semantics
+
+Venue confidence states map **one-way** from governed severity (rollup-derived via `OperationalEscalationPolicyManager::projectSeverityFromOperationalRollup()`). This is observability, not a second confidence authority for scanners.
+
+## Forbidden patterns
+
+- Websockets, polling coordination rooms, realtime incident boards, or live maps.
+- Notifications, queues, cron-driven coordination, staffing automation, or dispatch.
+- Mutating entitlement truth, scanner state, redemption logs, continuity blobs, or recovery `State` keys.
+- Duplicating timed-entry, session, zone, occupancy, continuity, or scanner evaluation logic — rollups and existing governance managers remain the sole inputs.
+- Twig-side calculations of posture, degradation, confidence, saturation, or readiness.
+- Exposing `replay_token`, QR payload material, device fingerprints, deterministic continuity descriptors, or customer identifiers through coordination projections.
+
+## Operational governance boundaries
+
+Coordination state remains **downstream of** entitlement, scanner, continuity, and diagnostics authorities. It provides **staff visibility** only and preserves separation of duties from escalation-only and ownership-only permissions.
+
+## Workspace integration
+
+- Route: `/admin/mel/operations` (unchanged).
+- **Coordination sections** (cards + coordination audit timeline) render only when the account holds **`govern mel operational coordination`** (restricted), separate from **`govern mel operational escalations`** and **`govern mel operational ownership`**.
+- `OperationalWorkspaceBuilder` appends coordination sections after ownership sections when permitted; sensitive keys are stripped before render.
+
+## Related documents
+
+- [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
+- [operational-observability.md](./operational-observability.md)
+- [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
+- [operational-assignment-ownership-governance.md](./operational-assignment-ownership-governance.md)
+- [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md)
+
+## Inventory reservation governance (Phase 4A, Commit 2)
+
+**Reservation governance** (`govern mel inventory reservations`) is a **separate permission slice** from coordination projections. Reservation sections normalize allocation lifecycle and inventory-boundary semantics from `fulfillment_operational_signals` and continuity rollups; they do **not** duplicate coordination state logic. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).

--- a/docs/operational-entitlement-capability-convergence.md
+++ b/docs/operational-entitlement-capability-convergence.md
@@ -1,0 +1,103 @@
+# Operational entitlement capability convergence (Phase 4A, Commit 3)
+
+## Authority boundaries
+
+Operational entitlement capability convergence is a **read-only normalization layer**. It **does not** own Commerce inventory, warehouse execution, shipping, dispatch, hospitality orchestration, scanner execution, or redemption mutation.
+
+| Authority | Role |
+| --- | --- |
+| Entitlement capability registry | Canonical capability semantics (`redeemable`, `multi_use`, `requires_fulfilment`, scanner action tokens, fulfilment modes). |
+| Scanner / check-in spine | Authoritative for admission execution, redemption execution, and consumption execution. Capability convergence exposes **scanner visibility** only. |
+| Inventory reservation governance | Authoritative for reservation state/type normalization consumed as **composition inputs** — not re-evaluated. |
+| Fulfillment operational signals | Per-ticket `fulfilment_status`, redemption counts, and ticket status from `OperationalIntegrityInspector` consumed as **signals**. |
+| Operational continuity policy | Continuity mode descriptors consumed as **signals** from merged inspector artifacts. |
+| Operational entitlement capability manager | Normalizes **capability types**, **capability states**, readiness/degradation/continuity **descriptors**, fulfillment/reservation capability summaries, and execution descriptors for display. |
+
+This layer **must not** reserve stock, decrement inventory, execute fulfillment, dispatch products, ship items, orchestrate hospitality systems, trigger notifications, introduce new scanner execution paths, or bypass scanner authority.
+
+## Canonical capability types
+
+Normalized strings (single source in `OperationalEntitlementCapabilityManager`):
+
+`admission`, `merch_pickup`, `hospitality_access`, `food_drink_redemption`, `parking_access`, `vip_access`, `cloakroom_retrieval`, `timed_collection`, `digital_redemption`.
+
+Types are derived from normalized entitlement types, reservation type hints from reservation governance, redemption limits, and timed-entry scanner state strings already materialized on inspector rows.
+
+## Canonical capability states
+
+`unavailable`, `available`, `reserved`, `prepared`, `ready`, `partially_ready`, `degraded`, `exhausted`, `redeemed`, `fulfilled`, `expired`, `cancelled`.
+
+Capability states compose from reservation governance states (mapped without re-evaluating reservation rows), fulfillment operational signals (`fulfilment_status`), and continuity mode descriptors. Terminal redeemed visibility surfaces when `fulfilment_status` is `redeemed`.
+
+## Fulfillment-capability composition
+
+Fulfillment-capability summaries compose from:
+
+- per-ticket `fulfilment_status` in `fulfillment_operational_signals`,
+- entitlement capability map flags (`requires_fulfilment`, `supports_collection`),
+- normalized capability state after reservation mapping.
+
+No stock decrement, warehouse slot assignment, dispatch, or shipping execution occurs in this layer.
+
+## Reservation-capability composition
+
+Reservation-capability summaries compose from `InventoryReservationGovernanceManager::composeReservationReadModel()` outputs:
+
+- `normalized_reservation_state` and `reservation_type` per ticket row,
+- allocation fraction and reservation type tallies from the reservation rollup.
+
+Reservation logic is **not** duplicated; the capability manager maps reservation tokens into capability vocabulary.
+
+## Degradation semantics
+
+Degradation descriptors inherit reservation governance rollup stress signals and add normalized degraded capability row counts. Degradation is composed in PHP services; Twig renders pre-built strings only.
+
+## Readiness semantics
+
+Readiness projections count rows in `prepared`, `ready`, `partially_ready`, and `available` capability states, plus type-specific readiness for merch pickup, hospitality access, and timed collection. Execution readiness is **visibility only**.
+
+## Continuity semantics
+
+Capability continuity projections compose guest continuity statuses and per-ticket continuity mode strings from merged rollups. Continuity policy is **not** re-evaluated in capability convergence.
+
+## Scanner authority
+
+Scanner remains authoritative for admission, redemption, and consumption execution. Capability convergence exposes read-only `scanner_visibility` strings (scanner action token, redeemable, multi_use) derived from `EntitlementCapabilityRegistry` — it does not mutate redemption truth or introduce alternate execution paths.
+
+## Workspace (`/admin/mel/operations`)
+
+Sections are gated by **`govern mel operational capabilities`** (separate from escalation, reservation, coordination, and fulfillment lifecycle permissions). Twig renders **pre-built cards and timelines only**; all arithmetic and ordering happen in PHP services.
+
+Services:
+
+| Service ID | Class |
+| --- | --- |
+| `myeventlane_tickets.operational_entitlement_capability_manager` | `OperationalEntitlementCapabilityManager` |
+| `myeventlane_tickets.operational_capability_projection_builder` | `OperationalCapabilityProjectionBuilder` |
+| `myeventlane_tickets.operational_capability_audit_projector` | `OperationalCapabilityAuditProjector` |
+
+Workspace section IDs:
+
+- `capability_governance_summary`
+- `capability_lifecycle_cards`
+- `capability_readiness_visibility`
+- `capability_lifecycle_audit_timeline`
+
+## Customer safety
+
+Customer-facing capability projections (when surfaced outside the staff workspace) must remain coarse: readiness hints and continuity hints only. Do not expose internal governance, escalation state, replay semantics, fingerprints, or topology internals.
+
+## Forbidden patterns
+
+Do not add: warehouse systems, stock orchestration, shipping execution, dispatch orchestration, hospitality orchestration, notifications, websocket infrastructure, realtime inventory, POS systems, or duplicate reservation/fulfillment/continuity/scanner policy stacks in Twig or ad-hoc controllers.
+
+Do not expose: `replay_token`, `qr_payload`, device fingerprints, raw scanner payloads, or customer-sensitive identifiers in capability audit projections.
+
+## Related documentation
+
+- [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
+- [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
+- [venue-operations-workspace-convergence.md](./venue-operations-workspace-convergence.md)
+- [operational-observability.md](./operational-observability.md)
+- [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md)
+- [entitlement-capability-convergence.md](./entitlement-capability-convergence.md)

--- a/docs/operational-observability.md
+++ b/docs/operational-observability.md
@@ -90,11 +90,16 @@ Staff may view **escalation governance**, **SLA acknowledgement projections**, *
 
 Staff may view **reservation governance**, **allocation continuity**, **degraded reservation visibility**, **readiness and partial allocation summaries**, and **reservation lifecycle audit timelines** when they hold **`govern mel inventory reservations`**. Normalization lives in `InventoryReservationGovernanceManager`; cards and audit sections are composed through `InventoryReservationProjectionBuilder` and `InventoryReservationAuditProjector`. This layer consumes `fulfillment_operational_signals` and continuity rollups as **inputs only** — it does not reserve stock, decrement inventory, or execute warehouse/shipping/dispatch. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
 
+## Operational entitlement capability convergence (Phase 4A, Commit 3)
+
+Staff may view **operational capability cards**, **capability readiness summaries**, **degradation visibility**, **fulfillment-capability visibility**, **reservation-capability visibility**, **capability continuity summaries**, and **capability lifecycle audit timelines** when they hold **`govern mel operational capabilities`**. Normalization lives in `OperationalEntitlementCapabilityManager`; cards and audit sections are composed through `OperationalCapabilityProjectionBuilder` and `OperationalCapabilityAuditProjector`. This layer composes reservation governance and fulfillment operational signals as **inputs only** — it does not execute fulfillment, mutate inventory, or bypass scanner authority. See [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md).
+
 ## Related documentation
 
 - [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md) — continuity / reconciliation metadata authority
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md) — escalation, resolution, suppression governance projections
 - [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md) — reservation lifecycle and allocation governance projections
+- [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md) — operational entitlement capability convergence projections
 - [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue gate policy, offline scaffolding, replay metadata
 - [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — capability registry delegation

--- a/docs/operational-observability.md
+++ b/docs/operational-observability.md
@@ -41,6 +41,7 @@ Normalized `inspectOrder(OrderInterface $order)` returns:
 | `recovery` | `OrderPaidConfirmationPdfRecoverySubscriber` state key via `recoveryStateKey()`, optional message sink for sent confirmation timestamps, mismatch when recovery appears required but completion state missing |
 | `compatibility` | Order-item PDF legacy surface availability, wallet resolution surface (`WalletTicketResolver`), ticket PDF path from `UniversalTicketViewModelBuilder` probe |
 | `guest_continuity` | Purchaser UID alignment with order customer, guest checkout pattern checks (no PII in output) |
+| `fulfillment_operational_signals` | Per issued ticket id: entitlement type, `fulfilment_status`, redemption count/limit, ticket status, admission checked-in flag (staff-safe; no QR or replay material) |
 
 Status values are **machine strings** (for example `valid`, `invalid`, `missing`, `canonical`, `legacy`, `mixed`, `recovered`, `pending`, `skipped`, `orphaned`, `unknown`) suitable for logs and automated checks—not UI copy.
 
@@ -85,10 +86,15 @@ Staff operational convergence now has a **canonical read-only shell** (`VenueOpe
 
 Staff may view **escalation governance**, **SLA acknowledgement projections**, **resolution lifecycle framing**, **suppression rule visibility**, and **audit-safe history summaries** in the same workspace when they hold **`govern mel operational escalations`**. Normalization and routing live in `OperationalEscalationPolicyManager` and `OperationalResolutionGovernanceManager`; card shapes are composed only through `OperationalEscalationAuditProjector`. This layer **does not** change inspector semantics, ticket entities, redemption logs, QR contracts, or continuity authority — see [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md).
 
+## Inventory reservation governance (Phase 4A, Commit 2)
+
+Staff may view **reservation governance**, **allocation continuity**, **degraded reservation visibility**, **readiness and partial allocation summaries**, and **reservation lifecycle audit timelines** when they hold **`govern mel inventory reservations`**. Normalization lives in `InventoryReservationGovernanceManager`; cards and audit sections are composed through `InventoryReservationProjectionBuilder` and `InventoryReservationAuditProjector`. This layer consumes `fulfillment_operational_signals` and continuity rollups as **inputs only** — it does not reserve stock, decrement inventory, or execute warehouse/shipping/dispatch. See [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md).
+
 ## Related documentation
 
 - [offline-reconciliation-operational-continuity.md](./offline-reconciliation-operational-continuity.md) — continuity / reconciliation metadata authority
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md) — escalation, resolution, suppression governance projections
+- [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md) — reservation lifecycle and allocation governance projections
 - [issuance-pipeline.md](./issuance-pipeline.md) — issuance order and attachment merge
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md) — venue gate policy, offline scaffolding, replay metadata
 - [entitlement-capability-convergence.md](./entitlement-capability-convergence.md) — capability registry delegation

--- a/docs/venue-operations-workspace-convergence.md
+++ b/docs/venue-operations-workspace-convergence.md
@@ -11,10 +11,13 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 | Component | Responsibility |
 | --- | --- |
 | `OperationalWorkspaceAccessChecker` (`myeventlane_tickets.operational_workspace_access`) | Route access only: anonymous denied; requires `view mel venue operations workspace` (restricted permission). |
-| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). When the account has `govern mel operational escalations`, appends **governance sections** produced exclusively by `OperationalEscalationAuditProjector` (escalation, SLA, resolution, suppression, audit visibility). |
+| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). When the account has `govern mel operational escalations`, appends **governance sections** produced exclusively by `OperationalEscalationAuditProjector` (escalation, SLA, resolution, suppression, audit visibility). When the account has `govern mel inventory reservations`, appends **reservation governance sections** from `InventoryReservationProjectionBuilder` and `InventoryReservationAuditProjector`. |
 | `OperationalEscalationPolicyManager` (`myeventlane_tickets.operational_escalation_policy_manager`) | Normalizes escalation and severity tokens, maps severity to escalation tiers, and defines SLA acknowledgement semantics for projections (not scanner authority). |
 | `OperationalResolutionGovernanceManager` (`myeventlane_tickets.operational_resolution_governance_manager`) | Resolution state normalization, suppression validation (explicit reason required), lifecycle transition matrix, acknowledgement timing projection. |
 | `OperationalEscalationAuditProjector` (`myeventlane_tickets.operational_escalation_audit_projector`) | Audit-safe escalation/resolution/suppression summaries for the workspace; no secrets or QR material. |
+| `InventoryReservationGovernanceManager` (`myeventlane_tickets.inventory_reservation_governance_manager`) | Reservation state/type normalization, allocation readiness/degradation/continuity descriptors (read-only; no stock execution). |
+| `InventoryReservationProjectionBuilder` (`myeventlane_tickets.inventory_reservation_projection_builder`) | Twig-safe reservation governance cards for the workspace. |
+| `InventoryReservationAuditProjector` (`myeventlane_tickets.inventory_reservation_audit_projector`) | Reservation lifecycle audit timelines and allocation continuity summaries; no secrets. |
 | `VenueOperationsController` | Resolves optional `?event={nid}` (event bundle only), invokes the builder, returns a themed render array with cache tags/contexts. |
 | `venue_operations_workspace` Twig template | Renders pre-shaped `sections` and `meta` only — **no policy branching, no calculations**. |
 
@@ -45,5 +48,6 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 
 - [operational-observability.md](./operational-observability.md)
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
+- [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)

--- a/docs/venue-operations-workspace-convergence.md
+++ b/docs/venue-operations-workspace-convergence.md
@@ -11,13 +11,16 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 | Component | Responsibility |
 | --- | --- |
 | `OperationalWorkspaceAccessChecker` (`myeventlane_tickets.operational_workspace_access`) | Route access only: anonymous denied; requires `view mel venue operations workspace` (restricted permission). |
-| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). When the account has `govern mel operational escalations`, appends **governance sections** produced exclusively by `OperationalEscalationAuditProjector` (escalation, SLA, resolution, suppression, audit visibility). When the account has `govern mel inventory reservations`, appends **reservation governance sections** from `InventoryReservationProjectionBuilder` and `InventoryReservationAuditProjector`. |
+| `OperationalWorkspaceBuilder` (`myeventlane_tickets.operational_workspace_builder`) | Samples Commerce orders for issued tickets on an optional event scope, calls `OperationalIntegrityInspector::inspectOrder()`, merges read-only diagnostics, and emits **Twig-safe section arrays** (cards with labels/values). When the account has `govern mel operational escalations`, appends **governance sections** produced exclusively by `OperationalEscalationAuditProjector` (escalation, SLA, resolution, suppression, audit visibility). When the account has `govern mel inventory reservations`, appends **reservation governance sections** from `InventoryReservationProjectionBuilder` and `InventoryReservationAuditProjector`. When the account has `govern mel operational capabilities`, appends **capability convergence sections** from `OperationalCapabilityProjectionBuilder` and `OperationalCapabilityAuditProjector`. |
 | `OperationalEscalationPolicyManager` (`myeventlane_tickets.operational_escalation_policy_manager`) | Normalizes escalation and severity tokens, maps severity to escalation tiers, and defines SLA acknowledgement semantics for projections (not scanner authority). |
 | `OperationalResolutionGovernanceManager` (`myeventlane_tickets.operational_resolution_governance_manager`) | Resolution state normalization, suppression validation (explicit reason required), lifecycle transition matrix, acknowledgement timing projection. |
 | `OperationalEscalationAuditProjector` (`myeventlane_tickets.operational_escalation_audit_projector`) | Audit-safe escalation/resolution/suppression summaries for the workspace; no secrets or QR material. |
 | `InventoryReservationGovernanceManager` (`myeventlane_tickets.inventory_reservation_governance_manager`) | Reservation state/type normalization, allocation readiness/degradation/continuity descriptors (read-only; no stock execution). |
 | `InventoryReservationProjectionBuilder` (`myeventlane_tickets.inventory_reservation_projection_builder`) | Twig-safe reservation governance cards for the workspace. |
 | `InventoryReservationAuditProjector` (`myeventlane_tickets.inventory_reservation_audit_projector`) | Reservation lifecycle audit timelines and allocation continuity summaries; no secrets. |
+| `OperationalEntitlementCapabilityManager` (`myeventlane_tickets.operational_entitlement_capability_manager`) | Capability type/state normalization, fulfillment/reservation capability composition, readiness/degradation/continuity descriptors (read-only; no execution). |
+| `OperationalCapabilityProjectionBuilder` (`myeventlane_tickets.operational_capability_projection_builder`) | Twig-safe operational capability cards for the workspace. |
+| `OperationalCapabilityAuditProjector` (`myeventlane_tickets.operational_capability_audit_projector`) | Capability lifecycle audit timelines and scanner visibility summaries; no secrets. |
 | `VenueOperationsController` | Resolves optional `?event={nid}` (event bundle only), invokes the builder, returns a themed render array with cache tags/contexts. |
 | `venue_operations_workspace` Twig template | Renders pre-shaped `sections` and `meta` only — **no policy branching, no calculations**. |
 
@@ -49,5 +52,6 @@ This commit is **read-only**: no websocket sync, no polling loops, no maps, no a
 - [operational-observability.md](./operational-observability.md)
 - [operational-escalation-resolution-governance.md](./operational-escalation-resolution-governance.md)
 - [inventory-reservation-governance-convergence.md](./inventory-reservation-governance-convergence.md)
+- [operational-entitlement-capability-convergence.md](./operational-entitlement-capability-convergence.md)
 - [issuance-pipeline.md](./issuance-pipeline.md)
 - [offline-venue-operations-convergence.md](./offline-venue-operations-convergence.md)

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.8
+  version: 1.11
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.11
+  version: 1.12
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -16,6 +16,7 @@ use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolver;
@@ -350,19 +351,15 @@ final class EventStudioAutosaveController {
       }
     }
 
-    $image_fids = $mel['field_event_image'] ?? [];
-    $image_fid = 0;
-    if (is_array($image_fids) && $image_fids !== []) {
-      $image_fid = (int) reset($image_fids);
-    }
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel);
 
     $payload = [
       'title' => $mel['title'] ?? $params['basics']['title'] ?? $params['title'] ?? '',
       'summary' => $mel['summary'] ?? $params['basics']['summary'] ?? $params['summary'] ?? '',
       'body' => $mel['body'] ?? $params['basics']['body'] ?? $params['body'] ?? '',
       'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? $params['field_event_intro'] ?? '')),
-      'field_event_image' => $image_fid,
-      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? $params['field_event_image_alt'] ?? '')),
+      'field_event_image' => $hero['fid'],
+      'field_event_image_alt' => $hero['alt'],
       'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? $params['field_contact_email'] ?? '')),
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? $params['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? $params['field_category'] ?? ''),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -5,84 +5,17 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Markup;
-use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\file\FileInterface;
-use Drupal\myeventlane_event_studio\Service\EntityAutocompleteMelNormalizer;
-use Drupal\myeventlane_event_studio\Service\EventStudioAiAssistBuilder;
-use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
-use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
-use Drupal\myeventlane_event_studio\Service\EventStudioWizardMelBaseline;
-use Drupal\myeventlane_location\Service\LocationProviderManager;
-use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Isolated Event Studio form for event branding.
  */
 final class EventBrandingForm extends EventStudioBaseForm {
-
-  public function __construct(
-    EntityFieldManagerInterface $entityFieldManager,
-    EntityTypeManagerInterface $entityTypeManager,
-    AccountProxyInterface $currentUser,
-    EventStudioSaveService $saveService,
-    EventStudioMelPayloadService $melPayloadService,
-    EventStudioWizardMelBaseline $wizardMelBaseline,
-    EntityAutocompleteMelNormalizer $entityAutocompleteMelNormalizer,
-    EventVendorAccessChecker $eventVendorAccessChecker,
-    EventStudioAutosaveService $autosaveService,
-    EventStudioAiAssistBuilder $aiAssistBuilder,
-    RequestStack $request_stack,
-    LoggerInterface $logger,
-    ?LocationProviderManager $eventStudioLocationProvider,
-    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {
-    parent::__construct(
-      $entityFieldManager,
-      $entityTypeManager,
-      $currentUser,
-      $saveService,
-      $melPayloadService,
-      $wizardMelBaseline,
-      $entityAutocompleteMelNormalizer,
-      $eventVendorAccessChecker,
-      $autosaveService,
-      $aiAssistBuilder,
-      $request_stack,
-      $logger,
-      $eventStudioLocationProvider,
-    );
-  }
-
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('entity_field.manager'),
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('myeventlane_event_studio.save'),
-      $container->get('myeventlane_event_studio.mel_payload'),
-      $container->get('myeventlane_event_studio.wizard_mel_baseline'),
-      $container->get('myeventlane_event_studio.entity_autocomplete_mel_normalizer'),
-      $container->get('myeventlane_vendor.event_access_checker'),
-      $container->get('myeventlane_event_studio.autosave'),
-      $container->get('myeventlane_event_studio.ai_assist_builder'),
-      $container->get('request_stack'),
-      $container->get('logger.factory')->get('myeventlane_event_studio'),
-      $container->has('myeventlane_location.provider_manager')
-        ? $container->get('myeventlane_location.provider_manager')
-        : NULL,
-      $container->get('file_url_generator'),
-    );
-  }
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_branding_form';
@@ -110,51 +43,74 @@ final class EventBrandingForm extends EventStudioBaseForm {
   }
 
   /**
-   * Resolves a usable image URL for the hero preview from mel baseline fids.
+   * {@inheritdoc}
    */
-  private function getHeroPreviewUrlFromMelDefaults(array $melDefaults): ?string {
-    $raw = $melDefaults['field_event_image'] ?? [];
-    if (!is_array($raw)) {
+  protected function persistWizardMel(FormStateInterface $form_state, bool $draft): ?array {
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid < 1) {
       return NULL;
     }
-    $fid = 0;
-    foreach ($raw as $item) {
-      $fid = (int) $item;
-      if ($fid > 0) {
-        break;
+    $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
+    if (!$loaded instanceof NodeInterface) {
+      return NULL;
+    }
+    $this->assertVendorEvent($loaded);
+
+    $complete_form = $form_state->getCompleteForm();
+    $mel_subform = $complete_form['mel'] ?? $form_state->getValue('mel') ?? [];
+    if (!is_array($mel_subform)) {
+      $mel_subform = [];
+    }
+
+    return $this->saveService->saveBrandingHero($loaded, $mel_subform, $form_state, $draft);
+  }
+
+  /**
+   * Applies restored-draft hero defaults onto a clone for widget rendering only.
+   */
+  private function applyDraftHeroOverlay(NodeInterface $target, array $melDefaults): void {
+    if (!array_key_exists('field_event_image', $melDefaults)) {
+      return;
+    }
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($melDefaults);
+    if ($hero['fid'] < 1) {
+      $target->set('field_event_image', []);
+      return;
+    }
+    $target->set('field_event_image', [
+      [
+        'target_id' => $hero['fid'],
+        'alt' => $hero['alt'],
+      ],
+    ]);
+  }
+
+  /**
+   * Disables image_widget_crop required-crop validation on Remove/AJAX rebuilds.
+   *
+   * Contrib assumes crop_wrapper is always present in form values; it is absent
+   * when the managed file is removed, which breaks the Remove button.
+   */
+  private function relaxImageCropValidation(array &$element): void {
+    if (($element['#type'] ?? '') === 'image_crop') {
+      unset($element['#element_validate']);
+      $element['#crop_types_required'] = [];
+    }
+    foreach (Element::children($element) as $child_key) {
+      if (isset($element[$child_key]) && is_array($element[$child_key])) {
+        $this->relaxImageCropValidation($element[$child_key]);
       }
     }
-    if ($fid < 1) {
-      return NULL;
-    }
-    $file = $this->entityTypeManager->getStorage('file')->load($fid);
-    if (!$file instanceof FileInterface) {
-      return NULL;
-    }
-    $uri = $file->getFileUri();
-    if ($uri === '') {
-      return NULL;
-    }
-    return $this->fileUrlGenerator->generateString($uri);
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
-    // Never put hero preview markup in #prefix on managed_file: core's
-    // ManagedFile::processManagedFile() replaces #prefix/#suffix with the AJAX
-    // wrapper (see web/core/modules/file/src/Element/ManagedFile.php).
-    $placeholder_src = Html::escape(myeventlane_event_studio_hero_placeholder_url());
+    $request = $this->requestStack->getCurrentRequest();
+    $restoreDraft = $request !== NULL && $request->query->getBoolean('restore_draft');
 
-    $heroPreviewUrl = $this->getHeroPreviewUrlFromMelDefaults($melDefaults);
-    $hero_alt = Html::escape(trim((string) ($melDefaults['field_event_image_alt'] ?? '')));
-
-    if ($heroPreviewUrl !== NULL && $heroPreviewUrl !== '') {
-      $preview_src = Html::escape($heroPreviewUrl);
-      $preview_img_markup = '<img class="mel-cover-preview__img" id="mel-cover-preview-img" src="' . $preview_src . '" alt="' . $hero_alt . '" width="1200" height="630" loading="lazy" />';
-      $empty_wrapper_attrs = ' id="mel-cover-preview-empty" class="mel-cover-preview__empty" hidden';
-    }
-    else {
-      $preview_img_markup = '<img class="mel-cover-preview__img" id="mel-cover-preview-img" src="" alt="" width="1200" height="630" loading="lazy" hidden />';
-      $empty_wrapper_attrs = ' id="mel-cover-preview-empty" class="mel-cover-preview__empty"';
+    $formNode = $node;
+    if ($restoreDraft) {
+      $formNode = clone $node;
+      $this->applyDraftHeroOverlay($formNode, $melDefaults);
     }
 
     $form['mel']['branding_hero_shell'] = [
@@ -164,51 +120,62 @@ final class EventBrandingForm extends EventStudioBaseForm {
         . '<header class="mel-es-field-group__header">'
         . '<h3 class="mel-es-field-group__title" id="mel-es-branding-title">' . Html::escape((string) $this->t('Branding')) . '</h3>'
         . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Shape how your event appears across MyEventLane and social sharing.')) . '</p>'
-        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('You can change visuals later. Accessibility text helps everyone understand the image.')) . '</p>'
+        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('Set the 1200×630 crop frame and tap the focal point so the hero stays centred on the event and book pages.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body">'
         . '<div class="mel-identity-media mel-identity-media--compact">'
-        . '<div class="mel-cover-preview" id="mel-cover-preview" data-mel-cover-preview>'
-        . $preview_img_markup
-        . '<div' . $empty_wrapper_attrs . '>'
-        . '<img class="mel-cover-preview__placeholder" src="' . $placeholder_src . '" width="800" height="450" loading="lazy" decoding="async" alt="" />'
-        . '<span class="mel-cover-preview__empty-icon" aria-hidden="true"></span>'
-        . '<span class="mel-cover-preview__empty-text">' . Html::escape((string) $this->t('No cover image yet — upload a hero image so attendees recognise your event.')) . '</span>'
-        . '</div></div>'
         . '<div class="mel-identity-media__fields mel-builder-fields mel-builder-fields--stack">'
       ),
       '#weight' => -10,
     ];
 
-    $form['mel']['field_event_image'] = [
-      '#type' => 'managed_file',
-      '#title' => $this->t('Hero image'),
-      '#upload_location' => 'public://events',
-      '#upload_validators' => [
-        'FileExtension' => ['extensions' => 'png gif jpg jpeg webp'],
-        'FileSizeLimit' => ['fileLimit' => 5 * 1024 * 1024],
-      ],
-      '#default_value' => $melDefaults['field_event_image'] ?? [],
-      '#attributes' => ['class' => ['mel-input-file']],
-      '#description' => $this->t('Optional, but recommended. A clear image helps attendees recognise your event.'),
-      '#weight' => 0,
-    ];
+    $form['mel']['#parents'] = ['mel'];
 
-    $form['mel']['field_event_image_alt'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Image alt text'),
-      '#default_value' => $melDefaults['field_event_image_alt'] ?? '',
-      '#description' => $this->t('Briefly describe the image for screen readers.'),
-      '#attributes' => ['class' => ['mel-input']],
-      '#suffix' => '</div></div></div></section>',
-      '#weight' => 1,
+    $form_display = $this->entityTypeManager->getStorage('entity_form_display')->load('node.event.studio_branding');
+    if (!$form_display instanceof EntityFormDisplay) {
+      $this->logger->error('Missing entity form display node.event.studio_branding while building branding for node @nid.', ['@nid' => (string) $node->id()]);
+      $form['mel']['field_event_image'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => Html::escape((string) $this->t('Hero image editor is not available. Import configuration or contact support.')),
+        '#attributes' => ['class' => ['messages', 'messages--error']],
+        '#weight' => 0,
+      ];
+    }
+    else {
+      $widget = $form_display->getRenderer('field_event_image');
+      if ($widget === NULL) {
+        $this->logger->error('Missing field_event_image widget on studio_branding display for node @nid.', ['@nid' => (string) $node->id()]);
+        $form['mel']['field_event_image'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => Html::escape((string) $this->t('Hero image widget is not configured.')),
+          '#attributes' => ['class' => ['messages', 'messages--error']],
+          '#weight' => 0,
+        ];
+      }
+      else {
+        // Field widgets return their subtree; core assigns it (see
+        // EntityFormDisplay::buildForm). Calling ::form() without assignment drops
+        // the entire image/crop UI from the render array.
+        $form['mel']['field_event_image'] = $widget->form($formNode->get('field_event_image'), $form['mel'], $form_state);
+        $this->relaxImageCropValidation($form['mel']['field_event_image']);
+        $form['mel']['field_event_image']['#weight'] = 0;
+      }
+    }
+
+    $form['mel']['branding_hero_close'] = [
+      '#type' => 'markup',
+      '#markup' => Markup::create('</div></div></div></section>'),
+      '#weight' => 5,
     ];
 
     $form['unavailable'] = [
       '#type' => 'container',
+      '#weight' => 20,
       '#attributes' => ['class' => ['mel-event-studio-section__placeholder']],
       'copy' => [
-        '#markup' => '<p>' . $this->t('More brand controls will appear here only when they are ready for creators. For now, image and alt text are enough for most events.') . '</p>',
+        '#markup' => '<p>' . $this->t('More brand controls will appear here only when they are ready for creators. For now, the hero image and crop are enough for most events.') . '</p>',
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -107,10 +107,13 @@ final class EventBrandingForm extends EventStudioBaseForm {
     $request = $this->requestStack->getCurrentRequest();
     $restoreDraft = $request !== NULL && $request->query->getBoolean('restore_draft');
 
-    $formNode = $node;
+    $formNode = clone $node;
     if ($restoreDraft) {
-      $formNode = clone $node;
       $this->applyDraftHeroOverlay($formNode, $melDefaults);
+    }
+    if ($this->saveService->isBrokenHeroImageReference($formNode)) {
+      $formNode->set('field_event_image', []);
+      $this->messenger()->addWarning($this->t('The previous cover image file is no longer available. Upload a new image, or click Save branding to clear the broken reference.'));
     }
 
     $form['mel']['branding_hero_shell'] = [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -22,6 +22,94 @@ final class EventStudioMelPayloadService {
   ) {}
 
   /**
+   * Normalizes hero fid + alt from `mel` or baseline fragments.
+   *
+   * Supports legacy `managed_file` values (`mel[field_event_image]` fid list),
+   * optional `mel[field_event_image_alt]`, and image / image_widget_crop widgets
+   * (`mel[field_event_image][0][fids]`, `…[0][alt]`).
+   *
+   * @param array<string, mixed> $fragment
+   *   Partial or full mel array containing `field_event_image` / `field_event_image_alt`.
+   *
+   * @return array{fid: int, alt: string}
+   */
+  public static function normalizeHeroFromMelFragment(array $fragment): array {
+    $alt = trim((string) ($fragment['field_event_image_alt'] ?? ''));
+    $raw = $fragment['field_event_image'] ?? NULL;
+    if (!is_array($raw)) {
+      return ['fid' => 0, 'alt' => $alt];
+    }
+
+    if (isset($raw[0]) && is_array($raw[0])) {
+      $delta = $raw[0];
+      $fid = self::firstPositiveIntFromFidsValue($delta['fids'] ?? NULL);
+      if ($fid < 1 && isset($delta['target_id'])) {
+        $fid = max(0, (int) $delta['target_id']);
+      }
+      $delta_alt = trim((string) ($delta['alt'] ?? ''));
+      if ($delta_alt !== '') {
+        $alt = $delta_alt;
+      }
+      return ['fid' => $fid, 'alt' => $alt];
+    }
+
+    if (array_key_exists('fids', $raw)) {
+      return ['fid' => self::firstPositiveIntFromFidsValue($raw['fids']), 'alt' => $alt];
+    }
+
+    $fid = 0;
+    foreach ($raw as $value) {
+      if (is_array($value)) {
+        continue;
+      }
+      if (is_numeric($value)) {
+        $candidate = (int) $value;
+        if ($candidate > 0) {
+          $fid = $candidate;
+          break;
+        }
+      }
+    }
+
+    return ['fid' => $fid, 'alt' => $alt];
+  }
+
+  /**
+   * @return int
+   *   First positive file id from a managed_file / image widget fids value.
+   */
+  private static function firstPositiveIntFromFidsValue(mixed $fids): int {
+    if ($fids === NULL || $fids === '') {
+      return 0;
+    }
+    if (is_array($fids)) {
+      foreach ($fids as $value) {
+        $candidate = (int) $value;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+      return 0;
+    }
+    if (is_string($fids)) {
+      $parts = preg_split('/\s+/', trim($fids));
+      if (!is_array($parts)) {
+        return 0;
+      }
+      foreach ($parts as $part) {
+        if ($part === '') {
+          continue;
+        }
+        $candidate = (int) $part;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+    }
+    return 0;
+  }
+
+  /**
    * @return array<string, mixed>
    */
   public function buildFromFormState(FormStateInterface $form_state, EntityTypeManagerInterface $entityTypeManager): array {
@@ -71,19 +159,15 @@ final class EventStudioMelPayloadService {
     $has_attendee_questions = $attendee_questions !== [];
     $collect_per_ticket = !empty($mel['collect_attendee_questions']) || $has_attendee_questions;
 
-    $image_fids = $mel['field_event_image'] ?? [];
-    $image_fid = 0;
-    if (is_array($image_fids) && $image_fids !== []) {
-      $image_fid = (int) reset($image_fids);
-    }
+    $hero = self::normalizeHeroFromMelFragment($mel);
 
     $payload = [
       'title' => $mel['title'] ?? '',
       'summary' => $mel['summary'] ?? '',
       'body' => $mel['body'] ?? '',
       'field_event_intro' => trim((string) ($mel['field_event_intro'] ?? '')),
-      'field_event_image' => $image_fid,
-      'field_event_image_alt' => trim((string) ($mel['field_event_image_alt'] ?? '')),
+      'field_event_image' => $hero['fid'],
+      'field_event_image_alt' => $hero['alt'],
       'field_contact_email' => trim((string) ($mel['field_contact_email'] ?? '')),
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? ''),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldWidgetInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
@@ -837,6 +840,86 @@ final class EventStudioSaveService {
       }
     }
     return $keys;
+  }
+
+  /**
+   * Persists branding hero image via the studio_branding field widget.
+   *
+   * Uses widget extraction so crop_wrapper / focal point values reach the entity
+   * before save (image_widget_crop + focal_point entity hooks).
+   *
+   * @param array<string, mixed> $mel_subform
+   *   The `mel` form fragment containing `field_event_image`.
+   *
+   * @return array{node: ?\Drupal\node\NodeInterface, errors: list<string>}
+   */
+  public function saveBrandingHero(NodeInterface $node, array $mel_subform, FormStateInterface $form_state, bool $draft = FALSE): array {
+    if (!$node->hasField('field_event_image')) {
+      return ['node' => $node, 'errors' => []];
+    }
+
+    $display = $this->entityTypeManager->getStorage('entity_form_display')->load('node.event.studio_branding');
+    if (!$display instanceof EntityFormDisplay) {
+      $this->logger->error('Branding save: missing form display node.event.studio_branding for node @nid.', ['@nid' => (string) $node->id()]);
+      return ['node' => NULL, 'errors' => ['Hero image editor is not available.']];
+    }
+
+    $widget = $display->getRenderer('field_event_image');
+    if (!$widget instanceof FieldWidgetInterface) {
+      $this->logger->error('Branding save: missing field_event_image widget for node @nid.', ['@nid' => (string) $node->id()]);
+      return ['node' => NULL, 'errors' => ['Hero image widget is not configured.']];
+    }
+
+    if (!isset($mel_subform['field_event_image'])) {
+      return ['node' => NULL, 'errors' => ['Hero image field is missing from the form.']];
+    }
+
+    $items = $node->get('field_event_image');
+    $widget->extractFormValues($items, $mel_subform, $form_state);
+
+    $fid = 0;
+    $alt = '';
+    if (!$items->isEmpty()) {
+      $value = $items->first()?->getValue() ?? [];
+      $fid = (int) ($value['target_id'] ?? 0);
+      $alt = trim((string) ($value['alt'] ?? ''));
+    }
+
+    if ($fid < 1) {
+      $node->set('field_event_image', []);
+    }
+    else {
+      if ($alt === '' && !$draft) {
+        return ['node' => NULL, 'errors' => ['Alt text is required for the cover image.']];
+      }
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      if (!$file instanceof FileInterface) {
+        $this->logger->warning('Branding save: missing file @fid for event image on node @nid.', [
+          '@fid' => (string) $fid,
+          '@nid' => (string) $node->id(),
+        ]);
+        return ['node' => NULL, 'errors' => ['The uploaded image could not be loaded. Try uploading again.']];
+      }
+      if ($file->isTemporary()) {
+        $file->setPermanent();
+        $file->save();
+      }
+      $node->set('field_event_image', $items);
+    }
+
+    EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio branding draft.' : 'Event Studio branding save.');
+    try {
+      $node->save();
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Branding hero save failed for node @nid: @m', [
+        '@nid' => (string) $node->id(),
+        '@m' => $e->getMessage(),
+      ]);
+      return ['node' => NULL, 'errors' => ['Could not save branding.']];
+    }
+
+    return ['node' => $node, 'errors' => []];
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -935,7 +935,18 @@ final class EventStudioSaveService {
           $file->setPermanent();
           $file->save();
         }
-        $node->set('field_event_image', $items);
+        if (!$items->isEmpty()) {
+          $node->set('field_event_image', $items);
+        }
+        else {
+          $node->set('field_event_image', [
+            [
+              'target_id' => $fid,
+              'alt' => $alt,
+              'title' => '',
+            ],
+          ]);
+        }
       }
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -7,7 +7,7 @@ namespace Drupal\myeventlane_event_studio\Service;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\Field\FieldWidgetInterface;
+use Drupal\Core\Field\WidgetInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
@@ -843,6 +843,20 @@ final class EventStudioSaveService {
   }
 
   /**
+   * Whether the event hero references a file record that is missing on disk.
+   */
+  public function isBrokenHeroImageReference(NodeInterface $node): bool {
+    if (!$node->hasField('field_event_image') || $node->get('field_event_image')->isEmpty()) {
+      return FALSE;
+    }
+    $file = $node->get('field_event_image')->entity;
+    if (!$file instanceof FileInterface) {
+      return TRUE;
+    }
+    return !$this->heroFileIsRenderable($file);
+  }
+
+  /**
    * Persists branding hero image via the studio_branding field widget.
    *
    * Uses widget extraction so crop_wrapper / focal point values reach the entity
@@ -864,18 +878,23 @@ final class EventStudioSaveService {
       return ['node' => NULL, 'errors' => ['Hero image editor is not available.']];
     }
 
+    $mel_values = $form_state->getValue('mel') ?? [];
+    if (!is_array($mel_values)) {
+      $mel_values = [];
+    }
+    $mel_structure = $form_state->getCompleteForm()['mel'] ?? $mel_subform;
+    if (!is_array($mel_structure) || !isset($mel_structure['field_event_image'])) {
+      return ['node' => NULL, 'errors' => ['Hero image field is missing from the form.']];
+    }
+
     $widget = $display->getRenderer('field_event_image');
-    if (!$widget instanceof FieldWidgetInterface) {
+    if (!$widget instanceof WidgetInterface) {
       $this->logger->error('Branding save: missing field_event_image widget for node @nid.', ['@nid' => (string) $node->id()]);
       return ['node' => NULL, 'errors' => ['Hero image widget is not configured.']];
     }
 
-    if (!isset($mel_subform['field_event_image'])) {
-      return ['node' => NULL, 'errors' => ['Hero image field is missing from the form.']];
-    }
-
     $items = $node->get('field_event_image');
-    $widget->extractFormValues($items, $mel_subform, $form_state);
+    $widget->extractFormValues($items, $mel_structure, $form_state);
 
     $fid = 0;
     $alt = '';
@@ -883,6 +902,17 @@ final class EventStudioSaveService {
       $value = $items->first()?->getValue() ?? [];
       $fid = (int) ($value['target_id'] ?? 0);
       $alt = trim((string) ($value['alt'] ?? ''));
+    }
+
+    // Fallback when widget extraction does not populate target_id (e.g. Remove).
+    if ($fid < 1) {
+      $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment([
+        'field_event_image' => $mel_values['field_event_image'] ?? [],
+      ]);
+      $fid = $hero['fid'];
+      if ($alt === '' && $hero['alt'] !== '') {
+        $alt = $hero['alt'];
+      }
     }
 
     if ($fid < 1) {
@@ -893,18 +923,20 @@ final class EventStudioSaveService {
         return ['node' => NULL, 'errors' => ['Alt text is required for the cover image.']];
       }
       $file = $this->entityTypeManager->getStorage('file')->load($fid);
-      if (!$file instanceof FileInterface) {
-        $this->logger->warning('Branding save: missing file @fid for event image on node @nid.', [
+      if (!$file instanceof FileInterface || !$this->heroFileIsRenderable($file)) {
+        $this->logger->warning('Branding save: clearing missing or unreadable hero file @fid on node @nid.', [
           '@fid' => (string) $fid,
           '@nid' => (string) $node->id(),
         ]);
-        return ['node' => NULL, 'errors' => ['The uploaded image could not be loaded. Try uploading again.']];
+        $node->set('field_event_image', []);
       }
-      if ($file->isTemporary()) {
-        $file->setPermanent();
-        $file->save();
+      else {
+        if ($file->isTemporary()) {
+          $file->setPermanent();
+          $file->save();
+        }
+        $node->set('field_event_image', $items);
       }
-      $node->set('field_event_image', $items);
     }
 
     EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio branding draft.' : 'Event Studio branding save.');
@@ -973,6 +1005,21 @@ final class EventStudioSaveService {
     if ($node->hasField('field_location_longitude') && $lng !== NULL && $lng !== '') {
       $node->set('field_location_longitude', (string) $lng);
     }
+  }
+
+  /**
+   * Whether a file entity URI exists and is a readable image for crop widgets.
+   */
+  private function heroFileIsRenderable(FileInterface $file): bool {
+    $uri = $file->getFileUri();
+    if ($uri === '' || !file_exists($uri)) {
+      return FALSE;
+    }
+    $mime = $file->getMimeType();
+    if ($mime !== '' && !str_starts_with($mime, 'image/')) {
+      return FALSE;
+    }
+    return TRUE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
@@ -40,6 +40,11 @@ govern mel inventory reservations:
   description: 'View reservation governance, allocation continuity, degradation, and lifecycle audit projections in the venue operations workspace.'
   restrict access: true
 
+govern mel operational capabilities:
+  title: 'Govern MyEventLane operational capabilities'
+  description: 'View operational entitlement capability convergence, readiness, degradation, fulfillment/reservation capability visibility, and lifecycle audit projections in the venue operations workspace.'
+  restrict access: true
+
 
 
 

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.permissions.yml
@@ -35,6 +35,11 @@ govern mel operational escalations:
   description: 'View escalation, SLA, resolution, and suppression governance projections in the venue operations workspace.'
   restrict access: true
 
+govern mel inventory reservations:
+  title: 'Govern MyEventLane inventory reservations'
+  description: 'View reservation governance, allocation continuity, degradation, and lifecycle audit projections in the venue operations workspace.'
+  restrict access: true
+
 
 
 

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -250,6 +250,22 @@ services:
       - '@myeventlane_tickets.operational_escalation_policy_manager'
       - '@myeventlane_tickets.operational_resolution_governance_manager'
 
+  myeventlane_tickets.inventory_reservation_governance_manager:
+    class: Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager
+    arguments:
+      - '@myeventlane_tickets.entitlement_capability_registry'
+      - '@logger.channel.myeventlane_tickets'
+
+  myeventlane_tickets.inventory_reservation_projection_builder:
+    class: Drupal\myeventlane_tickets\Service\InventoryReservationProjectionBuilder
+    arguments:
+      - '@myeventlane_tickets.inventory_reservation_governance_manager'
+
+  myeventlane_tickets.inventory_reservation_audit_projector:
+    class: Drupal\myeventlane_tickets\Service\InventoryReservationAuditProjector
+    arguments:
+      - '@myeventlane_tickets.inventory_reservation_governance_manager'
+
   myeventlane_tickets.operational_workspace_builder:
     class: Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder
     arguments:
@@ -260,6 +276,8 @@ services:
       - '@myeventlane_tickets.entitlement_capability_registry'
       - '@current_user'
       - '@myeventlane_tickets.operational_escalation_audit_projector'
+      - '@myeventlane_tickets.inventory_reservation_projection_builder'
+      - '@myeventlane_tickets.inventory_reservation_audit_projector'
 
   myeventlane_tickets.operational_workspace_access:
     class: Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -266,6 +266,23 @@ services:
     arguments:
       - '@myeventlane_tickets.inventory_reservation_governance_manager'
 
+  myeventlane_tickets.operational_entitlement_capability_manager:
+    class: Drupal\myeventlane_tickets\Service\OperationalEntitlementCapabilityManager
+    arguments:
+      - '@myeventlane_tickets.entitlement_capability_registry'
+      - '@myeventlane_tickets.inventory_reservation_governance_manager'
+      - '@logger.channel.myeventlane_tickets'
+
+  myeventlane_tickets.operational_capability_projection_builder:
+    class: Drupal\myeventlane_tickets\Service\OperationalCapabilityProjectionBuilder
+    arguments:
+      - '@myeventlane_tickets.operational_entitlement_capability_manager'
+
+  myeventlane_tickets.operational_capability_audit_projector:
+    class: Drupal\myeventlane_tickets\Service\OperationalCapabilityAuditProjector
+    arguments:
+      - '@myeventlane_tickets.operational_entitlement_capability_manager'
+
   myeventlane_tickets.operational_workspace_builder:
     class: Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder
     arguments:
@@ -278,6 +295,8 @@ services:
       - '@myeventlane_tickets.operational_escalation_audit_projector'
       - '@myeventlane_tickets.inventory_reservation_projection_builder'
       - '@myeventlane_tickets.inventory_reservation_audit_projector'
+      - '@myeventlane_tickets.operational_capability_projection_builder'
+      - '@myeventlane_tickets.operational_capability_audit_projector'
 
   myeventlane_tickets.operational_workspace_access:
     class: Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker

--- a/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationAuditProjector.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationAuditProjector.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+/**
+ * Inventory reservation audit visibility (ordering and continuity only).
+ *
+ * Emits normalized strings and deterministic ordering anchors — no replay
+ * tokens, QR payloads, device fingerprints, or customer identifiers.
+ */
+final class InventoryReservationAuditProjector {
+
+  public function __construct(
+    private readonly InventoryReservationGovernanceManager $inventoryReservationGovernanceManager,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildWorkspaceReservationAuditSections(array $merged, int $requestTime): array {
+    $model = $this->inventoryReservationGovernanceManager->composeReservationReadModel($merged, $requestTime);
+    $rollup = is_array($model['rollup'] ?? NULL) ? $model['rollup'] : [];
+    $tally = is_array($rollup['canonical_reservation_state_tally'] ?? NULL) ? $rollup['canonical_reservation_state_tally'] : [];
+    $degraded = (int) ($tally[InventoryReservationGovernanceManager::STATE_DEGRADED] ?? 0);
+    $tone = $degraded > 0 ? 'elevated' : 'low';
+
+    $timeline = $this->buildReservationOrderingTimeline($model, $requestTime);
+    $partial_note = $this->partialAllocationContinuityNote($model);
+    $degradation_ordering = $this->degradationOrderingSummary($model);
+
+    return [
+      [
+        'id' => 'reservation_lifecycle_audit_timeline',
+        'title' => 'Reservation lifecycle audit timeline',
+        'section_tone' => $tone,
+        'cards' => [
+          [
+            'label' => 'Reservation transition ordering',
+            'value' => $this->transitionOrderingSummary($model),
+          ],
+          [
+            'label' => 'Allocation audit summary',
+            'value' => $this->allocationAuditSummary($model),
+          ],
+          [
+            'label' => 'Reservation degradation ordering',
+            'value' => $degradation_ordering,
+          ],
+          [
+            'label' => 'Partial allocation continuity',
+            'value' => $partial_note,
+          ],
+          [
+            'label' => 'Reservation continuity summary',
+            'value' => $this->continuityAuditSummary($model),
+          ],
+        ],
+        'timeline' => $timeline,
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function buildReservationOrderingTimeline(array $model, int $requestTime): array {
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    $out = [];
+    $seq = 0;
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $seq++;
+      $state = (string) ($row['normalized_reservation_state'] ?? '');
+      $type = (string) ($row['reservation_type'] ?? '');
+      $partial = !empty($row['partial_allocation']) ? 'yes' : 'no';
+      $out[] = [
+        'lane_state' => $state,
+        'recorded_at_unix' => $requestTime + $seq,
+        'audit_note' => 'reservation_type=' . $type . '; partial=' . $partial . '; allocation=' . (string) ($row['allocation_summary'] ?? '') . '; continuity=' . (string) ($row['continuity_summary'] ?? ''),
+      ];
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function transitionOrderingSummary(array $model): string {
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    $ordered = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $ordered[] = (string) ($row['normalized_reservation_state'] ?? '');
+    }
+    return $ordered === [] ? 'no_rows' : implode(' → ', $ordered);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function allocationAuditSummary(array $model): string {
+    $parts = [];
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $parts[] = (string) ($row['allocation_summary'] ?? '');
+    }
+    return $parts === [] ? 'no_allocation_audit_rows' : implode(' | ', $parts);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function degradationOrderingSummary(array $model): string {
+    $degradation = is_array($model['degradation_projection'] ?? NULL) ? $model['degradation_projection'] : [];
+    $signals = is_array($degradation['signals'] ?? NULL) ? $degradation['signals'] : [];
+    if ($signals === []) {
+      return 'nominal';
+    }
+    return implode(' → ', $signals);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function partialAllocationContinuityNote(array $model): string {
+    $n = (int) (($model['rollup'] ?? [])['partial_allocation_rows'] ?? 0);
+    if ($n < 1) {
+      return 'no_partial_allocation_rows_observed';
+    }
+    return 'partial_allocation_rows=' . (string) $n . ' (multi-redeem reservation semantics)';
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function continuityAuditSummary(array $model): string {
+    $continuity = is_array($model['continuity_projection'] ?? NULL) ? $model['continuity_projection'] : [];
+    $statuses = is_array($continuity['guest_continuity_statuses'] ?? NULL) ? $continuity['guest_continuity_statuses'] : [];
+    return 'guest_continuity=' . ($statuses === [] ? 'n/a' : implode(',', $statuses))
+      . '; continuity_rows=' . (string) (int) ($continuity['continuity_row_count'] ?? 0);
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationGovernanceManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationGovernanceManager.php
@@ -1,0 +1,601 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+
+/**
+ * Canonical inventory reservation governance (read-model only).
+ *
+ * Normalizes reservation lifecycle semantics, allocation visibility, readiness,
+ * degradation, partial allocation, and continuity from merged inspector rollups.
+ * Does not reserve stock, decrement inventory, or orchestrate warehouse systems.
+ */
+final class InventoryReservationGovernanceManager {
+
+  public const STATE_UNRESERVED = 'unreserved';
+  public const STATE_RESERVED = 'reserved';
+  public const STATE_PARTIALLY_RESERVED = 'partially_reserved';
+  public const STATE_ALLOCATED = 'allocated';
+  public const STATE_PREPARED = 'prepared';
+  public const STATE_READY_FOR_COLLECTION = 'ready_for_collection';
+  public const STATE_DEGRADED = 'degraded';
+  public const STATE_EXHAUSTED = 'exhausted';
+  public const STATE_FULFILLED = 'fulfilled';
+  public const STATE_RELEASED = 'released';
+  public const STATE_EXPIRED = 'expired';
+  public const STATE_CANCELLED = 'cancelled';
+
+  public const TYPE_MERCH = 'merch';
+  public const TYPE_HOSPITALITY = 'hospitality';
+  public const TYPE_FOOD_DRINK = 'food_drink';
+  public const TYPE_PARKING = 'parking';
+  public const TYPE_VIP_PACKAGE = 'vip_package';
+  public const TYPE_EQUIPMENT = 'equipment';
+  public const TYPE_CLOAKROOM = 'cloakroom';
+  public const TYPE_TIMED_PICKUP = 'timed_pickup';
+  public const TYPE_DIGITAL_REDEMPTION = 'digital_redemption';
+
+  /**
+   * Canonical reservation ordering for audit continuity (low → progressed).
+   *
+   * @var list<string>
+   */
+  private const RESERVATION_ORDER = [
+    self::STATE_UNRESERVED,
+    self::STATE_RESERVED,
+    self::STATE_PARTIALLY_RESERVED,
+    self::STATE_ALLOCATED,
+    self::STATE_PREPARED,
+    self::STATE_READY_FOR_COLLECTION,
+    self::STATE_DEGRADED,
+    self::STATE_EXHAUSTED,
+    self::STATE_FULFILLED,
+    self::STATE_RELEASED,
+    self::STATE_EXPIRED,
+    self::STATE_CANCELLED,
+  ];
+
+  public function __construct(
+    private readonly EntitlementCapabilityRegistry $entitlementCapabilityRegistry,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Builds a single normalized reservation read-model for workspace layers.
+   *
+   * @param array<string, mixed> $merged
+   *   Output shape compatible with
+   *   {@see OperationalWorkspaceBuilder::mergeInspections()}.
+   *
+   * @return array<string, mixed>
+   */
+  public function composeReservationReadModel(array $merged, int $requestTime): array {
+    $signals = is_array($merged['fulfillment_signals'] ?? NULL) ? $merged['fulfillment_signals'] : [];
+    $by_ticket = is_array($signals['by_ticket_id'] ?? NULL) ? $signals['by_ticket_id'] : [];
+    $artifacts = is_array($merged['artifacts'] ?? NULL) ? $merged['artifacts'] : [];
+    $continuity = is_array($artifacts['operational_continuity'] ?? NULL) ? $artifacts['operational_continuity'] : [];
+    $timed = is_array($artifacts['timed_entry_policy'] ?? NULL) ? $artifacts['timed_entry_policy'] : [];
+    $issuance = is_array($merged['issuance'] ?? NULL) ? $merged['issuance'] : [];
+    $guest = is_array($merged['guest_continuity'] ?? NULL) ? $merged['guest_continuity'] : [];
+    $recovery = is_array($merged['recovery'] ?? NULL) ? $merged['recovery'] : [];
+    $canonical_pdf = (string) ($artifacts['canonical_pdf_readiness'] ?? 'missing');
+
+    $rollup_degraded = $this->rollupDegraded($issuance, $recovery, $guest, $canonical_pdf);
+    $issuance_aligned = ((string) ($issuance['worst_quantity_alignment_status'] ?? '')) === 'valid';
+
+    $ticket_projections = [];
+    $state_tally = array_fill_keys(self::RESERVATION_ORDER, 0);
+    $type_tally = [];
+    foreach (self::allReservationTypes() as $t) {
+      $type_tally[$t] = 0;
+    }
+
+    foreach ($by_ticket as $ticket_id => $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $entitlement = $this->entitlementCapabilityRegistry->normalizeEntitlementType((string) ($row['entitlement_type'] ?? ''));
+      $cap = $this->entitlementCapabilityRegistry->getCapabilityMap($entitlement);
+
+      $continuity_row = is_array($continuity[(string) $ticket_id] ?? NULL)
+        ? $continuity[(string) $ticket_id]
+        : [];
+      $continuity_mode = (string) (($continuity_row['continuity_summary']['continuity_mode'] ?? '') ?: '');
+      $timing_row = is_array($timed[(string) $ticket_id] ?? NULL) ? $timed[(string) $ticket_id] : [];
+      $timing_policy = is_array($timing_row['policy'] ?? NULL) ? $timing_row['policy'] : [];
+      $timed_scanner_state = (string) (($timing_policy['scanner']['state'] ?? '') ?: '');
+
+      $reservation_type = $this->mapEntitlementToReservationType($entitlement, (int) ($row['redemption_limit'] ?? 1), $timed_scanner_state);
+      $type_tally[$reservation_type] = ($type_tally[$reservation_type] ?? 0) + 1;
+
+      $normalized = $this->normalizeTicketReservationState(
+        $row,
+        $cap,
+        $rollup_degraded,
+        $canonical_pdf,
+        $continuity_mode,
+        $reservation_type,
+        $issuance_aligned,
+      );
+
+      $state_tally[$normalized] = ($state_tally[$normalized] ?? 0) + 1;
+
+      $allocation_summary = $this->buildAllocationSummary($row, $cap, $normalized, $reservation_type);
+      $readiness_summary = $this->buildReadinessSummary($normalized, $cap, $canonical_pdf, $timed_scanner_state);
+      $continuity_summary = $this->buildContinuitySummary($continuity_mode, $normalized);
+
+      $ticket_projections[] = [
+        'ticket_ordinal' => (int) $ticket_id,
+        'entitlement_type' => $entitlement,
+        'reservation_type' => $reservation_type,
+        'normalized_reservation_state' => $normalized,
+        'allocation_summary' => $allocation_summary,
+        'readiness_summary' => $readiness_summary,
+        'continuity_summary' => $continuity_summary,
+        'partial_allocation' => $this->isPartialAllocation($row, $cap),
+        'degradation_lane' => $rollup_degraded ? 'rollup_degraded' : 'nominal',
+      ];
+    }
+
+    usort($ticket_projections, static function (array $a, array $b): int {
+      return ($a['ticket_ordinal'] ?? 0) <=> ($b['ticket_ordinal'] ?? 0);
+    });
+
+    return [
+      'request_time' => $requestTime,
+      'rollup' => [
+        'canonical_reservation_state_tally' => $state_tally,
+        'reservation_type_tally' => $type_tally,
+        'sampled_ticket_rows' => count($ticket_projections),
+        'partial_allocation_rows' => $this->countPartialRows($ticket_projections),
+        'rollup_continuity_composition' => [
+          'guest_continuity_statuses' => $guest['continuity_statuses_observed'] ?? [],
+          'worst_quantity_alignment_status' => (string) ($issuance['worst_quantity_alignment_status'] ?? ''),
+          'canonical_pdf_readiness' => $canonical_pdf,
+          'issuance_aligned' => $issuance_aligned,
+        ],
+      ],
+      'ticket_projections' => $ticket_projections,
+      'readiness_projection' => $this->buildReadinessProjection($state_tally, $ticket_projections, $canonical_pdf),
+      'degradation_projection' => $this->buildDegradationProjection($rollup_degraded, $state_tally, $canonical_pdf),
+      'continuity_projection' => $this->buildContinuityProjection($ticket_projections, $guest),
+      'allocation_projection' => $this->buildAllocationProjection($state_tally, count($ticket_projections)),
+    ];
+  }
+
+  /**
+   * Normalizes a reservation state token.
+   */
+  public function normalizeReservationState(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return self::STATE_UNRESERVED;
+    }
+    if (!in_array($token, self::RESERVATION_ORDER, TRUE)) {
+      $this->logger->warning('InventoryReservationGovernanceManager: unknown reservation state @token normalized to unreserved.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return self::STATE_UNRESERVED;
+    }
+    return $token;
+  }
+
+  /**
+   * Normalizes a reservation type token.
+   */
+  public function normalizeReservationType(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return self::TYPE_DIGITAL_REDEMPTION;
+    }
+    if (!in_array($token, self::allReservationTypes(), TRUE)) {
+      $this->logger->warning('InventoryReservationGovernanceManager: unknown reservation type @token normalized to digital_redemption.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return self::TYPE_DIGITAL_REDEMPTION;
+    }
+    return $token;
+  }
+
+  /**
+   * Projects an observational reservation state from merged rollup keys only.
+   *
+   * @param array<string, mixed> $merged
+   */
+  public function projectReservationStateFromRollup(array $merged): string {
+    if ($merged === []) {
+      return self::STATE_UNRESERVED;
+    }
+    $model = $this->composeReservationReadModel($merged, 0);
+    $tally = is_array($model['rollup']['canonical_reservation_state_tally'] ?? NULL)
+      ? $model['rollup']['canonical_reservation_state_tally']
+      : [];
+    foreach (array_reverse(self::RESERVATION_ORDER) as $state) {
+      if (($tally[$state] ?? 0) > 0) {
+        return $state;
+      }
+    }
+    return self::STATE_UNRESERVED;
+  }
+
+  /**
+   * Maps stored entitlement types to canonical reservation types.
+   */
+  public function mapEntitlementToReservationType(
+    string $entitlement_type,
+    int $redemption_limit,
+    string $timed_scanner_state = '',
+  ): string {
+    $ent = $this->entitlementCapabilityRegistry->normalizeEntitlementType($entitlement_type);
+    if ($timed_scanner_state !== '' && $timed_scanner_state !== 'n/a') {
+      return self::TYPE_TIMED_PICKUP;
+    }
+    return match ($ent) {
+      Ticket::ENTITLEMENT_MERCH => self::TYPE_MERCH,
+      Ticket::ENTITLEMENT_PARKING => self::TYPE_PARKING,
+      Ticket::ENTITLEMENT_DRINK => self::TYPE_FOOD_DRINK,
+      Ticket::ENTITLEMENT_FOOD => self::TYPE_FOOD_DRINK,
+      Ticket::ENTITLEMENT_VIP => self::TYPE_VIP_PACKAGE,
+      Ticket::ENTITLEMENT_ADDON => $redemption_limit > 1 ? self::TYPE_EQUIPMENT : self::TYPE_HOSPITALITY,
+      default => self::TYPE_DIGITAL_REDEMPTION,
+    };
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $cap
+   */
+  public function isPartialAllocation(array $row, array $cap): bool {
+    $count = (int) ($row['redemption_count'] ?? 0);
+    $limit = max(0, (int) ($row['redemption_limit'] ?? 0));
+    $redeemable = (bool) ($cap['redeemable'] ?? FALSE);
+    $multi = (bool) ($cap['multi_use'] ?? FALSE);
+    return $redeemable && $multi && $limit > 1 && $count > 0 && $count < $limit;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $cap
+   */
+  public function normalizeTicketReservationState(
+    array $row,
+    array $cap,
+    bool $rollup_degraded,
+    string $canonical_pdf_readiness,
+    string $continuity_mode,
+    string $reservation_type,
+    bool $issuance_aligned,
+  ): string {
+    if ($rollup_degraded && $continuity_mode === 'degraded') {
+      return self::STATE_DEGRADED;
+    }
+    if ($rollup_degraded) {
+      return self::STATE_DEGRADED;
+    }
+
+    $fulfilment = (string) ($row['fulfilment_status'] ?? '');
+    $ticket_status = (string) ($row['ticket_status'] ?? '');
+    $admission_in = !empty($row['admission_checked_in']);
+    $count = (int) ($row['redemption_count'] ?? 0);
+    $limit = max(0, (int) ($row['redemption_limit'] ?? 0));
+    $redeemable = (bool) ($cap['redeemable'] ?? FALSE);
+    $multi = (bool) ($cap['multi_use'] ?? FALSE);
+    $requires_fulfilment = (bool) ($cap['requires_fulfilment'] ?? FALSE);
+    $supports_collection = (bool) ($cap['supports_collection'] ?? FALSE);
+
+    if ($ticket_status === Ticket::STATUS_VOID || $fulfilment === Ticket::FULFILMENT_CANCELLED) {
+      return self::STATE_CANCELLED;
+    }
+    if ($ticket_status === Ticket::STATUS_REFUNDED) {
+      return self::STATE_RELEASED;
+    }
+    if ($fulfilment === Ticket::FULFILMENT_EXPIRED) {
+      return self::STATE_EXPIRED;
+    }
+
+    if ($redeemable && $multi && $limit > 0 && $count >= $limit) {
+      return self::STATE_EXHAUSTED;
+    }
+    if ($fulfilment === Ticket::FULFILMENT_REDEEMED) {
+      return self::STATE_FULFILLED;
+    }
+    if ($fulfilment === Ticket::FULFILMENT_COLLECTED) {
+      return self::STATE_FULFILLED;
+    }
+
+    $entitlement = $this->entitlementCapabilityRegistry->normalizeEntitlementType((string) ($row['entitlement_type'] ?? ''));
+    if ($this->entitlementCapabilityRegistry->isAdmissionEntitlementType($entitlement) && $admission_in) {
+      return self::STATE_FULFILLED;
+    }
+
+    if ($this->isPartialAllocation($row, $cap)) {
+      return self::STATE_PARTIALLY_RESERVED;
+    }
+
+    if ($fulfilment === Ticket::FULFILMENT_READY) {
+      if ($supports_collection) {
+        return self::STATE_READY_FOR_COLLECTION;
+      }
+      return self::STATE_ALLOCATED;
+    }
+
+    if ($fulfilment === Ticket::FULFILMENT_PENDING) {
+      if (!$issuance_aligned) {
+        return self::STATE_UNRESERVED;
+      }
+      if ($requires_fulfilment && $reservation_type === self::TYPE_MERCH
+        && in_array($canonical_pdf_readiness, ['valid', 'canonical'], TRUE)) {
+        return self::STATE_PREPARED;
+      }
+      if ($reservation_type === self::TYPE_PARKING || $reservation_type === self::TYPE_VIP_PACKAGE) {
+        return self::STATE_ALLOCATED;
+      }
+      if ($reservation_type === self::TYPE_TIMED_PICKUP) {
+        return self::STATE_RESERVED;
+      }
+      return self::STATE_RESERVED;
+    }
+
+    return self::STATE_UNRESERVED;
+  }
+
+  /**
+   * Builds a read-only audit timeline from normalized reservation events.
+   *
+   * @param list<array<string, mixed>> $events
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function projectReservationAuditTimeline(array $events): array {
+    $out = [];
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $state = $this->normalizeReservationState(isset($event['state']) ? (string) $event['state'] : NULL);
+      $at = (int) ($event['recorded_at'] ?? 0);
+      $note = trim((string) ($event['note'] ?? ''));
+      $out[] = [
+        'reservation_state' => $state,
+        'recorded_at_unix' => $at,
+        'audit_note' => $note !== '' ? $note : 'reservation_governance_event',
+      ];
+    }
+    usort($out, static function (array $a, array $b): int {
+      return ($a['recorded_at_unix'] ?? 0) <=> ($b['recorded_at_unix'] ?? 0);
+    });
+    return $out;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function allCanonicalStates(): array {
+    return self::RESERVATION_ORDER;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function allReservationTypes(): array {
+    return [
+      self::TYPE_MERCH,
+      self::TYPE_HOSPITALITY,
+      self::TYPE_FOOD_DRINK,
+      self::TYPE_PARKING,
+      self::TYPE_VIP_PACKAGE,
+      self::TYPE_EQUIPMENT,
+      self::TYPE_CLOAKROOM,
+      self::TYPE_TIMED_PICKUP,
+      self::TYPE_DIGITAL_REDEMPTION,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $issuance
+   * @param array<string, mixed> $recovery
+   * @param array<string, mixed> $guest
+   */
+  private function rollupDegraded(
+    array $issuance,
+    array $recovery,
+    array $guest,
+    string $canonical_pdf_readiness,
+  ): bool {
+    if (!empty($recovery['recovery_mismatch_observed'])) {
+      return TRUE;
+    }
+    $worst = (string) ($issuance['worst_quantity_alignment_status'] ?? '');
+    if (in_array($worst, ['invalid', 'missing'], TRUE)) {
+      return TRUE;
+    }
+    foreach ($guest['continuity_statuses_observed'] ?? [] as $st) {
+      if ((string) $st === 'invalid') {
+        return TRUE;
+      }
+    }
+    if ($canonical_pdf_readiness !== 'valid' && $canonical_pdf_readiness !== 'canonical') {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $cap
+   */
+  private function buildAllocationSummary(
+    array $row,
+    array $cap,
+    string $normalized,
+    string $reservation_type,
+  ): string {
+    $pieces = [
+      'reservation_type=' . $reservation_type,
+      'state=' . $normalized,
+      'redemptions=' . (string) (int) ($row['redemption_count'] ?? 0) . '/' . (string) (int) ($row['redemption_limit'] ?? 0),
+    ];
+    if ($this->isPartialAllocation($row, $cap)) {
+      $pieces[] = 'partial_allocation=yes';
+    }
+    else {
+      $pieces[] = 'partial_allocation=no';
+    }
+    return implode('; ', $pieces);
+  }
+
+  private function buildReadinessSummary(
+    string $normalized,
+    array $cap,
+    string $canonical_pdf_readiness,
+    string $timed_scanner_state,
+  ): string {
+    return 'lifecycle=' . $normalized
+      . '; requires_fulfilment=' . ((bool) ($cap['requires_fulfilment'] ?? FALSE) ? 'yes' : 'no')
+      . '; pdf=' . $canonical_pdf_readiness
+      . '; timed=' . ($timed_scanner_state !== '' ? $timed_scanner_state : 'n/a');
+  }
+
+  private function buildContinuitySummary(string $continuity_mode, string $normalized): string {
+    return 'continuity_mode=' . ($continuity_mode !== '' ? $continuity_mode : 'n/a')
+      . '; reservation_state=' . $normalized;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   */
+  private function countPartialRows(array $ticket_projections): int {
+    $n = 0;
+    foreach ($ticket_projections as $p) {
+      if (!empty($p['partial_allocation'])) {
+        $n++;
+      }
+    }
+    return $n;
+  }
+
+  /**
+   * @param array<string, int> $state_tally
+   * @param list<array<string, mixed>> $ticket_projections
+   *
+   * @return array<string, mixed>
+   */
+  private function buildReadinessProjection(
+    array $state_tally,
+    array $ticket_projections,
+    string $canonical_pdf_readiness,
+  ): array {
+    $readyish = ($state_tally[self::STATE_PREPARED] ?? 0)
+      + ($state_tally[self::STATE_READY_FOR_COLLECTION] ?? 0)
+      + ($state_tally[self::STATE_ALLOCATED] ?? 0)
+      + ($state_tally[self::STATE_PARTIALLY_RESERVED] ?? 0);
+    return [
+      'descriptor' => 'reservation_readiness_visibility',
+      'collection_ready_rows' => (int) ($state_tally[self::STATE_READY_FOR_COLLECTION] ?? 0),
+      'execution_ready_rows' => $readyish,
+      'artifact_readiness_signal' => $canonical_pdf_readiness,
+      'timed_pickup_ready_rows' => $this->countTimedPickupReady($ticket_projections),
+    ];
+  }
+
+  /**
+   * @param array<string, int> $state_tally
+   *
+   * @return array<string, mixed>
+   */
+  private function buildDegradationProjection(
+    bool $rollup_degraded,
+    array $state_tally,
+    string $canonical_pdf_readiness,
+  ): array {
+    $parts = [];
+    if ($rollup_degraded) {
+      $parts[] = 'rollup_or_continuity_degraded';
+    }
+    if (($state_tally[self::STATE_DEGRADED] ?? 0) > 0) {
+      $parts[] = 'normalized_degraded_rows';
+    }
+    if ($canonical_pdf_readiness !== 'valid' && $canonical_pdf_readiness !== 'canonical') {
+      $parts[] = 'artifact_readiness_degraded';
+    }
+    return [
+      'descriptor' => $parts === [] ? 'nominal' : implode(';', $parts),
+      'signals' => $parts,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   * @param array<string, mixed> $guest
+   *
+   * @return array<string, mixed>
+   */
+  private function buildContinuityProjection(array $ticket_projections, array $guest): array {
+    $modes = [];
+    foreach ($ticket_projections as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $summary = (string) ($row['continuity_summary'] ?? '');
+      if (str_contains($summary, 'continuity_mode=')) {
+        $modes[] = $summary;
+      }
+    }
+    return [
+      'descriptor' => 'reservation_continuity_visibility',
+      'guest_continuity_statuses' => $guest['continuity_statuses_observed'] ?? [],
+      'continuity_row_count' => count($modes),
+    ];
+  }
+
+  /**
+   * @param array<string, int> $state_tally
+   *
+   * @return array<string, mixed>
+   */
+  private function buildAllocationProjection(array $state_tally, int $sampled): array {
+    if ($sampled < 1) {
+      return [
+        'descriptor' => 'no_sampled_ticket_rows',
+        'allocated_fraction' => 0.0,
+      ];
+    }
+    $allocated = ($state_tally[self::STATE_ALLOCATED] ?? 0)
+      + ($state_tally[self::STATE_PREPARED] ?? 0)
+      + ($state_tally[self::STATE_READY_FOR_COLLECTION] ?? 0)
+      + ($state_tally[self::STATE_PARTIALLY_RESERVED] ?? 0)
+      + ($state_tally[self::STATE_RESERVED] ?? 0);
+    return [
+      'descriptor' => 'allocation_visibility',
+      'allocated_fraction' => round($allocated / $sampled, 4),
+      'allocated_rows' => $allocated,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   */
+  private function countTimedPickupReady(array $ticket_projections): int {
+    $n = 0;
+    foreach ($ticket_projections as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      if (($row['reservation_type'] ?? '') !== self::TYPE_TIMED_PICKUP) {
+        continue;
+      }
+      $state = (string) ($row['normalized_reservation_state'] ?? '');
+      if (in_array($state, [self::STATE_PREPARED, self::STATE_READY_FOR_COLLECTION, self::STATE_ALLOCATED], TRUE)) {
+        $n++;
+      }
+    }
+    return $n;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationProjectionBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/InventoryReservationProjectionBuilder.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+/**
+ * Twig-safe inventory reservation cards for the venue operations workspace.
+ *
+ * Values are pre-normalized by {@see InventoryReservationGovernanceManager}.
+ */
+final class InventoryReservationProjectionBuilder {
+
+  public function __construct(
+    private readonly InventoryReservationGovernanceManager $inventoryReservationGovernanceManager,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildWorkspaceReservationSections(array $merged, int $requestTime): array {
+    $model = $this->inventoryReservationGovernanceManager->composeReservationReadModel($merged, $requestTime);
+    $rollup = is_array($model['rollup'] ?? NULL) ? $model['rollup'] : [];
+    $tally = is_array($rollup['canonical_reservation_state_tally'] ?? NULL) ? $rollup['canonical_reservation_state_tally'] : [];
+    $types = is_array($rollup['reservation_type_tally'] ?? NULL) ? $rollup['reservation_type_tally'] : [];
+    $readiness = is_array($model['readiness_projection'] ?? NULL) ? $model['readiness_projection'] : [];
+    $degradation = is_array($model['degradation_projection'] ?? NULL) ? $model['degradation_projection'] : [];
+    $continuity = is_array($model['continuity_projection'] ?? NULL) ? $model['continuity_projection'] : [];
+    $allocation = is_array($model['allocation_projection'] ?? NULL) ? $model['allocation_projection'] : [];
+
+    $degraded = (int) ($tally[InventoryReservationGovernanceManager::STATE_DEGRADED] ?? 0);
+    $tone = $degraded > 0 || (string) ($degradation['descriptor'] ?? '') !== 'nominal' ? 'elevated' : 'low';
+
+    $type_cards = [];
+    foreach ($types as $type => $count) {
+      if ((int) $count < 1) {
+        continue;
+      }
+      $type_cards[] = [
+        'label' => 'Reservation type — ' . (string) $type,
+        'value' => (string) (int) $count,
+      ];
+    }
+    if ($type_cards === []) {
+      $type_cards[] = [
+        'label' => 'Reservation type coverage',
+        'value' => 'no_sampled_rows',
+      ];
+    }
+
+    return [
+      [
+        'id' => 'reservation_governance_summary',
+        'title' => 'Reservation governance summary',
+        'section_tone' => $tone,
+        'cards' => [
+          [
+            'label' => 'Sampled ticket rows (reservation lens)',
+            'value' => (string) (int) ($rollup['sampled_ticket_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Partial allocation rows',
+            'value' => (string) (int) ($rollup['partial_allocation_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Allocation continuity projection',
+            'value' => (string) ($allocation['descriptor'] ?? '') . '; allocated_fraction=' . (string) ($allocation['allocated_fraction'] ?? 0),
+          ],
+          [
+            'label' => 'Reservation readiness projection',
+            'value' => (string) ($readiness['descriptor'] ?? '') . '; collection_ready=' . (string) (int) ($readiness['collection_ready_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Reservation degradation projection',
+            'value' => (string) ($degradation['descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'Reservation continuity projection',
+            'value' => (string) ($continuity['descriptor'] ?? '') . '; continuity_rows=' . (string) (int) ($continuity['continuity_row_count'] ?? 0),
+          ],
+        ],
+      ],
+      [
+        'id' => 'reservation_lifecycle_cards',
+        'title' => 'Reservation lifecycle cards',
+        'section_tone' => $tone,
+        'cards' => $this->flattenReservationTallyCards($tally),
+      ],
+      [
+        'id' => 'reservation_allocation_visibility',
+        'title' => 'Allocation and readiness visibility',
+        'section_tone' => $tone,
+        'cards' => array_merge(
+          [
+            [
+              'label' => 'Collection-ready rows',
+              'value' => (string) (int) ($readiness['collection_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Timed pickup readiness rows',
+              'value' => (string) (int) ($readiness['timed_pickup_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Degraded reservation rows',
+              'value' => (string) $degraded,
+            ],
+            [
+              'label' => 'Partial allocation visibility',
+              'value' => (string) (int) ($rollup['partial_allocation_rows'] ?? 0),
+            ],
+          ],
+          $type_cards,
+        ),
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, int> $tally
+   *
+   * @return list<array<string, string>>
+   */
+  private function flattenReservationTallyCards(array $tally): array {
+    $cards = [];
+    foreach ($this->inventoryReservationGovernanceManager->allCanonicalStates() as $state) {
+      $cards[] = [
+        'label' => 'Reservation — ' . $state,
+        'value' => (string) (int) ($tally[$state] ?? 0),
+      ];
+    }
+    return $cards;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalCapabilityAuditProjector.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalCapabilityAuditProjector.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+/**
+ * Operational capability audit visibility (ordering and continuity only).
+ *
+ * Emits normalized strings and deterministic ordering anchors — no replay
+ * tokens, QR payloads, device fingerprints, or customer identifiers.
+ */
+final class OperationalCapabilityAuditProjector {
+
+  public function __construct(
+    private readonly OperationalEntitlementCapabilityManager $operationalEntitlementCapabilityManager,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildWorkspaceCapabilityAuditSections(array $merged, int $requestTime): array {
+    $model = $this->operationalEntitlementCapabilityManager->composeCapabilityReadModel($merged, $requestTime);
+    $rollup = is_array($model['rollup'] ?? NULL) ? $model['rollup'] : [];
+    $tally = is_array($rollup['canonical_capability_state_tally'] ?? NULL) ? $rollup['canonical_capability_state_tally'] : [];
+    $degraded = (int) ($tally[OperationalEntitlementCapabilityManager::STATE_DEGRADED] ?? 0);
+    $tone = $degraded > 0 ? 'elevated' : 'low';
+
+    $timeline = $this->buildCapabilityOrderingTimeline($model, $requestTime);
+
+    return [
+      [
+        'id' => 'capability_lifecycle_audit_timeline',
+        'title' => 'Capability lifecycle audit timeline',
+        'section_tone' => $tone,
+        'cards' => [
+          [
+            'label' => 'Capability transition ordering',
+            'value' => $this->transitionOrderingSummary($model),
+          ],
+          [
+            'label' => 'Fulfillment-capability audit summary',
+            'value' => $this->fulfillmentAuditSummary($model),
+          ],
+          [
+            'label' => 'Reservation-capability audit summary',
+            'value' => $this->reservationAuditSummary($model),
+          ],
+          [
+            'label' => 'Capability degradation ordering',
+            'value' => $this->degradationOrderingSummary($model),
+          ],
+          [
+            'label' => 'Capability continuity summary',
+            'value' => $this->continuityAuditSummary($model),
+          ],
+          [
+            'label' => 'Scanner capability visibility (read-only)',
+            'value' => $this->scannerVisibilitySummary($model),
+          ],
+        ],
+        'timeline' => $timeline,
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function buildCapabilityOrderingTimeline(array $model, int $requestTime): array {
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    $out = [];
+    $seq = 0;
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $seq++;
+      $state = (string) ($row['normalized_capability_state'] ?? '');
+      $type = (string) ($row['capability_type'] ?? '');
+      $out[] = [
+        'lane_state' => $state,
+        'recorded_at_unix' => $requestTime + $seq,
+        'audit_note' => 'capability_type=' . $type
+          . '; execution=' . (string) ($row['execution_descriptor'] ?? '')
+          . '; fulfillment=' . (string) ($row['fulfillment_capability_summary'] ?? '')
+          . '; reservation=' . (string) ($row['reservation_capability_summary'] ?? '')
+          . '; continuity=' . (string) ($row['continuity_summary'] ?? ''),
+      ];
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function transitionOrderingSummary(array $model): string {
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    $ordered = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $ordered[] = (string) ($row['normalized_capability_state'] ?? '');
+    }
+    return $ordered === [] ? 'no_rows' : implode(' → ', $ordered);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function fulfillmentAuditSummary(array $model): string {
+    $parts = [];
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $parts[] = (string) ($row['fulfillment_capability_summary'] ?? '');
+    }
+    return $parts === [] ? 'no_fulfillment_capability_rows' : implode(' | ', $parts);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function reservationAuditSummary(array $model): string {
+    $parts = [];
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $parts[] = (string) ($row['reservation_capability_summary'] ?? '');
+    }
+    return $parts === [] ? 'no_reservation_capability_rows' : implode(' | ', $parts);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function degradationOrderingSummary(array $model): string {
+    $degradation = is_array($model['degradation_projection'] ?? NULL) ? $model['degradation_projection'] : [];
+    $signals = is_array($degradation['signals'] ?? NULL) ? $degradation['signals'] : [];
+    if ($signals === []) {
+      return 'nominal';
+    }
+    return implode(' → ', $signals);
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function continuityAuditSummary(array $model): string {
+    $continuity = is_array($model['continuity_projection'] ?? NULL) ? $model['continuity_projection'] : [];
+    $statuses = is_array($continuity['guest_continuity_statuses'] ?? NULL) ? $continuity['guest_continuity_statuses'] : [];
+    return 'guest_continuity=' . ($statuses === [] ? 'n/a' : implode(',', $statuses))
+      . '; continuity_rows=' . (string) (int) ($continuity['continuity_row_count'] ?? 0)
+      . '; reservation_signal=' . (string) ($continuity['reservation_continuity_signal'] ?? '');
+  }
+
+  /**
+   * @param array<string, mixed> $model
+   */
+  private function scannerVisibilitySummary(array $model): string {
+    $parts = [];
+    $rows = is_array($model['ticket_projections'] ?? NULL) ? $model['ticket_projections'] : [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $parts[] = (string) ($row['scanner_visibility'] ?? '');
+    }
+    return $parts === [] ? 'no_scanner_visibility_rows' : implode(' | ', $parts);
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalCapabilityProjectionBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalCapabilityProjectionBuilder.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+/**
+ * Twig-safe operational capability cards for the venue operations workspace.
+ *
+ * Values are pre-normalized by {@see OperationalEntitlementCapabilityManager}.
+ */
+final class OperationalCapabilityProjectionBuilder {
+
+  public function __construct(
+    private readonly OperationalEntitlementCapabilityManager $operationalEntitlementCapabilityManager,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $merged
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildWorkspaceCapabilitySections(array $merged, int $requestTime): array {
+    $model = $this->operationalEntitlementCapabilityManager->composeCapabilityReadModel($merged, $requestTime);
+    $rollup = is_array($model['rollup'] ?? NULL) ? $model['rollup'] : [];
+    $tally = is_array($rollup['canonical_capability_state_tally'] ?? NULL) ? $rollup['canonical_capability_state_tally'] : [];
+    $types = is_array($rollup['capability_type_tally'] ?? NULL) ? $rollup['capability_type_tally'] : [];
+    $readiness = is_array($model['readiness_projection'] ?? NULL) ? $model['readiness_projection'] : [];
+    $degradation = is_array($model['degradation_projection'] ?? NULL) ? $model['degradation_projection'] : [];
+    $continuity = is_array($model['continuity_projection'] ?? NULL) ? $model['continuity_projection'] : [];
+    $fulfillment = is_array($model['fulfillment_capability_projection'] ?? NULL)
+      ? $model['fulfillment_capability_projection']
+      : [];
+    $reservation = is_array($model['reservation_capability_projection'] ?? NULL)
+      ? $model['reservation_capability_projection']
+      : [];
+
+    $degraded = (int) ($tally[OperationalEntitlementCapabilityManager::STATE_DEGRADED] ?? 0);
+    $tone = $degraded > 0 || (string) ($degradation['descriptor'] ?? '') !== 'nominal' ? 'elevated' : 'low';
+
+    $type_cards = [];
+    foreach ($types as $type => $count) {
+      if ((int) $count < 1) {
+        continue;
+      }
+      $type_cards[] = [
+        'label' => 'Capability type — ' . (string) $type,
+        'value' => (string) (int) $count,
+      ];
+    }
+    if ($type_cards === []) {
+      $type_cards[] = [
+        'label' => 'Capability type coverage',
+        'value' => 'no_sampled_rows',
+      ];
+    }
+
+    return [
+      [
+        'id' => 'capability_governance_summary',
+        'title' => 'Operational capability summary',
+        'section_tone' => $tone,
+        'cards' => [
+          [
+            'label' => 'Sampled ticket rows (capability lens)',
+            'value' => (string) (int) ($rollup['sampled_ticket_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Capability readiness projection',
+            'value' => (string) ($readiness['descriptor'] ?? '') . '; execution_ready=' . (string) (int) ($readiness['execution_ready_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Capability degradation projection',
+            'value' => (string) ($degradation['descriptor'] ?? ''),
+          ],
+          [
+            'label' => 'Capability continuity projection',
+            'value' => (string) ($continuity['descriptor'] ?? '') . '; continuity_rows=' . (string) (int) ($continuity['continuity_row_count'] ?? 0),
+          ],
+          [
+            'label' => 'Fulfillment-capability visibility',
+            'value' => (string) ($fulfillment['descriptor'] ?? '') . '; collect_rows=' . (string) (int) ($fulfillment['fulfilment_collect_rows'] ?? 0),
+          ],
+          [
+            'label' => 'Reservation-capability visibility',
+            'value' => (string) ($reservation['descriptor'] ?? '') . '; allocated_fraction=' . (string) ($reservation['allocated_fraction'] ?? 0),
+          ],
+        ],
+      ],
+      [
+        'id' => 'capability_lifecycle_cards',
+        'title' => 'Capability lifecycle cards',
+        'section_tone' => $tone,
+        'cards' => $this->flattenCapabilityTallyCards($tally),
+      ],
+      [
+        'id' => 'capability_readiness_visibility',
+        'title' => 'Capability readiness and execution visibility',
+        'section_tone' => $tone,
+        'cards' => array_merge(
+          [
+            [
+              'label' => 'Collection-ready capability rows',
+              'value' => (string) (int) ($readiness['collection_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Merch pickup readiness rows',
+              'value' => (string) (int) ($readiness['merch_pickup_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Hospitality access readiness rows',
+              'value' => (string) (int) ($readiness['hospitality_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Timed collection readiness rows',
+              'value' => (string) (int) ($readiness['timed_collection_ready_rows'] ?? 0),
+            ],
+            [
+              'label' => 'Degraded capability rows',
+              'value' => (string) $degraded,
+            ],
+            [
+              'label' => 'Fulfilment redeemed rows (visibility)',
+              'value' => (string) (int) ($fulfillment['fulfilment_redeemed_rows'] ?? 0),
+            ],
+          ],
+          $type_cards,
+        ),
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, int> $tally
+   *
+   * @return list<array<string, string>>
+   */
+  private function flattenCapabilityTallyCards(array $tally): array {
+    $cards = [];
+    foreach ($this->operationalEntitlementCapabilityManager->allCanonicalStates() as $state) {
+      $cards[] = [
+        'label' => 'Capability — ' . $state,
+        'value' => (string) (int) ($tally[$state] ?? 0),
+      ];
+    }
+    return $cards;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalEntitlementCapabilityManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalEntitlementCapabilityManager.php
@@ -1,0 +1,571 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+
+/**
+ * Canonical operational entitlement capability convergence (read-model only).
+ *
+ * Normalizes capability types/states, merch/hospitality/redemption/pickup
+ * semantics, and execution descriptors by composing reservation governance,
+ * fulfillment operational signals, continuity semantics, and the entitlement
+ * capability registry. Does not mutate inventory, execute fulfillment, or
+ * bypass scanner authority.
+ */
+final class OperationalEntitlementCapabilityManager {
+
+  public const TYPE_ADMISSION = 'admission';
+  public const TYPE_MERCH_PICKUP = 'merch_pickup';
+  public const TYPE_HOSPITALITY_ACCESS = 'hospitality_access';
+  public const TYPE_FOOD_DRINK_REDEMPTION = 'food_drink_redemption';
+  public const TYPE_PARKING_ACCESS = 'parking_access';
+  public const TYPE_VIP_ACCESS = 'vip_access';
+  public const TYPE_CLOAKROOM_RETRIEVAL = 'cloakroom_retrieval';
+  public const TYPE_TIMED_COLLECTION = 'timed_collection';
+  public const TYPE_DIGITAL_REDEMPTION = 'digital_redemption';
+
+  public const STATE_UNAVAILABLE = 'unavailable';
+  public const STATE_AVAILABLE = 'available';
+  public const STATE_RESERVED = 'reserved';
+  public const STATE_PREPARED = 'prepared';
+  public const STATE_READY = 'ready';
+  public const STATE_PARTIALLY_READY = 'partially_ready';
+  public const STATE_DEGRADED = 'degraded';
+  public const STATE_EXHAUSTED = 'exhausted';
+  public const STATE_REDEEMED = 'redeemed';
+  public const STATE_FULFILLED = 'fulfilled';
+  public const STATE_EXPIRED = 'expired';
+  public const STATE_CANCELLED = 'cancelled';
+
+  /**
+   * Canonical capability ordering for audit continuity (low → progressed).
+   *
+   * @var list<string>
+   */
+  private const CAPABILITY_ORDER = [
+    self::STATE_UNAVAILABLE,
+    self::STATE_AVAILABLE,
+    self::STATE_RESERVED,
+    self::STATE_PREPARED,
+    self::STATE_READY,
+    self::STATE_PARTIALLY_READY,
+    self::STATE_DEGRADED,
+    self::STATE_EXHAUSTED,
+    self::STATE_REDEEMED,
+    self::STATE_FULFILLED,
+    self::STATE_EXPIRED,
+    self::STATE_CANCELLED,
+  ];
+
+  public function __construct(
+    private readonly EntitlementCapabilityRegistry $entitlementCapabilityRegistry,
+    private readonly InventoryReservationGovernanceManager $inventoryReservationGovernanceManager,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Builds a single normalized capability read-model for workspace layers.
+   *
+   * @param array<string, mixed> $merged
+   *   Output shape compatible with
+   *   {@see OperationalWorkspaceBuilder::mergeInspections()}.
+   *
+   * @return array<string, mixed>
+   */
+  public function composeCapabilityReadModel(array $merged, int $requestTime): array {
+    $reservation_model = $this->inventoryReservationGovernanceManager->composeReservationReadModel($merged, $requestTime);
+    $reservation_rows = is_array($reservation_model['ticket_projections'] ?? NULL)
+      ? $reservation_model['ticket_projections']
+      : [];
+    $signals = is_array($merged['fulfillment_signals'] ?? NULL) ? $merged['fulfillment_signals'] : [];
+    $by_ticket = is_array($signals['by_ticket_id'] ?? NULL) ? $signals['by_ticket_id'] : [];
+    $artifacts = is_array($merged['artifacts'] ?? NULL) ? $merged['artifacts'] : [];
+    $continuity = is_array($artifacts['operational_continuity'] ?? NULL) ? $artifacts['operational_continuity'] : [];
+    $timed = is_array($artifacts['timed_entry_policy'] ?? NULL) ? $artifacts['timed_entry_policy'] : [];
+
+    $state_tally = array_fill_keys(self::CAPABILITY_ORDER, 0);
+    $type_tally = [];
+    foreach ($this->allCanonicalTypes() as $t) {
+      $type_tally[$t] = 0;
+    }
+
+    $ticket_projections = [];
+    foreach ($reservation_rows as $reservation_row) {
+      if (!is_array($reservation_row)) {
+        continue;
+      }
+      $ticket_id = (string) ($reservation_row['ticket_ordinal'] ?? '');
+      $signal_row = is_array($by_ticket[$ticket_id] ?? NULL) ? $by_ticket[$ticket_id] : [];
+      $entitlement = $this->entitlementCapabilityRegistry->normalizeEntitlementType(
+        (string) ($reservation_row['entitlement_type'] ?? ($signal_row['entitlement_type'] ?? ''))
+      );
+      $cap = $this->entitlementCapabilityRegistry->getCapabilityMap($entitlement);
+
+      $continuity_row = is_array($continuity[$ticket_id] ?? NULL) ? $continuity[$ticket_id] : [];
+      $continuity_mode = (string) (($continuity_row['continuity_summary']['continuity_mode'] ?? '') ?: '');
+      $timing_row = is_array($timed[$ticket_id] ?? NULL) ? $timed[$ticket_id] : [];
+      $timing_policy = is_array($timing_row['policy'] ?? NULL) ? $timing_row['policy'] : [];
+      $timed_scanner_state = (string) (($timing_policy['scanner']['state'] ?? '') ?: '');
+
+      $capability_type = $this->mapEntitlementToCapabilityType(
+        $entitlement,
+        (int) ($signal_row['redemption_limit'] ?? ($reservation_row['redemption_limit'] ?? 1)),
+        $timed_scanner_state,
+        (string) ($reservation_row['reservation_type'] ?? ''),
+      );
+      $type_tally[$capability_type] = ($type_tally[$capability_type] ?? 0) + 1;
+
+      $reservation_state = (string) ($reservation_row['normalized_reservation_state'] ?? '');
+      $normalized = $this->normalizeCapabilityStateFromComposition(
+        $reservation_state,
+        $signal_row,
+        $cap,
+        $continuity_mode,
+      );
+      $state_tally[$normalized] = ($state_tally[$normalized] ?? 0) + 1;
+
+      $execution_descriptor = $this->normalizeExecutionDescriptor($cap, $capability_type, $normalized);
+      $fulfillment_summary = $this->buildFulfillmentCapabilitySummary($signal_row, $cap, $normalized);
+      $reservation_summary = $this->buildReservationCapabilitySummary($reservation_row, $normalized);
+
+      $ticket_projections[] = [
+        'ticket_ordinal' => (int) ($reservation_row['ticket_ordinal'] ?? 0),
+        'entitlement_type' => $entitlement,
+        'capability_type' => $capability_type,
+        'normalized_capability_state' => $normalized,
+        'execution_descriptor' => $execution_descriptor,
+        'scanner_visibility' => $this->buildScannerVisibility($cap),
+        'fulfillment_capability_summary' => $fulfillment_summary,
+        'reservation_capability_summary' => $reservation_summary,
+        'readiness_summary' => $this->buildReadinessSummary($normalized, $cap, $fulfillment_summary),
+        'continuity_summary' => $this->buildContinuitySummary($continuity_mode, $normalized),
+        'degradation_lane' => (string) ($reservation_row['degradation_lane'] ?? 'nominal'),
+      ];
+    }
+
+    usort($ticket_projections, static function (array $a, array $b): int {
+      return ($a['ticket_ordinal'] ?? 0) <=> ($b['ticket_ordinal'] ?? 0);
+    });
+
+    $reservation_rollup = is_array($reservation_model['rollup'] ?? NULL) ? $reservation_model['rollup'] : [];
+    $reservation_readiness = is_array($reservation_model['readiness_projection'] ?? NULL)
+      ? $reservation_model['readiness_projection']
+      : [];
+    $reservation_degradation = is_array($reservation_model['degradation_projection'] ?? NULL)
+      ? $reservation_model['degradation_projection']
+      : [];
+    $reservation_continuity = is_array($reservation_model['continuity_projection'] ?? NULL)
+      ? $reservation_model['continuity_projection']
+      : [];
+
+    return [
+      'request_time' => $requestTime,
+      'rollup' => [
+        'canonical_capability_state_tally' => $state_tally,
+        'capability_type_tally' => $type_tally,
+        'sampled_ticket_rows' => count($ticket_projections),
+        'rollup_continuity_composition' => $reservation_rollup['rollup_continuity_composition'] ?? [],
+        'reservation_state_tally' => $reservation_rollup['canonical_reservation_state_tally'] ?? [],
+      ],
+      'ticket_projections' => $ticket_projections,
+      'readiness_projection' => $this->buildReadinessProjection($state_tally, $ticket_projections, $reservation_readiness),
+      'degradation_projection' => $this->buildDegradationProjection($state_tally, $reservation_degradation),
+      'continuity_projection' => $this->buildContinuityProjection($ticket_projections, $reservation_continuity),
+      'fulfillment_capability_projection' => $this->buildFulfillmentCapabilityProjection($ticket_projections),
+      'reservation_capability_projection' => $this->buildReservationCapabilityProjection($reservation_model),
+    ];
+  }
+
+  /**
+   * Normalizes a capability type token.
+   */
+  public function normalizeCapabilityType(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return self::TYPE_DIGITAL_REDEMPTION;
+    }
+    if (!in_array($token, $this->allCanonicalTypes(), TRUE)) {
+      $this->logger->warning('OperationalEntitlementCapabilityManager: unknown capability type @token normalized to digital_redemption.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return self::TYPE_DIGITAL_REDEMPTION;
+    }
+    return $token;
+  }
+
+  /**
+   * Normalizes a capability state token.
+   */
+  public function normalizeCapabilityState(?string $raw): string {
+    $token = strtolower(trim((string) $raw));
+    if ($token === '') {
+      return self::STATE_UNAVAILABLE;
+    }
+    if (!in_array($token, self::CAPABILITY_ORDER, TRUE)) {
+      $this->logger->warning('OperationalEntitlementCapabilityManager: unknown capability state @token normalized to unavailable.', [
+        '@token' => $token,
+        'token' => $token,
+      ]);
+      return self::STATE_UNAVAILABLE;
+    }
+    return $token;
+  }
+
+  /**
+   * Projects an observational capability state from merged rollup keys only.
+   *
+   * @param array<string, mixed> $merged
+   */
+  public function projectCapabilityStateFromRollup(array $merged): string {
+    if ($merged === []) {
+      return self::STATE_UNAVAILABLE;
+    }
+    $model = $this->composeCapabilityReadModel($merged, 0);
+    $tally = is_array($model['rollup']['canonical_capability_state_tally'] ?? NULL)
+      ? $model['rollup']['canonical_capability_state_tally']
+      : [];
+    foreach (array_reverse(self::CAPABILITY_ORDER) as $state) {
+      if (($tally[$state] ?? 0) > 0) {
+        return $state;
+      }
+    }
+    return self::STATE_UNAVAILABLE;
+  }
+
+  /**
+   * Maps stored entitlement types to canonical capability types.
+   */
+  public function mapEntitlementToCapabilityType(
+    string $entitlement_type,
+    int $redemption_limit,
+    string $timed_scanner_state = '',
+    string $reservation_type_hint = '',
+  ): string {
+    if ($reservation_type_hint !== '') {
+      return $this->mapReservationTypeToCapabilityType($reservation_type_hint);
+    }
+    if ($timed_scanner_state !== '' && $timed_scanner_state !== 'n/a') {
+      return self::TYPE_TIMED_COLLECTION;
+    }
+    $ent = $this->entitlementCapabilityRegistry->normalizeEntitlementType($entitlement_type);
+    return match ($ent) {
+      Ticket::ENTITLEMENT_TICKET => self::TYPE_ADMISSION,
+      Ticket::ENTITLEMENT_MERCH => self::TYPE_MERCH_PICKUP,
+      Ticket::ENTITLEMENT_PARKING => self::TYPE_PARKING_ACCESS,
+      Ticket::ENTITLEMENT_DRINK, Ticket::ENTITLEMENT_FOOD => self::TYPE_FOOD_DRINK_REDEMPTION,
+      Ticket::ENTITLEMENT_VIP => self::TYPE_VIP_ACCESS,
+      Ticket::ENTITLEMENT_ADDON => $redemption_limit > 1
+        ? self::TYPE_HOSPITALITY_ACCESS
+        : self::TYPE_CLOAKROOM_RETRIEVAL,
+      default => self::TYPE_DIGITAL_REDEMPTION,
+    };
+  }
+
+  /**
+   * Builds a read-only audit timeline from normalized capability events.
+   *
+   * @param list<array<string, mixed>> $events
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function projectCapabilityAuditTimeline(array $events): array {
+    $out = [];
+    foreach ($events as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      $state = $this->normalizeCapabilityState(isset($event['state']) ? (string) $event['state'] : NULL);
+      $at = (int) ($event['recorded_at'] ?? 0);
+      $note = trim((string) ($event['note'] ?? ''));
+      $out[] = [
+        'capability_state' => $state,
+        'recorded_at_unix' => $at,
+        'audit_note' => $note !== '' ? $note : 'capability_governance_event',
+      ];
+    }
+    usort($out, static function (array $a, array $b): int {
+      return ($a['recorded_at_unix'] ?? 0) <=> ($b['recorded_at_unix'] ?? 0);
+    });
+    return $out;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function allCanonicalStates(): array {
+    return self::CAPABILITY_ORDER;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function allCanonicalTypes(): array {
+    return [
+      self::TYPE_ADMISSION,
+      self::TYPE_MERCH_PICKUP,
+      self::TYPE_HOSPITALITY_ACCESS,
+      self::TYPE_FOOD_DRINK_REDEMPTION,
+      self::TYPE_PARKING_ACCESS,
+      self::TYPE_VIP_ACCESS,
+      self::TYPE_CLOAKROOM_RETRIEVAL,
+      self::TYPE_TIMED_COLLECTION,
+      self::TYPE_DIGITAL_REDEMPTION,
+    ];
+  }
+
+  /**
+   * Maps reservation governance type tokens to capability types.
+   */
+  public function mapReservationTypeToCapabilityType(string $reservation_type): string {
+    return match ($this->inventoryReservationGovernanceManager->normalizeReservationType($reservation_type)) {
+      InventoryReservationGovernanceManager::TYPE_MERCH => self::TYPE_MERCH_PICKUP,
+      InventoryReservationGovernanceManager::TYPE_HOSPITALITY => self::TYPE_HOSPITALITY_ACCESS,
+      InventoryReservationGovernanceManager::TYPE_FOOD_DRINK => self::TYPE_FOOD_DRINK_REDEMPTION,
+      InventoryReservationGovernanceManager::TYPE_PARKING => self::TYPE_PARKING_ACCESS,
+      InventoryReservationGovernanceManager::TYPE_VIP_PACKAGE => self::TYPE_VIP_ACCESS,
+      InventoryReservationGovernanceManager::TYPE_CLOAKROOM => self::TYPE_CLOAKROOM_RETRIEVAL,
+      InventoryReservationGovernanceManager::TYPE_TIMED_PICKUP => self::TYPE_TIMED_COLLECTION,
+      InventoryReservationGovernanceManager::TYPE_EQUIPMENT => self::TYPE_HOSPITALITY_ACCESS,
+      default => self::TYPE_DIGITAL_REDEMPTION,
+    };
+  }
+
+  /**
+   * Maps reservation governance state to capability state without re-evaluating rows.
+   */
+  public function mapReservationStateToCapabilityState(string $reservation_state): string {
+    return match ($this->inventoryReservationGovernanceManager->normalizeReservationState($reservation_state)) {
+      InventoryReservationGovernanceManager::STATE_UNRESERVED => self::STATE_UNAVAILABLE,
+      InventoryReservationGovernanceManager::STATE_RESERVED => self::STATE_RESERVED,
+      InventoryReservationGovernanceManager::STATE_PARTIALLY_RESERVED => self::STATE_PARTIALLY_READY,
+      InventoryReservationGovernanceManager::STATE_ALLOCATED => self::STATE_PREPARED,
+      InventoryReservationGovernanceManager::STATE_PREPARED => self::STATE_PREPARED,
+      InventoryReservationGovernanceManager::STATE_READY_FOR_COLLECTION => self::STATE_READY,
+      InventoryReservationGovernanceManager::STATE_DEGRADED => self::STATE_DEGRADED,
+      InventoryReservationGovernanceManager::STATE_EXHAUSTED => self::STATE_EXHAUSTED,
+      InventoryReservationGovernanceManager::STATE_FULFILLED => self::STATE_FULFILLED,
+      InventoryReservationGovernanceManager::STATE_RELEASED => self::STATE_AVAILABLE,
+      InventoryReservationGovernanceManager::STATE_EXPIRED => self::STATE_EXPIRED,
+      InventoryReservationGovernanceManager::STATE_CANCELLED => self::STATE_CANCELLED,
+      default => self::STATE_UNAVAILABLE,
+    };
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $cap
+   */
+  public function normalizeCapabilityStateFromComposition(
+    string $reservation_state,
+    array $row,
+    array $cap,
+    string $continuity_mode,
+  ): string {
+    $fulfilment = (string) ($row['fulfilment_status'] ?? '');
+    if ($fulfilment === Ticket::FULFILMENT_REDEEMED) {
+      return self::STATE_REDEEMED;
+    }
+    if ($continuity_mode === 'degraded' && $reservation_state === InventoryReservationGovernanceManager::STATE_DEGRADED) {
+      return self::STATE_DEGRADED;
+    }
+    $base = $this->mapReservationStateToCapabilityState($reservation_state);
+    if ($base === self::STATE_UNAVAILABLE && (bool) ($cap['redeemable'] ?? FALSE)) {
+      return self::STATE_AVAILABLE;
+    }
+    return $base;
+  }
+
+  /**
+   * @param array<string, mixed> $cap
+   */
+  public function normalizeExecutionDescriptor(array $cap, string $capability_type, string $capability_state): string {
+    $scanner = (string) ($cap['scanner_mode'] ?? '');
+    $fulfilment_mode = (string) ($cap['fulfilment_mode'] ?? 'none');
+    return 'capability_type=' . $capability_type
+      . '; state=' . $capability_state
+      . '; scanner_action=' . ($scanner !== '' ? $scanner : 'n/a')
+      . '; fulfilment_mode=' . $fulfilment_mode
+      . '; scan_required=' . ((bool) ($cap['scan_required'] ?? FALSE) ? 'yes' : 'no');
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $cap
+   */
+  private function buildFulfillmentCapabilitySummary(array $row, array $cap, string $normalized): string {
+    $fulfilment = (string) ($row['fulfilment_status'] ?? '');
+    return 'fulfilment_status=' . ($fulfilment !== '' ? $fulfilment : 'n/a')
+      . '; capability_state=' . $normalized
+      . '; requires_fulfilment=' . ((bool) ($cap['requires_fulfilment'] ?? FALSE) ? 'yes' : 'no')
+      . '; supports_collection=' . ((bool) ($cap['supports_collection'] ?? FALSE) ? 'yes' : 'no');
+  }
+
+  /**
+   * @param array<string, mixed> $reservation_row
+   */
+  private function buildReservationCapabilitySummary(array $reservation_row, string $normalized): string {
+    return 'reservation_state=' . (string) ($reservation_row['normalized_reservation_state'] ?? '')
+      . '; capability_state=' . $normalized
+      . '; reservation_type=' . (string) ($reservation_row['reservation_type'] ?? '');
+  }
+
+  /**
+   * @param array<string, mixed> $cap
+   */
+  private function buildScannerVisibility(array $cap): string {
+    return 'scanner_action=' . (string) ($cap['scanner_mode'] ?? 'n/a')
+      . '; redeemable=' . ((bool) ($cap['redeemable'] ?? FALSE) ? 'yes' : 'no')
+      . '; multi_use=' . ((bool) ($cap['multi_use'] ?? FALSE) ? 'yes' : 'no');
+  }
+
+  private function buildReadinessSummary(string $normalized, array $cap, string $fulfillment_summary): string {
+    return 'capability_state=' . $normalized
+      . '; redeemable=' . ((bool) ($cap['redeemable'] ?? FALSE) ? 'yes' : 'no')
+      . '; ' . $fulfillment_summary;
+  }
+
+  private function buildContinuitySummary(string $continuity_mode, string $normalized): string {
+    return 'continuity_mode=' . ($continuity_mode !== '' ? $continuity_mode : 'n/a')
+      . '; capability_state=' . $normalized;
+  }
+
+  /**
+   * @param array<string, int> $state_tally
+   * @param list<array<string, mixed>> $ticket_projections
+   * @param array<string, mixed> $reservation_readiness
+   *
+   * @return array<string, mixed>
+   */
+  private function buildReadinessProjection(
+    array $state_tally,
+    array $ticket_projections,
+    array $reservation_readiness,
+  ): array {
+    $readyish = ($state_tally[self::STATE_PREPARED] ?? 0)
+      + ($state_tally[self::STATE_READY] ?? 0)
+      + ($state_tally[self::STATE_PARTIALLY_READY] ?? 0)
+      + ($state_tally[self::STATE_AVAILABLE] ?? 0);
+    return [
+      'descriptor' => 'capability_readiness_visibility',
+      'execution_ready_rows' => $readyish,
+      'collection_ready_rows' => (int) ($state_tally[self::STATE_READY] ?? 0),
+      'reservation_readiness_signal' => (string) ($reservation_readiness['descriptor'] ?? ''),
+      'timed_collection_ready_rows' => $this->countTimedCollectionReady($ticket_projections),
+      'merch_pickup_ready_rows' => $this->countTypeReady($ticket_projections, self::TYPE_MERCH_PICKUP),
+      'hospitality_ready_rows' => $this->countTypeReady($ticket_projections, self::TYPE_HOSPITALITY_ACCESS),
+    ];
+  }
+
+  /**
+   * @param array<string, int> $state_tally
+   * @param array<string, mixed> $reservation_degradation
+   *
+   * @return array<string, mixed>
+   */
+  private function buildDegradationProjection(array $state_tally, array $reservation_degradation): array {
+    $parts = [];
+    $res_signals = is_array($reservation_degradation['signals'] ?? NULL) ? $reservation_degradation['signals'] : [];
+    foreach ($res_signals as $signal) {
+      $parts[] = (string) $signal;
+    }
+    if (($state_tally[self::STATE_DEGRADED] ?? 0) > 0) {
+      $parts[] = 'normalized_degraded_capability_rows';
+    }
+    return [
+      'descriptor' => $parts === [] ? 'nominal' : implode(';', $parts),
+      'signals' => $parts,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   * @param array<string, mixed> $reservation_continuity
+   *
+   * @return array<string, mixed>
+   */
+  private function buildContinuityProjection(array $ticket_projections, array $reservation_continuity): array {
+    return [
+      'descriptor' => 'capability_continuity_visibility',
+      'guest_continuity_statuses' => $reservation_continuity['guest_continuity_statuses'] ?? [],
+      'continuity_row_count' => count($ticket_projections),
+      'reservation_continuity_signal' => (string) ($reservation_continuity['descriptor'] ?? ''),
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   *
+   * @return array<string, mixed>
+   */
+  private function buildFulfillmentCapabilityProjection(array $ticket_projections): array {
+    $collect = 0;
+    $redeem = 0;
+    foreach ($ticket_projections as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $summary = (string) ($row['fulfillment_capability_summary'] ?? '');
+      if (str_contains($summary, 'requires_fulfilment=yes')) {
+        $collect++;
+      }
+      if (str_contains($summary, 'fulfilment_status=' . Ticket::FULFILMENT_REDEEMED)) {
+        $redeem++;
+      }
+    }
+    return [
+      'descriptor' => 'fulfillment_capability_visibility',
+      'fulfilment_collect_rows' => $collect,
+      'fulfilment_redeemed_rows' => $redeem,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $reservation_model
+   *
+   * @return array<string, mixed>
+   */
+  private function buildReservationCapabilityProjection(array $reservation_model): array {
+    $rollup = is_array($reservation_model['rollup'] ?? NULL) ? $reservation_model['rollup'] : [];
+    $allocation = is_array($reservation_model['allocation_projection'] ?? NULL)
+      ? $reservation_model['allocation_projection']
+      : [];
+    return [
+      'descriptor' => 'reservation_capability_visibility',
+      'reservation_type_tally' => $rollup['reservation_type_tally'] ?? [],
+      'allocated_fraction' => (float) ($allocation['allocated_fraction'] ?? 0.0),
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   */
+  private function countTimedCollectionReady(array $ticket_projections): int {
+    return $this->countTypeReady($ticket_projections, self::TYPE_TIMED_COLLECTION);
+  }
+
+  /**
+   * @param list<array<string, mixed>> $ticket_projections
+   */
+  private function countTypeReady(array $ticket_projections, string $capability_type): int {
+    $n = 0;
+    foreach ($ticket_projections as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      if (($row['capability_type'] ?? '') !== $capability_type) {
+        continue;
+      }
+      $state = (string) ($row['normalized_capability_state'] ?? '');
+      if (in_array($state, [self::STATE_PREPARED, self::STATE_READY, self::STATE_PARTIALLY_READY], TRUE)) {
+        $n++;
+      }
+    }
+    return $n;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalIntegrityInspector.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalIntegrityInspector.php
@@ -60,7 +60,8 @@ final class OperationalIntegrityInspector {
    *   artifacts: array<string, mixed>,
    *   recovery: array<string, mixed>,
    *   compatibility: array<string, mixed>,
-   *   guest_continuity: array<string, mixed>
+   *   guest_continuity: array<string, mixed>,
+   *   fulfillment_operational_signals: array<string, mixed>
    * }
    *
    * Artifacts include `venue_operation_policy` (machine-only venue gate
@@ -103,6 +104,7 @@ final class OperationalIntegrityInspector {
     $recovery = $this->buildRecoveryDomain($order, $tickets);
     $compatibility = $this->buildCompatibilityDomain($order, $tickets, $artifacts);
     $guest_continuity = $this->buildGuestContinuityDomain($order, $tickets);
+    $fulfillment_operational_signals = $this->buildFulfillmentOperationalSignalsDomain($tickets);
 
     $this->maybeLogAnomalies(
       $orderId,
@@ -116,6 +118,7 @@ final class OperationalIntegrityInspector {
       'recovery' => $recovery,
       'compatibility' => $compatibility,
       'guest_continuity' => $guest_continuity,
+      'fulfillment_operational_signals' => $fulfillment_operational_signals,
     ];
   }
 
@@ -166,6 +169,34 @@ final class OperationalIntegrityInspector {
         'purchaser_identity_continuity_valid' => FALSE,
         'continuity_status' => 'invalid',
       ],
+      'fulfillment_operational_signals' => [
+        'by_ticket_id' => [],
+      ],
+    ];
+  }
+
+  /**
+   * @param list<Ticket> $tickets
+   *
+   * @return array<string, mixed>
+   *   Staff-safe operational signals for reservation governance read-models.
+   */
+  private function buildFulfillmentOperationalSignalsDomain(array $tickets): array {
+    $by = [];
+    foreach ($tickets as $ticket) {
+      $id = (string) $ticket->id();
+      $type = $this->ticketCapabilityManager->getEntitlementType($ticket);
+      $by[$id] = [
+        'entitlement_type' => $type,
+        'fulfilment_status' => $ticket->getFulfilmentStatus(),
+        'redemption_count' => $ticket->getRedemptionCount(),
+        'redemption_limit' => $ticket->getRedemptionLimit(),
+        'ticket_status' => (string) ($ticket->get('status')->value ?? ''),
+        'admission_checked_in' => ((string) ($ticket->get('status')->value ?? '')) === Ticket::STATUS_CHECKED_IN,
+      ];
+    }
+    return [
+      'by_ticket_id' => $by,
     ];
   }
 

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
@@ -44,6 +44,8 @@ final class OperationalWorkspaceBuilder {
     private readonly EntitlementCapabilityRegistry $entitlementCapabilityRegistry,
     private readonly AccountProxyInterface $currentUser,
     private readonly OperationalEscalationAuditProjector $operationalEscalationAuditProjector,
+    private readonly InventoryReservationProjectionBuilder $inventoryReservationProjectionBuilder,
+    private readonly InventoryReservationAuditProjector $inventoryReservationAuditProjector,
   ) {}
 
   /**
@@ -61,6 +63,7 @@ final class OperationalWorkspaceBuilder {
     $cache_contexts = ['user.permissions', 'user'];
 
     $governance_enabled = $this->currentUser->hasPermission('govern mel operational escalations');
+    $reservation_projection_enabled = $this->currentUser->hasPermission('govern mel inventory reservations');
 
     $meta = [
       'built_at' => $this->time->getRequestTime(),
@@ -70,6 +73,7 @@ final class OperationalWorkspaceBuilder {
       'sampled_orders' => 0,
       'sampled_tickets' => 0,
       'governance_projection_enabled' => $governance_enabled,
+      'reservation_projection_enabled' => $reservation_projection_enabled,
     ];
 
     if ($event) {
@@ -95,6 +99,23 @@ final class OperationalWorkspaceBuilder {
       );
       foreach ($governance as $gov_section) {
         $sections[] = $gov_section;
+      }
+    }
+
+    if ($reservation_projection_enabled) {
+      $reservation_sections = $this->inventoryReservationProjectionBuilder->buildWorkspaceReservationSections(
+        $merged,
+        (int) $meta['built_at']
+      );
+      foreach ($reservation_sections as $reservation_section) {
+        $sections[] = $reservation_section;
+      }
+      $reservation_audit = $this->inventoryReservationAuditProjector->buildWorkspaceReservationAuditSections(
+        $merged,
+        (int) $meta['built_at']
+      );
+      foreach ($reservation_audit as $reservation_audit_section) {
+        $sections[] = $reservation_audit_section;
       }
     }
 
@@ -159,6 +180,9 @@ final class OperationalWorkspaceBuilder {
         'artifacts' => [],
         'recovery' => [],
         'guest_continuity' => [],
+        'fulfillment_signals' => [
+          'by_ticket_id' => [],
+        ],
       ];
     }
 
@@ -166,12 +190,35 @@ final class OperationalWorkspaceBuilder {
     $merged_recovery = $this->mergeRecoveryRollup($inspections);
     $merged_guest = $this->mergeGuestContinuityRollup($inspections);
     $merged_artifacts = $this->mergeArtifactDomains($inspections);
+    $merged_fulfillment = $this->mergeFulfillmentSignals($inspections);
 
     return [
       'issuance' => $merged_issuance,
       'artifacts' => $merged_artifacts,
       'recovery' => $merged_recovery,
       'guest_continuity' => $merged_guest,
+      'fulfillment_signals' => $merged_fulfillment,
+    ];
+  }
+
+  /**
+   * @param array<int|string, array<string, mixed>> $inspections
+   *
+   * @return array<string, mixed>
+   */
+  private function mergeFulfillmentSignals(array $inspections): array {
+    $by = [];
+    foreach ($inspections as $row) {
+      $sig = $row['fulfillment_operational_signals'] ?? [];
+      $chunk = is_array($sig['by_ticket_id'] ?? NULL) ? $sig['by_ticket_id'] : [];
+      foreach ($chunk as $tid => $slice) {
+        if (is_array($slice)) {
+          $by[(string) $tid] = $slice;
+        }
+      }
+    }
+    return [
+      'by_ticket_id' => $by,
     ];
   }
 

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalWorkspaceBuilder.php
@@ -46,6 +46,8 @@ final class OperationalWorkspaceBuilder {
     private readonly OperationalEscalationAuditProjector $operationalEscalationAuditProjector,
     private readonly InventoryReservationProjectionBuilder $inventoryReservationProjectionBuilder,
     private readonly InventoryReservationAuditProjector $inventoryReservationAuditProjector,
+    private readonly OperationalCapabilityProjectionBuilder $operationalCapabilityProjectionBuilder,
+    private readonly OperationalCapabilityAuditProjector $operationalCapabilityAuditProjector,
   ) {}
 
   /**
@@ -64,6 +66,7 @@ final class OperationalWorkspaceBuilder {
 
     $governance_enabled = $this->currentUser->hasPermission('govern mel operational escalations');
     $reservation_projection_enabled = $this->currentUser->hasPermission('govern mel inventory reservations');
+    $capability_projection_enabled = $this->currentUser->hasPermission('govern mel operational capabilities');
 
     $meta = [
       'built_at' => $this->time->getRequestTime(),
@@ -74,6 +77,7 @@ final class OperationalWorkspaceBuilder {
       'sampled_tickets' => 0,
       'governance_projection_enabled' => $governance_enabled,
       'reservation_projection_enabled' => $reservation_projection_enabled,
+      'capability_projection_enabled' => $capability_projection_enabled,
     ];
 
     if ($event) {
@@ -116,6 +120,23 @@ final class OperationalWorkspaceBuilder {
       );
       foreach ($reservation_audit as $reservation_audit_section) {
         $sections[] = $reservation_audit_section;
+      }
+    }
+
+    if ($capability_projection_enabled) {
+      $capability_sections = $this->operationalCapabilityProjectionBuilder->buildWorkspaceCapabilitySections(
+        $merged,
+        (int) $meta['built_at']
+      );
+      foreach ($capability_sections as $capability_section) {
+        $sections[] = $capability_section;
+      }
+      $capability_audit = $this->operationalCapabilityAuditProjector->buildWorkspaceCapabilityAuditSections(
+        $merged,
+        (int) $meta['built_at']
+      );
+      foreach ($capability_audit as $capability_audit_section) {
+        $sections[] = $capability_audit_section;
       }
     }
 

--- a/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
+++ b/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
@@ -15,6 +15,9 @@
     {% if meta.governance_projection_enabled is defined and meta.governance_projection_enabled %}
       <p class="mel-ops-workspace__meta mel-ops-workspace__meta--governance">{{ 'Escalation and resolution governance projections are enabled for your account (read-only).'|t }}</p>
     {% endif %}
+    {% if meta.reservation_projection_enabled is defined and meta.reservation_projection_enabled %}
+      <p class="mel-ops-workspace__meta mel-ops-workspace__meta--governance">{{ 'Inventory reservation governance projections are enabled for your account (read-only).'|t }}</p>
+    {% endif %}
   </header>
 
   {% for section in sections %}
@@ -28,6 +31,17 @@
           </article>
         {% endfor %}
       </div>
+      {% if section.timeline is defined and section.timeline %}
+        <ol class="mel-ops-workspace__timeline">
+          {% for entry in section.timeline %}
+            <li class="mel-ops-workspace__timeline-entry">
+              <span class="mel-ops-workspace__timeline-state">{{ entry.lane_state }}</span>
+              <span class="mel-ops-workspace__timeline-at">{{ entry.recorded_at_unix }}</span>
+              <span class="mel-ops-workspace__timeline-note">{{ entry.audit_note }}</span>
+            </li>
+          {% endfor %}
+        </ol>
+      {% endif %}
     </section>
   {% endfor %}
 </div>

--- a/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
+++ b/web/modules/custom/myeventlane_tickets/templates/venue-operations-workspace.html.twig
@@ -18,6 +18,9 @@
     {% if meta.reservation_projection_enabled is defined and meta.reservation_projection_enabled %}
       <p class="mel-ops-workspace__meta mel-ops-workspace__meta--governance">{{ 'Inventory reservation governance projections are enabled for your account (read-only).'|t }}</p>
     {% endif %}
+    {% if meta.capability_projection_enabled is defined and meta.capability_projection_enabled %}
+      <p class="mel-ops-workspace__meta mel-ops-workspace__meta--governance">{{ 'Operational entitlement capability projections are enabled for your account (read-only).'|t }}</p>
+    {% endif %}
   </header>
 
   {% for section in sections %}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/InventoryReservationGovernanceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/InventoryReservationGovernanceKernelTest.php
@@ -1,0 +1,603 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel;
+
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_order\Entity\OrderItem;
+use Drupal\commerce_order\Entity\OrderItemType;
+use Drupal\commerce_order\Entity\OrderType;
+use Drupal\commerce_price\Entity\Currency;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Drupal\myeventlane_tickets\Service\InventoryReservationAuditProjector;
+use Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager;
+use Drupal\myeventlane_tickets\Service\InventoryReservationProjectionBuilder;
+use Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager
+ *
+ * @group myeventlane_tickets
+ */
+#[RunTestsInSeparateProcesses]
+final class InventoryReservationGovernanceKernelTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'link',
+    'path',
+    'path_alias',
+    'views',
+    'address',
+    'node',
+    'options',
+    'datetime',
+    'datetime_range',
+    'commerce',
+    'commerce_number_pattern',
+    'commerce_price',
+    'commerce_order',
+    'commerce_product',
+    'commerce_store',
+    'entity_reference_revisions',
+    'paragraphs',
+    'profile',
+    'state_machine',
+    'mel_ticket',
+    'myeventlane_vendor',
+    'myeventlane_tickets',
+    'myeventlane_wallet',
+  ];
+
+  private Node $event;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    foreach (array_keys($container->getDefinitions()) as $service_id) {
+      if (str_starts_with($service_id, 'myeventlane_vendor.') && $service_id !== 'myeventlane_vendor.event_access_checker') {
+        $container->removeDefinition($service_id);
+      }
+    }
+
+    $container->register('myeventlane_vendor.event_access_checker', EventVendorAccessChecker::class);
+    $container->register('myeventlane_onboarding.manager', \stdClass::class);
+    $container->register('myeventlane_core.vendor_follow', \stdClass::class);
+    $container->register('myeventlane_event_studio.save', \stdClass::class);
+    $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
+    $container->register('myeventlane_core.domain_detector', \stdClass::class);
+    $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
+    $container->register('myeventlane_boost.manager', \stdClass::class);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('commerce_currency');
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_order');
+    $this->installEntitySchema('commerce_order_item');
+    $this->installEntitySchema('myeventlane_ticket');
+    $this->installConfig(['commerce_store', 'commerce_product', 'commerce_order', 'user']);
+    $this->ensureWorkspaceRoles();
+
+    NodeType::create([
+      'type' => 'event',
+      'name' => 'Event',
+    ])->save();
+    $this->createEventFields();
+    $this->ensureProductEventField();
+
+    if (!OrderItemType::load('default')) {
+      OrderItemType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'purchasableEntityType' => 'commerce_product_variation',
+        'orderType' => 'default',
+      ])->save();
+    }
+    if (!OrderType::load('default')) {
+      OrderType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'workflow' => 'order_default',
+      ])->save();
+    }
+    if (!Currency::load('AUD')) {
+      Currency::create([
+        'currencyCode' => 'AUD',
+        'name' => 'Australian Dollar',
+        'numericCode' => '036',
+        'symbol' => '$',
+        'fractionDigits' => 2,
+      ])->save();
+    }
+
+    $store_type_storage = $this->container->get('entity_type.manager')->getStorage('commerce_store_type');
+    if (!$store_type_storage->load('online')) {
+      $store_type_storage->create(['id' => 'online', 'label' => 'Online'])->save();
+    }
+    $store = Store::create([
+      'type' => 'online',
+      'name' => 'Reservation Store',
+      'mail' => 'store@example.test',
+      'default_currency' => 'AUD',
+      'status' => 1,
+    ]);
+    $store->save();
+
+    $customer = User::create([
+      'name' => 'reservation_customer',
+      'mail' => 'reservation@example.test',
+      'status' => 1,
+    ]);
+    $customer->save();
+
+    $this->event = Node::create([
+      'type' => 'event',
+      'title' => 'Reservation Event',
+      'uid' => $customer->id(),
+      'status' => 1,
+      'field_event_start' => '2026-08-01T10:00:00',
+      'field_event_end' => '2026-08-01T12:00:00',
+      'field_venue_name' => 'Hall B',
+      'field_event_vendor' => $customer->id(),
+    ]);
+    $this->event->save();
+
+    $product = Product::create([
+      'type' => 'default',
+      'title' => 'Reservation Product',
+      'stores' => [$store],
+      'field_event' => $this->event->id(),
+    ]);
+    $product->save();
+
+    $variation = ProductVariation::create([
+      'type' => 'default',
+      'sku' => 'RESERVATION-SKU',
+      'title' => 'Merch',
+      'product_id' => $product->id(),
+      'price' => new Price('25.00', 'AUD'),
+      'status' => 1,
+    ]);
+    $variation->save();
+
+    $order = Order::create([
+      'type' => 'default',
+      'store_id' => $store->id(),
+      'state' => 'completed',
+      'uid' => $customer->id(),
+      'mail' => 'reservation@example.test',
+      'placed' => time(),
+    ]);
+    $order->save();
+
+    $item = OrderItem::create([
+      'type' => 'default',
+      'purchased_entity' => $variation,
+      'quantity' => 1,
+      'unit_price' => new Price('25.00', 'AUD'),
+      'order_id' => $order->id(),
+    ]);
+    $item->save();
+    $order->addItem($item);
+    $order->save();
+  }
+
+  public function testReservationStateNormalization(): void {
+    $m = $this->governanceManager();
+    $this->assertSame('unreserved', $m->normalizeReservationState(''));
+    $this->assertSame('reserved', $m->normalizeReservationState('reserved'));
+    $this->assertSame('ready_for_collection', $m->normalizeReservationState('ready_for_collection'));
+  }
+
+  public function testReservationTypeNormalization(): void {
+    $m = $this->governanceManager();
+    $this->assertSame('digital_redemption', $m->normalizeReservationType(''));
+    $this->assertSame('merch', $m->normalizeReservationType('merch'));
+    $this->assertSame('timed_pickup', $m->normalizeReservationType('timed_pickup'));
+  }
+
+  public function testPartialAllocationSemantics(): void {
+    $m = $this->governanceManager();
+    $cap = $this->container->get('myeventlane_tickets.entitlement_capability_registry')->getCapabilityMap(Ticket::ENTITLEMENT_DRINK);
+    $row = [
+      'entitlement_type' => Ticket::ENTITLEMENT_DRINK,
+      'redemption_count' => 1,
+      'redemption_limit' => 3,
+    ];
+    $this->assertTrue($m->isPartialAllocation($row, $cap));
+    $state = $m->normalizeTicketReservationState(
+      $row,
+      $cap,
+      FALSE,
+      'valid',
+      'online',
+      InventoryReservationGovernanceManager::TYPE_FOOD_DRINK,
+      TRUE,
+    );
+    $this->assertSame('partially_reserved', $state);
+  }
+
+  public function testReservationReadinessProjections(): void {
+    $model = $this->governanceManager()->composeReservationReadModel($this->sampleMerged(), 1_700_000_000);
+    $readiness = $model['readiness_projection'] ?? [];
+    $this->assertSame('reservation_readiness_visibility', $readiness['descriptor'] ?? '');
+    $this->assertArrayHasKey('collection_ready_rows', $readiness);
+  }
+
+  public function testReservationDegradationProjections(): void {
+    $merged = $this->sampleMerged();
+    $merged['recovery']['recovery_mismatch_observed'] = TRUE;
+    $model = $this->governanceManager()->composeReservationReadModel($merged, 1_700_000_000);
+    $degradation = $model['degradation_projection'] ?? [];
+    $this->assertNotSame('nominal', $degradation['descriptor'] ?? 'nominal');
+  }
+
+  public function testReservationContinuityOrdering(): void {
+    $timeline = $this->governanceManager()->projectReservationAuditTimeline([
+      ['state' => 'reserved', 'recorded_at' => 200, 'note' => 'second'],
+      ['state' => 'allocated', 'recorded_at' => 100, 'note' => 'first'],
+    ]);
+    $this->assertSame(100, $timeline[0]['recorded_at_unix']);
+    $this->assertSame(200, $timeline[1]['recorded_at_unix']);
+  }
+
+  public function testWorkspaceReservationRendering(): void {
+    $this->seedEventTickets();
+    $staff = $this->staffWithReservationPermission();
+    /** @var AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($staff);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertContains('reservation_governance_summary', $ids);
+    $this->assertContains('reservation_lifecycle_cards', $ids);
+    $this->assertContains('reservation_allocation_visibility', $ids);
+    $this->assertContains('reservation_lifecycle_audit_timeline', $ids);
+
+    $switcher->switchBack();
+  }
+
+  public function testPermissionSeparation(): void {
+    $this->seedEventTickets();
+    $viewer = User::create([
+      'name' => 'reservation_view_only',
+      'mail' => 'res-view@example.test',
+      'status' => 1,
+    ]);
+    $viewer->addRole('mel_ws_ops_view');
+    $viewer->save();
+    $viewer = User::load($viewer->id());
+    $this->assertNotFalse($viewer);
+
+    /** @var AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($viewer);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $this->assertFalse($workspace['meta']['reservation_projection_enabled']);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertNotContains('reservation_governance_summary', $ids);
+
+    $switcher->switchBack();
+  }
+
+  public function testAuditContinuityOrdering(): void {
+    $sections = $this->auditProjector()->buildWorkspaceReservationAuditSections($this->sampleMerged(), 1_700_000_000);
+    $timeline = $sections[0]['timeline'] ?? [];
+    $this->assertNotEmpty($timeline);
+    $times = array_column($timeline, 'recorded_at_unix');
+    $sorted = $times;
+    sort($sorted);
+    $this->assertSame($sorted, $times);
+  }
+
+  public function testNoReplayLeakage(): void {
+    $merged = $this->sampleMergedWithSecrets();
+    $sections = $this->projectionBuilder()->buildWorkspaceReservationSections($merged, 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('replay_token', $blob);
+  }
+
+  public function testNoQrLeakage(): void {
+    $sections = $this->auditProjector()->buildWorkspaceReservationAuditSections($this->sampleMergedWithSecrets(), 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('qr_payload', $blob);
+  }
+
+  public function testNoDeviceFingerprintLeakage(): void {
+    $sections = $this->auditProjector()->buildWorkspaceReservationAuditSections($this->sampleMergedWithSecrets(), 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('device_fingerprint', $blob);
+    $this->assertStringNotContainsString('fingerprint', strtolower($blob));
+  }
+
+  public function testInvalidReservationNormalization(): void {
+    $m = $this->governanceManager();
+    $this->assertSame('unreserved', $m->normalizeReservationState('not_a_state'));
+    $this->assertSame('digital_redemption', $m->normalizeReservationType('warehouse_slot'));
+  }
+
+  public function testReservationLifecycleContinuity(): void {
+    $model = $this->governanceManager()->composeReservationReadModel($this->sampleMerged(), 1_700_000_000);
+    $continuity = $model['continuity_projection'] ?? [];
+    $this->assertSame('reservation_continuity_visibility', $continuity['descriptor'] ?? '');
+    $this->assertArrayHasKey('guest_continuity_statuses', $continuity);
+  }
+
+  public function testAllocationDegradationSemantics(): void {
+    $merged = $this->sampleMerged();
+    $merged['issuance']['worst_quantity_alignment_status'] = 'invalid';
+    $model = $this->governanceManager()->composeReservationReadModel($merged, 1_700_000_000);
+    $allocation = $model['allocation_projection'] ?? [];
+    $this->assertSame('allocation_visibility', $allocation['descriptor'] ?? '');
+    $degradation = $model['degradation_projection'] ?? [];
+    $this->assertStringContainsString('rollup_or_continuity_degraded', (string) ($degradation['descriptor'] ?? ''));
+  }
+
+  public function testTimedPickupReservationSemantics(): void {
+    $m = $this->governanceManager();
+    $type = $m->mapEntitlementToReservationType(Ticket::ENTITLEMENT_TICKET, 1, 'early');
+    $this->assertSame('timed_pickup', $type);
+    $merged = $this->sampleMerged();
+    $merged['artifacts']['timed_entry_policy'] = [
+      '1' => [
+        'policy' => [
+          'scanner' => ['state' => 'open'],
+        ],
+      ],
+    ];
+    $model = $m->composeReservationReadModel($merged, 1_700_000_000);
+    $readiness = $model['readiness_projection'] ?? [];
+    $this->assertArrayHasKey('timed_pickup_ready_rows', $readiness);
+  }
+
+  public function testRollupCompositionContinuity(): void {
+    $m = $this->governanceManager();
+    $state = $m->projectReservationStateFromRollup($this->sampleMerged());
+    $this->assertContains($state, $m->allCanonicalStates());
+    $rollup = $m->composeReservationReadModel($this->sampleMerged(), 1_700_000_000)['rollup'] ?? [];
+    $this->assertArrayHasKey('rollup_continuity_composition', $rollup);
+    $this->assertArrayHasKey('canonical_reservation_state_tally', $rollup);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function sampleMerged(): array {
+    return [
+      'issuance' => [
+        'worst_quantity_alignment_status' => 'valid',
+        'aggregated_expected_quantity' => 1,
+        'aggregated_issued_ticket_count' => 1,
+      ],
+      'recovery' => ['recovery_mismatch_observed' => FALSE],
+      'guest_continuity' => ['continuity_statuses_observed' => ['valid']],
+      'artifacts' => [
+        'canonical_pdf_readiness' => 'valid',
+        'operational_continuity' => [
+          '1' => ['continuity_summary' => ['continuity_mode' => 'online']],
+        ],
+        'timed_entry_policy' => [],
+      ],
+      'fulfillment_signals' => [
+        'by_ticket_id' => [
+          '1' => [
+            'entitlement_type' => Ticket::ENTITLEMENT_MERCH,
+            'fulfilment_status' => Ticket::FULFILMENT_READY,
+            'redemption_count' => 0,
+            'redemption_limit' => 1,
+            'ticket_status' => Ticket::STATUS_ASSIGNED,
+            'admission_checked_in' => FALSE,
+          ],
+          '2' => [
+            'entitlement_type' => Ticket::ENTITLEMENT_DRINK,
+            'fulfilment_status' => Ticket::FULFILMENT_PENDING,
+            'redemption_count' => 1,
+            'redemption_limit' => 3,
+            'ticket_status' => Ticket::STATUS_ASSIGNED,
+            'admission_checked_in' => FALSE,
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function sampleMergedWithSecrets(): array {
+    $merged = $this->sampleMerged();
+    $merged['artifacts']['operational_continuity']['1']['replay_token'] = 'secret-replay';
+    $merged['artifacts']['operational_continuity']['1']['qr_payload'] = 'qr-bytes';
+    $merged['artifacts']['operational_continuity']['1']['device_fingerprint'] = 'fp-123';
+    return $merged;
+  }
+
+  private function seedEventTickets(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertNotEmpty($tickets);
+    foreach ($tickets as $ticket) {
+      $ticket->set('event_id', $this->event->id());
+      $ticket->set('entitlement_type', Ticket::ENTITLEMENT_MERCH);
+      $ticket->set('fulfilment_status', Ticket::FULFILMENT_READY);
+      $ticket->save();
+    }
+  }
+
+  private function staffWithReservationPermission(): User {
+    if (!Role::load('mel_ws_reservation')) {
+      Role::create([
+        'id' => 'mel_ws_reservation',
+        'label' => 'MEL workspace reservation',
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->grantPermission('govern mel inventory reservations')
+        ->save();
+    }
+    $staff = User::create([
+      'name' => 'reservation_staff',
+      'mail' => 'res-staff@example.test',
+      'status' => 1,
+    ]);
+    $staff->addRole('mel_ws_reservation');
+    $staff->save();
+    $loaded = User::load($staff->id());
+    $this->assertInstanceOf(User::class, $loaded);
+    return $loaded;
+  }
+
+  private function ensureWorkspaceRoles(): void {
+    if (!Role::load('mel_ws_ops_view')) {
+      Role::create([
+        'id' => 'mel_ws_ops_view',
+        'label' => 'MEL workspace view only',
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->save();
+    }
+  }
+
+  private function governanceManager(): InventoryReservationGovernanceManager {
+    return $this->container->get('myeventlane_tickets.inventory_reservation_governance_manager');
+  }
+
+  private function projectionBuilder(): InventoryReservationProjectionBuilder {
+    return $this->container->get('myeventlane_tickets.inventory_reservation_projection_builder');
+  }
+
+  private function auditProjector(): InventoryReservationAuditProjector {
+    return $this->container->get('myeventlane_tickets.inventory_reservation_audit_projector');
+  }
+
+  private function workspaceBuilder(): OperationalWorkspaceBuilder {
+    return $this->container->get('myeventlane_tickets.operational_workspace_builder');
+  }
+
+  private function issuer(): TicketIssuer {
+    return $this->container->get('myeventlane_tickets.ticket_issuer');
+  }
+
+  private function loadOrder(): Order {
+    $storage = $this->container->get('entity_type.manager')->getStorage('commerce_order');
+    $ids = $storage->getQuery()->accessCheck(FALSE)->sort('order_id')->execute();
+    $this->assertNotEmpty($ids);
+    $order = $storage->load(reset($ids));
+    $this->assertInstanceOf(Order::class, $order);
+    return $order;
+  }
+
+  /**
+   * @return array<int, Ticket>
+   */
+  private function loadTicketsForOrder(int $order_id): array {
+    $storage = $this->container->get('entity_type.manager')->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_id', $order_id)
+      ->sort('id')
+      ->execute();
+    if (!$ids) {
+      return [];
+    }
+    return array_values($storage->loadMultiple($ids));
+  }
+
+  /**
+   * @return array<string, array{type: string, settings: array<string, mixed>}>
+   */
+  private function eventFieldDefinitions(): array {
+    return [
+      'field_event_start' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_event_end' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_venue_name' => [
+        'type' => 'string',
+        'settings' => ['max_length' => 255],
+      ],
+      'field_event_vendor' => [
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'user'],
+      ],
+    ];
+  }
+
+  private function createEventFields(): void {
+    foreach ($this->eventFieldDefinitions() as $field_name => $definition) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'type' => $definition['type'],
+        'settings' => $definition['settings'],
+      ])->save();
+
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'bundle' => 'event',
+        'label' => $field_name,
+      ])->save();
+    }
+  }
+
+  private function ensureProductEventField(): void {
+    if (FieldStorageConfig::loadByName('commerce_product', 'field_event')) {
+      return;
+    }
+    FieldStorageConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'bundle' => 'default',
+      'label' => 'Event',
+    ])->save();
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEntitlementCapabilityKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEntitlementCapabilityKernelTest.php
@@ -1,0 +1,613 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel;
+
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_order\Entity\OrderItem;
+use Drupal\commerce_order\Entity\OrderItemType;
+use Drupal\commerce_order\Entity\OrderType;
+use Drupal\commerce_price\Entity\Currency;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_tickets\Entity\Ticket;
+use Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager;
+use Drupal\myeventlane_tickets\Service\OperationalCapabilityAuditProjector;
+use Drupal\myeventlane_tickets\Service\OperationalCapabilityProjectionBuilder;
+use Drupal\myeventlane_tickets\Service\OperationalEntitlementCapabilityManager;
+use Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Service\OperationalEntitlementCapabilityManager
+ *
+ * @group myeventlane_tickets
+ */
+#[RunTestsInSeparateProcesses]
+final class OperationalEntitlementCapabilityKernelTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'link',
+    'path',
+    'path_alias',
+    'views',
+    'address',
+    'node',
+    'options',
+    'datetime',
+    'datetime_range',
+    'commerce',
+    'commerce_number_pattern',
+    'commerce_price',
+    'commerce_order',
+    'commerce_product',
+    'commerce_store',
+    'entity_reference_revisions',
+    'paragraphs',
+    'profile',
+    'state_machine',
+    'mel_ticket',
+    'myeventlane_vendor',
+    'myeventlane_tickets',
+    'myeventlane_wallet',
+  ];
+
+  private Node $event;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    foreach (array_keys($container->getDefinitions()) as $service_id) {
+      if (str_starts_with($service_id, 'myeventlane_vendor.') && $service_id !== 'myeventlane_vendor.event_access_checker') {
+        $container->removeDefinition($service_id);
+      }
+    }
+
+    $container->register('myeventlane_vendor.event_access_checker', EventVendorAccessChecker::class);
+    $container->register('myeventlane_onboarding.manager', \stdClass::class);
+    $container->register('myeventlane_core.vendor_follow', \stdClass::class);
+    $container->register('myeventlane_event_studio.save', \stdClass::class);
+    $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
+    $container->register('myeventlane_core.domain_detector', \stdClass::class);
+    $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
+    $container->register('myeventlane_boost.manager', \stdClass::class);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('commerce_currency');
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_order');
+    $this->installEntitySchema('commerce_order_item');
+    $this->installEntitySchema('myeventlane_ticket');
+    $this->installConfig(['commerce_store', 'commerce_product', 'commerce_order', 'user']);
+    $this->ensureWorkspaceRoles();
+
+    NodeType::create([
+      'type' => 'event',
+      'name' => 'Event',
+    ])->save();
+    $this->createEventFields();
+    $this->ensureProductEventField();
+
+    if (!OrderItemType::load('default')) {
+      OrderItemType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'purchasableEntityType' => 'commerce_product_variation',
+        'orderType' => 'default',
+      ])->save();
+    }
+    if (!OrderType::load('default')) {
+      OrderType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'workflow' => 'order_default',
+      ])->save();
+    }
+    if (!Currency::load('AUD')) {
+      Currency::create([
+        'currencyCode' => 'AUD',
+        'name' => 'Australian Dollar',
+        'numericCode' => '036',
+        'symbol' => '$',
+        'fractionDigits' => 2,
+      ])->save();
+    }
+
+    $store_type_storage = $this->container->get('entity_type.manager')->getStorage('commerce_store_type');
+    if (!$store_type_storage->load('online')) {
+      $store_type_storage->create(['id' => 'online', 'label' => 'Online'])->save();
+    }
+    $store = Store::create([
+      'type' => 'online',
+      'name' => 'Capability Store',
+      'mail' => 'store@example.test',
+      'default_currency' => 'AUD',
+      'status' => 1,
+    ]);
+    $store->save();
+
+    $customer = User::create([
+      'name' => 'capability_customer',
+      'mail' => 'capability@example.test',
+      'status' => 1,
+    ]);
+    $customer->save();
+
+    $this->event = Node::create([
+      'type' => 'event',
+      'title' => 'Capability Event',
+      'uid' => $customer->id(),
+      'status' => 1,
+      'field_event_start' => '2026-08-01T10:00:00',
+      'field_event_end' => '2026-08-01T12:00:00',
+      'field_venue_name' => 'Hall C',
+      'field_event_vendor' => $customer->id(),
+    ]);
+    $this->event->save();
+
+    $product = Product::create([
+      'type' => 'default',
+      'title' => 'Capability Product',
+      'stores' => [$store],
+      'field_event' => $this->event->id(),
+    ]);
+    $product->save();
+
+    $variation = ProductVariation::create([
+      'type' => 'default',
+      'sku' => 'CAPABILITY-SKU',
+      'title' => 'Merch',
+      'product_id' => $product->id(),
+      'price' => new Price('25.00', 'AUD'),
+      'status' => 1,
+    ]);
+    $variation->save();
+
+    $order = Order::create([
+      'type' => 'default',
+      'store_id' => $store->id(),
+      'state' => 'completed',
+      'uid' => $customer->id(),
+      'mail' => 'capability@example.test',
+      'placed' => time(),
+    ]);
+    $order->save();
+
+    $item = OrderItem::create([
+      'type' => 'default',
+      'purchased_entity' => $variation,
+      'quantity' => 1,
+      'unit_price' => new Price('25.00', 'AUD'),
+      'order_id' => $order->id(),
+    ]);
+    $item->save();
+    $order->addItem($item);
+    $order->save();
+  }
+
+  public function testCapabilityTypeNormalization(): void {
+    $m = $this->capabilityManager();
+    $this->assertSame('digital_redemption', $m->normalizeCapabilityType(''));
+    $this->assertSame('merch_pickup', $m->normalizeCapabilityType('merch_pickup'));
+    $this->assertSame('hospitality_access', $m->normalizeCapabilityType('hospitality_access'));
+    $this->assertSame('timed_collection', $m->normalizeCapabilityType('timed_collection'));
+  }
+
+  public function testCapabilityStateNormalization(): void {
+    $m = $this->capabilityManager();
+    $this->assertSame('unavailable', $m->normalizeCapabilityState(''));
+    $this->assertSame('reserved', $m->normalizeCapabilityState('reserved'));
+    $this->assertSame('ready', $m->normalizeCapabilityState('ready'));
+    $this->assertSame('redeemed', $m->normalizeCapabilityState('redeemed'));
+  }
+
+  public function testCapabilityReadinessProjections(): void {
+    $model = $this->capabilityManager()->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000);
+    $readiness = $model['readiness_projection'] ?? [];
+    $this->assertSame('capability_readiness_visibility', $readiness['descriptor'] ?? '');
+    $this->assertArrayHasKey('execution_ready_rows', $readiness);
+    $this->assertArrayHasKey('merch_pickup_ready_rows', $readiness);
+  }
+
+  public function testCapabilityDegradationProjections(): void {
+    $merged = $this->sampleMerged();
+    $merged['recovery']['recovery_mismatch_observed'] = TRUE;
+    $model = $this->capabilityManager()->composeCapabilityReadModel($merged, 1_700_000_000);
+    $degradation = $model['degradation_projection'] ?? [];
+    $this->assertNotSame('nominal', $degradation['descriptor'] ?? 'nominal');
+  }
+
+  public function testCapabilityContinuityOrdering(): void {
+    $timeline = $this->capabilityManager()->projectCapabilityAuditTimeline([
+      ['state' => 'reserved', 'recorded_at' => 200, 'note' => 'second'],
+      ['state' => 'ready', 'recorded_at' => 100, 'note' => 'first'],
+    ]);
+    $this->assertSame(100, $timeline[0]['recorded_at_unix']);
+    $this->assertSame(200, $timeline[1]['recorded_at_unix']);
+  }
+
+  public function testWorkspaceCapabilityRendering(): void {
+    $this->seedEventTickets();
+    $staff = $this->staffWithCapabilityPermission();
+    /** @var AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($staff);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertContains('capability_governance_summary', $ids);
+    $this->assertContains('capability_lifecycle_cards', $ids);
+    $this->assertContains('capability_readiness_visibility', $ids);
+    $this->assertContains('capability_lifecycle_audit_timeline', $ids);
+
+    $switcher->switchBack();
+  }
+
+  public function testPermissionSeparation(): void {
+    $this->seedEventTickets();
+    $viewer = User::create([
+      'name' => 'capability_view_only',
+      'mail' => 'cap-view@example.test',
+      'status' => 1,
+    ]);
+    $viewer->addRole('mel_ws_ops_view');
+    $viewer->save();
+    $viewer = User::load($viewer->id());
+    $this->assertNotFalse($viewer);
+
+    /** @var AccountSwitcherInterface $switcher */
+    $switcher = $this->container->get('account_switcher');
+    $switcher->switchTo($viewer);
+
+    $workspace = $this->workspaceBuilder()->build($this->event);
+    $this->assertFalse($workspace['meta']['capability_projection_enabled']);
+    $ids = array_column($workspace['sections'], 'id');
+    $this->assertNotContains('capability_governance_summary', $ids);
+
+    $switcher->switchBack();
+  }
+
+  public function testReservationCapabilityComposition(): void {
+    $model = $this->capabilityManager()->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000);
+    $reservation = $model['reservation_capability_projection'] ?? [];
+    $this->assertSame('reservation_capability_visibility', $reservation['descriptor'] ?? '');
+    $this->assertArrayHasKey('allocated_fraction', $reservation);
+    $rows = $model['ticket_projections'] ?? [];
+    $this->assertNotEmpty($rows);
+    $this->assertStringContainsString('reservation_state=', (string) ($rows[0]['reservation_capability_summary'] ?? ''));
+  }
+
+  public function testFulfillmentCapabilityComposition(): void {
+    $model = $this->capabilityManager()->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000);
+    $fulfillment = $model['fulfillment_capability_projection'] ?? [];
+    $this->assertSame('fulfillment_capability_visibility', $fulfillment['descriptor'] ?? '');
+    $this->assertArrayHasKey('fulfilment_collect_rows', $fulfillment);
+    $rows = $model['ticket_projections'] ?? [];
+    $this->assertNotEmpty($rows);
+    $this->assertStringContainsString('fulfilment_status=', (string) ($rows[0]['fulfillment_capability_summary'] ?? ''));
+  }
+
+  public function testNoReplayLeakage(): void {
+    $sections = $this->projectionBuilder()->buildWorkspaceCapabilitySections($this->sampleMergedWithSecrets(), 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('replay_token', $blob);
+  }
+
+  public function testNoQrLeakage(): void {
+    $sections = $this->auditProjector()->buildWorkspaceCapabilityAuditSections($this->sampleMergedWithSecrets(), 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('qr_payload', $blob);
+  }
+
+  public function testNoDeviceFingerprintLeakage(): void {
+    $sections = $this->auditProjector()->buildWorkspaceCapabilityAuditSections($this->sampleMergedWithSecrets(), 1_700_000_000);
+    $blob = json_encode($sections, JSON_THROW_ON_ERROR);
+    $this->assertStringNotContainsString('device_fingerprint', $blob);
+    $this->assertStringNotContainsString('fingerprint', strtolower($blob));
+  }
+
+  public function testInvalidCapabilityNormalization(): void {
+    $m = $this->capabilityManager();
+    $this->assertSame('unavailable', $m->normalizeCapabilityState('not_a_state'));
+    $this->assertSame('digital_redemption', $m->normalizeCapabilityType('warehouse_slot'));
+  }
+
+  public function testCapabilityLifecycleContinuity(): void {
+    $model = $this->capabilityManager()->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000);
+    $continuity = $model['continuity_projection'] ?? [];
+    $this->assertSame('capability_continuity_visibility', $continuity['descriptor'] ?? '');
+    $this->assertArrayHasKey('guest_continuity_statuses', $continuity);
+  }
+
+  public function testTimedCollectionCapabilitySemantics(): void {
+    $m = $this->capabilityManager();
+    $type = $m->mapEntitlementToCapabilityType(Ticket::ENTITLEMENT_TICKET, 1, 'early');
+    $this->assertSame('timed_collection', $type);
+    $merged = $this->sampleMerged();
+    $merged['artifacts']['timed_entry_policy'] = [
+      '1' => [
+        'policy' => [
+          'scanner' => ['state' => 'open'],
+        ],
+      ],
+    ];
+    $model = $m->composeCapabilityReadModel($merged, 1_700_000_000);
+    $readiness = $model['readiness_projection'] ?? [];
+    $this->assertArrayHasKey('timed_collection_ready_rows', $readiness);
+  }
+
+  public function testMerchPickupCapabilitySemantics(): void {
+    $m = $this->capabilityManager();
+    $type = $m->mapEntitlementToCapabilityType(Ticket::ENTITLEMENT_MERCH, 1);
+    $this->assertSame('merch_pickup', $type);
+    $model = $m->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000);
+    $types = $model['rollup']['capability_type_tally'] ?? [];
+    $this->assertGreaterThan(0, (int) ($types['merch_pickup'] ?? 0));
+  }
+
+  public function testHospitalityCapabilitySemantics(): void {
+    $m = $this->capabilityManager();
+    $type = $m->mapEntitlementToCapabilityType(Ticket::ENTITLEMENT_ADDON, 3);
+    $this->assertSame('hospitality_access', $type);
+    $reservation_type = $m->mapReservationTypeToCapabilityType(InventoryReservationGovernanceManager::TYPE_HOSPITALITY);
+    $this->assertSame('hospitality_access', $reservation_type);
+  }
+
+  public function testRollupCompositionContinuity(): void {
+    $m = $this->capabilityManager();
+    $state = $m->projectCapabilityStateFromRollup($this->sampleMerged());
+    $this->assertContains($state, $m->allCanonicalStates());
+    $rollup = $m->composeCapabilityReadModel($this->sampleMerged(), 1_700_000_000)['rollup'] ?? [];
+    $this->assertArrayHasKey('rollup_continuity_composition', $rollup);
+    $this->assertArrayHasKey('canonical_capability_state_tally', $rollup);
+    $this->assertArrayHasKey('reservation_state_tally', $rollup);
+  }
+
+  public function testAuditContinuityOrdering(): void {
+    $sections = $this->auditProjector()->buildWorkspaceCapabilityAuditSections($this->sampleMerged(), 1_700_000_000);
+    $timeline = $sections[0]['timeline'] ?? [];
+    $this->assertNotEmpty($timeline);
+    $times = array_column($timeline, 'recorded_at_unix');
+    $sorted = $times;
+    sort($sorted);
+    $this->assertSame($sorted, $times);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function sampleMerged(): array {
+    return [
+      'issuance' => [
+        'worst_quantity_alignment_status' => 'valid',
+        'aggregated_expected_quantity' => 1,
+        'aggregated_issued_ticket_count' => 1,
+      ],
+      'recovery' => ['recovery_mismatch_observed' => FALSE],
+      'guest_continuity' => ['continuity_statuses_observed' => ['valid']],
+      'artifacts' => [
+        'canonical_pdf_readiness' => 'valid',
+        'operational_continuity' => [
+          '1' => ['continuity_summary' => ['continuity_mode' => 'online']],
+        ],
+        'timed_entry_policy' => [],
+      ],
+      'fulfillment_signals' => [
+        'by_ticket_id' => [
+          '1' => [
+            'entitlement_type' => Ticket::ENTITLEMENT_MERCH,
+            'fulfilment_status' => Ticket::FULFILMENT_READY,
+            'redemption_count' => 0,
+            'redemption_limit' => 1,
+            'ticket_status' => Ticket::STATUS_ASSIGNED,
+            'admission_checked_in' => FALSE,
+          ],
+          '2' => [
+            'entitlement_type' => Ticket::ENTITLEMENT_DRINK,
+            'fulfilment_status' => Ticket::FULFILMENT_PENDING,
+            'redemption_count' => 1,
+            'redemption_limit' => 3,
+            'ticket_status' => Ticket::STATUS_ASSIGNED,
+            'admission_checked_in' => FALSE,
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function sampleMergedWithSecrets(): array {
+    $merged = $this->sampleMerged();
+    $merged['artifacts']['operational_continuity']['1']['replay_token'] = 'secret-replay';
+    $merged['artifacts']['operational_continuity']['1']['qr_payload'] = 'qr-bytes';
+    $merged['artifacts']['operational_continuity']['1']['device_fingerprint'] = 'fp-123';
+    return $merged;
+  }
+
+  private function seedEventTickets(): void {
+    $order = $this->loadOrder();
+    $this->issuer()->issueForOrder($order);
+    $tickets = $this->loadTicketsForOrder((int) $order->id());
+    $this->assertNotEmpty($tickets);
+    foreach ($tickets as $ticket) {
+      $ticket->set('event_id', $this->event->id());
+      $ticket->set('entitlement_type', Ticket::ENTITLEMENT_MERCH);
+      $ticket->set('fulfilment_status', Ticket::FULFILMENT_READY);
+      $ticket->save();
+    }
+  }
+
+  private function staffWithCapabilityPermission(): User {
+    if (!Role::load('mel_ws_capability')) {
+      Role::create([
+        'id' => 'mel_ws_capability',
+        'label' => 'MEL workspace capability',
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->grantPermission('govern mel operational capabilities')
+        ->save();
+    }
+    $staff = User::create([
+      'name' => 'capability_staff',
+      'mail' => 'cap-staff@example.test',
+      'status' => 1,
+    ]);
+    $staff->addRole('mel_ws_capability');
+    $staff->save();
+    $loaded = User::load($staff->id());
+    $this->assertInstanceOf(User::class, $loaded);
+    return $loaded;
+  }
+
+  private function ensureWorkspaceRoles(): void {
+    if (!Role::load('mel_ws_ops_view')) {
+      Role::create([
+        'id' => 'mel_ws_ops_view',
+        'label' => 'MEL workspace view only',
+      ])
+        ->grantPermission('view mel venue operations workspace')
+        ->save();
+    }
+  }
+
+  private function capabilityManager(): OperationalEntitlementCapabilityManager {
+    return $this->container->get('myeventlane_tickets.operational_entitlement_capability_manager');
+  }
+
+  private function projectionBuilder(): OperationalCapabilityProjectionBuilder {
+    return $this->container->get('myeventlane_tickets.operational_capability_projection_builder');
+  }
+
+  private function auditProjector(): OperationalCapabilityAuditProjector {
+    return $this->container->get('myeventlane_tickets.operational_capability_audit_projector');
+  }
+
+  private function workspaceBuilder(): OperationalWorkspaceBuilder {
+    return $this->container->get('myeventlane_tickets.operational_workspace_builder');
+  }
+
+  private function issuer(): TicketIssuer {
+    return $this->container->get('myeventlane_tickets.ticket_issuer');
+  }
+
+  private function loadOrder(): Order {
+    $storage = $this->container->get('entity_type.manager')->getStorage('commerce_order');
+    $ids = $storage->getQuery()->accessCheck(FALSE)->sort('order_id')->execute();
+    $this->assertNotEmpty($ids);
+    $order = $storage->load(reset($ids));
+    $this->assertInstanceOf(Order::class, $order);
+    return $order;
+  }
+
+  /**
+   * @return array<int, Ticket>
+   */
+  private function loadTicketsForOrder(int $order_id): array {
+    $storage = $this->container->get('entity_type.manager')->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_id', $order_id)
+      ->sort('id')
+      ->execute();
+    if (!$ids) {
+      return [];
+    }
+    return array_values($storage->loadMultiple($ids));
+  }
+
+  /**
+   * @return array<string, array{type: string, settings: array<string, mixed>}>
+   */
+  private function eventFieldDefinitions(): array {
+    return [
+      'field_event_start' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_event_end' => [
+        'type' => 'datetime',
+        'settings' => ['datetime_type' => 'datetime'],
+      ],
+      'field_venue_name' => [
+        'type' => 'string',
+        'settings' => ['max_length' => 255],
+      ],
+      'field_event_vendor' => [
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'user'],
+      ],
+    ];
+  }
+
+  private function createEventFields(): void {
+    foreach ($this->eventFieldDefinitions() as $field_name => $definition) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'type' => $definition['type'],
+        'settings' => $definition['settings'],
+      ])->save();
+
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'bundle' => 'event',
+        'label' => $field_name,
+      ])->save();
+    }
+  }
+
+  private function ensureProductEventField(): void {
+    if (FieldStorageConfig::loadByName('commerce_product', 'field_event')) {
+      return;
+    }
+    FieldStorageConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_event',
+      'entity_type' => 'commerce_product',
+      'bundle' => 'default',
+      'label' => 'Event',
+    ])->save();
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
@@ -19,6 +19,8 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker;
 use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\myeventlane_tickets\Service\InventoryReservationAuditProjector;
+use Drupal\myeventlane_tickets\Service\InventoryReservationProjectionBuilder;
 use Drupal\myeventlane_tickets\Service\OperationalEscalationAuditProjector;
 use Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector;
 use Drupal\myeventlane_tickets\Service\OperationalWorkspaceBuilder;
@@ -297,6 +299,20 @@ final class OperationalWorkspaceConvergenceKernelTest extends KernelTestBase {
       }
     }
     $this->assertContains(OperationalEscalationAuditProjector::class, $types);
+  }
+
+  public function testBuilderUsesReservationProjectors(): void {
+    $ref = new ReflectionClass(OperationalWorkspaceBuilder::class);
+    $params = $ref->getConstructor()?->getParameters() ?? [];
+    $types = [];
+    foreach ($params as $p) {
+      $t = $p->getType();
+      if ($t instanceof \ReflectionNamedType) {
+        $types[] = $t->getName();
+      }
+    }
+    $this->assertContains(InventoryReservationProjectionBuilder::class, $types);
+    $this->assertContains(InventoryReservationAuditProjector::class, $types);
   }
 
   public function testGovernanceSectionsIncludedForStaffWithEscalationPermission(): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new staff-only operational governance projection services and permissions, and changes Event Studio hero image editing to use crop/focal-point widgets; misconfiguration or edge cases could affect admin visibility and event image persistence.
> 
> **Overview**
> Adds an Event Studio **branding form mode** for `node:event` that edits `field_event_image` via `image_widget_crop` with a new fixed `event_hero` crop type plus focal-point support, and switches the full event view to render a new `mel_event_hero_featured` image style.
> 
> Updates Event Studio saving/autosave to normalize hero image payloads across legacy and crop-widget shapes, persist hero image/crop via widget extraction (`saveBrandingHero`), and handle broken/missing hero file references and Remove/AJAX validation quirks.
> 
> Extends the staff `/admin/mel/operations` workspace with new permission-gated, read-only sections and timelines for **inventory reservation governance** and **operational entitlement capability** projections, backed by new managers/builders/audit projectors and new `fulfillment_operational_signals` emitted by `OperationalIntegrityInspector` (with kernel tests covering normalization and secret stripping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa26d829aa02d065e18e66902d8a08b00aac262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->