### PR TITLE
Feature/vendor product creation wizard

### DIFF
--- a/config/sync/commerce_product.commerce_product_type.hospitality_package.yml
+++ b/config/sync/commerce_product.commerce_product_type.hospitality_package.yml
@@ -1,0 +1,13 @@
+uuid: d6af694b-bc3f-47a6-aa55-9e51aac52492
+langcode: en
+status: true
+dependencies: {  }
+id: hospitality_package
+label: 'Hospitality package'
+traits: {  }
+locked: false
+description: 'Hospitality access products with operational messaging only.'
+variationTypes:
+  - hospitality_package_var
+multipleVariations: true
+injectVariationFields: true

--- a/config/sync/commerce_product.commerce_product_type.operational_bundle.yml
+++ b/config/sync/commerce_product.commerce_product_type.operational_bundle.yml
@@ -1,0 +1,13 @@
+uuid: 3de11c2c-4c40-4124-aaf2-ab4ca6112826
+langcode: en
+status: true
+dependencies: {  }
+id: operational_bundle
+label: 'Operational bundle'
+traits: {  }
+locked: false
+description: 'Grouped operational commerce packages (VIP + drink, ticket + merch, etc.).'
+variationTypes:
+  - operational_bundle_var
+multipleVariations: true
+injectVariationFields: true

--- a/config/sync/commerce_product.commerce_product_type.operational_merchandise.yml
+++ b/config/sync/commerce_product.commerce_product_type.operational_merchandise.yml
@@ -1,0 +1,13 @@
+uuid: d04d00ec-f0fe-468a-9c7e-a1841f8f7dce
+langcode: en
+status: true
+dependencies: {  }
+id: operational_merchandise
+label: 'Operational merchandise'
+traits: {  }
+locked: false
+description: 'MEL operational merchandise products (pickup semantics; Commerce remains authoritative for catalog and pricing).'
+variationTypes:
+  - operational_merchandise_var
+multipleVariations: true
+injectVariationFields: true

--- a/config/sync/commerce_product.commerce_product_type.timed_collection_product.yml
+++ b/config/sync/commerce_product.commerce_product_type.timed_collection_product.yml
@@ -1,0 +1,13 @@
+uuid: c69b955b-e55e-42d8-8649-319b7de774c4
+langcode: en
+status: true
+dependencies: {  }
+id: timed_collection_product
+label: 'Timed collection product'
+traits: {  }
+locked: false
+description: 'Timed collection window products (operational guidance only).'
+variationTypes:
+  - timed_collection_var
+multipleVariations: true
+injectVariationFields: true

--- a/config/sync/commerce_product.commerce_product_variation_type.hospitality_package_var.yml
+++ b/config/sync/commerce_product.commerce_product_variation_type.hospitality_package_var.yml
@@ -1,0 +1,10 @@
+uuid: a01610a6-b721-4591-93eb-3decba86c90c
+langcode: en
+status: true
+dependencies: {  }
+id: hospitality_package_var
+label: 'Hospitality package variation'
+traits: {  }
+locked: false
+orderItemType: default
+generateTitle: true

--- a/config/sync/commerce_product.commerce_product_variation_type.operational_bundle_var.yml
+++ b/config/sync/commerce_product.commerce_product_variation_type.operational_bundle_var.yml
@@ -1,0 +1,10 @@
+uuid: 7a3671d8-e367-4c54-8ebb-6ae750505d67
+langcode: en
+status: true
+dependencies: {  }
+id: operational_bundle_var
+label: 'Operational bundle variation'
+traits: {  }
+locked: false
+orderItemType: default
+generateTitle: true

--- a/config/sync/commerce_product.commerce_product_variation_type.operational_merchandise_var.yml
+++ b/config/sync/commerce_product.commerce_product_variation_type.operational_merchandise_var.yml
@@ -1,0 +1,10 @@
+uuid: 123c6c09-078e-40cc-ba5f-44588cb00ab3
+langcode: en
+status: true
+dependencies: {  }
+id: operational_merchandise_var
+label: 'Operational merchandise variation'
+traits: {  }
+locked: false
+orderItemType: default
+generateTitle: true

--- a/config/sync/commerce_product.commerce_product_variation_type.timed_collection_var.yml
+++ b/config/sync/commerce_product.commerce_product_variation_type.timed_collection_var.yml
@@ -1,0 +1,10 @@
+uuid: fab3f316-618c-4eea-a43d-95a342d37d1a
+langcode: en
+status: true
+dependencies: {  }
+id: timed_collection_var
+label: 'Timed collection variation'
+traits: {  }
+locked: false
+orderItemType: default
+generateTitle: true

--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -71,16 +71,16 @@ content:
     weight: 0
     region: content
     settings:
-      show_crop_area: true
-      show_default_crop: true
-      warn_multiple_usages: false
-      crop_types_required:
-        - event_hero
+      progress_indicator: throbber
       preview_image_style: thumbnail
       crop_preview_image_style: crop_thumbnail
       crop_list:
         - event_hero
-      progress_indicator: throbber
+      crop_types_required:
+        - event_hero
+      warn_multiple_usages: false
+      show_crop_area: true
+      show_default_crop: true
     third_party_settings: {  }
 hidden:
   body: true
@@ -121,6 +121,7 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_op_capabilities: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true

--- a/config/sync/field.field.commerce_product.hospitality_package.field_event.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_event.yml
@@ -1,0 +1,21 @@
+uuid: 7a1e7809-e471-406e-b476-96a4f05ee736
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.storage.commerce_product.field_event
+id: commerce_product.hospitality_package.field_event
+field_name: field_event
+entity_type: commerce_product
+bundle: hospitality_package
+label: Event
+description: 'Link this operational product to an event for vendor authoring and customer projections.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_operational_product.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_operational_product.yml
@@ -1,0 +1,19 @@
+uuid: 53530d46-c65e-4ab0-98cb-125a17511b26
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.storage.commerce_product.field_mel_operational_product
+id: commerce_product.hospitality_package.field_mel_operational_product
+field_name: field_mel_operational_product
+entity_type: commerce_product
+bundle: hospitality_package
+label: 'MEL operational product'
+description: 'JSON document keyed mel_operational_product (authoring + projections).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_bundle.field_event.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_event.yml
@@ -1,0 +1,21 @@
+uuid: ae29fab4-e4a9-4fc2-9fbd-975bde826281
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.storage.commerce_product.field_event
+id: commerce_product.operational_bundle.field_event
+field_name: field_event
+entity_type: commerce_product
+bundle: operational_bundle
+label: Event
+description: 'Link this operational product to an event for vendor authoring and customer projections.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_operational_product.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_operational_product.yml
@@ -1,0 +1,19 @@
+uuid: 56820744-0c0d-4fef-846e-1f10471cb272
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.storage.commerce_product.field_mel_operational_product
+id: commerce_product.operational_bundle.field_mel_operational_product
+field_name: field_mel_operational_product
+entity_type: commerce_product
+bundle: operational_bundle
+label: 'MEL operational product'
+description: 'JSON document keyed mel_operational_product (authoring + projections).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_event.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_event.yml
@@ -1,0 +1,21 @@
+uuid: 1d59731f-65ca-4721-b733-fef07de683ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.storage.commerce_product.field_event
+id: commerce_product.operational_merchandise.field_event
+field_name: field_event
+entity_type: commerce_product
+bundle: operational_merchandise
+label: Event
+description: 'Link this operational product to an event for vendor authoring and customer projections.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_operational_product.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_operational_product.yml
@@ -1,0 +1,19 @@
+uuid: 5d360ef6-e9dd-4c62-a079-2dc437e58361
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.storage.commerce_product.field_mel_operational_product
+id: commerce_product.operational_merchandise.field_mel_operational_product
+field_name: field_mel_operational_product
+entity_type: commerce_product
+bundle: operational_merchandise
+label: 'MEL operational product'
+description: 'JSON document keyed mel_operational_product (authoring + projections).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_event.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_event.yml
@@ -1,0 +1,21 @@
+uuid: f1f04c2a-d14a-4962-8cd7-e28d0044fc1a
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.storage.commerce_product.field_event
+id: commerce_product.timed_collection_product.field_event
+field_name: field_event
+entity_type: commerce_product
+bundle: timed_collection_product
+label: Event
+description: 'Link this operational product to an event for vendor authoring and customer projections.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_operational_product.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_operational_product.yml
@@ -1,0 +1,19 @@
+uuid: af751008-23bc-46a5-bc2a-66404492e7c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.storage.commerce_product.field_mel_operational_product
+id: commerce_product.timed_collection_product.field_mel_operational_product
+field_name: field_mel_operational_product
+entity_type: commerce_product
+bundle: timed_collection_product
+label: 'MEL operational product'
+description: 'JSON document keyed mel_operational_product (authoring + projections).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.commerce_product.field_mel_operational_product.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_operational_product.yml
@@ -1,0 +1,19 @@
+uuid: eca1fa64-dded-4166-8a22-a5769385bf68
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product.field_mel_operational_product
+field_name: field_mel_operational_product
+entity_type: commerce_product
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docs/customer-operational-commerce-experience.md
+++ b/docs/customer-operational-commerce-experience.md
@@ -39,7 +39,7 @@ The builder delegates inward to:
 
 It does **not** re-map capabilities or duplicate registry logic beyond assembling labels and chips.
 
-Phase 4D adds **`OperationalPurchaseCompositionManager`** output (`mel_operational_purchase_composition`) as a **sibling** themed strip for operational **Commerce product** grouping (merch, hospitality, timed collection, bundles). It stays Commerce-backed and read-only; see [operational-merchandise-architecture.md](./operational-merchandise-architecture.md).
+Phase 4D adds **`OperationalPurchaseCompositionManager`** output (`mel_operational_purchase_composition`) as a **sibling** themed strip for operational **Commerce product** grouping (merch, hospitality, timed collection, bundles). It stays Commerce-backed and read-only; see [operational-merchandise-architecture.md](./operational-merchandise-architecture.md). Vendor-authored products created through the [Vendor Product Creation Wizard](vendor-product-creation-wizard.md) flow into the same customer-safe projections once linked on the event.
 
 The same phase adds **`OperationalCheckoutOrchestrationManager`** (`mel_operational_checkout`) as another **sibling** strip that only **re-groups** composition output for cart/checkout/order/event UX; see [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md).
 

--- a/docs/operational-cart-checkout-orchestration.md
+++ b/docs/operational-cart-checkout-orchestration.md
@@ -6,7 +6,7 @@ This document describes the **presentation-only** layer that groups operational 
 
 - **Commerce checkout / order / cart** own all mutation and state transitions.
 - **Operational purchase composition** (`OperationalPurchaseCompositionManager`) remains the single source for how order lines are classified into operational product groups.
-- **Operational checkout orchestration** (`OperationalCheckoutOrchestrationManager`) only **reshapes** composition output into the `mel_operational_checkout` customer contract: grouped sections, readiness rollup, pickup slices, continuity rows, governance labels, deterministic guidance, and a mobile projection slice. It never writes to orders, line items, checkout panes, inventory, shipments, entitlements, scanners, or QR payloads.
+- **Operational checkout orchestration** (`OperationalCheckoutOrchestrationManager`) only **reshapes** composition output into the `mel_operational_checkout` customer contract: grouped sections, readiness rollup, pickup slices, continuity rows, governance labels, deterministic guidance, and a mobile projection slice. It never writes to orders, line items, checkout panes, inventory, shipments, entitlements, scanners, or QR payloads. Event Studio’s [Vendor Product Creation Wizard](vendor-product-creation-wizard.md) does not touch carts or checkout; it only creates catalog rows on explicit vendor save.
 
 ## Customer contract (`mel_operational_checkout`)
 

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -31,7 +31,7 @@ Top-level contract flag: `mel_operational_product: true`.
 
 ## Event Studio: `operational_merchandise` authoring
 
-Persisted under `field_mel_op_capabilities` as part of the operational capabilities document. Vendors link **operational** products to an event (`linked_products`), assign **roles** (`merch_pickup`, `operational_bundle`, `hospitality`, `timed_collection`, `parking`), and optional **bundle_group** labels for composition. `OperationalMerchandiseManager::normalizeEventMerchandiseAuthoring()` validates product IDs, enforces operational bundles, requires `field_event` alignment to the event, and merges normalized `product_payload` from the product field.
+Persisted under `field_mel_op_capabilities` as part of the operational capabilities document. Vendors link **operational** products to an event (`linked_products`), assign **roles** (`merch_pickup`, `operational_bundle`, `hospitality`, `timed_collection`, `parking`), and optional **bundle_group** labels for composition. `OperationalMerchandiseManager::normalizeEventMerchandiseAuthoring()` validates product IDs, enforces operational bundles, requires `field_event` alignment to the event, and merges normalized `product_payload` from the product field. Vendors may also **create** new operational products from Event Studio on explicit save via the [Vendor Product Creation Wizard](vendor-product-creation-wizard.md) (Commerce entities only through `VendorOperationalProductCreationManager`).
 
 ## Purchase composition
 

--- a/docs/vendor-product-creation-wizard.md
+++ b/docs/vendor-product-creation-wizard.md
@@ -1,0 +1,69 @@
+# Vendor Product Creation Wizard
+
+## Purpose
+
+The **Vendor Product Creation Wizard** is an Event Studio authoring path that lets vendors **create and link** operational Commerce products (products + variations) from the productisation workflow. It runs **only on explicit Save** of the productisation form — never during autosave.
+
+## Authority
+
+- **Commerce** remains the system of record for catalog entities, carts, checkout, and orders.
+- **Creation** is delegated to `myeventlane_event_studio.vendor_operational_product_creation_manager` (`VendorOperationalProductCreationManager`), which uses `commerce_product` and `commerce_product_variation` APIs only (no parallel catalog).
+- **Event node** still stores authoring in `field_mel_op_capabilities` → `operational_merchandise.productisation_items` and derived `linked_products` after normalization.
+
+## Vendor store boundary
+
+- Target store is resolved by `OperationalCapabilityCommerceLinkManager::resolveStoreIdForOperationalProductCreation()` (vendor store first, then `field_event_store` on the event when no vendor store applies).
+- Non-admin accounts may not create when the resolved store does not match `resolveVendorStoreIdForEvent()` when a vendor store is present (prevents cross-vendor store assignment).
+- Currency for vendors must match the store default currency unless the account may administer nodes.
+
+## Supported productisation types
+
+Wizard rows map to existing operational Commerce bundles (see `OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES` and `myeventlane_commerce_update_10004`):
+
+| Productisation type | Commerce product bundle | Variation bundle |
+|---------------------|-------------------------|------------------|
+| `merchandise` | `operational_merchandise` | `operational_merchandise_var` |
+| `hospitality_package` | `hospitality_package` | `hospitality_package_var` |
+| `timed_collection` | `timed_collection_product` | `timed_collection_var` |
+| `parking_addon` | `operational_merchandise` | `operational_merchandise_var` |
+| `operational_bundle` | `operational_bundle` | `operational_bundle_var` |
+
+## `field_mel_operational_product` contract
+
+- Only **whitelisted** operational metadata is written, after `OperationalMerchandiseManager::normalizeProductFieldValue()`.
+- Customer title and summary are **plain text** (HTML stripped, length capped).
+- Price is validated as a non-negative decimal and stored on the **variation** via Commerce `Price`.
+
+## Payload contract (creation)
+
+Required keys (after forbidden-key stripping): `productisation_type`, `event_id` (must match the event being edited), `title`, `customer_summary`, `price_amount`, `currency_code`, `customer_visibility`, `fulfillment_mode`, `reservation_mode`.
+
+Optional: `sku`, `pickup_mode`, `timed_collection_window_copy`, `hospitality_benefits_summary`, `parking_guidance`, `bundle_capability_types`, `existing_product_id` (idempotency when a product was already created for this row).
+
+Forbidden keys are stripped recursively (see `VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS`), including inventory, warehouse, shipment, scanner, QR, entitlement, and ticket identifiers.
+
+## Autosave boundary
+
+- `EventStudioAutosaveController` continues to persist **tempstore drafts only** for the `merchandise` section.
+- Draft JSON may include wizard field values; **no** Commerce `save()` runs on autosave.
+- Product and variation creation runs only from `EventStudioProductisationForm::submitForm()` after validation.
+
+## Explicit non-goals
+
+- No stock decrement or inventory execution.
+- No warehouse planning or shipping orchestration.
+- No scanner mutation, QR payload authoring, or entitlement issuance.
+- No cart, checkout, or order mutation from this wizard.
+
+## Tests
+
+- **Kernel:** `Drupal\Tests\myeventlane_commerce\Kernel\OperationalMerchandiseKernelTest` — methods named `testVendorProductCreationWizard…` (Commerce kernel fixtures + `field_event_store` on the test event for store resolution when `myeventlane_vendor` is not in the kernel module list). `OperationalCapabilityCommerceLinkManager::resolveActingVendorStoreId()` uses `EntityTypeManagerInterface::hasDefinition('myeventlane_vendor')` before touching vendor storage so lightweight kernels do not fatal. Run e.g.  
+  `export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php --filter VendorProductCreationWizard`
+- **Unit:** `Drupal\Tests\myeventlane_event_studio\Unit\VendorOperationalProductCreationManagerTest` — forbidden-key contract checks.
+
+## Related docs
+
+- [Vendor Productisation Studio](vendor-productisation-studio.md)
+- [Operational merchandise architecture](operational-merchandise-architecture.md)
+- [Operational cart & checkout orchestration](operational-cart-checkout-orchestration.md)
+- [Customer operational Commerce experience](customer-operational-commerce-experience.md)

--- a/docs/vendor-productisation-studio.md
+++ b/docs/vendor-productisation-studio.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The Vendor Productisation Studio is the Event Studio surface where vendors **author** operational Commerce offers for an event: merchandise, hospitality packages, timed collection, parking add-ons, and operational bundles. It is **authoring and linkage only**.
+The Vendor Productisation Studio is the Event Studio surface where vendors **author** operational Commerce offers for an event: merchandise, hospitality packages, timed collection, parking add-ons, and operational bundles. It is **authoring and linkage** (plus **validated catalog create** on explicit save via the wizard).
 
 ## Authority
 
@@ -25,16 +25,17 @@ The Vendor Productisation Studio is the Event Studio surface where vendors **aut
 
 - `myeventlane_event_studio.vendor_productisation_studio_manager` — payload normalization, forbidden-key stripping, linkage validation delegation, merge of derived `linked_products` before `OperationalMerchandiseManager::normalizeEventMerchandiseAuthoring()`.
 - `myeventlane_event_studio.vendor_productisation_studio_builder` — render arrays, cards, CTAs, validation summary, customer preview strip (includes the same customer-safe capability projection as storefront via `CustomerOperationalCommerceExperienceBuilder`).
+- `myeventlane_event_studio.vendor_operational_product_creation_manager` — validated operational Commerce product + variation creation on **explicit productisation save** (see [Vendor Product Creation Wizard](vendor-product-creation-wizard.md)).
 
 ## Commerce linkage boundary
 
-- Vendors may only **select existing** Commerce products that belong to the event (`field_event`) and use **operational** product bundles (`OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES`).
-- `OperationalCapabilityCommerceLinkManager` validates product/store/variation relationships **read-only** (loads entities to verify, does not mutate catalog).
+- Vendors may **select existing** Commerce products that belong to the event (`field_event`) and use **operational** product bundles (`OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES`), or **create** new operational products via the wizard on explicit save (see [Vendor Product Creation Wizard](vendor-product-creation-wizard.md)).
+- `OperationalCapabilityCommerceLinkManager` validates product/store/variation relationships **read-only** for linkage checks (creation uses the same resolver for store context; catalog writes happen only in `VendorOperationalProductCreationManager`).
 
 ## Save boundary
 
 - Saves flow through `OperationalCapabilityStudioManager::persistToEvent()` → event field JSON only.
-- **No** Commerce `->save()` on products or variations from productisation services.
+- **No** ad-hoc Commerce `->save()` on products or variations from productisation **services**; the dedicated creation manager performs **only** the validated create path on explicit form submit.
 - **No** checkout, cart, order, entitlement, or scanner mutation.
 
 ## Autosave boundary
@@ -53,7 +54,6 @@ Authoring payloads must never carry execution tokens or inventory/shipment seman
 
 ## Future phases (out of scope here)
 
-- Product creation wizard inside Event Studio.
 - Inventory execution and stock decrement.
 - Shipping orchestration and warehouse planning.
 - Staff fulfilment tooling and scanner policy editing (remains in operational tooling, not vendor authoring).

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -21,6 +21,14 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager;
+use Drupal\myeventlane_event_studio\Service\OperationalCapabilityCommerceLinkManager;
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
+use Drupal\myeventlane_tickets\Service\EntitlementCapabilityRegistry;
+use Drupal\myeventlane_tickets\Service\FulfillmentLifecycleManager;
+use Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager;
+use Drupal\myeventlane_tickets\Service\OperationalEntitlementCapabilityManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\User;
@@ -138,6 +146,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
       'status' => 1,
     ]);
     $this->event->save();
+    $this->ensureKernelEventStoreReferenceForWizard();
   }
 
   public function testNormalizeEventMerchandiseAuthoringLinksOperationalProduct(): void {
@@ -375,6 +384,266 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $reloaded = Product::load($product->id());
     $this->assertInstanceOf(Product::class, $reloaded);
     return $reloaded;
+  }
+
+  /**
+   * Lets Event Studio store resolution fall back to field_event_store in kernel tests.
+   */
+  protected function ensureKernelEventStoreReferenceForWizard(): void {
+    if (!FieldStorageConfig::loadByName('node', 'field_event_store')) {
+      FieldStorageConfig::create([
+        'field_name' => 'field_event_store',
+        'entity_type' => 'node',
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'commerce_store'],
+        'cardinality' => 1,
+      ])->save();
+    }
+    if (!FieldConfig::loadByName('node', 'event', 'field_event_store')) {
+      FieldConfig::create([
+        'field_name' => 'field_event_store',
+        'entity_type' => 'node',
+        'bundle' => 'event',
+        'label' => 'Event store',
+      ])->save();
+    }
+    $this->container->get('entity_field.manager')->clearCachedFieldDefinitions();
+    $reloaded = Node::load($this->event->id());
+    $this->assertInstanceOf(Node::class, $reloaded);
+    $this->event = $reloaded;
+    $this->event->set('field_event_store', ['target_id' => $this->store->id()]);
+    $this->event->save();
+  }
+
+  public function testVendorProductCreationWizardStripForbiddenFromPayloadRecursively(): void {
+    $manager = $this->commerceWizardCreationManager();
+    $out = $manager->stripForbiddenFromPayload([
+      'title' => 'OK',
+      'nested' => [
+        'inventory_quantity' => 99,
+        'child' => ['qr_payload' => 'x'],
+      ],
+    ]);
+    $this->assertSame('OK', $out['title']);
+    $this->assertArrayNotHasKey('inventory_quantity', $out['nested']);
+    $this->assertArrayNotHasKey('qr_payload', $out['nested']['child']);
+  }
+
+  public function testVendorProductCreationWizardCreatesMerchandiseWithStoreAndPrice(): void {
+    $owner = User::load($this->event->getOwnerId());
+    $this->assertNotNull($owner);
+    $this->container->get('current_user')->setAccount($owner);
+
+    $manager = $this->commerceWizardCreationManager();
+    $payload = [
+      'productisation_type' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      'event_id' => (int) $this->event->id(),
+      'title' => 'Kernel wizard tee',
+      'customer_summary' => 'Pick up at desk',
+      'price_amount' => '12.50',
+      'currency_code' => 'AUD',
+      'customer_visibility' => 'visible',
+      'fulfillment_mode' => 'counter',
+      'reservation_mode' => 'operational_projection',
+      'pickup_mode' => 'counter',
+    ];
+    $created = $manager->createOperationalProductForEvent($owner, $this->event, $payload);
+    $this->assertGreaterThan(0, $created['product_id']);
+    $this->assertSame((int) $this->store->id(), $created['store_id']);
+    $this->assertNotEmpty($created['variation_ids']);
+
+    $product = Product::load($created['product_id']);
+    $this->assertNotNull($product);
+    $this->assertTrue($this->wizardProductHasStore($product, (int) $this->store->id()));
+    $vars = $product->getVariations();
+    $this->assertNotEmpty($vars);
+    $this->assertSame('12.50', number_format((float) $vars[0]->getPrice()->getNumber(), 2, '.', ''));
+  }
+
+  public function testVendorProductCreationWizardCreatesHospitalityPackage(): void {
+    $owner = User::load($this->event->getOwnerId());
+    $this->assertNotNull($owner);
+    $this->container->get('current_user')->setAccount($owner);
+
+    $manager = $this->commerceWizardCreationManager();
+    $payload = [
+      'productisation_type' => VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+      'event_id' => (int) $this->event->id(),
+      'title' => 'VIP lounge',
+      'customer_summary' => 'Includes drinks',
+      'price_amount' => '200.00',
+      'currency_code' => 'AUD',
+      'customer_visibility' => 'visible',
+      'fulfillment_mode' => 'redeem',
+      'reservation_mode' => 'operational_projection',
+      'hospitality_benefits_summary' => 'Premium seating',
+    ];
+    $created = $manager->createOperationalProductForEvent($owner, $this->event, $payload);
+    $product = Product::load($created['product_id']);
+    $this->assertNotNull($product);
+    $this->assertSame('hospitality_package', $product->bundle());
+  }
+
+  public function testVendorProductCreationWizardIdempotentExistingProductId(): void {
+    $owner = User::load($this->event->getOwnerId());
+    $this->assertNotNull($owner);
+    $this->container->get('current_user')->setAccount($owner);
+
+    $manager = $this->commerceWizardCreationManager();
+    $payload = [
+      'productisation_type' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      'event_id' => (int) $this->event->id(),
+      'title' => 'Idempotent cap',
+      'customer_summary' => 'One run',
+      'price_amount' => '5.00',
+      'currency_code' => 'AUD',
+      'customer_visibility' => 'visible',
+      'fulfillment_mode' => 'counter',
+      'reservation_mode' => 'operational_projection',
+    ];
+    $first = $manager->createOperationalProductForEvent($owner, $this->event, $payload);
+    $before = $this->commerceProductCountForWizard();
+
+    $second = $manager->createOperationalProductForEvent($owner, $this->event, $payload + [
+      'existing_product_id' => $first['product_id'],
+    ]);
+    $this->assertSame($first['product_id'], $second['product_id']);
+    $this->assertSame($before, $this->commerceProductCountForWizard());
+  }
+
+  public function testVendorProductCreationWizardAnonymousDenied(): void {
+    $this->container->get('current_user')->setAccount(User::getAnonymousUser());
+    $manager = $this->commerceWizardCreationManager();
+    $errors = $manager->validateCreationPayload(User::getAnonymousUser(), $this->event, [
+      'productisation_type' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      'event_id' => (int) $this->event->id(),
+      'title' => 'X',
+      'customer_summary' => 'Y',
+      'price_amount' => '1.00',
+      'currency_code' => 'AUD',
+    ]);
+    $this->assertNotSame([], $errors);
+  }
+
+  public function testVendorProductCreationWizardFailsClosedWithoutResolvableStore(): void {
+    $owner = User::load($this->event->getOwnerId());
+    $this->assertNotNull($owner);
+    $this->container->get('current_user')->setAccount($owner);
+
+    $bare = Node::create([
+      'type' => 'event',
+      'title' => 'Kernel event without store linkage',
+      'uid' => $owner->id(),
+      'status' => 1,
+    ]);
+    $bare->save();
+
+    $manager = $this->commerceWizardCreationManager();
+    $payload = [
+      'productisation_type' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      'event_id' => (int) $bare->id(),
+      'title' => 'Should not create',
+      'customer_summary' => 'No resolvable Commerce store',
+      'price_amount' => '1.00',
+      'currency_code' => 'AUD',
+      'customer_visibility' => 'visible',
+      'fulfillment_mode' => 'counter',
+      'reservation_mode' => 'operational_projection',
+    ];
+    $this->expectException(\InvalidArgumentException::class);
+    $manager->createOperationalProductForEvent($owner, $bare, $payload);
+  }
+
+  public function testVendorProductCreationWizardApplyMergesCommerceIntoItems(): void {
+    $owner = User::load($this->event->getOwnerId());
+    $this->assertNotNull($owner);
+    $this->container->get('current_user')->setAccount($owner);
+
+    $manager = $this->commerceWizardCreationManager();
+    $studio = new VendorProductisationStudioManager(
+      new OperationalMerchandiseManager(
+        $this->container->get('entity_type.manager'),
+        $this->container->get('string_translation'),
+        $this->container->get('logger.factory')->get('test'),
+      ),
+      $this->commerceWizardLinkManager(),
+    );
+    $items = [];
+    foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $t) {
+      $items[] = $studio->emptyItem($t);
+    }
+    $rows = [];
+    foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $t) {
+      $rows[$t] = ['commerce_mode' => 'link'];
+    }
+    $rows[VendorProductisationStudioManager::TYPE_MERCHANDISE] = [
+      'commerce_mode' => 'create',
+      'wizard_create' => [],
+      'title' => 'Walk-up hat',
+      'customer_summary' => 'Branded',
+      'customer_visibility' => 'visible',
+      'pickup_mode' => 'counter',
+      'commerce_create_price' => '9.99',
+      'commerce_create_currency' => 'AUD',
+    ];
+    $out = $manager->applyProductisationWizardCreates($owner, $this->event, $items, $rows);
+    $idx = array_search(VendorProductisationStudioManager::TYPE_MERCHANDISE, VendorProductisationStudioManager::PRODUCTISATION_TYPES, TRUE);
+    $this->assertIsInt($idx);
+    $this->assertGreaterThan(0, $out[$idx]['commerce']['product_id']);
+  }
+
+  private function commerceWizardCreationManager(): VendorOperationalProductCreationManager {
+    $etm = $this->container->get('entity_type.manager');
+    $merch = new OperationalMerchandiseManager(
+      $etm,
+      $this->container->get('string_translation'),
+      $this->container->get('logger.factory')->get('test'),
+    );
+    return new VendorOperationalProductCreationManager(
+      $etm,
+      $merch,
+      $this->commerceWizardLinkManager(),
+      new EventVendorAccessChecker(),
+      $this->container->get('string_translation'),
+      $this->container->get('logger.factory')->get('test'),
+    );
+  }
+
+  private function commerceWizardLinkManager(): OperationalCapabilityCommerceLinkManager {
+    $registry = new EntitlementCapabilityRegistry();
+    $logger = $this->container->get('logger.factory')->get('commerce_wizard_kernel');
+    $reservation = new InventoryReservationGovernanceManager($registry, $logger);
+    $oecm = new OperationalEntitlementCapabilityManager($registry, $reservation, $logger);
+    $fulfillment = new FulfillmentLifecycleManager($registry);
+    return new OperationalCapabilityCommerceLinkManager(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('current_user'),
+      $registry,
+      $oecm,
+      $fulfillment,
+      $reservation,
+    );
+  }
+
+  private function commerceProductCountForWizard(): int {
+    $ids = $this->container->get('entity_type.manager')
+      ->getStorage('commerce_product')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->execute();
+    return count($ids ?: []);
+  }
+
+  private function wizardProductHasStore(object $product, int $store_id): bool {
+    if (!$product->hasField('stores') || $product->get('stores')->isEmpty()) {
+      return FALSE;
+    }
+    foreach ($product->get('stores')->getValue() as $item) {
+      if ((int) ($item['target_id'] ?? 0) === $store_id) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-vendor-productisation-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-vendor-productisation-studio.css
@@ -148,3 +148,39 @@
   margin: 1rem 0 0.25rem;
   font-weight: 600;
 }
+
+.mel-productisation-wizard-mode .form-radios {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 40rem) {
+  .mel-productisation-wizard-mode .form-radios {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+}
+
+.mel-productisation-wizard-create {
+  margin-top: 0.75rem;
+  padding: 1rem 1.1rem;
+}
+
+.mel-productisation-wizard-warning {
+  margin: 0 0 0.75rem;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.mel-productisation-wizard-chips,
+.mel-productisation-wizard-preview-hint {
+  margin: 0.35rem 0;
+  font-size: 0.88rem;
+  color: #475569;
+}
+
+.mel-productisation-wizard-link {
+  margin-top: 0.5rem;
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -212,6 +212,16 @@ services:
       - '@myeventlane_commerce.operational_merchandise_manager'
       - '@myeventlane_event_studio.operational_capability_commerce_link_manager'
 
+  myeventlane_event_studio.vendor_operational_product_creation_manager:
+    class: Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@myeventlane_event_studio.operational_capability_commerce_link_manager'
+      - '@myeventlane_vendor.event_access_checker'
+      - '@string_translation'
+      - '@logger.channel.myeventlane_event_studio'
+
   myeventlane_event_studio.vendor_productisation_studio_builder:
     class: Drupal\myeventlane_event_studio\Service\VendorProductisationStudioBuilder
     arguments:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
@@ -13,6 +13,7 @@ use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\OperationalCapabilityCommerceLinkManager;
 use Drupal\myeventlane_event_studio\Service\OperationalCapabilityStudioManager;
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
 use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioBuilder;
 use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
 use Drupal\myeventlane_tickets\Service\OperationalEntitlementCapabilityManager;
@@ -24,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Vendor productisation authoring for operational Commerce (link + copy only).
+ * Vendor productisation authoring for operational Commerce (link + optional wizard create on explicit save).
  */
 final class EventStudioProductisationForm extends FormBase {
 
@@ -37,6 +38,8 @@ final class EventStudioProductisationForm extends FormBase {
     private readonly EventStudioAutosaveService $autosaveService,
     private readonly AccountProxyInterface $currentUser,
     private readonly LoggerInterface $logger,
+    private readonly VendorOperationalProductCreationManager $vendorOperationalProductCreationManager,
+    private readonly OperationalCapabilityCommerceLinkManager $operationalCapabilityCommerceLinkManager,
   ) {}
 
   public static function create(ContainerInterface $container): static {
@@ -49,6 +52,8 @@ final class EventStudioProductisationForm extends FormBase {
       $container->get('myeventlane_event_studio.autosave'),
       $container->get('current_user'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
+      $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
+      $container->get('myeventlane_event_studio.operational_capability_commerce_link_manager'),
     );
   }
 
@@ -106,7 +111,7 @@ final class EventStudioProductisationForm extends FormBase {
       'hint' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Attach existing operational Commerce products and customer-facing copy. Commerce owns catalog, carts, and checkout — this screen stores event-scoped authoring metadata only.'),
+        '#value' => $this->t('Link existing operational Commerce products or create new ones using the wizard (created only when you press Save). Commerce owns catalog, carts, and checkout — this screen stores event-scoped authoring metadata; stock, shipping, and fulfilment execution are configured later.'),
         '#attributes' => ['class' => ['mel-es-card__hint']],
       ],
     ];
@@ -132,7 +137,7 @@ final class EventStudioProductisationForm extends FormBase {
 
     foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $type) {
       $row = $byType[$type] ?? $this->vendorProductisationManager->emptyItem($type);
-      $form['mel']['productisation']['types'][$type] = $this->buildEditorForType($type, $row);
+      $form['mel']['productisation']['types'][$type] = $this->buildEditorForType($type, $row, $event);
     }
 
     $form['actions'] = [
@@ -169,6 +174,22 @@ final class EventStudioProductisationForm extends FormBase {
     foreach ($errors as $error) {
       $form_state->setErrorByName('', $error);
     }
+
+    $rawTypes = (array) ($form_state->getValue(['mel', 'productisation', 'types']) ?? []);
+    foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $type) {
+      $row = is_array($rawTypes[$type] ?? NULL) ? $rawTypes[$type] : [];
+      $row = $this->flattenProductisationWizardRow($row);
+      if ((string) ($row['commerce_mode'] ?? 'link') !== 'create') {
+        continue;
+      }
+      if ($this->extractCommerceProductIdFromFormRow($row) > 0) {
+        continue;
+      }
+      $payload = $this->vendorOperationalProductCreationManager->buildWizardCreationPayload($type, $row, $event);
+      foreach ($this->vendorOperationalProductCreationManager->validateCreationPayload($this->currentUser(), $event, $payload) as $error) {
+        $form_state->setErrorByName('', (string) $error);
+      }
+    }
   }
 
   public function submitForm(array &$form, FormStateInterface $form_state): void {
@@ -179,7 +200,19 @@ final class EventStudioProductisationForm extends FormBase {
     }
     try {
       $base = $this->capabilityStudioManager->extractFromEvent($event);
+      $rawTypes = (array) ($form_state->getValue(['mel', 'productisation', 'types']) ?? []);
       $items = $this->collectItemsFromFormState($form_state);
+      $flatTypes = [];
+      foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $ptype) {
+        $r = is_array($rawTypes[$ptype] ?? NULL) ? $rawTypes[$ptype] : [];
+        $flatTypes[$ptype] = $this->flattenProductisationWizardRow($r);
+      }
+      $items = $this->vendorOperationalProductCreationManager->applyProductisationWizardCreates(
+        $this->currentUser(),
+        $event,
+        $items,
+        $flatTypes,
+      );
       $base['operational_merchandise'] = is_array($base['operational_merchandise'] ?? NULL)
         ? $base['operational_merchandise']
         : $this->capabilityStudioManager->emptyDocument()['operational_merchandise'];
@@ -189,6 +222,9 @@ final class EventStudioProductisationForm extends FormBase {
       $event->save();
       $this->autosaveService->clearDraft($event, 'merchandise');
       $this->messenger()->addStatus($this->t('Productisation saved.'));
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->messenger()->addError($e->getMessage());
     }
     catch (\Throwable $e) {
       $this->logger->error('Vendor productisation save failed for event @nid: @message', [
@@ -205,7 +241,7 @@ final class EventStudioProductisationForm extends FormBase {
    *
    * @return array<string, mixed>
    */
-  private function buildEditorForType(string $type, array $row): array {
+  private function buildEditorForType(string $type, array $row, NodeInterface $event): array {
     $commerce = is_array($row['commerce'] ?? NULL) ? $row['commerce'] : [];
     $product_id = (int) ($commerce['product_id'] ?? 0);
     $link_mode = (string) ($commerce['linkage_mode'] ?? OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT);
@@ -213,6 +249,9 @@ final class EventStudioProductisationForm extends FormBase {
     foreach ($this->normalizeVariationIds($commerce['variation_ids'] ?? []) as $vid) {
       $var_defaults[(string) $vid] = (string) $vid;
     }
+
+    $default_currency = $this->defaultCommerceCurrencyForEvent($event);
+    $mode_input = 'mel[productisation][types][' . $type . '][commerce_mode]';
 
     $fieldset = [
       '#type' => 'fieldset',
@@ -371,48 +410,168 @@ final class EventStudioProductisationForm extends FormBase {
       default => [],
     };
 
-    $fieldset['commerce_heading'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'p',
-      '#value' => $this->t('Commerce link (existing product)'),
-      '#attributes' => ['class' => ['mel-productisation-editor__commerce-title']],
-    ];
-    $fieldset['commerce_product'] = [
-      '#type' => 'entity_autocomplete',
-      '#title' => $this->t('Commerce product'),
-      '#target_type' => 'commerce_product',
-      '#max_length' => 512,
-      '#default_value' => $product_id > 0 ? $this->entityTypeManager->getStorage('commerce_product')->load($product_id) : NULL,
-    ];
-    $fieldset['commerce_product_id'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Commerce product ID'),
-      '#min' => 0,
-      '#default_value' => $product_id > 0 ? $product_id : NULL,
-      '#description' => $this->t('Autocomplete fills this ID for autosave compatibility.'),
-    ];
-    $fieldset['commerce_linkage_mode'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Variation linkage'),
+    $fieldset['commerce_mode'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Catalog path'),
       '#options' => [
-        OperationalCapabilityCommerceLinkManager::LINKAGE_NONE => $this->t('None'),
-        OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT => $this->t('Whole product'),
-        OperationalCapabilityCommerceLinkManager::LINKAGE_VARIATIONS => $this->t('Specific variations'),
+        'link' => $this->t('Link existing product'),
+        'create' => $this->t('Create new operational product'),
       ],
-      '#default_value' => in_array($link_mode, [
-        OperationalCapabilityCommerceLinkManager::LINKAGE_NONE,
-        OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT,
-        OperationalCapabilityCommerceLinkManager::LINKAGE_VARIATIONS,
-      ], TRUE) ? $link_mode : OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT,
+      '#default_value' => $product_id > 0 ? 'link' : 'link',
+      '#attributes' => ['class' => ['mel-productisation-wizard-mode']],
     ];
-    $fieldset['commerce_variations'] = [
-      '#type' => 'checkboxes',
-      '#title' => $this->t('Allowed variations'),
-      '#options' => $this->buildVariationOptionsForProduct($product_id),
-      '#default_value' => $var_defaults,
+
+    $fieldset['wizard_create'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-productisation-wizard-create']],
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $mode_input . '"]' => ['value' => 'create'],
+        ],
+      ],
+      'notice' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Stock counts, warehouse routing, shipping labels, scanners, QR payloads, and entitlement issuance are <strong>not</strong> configured here — they are handled later in Commerce and operations tooling.'),
+        '#attributes' => ['class' => ['mel-productisation-wizard-warning']],
+      ],
+      'readiness_chips' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Operational readiness: authoring · pricing · customer copy'),
+        '#attributes' => ['class' => ['mel-productisation-wizard-chips']],
+      ],
+      'customer_preview_label' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Customer sees this (from your summary fields and the product title below).'),
+        '#attributes' => ['class' => ['mel-productisation-wizard-preview-hint']],
+      ],
+      'commerce_create_title' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Catalog title'),
+        '#default_value' => '',
+        '#maxlength' => 255,
+        '#description' => $this->t('Plain text only. Defaults from the fields above when left blank.'),
+      ],
+      'commerce_create_customer_summary' => [
+        '#type' => 'textarea',
+        '#title' => $this->t('Short customer summary'),
+        '#rows' => 3,
+        '#default_value' => '',
+      ],
+      'commerce_create_price' => [
+        '#type' => 'number',
+        '#title' => $this->t('Price'),
+        '#min' => 0,
+        '#step' => 0.01,
+        '#default_value' => NULL,
+      ],
+      'commerce_create_currency' => [
+        '#type' => 'hidden',
+        '#default_value' => $default_currency,
+      ],
+      'commerce_create_currency_display' => [
+        '#type' => 'item',
+        '#title' => $this->t('Currency'),
+        '#markup' => '<p class="mel-text--muted">' . $this->t('Charges use your event store currency: @code', ['@code' => $default_currency]) . '</p>',
+      ],
+      'commerce_create_sku' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('SKU (optional)'),
+        '#maxlength' => 128,
+        '#default_value' => '',
+      ],
+      'commerce_create_fulfillment_mode' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Fulfilment mode token (optional)'),
+        '#default_value' => '',
+        '#maxlength' => 64,
+        '#access' => $type !== VendorProductisationStudioManager::TYPE_MERCHANDISE
+          && $type !== VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+      ],
+      'commerce_create_reservation_mode' => [
+        '#type' => 'value',
+        '#value' => 'operational_projection',
+      ],
+    ];
+
+    $fieldset['wizard_link'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-productisation-wizard-link']],
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $mode_input . '"]' => ['value' => 'link'],
+        ],
+      ],
+      'commerce_heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Commerce link (existing product)'),
+        '#attributes' => ['class' => ['mel-productisation-editor__commerce-title']],
+      ],
+      'commerce_product' => [
+        '#type' => 'entity_autocomplete',
+        '#title' => $this->t('Commerce product'),
+        '#target_type' => 'commerce_product',
+        '#max_length' => 512,
+        '#default_value' => $product_id > 0 ? $this->entityTypeManager->getStorage('commerce_product')->load($product_id) : NULL,
+      ],
+      'commerce_product_id' => [
+        '#type' => 'number',
+        '#title' => $this->t('Commerce product ID'),
+        '#min' => 0,
+        '#default_value' => $product_id > 0 ? $product_id : NULL,
+        '#description' => $this->t('Autocomplete fills this ID for autosave compatibility.'),
+      ],
+      'commerce_linkage_mode' => [
+        '#type' => 'select',
+        '#title' => $this->t('Variation linkage'),
+        '#options' => [
+          OperationalCapabilityCommerceLinkManager::LINKAGE_NONE => $this->t('None'),
+          OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT => $this->t('Whole product'),
+          OperationalCapabilityCommerceLinkManager::LINKAGE_VARIATIONS => $this->t('Specific variations'),
+        ],
+        '#default_value' => in_array($link_mode, [
+          OperationalCapabilityCommerceLinkManager::LINKAGE_NONE,
+          OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT,
+          OperationalCapabilityCommerceLinkManager::LINKAGE_VARIATIONS,
+        ], TRUE) ? $link_mode : OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT,
+      ],
+      'commerce_variations' => [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Allowed variations'),
+        '#options' => $this->buildVariationOptionsForProduct($product_id),
+        '#default_value' => $var_defaults,
+      ],
     ];
 
     return $fieldset;
+  }
+
+  private function defaultCommerceCurrencyForEvent(NodeInterface $event): string {
+    $sid = $this->operationalCapabilityCommerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+    if ($sid === NULL || $sid < 1) {
+      return 'AUD';
+    }
+    $store = $this->entityTypeManager->getStorage('commerce_store')->load($sid);
+    if (!is_object($store) || !method_exists($store, 'getDefaultCurrencyCode')) {
+      return 'AUD';
+    }
+    return (string) $store->getDefaultCurrencyCode();
+  }
+
+  /**
+   * Merges nested wizard containers into a flat row for mapping and validation.
+   *
+   * @param array<string, mixed> $row
+   *
+   * @return array<string, mixed>
+   */
+  private function flattenProductisationWizardRow(array $row): array {
+    $link = is_array($row['wizard_link'] ?? NULL) ? $row['wizard_link'] : [];
+    $create = is_array($row['wizard_create'] ?? NULL) ? $row['wizard_create'] : [];
+    return array_merge($row, $link, $create);
   }
 
   /**
@@ -477,6 +636,7 @@ final class EventStudioProductisationForm extends FormBase {
    * @return array<string, mixed>
    */
   private function mapRowToItem(string $type, array $row): array {
+    $row = $this->flattenProductisationWizardRow($row);
     $base = $this->vendorProductisationManager->emptyItem($type);
     $product_id = $this->extractCommerceProductIdFromFormRow($row);
     $mode = (string) ($row['commerce_linkage_mode'] ?? OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT);
@@ -543,6 +703,7 @@ final class EventStudioProductisationForm extends FormBase {
    * @param array<string, mixed> $row
    */
   private function extractCommerceProductIdFromFormRow(array $row): int {
+    $row = $this->flattenProductisationWizardRow($row);
     $n = (int) ($row['commerce_product_id'] ?? 0);
     if ($n > 0) {
       return $n;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/OperationalCapabilityCommerceLinkManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/OperationalCapabilityCommerceLinkManager.php
@@ -135,7 +135,7 @@ final class OperationalCapabilityCommerceLinkManager {
       return $this->invalidateLinkage('A Commerce product must be selected for this capability.');
     }
 
-    $vendor_store_id = $this->resolveEventVendorStoreId($event);
+    $vendor_store_id = $this->resolveVendorStoreIdForEvent($event);
     if ($vendor_store_id === NULL) {
       return $this->invalidateLinkage('Vendor store could not be resolved for this event.');
     }
@@ -342,6 +342,27 @@ final class OperationalCapabilityCommerceLinkManager {
     return in_array($t, ['inherit', 'hidden', 'visible', 'after_purchase'], TRUE) ? $t : 'inherit';
   }
 
+  /**
+   * Resolves the vendor Commerce store ID for an event (vendor entity store).
+   */
+  public function resolveVendorStoreIdForEvent(NodeInterface $event): ?int {
+    return $this->resolveEventVendorStoreId($event);
+  }
+
+  /**
+   * Resolves a store for operational product authoring (vendor store, then event store field).
+   */
+  public function resolveStoreIdForOperationalProductCreation(NodeInterface $event): ?int {
+    $id = $this->resolveEventVendorStoreId($event);
+    if ($id !== NULL) {
+      return $id;
+    }
+    if ($event->hasField('field_event_store') && !$event->get('field_event_store')->isEmpty()) {
+      return (int) $event->get('field_event_store')->target_id;
+    }
+    return NULL;
+  }
+
   private function resolveEventVendorStoreId(NodeInterface $event): ?int {
     if (!$event->hasField('field_event_vendor') || $event->get('field_event_vendor')->isEmpty()) {
       return $this->resolveActingVendorStoreId();
@@ -359,6 +380,9 @@ final class OperationalCapabilityCommerceLinkManager {
   private function resolveActingVendorStoreId(): ?int {
     $uid = (int) $this->currentUser->id();
     if ($uid < 1) {
+      return NULL;
+    }
+    if (!$this->entityTypeManager->hasDefinition('myeventlane_vendor')) {
       return NULL;
     }
     $storage = $this->entityTypeManager->getStorage('myeventlane_vendor');

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -1,0 +1,572 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product as CommerceProduct;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Creates operational Commerce products/variations for Event Studio (explicit save only).
+ *
+ * Commerce remains authoritative for catalog, carts, checkout, and orders.
+ * No stock, warehouse, shipping, scanners, QR, entitlements, or checkout mutation.
+ */
+final class VendorOperationalProductCreationManager {
+
+  /**
+   * @var list<string>
+   */
+  public const FORBIDDEN_CREATION_KEYS = [
+    'inventory_quantity',
+    'stock_count',
+    'stock_level',
+    'warehouse_ids',
+    'warehouse_slot',
+    'shipment_provider',
+    'shipment_state',
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_tokens',
+    'scanner_secret',
+    'entitlement_id',
+    'ticket_id',
+    'device_fingerprint',
+    'operational_fingerprint',
+    'staff_integrity',
+    'metadata_json',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly OperationalCapabilityCommerceLinkManager $commerceLinkManager,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly TranslationInterface $translation,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $payload
+   *   Normalized creation payload (see stripForbiddenFromPayload).
+   *
+   * @return list<string>
+   */
+  public function validateCreationPayload(AccountInterface $account, NodeInterface $event, array $payload): array {
+    $errors = [];
+    if ($account->isAnonymous()) {
+      return ['Authentication is required to create products.'];
+    }
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)
+      && !$account->hasPermission('administer nodes')) {
+      return ['You do not have permission to create products for this event.'];
+    }
+    $store_id = $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+    if ($store_id === NULL || $store_id < 1) {
+      $errors[] = 'No Commerce store could be resolved for this event.';
+    }
+    $type = $this->normalizeProductisationType((string) ($payload['productisation_type'] ?? ''));
+    if ($type === '') {
+      $errors[] = 'A valid productisation type is required.';
+    }
+    $title = trim((string) ($payload['title'] ?? ''));
+    if ($title === '') {
+      $errors[] = 'Title is required.';
+    }
+    $summary = trim((string) ($payload['customer_summary'] ?? ''));
+    if ($summary === '') {
+      $errors[] = 'Customer summary is required.';
+    }
+    $currency = $this->normalizeCurrencyCode((string) ($payload['currency_code'] ?? ''));
+    if (strlen($currency) !== 3) {
+      $errors[] = 'A valid currency code is required.';
+    }
+    $amount = $this->normalizePriceAmount($payload['price_amount'] ?? NULL);
+    if ($amount === NULL) {
+      $errors[] = 'A valid price amount is required.';
+    }
+    if ((int) ($payload['event_id'] ?? 0) !== (int) $event->id()) {
+      $errors[] = 'Event context mismatch.';
+    }
+    return $errors;
+  }
+
+  /**
+   * Creates an operational Commerce product + default variation for an event.
+   *
+   * @param array<string, mixed> $payload
+   *   Raw payload; forbidden keys are stripped recursively.
+   *
+   * @return array<string, mixed>
+   *   Keys: product_id, variation_ids, store_id, customer_summary, product_bundle.
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function createOperationalProductForEvent(AccountInterface $account, NodeInterface $event, array $payload): array {
+    $payload = $this->stripForbiddenFromPayload($payload);
+    $errors = $this->validateCreationPayload($account, $event, $payload);
+    if ($errors !== []) {
+      throw new \InvalidArgumentException(implode(' ', $errors));
+    }
+
+    $store_id = (int) $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+    $store = $this->entityTypeManager->getStorage('commerce_store')->load($store_id);
+    if (!$store instanceof StoreInterface) {
+      throw new \InvalidArgumentException('Commerce store could not be loaded.');
+    }
+
+    if (!$account->hasPermission('administer nodes')) {
+      $vendor_store = $this->commerceLinkManager->resolveVendorStoreIdForEvent($event);
+      if ($vendor_store !== NULL && $vendor_store !== $store_id) {
+        throw new \InvalidArgumentException('Resolved Commerce store does not match the vendor store for this event.');
+      }
+    }
+
+    $existing = (int) ($payload['existing_product_id'] ?? 0);
+    if ($existing > 0) {
+      return $this->resolveExistingOperationalProduct($event, $existing, $store_id);
+    }
+
+    $type = $this->normalizeProductisationType((string) $payload['productisation_type']);
+    $bundles = $this->mapProductisationTypeToCommerceBundles($type);
+    $currency = $this->normalizeCurrencyCode((string) $payload['currency_code']);
+    $default_currency = $store->getDefaultCurrencyCode();
+    if (!$account->hasPermission('administer nodes') && strtoupper($currency) !== strtoupper($default_currency)) {
+      throw new \InvalidArgumentException('Currency must match the event store default currency.');
+    }
+
+    $amount = (string) $this->normalizePriceAmount($payload['price_amount'] ?? NULL);
+    $title = $this->sanitizePlainText((string) $payload['title'], 255);
+    $summary = $this->sanitizePlainText((string) $payload['customer_summary'], 600);
+    $sku_base = trim((string) ($payload['sku'] ?? ''));
+    $sku = $sku_base !== '' ? $this->sanitizePlainText($sku_base, 128) : $this->generateSku($event, $type);
+
+    $metadata = $this->buildOperationalMetadata($type, $payload, $summary);
+    $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+    $product = CommerceProduct::create([
+      'type' => $bundles['product_type'],
+      'title' => $title,
+      'status' => 1,
+      'stores' => [$store_id],
+      'uid' => (int) $account->id(),
+      'field_event' => ['target_id' => (int) $event->id()],
+      'field_mel_operational_product' => $encoded,
+    ]);
+    $product->save();
+
+    $price = new Price($amount, strtoupper($currency));
+
+    $variation = ProductVariation::create([
+      'type' => $bundles['variation_type'],
+      'sku' => $sku,
+      'title' => $title,
+      'status' => 1,
+      'price' => $price,
+    ]);
+    $variation->save();
+
+    $product->addVariation($variation);
+    $product->save();
+
+    $reloaded = $this->entityTypeManager->getStorage('commerce_product')->load($product->id());
+    if (!$reloaded instanceof ProductInterface) {
+      throw new \RuntimeException('Operational product could not be reloaded after save.');
+    }
+
+    $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation(
+      $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($reloaded),
+    );
+
+    $this->logger->notice('Vendor operational product @pid created for event @eid (bundle @bundle).', [
+      '@pid' => (string) $reloaded->id(),
+      '@eid' => (string) $event->id(),
+      '@bundle' => $bundles['product_type'],
+    ]);
+
+    $vars = [];
+    foreach ($reloaded->getVariations() as $v) {
+      $vars[] = (int) $v->id();
+    }
+
+    return [
+      'product_id' => (int) $reloaded->id(),
+      'variation_ids' => $vars,
+      'store_id' => $store_id,
+      'customer_summary' => (string) ($presentation['operational_summary'] ?? $summary),
+      'product_bundle' => $bundles['product_type'],
+    ];
+  }
+
+  /**
+   * Applies explicit-save operational Commerce creates from wizard rows (no autosave).
+   *
+   * @param list<array<string, mixed>> $items
+   *   Productisation items in {@see VendorProductisationStudioManager::PRODUCTISATION_TYPES} order.
+   * @param array<string, array<string, mixed>> $wizardRowsByType
+   *   Raw form rows keyed by productisation type (includes commerce_mode and create fields).
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function applyProductisationWizardCreates(AccountInterface $account, NodeInterface $event, array $items, array $wizardRowsByType): array {
+    foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $idx => $type) {
+      if (!isset($items[$idx]) || !is_array($items[$idx])) {
+        continue;
+      }
+      $row = $this->flattenWizardFormRow(is_array($wizardRowsByType[$type] ?? NULL) ? $wizardRowsByType[$type] : []);
+      if ((string) ($row['commerce_mode'] ?? 'link') !== 'create') {
+        continue;
+      }
+      if ($this->extractWizardCommerceProductId($row) > 0) {
+        continue;
+      }
+      $payload = $this->buildWizardCreationPayload($type, $row, $event);
+      $created = $this->createOperationalProductForEvent($account, $event, $payload);
+      $items[$idx]['commerce']['product_id'] = (int) $created['product_id'];
+      $items[$idx]['commerce']['variation_ids'] = array_map('intval', is_array($created['variation_ids'] ?? NULL) ? $created['variation_ids'] : []);
+      $items[$idx]['commerce']['linkage_mode'] = OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT;
+    }
+    return $items;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   *
+   * @return array<string, mixed>
+   */
+  public function buildWizardCreationPayload(string $productisation_type, array $row, NodeInterface $event): array {
+    $row = $this->flattenWizardFormRow($row);
+    $type = $this->normalizeProductisationType($productisation_type);
+    if ($type === '') {
+      $type = VendorProductisationStudioManager::TYPE_MERCHANDISE;
+    }
+    [$title, $summary] = $this->wizardTitleAndSummary($type, $row);
+    $title = trim((string) ($row['commerce_create_title'] ?? '')) !== '' ? trim(strip_tags((string) $row['commerce_create_title'])) : $title;
+    $summary = trim((string) ($row['commerce_create_customer_summary'] ?? '')) !== '' ? trim(strip_tags((string) $row['commerce_create_customer_summary'])) : $summary;
+    $fulfillment = match ($type) {
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => (string) ($row['fulfillment_mode'] ?? 'redeem'),
+      VendorProductisationStudioManager::TYPE_MERCHANDISE => (string) ($row['pickup_mode'] ?? 'counter'),
+      default => (string) ($row['commerce_create_fulfillment_mode'] ?? 'collect'),
+    };
+    $reservation = (string) ($row['commerce_create_reservation_mode'] ?? 'operational_projection');
+    $visibility = match ($type) {
+      VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE => (string) ($row['visibility'] ?? 'visible'),
+      default => (string) ($row['customer_visibility'] ?? 'visible'),
+    };
+    $bundle_caps = [];
+    if ($type === VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE) {
+      $g = is_array($row['grouped_capability_types'] ?? NULL) ? $row['grouped_capability_types'] : [];
+      foreach ($g as $cap => $on) {
+        if (!empty($on)) {
+          $bundle_caps[] = (string) $cap;
+        }
+      }
+    }
+    $payload = [
+      'productisation_type' => $type,
+      'event_id' => (int) $event->id(),
+      'title' => $title,
+      'customer_summary' => $summary,
+      'price_amount' => $row['commerce_create_price'] ?? NULL,
+      'currency_code' => (string) ($row['commerce_create_currency'] ?? ''),
+      'customer_visibility' => $visibility,
+      'fulfillment_mode' => $fulfillment,
+      'reservation_mode' => $reservation,
+      'sku' => $row['commerce_create_sku'] ?? NULL,
+      'pickup_mode' => (string) ($row['pickup_mode'] ?? ''),
+      'timed_collection_window_copy' => (string) ($row['pickup_window_copy'] ?? ''),
+      'hospitality_benefits_summary' => (string) ($row['benefits_summary'] ?? ''),
+      'parking_guidance' => (string) ($row['parking_guidance'] ?? ''),
+      'bundle_capability_types' => $bundle_caps,
+    ];
+    return $this->stripForbiddenFromPayload($payload);
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   *
+   * @return array{0: string, 1: string}
+   */
+  private function wizardTitleAndSummary(string $type, array $row): array {
+    return match ($type) {
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => [
+        trim((string) ($row['package_name'] ?? '')),
+        trim((string) ($row['benefits_summary'] ?? '')),
+      ],
+      VendorProductisationStudioManager::TYPE_TIMED_COLLECTION => [
+        trim((string) ($row['collection_label'] ?? '')),
+        trim((string) ($row['collection_guidance'] ?? '')),
+      ],
+      VendorProductisationStudioManager::TYPE_PARKING_ADDON => [
+        trim((string) ($row['access_timing_copy'] ?? '')) !== ''
+          ? trim((string) ($row['access_timing_copy'] ?? ''))
+          : (string) $this->translation->translate('Parking add-on'),
+        trim((string) ($row['parking_guidance'] ?? '')),
+      ],
+      VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE => [
+        trim((string) ($row['bundle_label'] ?? '')),
+        trim((string) ($row['customer_summary'] ?? '')),
+      ],
+      default => [
+        trim((string) ($row['title'] ?? '')),
+        trim((string) ($row['customer_summary'] ?? '')),
+      ],
+    };
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   */
+  private function extractWizardCommerceProductId(array $row): int {
+    $row = $this->flattenWizardFormRow($row);
+    $n = (int) ($row['commerce_product_id'] ?? 0);
+    if ($n > 0) {
+      return $n;
+    }
+    $ac = $row['commerce_product'] ?? '';
+    if (is_array($ac) && isset($ac['target_id'])) {
+      return (int) $ac['target_id'];
+    }
+    return 0;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   *
+   * @return array<string, mixed>
+   */
+  private function flattenWizardFormRow(array $row): array {
+    $link = is_array($row['wizard_link'] ?? NULL) ? $row['wizard_link'] : [];
+    $create = is_array($row['wizard_create'] ?? NULL) ? $row['wizard_create'] : [];
+    return array_merge($row, $link, $create);
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return array<string, mixed>
+   */
+  public function stripForbiddenFromPayload(array $payload): array {
+    return $this->stripForbiddenRecursive($payload);
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  private function stripForbiddenRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_CREATION_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildOperationalMetadata(string $type, array $payload, string $summary): array {
+    $fulfillment = $this->sanitizePlainText((string) ($payload['fulfillment_mode'] ?? 'collect'), 64);
+    $reservation = $this->sanitizePlainText((string) ($payload['reservation_mode'] ?? 'operational_projection'), 64);
+    $visibility = $this->normalizeVisibility((string) ($payload['customer_visibility'] ?? 'visible'));
+    $pickup = $this->sanitizePlainText((string) ($payload['pickup_mode'] ?? ''), 64);
+    $timed_copy = $this->sanitizePlainText((string) ($payload['timed_collection_window_copy'] ?? ''), 400);
+    $hospitality = $this->sanitizePlainText((string) ($payload['hospitality_benefits_summary'] ?? ''), 600);
+    $parking = $this->sanitizePlainText((string) ($payload['parking_guidance'] ?? ''), 600);
+    $bundle_types = is_array($payload['bundle_capability_types'] ?? NULL) ? $payload['bundle_capability_types'] : [];
+
+    $product_type_token = match ($type) {
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => 'hospitality_package',
+      VendorProductisationStudioManager::TYPE_TIMED_COLLECTION => 'timed_collection_product',
+      VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE => 'operational_bundle',
+      VendorProductisationStudioManager::TYPE_PARKING_ADDON => 'merch_pickup',
+      default => 'merch_pickup',
+    };
+
+    $chips = [];
+    if ($timed_copy !== '') {
+      $chips[] = ['label' => $timed_copy, 'tone' => 'info'];
+    }
+    if ($hospitality !== '') {
+      $chips[] = ['label' => $hospitality, 'tone' => 'info'];
+    }
+    if ($parking !== '') {
+      $chips[] = ['label' => $parking, 'tone' => 'info'];
+    }
+    if ($type === VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE && $bundle_types !== []) {
+      $chips[] = ['label' => implode(', ', array_map('strval', $bundle_types)), 'tone' => 'muted'];
+    }
+
+    return [
+      'operational_product_type' => $product_type_token,
+      'fulfillment_mode' => $fulfillment !== '' ? $fulfillment : 'collect',
+      'reservation_mode' => $reservation !== '' ? $reservation : 'operational_projection',
+      'pickup_mode' => $pickup !== '' ? $pickup : 'counter',
+      'readiness_mode' => 'authoring',
+      'continuity_mode' => 'collect_after_entry',
+      'capability_reference' => $type,
+      'customer_visibility' => $visibility,
+      'collection_rules' => [],
+      'hospitality_rules' => [],
+      'operational_summary' => $summary,
+      'operational_chips' => $chips,
+    ];
+  }
+
+  /**
+   * @return array{product_type: string, variation_type: string}
+   */
+  private function mapProductisationTypeToCommerceBundles(string $type): array {
+    return match ($type) {
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => [
+        'product_type' => 'hospitality_package',
+        'variation_type' => 'hospitality_package_var',
+      ],
+      VendorProductisationStudioManager::TYPE_TIMED_COLLECTION => [
+        'product_type' => 'timed_collection_product',
+        'variation_type' => 'timed_collection_var',
+      ],
+      VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE => [
+        'product_type' => 'operational_bundle',
+        'variation_type' => 'operational_bundle_var',
+      ],
+      VendorProductisationStudioManager::TYPE_PARKING_ADDON => [
+        'product_type' => 'operational_merchandise',
+        'variation_type' => 'operational_merchandise_var',
+      ],
+      default => [
+        'product_type' => 'operational_merchandise',
+        'variation_type' => 'operational_merchandise_var',
+      ],
+    };
+  }
+
+  private function normalizeProductisationType(string $raw): string {
+    $t = strtolower(trim($raw));
+    return in_array($t, VendorProductisationStudioManager::PRODUCTISATION_TYPES, TRUE) ? $t : '';
+  }
+
+  private function normalizeCurrencyCode(string $code): string {
+    return strtoupper(preg_replace('/[^A-Za-z]/', '', $code) ?? '');
+  }
+
+  private function normalizePriceAmount(mixed $raw): ?string {
+    if ($raw === NULL || $raw === '') {
+      return NULL;
+    }
+    if (is_int($raw) || is_float($raw)) {
+      $raw = (string) $raw;
+    }
+    if (!is_string($raw)) {
+      return NULL;
+    }
+    $raw = trim($raw);
+    if ($raw === '' || !is_numeric($raw)) {
+      return NULL;
+    }
+    if ((float) $raw < 0) {
+      return NULL;
+    }
+    return number_format((float) $raw, 2, '.', '');
+  }
+
+  private function normalizeVisibility(string $raw): string {
+    $v = strtolower(trim($raw));
+    return in_array($v, ['visible', 'hidden', 'after_purchase'], TRUE) ? $v : 'visible';
+  }
+
+  private function sanitizePlainText(string $text, int $max): string {
+    $text = trim(strip_tags($text));
+    if (strlen($text) > $max) {
+      return substr($text, 0, $max - 1) . '…';
+    }
+    return $text;
+  }
+
+  private function generateSku(NodeInterface $event, string $type): string {
+    $slug = preg_replace('/[^a-z0-9]+/i', '-', $type) ?: 'op';
+    return 'mel-op-' . (int) $event->id() . '-' . $slug . '-' . substr(sha1((string) microtime(TRUE)), 0, 8);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function resolveExistingOperationalProduct(NodeInterface $event, int $product_id, int $store_id): array {
+    $product = $this->entityTypeManager->getStorage('commerce_product')->load($product_id);
+    if (!$product instanceof ProductInterface) {
+      throw new \InvalidArgumentException('Existing product was not found.');
+    }
+    if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+      throw new \InvalidArgumentException('Existing product is not an operational Commerce bundle.');
+    }
+    $linked = $this->operationalMerchandiseManager->normalizeEventMerchandiseAuthoring([
+      'linked_products' => [['product_id' => $product_id, 'role' => 'merch_pickup']],
+    ], $event)['linked_products'] ?? [];
+    if ($linked === []) {
+      throw new \InvalidArgumentException('Existing product is not scoped to this event.');
+    }
+    if (!$this->productInStore($product, $store_id)) {
+      throw new \InvalidArgumentException('Existing product is not available in the resolved store.');
+    }
+    $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation(
+      $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product),
+    );
+    $vars = [];
+    foreach ($product->getVariations() as $v) {
+      $vars[] = (int) $v->id();
+    }
+    return [
+      'product_id' => $product_id,
+      'variation_ids' => $vars,
+      'store_id' => $store_id,
+      'customer_summary' => (string) ($presentation['operational_summary'] ?? ''),
+      'product_bundle' => $product->bundle(),
+    ];
+  }
+
+  private function productInStore(ProductInterface $product, int $store_id): bool {
+    if (!$product->hasField('stores') || $product->get('stores')->isEmpty()) {
+      return FALSE;
+    }
+    foreach ($product->get('stores')->getValue() as $item) {
+      if ((int) ($item['target_id'] ?? 0) === $store_id) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorProductisationStudioBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorProductisationStudioBuilder.php
@@ -135,7 +135,7 @@ final class VendorProductisationStudioBuilder {
       return [
         'headline' => $this->customerFacingHeadline($item),
         'presentation' => [],
-        'note' => (string) $this->t('Link a Commerce product to show the same customer-safe operational summary used on the event page.'),
+        'note' => (string) $this->t('Link a product or use the create path — after save, the customer-safe operational summary appears here.'),
       ];
     }
     $product = $this->entityTypeManager->getStorage('commerce_product')->load($pid);
@@ -167,9 +167,9 @@ final class VendorProductisationStudioBuilder {
     }
     $commerce = is_array($item['commerce'] ?? NULL) ? $item['commerce'] : [];
     if ((int) ($commerce['product_id'] ?? 0) < 1) {
-      return ['label' => (string) $this->t('Draft'), 'tone' => 'muted'];
+      return ['label' => (string) $this->t('Draft only'), 'tone' => 'muted'];
     }
-    return ['label' => (string) $this->t('Linked'), 'tone' => 'success'];
+    return ['label' => (string) $this->t('Linked to Commerce product'), 'tone' => 'success'];
   }
 
   private function typeLabel(string $type): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorProductisationStudioManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorProductisationStudioManager.php
@@ -62,6 +62,8 @@ final class VendorProductisationStudioManager {
     'device_fingerprint',
     'entitlement_token',
     'ticket_code',
+    'entitlement_id',
+    'ticket_id',
   ];
 
   public function __construct(

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Lightweight contract tests for vendor operational product creation payloads.
+ *
+ * @group myeventlane_event_studio
+ */
+#[Group('myeventlane_event_studio')]
+final class VendorOperationalProductCreationManagerTest extends TestCase {
+
+  public function testForbiddenCreationKeysList(): void {
+    $this->assertContains('inventory_quantity', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+    $this->assertContains('qr_payload', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+    $this->assertContains('entitlement_id', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new code path that creates Drupal Commerce products/variations during Event Studio form submission, including store/currency resolution and access checks; mistakes here could create catalog data in the wrong store or with invalid metadata. Config changes also introduce new product types/fields, which can affect deployments and content sync.
> 
> **Overview**
> Enables vendors to **create new operational Commerce products** directly from the Event Studio Productisation flow (in addition to linking existing products), with creation happening **only on explicit Save**.
> 
> Adds `VendorOperationalProductCreationManager` to validate and create products/variations for operational bundles (merch, hospitality, timed collection, bundles), including recursive forbidden-key stripping, event/store scoping, currency enforcement, and idempotency via `existing_product_id`. `EventStudioProductisationForm` is updated to render a link-vs-create UI, validate wizard rows, and apply creates before persisting productisation items.
> 
> Introduces new Commerce config for operational product/variation types plus `field_mel_operational_product` storage and per-bundle field instances, adjusts store resolution in `OperationalCapabilityCommerceLinkManager` (including a safe `hasDefinition()` guard), and expands kernel/unit tests + docs/CSS to cover the wizard behavior and boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979fa5f3bf27589b91814a1b9d1a061dfc19a9dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->