### PR TITLE
Fix/event studio productisation bugbot review

### DIFF
--- a/docs/customer-operational-addons-booking.md
+++ b/docs/customer-operational-addons-booking.md
@@ -1,0 +1,72 @@
+# Customer operational add-ons on event booking (Phase 4F)
+
+## Architecture
+
+Paid event booking (`/event/{node}/book`, `BookController`) embeds a **read-only** catalog slice built by `myeventlane_commerce.event_operational_addon_builder` (`EventOperationalAddonBuilder`) and a **Commerce cart** form `EventOperationalAddonCartForm`. **Drupal Commerce** remains authoritative for carts, checkout, order items, pricing, stores, and order state.
+
+- **No** parallel cart system, **no** manual stock decrement, **no** warehouse or shipping orchestration, **no** QR/scanner/entitlement mutations from this layer.
+- Add-to-cart uses `commerce_cart.cart_provider` and `commerce_cart.cart_manager` (`addEntity()`), mirroring ticket selection patterns.
+
+## Services
+
+| ID | Class | Role |
+| --- | --- | --- |
+| `myeventlane_commerce.event_operational_addon_builder` | `EventOperationalAddonBuilder` | Entity query for operational product bundles with `field_event` = event, published products, published variations; customer-safe operational copy via `OperationalMerchandiseManager`. |
+| `myeventlane_commerce.operational_merchandise_manager` | `OperationalMerchandiseManager` | Reused for normalization + `buildCustomerSafeProductPresentation()` (existing contract). |
+
+Form dependencies (constructor / `create()`): `entity_type.manager`, `commerce_cart.cart_provider`, `commerce_cart.cart_manager`, `event_operational_addon_builder`, `commerce_price.currency_formatter`, `logger.factory`.
+
+## Customer flow
+
+1. Customer opens the paid event book page.
+2. If at least one eligible operational product exists for the event, the **“Add something extra”** section renders below the ticket matrix (same main column).
+3. Customer sets quantities (0–10 UI cap; **not** inventory enforcement unless Commerce stock modules apply their own rules elsewhere).
+4. Submit calls `CartManagerInterface::addEntity()` per line with `combine = TRUE`, resolves store from the product’s Commerce stores (first store), sets `field_target_event` on new order items when present (same presave contract as tickets).
+5. Redirect returns to the same event book route with a status message; cart/checkout CTAs elsewhere are unchanged.
+
+## Security checks
+
+- Submitted variation IDs are validated against a **fresh allowlist** from `EventOperationalAddonBuilder::buildForEvent()` (no trust in hidden defaults for linkage).
+- Product must be **published**, bundle ∈ `OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES`, `field_event` must match the event node, variation must be **published**, product must expose at least one Commerce store.
+- Customer payloads strip forbidden keys (see `EventOperationalAddonBuilder::FORBIDDEN_CUSTOMER_ADDON_KEYS`) in addition to `OperationalMerchandiseManager` normalization.
+
+## Deliberately not implemented
+
+- Stock reservation, warehouse routing, shipment creation, scanner/QR mutation, entitlement issuance, checkout pane changes, multi-step checkout redirects from this form, and “hard” per-line inventory caps (UI cap only).
+
+## Theming
+
+- Library: `myeventlane_commerce/operational_addons` → `css/mel-operational-addons.css`.
+- Submit uses existing `mel-btn mel-btn--primary` classes for coral CTA consistency with the theme.
+
+## Tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php --do-not-cache-result
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/EventOperationalAddonBuilderKernelTest.php --do-not-cache-result
+```
+
+Kernel tests reuse `OperationalMerchandiseKernelTest` fixtures (Commerce catalog + `field_event`). If `SIMPLETEST_DB` is required in your environment, follow the project pattern:
+
+```bash
+ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/EventOperationalAddonBuilderKernelTest.php --do-not-cache-result'
+```
+
+**Cart form automated tests:** Full Commerce cart kernel coverage is not included here (heavy fixture surface). Manual QA covers add-to-cart, invalid variation rejection, and multi-store behaviour.
+
+## Manual QA checklist
+
+- [ ] Paid event **without** operational products: add-on section **hidden**; booking otherwise normal.
+- [ ] Paid event **with** linked operational product(s): section shows title, summary/chips, price, quantity; submit with all zeros shows neutral status.
+- [ ] Submit quantity > 0: items appear in Commerce cart; `field_target_event` populated when configured.
+- [ ] Unpublished product or variation: disappears from list after change (cache rebuild / refresh).
+- [ ] Product linked to **different** event: never listed.
+- [ ] Tampered POST (invalid variation id): validation error, nothing added to cart.
+- [ ] Mixed ticket + add-on: both land in appropriate Commerce carts per store rules.
+
+## Related documentation
+
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
+- [vendor-product-creation-wizard.md](./vendor-product-creation-wizard.md)
+- [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)

--- a/docs/operational-cart-checkout-orchestration.md
+++ b/docs/operational-cart-checkout-orchestration.md
@@ -28,6 +28,7 @@ Forbidden keys are stripped recursively (`OperationalCheckoutOrchestrationManage
 
 - Theme hook `mel_operational_checkout` ships in `myeventlane_commerce` with library `myeventlane_commerce/mel_operational_checkout`.
 - `myeventlane_theme` preprocessors attach `mel_operational_checkout` render arrays wherever `mel_operational_purchase_composition` already appears (cart summary, checkout sidebar + completion, checkout order summary pane, commerce order user view, My Tickets cards, order detail). The event book adds the strip via `myeventlane_commerce_preprocess_myeventlane_event_book()`.
+- **Phase 4F:** the same booking page can embed `EventOperationalAddonCartForm` (operational add-ons to cart) when `EventOperationalAddonBuilder` finds eligible products; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
 
 ## Anti-patterns
 

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -43,6 +43,8 @@ Theme and checkout-flow templates render the composition strip next to existing 
 
 **Operational checkout orchestration** (`mel_operational_checkout`, `OperationalCheckoutOrchestrationManager`) adds a grouped **checkout plan** card fed only from purchase composition output. It does not replace merchandise normalization or composition classification; see [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md).
 
+**Phase 4F — Customer booking add-ons:** event book embeds operational Commerce add-ons (cart via `EventOperationalAddonCartForm`) when products are linked through `field_event`; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
+
 ## Anti-patterns
 
 - Duplicating `FulfillmentLifecycleManager`, `InventoryReservationGovernanceManager`, scanner authority, or entitlement issuance in merchandise services or Twig.
@@ -59,3 +61,4 @@ Theme and checkout-flow templates render the composition strip next to existing 
 - [vendor-operational-capability-studio.md](./vendor-operational-capability-studio.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
 - [operational-commerce-capability-linking.md](./operational-commerce-capability-linking.md)
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)

--- a/docs/operational-purchase-composition-convergence.md
+++ b/docs/operational-purchase-composition-convergence.md
@@ -25,4 +25,5 @@ Phase 4C adds **`OperationalFulfillmentExecutionProjectionBuilder::buildCustomer
 - [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
 - [operational-fulfillment-execution-convergence.md](./operational-fulfillment-execution-convergence.md)
 - [customer-operational-commerce-experience.md](./customer-operational-commerce-experience.md)
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)

--- a/docs/vendor-product-creation-wizard.md
+++ b/docs/vendor-product-creation-wizard.md
@@ -34,6 +34,8 @@ Wizard rows map to existing operational Commerce bundles (see `OperationalMercha
 - Customer title and summary are **plain text** (HTML stripped, length capped).
 - Price is validated as a non-negative decimal and stored on the **variation** via Commerce `Price`.
 
+Customer booking after catalog exists: see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
+
 ## Payload contract (creation)
 
 Required keys (after forbidden-key stripping): `productisation_type`, `event_id` (must match the event being edited), `title`, `customer_summary`, `price_amount`, `currency_code`, `customer_visibility`, `fulfillment_mode`, `reservation_mode`.
@@ -67,3 +69,4 @@ Forbidden keys are stripped recursively (see `VendorOperationalProductCreationMa
 - [Operational merchandise architecture](operational-merchandise-architecture.md)
 - [Operational cart & checkout orchestration](operational-cart-checkout-orchestration.md)
 - [Customer operational Commerce experience](customer-operational-commerce-experience.md)
+- [Customer operational add-ons on booking](customer-operational-addons-booking.md)

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -1,0 +1,121 @@
+/**
+ * Customer operational add-ons on the event booking page.
+ *
+ * Mobile-first cards; coral primary CTA uses theme `.mel-btn--primary`.
+ */
+.mel-operational-addons-section {
+  margin-top: 1.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.mel-operational-addons-section__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.mel-operational-addons-form__intro {
+  margin: 0 0 1rem;
+  color: rgba(15, 23, 42, 0.72);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.mel-operational-addons-form__lines {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mel-operational-addon-card {
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.mel-operational-addon-card__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.mel-operational-addon-card__summary-text {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-operational-addon-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.mel-operational-addon-card__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(15, 23, 42, 0.08);
+}
+
+.mel-operational-addon-card__row:first-of-type {
+  margin-top: 0.35rem;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.mel-operational-addon-card__row-meta {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.mel-operational-addon-card__variation-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.mel-operational-addon-card__price {
+  margin-top: 0.2rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.88);
+}
+
+.mel-operational-addon-card__qty {
+  flex: 0 0 auto;
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.65rem;
+  font-size: 1rem;
+}
+
+.mel-operational-addons-form__actions {
+  margin-top: 1.25rem;
+}
+
+.mel-operational-addons-form__actions .mel-btn {
+  min-height: 44px;
+  min-width: 44px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.mel-operational-addons-form__actions .mel-btn--primary {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .mel-operational-addons-form__actions .mel-btn--primary {
+    width: auto;
+  }
+}

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -35,3 +35,11 @@ mel_operational_checkout:
   dependencies:
     - core/drupal
     - core/once
+
+operational_addons:
+  version: 1.0
+  css:
+    theme:
+      css/mel-operational-addons.css: {}
+  dependencies:
+    - core/drupal

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -300,6 +300,8 @@ function myeventlane_commerce_theme(): array {
         'recommended_events' => [],
         'mel_operational_purchase_composition' => NULL,
         'mel_operational_checkout' => NULL,
+        'addons_available' => FALSE,
+        'operational_addon_form' => [],
       ],
       'template' => 'myeventlane-event-book',
     ],

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -197,6 +197,13 @@ services:
       - '@string_translation'
       - '@logger.channel.myeventlane_commerce'
 
+  myeventlane_commerce.event_operational_addon_builder:
+    class: Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@string_translation'
+
   myeventlane_commerce.operational_merchandise_governance_manager:
     class: Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager
     arguments:

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -8,7 +8,9 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_rsvp\Form\RsvpPublicForm;
 use Drupal\node\NodeInterface;
@@ -33,11 +35,14 @@ final class BookController extends ControllerBase {
    *   The canonical booking flow resolver.
    * @param \Drupal\Core\Form\FormBuilderInterface $formBuilderService
    *   The form builder.
+   * @param \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder $eventOperationalAddonBuilder
+   *   Customer operational add-on read model for paid booking pages.
    */
   public function __construct(
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
     private readonly BookingFlowResolver $bookingFlowResolver,
     private readonly FormBuilderInterface $formBuilderService,
+    private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
   ) {}
 
   /**
@@ -48,6 +53,7 @@ final class BookController extends ControllerBase {
       $container->get('file_url_generator'),
       $container->get('myeventlane_event.booking_flow_resolver'),
       $container->get('form_builder'),
+      $container->get('myeventlane_commerce.event_operational_addon_builder'),
     );
   }
 
@@ -127,6 +133,8 @@ final class BookController extends ControllerBase {
       '#event_cta' => $primaryCta,
       '#event_mode' => $bookingMode,
       '#event' => $node,
+      '#addons_available' => FALSE,
+      '#operational_addon_form' => [],
       '#cache' => [
         'contexts' => ['route', 'user.roles', 'url.query_args', 'session'],
         'tags' => $node->getCacheTags(),
@@ -154,6 +162,22 @@ final class BookController extends ControllerBase {
         $build['#matrix_form'] = $this->buildUnavailable($availability);
         break;
     }
+
+    if ($isPaid) {
+      $addon_catalog = $this->eventOperationalAddonBuilder->buildForEvent($node);
+      if ($addon_catalog['addons'] !== []) {
+        $build['#addons_available'] = TRUE;
+        foreach ($addon_catalog['product_ids'] as $pid) {
+          $build['#cache']['tags'][] = 'commerce_product:' . $pid;
+        }
+        $build['#operational_addon_form'] = $this->formBuilderService->getForm(
+          EventOperationalAddonCartForm::class,
+          $node,
+        );
+      }
+    }
+
+    $build['#cache']['tags'] = array_values(array_unique($build['#cache']['tags']));
 
     return $build;
   }

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Form;
+
+use Drupal\commerce_cart\CartManagerInterface;
+use Drupal\commerce_cart\CartProviderInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Customer form: add event-linked operational add-ons to the Commerce cart.
+ */
+final class EventOperationalAddonCartForm extends FormBase {
+
+  private const UI_QTY_MAX = 10;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CartProviderInterface $cartProvider,
+    private readonly CartManagerInterface $cartManager,
+    private readonly EventOperationalAddonBuilder $addonBuilder,
+    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('commerce_cart.cart_provider'),
+      $container->get('commerce_cart.cart_manager'),
+      $container->get('myeventlane_commerce.event_operational_addon_builder'),
+      $container->get('commerce_price.currency_formatter'),
+      $container->get('logger.factory'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'myeventlane_event_operational_addon_cart_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $event = NULL): array {
+    if (!$event instanceof NodeInterface || $event->bundle() !== 'event') {
+      return $form;
+    }
+
+    $built = $this->addonBuilder->buildForEvent($event);
+    $addons = $built['addons'] ?? [];
+    if ($addons === []) {
+      return $form;
+    }
+
+    $form['#node'] = $event;
+    $form['#tree'] = TRUE;
+    $form['#attributes']['class'][] = 'mel-operational-addons-form';
+    $form['#attached']['library'][] = 'myeventlane_commerce/operational_addons';
+
+    $cache_tags = $event->getCacheTags();
+    foreach ($built['product_ids'] ?? [] as $pid) {
+      $cache_tags[] = 'commerce_product:' . $pid;
+    }
+    $form['#cache']['tags'] = array_values(array_unique($cache_tags));
+    $form['#cache']['contexts'] = ['user', 'session'];
+
+    $form['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Merch, hospitality and collection add-ons linked to this event.'),
+      '#attributes' => ['class' => ['mel-operational-addons-form__intro']],
+    ];
+
+    $form['lines'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-operational-addons-form__lines']],
+    ];
+
+    foreach ($addons as $index => $addon) {
+      if (!is_array($addon)) {
+        continue;
+      }
+      $pid = (int) ($addon['product_id'] ?? 0);
+      $title = (string) ($addon['title'] ?? '');
+      $operational = is_array($addon['operational'] ?? NULL) ? $addon['operational'] : [];
+      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+
+      $card = [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-operational-addon-card'],
+          'data-product-id' => (string) $pid,
+        ],
+      ];
+
+      $card['title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $title !== '' ? $title : $this->t('Add-on'),
+        '#attributes' => ['class' => ['mel-operational-addon-card__title']],
+      ];
+
+      if ($operational !== []) {
+        $card['summary'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__summary']],
+        ];
+        $summary_text = trim((string) ($operational['operational_summary'] ?? ''));
+        if ($summary_text !== '') {
+          $card['summary']['text'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $summary_text,
+            '#attributes' => ['class' => ['mel-operational-addon-card__summary-text']],
+          ];
+        }
+        $chips = is_array($operational['operational_chips'] ?? NULL) ? $operational['operational_chips'] : [];
+        if ($chips !== []) {
+          $card['summary']['chips'] = [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['mel-operational-addon-card__chips']],
+          ];
+          foreach ($chips as $chip) {
+            if (!is_array($chip)) {
+              continue;
+            }
+            $label = trim((string) ($chip['label'] ?? ''));
+            if ($label === '') {
+              continue;
+            }
+            $tone = $this->chipToneClass((string) ($chip['tone'] ?? 'muted'));
+            $card['summary']['chips'][] = [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $label,
+              '#attributes' => [
+                'class' => [
+                  'mel-pill',
+                  'mel-pill--operational',
+                  'mel-pill--tone-' . $tone,
+                ],
+              ],
+            ];
+          }
+        }
+      }
+
+      $card['variations'] = [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-operational-addon-card__variations']],
+      ];
+
+      foreach ($variations as $v) {
+        if (!is_array($v)) {
+          continue;
+        }
+        $vid = (int) ($v['variation_id'] ?? 0);
+        if ($vid < 1) {
+          continue;
+        }
+        $v_label = (string) ($v['label'] ?? '');
+        $price_number = (string) ($v['price_number'] ?? '');
+        $currency = (string) ($v['price_currency_code'] ?? '');
+        $price_display = '';
+        if ($price_number !== '' && $currency !== '') {
+          $price_display = $this->currencyFormatter->format($price_number, $currency);
+        }
+
+        $row = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__row']],
+        ];
+        $row['meta'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__row-meta']],
+        ];
+        $row['meta']['variation_title'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#value' => $v_label !== '' ? $v_label : $this->t('Option'),
+          '#attributes' => ['class' => ['mel-operational-addon-card__variation-title']],
+        ];
+        if ($price_display !== '') {
+          $row['meta']['price'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'div',
+            '#value' => $price_display,
+            '#attributes' => ['class' => ['mel-operational-addon-card__price']],
+          ];
+        }
+
+        $row['qty'] = [
+          '#type' => 'number',
+          '#title' => $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $this->t('this option')]),
+          '#title_display' => 'invisible',
+          '#min' => 0,
+          '#max' => self::UI_QTY_MAX,
+          '#step' => 1,
+          '#default_value' => 0,
+          '#attributes' => [
+            'class' => ['mel-operational-addon-card__qty'],
+            'inputmode' => 'numeric',
+            'aria-label' => (string) $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $title]),
+          ],
+        ];
+
+        $card['variations'][$vid] = $row;
+      }
+
+      $form['lines'][$index] = $card;
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#attributes' => ['class' => ['mel-operational-addons-form__actions']],
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add extras to cart'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-btn--xl']],
+    ];
+
+    return $form;
+  }
+
+  private function chipToneClass(string $tone): string {
+    $tone = strtolower(trim($tone));
+    return preg_match('/^[a-z0-9_-]{1,32}$/', $tone) ? $tone : 'muted';
+  }
+
+  /**
+   * @param list<array<string, mixed>> $addons
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function buildAllowlistFromAddons(array $addons): array {
+    $map = [];
+    foreach ($addons as $addon) {
+      if (!is_array($addon)) {
+        continue;
+      }
+      $product_id = (int) ($addon['product_id'] ?? 0);
+      $bundle = (string) ($addon['bundle'] ?? '');
+      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+      foreach ($variations as $v) {
+        if (!is_array($v)) {
+          continue;
+        }
+        $vid = (int) ($v['variation_id'] ?? 0);
+        if ($vid < 1) {
+          continue;
+        }
+        $map[$vid] = [
+          'product_id' => $product_id,
+          'bundle' => $bundle,
+        ];
+      }
+    }
+    return $map;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $event = $form['#node'] ?? NULL;
+    if (!$event instanceof NodeInterface) {
+      $form_state->setErrorByName('lines', $this->t('This form is no longer valid. Please refresh the page.'));
+      return;
+    }
+
+    $fresh = $this->addonBuilder->buildForEvent($event);
+    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+
+    $lines = $form_state->getValue('lines');
+    if (!is_array($lines)) {
+      return;
+    }
+
+    foreach ($lines as $line) {
+      if (!is_array($line)) {
+        continue;
+      }
+      $variations = $line['variations'] ?? NULL;
+      if (!is_array($variations)) {
+        continue;
+      }
+      foreach ($variations as $vid_key => $row) {
+        $vid = (int) $vid_key;
+        if ($vid < 1) {
+          $this->loggerFactory->get('myeventlane_commerce')->warning('Operational add-on submit ignored malformed variation key @key.', ['@key' => (string) $vid_key]);
+          $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));
+          return;
+        }
+        if (!isset($allowlist[$vid])) {
+          $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on validation rejected variation @vid for event @eid (not allowlisted).', [
+            '@vid' => (string) $vid,
+            '@eid' => (string) $event->id(),
+          ]);
+          $form_state->setErrorByName('lines', $this->t('One or more selected add-ons are not available for this event.'));
+          return;
+        }
+        if (!is_array($row)) {
+          continue;
+        }
+        $qty = (int) ($row['qty'] ?? 0);
+        if ($qty < 0) {
+          $form_state->setErrorByName('lines', $this->t('Quantities cannot be negative.'));
+          return;
+        }
+        if ($qty > self::UI_QTY_MAX) {
+          $form_state->setErrorByName('lines', $this->t('Please choose a smaller quantity for add-ons.'));
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $event = $form['#node'] ?? NULL;
+    if (!$event instanceof NodeInterface) {
+      return;
+    }
+
+    $fresh = $this->addonBuilder->buildForEvent($event);
+    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+
+    $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
+
+    $lines = $form_state->getValue('lines');
+    if (!is_array($lines)) {
+      return;
+    }
+
+    $to_add = [];
+    foreach ($lines as $line) {
+      if (!is_array($line)) {
+        continue;
+      }
+      $variations = $line['variations'] ?? NULL;
+      if (!is_array($variations)) {
+        continue;
+      }
+      foreach ($variations as $vid => $row) {
+        $vid = (int) $vid;
+        if ($vid < 1 || !is_array($row)) {
+          continue;
+        }
+        $qty = (int) ($row['qty'] ?? 0);
+        if ($qty < 1) {
+          continue;
+        }
+        if (!isset($allowlist[$vid])) {
+          $this->messenger()->addError($this->t('Add-ons could not be updated. Please refresh the page.'));
+          $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit aborted: variation @vid not allowlisted post-validate.', ['@vid' => (string) $vid]);
+          return;
+        }
+        $to_add[$vid] = $qty;
+      }
+    }
+
+    if ($to_add === []) {
+      $this->messenger()->addStatus($this->t('Choose a quantity greater than zero to add extras.'));
+      return;
+    }
+
+    foreach ($to_add as $variation_id => $quantity) {
+      /** @var \Drupal\commerce_product\Entity\ProductVariationInterface|null $variation */
+      $variation = $variation_storage->load($variation_id);
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
+        return;
+      }
+
+      $product = $variation->getProduct();
+      if (!$product instanceof ProductInterface) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        return;
+      }
+
+      if (!$product->isPublished()) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        return;
+      }
+
+      if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected bundle @bundle for variation @vid.', [
+          '@bundle' => $product->bundle(),
+          '@vid' => (string) $variation_id,
+        ]);
+        return;
+      }
+
+      if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()
+        || (int) $product->get('field_event')->target_id !== (int) $event->id()) {
+        $this->messenger()->addError($this->t('An add-on is not linked to this event.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected event mismatch for product @pid.', ['@pid' => (string) $product->id()]);
+        return;
+      }
+
+      $expected_pid = (int) ($allowlist[$variation_id]['product_id'] ?? 0);
+      if ($expected_pid > 0 && (int) $product->id() !== $expected_pid) {
+        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
+        return;
+      }
+
+      $stores = $product->getStores();
+      if ($stores === []) {
+        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
+        $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit failed: product @pid has no stores.', ['@pid' => (string) $product->id()]);
+        return;
+      }
+      $store = reset($stores);
+      if (!$store) {
+        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
+        return;
+      }
+
+      $cart = $this->cartProvider->getCart('default', $store)
+        ?: $this->cartProvider->createCart('default', $store);
+
+      $order_item = $this->cartManager->addEntity($cart, $variation, $quantity, TRUE);
+      if ($order_item && $order_item->hasField('field_target_event')) {
+        $order_item->set('field_target_event', ['target_id' => $event->id()]);
+        $order_item->save();
+      }
+    }
+
+    $this->messenger()->addStatus($this->t('Add-ons added to your booking.'));
+    $form_state->setRedirectUrl(Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event->id()]));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Customer read model: operational Commerce products linked to an event.
+ *
+ * Commerce owns carts, pricing, and inventory. This service returns only
+ * render-safe metadata for booking-page add-on selection.
+ */
+final class EventOperationalAddonBuilder {
+
+  use StringTranslationTrait;
+
+  /**
+   * Keys that must never appear in customer-facing add-on payloads.
+   *
+   * @var list<string>
+   */
+  public const FORBIDDEN_CUSTOMER_ADDON_KEYS = [
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_secret',
+    'scanner_tokens',
+    'device_fingerprint',
+    'payload_sha256',
+    'inventory_quantity',
+    'stock_count',
+    'stock_level',
+    'warehouse_ids',
+    'shipment_provider',
+    'shipment_state',
+    'private_notes',
+    'internal_cost',
+    'vendor_margin',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds add-on rows for every eligible operational product on the event.
+   *
+   * @return array{addons: list<array<string, mixed>>, product_ids: list<int>}
+   *   Render-safe add-on rows plus product IDs for cache tagging (internal).
+   */
+  public function buildForEvent(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    if ($event_id < 1) {
+      return ['addons' => [], 'product_ids' => []];
+    }
+
+    $storage = $this->entityTypeManager->getStorage('commerce_product');
+    $ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, 'IN')
+      ->condition('field_event', $event_id)
+      ->condition('status', 1)
+      ->sort('title', 'ASC')
+      ->execute();
+
+    if (!$ids) {
+      return ['addons' => [], 'product_ids' => []];
+    }
+
+    /** @var \Drupal\commerce_product\Entity\ProductInterface[] $products */
+    $products = $storage->loadMultiple($ids);
+    $addons = [];
+    $product_ids = [];
+
+    foreach ($products as $product) {
+      if (!$product instanceof ProductInterface) {
+        continue;
+      }
+      if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+        continue;
+      }
+      if (!$product->isPublished()) {
+        continue;
+      }
+      if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()) {
+        continue;
+      }
+      if ((int) $product->get('field_event')->target_id !== $event_id) {
+        continue;
+      }
+
+      $variations = [];
+      foreach ($product->getVariations() as $variation) {
+        if (!$variation instanceof ProductVariationInterface) {
+          continue;
+        }
+        if (!$variation->isPublished()) {
+          continue;
+        }
+        $price = $variation->getPrice();
+        $variations[] = [
+          'variation_id' => (int) $variation->id(),
+          'label' => (string) $variation->label(),
+          'price_number' => $price ? (string) $price->getNumber() : '',
+          'price_currency_code' => $price ? (string) $price->getCurrencyCode() : '',
+        ];
+      }
+
+      if ($variations === []) {
+        continue;
+      }
+
+      $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+      $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+
+      $row = $this->sanitizeAddon([
+        'product_id' => (int) $product->id(),
+        'bundle' => $product->bundle(),
+        'title' => (string) $product->label(),
+        'variations' => $variations,
+        'operational' => $presentation,
+      ]);
+
+      $addons[] = $row;
+      $product_ids[] = (int) $product->id();
+    }
+
+    return [
+      'addons' => $addons,
+      'product_ids' => $product_ids,
+    ];
+  }
+
+  public function hasAddons(NodeInterface $event): bool {
+    return $this->buildForEvent($event)['addons'] !== [];
+  }
+
+  /**
+   * @param array<string, mixed> $addon
+   *
+   * @return array<string, mixed>
+   */
+  public function sanitizeAddon(array $addon): array {
+    return $this->stripForbiddenKeysRecursive($addon);
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  private function stripForbiddenKeysRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenKeysRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_CUSTOMER_ADDON_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenKeysRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -118,6 +118,13 @@
               {% endif %}
             </div>
           </div>
+
+          {% if addons_available and operational_addon_form %}
+            <section class="mel-operational-addons-section" aria-labelledby="mel-operational-addons-title">
+              <h2 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ 'Add something extra'|t }}</h2>
+              {{ operational_addon_form }}
+            </section>
+          {% endif %}
         </div>
 
         {% if event_mode == 'paid' %}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -330,6 +330,104 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $this->assertSame('elevated', $doc['governance']['severity']);
   }
 
+  public function testEventOperationalAddonBuilderReturnsLinkedOperationalProducts(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-K1');
+    $product->set('field_mel_operational_product', json_encode([
+      'operational_product_type' => 'merch_pickup',
+      'operational_summary' => 'Pick up at desk',
+      'inventory_quantity' => 50,
+      'qr_payload' => 'nope',
+      'operational_chips' => [
+        ['label' => 'After entry', 'tone' => 'info'],
+      ],
+    ], JSON_THROW_ON_ERROR));
+    $product->save();
+
+    $builder = new \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertNotSame([], $built['addons']);
+    $first = $built['addons'][0];
+    $this->assertSame((int) $product->id(), (int) ($first['product_id'] ?? 0));
+    $this->assertArrayHasKey('operational', $first);
+    $this->assertArrayNotHasKey('inventory_quantity', $first['operational']);
+    $this->assertArrayNotHasKey('qr_payload', $first['operational']);
+    $this->assertSame('Pick up at desk', $first['operational']['operational_summary']);
+    $this->assertNotEmpty($first['variations']);
+  }
+
+  public function testEventOperationalAddonBuilderExcludesUnpublishedProduct(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-OFF');
+    $product->set('status', 0);
+    $product->save();
+
+    $builder = new \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderExcludesUnpublishedVariation(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-VAROFF');
+    foreach ($product->getVariations() as $variation) {
+      $variation->set('status', 0);
+      $variation->save();
+    }
+    $product->save();
+
+    $builder = new \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderEmptyWhenWrongEvent(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-OTHER');
+    $other = Node::create([
+      'type' => 'event',
+      'title' => 'Other event',
+      'uid' => $this->event->getOwnerId(),
+      'status' => 1,
+    ]);
+    $other->save();
+    $product->set('field_event', ['target_id' => $other->id()]);
+    $product->set('status', 1);
+    $product->save();
+
+    $builder = new \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderHasAddonsFalseWhenNoProducts(): void {
+    $empty_event = Node::create([
+      'type' => 'event',
+      'title' => 'No merch',
+      'uid' => $this->event->getOwnerId(),
+      'status' => 1,
+    ]);
+    $empty_event->save();
+    $builder = new \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $this->assertFalse($builder->hasAddons($empty_event));
+  }
+
   protected function merchandiseManager(): OperationalMerchandiseManager {
     return new OperationalMerchandiseManager(
       $this->container->get('entity_type.manager'),

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class EventOperationalAddonBuilderTest extends UnitTestCase {
+
+  private function builder(): EventOperationalAddonBuilder {
+    $etm = $this->createMock(\Drupal\Core\Entity\EntityTypeManagerInterface::class);
+    $logger = $this->createMock(LoggerInterface::class);
+    $merch = new OperationalMerchandiseManager(
+      $etm,
+      $this->getStringTranslationStub(),
+      $logger,
+    );
+    return new EventOperationalAddonBuilder(
+      $etm,
+      $merch,
+      $this->getStringTranslationStub(),
+    );
+  }
+
+  public function testSanitizeAddonStripsForbiddenKeys(): void {
+    $dirty = [
+      'title' => 'Tee',
+      'qr_payload' => 'secret',
+      'nested' => [
+        'scanner_secret' => 'x',
+        'ok' => 1,
+      ],
+    ];
+    $clean = $this->builder()->sanitizeAddon($dirty);
+    $this->assertSame('Tee', $clean['title']);
+    $this->assertArrayNotHasKey('qr_payload', $clean);
+    $this->assertArrayNotHasKey('scanner_secret', $clean['nested']);
+    $this->assertSame(1, $clean['nested']['ok']);
+  }
+
+  public function testSanitizeAddonStripsStockAndWarehouseKeys(): void {
+    $dirty = [
+      'stock_count' => 5,
+      'warehouse_ids' => [1],
+      'vendor_margin' => '10',
+    ];
+    $clean = $this->builder()->sanitizeAddon($dirty);
+    $this->assertSame([], $clean);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Form;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
 use Drupal\Core\Form\FormBase;
@@ -40,6 +41,7 @@ final class EventStudioProductisationForm extends FormBase {
     private readonly LoggerInterface $logger,
     private readonly VendorOperationalProductCreationManager $vendorOperationalProductCreationManager,
     private readonly OperationalCapabilityCommerceLinkManager $operationalCapabilityCommerceLinkManager,
+    private readonly Connection $database,
   ) {}
 
   public static function create(ContainerInterface $container): static {
@@ -54,6 +56,7 @@ final class EventStudioProductisationForm extends FormBase {
       $container->get('logger.factory')->get('myeventlane_event_studio'),
       $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
       $container->get('myeventlane_event_studio.operational_capability_commerce_link_manager'),
+      $container->get('database'),
     );
   }
 
@@ -178,7 +181,7 @@ final class EventStudioProductisationForm extends FormBase {
     $rawTypes = (array) ($form_state->getValue(['mel', 'productisation', 'types']) ?? []);
     foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $type) {
       $row = is_array($rawTypes[$type] ?? NULL) ? $rawTypes[$type] : [];
-      $row = $this->flattenProductisationWizardRow($row);
+      $row = $this->vendorOperationalProductCreationManager->flattenProductisationWizardFormRow($row);
       if ((string) ($row['commerce_mode'] ?? 'link') !== 'create') {
         continue;
       }
@@ -198,6 +201,7 @@ final class EventStudioProductisationForm extends FormBase {
       $this->messenger()->addError($this->t('The event could not be loaded.'));
       return;
     }
+    $transaction = $this->database->startTransaction();
     try {
       $base = $this->capabilityStudioManager->extractFromEvent($event);
       $rawTypes = (array) ($form_state->getValue(['mel', 'productisation', 'types']) ?? []);
@@ -205,7 +209,7 @@ final class EventStudioProductisationForm extends FormBase {
       $flatTypes = [];
       foreach (VendorProductisationStudioManager::PRODUCTISATION_TYPES as $ptype) {
         $r = is_array($rawTypes[$ptype] ?? NULL) ? $rawTypes[$ptype] : [];
-        $flatTypes[$ptype] = $this->flattenProductisationWizardRow($r);
+        $flatTypes[$ptype] = $this->vendorOperationalProductCreationManager->flattenProductisationWizardFormRow($r);
       }
       $items = $this->vendorOperationalProductCreationManager->applyProductisationWizardCreates(
         $this->currentUser(),
@@ -224,9 +228,11 @@ final class EventStudioProductisationForm extends FormBase {
       $this->messenger()->addStatus($this->t('Productisation saved.'));
     }
     catch (\InvalidArgumentException $e) {
+      $transaction->rollBack();
       $this->messenger()->addError($e->getMessage());
     }
     catch (\Throwable $e) {
+      $transaction->rollBack();
       $this->logger->error('Vendor productisation save failed for event @nid: @message', [
         '@nid' => (string) $event->id(),
         '@message' => $e->getMessage(),
@@ -417,7 +423,7 @@ final class EventStudioProductisationForm extends FormBase {
         'link' => $this->t('Link existing product'),
         'create' => $this->t('Create new operational product'),
       ],
-      '#default_value' => $product_id > 0 ? 'link' : 'link',
+      '#default_value' => $product_id > 0 ? 'link' : 'create',
       '#attributes' => ['class' => ['mel-productisation-wizard-mode']],
     ];
 
@@ -562,19 +568,6 @@ final class EventStudioProductisationForm extends FormBase {
   }
 
   /**
-   * Merges nested wizard containers into a flat row for mapping and validation.
-   *
-   * @param array<string, mixed> $row
-   *
-   * @return array<string, mixed>
-   */
-  private function flattenProductisationWizardRow(array $row): array {
-    $link = is_array($row['wizard_link'] ?? NULL) ? $row['wizard_link'] : [];
-    $create = is_array($row['wizard_create'] ?? NULL) ? $row['wizard_create'] : [];
-    return array_merge($row, $link, $create);
-  }
-
-  /**
    * @param list<string>|mixed $keys
    *
    * @return array<string, string>
@@ -636,7 +629,7 @@ final class EventStudioProductisationForm extends FormBase {
    * @return array<string, mixed>
    */
   private function mapRowToItem(string $type, array $row): array {
-    $row = $this->flattenProductisationWizardRow($row);
+    $row = $this->vendorOperationalProductCreationManager->flattenProductisationWizardFormRow($row);
     $base = $this->vendorProductisationManager->emptyItem($type);
     $product_id = $this->extractCommerceProductIdFromFormRow($row);
     $mode = (string) ($row['commerce_linkage_mode'] ?? OperationalCapabilityCommerceLinkManager::LINKAGE_PRODUCT);
@@ -703,7 +696,7 @@ final class EventStudioProductisationForm extends FormBase {
    * @param array<string, mixed> $row
    */
   private function extractCommerceProductIdFromFormRow(array $row): int {
-    $row = $this->flattenProductisationWizardRow($row);
+    $row = $this->vendorOperationalProductCreationManager->flattenProductisationWizardFormRow($row);
     $n = (int) ($row['commerce_product_id'] ?? 0);
     if ($n > 0) {
       return $n;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -225,7 +225,7 @@ final class VendorOperationalProductCreationManager {
       if (!isset($items[$idx]) || !is_array($items[$idx])) {
         continue;
       }
-      $row = $this->flattenWizardFormRow(is_array($wizardRowsByType[$type] ?? NULL) ? $wizardRowsByType[$type] : []);
+      $row = $this->flattenProductisationWizardFormRow(is_array($wizardRowsByType[$type] ?? NULL) ? $wizardRowsByType[$type] : []);
       if ((string) ($row['commerce_mode'] ?? 'link') !== 'create') {
         continue;
       }
@@ -247,7 +247,7 @@ final class VendorOperationalProductCreationManager {
    * @return array<string, mixed>
    */
   public function buildWizardCreationPayload(string $productisation_type, array $row, NodeInterface $event): array {
-    $row = $this->flattenWizardFormRow($row);
+    $row = $this->flattenProductisationWizardFormRow($row);
     $type = $this->normalizeProductisationType($productisation_type);
     if ($type === '') {
       $type = VendorProductisationStudioManager::TYPE_MERCHANDISE;
@@ -330,7 +330,7 @@ final class VendorOperationalProductCreationManager {
    * @param array<string, mixed> $row
    */
   private function extractWizardCommerceProductId(array $row): int {
-    $row = $this->flattenWizardFormRow($row);
+    $row = $this->flattenProductisationWizardFormRow($row);
     $n = (int) ($row['commerce_product_id'] ?? 0);
     if ($n > 0) {
       return $n;
@@ -343,11 +343,13 @@ final class VendorOperationalProductCreationManager {
   }
 
   /**
+   * Merges nested wizard_link / wizard_create containers into one row for validation and create.
+   *
    * @param array<string, mixed> $row
    *
    * @return array<string, mixed>
    */
-  private function flattenWizardFormRow(array $row): array {
+  public function flattenProductisationWizardFormRow(array $row): array {
     $link = is_array($row['wizard_link'] ?? NULL) ? $row['wizard_link'] : [];
     $create = is_array($row['wizard_create'] ?? NULL) ? $row['wizard_create'] : [];
     return array_merge($row, $link, $create);


### PR DESCRIPTION
Paid event booking (`/event/{node}/book`, `BookController`) embeds a **read-only** catalog slice built by `myeventlane_commerce.event_operational_addon_builder` (`EventOperationalAddonBuilder`) and a **Commerce cart** form `EventOperationalAddonCartForm`. **Drupal Commerce** remains authoritative for carts, checkout, order items, pricing, stores, and order state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new customer-facing add-to-cart flow on the paid booking page and touches Commerce cart/order-item creation logic, which can affect purchasing behavior and cache tagging. Also changes Event Studio productisation submission defaults and wraps saves in a DB transaction, which could impact vendor authoring if rollback behavior differs.
> 
> **Overview**
> Paid event booking now optionally renders an **“Add something extra”** section that lets customers add event-linked *operational* Commerce products to their cart. This introduces `EventOperationalAddonBuilder` (read-only catalog slice filtered by `field_event`, published status, and published variations with forbidden-key stripping) and a new `EventOperationalAddonCartForm` that validates submitted variation IDs against a fresh allowlist and adds quantities to the appropriate store cart via `CartManagerInterface::addEntity()`.
> 
> Adds theming support via a new `operational_addons` library + CSS, wires the form into `BookController`/`myeventlane-event-book.html.twig` with cache tags for referenced products, and adds unit/kernel coverage for the builder’s filtering/sanitization behavior.
> 
> Separately, Event Studio productisation fixes wizard handling by moving row-flattening into `VendorOperationalProductCreationManager`, defaulting new rows to **create** mode when no product is linked, and wrapping submit processing in a DB transaction with explicit rollbacks on errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2f3ae3273da8c2ed872914e4add43cca873635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->