### PR TITLE
Fix/bugbot operational composition parking utf8

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalMerchandiseManager.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalMerchandiseManager.php
@@ -376,8 +376,8 @@ final class OperationalMerchandiseManager {
 
   private function sanitizeLabel(string $label, int $max = 128): string {
     $label = trim($label);
-    if (strlen($label) > $max) {
-      return substr($label, 0, $max - 1) . '…';
+    if (mb_strlen($label, 'UTF-8') > $max) {
+      return mb_substr($label, 0, $max - 1, 'UTF-8') . '…';
     }
     return $label;
   }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalPurchaseCompositionManager.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalPurchaseCompositionManager.php
@@ -21,6 +21,14 @@ final class OperationalPurchaseCompositionManager {
 
   public const CONTRACT_FLAG = 'mel_operational_purchase_composition';
 
+  /**
+   * Capability reference written for Event Studio parking add-ons on Commerce products.
+   *
+   * Must match {@see \Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager::TYPE_PARKING_ADDON}
+   * and {@see \Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager::buildOperationalMetadata()}.
+   */
+  private const PARKING_ADDON_CAPABILITY_REFERENCE = 'parking_addon';
+
   public function __construct(
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
     private readonly OperationalMerchandiseGovernanceManager $operationalMerchandiseGovernanceManager,
@@ -63,10 +71,14 @@ final class OperationalPurchaseCompositionManager {
         'bundle_group' => $bundle,
         'presentation' => $presentation,
       ];
-      match ($bundle) {
-        'hospitality_package' => $groups['hospitality'][] = $line,
-        'timed_collection_product' => $groups['timed_collection'][] = $line,
-        'operational_bundle' => $groups['bundles'][] = $line,
+      $capability_reference = (string) ($payload['capability_reference'] ?? '');
+      $is_parking_addon_merch_bundle = $bundle === 'operational_merchandise'
+        && $capability_reference === self::PARKING_ADDON_CAPABILITY_REFERENCE;
+      match (TRUE) {
+        $bundle === 'hospitality_package' => $groups['hospitality'][] = $line,
+        $bundle === 'timed_collection_product' => $groups['timed_collection'][] = $line,
+        $bundle === 'operational_bundle' => $groups['bundles'][] = $line,
+        $is_parking_addon_merch_bundle => $groups['parking'][] = $line,
         default => $groups['merchandise'][] = $line,
       };
     }

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -235,6 +235,72 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $this->assertSame('Collect at north counter', $pres['operational_summary']);
   }
 
+  public function testComposeForOrderGroupsParkingAddonByCapabilityReference(): void {
+    $customer = User::create([
+      'name' => 'merch_kernel_parking_buyer',
+      'mail' => 'merch-kernel-parking@example.test',
+      'status' => 1,
+    ]);
+    $customer->save();
+
+    $parkingProduct = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'PARK-ORDER');
+    $parkingProduct->set('field_mel_operational_product', json_encode([
+      'operational_product_type' => 'merch_pickup',
+      'capability_reference' => 'parking_addon',
+      'operational_summary' => 'Lot B after 5pm',
+      'operational_chips' => [],
+    ], JSON_THROW_ON_ERROR));
+    $parkingProduct->save();
+
+    $plainMerch = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'MERCH-WITH-PARK');
+    $plainMerch->set('field_mel_operational_product', json_encode([
+      'operational_product_type' => 'merch_pickup',
+      'capability_reference' => 'merchandise',
+      'operational_summary' => 'Counter pickup',
+      'operational_chips' => [],
+    ], JSON_THROW_ON_ERROR));
+    $plainMerch->save();
+
+    $parkingVariation = $parkingProduct->getVariations()[0];
+    $merchVariation = $plainMerch->getVariations()[0];
+
+    $order = Order::create([
+      'type' => 'default',
+      'store_id' => $this->store->id(),
+      'state' => 'draft',
+      'uid' => $customer->id(),
+      'mail' => 'merch-kernel-parking@example.test',
+    ]);
+    $order->save();
+
+    $itemParking = OrderItem::create([
+      'type' => 'default',
+      'order_id' => $order->id(),
+      'purchased_entity' => $parkingVariation,
+      'quantity' => 1,
+      'unit_price' => new Price('5.00', 'AUD'),
+    ]);
+    $itemParking->save();
+
+    $itemMerch = OrderItem::create([
+      'type' => 'default',
+      'order_id' => $order->id(),
+      'purchased_entity' => $merchVariation,
+      'quantity' => 2,
+      'unit_price' => new Price('10.00', 'AUD'),
+    ]);
+    $itemMerch->save();
+
+    $order->addItem($itemParking);
+    $order->addItem($itemMerch);
+    $order->save();
+
+    $doc = $this->compositionManager()->composeForOrder($order);
+    $this->assertCount(1, $doc['groups']['parking']);
+    $this->assertCount(1, $doc['groups']['merchandise']);
+    $this->assertSame('Lot B after 5pm', $doc['groups']['parking'][0]['presentation']['operational_summary']);
+  }
+
   public function testComposePreviewFromEventReadsOperationalMerchandiseJson(): void {
     $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'MERCH-PREVIEW');
     $product->save();

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalMerchandiseManagerTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalMerchandiseManagerTest.php
@@ -61,6 +61,27 @@ final class OperationalMerchandiseManagerTest extends UnitTestCase {
     $this->assertSame('After check-in', $safe['operational_chips'][0]['label']);
   }
 
+  public function testBuildCustomerSafeProductPresentationTruncatesUnicodeWithoutInvalidUtf8(): void {
+    // U+0100 (Ā) is two UTF-8 bytes; byte-oriented truncation used to split code units.
+    $long_label = str_repeat("\u{0100}", 150);
+    $raw = [
+      'operational_product_type' => 'merch_pickup',
+      'operational_summary' => 'Short',
+      'operational_chips' => [
+        ['label' => $long_label, 'tone' => 'info'],
+      ],
+      'customer_visibility' => 'visible',
+      'pickup_mode' => 'counter',
+      'readiness_mode' => 'authoring',
+    ];
+    $safe = $this->manager()->buildCustomerSafeProductPresentation($raw);
+    $this->assertCount(1, $safe['operational_chips']);
+    $truncated = $safe['operational_chips'][0]['label'];
+    $this->assertLessThanOrEqual(128, mb_strlen($truncated, 'UTF-8'));
+    $this->assertTrue(mb_check_encoding($truncated, 'UTF-8'));
+    $this->assertStringEndsWith('…', $truncated);
+  }
+
   public function testStripForbiddenRecursiveRemovesNestedForbidden(): void {
     $data = [
       'outer' => [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -510,8 +510,8 @@ final class VendorOperationalProductCreationManager {
 
   private function sanitizePlainText(string $text, int $max): string {
     $text = trim(strip_tags($text));
-    if (strlen($text) > $max) {
-      return substr($text, 0, $max - 1) . '…';
+    if (mb_strlen($text, 'UTF-8') > $max) {
+      return mb_substr($text, 0, $max - 1, 'UTF-8') . '…';
     }
     return $text;
   }


### PR DESCRIPTION
fix(commerce): route parking add-ons to composition parking group on orders
fix: truncate operational labels using multibyte-safe string functions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how order lines are grouped into `parking` vs `merchandise`, which can affect customer-facing operational messaging; the UTF-8 truncation change is low risk but touches shared sanitization helpers.
> 
> **Overview**
> Fixes operational purchase composition so *parking add-ons* (Commerce `operational_merchandise` products with `capability_reference=parking_addon`) are routed into the `parking` group instead of falling through to `merchandise`, and adds kernel coverage for that behavior.
> 
> Updates label/text truncation in both Commerce and Event Studio helpers to use multibyte-safe `mb_*` functions, and adds a unit test to ensure truncated chip labels remain valid UTF-8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6877bd5e6c8574d25d747d7499833f2958ecbedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->