### PR TITLE
Feature/operational addons mvp hardening

### DIFF
--- a/docs/customer-operational-addon-confirmation-guidance.md
+++ b/docs/customer-operational-addon-confirmation-guidance.md
@@ -1,0 +1,67 @@
+# Customer operational add-on confirmation guidance (Phase 4F Commit 2)
+
+## Architecture
+
+Read-only **presentation** layer: customers who purchased operational Commerce add-ons see a compact **“Your add-ons”** strip on checkout completion, My Tickets, booking detail, and the Commerce order user view. **Drupal Commerce** remains authoritative for carts, orders, prices, checkout state, and inventory.
+
+- **Service:** `myeventlane_commerce.operational_addon_guidance_builder` → `OperationalAddonGuidanceBuilder`.
+- **Inputs:** `mel_operational_purchase_composition` document from `OperationalPurchaseCompositionManager::composeForOrder()` (and optionally the `mel_operational_checkout` contract array for extra deterministic guidance sentences).
+- **No** second line classifier, **no** new order-item storage, **no** checkout panes, **no** checkout mutation, **no** stock decrement, **no** warehouse/shipping orchestration, **no** scanner or QR payload changes, **no** entitlement issuance.
+
+## Reused services
+
+| Component | Role |
+| --- | --- |
+| `OperationalPurchaseCompositionManager` | Single grouping + customer-safe line payloads (`composeForOrder`, `buildOrderRenderArrayFromDocument`). |
+| `OperationalCheckoutOrchestrationManager` | `buildOrderRenderArrayFromComposition()` / `buildCheckoutContractFromComposition()` reuse the same `finalizeContractFromComposition` path as cart/checkout strips. |
+| `OperationalAddonGuidanceBuilder` | Maps composition (+ optional checkout contract) into a small customer document; strips forbidden keys recursively. |
+
+## Theme integration
+
+| Surface | Integration |
+| --- | --- |
+| **Checkout completion** | `myeventlane_theme_preprocess_commerce_checkout_form()` → `_myeventlane_theme_attach_operational_addon_guidance()`; variable `operational_addon_guidance` rendered in `commerce-checkout-completion.html.twig` after event/ticket summary and before donation / “what’s next”. |
+| **My Tickets** | `myeventlane_theme_preprocess_myeventlane_my_tickets()` sets `order_data.operational_addon_guidance` via `_myeventlane_theme_mel_operational_addon_guidance_for_order()`. |
+| **Order detail** | `myeventlane_theme_preprocess_myeventlane_order_detail()` → `_myeventlane_theme_attach_operational_addon_guidance()`. |
+| **Commerce order (user)** | `myeventlane_theme_preprocess_commerce_order()` → same attach helper. |
+
+Request-local caching: `_myeventlane_theme_mel_operational_composition_document()` and `_myeventlane_theme_mel_operational_checkout_render_for_order()` avoid duplicate `composeForOrder` / orchestration work per order in a single request.
+
+## Customer-visible output
+
+- Hook `mel_operational_addon_guidance`, template `mel-operational-addon-guidance.html.twig`, library `myeventlane_commerce/operational_addon_guidance`.
+- Friendly copy: “Your add-ons”, “Collect at the event”, “Show your order confirmation if asked”, “Hospitality access is linked to this booking”, plus a muted note that **shipping** and **QR wallet collection** are **not** shown here yet.
+- If the order has **only** tickets (no operational product groups), the strip is omitted.
+
+## Deliberately not implemented
+
+- Shipping labels, tracking, warehouse routing, stock reservation messaging beyond Commerce.
+- QR wallet / scanner redemption flows.
+- Staff or vendor dashboards; this is customer-safe copy only.
+
+## Manual QA checklist
+
+- [ ] Order with **tickets only**: no add-on strip on completion, My Tickets, order detail, or `commerce_order` user view.
+- [ ] Order with **operational merch** (and/or hospitality / timed / bundles / parking): strip appears once per surface; no raw JSON or internal keys.
+- [ ] Completion page: strip sits **after** event/ticket summary and **before** “What’s next” / organiser trust blocks.
+- [ ] Mobile: readable spacing, chips wrap, no horizontal overflow.
+- [ ] Cache rebuild after deploy: `ddev drush cr` (or equivalent).
+
+## Automated tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php --do-not-cache-result
+```
+
+Kernel coverage for orchestration/composition is unchanged; optional regression:
+
+```bash
+ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalCheckoutOrchestrationManagerTest.php --do-not-cache-result'
+```
+
+## Related documentation
+
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
+- [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)

--- a/docs/customer-operational-addon-confirmation-guidance.md
+++ b/docs/customer-operational-addon-confirmation-guidance.md
@@ -65,3 +65,4 @@ ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && .
 - [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
 - [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
 - [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)

--- a/docs/customer-operational-addons-booking.md
+++ b/docs/customer-operational-addons-booking.md
@@ -72,3 +72,4 @@ ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && .
 - [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
 - [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
 - [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)
+- [operational-addons-mvp-qa.md](./operational-addons-mvp-qa.md)

--- a/docs/customer-operational-addons-booking.md
+++ b/docs/customer-operational-addons-booking.md
@@ -1,0 +1,72 @@
+# Customer operational add-ons on event booking (Phase 4F)
+
+## Architecture
+
+Paid event booking (`/event/{node}/book`, `BookController`) embeds a **read-only** catalog slice built by `myeventlane_commerce.event_operational_addon_builder` (`EventOperationalAddonBuilder`) and a **Commerce cart** form `EventOperationalAddonCartForm`. **Drupal Commerce** remains authoritative for carts, checkout, order items, pricing, stores, and order state.
+
+- **No** parallel cart system, **no** manual stock decrement, **no** warehouse or shipping orchestration, **no** QR/scanner/entitlement mutations from this layer.
+- Add-to-cart uses `commerce_cart.cart_provider` and `commerce_cart.cart_manager` (`addEntity()`), mirroring ticket selection patterns.
+
+## Services
+
+| ID | Class | Role |
+| --- | --- | --- |
+| `myeventlane_commerce.event_operational_addon_builder` | `EventOperationalAddonBuilder` | Entity query for operational product bundles with `field_event` = event, published products, published variations; customer-safe operational copy via `OperationalMerchandiseManager`. |
+| `myeventlane_commerce.operational_merchandise_manager` | `OperationalMerchandiseManager` | Reused for normalization + `buildCustomerSafeProductPresentation()` (existing contract). |
+
+Form dependencies (constructor / `create()`): `entity_type.manager`, `commerce_cart.cart_provider`, `commerce_cart.cart_manager`, `event_operational_addon_builder`, `commerce_price.currency_formatter`, `logger.factory`.
+
+## Customer flow
+
+1. Customer opens the paid event book page.
+2. If at least one eligible operational product exists for the event, the **“Add something extra”** section renders below the ticket matrix (same main column).
+3. Customer sets quantities (0–10 UI cap; **not** inventory enforcement unless Commerce stock modules apply their own rules elsewhere).
+4. Submit calls `CartManagerInterface::addEntity()` per line with `combine = TRUE`, resolves store from the product’s Commerce stores (first store), sets `field_target_event` on new order items when present (same presave contract as tickets).
+5. Redirect returns to the same event book route with a status message; cart/checkout CTAs elsewhere are unchanged.
+
+## Security checks
+
+- Submitted variation IDs are validated against a **fresh allowlist** from `EventOperationalAddonBuilder::buildForEvent()` (no trust in hidden defaults for linkage).
+- Product must be **published**, bundle ∈ `OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES`, `field_event` must match the event node, variation must be **published**, product must expose at least one Commerce store.
+- Customer payloads strip forbidden keys (see `EventOperationalAddonBuilder::FORBIDDEN_CUSTOMER_ADDON_KEYS`) in addition to `OperationalMerchandiseManager` normalization.
+
+## Deliberately not implemented
+
+- Stock reservation, warehouse routing, shipment creation, scanner/QR mutation, entitlement issuance, checkout pane changes, multi-step checkout redirects from this form, and “hard” per-line inventory caps (UI cap only).
+
+## Theming
+
+- Library: `myeventlane_commerce/operational_addons` → `css/mel-operational-addons.css`.
+- Submit uses existing `mel-btn mel-btn--primary` classes for coral CTA consistency with the theme.
+
+## Tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php --do-not-cache-result
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php --filter EventOperationalAddonBuilder --do-not-cache-result
+```
+
+Kernel tests live in `OperationalMerchandiseKernelTest` (shared Commerce fixtures). If `SIMPLETEST_DB` is required in your environment:
+
+```bash
+ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php --filter EventOperationalAddonBuilder --do-not-cache-result'
+```
+
+**Cart form automated tests:** Full Commerce cart kernel coverage is not included here (heavy fixture surface). Manual QA covers add-to-cart, invalid variation rejection, and multi-store behaviour.
+
+## Manual QA checklist
+
+- [ ] Paid event **without** operational products: add-on section **hidden**; booking otherwise normal.
+- [ ] Paid event **with** linked operational product(s): section shows title, summary/chips, price, quantity; submit with all zeros shows neutral status.
+- [ ] Submit quantity > 0: items appear in Commerce cart; `field_target_event` populated when configured.
+- [ ] Unpublished product or variation: disappears from list after change (cache rebuild / refresh).
+- [ ] Product linked to **different** event: never listed.
+- [ ] Tampered POST (invalid variation id): validation error, nothing added to cart.
+- [ ] Mixed ticket + add-on: both land in appropriate Commerce carts per store rules.
+
+## Related documentation
+
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
+- [vendor-product-creation-wizard.md](./vendor-product-creation-wizard.md)
+- [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)

--- a/docs/customer-operational-addons-booking.md
+++ b/docs/customer-operational-addons-booking.md
@@ -71,3 +71,4 @@ ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && .
 - [vendor-product-creation-wizard.md](./vendor-product-creation-wizard.md)
 - [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
 - [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)

--- a/docs/customer-operational-addons-booking.md
+++ b/docs/customer-operational-addons-booking.md
@@ -70,3 +70,4 @@ ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && .
 - [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
 - [vendor-product-creation-wizard.md](./vendor-product-creation-wizard.md)
 - [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
+- [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)

--- a/docs/operational-addons-mvp-qa.md
+++ b/docs/operational-addons-mvp-qa.md
@@ -78,6 +78,7 @@ ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && .
 
 ## Related documentation
 
+- [operational-addons-staging-qa.md](./operational-addons-staging-qa.md) — staging deploy and browser QA checklist
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
 - [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
 - [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)

--- a/docs/operational-addons-mvp-qa.md
+++ b/docs/operational-addons-mvp-qa.md
@@ -1,0 +1,84 @@
+# Operational add-ons MVP — manual QA script
+
+End-to-end checks for Phase 4F (vendor catalog → customer booking → post-purchase guidance → vendor order visibility). **Read-only / presentation only** — no fulfilment mutation, stock, shipping, scanners, or QR.
+
+## Prerequisites
+
+- Local site via DDEV (`ddev drush cr` after deploy).
+- Vendor user with event workspace access and at least one paid event.
+- Stripe/test checkout enabled for ticket purchases.
+
+## A. Setup
+
+1. Create or open a **paid** event with a published ticket product (`field_product_target`).
+2. In Event Studio (or Commerce admin), **create/link** an operational product:
+   - Bundle ∈ operational types (`operational_merchandise`, `hospitality_package`, `timed_collection_product`, `operational_bundle`, or parking type per site config).
+   - `field_event` = this event.
+   - At least one **published** variation with price.
+   - Product assigned to a **Commerce store** (required — products without stores must not appear on the book page).
+3. Publish product and variation.
+
+## B. Customer booking
+
+1. Visit `/event/{nid}/book` as an anonymous or customer account.
+2. Confirm **“Add something extra”** section appears below tickets with lede copy about collecting at the event.
+3. Add ticket(s) to cart; add at least one add-on quantity &gt; 0; submit **Add extras to cart**.
+4. Complete checkout (test card).
+5. Confirm add-on line items appear in cart/checkout with correct event linkage (`field_target_event` when configured).
+
+## C. Customer post-purchase
+
+For the completed order:
+
+1. **Checkout completion** — “Your add-ons” guidance strip when order includes operational lines; absent for tickets-only orders.
+2. **My Tickets** — same guidance on the order card.
+3. **Order detail** (`myeventlane_order_detail` or equivalent) — guidance present.
+4. **Commerce order user view** (`/user/{uid}/orders/{order}`) — guidance present.
+5. Guidance must **not** show QR payloads, scanner language, warehouse/shipping promises, or stock guarantees (support hint may note shipping/QR are not shown yet).
+
+## D. Vendor visibility
+
+1. Log in as **event owner** or vendor team member linked via `field_event_vendor` → `field_vendor_users`.
+2. Open event workspace `/vendor/events/{event}`.
+3. Confirm shortcut **“View add-on orders”** when catalog exists or purchases exist.
+4. Open `/vendor/events/{event}/addons`.
+5. Confirm summary counts, order cards, grouped lines (merch/hospitality/timed/bundles/parking), chips, prepare hint.
+6. Customer label shows **display name** or **Customer #id** or **Guest customer** — not raw email on this page.
+7. Log in as **unrelated** authenticated user → route forbidden.
+8. **Anonymous** → denied (vendor console gate).
+
+## E. Negative cases
+
+| Case | Expected |
+| --- | --- |
+| Tickets-only order | No add-on guidance strip on customer surfaces |
+| Unpublished product | Hidden from book page after cache refresh |
+| Unpublished variation | Hidden from book page |
+| Product `field_event` = different event | Never listed on book page |
+| Tampered variation id on POST | Validation error; nothing added to cart |
+| Product with **no** Commerce store | Not listed on book page; submit fails closed if forced |
+| Unpublished product after purchase | Vendor list may still show historical order lines; catalog tab rules per `shouldSurfaceVendorAddonsTab()` |
+
+## Cache / freshness notes
+
+- Vendor add-on orders page uses event + `commerce_product` tags, qualifying `commerce_order` tags when enumerated, `user` + `user.permissions` contexts, and **max-age 300s** as a conservative bound when tag enumeration is costly.
+- Event workspace shortcut visibility is computed per request; a new purchase may take up to **5 minutes** to appear if order cache tags were not collected — refresh after `ddev drush cr` if testing immediately.
+
+## Automated tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php \
+  --do-not-cache-result
+
+ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php --filter EventOperationalAddon --do-not-cache-result'
+```
+
+## Related documentation
+
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)

--- a/docs/operational-addons-staging-qa.md
+++ b/docs/operational-addons-staging-qa.md
@@ -1,0 +1,195 @@
+# Operational add-ons MVP — staging deployment and QA
+
+Staging readiness checklist for Phase 4F (customer booking add-ons, post-purchase guidance, vendor order visibility, MVP hardening). **Presentation/read-only only** — no fulfilment mutation.
+
+**Related:** [operational-addons-mvp-qa.md](./operational-addons-mvp-qa.md) (local DDEV script), [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md).
+
+## Workflow
+
+DDEV → feature branch → PR → merge to `main` → CI build artifact → `deploy-staging.yml` → browser QA on staging.
+
+Do **not** patch staging directly from a laptop.
+
+---
+
+## A. Pre-deploy checks
+
+| Check | Command / action | Pass criteria |
+| --- | --- | --- |
+| Branch | `git branch --show-current` | Target feature branch merged to `main` via PR (e.g. `feature/operational-addons-mvp-hardening`) |
+| Latest hardening | `git log --oneline -5` | Includes `fix(commerce): harden operational add-ons mvp flow` (549bb5ce or later on merged line) |
+| Working tree | `git status --short` | Clean before PR merge |
+| Remote sync | `git fetch origin && git branch -vv` | Branch pushed; resolve ahead/behind before PR if diverged |
+| Composer | `composer validate --no-check-publish` | Valid |
+| PHP lint | `php -l` on changed operational add-on PHP | No syntax errors |
+| Whitespace | `git diff --check` | Clean |
+| Theme lint/build | `npm run mel:lint` && `npm run mel:build` | Pass |
+| Unit tests | See [Automated tests](#automated-tests) | All pass |
+| Config review | `ddev drush cst` / `ddev drush config:status` | No unexpected **deletions** of `field_mel_op_capabilities`, operational Commerce types, or `field_mel_operational_product` |
+| Deploy script | `scripts/deploy/remote-deploy.sh` | Present in artifact; validates theme `dist/` and vendor theme `dist/` |
+
+### Config classification (local baseline 2026-05-16)
+
+| Item | Classification | Notes |
+| --- | --- | --- |
+| `crop.type.event_hero` | **B — Known unrelated drift** | Only `Different` entry in `drush cst`; review before any `cim`, not introduced by Phase 4F |
+| Operational Commerce types/fields in `config/sync` | **A — Expected** (already in repo) | e.g. `commerce_product.commerce_product_type.operational_merchandise`, `field.storage.commerce_product.field_mel_operational_product`, `field.field.commerce_product.*.field_event` |
+| `field_mel_op_capabilities` on events | **A — Expected** | Present in sync; **STOP** if `config:status` shows **delete** for this field |
+
+Phase 4F commits (`d0c68a69` … `84d4c3d1`) did **not** change `config/sync` — this release slice is **code + module CSS + docs**.
+
+### Staging deploy expectations
+
+| Step | Required for this MVP? | Notes |
+| --- | --- | --- |
+| CI `composer install` + theme `npm run build` | **Yes** | `reusable-build.yml`; artifact includes `vendor/`, theme `dist/`, module CSS under `myeventlane_commerce/css/` |
+| `RUN_UPDB=1` on remote deploy | **No** (unless staging pending updates) | Local: `drush updatedb:status` → no pending. Phase 4F did not add new `hook_update_N` for add-ons |
+| `RUN_CIM=1` on remote deploy | **Only if** staging lacks operational Commerce config from earlier phases | Default staging workflow does **not** set `RUN_CIM`; operational types must already exist on staging or run a one-off `cim` with ops approval |
+| `drush cr` | **Yes** | Always runs in `remote-deploy.sh` finalize |
+| Frontend rebuild on server | **No** | Built in CI artifact |
+
+Default `deploy-staging.yml` invokes `remote-deploy.sh` **without** `RUN_UPDB` / `RUN_CIM` (both default `0`).
+
+---
+
+## B. Post-deploy smoke checks
+
+| # | Test | Expected |
+| --- | --- | --- |
+| 1 | `https://staging.myeventlane.com.au` | Homepage loads |
+| 2 | Vendor domain login | Vendor console accessible |
+| 3 | `/vendor/events/{event}` | Event workspace loads |
+| 4 | `/event/{nid}/book` (paid event) | Booking page loads |
+| 5 | Checkout | Completes with test payment |
+| 6 | My Tickets | Loads for purchaser |
+| 7 | Order detail / commerce order user view | Loads |
+
+---
+
+## C. Add-on setup QA
+
+| # | Step | Expected |
+| --- | --- | --- |
+| 1 | Paid event with ticket product | Event bookable |
+| 2 | Create/link operational product (Event Studio productisation or Commerce admin) | Product bundle ∈ operational types |
+| 3 | Publish product + variation | Both visible in admin |
+| 4 | Assign Commerce store | Required — no store → hidden on book page |
+| 5 | `field_event` = event | Product scoped to event |
+| 6 | `field_mel_operational_product` JSON | Normalized operational metadata (summary/chips) |
+
+---
+
+## D. Customer booking QA
+
+| # | Test | Expected |
+| --- | --- | --- |
+| 1 | `/event/{nid}/book` | Ticket matrix renders |
+| 2 | Add-on section | Below tickets when catalog exists; lede about collect at event |
+| 3 | Add ticket + add-on qty &gt; 0 | Submit **Add extras to cart** |
+| 4 | Cart / checkout | Ticket + add-on lines; `field_target_event` on add-on items when configured |
+| 5 | Complete checkout | Success |
+| 6 | Checkout completion | **Your add-ons** guidance when order has operational lines |
+
+---
+
+## E. Customer account QA
+
+| # | Surface | Expected |
+| --- | --- | --- |
+| 1 | Checkout completion | Add-on guidance strip |
+| 2 | My Tickets | Guidance on order card |
+| 3 | Order detail | Guidance present |
+| 4 | Commerce order user view | Guidance present |
+| 5 | Tickets-only order | **No** add-on guidance strip |
+
+---
+
+## F. Vendor QA
+
+| # | Test | Expected |
+| --- | --- | --- |
+| 1 | Event workspace | **View add-on orders** shortcut when catalog or purchases exist |
+| 2 | `/vendor/events/{event}/addons` | Page loads for event owner / vendor team |
+| 3 | Purchased add-ons | Grouped list (merch, hospitality, timed, bundles, parking) |
+| 4 | No purchases | Empty state message |
+| 5 | Unrelated vendor user | Access denied |
+| 6 | Anonymous | Denied (vendor console gate) |
+| 7 | Customer label | Display name / Customer #id / Guest — **not** raw email on add-on orders page |
+
+---
+
+## G. Negative QA
+
+| # | Case | Expected |
+| --- | --- | --- |
+| 1 | Unpublished product | Hidden on book page |
+| 2 | Unpublished variation | Hidden on book page |
+| 3 | Product `field_event` ≠ event | Not listed on book page |
+| 4 | Tampered variation id on POST | Validation error |
+| 5 | Tickets-only order | No add-on guidance |
+| 6 | Product without store | Not on book page; submit fails closed |
+
+---
+
+## H. Mobile QA
+
+| # | Check | Expected |
+| --- | --- | --- |
+| 1 | Booking add-on section | No horizontal overflow |
+| 2 | Chips | Wrap on narrow viewport |
+| 3 | Add-on cards | Readable; qty inputs usable |
+| 4 | Vendor add-on orders page | Cards readable; summary stats visible |
+| 5 | Primary CTA | ~44px min tap target (`.mel-btn` on add-to-cart) |
+
+---
+
+## I. Pass/fail table
+
+Copy into staging QA session notes:
+
+| Area | Test | Expected result | Actual result | Pass/fail | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Smoke | Staging homepage | Loads | | | |
+| Smoke | Vendor login | Works | | | |
+| Setup | Operational product + store + field_event | Configured | | | |
+| Customer | Book page add-on section | Visible when catalog exists | | | |
+| Customer | Cart + checkout | Ticket + add-on | | | |
+| Customer | Completion guidance | Shown for add-on order | | | |
+| Customer | My Tickets guidance | Shown | | | |
+| Customer | Tickets-only order | No guidance strip | | | |
+| Vendor | Add-on orders page | Loads for owner | | | |
+| Vendor | Unrelated user | Denied | | | |
+| Negative | Unpublished product | Hidden | | | |
+| Mobile | Booking overflow | None | | | |
+
+---
+
+## Automated tests
+
+Run before PR merge (local or CI):
+
+```bash
+composer validate --no-check-publish
+
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php \
+  --do-not-cache-result
+
+ddev exec bash -lc 'export SIMPLETEST_DB=sqlite://localhost/tmp/test.sqlite && ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php --filter EventOperationalAddon --do-not-cache-result'
+```
+
+---
+
+## Residual risks
+
+- **Branch divergence:** If local and `origin/feature/operational-addons-mvp-hardening` differ, reconcile (rebase/merge) before PR.
+- **Staging config:** Operational Commerce types must exist on staging from an earlier deploy; Phase 4F alone does not export new config.
+- **Cache freshness:** Vendor add-on orders page uses order/product tags + **max-age 300s**; new purchase may take up to 5 minutes to appear without cache rebuild.
+- **Performance:** `shouldSurfaceVendorAddonsTab()` scans orders — acceptable for MVP; watch large events on staging.
+- **Default deploy:** `RUN_CIM=0` — confirm staging already has operational product types before relying on add-on UI.
+
+## Explicit non-goals (staging)
+
+No mark collected, mark prepared, scanner, QR wallet, entitlements, stock decrement, warehouse, shipping orchestration, checkout pane changes, or order mutation in this MVP.

--- a/docs/operational-cart-checkout-orchestration.md
+++ b/docs/operational-cart-checkout-orchestration.md
@@ -28,6 +28,7 @@ Forbidden keys are stripped recursively (`OperationalCheckoutOrchestrationManage
 
 - Theme hook `mel_operational_checkout` ships in `myeventlane_commerce` with library `myeventlane_commerce/mel_operational_checkout`.
 - `myeventlane_theme` preprocessors attach `mel_operational_checkout` render arrays wherever `mel_operational_purchase_composition` already appears (cart summary, checkout sidebar + completion, checkout order summary pane, commerce order user view, My Tickets cards, order detail). The event book adds the strip via `myeventlane_commerce_preprocess_myeventlane_event_book()`.
+- **Phase 4F:** the same booking page can embed `EventOperationalAddonCartForm` (operational add-ons to cart) when eligible products exist; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
 
 ## Anti-patterns
 

--- a/docs/operational-cart-checkout-orchestration.md
+++ b/docs/operational-cart-checkout-orchestration.md
@@ -29,6 +29,7 @@ Forbidden keys are stripped recursively (`OperationalCheckoutOrchestrationManage
 - Theme hook `mel_operational_checkout` ships in `myeventlane_commerce` with library `myeventlane_commerce/mel_operational_checkout`.
 - `myeventlane_theme` preprocessors attach `mel_operational_checkout` render arrays wherever `mel_operational_purchase_composition` already appears (cart summary, checkout sidebar + completion, checkout order summary pane, commerce order user view, My Tickets cards, order detail). The event book adds the strip via `myeventlane_commerce_preprocess_myeventlane_event_book()`.
 - **Phase 4F:** the same booking page can embed `EventOperationalAddonCartForm` (operational add-ons to cart) when eligible products exist; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
+- **Phase 4F (Commit 2):** post-purchase **add-on confirmation** strip (`mel_operational_addon_guidance`) reuses composition + checkout contracts; see [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md).
 
 ## Anti-patterns
 

--- a/docs/operational-cart-checkout-orchestration.md
+++ b/docs/operational-cart-checkout-orchestration.md
@@ -30,6 +30,7 @@ Forbidden keys are stripped recursively (`OperationalCheckoutOrchestrationManage
 - `myeventlane_theme` preprocessors attach `mel_operational_checkout` render arrays wherever `mel_operational_purchase_composition` already appears (cart summary, checkout sidebar + completion, checkout order summary pane, commerce order user view, My Tickets cards, order detail). The event book adds the strip via `myeventlane_commerce_preprocess_myeventlane_event_book()`.
 - **Phase 4F:** the same booking page can embed `EventOperationalAddonCartForm` (operational add-ons to cart) when eligible products exist; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
 - **Phase 4F (Commit 2):** post-purchase **add-on confirmation** strip (`mel_operational_addon_guidance`) reuses composition + checkout contracts; see [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md).
+- **Phase 4F (Commit 3):** vendor **read-only** add-on order list per event (no fulfilment execution, no order mutation); see [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md).
 
 ## Anti-patterns
 

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -62,3 +62,4 @@ Theme and checkout-flow templates render the composition strip next to existing 
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
 - [operational-commerce-capability-linking.md](./operational-commerce-capability-linking.md)
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -43,6 +43,8 @@ Theme and checkout-flow templates render the composition strip next to existing 
 
 **Operational checkout orchestration** (`mel_operational_checkout`, `OperationalCheckoutOrchestrationManager`) adds a grouped **checkout plan** card fed only from purchase composition output. It does not replace merchandise normalization or composition classification; see [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md).
 
+**Phase 4F — Customer booking add-ons:** the paid event book page can embed `EventOperationalAddonCartForm` when `EventOperationalAddonBuilder` finds eligible operational products linked via `field_event`; see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
+
 ## Anti-patterns
 
 - Duplicating `FulfillmentLifecycleManager`, `InventoryReservationGovernanceManager`, scanner authority, or entitlement issuance in merchandise services or Twig.
@@ -59,3 +61,4 @@ Theme and checkout-flow templates render the composition strip next to existing 
 - [vendor-operational-capability-studio.md](./vendor-operational-capability-studio.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)
 - [operational-commerce-capability-linking.md](./operational-commerce-capability-linking.md)
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -63,3 +63,4 @@ Theme and checkout-flow templates render the composition strip next to existing 
 - [operational-commerce-capability-linking.md](./operational-commerce-capability-linking.md)
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
 - [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)

--- a/docs/operational-purchase-composition-convergence.md
+++ b/docs/operational-purchase-composition-convergence.md
@@ -25,4 +25,5 @@ Phase 4C adds **`OperationalFulfillmentExecutionProjectionBuilder::buildCustomer
 - [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)
 - [operational-fulfillment-execution-convergence.md](./operational-fulfillment-execution-convergence.md)
 - [customer-operational-commerce-experience.md](./customer-operational-commerce-experience.md)
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)

--- a/docs/operational-purchase-composition-convergence.md
+++ b/docs/operational-purchase-composition-convergence.md
@@ -26,4 +26,5 @@ Phase 4C adds **`OperationalFulfillmentExecutionProjectionBuilder::buildCustomer
 - [operational-fulfillment-execution-convergence.md](./operational-fulfillment-execution-convergence.md)
 - [customer-operational-commerce-experience.md](./customer-operational-commerce-experience.md)
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)

--- a/docs/operational-purchase-composition-convergence.md
+++ b/docs/operational-purchase-composition-convergence.md
@@ -27,4 +27,5 @@ Phase 4C adds **`OperationalFulfillmentExecutionProjectionBuilder::buildCustomer
 - [customer-operational-commerce-experience.md](./customer-operational-commerce-experience.md)
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
 - [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)
 - [fulfillment-lifecycle-convergence.md](./fulfillment-lifecycle-convergence.md)

--- a/docs/vendor-operational-addon-order-visibility.md
+++ b/docs/vendor-operational-addon-order-visibility.md
@@ -1,0 +1,86 @@
+# Vendor operational add-on order visibility (Phase 4F Commit 3)
+
+## Purpose
+
+Give **organisers** a read-only list of **operational add-on** purchases (merch, hospitality, timed collection, bundles, parking) tied to an event, so they can plan on-site fulfilment. **Drupal Commerce** remains the system of record for orders, items, prices, and state. This layer does **not** change orders, stock, shipping, warehouses, scanners, QR payloads, or entitlements.
+
+## Route and UI
+
+| Item | Value |
+| --- | --- |
+| Path | `/vendor/events/{event}/addons` |
+| Route name | `myeventlane_vendor.console.event_operational_addon_orders` |
+| Controller | `Drupal\myeventlane_vendor\Controller\VendorOperationalAddonOrdersController::addons()` |
+| Shell | Same `mel_event_workspace` vendor console layout as other event tools (tabs + main column). |
+
+The route is registered in `myeventlane_vendor` (with the other `/vendor/events/{event}/…` console routes) to avoid a **commerce ↔ vendor circular module dependency**, while the **read model** lives in `myeventlane_commerce` as specified below.
+
+## Service contract
+
+| Service ID | Class |
+| --- | --- |
+| `myeventlane_commerce.vendor_operational_addon_order_builder` | `Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder` |
+
+### Methods (caller enforces access)
+
+- `buildForEvent(NodeInterface $event, AccountInterface $account): array` — document for `mel_vendor_operational_addon_orders`. The account parameter is reserved for future use; **the controller must** call `VendorConsoleBaseController::assertEventOwnership()` before invoking the builder.
+- `buildForOrder(OrderInterface $order, AccountInterface $account, int $eventId): array` — single-order slice for the same document shape (optional reuse from future order views).
+- `orderHasOperationalAddons(OrderInterface $order, ?int $eventId = NULL): bool` — uses `OperationalPurchaseCompositionManager::composeForOrder()` only (no manual bundle typing).
+- `shouldSurfaceVendorAddonsTab(NodeInterface $event): bool` — `TRUE` when the event has configured operational add-ons **or** at least one qualifying completed/placed order contains operational lines for the event.
+- `stripForbiddenRecursive(array $data): array` — strips vendor-forbidden keys recursively (list-safe).
+
+### Data source
+
+Order discovery and state filtering follow the same approach as `VendorEventOrdersController::getOrdersForEvent()` (event-linked order items, variation/product `field_event` fallbacks, store-scoped fallback, states `completed`, `partially_refunded`, `refunded`, `placed`, `fulfilled`, `fulfillment`). **Line detail** comes from `OperationalPurchaseCompositionManager::composeForOrder()`, then lines are **restricted to items that belong to the event** using the same event-matching rules as the vendor orders list.
+
+## Access model
+
+- Route `requirements`: `myeventlane_vendor.access.vendor_console:access` (same family as event orders).
+- Controller: `assertEventOwnership($event)` — vendor console trust, admin bypass, node owner, or `field_event_vendor` → `field_vendor_users` membership (aligned with `EventVendorAccessChecker::accountHasWorkspaceParityForEvent()`).
+
+## Privacy model
+
+- Customer label: prefer `Customer #<uid>` when the order has a customer id; otherwise the order email if present (consistent with the existing vendor **Orders** list); otherwise a neutral guest label.
+- No attendee Q&A payloads, no internal cost/margin, no scanner/warehouse/shipment material. Keys stripped match `VendorOperationalAddonOrderBuilder::FORBIDDEN_VENDOR_ORDER_KEYS`.
+
+## What vendors see
+
+- Summary: count of orders with add-ons, add-on line count, counts per operational group.
+- Per order: order number, placed date, customer-safe label, grouped lines with product/variation labels, operational summary text, readiness/pickup strings when present, customer-facing chips.
+
+## Deliberately not implemented
+
+- Fulfilment execution state, “mark collected”, stock decrement, shipping labels, warehouse routing, QR wallet / scanner redemption, entitlement mutation, checkout or order writes.
+
+## Dashboard / navigation integration
+
+- **Tabs:** `VendorEventTabsService` adds an **Add-on orders** tab when the route exists and the surface gate passes (`paid tickets` + `shouldSurfaceVendorAddonsTab()`).
+- **Workspace shortcuts:** `VendorEventWorkspaceViewModelBuilder` exposes `actions.addon_orders` when paid/both mode, the route is allowed for the account, and the surface gate passes; `mel-event-workspace.html.twig` renders **View add-on orders**.
+- **Local tasks:** `myeventlane_vendor.links.task.yml` secondary tab for the same route.
+
+## Manual QA checklist
+
+- [ ] Non-vendor / anonymous user cannot open `/vendor/events/{id}/addons`.
+- [ ] Event owner and vendor team member (linked vendor users) can open the page; unrelated authenticated user cannot.
+- [ ] Admin (`administer nodes`) can open the page.
+- [ ] Event with **no** operational catalog and **no** qualifying orders: tab disabled with reason; workspace shortcut absent; page shows empty state when reached via URL.
+- [ ] Event with **catalog only**: tab enabled; page may show empty orders with intro.
+- [ ] Event with **purchased** operational add-ons: orders listed; no forbidden JSON keys in View Source / Devel (spot check).
+- [ ] Mobile: cards readable, no horizontal overflow.
+
+## Test commands
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php --do-not-cache-result
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php --do-not-cache-result
+```
+
+Kernel coverage for vendor access is not added in this slice (would duplicate large Commerce fixtures); rely on manual QA above plus existing vendor console kernel tests where applicable.
+
+## Related documentation
+
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [customer-operational-addon-confirmation-guidance.md](./customer-operational-addon-confirmation-guidance.md)
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [operational-purchase-composition-convergence.md](./operational-purchase-composition-convergence.md)
+- [operational-cart-checkout-orchestration.md](./operational-cart-checkout-orchestration.md)

--- a/docs/vendor-operational-addon-order-visibility.md
+++ b/docs/vendor-operational-addon-order-visibility.md
@@ -40,7 +40,7 @@ Order discovery and state filtering follow the same approach as `VendorEventOrde
 
 ## Privacy model
 
-- Customer label: prefer `Customer #<uid>` when the order has a customer id; otherwise the order email if present (consistent with the existing vendor **Orders** list); otherwise a neutral guest label.
+- Customer label: purchaser **display name** when available; otherwise `Customer #<uid>`; otherwise **Guest customer**. Raw order email is **not** exposed on the add-on orders page (vendor **Orders** may still show email separately).
 - No attendee Q&A payloads, no internal cost/margin, no scanner/warehouse/shipment material. Keys stripped match `VendorOperationalAddonOrderBuilder::FORBIDDEN_VENDOR_ORDER_KEYS`.
 
 ## What vendors see
@@ -57,6 +57,16 @@ Order discovery and state filtering follow the same approach as `VendorEventOrde
 - **Tabs:** `VendorEventTabsService` adds an **Add-on orders** tab when the route exists and the surface gate passes (`paid tickets` + `shouldSurfaceVendorAddonsTab()`).
 - **Workspace shortcuts:** `VendorEventWorkspaceViewModelBuilder` exposes `actions.addon_orders` when paid/both mode, the route is allowed for the account, and the surface gate passes; `mel-event-workspace.html.twig` renders **View add-on orders**.
 - **Local tasks:** `myeventlane_vendor.links.task.yml` secondary tab for the same route.
+
+## Cache metadata (MVP hardening)
+
+| Surface | Tags / contexts / max-age |
+| --- | --- |
+| Vendor add-on orders page | `collectCacheTagsForEvent()`: event + linked `commerce_product` + qualifying `commerce_order` tags; contexts `user`, `user.permissions`, `languages:language_interface`; **max-age 300** (`VendorOperationalAddonOrderBuilder::VENDOR_ADDON_ORDERS_MAX_AGE`) |
+| Event book add-on form | Event tags + `commerce_product:{id}`; contexts `user`, `session`, `languages:language_interface` |
+| Customer guidance strip | `commerce_order` tags; contexts `user`, `languages:language_interface` |
+
+Full scripted QA: [operational-addons-mvp-qa.md](./operational-addons-mvp-qa.md).
 
 ## Manual QA checklist
 

--- a/docs/vendor-product-creation-wizard.md
+++ b/docs/vendor-product-creation-wizard.md
@@ -34,6 +34,8 @@ Wizard rows map to existing operational Commerce bundles (see `OperationalMercha
 - Customer title and summary are **plain text** (HTML stripped, length capped).
 - Price is validated as a non-negative decimal and stored on the **variation** via Commerce `Price`.
 
+Customer booking after catalog exists: see [customer-operational-addons-booking.md](./customer-operational-addons-booking.md).
+
 ## Payload contract (creation)
 
 Required keys (after forbidden-key stripping): `productisation_type`, `event_id` (must match the event being edited), `title`, `customer_summary`, `price_amount`, `currency_code`, `customer_visibility`, `fulfillment_mode`, `reservation_mode`.
@@ -67,3 +69,4 @@ Forbidden keys are stripped recursively (see `VendorOperationalProductCreationMa
 - [Operational merchandise architecture](operational-merchandise-architecture.md)
 - [Operational cart & checkout orchestration](operational-cart-checkout-orchestration.md)
 - [Customer operational Commerce experience](customer-operational-commerce-experience.md)
+- [Customer operational add-ons on booking](customer-operational-addons-booking.md)

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-my-tickets.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-my-tickets.html.twig
@@ -80,6 +80,12 @@
                 </div>
               {% endif %}
 
+              {% if order_data.operational_addon_guidance %}
+                <div class="mel-my-tickets-addon-guidance mel-mt-3" role="region" aria-label="{{ 'Your add-ons'|t }}">
+                  {{ order_data.operational_addon_guidance }}
+                </div>
+              {% endif %}
+
               <div class="mel-order-actions mel-mt-4">
                 <a href="{{ url('myeventlane_checkout_flow.order_detail', {'commerce_order': order_data.order_id}) }}"
                    class="mel-button mel-button--primary">
@@ -157,6 +163,12 @@
                 {% if order_data.mel_operational_checkout %}
                   <div class="mel-my-tickets-operational-checkout mel-mt-3" role="region" aria-label="{{ 'Operational checkout plan'|t }}">
                     {{ order_data.mel_operational_checkout }}
+                  </div>
+                {% endif %}
+
+                {% if order_data.operational_addon_guidance %}
+                  <div class="mel-my-tickets-addon-guidance mel-mt-3" role="region" aria-label="{{ 'Your add-ons'|t }}">
+                    {{ order_data.operational_addon_guidance }}
                   </div>
                 {% endif %}
 

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
@@ -52,6 +52,12 @@
     </div>
   {% endif %}
 
+  {% if operational_addon_guidance %}
+    <div class="mel-order-detail-addon-guidance mel-section mel-mt-4" role="region" aria-label="{{ 'Your add-ons'|t }}">
+      {{ operational_addon_guidance }}
+    </div>
+  {% endif %}
+
   {% if order.events|length > 0 %}
     <div class="mel-section mel-mt-6">
       <h2 class="mel-section-title">{{ 'Your events'|t }}</h2>

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addon-guidance.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addon-guidance.css
@@ -1,0 +1,115 @@
+/**
+ * @file
+ * Compact add-on confirmation strip (checkout completion, tickets, orders).
+ */
+
+.mel-addon-guidance {
+  box-sizing: border-box;
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 1rem 1.125rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.mel-addon-guidance__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.mel-addon-guidance__intro {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-addon-guidance__sections {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-addon-guidance__section {
+  margin: 0 0 0.85rem;
+  padding: 0 0 0.85rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.mel-addon-guidance__section:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.mel-addon-guidance__section-title {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.mel-addon-guidance__summaries,
+.mel-addon-guidance__chips {
+  margin: 0.25rem 0 0.5rem;
+  padding-left: 1.1rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.82);
+}
+
+.mel-addon-guidance__chips {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.mel-addon-guidance__chip {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.mel-addon-guidance__chip--info {
+  border-color: rgba(14, 165, 233, 0.35);
+  background: rgba(224, 242, 254, 0.55);
+}
+
+.mel-addon-guidance__chip--warning {
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(254, 243, 199, 0.45);
+}
+
+.mel-addon-guidance__next,
+.mel-addon-guidance__hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.mel-addon-guidance__footer {
+  margin: 0.75rem 0 0.35rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  font-weight: 500;
+}
+
+.mel-addon-guidance__support {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+@media (min-width: 48rem) {
+  .mel-addon-guidance {
+    padding: 1.125rem 1.25rem;
+  }
+}

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addon-guidance.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addon-guidance.css
@@ -11,6 +11,7 @@
   border-radius: 0.75rem;
   border: 1px solid rgba(15, 23, 42, 0.08);
   background: rgba(255, 255, 255, 0.92);
+  overflow-x: hidden;
 }
 
 .mel-addon-guidance__title {

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -7,12 +7,20 @@
   margin-top: 1.75rem;
   padding-top: 1.5rem;
   border-top: 1px solid rgba(15, 23, 42, 0.08);
+  overflow-x: hidden;
 }
 
 .mel-operational-addons-section__title {
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.35rem;
   font-size: 1.125rem;
   font-weight: 700;
+}
+
+.mel-operational-addons-section__lede {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.72);
 }
 
 .mel-operational-addons-form__intro {

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -1,0 +1,121 @@
+/**
+ * Customer operational add-ons on the event booking page.
+ *
+ * Mobile-first cards; coral primary CTA uses theme `.mel-btn--primary`.
+ */
+.mel-operational-addons-section {
+  margin-top: 1.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.mel-operational-addons-section__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.mel-operational-addons-form__intro {
+  margin: 0 0 1rem;
+  color: rgba(15, 23, 42, 0.72);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.mel-operational-addons-form__lines {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mel-operational-addon-card {
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.mel-operational-addon-card__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.mel-operational-addon-card__summary-text {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-operational-addon-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.mel-operational-addon-card__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(15, 23, 42, 0.08);
+}
+
+.mel-operational-addon-card__row:first-of-type {
+  margin-top: 0.35rem;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.mel-operational-addon-card__row-meta {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.mel-operational-addon-card__variation-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.mel-operational-addon-card__price {
+  margin-top: 0.2rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.88);
+}
+
+.mel-operational-addon-card__qty {
+  flex: 0 0 auto;
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.65rem;
+  font-size: 1rem;
+}
+
+.mel-operational-addons-form__actions {
+  margin-top: 1.25rem;
+}
+
+.mel-operational-addons-form__actions .mel-btn {
+  min-height: 44px;
+  min-width: 44px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.mel-operational-addons-form__actions .mel-btn--primary {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .mel-operational-addons-form__actions .mel-btn--primary {
+    width: auto;
+  }
+}

--- a/web/modules/custom/myeventlane_commerce/css/mel-vendor-operational-addon-orders.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-vendor-operational-addon-orders.css
@@ -5,6 +5,7 @@
 
 .mel-vendor-addon-orders {
   max-width: 52rem;
+  overflow-x: hidden;
 }
 
 .mel-vendor-addon-orders__intro {
@@ -12,6 +13,17 @@
   font-size: 0.95rem;
   line-height: 1.45;
   color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-vendor-addon-orders__prepare-hint {
+  margin: 0 0 1rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  background: rgba(254, 243, 232, 0.65);
+  border: 1px solid rgba(251, 146, 60, 0.25);
+  color: rgba(15, 23, 42, 0.82);
 }
 
 .mel-vendor-addon-orders__empty-text {

--- a/web/modules/custom/myeventlane_commerce/css/mel-vendor-operational-addon-orders.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-vendor-operational-addon-orders.css
@@ -1,0 +1,183 @@
+/**
+ * @file
+ * Vendor operational add-on order list (read-only).
+ */
+
+.mel-vendor-addon-orders {
+  max-width: 52rem;
+}
+
+.mel-vendor-addon-orders__intro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-vendor-addon-orders__empty-text {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.mel-vendor-addon-orders__summary-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.mel-vendor-addon-orders__stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-vendor-addon-orders__stat {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.5rem;
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.mel-vendor-addon-orders__stat-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.mel-vendor-addon-orders__stat-value {
+  font-size: 1.35rem;
+  font-weight: 650;
+}
+
+.mel-vendor-addon-orders__group-counts {
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.mel-vendor-addon-orders__order-head {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.mel-vendor-addon-orders__order-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mel-vendor-addon-orders__order-meta {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.mel-vendor-addon-orders__customer-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.mel-vendor-addon-orders__group {
+  margin-top: 1rem;
+}
+
+.mel-vendor-addon-orders__group-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.mel-vendor-addon-orders__lines {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-vendor-addon-orders__line {
+  padding: 0.65rem 0;
+  border-top: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.mel-vendor-addon-orders__line:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.mel-vendor-addon-orders__line-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.65rem;
+  align-items: baseline;
+  font-weight: 500;
+}
+
+.mel-vendor-addon-orders__line-variation {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.mel-vendor-addon-orders__line-qty {
+  font-size: 0.85rem;
+}
+
+.mel-vendor-addon-orders__line-summary {
+  margin: 0.35rem 0 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.mel-vendor-addon-orders__line-modes {
+  margin: 0.35rem 0 0;
+}
+
+.mel-vendor-addon-orders__pill {
+  display: inline-block;
+  margin-right: 0.35rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.35rem;
+  font-size: 0.72rem;
+  background: rgba(241, 245, 249, 0.9);
+}
+
+.mel-vendor-addon-orders__chips {
+  margin: 0.4rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.mel-vendor-addon-orders__chip {
+  display: inline-block;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.mel-vendor-addon-orders__chip--info {
+  border-color: rgba(14, 165, 233, 0.35);
+  background: rgba(224, 242, 254, 0.45);
+}
+
+.mel-vendor-addon-orders__chip--warning {
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(254, 243, 199, 0.45);
+}
+
+@media (max-width: 36rem) {
+  .mel-vendor-addon-orders__order-head {
+    flex-direction: column;
+  }
+}

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -44,6 +44,14 @@ operational_addon_guidance:
   dependencies:
     - core/drupal
 
+vendor_operational_addon_orders:
+  version: 1.0
+  css:
+    theme:
+      css/mel-vendor-operational-addon-orders.css: {}
+  dependencies:
+    - core/drupal
+
 operational_addons:
   version: 1.0
   css:

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -35,3 +35,11 @@ mel_operational_checkout:
   dependencies:
     - core/drupal
     - core/once
+
+operational_addons:
+  version: 1.0
+  css:
+    theme:
+      css/mel-operational-addons.css: {}
+  dependencies:
+    - core/drupal

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -36,6 +36,14 @@ mel_operational_checkout:
     - core/drupal
     - core/once
 
+operational_addon_guidance:
+  version: 1.0
+  css:
+    theme:
+      css/mel-operational-addon-guidance.css: {}
+  dependencies:
+    - core/drupal
+
 operational_addons:
   version: 1.0
   css:

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -317,6 +317,12 @@ function myeventlane_commerce_theme(): array {
       ],
       'template' => 'mel-operational-checkout',
     ],
+    'mel_operational_addon_guidance' => [
+      'variables' => [
+        'guidance' => [],
+      ],
+      'template' => 'mel-operational-addon-guidance',
+    ],
     'mel_waitlist_offer_countdown' => [
       'variables' => [
         'expires_timestamp' => 0,
@@ -397,7 +403,7 @@ function myeventlane_commerce_theme_registry_alter(array &$registry): void {
   $theme = \Drupal::theme()->getActiveTheme()->getName();
   $theme_path = \Drupal::service('extension.list.theme')->getPath($theme);
   $commerce_tpl_dir = $theme_path . '/templates/commerce';
-  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout'] as $hook) {
+  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout', 'mel_operational_addon_guidance'] as $hook) {
     if (!isset($registry[$hook])) {
       continue;
     }

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -323,6 +323,12 @@ function myeventlane_commerce_theme(): array {
       ],
       'template' => 'mel-operational-addon-guidance',
     ],
+    'mel_vendor_operational_addon_orders' => [
+      'variables' => [
+        'document' => [],
+      ],
+      'template' => 'mel-vendor-operational-addon-orders',
+    ],
     'mel_waitlist_offer_countdown' => [
       'variables' => [
         'expires_timestamp' => 0,
@@ -403,7 +409,7 @@ function myeventlane_commerce_theme_registry_alter(array &$registry): void {
   $theme = \Drupal::theme()->getActiveTheme()->getName();
   $theme_path = \Drupal::service('extension.list.theme')->getPath($theme);
   $commerce_tpl_dir = $theme_path . '/templates/commerce';
-  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout', 'mel_operational_addon_guidance'] as $hook) {
+  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout', 'mel_operational_addon_guidance', 'mel_vendor_operational_addon_orders'] as $hook) {
     if (!isset($registry[$hook])) {
       continue;
     }

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -300,6 +300,8 @@ function myeventlane_commerce_theme(): array {
         'recommended_events' => [],
         'mel_operational_purchase_composition' => NULL,
         'mel_operational_checkout' => NULL,
+        'addons_available' => FALSE,
+        'operational_addon_form' => [],
       ],
       'template' => 'myeventlane-event-book',
     ],

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -197,6 +197,13 @@ services:
       - '@string_translation'
       - '@logger.channel.myeventlane_commerce'
 
+  myeventlane_commerce.event_operational_addon_builder:
+    class: Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@string_translation'
+
   myeventlane_commerce.operational_merchandise_governance_manager:
     class: Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager
     arguments:

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -240,3 +240,8 @@ services:
       - '@myeventlane_commerce.operational_customer_guidance_builder'
       - '@myeventlane_commerce.operational_cart_projection_builder'
       - '@string_translation'
+
+  myeventlane_commerce.operational_addon_guidance_builder:
+    class: Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder
+    arguments:
+      - '@string_translation'

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -245,3 +245,12 @@ services:
     class: Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder
     arguments:
       - '@string_translation'
+
+  myeventlane_commerce.vendor_operational_addon_order_builder:
+    class: Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.operational_purchase_composition_manager'
+      - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@date.formatter'
+      - '@string_translation'

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -8,7 +8,9 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_rsvp\Form\RsvpPublicForm;
 use Drupal\node\NodeInterface;
@@ -33,11 +35,14 @@ final class BookController extends ControllerBase {
    *   The canonical booking flow resolver.
    * @param \Drupal\Core\Form\FormBuilderInterface $formBuilderService
    *   The form builder.
+   * @param \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder $eventOperationalAddonBuilder
+   *   Customer operational add-on read model for paid booking pages.
    */
   public function __construct(
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
     private readonly BookingFlowResolver $bookingFlowResolver,
     private readonly FormBuilderInterface $formBuilderService,
+    private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
   ) {}
 
   /**
@@ -48,6 +53,7 @@ final class BookController extends ControllerBase {
       $container->get('file_url_generator'),
       $container->get('myeventlane_event.booking_flow_resolver'),
       $container->get('form_builder'),
+      $container->get('myeventlane_commerce.event_operational_addon_builder'),
     );
   }
 
@@ -127,6 +133,8 @@ final class BookController extends ControllerBase {
       '#event_cta' => $primaryCta,
       '#event_mode' => $bookingMode,
       '#event' => $node,
+      '#addons_available' => FALSE,
+      '#operational_addon_form' => [],
       '#cache' => [
         'contexts' => ['route', 'user.roles', 'url.query_args', 'session'],
         'tags' => $node->getCacheTags(),
@@ -154,6 +162,22 @@ final class BookController extends ControllerBase {
         $build['#matrix_form'] = $this->buildUnavailable($availability);
         break;
     }
+
+    if ($isPaid) {
+      $addon_catalog = $this->eventOperationalAddonBuilder->buildForEvent($node);
+      if ($addon_catalog['addons'] !== []) {
+        $build['#addons_available'] = TRUE;
+        foreach ($addon_catalog['product_ids'] as $pid) {
+          $build['#cache']['tags'][] = 'commerce_product:' . $pid;
+        }
+        $build['#operational_addon_form'] = $this->formBuilderService->getForm(
+          EventOperationalAddonCartForm::class,
+          $node,
+        );
+      }
+    }
+
+    $build['#cache']['tags'] = array_values(array_unique($build['#cache']['tags']));
 
     return $build;
   }

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -136,7 +136,7 @@ final class BookController extends ControllerBase {
       '#addons_available' => FALSE,
       '#operational_addon_form' => [],
       '#cache' => [
-        'contexts' => ['route', 'user.roles', 'url.query_args', 'session'],
+        'contexts' => ['route', 'user.roles', 'url.query_args', 'session', 'languages:language_interface'],
         'tags' => $node->getCacheTags(),
       ],
     ];

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -80,12 +80,12 @@ final class EventOperationalAddonCartForm extends FormBase {
       $cache_tags[] = 'commerce_product:' . $pid;
     }
     $form['#cache']['tags'] = array_values(array_unique($cache_tags));
-    $form['#cache']['contexts'] = ['user', 'session'];
+    $form['#cache']['contexts'] = ['user', 'session', 'languages:language_interface'];
 
     $form['intro'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('Merch, hospitality and collection add-ons linked to this event.'),
+      '#value' => $this->t('Optional extras for this event — add to your booking, then collect on site after checkout. Quantities are not stock guarantees.'),
       '#attributes' => ['class' => ['mel-operational-addons-form__intro']],
     ];
 

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Form;
+
+use Drupal\commerce_cart\CartManagerInterface;
+use Drupal\commerce_cart\CartProviderInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Customer form: add event-linked operational add-ons to the Commerce cart.
+ */
+final class EventOperationalAddonCartForm extends FormBase {
+
+  private const UI_QTY_MAX = 10;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CartProviderInterface $cartProvider,
+    private readonly CartManagerInterface $cartManager,
+    private readonly EventOperationalAddonBuilder $addonBuilder,
+    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('commerce_cart.cart_provider'),
+      $container->get('commerce_cart.cart_manager'),
+      $container->get('myeventlane_commerce.event_operational_addon_builder'),
+      $container->get('commerce_price.currency_formatter'),
+      $container->get('logger.factory'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'myeventlane_event_operational_addon_cart_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $event = NULL): array {
+    if (!$event instanceof NodeInterface || $event->bundle() !== 'event') {
+      return $form;
+    }
+
+    $built = $this->addonBuilder->buildForEvent($event);
+    $addons = $built['addons'] ?? [];
+    if ($addons === []) {
+      return $form;
+    }
+
+    $form['#node'] = $event;
+    $form['#tree'] = TRUE;
+    $form['#attributes']['class'][] = 'mel-operational-addons-form';
+    $form['#attached']['library'][] = 'myeventlane_commerce/operational_addons';
+
+    $cache_tags = $event->getCacheTags();
+    foreach ($built['product_ids'] ?? [] as $pid) {
+      $cache_tags[] = 'commerce_product:' . $pid;
+    }
+    $form['#cache']['tags'] = array_values(array_unique($cache_tags));
+    $form['#cache']['contexts'] = ['user', 'session'];
+
+    $form['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Merch, hospitality and collection add-ons linked to this event.'),
+      '#attributes' => ['class' => ['mel-operational-addons-form__intro']],
+    ];
+
+    $form['lines'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-operational-addons-form__lines']],
+    ];
+
+    foreach ($addons as $index => $addon) {
+      if (!is_array($addon)) {
+        continue;
+      }
+      $pid = (int) ($addon['product_id'] ?? 0);
+      $title = (string) ($addon['title'] ?? '');
+      $operational = is_array($addon['operational'] ?? NULL) ? $addon['operational'] : [];
+      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+
+      $card = [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-operational-addon-card'],
+          'data-product-id' => (string) $pid,
+        ],
+      ];
+
+      $card['title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $title !== '' ? $title : $this->t('Add-on'),
+        '#attributes' => ['class' => ['mel-operational-addon-card__title']],
+      ];
+
+      if ($operational !== []) {
+        $card['summary'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__summary']],
+        ];
+        $summary_text = trim((string) ($operational['operational_summary'] ?? ''));
+        if ($summary_text !== '') {
+          $card['summary']['text'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $summary_text,
+            '#attributes' => ['class' => ['mel-operational-addon-card__summary-text']],
+          ];
+        }
+        $chips = is_array($operational['operational_chips'] ?? NULL) ? $operational['operational_chips'] : [];
+        if ($chips !== []) {
+          $card['summary']['chips'] = [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['mel-operational-addon-card__chips']],
+          ];
+          foreach ($chips as $chip) {
+            if (!is_array($chip)) {
+              continue;
+            }
+            $label = trim((string) ($chip['label'] ?? ''));
+            if ($label === '') {
+              continue;
+            }
+            $tone = $this->chipToneClass((string) ($chip['tone'] ?? 'muted'));
+            $card['summary']['chips'][] = [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $label,
+              '#attributes' => [
+                'class' => [
+                  'mel-pill',
+                  'mel-pill--operational',
+                  'mel-pill--tone-' . $tone,
+                ],
+              ],
+            ];
+          }
+        }
+      }
+
+      $card['variations'] = [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-operational-addon-card__variations']],
+      ];
+
+      foreach ($variations as $v) {
+        if (!is_array($v)) {
+          continue;
+        }
+        $vid = (int) ($v['variation_id'] ?? 0);
+        if ($vid < 1) {
+          continue;
+        }
+        $v_label = (string) ($v['label'] ?? '');
+        $price_number = (string) ($v['price_number'] ?? '');
+        $currency = (string) ($v['price_currency_code'] ?? '');
+        $price_display = '';
+        if ($price_number !== '' && $currency !== '') {
+          $price_display = $this->currencyFormatter->format($price_number, $currency);
+        }
+
+        $row = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__row']],
+        ];
+        $row['meta'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-operational-addon-card__row-meta']],
+        ];
+        $row['meta']['variation_title'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#value' => $v_label !== '' ? $v_label : $this->t('Option'),
+          '#attributes' => ['class' => ['mel-operational-addon-card__variation-title']],
+        ];
+        if ($price_display !== '') {
+          $row['meta']['price'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'div',
+            '#value' => $price_display,
+            '#attributes' => ['class' => ['mel-operational-addon-card__price']],
+          ];
+        }
+
+        $row['qty'] = [
+          '#type' => 'number',
+          '#title' => $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $this->t('this option')]),
+          '#title_display' => 'invisible',
+          '#min' => 0,
+          '#max' => self::UI_QTY_MAX,
+          '#step' => 1,
+          '#default_value' => 0,
+          '#attributes' => [
+            'class' => ['mel-operational-addon-card__qty'],
+            'inputmode' => 'numeric',
+            'aria-label' => (string) $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $title]),
+          ],
+        ];
+
+        $card['variations'][$vid] = $row;
+      }
+
+      $form['lines'][$index] = $card;
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#attributes' => ['class' => ['mel-operational-addons-form__actions']],
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add extras to cart'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-btn--xl']],
+    ];
+
+    return $form;
+  }
+
+  private function chipToneClass(string $tone): string {
+    $tone = strtolower(trim($tone));
+    return preg_match('/^[a-z0-9_-]{1,32}$/', $tone) ? $tone : 'muted';
+  }
+
+  /**
+   * @param list<array<string, mixed>> $addons
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function buildAllowlistFromAddons(array $addons): array {
+    $map = [];
+    foreach ($addons as $addon) {
+      if (!is_array($addon)) {
+        continue;
+      }
+      $product_id = (int) ($addon['product_id'] ?? 0);
+      $bundle = (string) ($addon['bundle'] ?? '');
+      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+      foreach ($variations as $v) {
+        if (!is_array($v)) {
+          continue;
+        }
+        $vid = (int) ($v['variation_id'] ?? 0);
+        if ($vid < 1) {
+          continue;
+        }
+        $map[$vid] = [
+          'product_id' => $product_id,
+          'bundle' => $bundle,
+        ];
+      }
+    }
+    return $map;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $event = $form['#node'] ?? NULL;
+    if (!$event instanceof NodeInterface) {
+      $form_state->setErrorByName('lines', $this->t('This form is no longer valid. Please refresh the page.'));
+      return;
+    }
+
+    $fresh = $this->addonBuilder->buildForEvent($event);
+    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+
+    $lines = $form_state->getValue('lines');
+    if (!is_array($lines)) {
+      return;
+    }
+
+    foreach ($lines as $line) {
+      if (!is_array($line)) {
+        continue;
+      }
+      $variations = $line['variations'] ?? NULL;
+      if (!is_array($variations)) {
+        continue;
+      }
+      foreach ($variations as $vid_key => $row) {
+        $vid = (int) $vid_key;
+        if ($vid < 1) {
+          $this->loggerFactory->get('myeventlane_commerce')->warning('Operational add-on submit ignored malformed variation key @key.', ['@key' => (string) $vid_key]);
+          $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));
+          return;
+        }
+        if (!isset($allowlist[$vid])) {
+          $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on validation rejected variation @vid for event @eid (not allowlisted).', [
+            '@vid' => (string) $vid,
+            '@eid' => (string) $event->id(),
+          ]);
+          $form_state->setErrorByName('lines', $this->t('One or more selected add-ons are not available for this event.'));
+          return;
+        }
+        if (!is_array($row)) {
+          continue;
+        }
+        $qty = (int) ($row['qty'] ?? 0);
+        if ($qty < 0) {
+          $form_state->setErrorByName('lines', $this->t('Quantities cannot be negative.'));
+          return;
+        }
+        if ($qty > self::UI_QTY_MAX) {
+          $form_state->setErrorByName('lines', $this->t('Please choose a smaller quantity for add-ons.'));
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $event = $form['#node'] ?? NULL;
+    if (!$event instanceof NodeInterface) {
+      return;
+    }
+
+    $fresh = $this->addonBuilder->buildForEvent($event);
+    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+
+    $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
+
+    $lines = $form_state->getValue('lines');
+    if (!is_array($lines)) {
+      return;
+    }
+
+    $to_add = [];
+    foreach ($lines as $line) {
+      if (!is_array($line)) {
+        continue;
+      }
+      $variations = $line['variations'] ?? NULL;
+      if (!is_array($variations)) {
+        continue;
+      }
+      foreach ($variations as $vid => $row) {
+        $vid = (int) $vid;
+        if ($vid < 1 || !is_array($row)) {
+          continue;
+        }
+        $qty = (int) ($row['qty'] ?? 0);
+        if ($qty < 1) {
+          continue;
+        }
+        if (!isset($allowlist[$vid])) {
+          $this->messenger()->addError($this->t('Add-ons could not be updated. Please refresh the page.'));
+          $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit aborted: variation @vid not allowlisted post-validate.', ['@vid' => (string) $vid]);
+          return;
+        }
+        $to_add[$vid] = $qty;
+      }
+    }
+
+    if ($to_add === []) {
+      $this->messenger()->addStatus($this->t('Choose a quantity greater than zero to add extras.'));
+      return;
+    }
+
+    foreach ($to_add as $variation_id => $quantity) {
+      /** @var \Drupal\commerce_product\Entity\ProductVariationInterface|null $variation */
+      $variation = $variation_storage->load($variation_id);
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
+        return;
+      }
+
+      $product = $variation->getProduct();
+      if (!$product instanceof ProductInterface) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        return;
+      }
+
+      if (!$product->isPublished()) {
+        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        return;
+      }
+
+      if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected bundle @bundle for variation @vid.', [
+          '@bundle' => $product->bundle(),
+          '@vid' => (string) $variation_id,
+        ]);
+        return;
+      }
+
+      if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()
+        || (int) $product->get('field_event')->target_id !== (int) $event->id()) {
+        $this->messenger()->addError($this->t('An add-on is not linked to this event.'));
+        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected event mismatch for product @pid.', ['@pid' => (string) $product->id()]);
+        return;
+      }
+
+      $expected_pid = (int) ($allowlist[$variation_id]['product_id'] ?? 0);
+      if ($expected_pid > 0 && (int) $product->id() !== $expected_pid) {
+        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
+        return;
+      }
+
+      $stores = $product->getStores();
+      if ($stores === []) {
+        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
+        $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit failed: product @pid has no stores.', ['@pid' => (string) $product->id()]);
+        return;
+      }
+      $store = reset($stores);
+      if (!$store) {
+        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
+        return;
+      }
+
+      $cart = $this->cartProvider->getCart('default', $store)
+        ?: $this->cartProvider->createCart('default', $store);
+
+      $order_item = $this->cartManager->addEntity($cart, $variation, $quantity, TRUE);
+      if ($order_item && $order_item->hasField('field_target_event')) {
+        $order_item->set('field_target_event', ['target_id' => $event->id()]);
+        $order_item->save();
+      }
+    }
+
+    $this->messenger()->addStatus($this->t('Add-ons added to your booking.'));
+    $form_state->setRedirectUrl(Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event->id()]));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Customer read model: operational Commerce products linked to an event.
+ *
+ * Commerce owns carts, pricing, and inventory. This service returns only
+ * render-safe metadata for booking-page add-on selection.
+ */
+final class EventOperationalAddonBuilder {
+
+  use StringTranslationTrait;
+
+  /**
+   * Keys that must never appear in customer-facing add-on payloads.
+   *
+   * @var list<string>
+   */
+  public const FORBIDDEN_CUSTOMER_ADDON_KEYS = [
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_secret',
+    'scanner_tokens',
+    'device_fingerprint',
+    'payload_sha256',
+    'inventory_quantity',
+    'stock_count',
+    'stock_level',
+    'warehouse_ids',
+    'shipment_provider',
+    'shipment_state',
+    'private_notes',
+    'internal_cost',
+    'vendor_margin',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds add-on rows for every eligible operational product on the event.
+   *
+   * @return array{addons: list<array<string, mixed>>, product_ids: list<int>}
+   *   Render-safe add-on rows plus product IDs for cache tagging (internal).
+   */
+  public function buildForEvent(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    if ($event_id < 1) {
+      return ['addons' => [], 'product_ids' => []];
+    }
+
+    $storage = $this->entityTypeManager->getStorage('commerce_product');
+    $ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, 'IN')
+      ->condition('field_event', $event_id)
+      ->condition('status', 1)
+      ->sort('title', 'ASC')
+      ->execute();
+
+    if (!$ids) {
+      return ['addons' => [], 'product_ids' => []];
+    }
+
+    /** @var \Drupal\commerce_product\Entity\ProductInterface[] $products */
+    $products = $storage->loadMultiple($ids);
+    $addons = [];
+    $product_ids = [];
+
+    foreach ($products as $product) {
+      if (!$product instanceof ProductInterface) {
+        continue;
+      }
+      if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+        continue;
+      }
+      if (!$product->isPublished()) {
+        continue;
+      }
+      if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()) {
+        continue;
+      }
+      if ((int) $product->get('field_event')->target_id !== $event_id) {
+        continue;
+      }
+
+      $variations = [];
+      foreach ($product->getVariations() as $variation) {
+        if (!$variation instanceof ProductVariationInterface) {
+          continue;
+        }
+        if (!$variation->isPublished()) {
+          continue;
+        }
+        $price = $variation->getPrice();
+        $variations[] = [
+          'variation_id' => (int) $variation->id(),
+          'label' => (string) $variation->label(),
+          'price_number' => $price ? (string) $price->getNumber() : '',
+          'price_currency_code' => $price ? (string) $price->getCurrencyCode() : '',
+        ];
+      }
+
+      if ($variations === []) {
+        continue;
+      }
+
+      $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+      $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+
+      $row = $this->sanitizeAddon([
+        'product_id' => (int) $product->id(),
+        'bundle' => $product->bundle(),
+        'title' => (string) $product->label(),
+        'variations' => $variations,
+        'operational' => $presentation,
+      ]);
+
+      $addons[] = $row;
+      $product_ids[] = (int) $product->id();
+    }
+
+    return [
+      'addons' => $addons,
+      'product_ids' => $product_ids,
+    ];
+  }
+
+  public function hasAddons(NodeInterface $event): bool {
+    return $this->buildForEvent($event)['addons'] !== [];
+  }
+
+  /**
+   * @param array<string, mixed> $addon
+   *
+   * @return array<string, mixed>
+   */
+  public function sanitizeAddon(array $addon): array {
+    return $this->stripForbiddenKeysRecursive($addon);
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  private function stripForbiddenKeysRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenKeysRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_CUSTOMER_ADDON_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenKeysRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
@@ -93,6 +93,9 @@ final class EventOperationalAddonBuilder {
       if (!$product->isPublished()) {
         continue;
       }
+      if ($product->getStores() === []) {
+        continue;
+      }
       if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()) {
         continue;
       }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Read-only customer guidance derived from purchase composition (and optional checkout contract).
+ *
+ * Does not query Commerce entities or re-classify order lines; consumes documents
+ * produced by {@see OperationalPurchaseCompositionManager} and optionally
+ * {@see OperationalCheckoutOrchestrationManager}.
+ */
+final class OperationalAddonGuidanceBuilder {
+
+  use StringTranslationTrait;
+
+  public const CONTRACT_FLAG = 'mel_operational_addon_guidance';
+
+  /**
+   * @var list<string>
+   */
+  public const FORBIDDEN_GUIDANCE_KEYS = [
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_secret',
+    'device_fingerprint',
+    'payload_sha256',
+    'inventory_quantity',
+    'stock_count',
+    'warehouse_ids',
+    'shipment_provider',
+    'internal_cost',
+    'vendor_margin',
+    'private_notes',
+  ];
+
+  /**
+   * @var list<string>
+   */
+  private const GROUP_KEYS = [
+    'merchandise',
+    'hospitality',
+    'timed_collection',
+    'bundles',
+    'parking',
+  ];
+
+  public function __construct(TranslationInterface $string_translation) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @param array<string, mixed> $composition
+   *   Document from {@see OperationalPurchaseCompositionManager::composeForOrder()}.
+   * @param array<string, mixed>|null $checkout_document
+   *   Optional checkout contract from orchestration (same shape as #checkout).
+   *
+   * @return array<string, mixed>
+   *   Sanitised guidance document, or [] when there are no operational add-ons.
+   */
+  public function buildFromComposition(array $composition, ?array $checkout_document = NULL): array {
+    $groups = is_array($composition['groups'] ?? NULL) ? $composition['groups'] : [];
+    $has_operational = FALSE;
+    foreach (self::GROUP_KEYS as $key) {
+      if (isset($groups[$key]) && is_array($groups[$key]) && $groups[$key] !== []) {
+        $has_operational = TRUE;
+        break;
+      }
+    }
+    if (!$has_operational) {
+      return [];
+    }
+
+    $checkout_extra = $this->extractCheckoutGuidanceBodies($checkout_document);
+
+    $sections = [];
+    foreach (self::GROUP_KEYS as $group_key) {
+      $lines = is_array($groups[$group_key] ?? NULL) ? $groups[$group_key] : [];
+      if ($lines === []) {
+        continue;
+      }
+      $sections[] = $this->buildSection($group_key, $lines, $checkout_extra);
+    }
+
+    $out = [
+      self::CONTRACT_FLAG => TRUE,
+      'schema_version' => 1,
+      'page_title' => (string) $this->t('Your add-ons'),
+      'page_intro' => (string) $this->t('Merch, hospitality, and collection items linked to this booking are shown below. Collect at the event when the organiser is ready.'),
+      'sections' => $sections,
+      'footer_note' => (string) $this->t('Show your order confirmation if staff ask. Hospitality access stays linked to this booking — follow organiser instructions on the day.'),
+      'support_hint' => (string) $this->t('Shipping and QR wallet collection are not shown here yet; use your confirmation email and organiser updates for the latest details.'),
+    ];
+    return $this->stripForbiddenRecursive($out);
+  }
+
+  /**
+   * @param array<string, mixed> $composition
+   * @param array<string, mixed>|null $checkout_document
+   *
+   * @return array<string, mixed>|null
+   */
+  public function buildRenderArray(OrderInterface $order, array $composition, ?array $checkout_document = NULL): ?array {
+    $guidance = $this->buildFromComposition($composition, $checkout_document);
+    if ($guidance === []) {
+      return NULL;
+    }
+    return [
+      '#theme' => 'mel_operational_addon_guidance',
+      '#guidance' => $guidance,
+      '#attached' => [
+        'library' => ['myeventlane_commerce/operational_addon_guidance'],
+      ],
+      '#cache' => [
+        'tags' => $order->getCacheTags(),
+        'contexts' => ['languages:language_interface'],
+      ],
+    ];
+  }
+
+  /**
+   * @param list<string> $checkout_bodies
+   * @param list<array<string, mixed>> $lines
+   *
+   * @return array<string, mixed>
+   */
+  private function buildSection(string $group_key, array $lines, array $checkout_bodies): array {
+    $summaries = [];
+    $chips_out = [];
+    $seen_chip = [];
+    $readiness_modes = [];
+    $visibility = '';
+
+    foreach ($lines as $line) {
+      if (!is_array($line)) {
+        continue;
+      }
+      $pres = is_array($line['presentation'] ?? NULL) ? $line['presentation'] : [];
+      $pres = $this->stripForbiddenRecursive($pres);
+      $summary = trim((string) ($pres['operational_summary'] ?? ''));
+      if ($summary !== '') {
+        $summaries[] = $summary;
+      }
+      $raw_chips = is_array($pres['operational_chips'] ?? NULL) ? $pres['operational_chips'] : [];
+      foreach ($raw_chips as $chip) {
+        if (!is_array($chip)) {
+          continue;
+        }
+        $label = trim((string) ($chip['label'] ?? ''));
+        if ($label === '' || isset($seen_chip[$label])) {
+          continue;
+        }
+        $seen_chip[$label] = TRUE;
+        $tone = strtolower(trim((string) ($chip['tone'] ?? 'muted')));
+        if (!preg_match('/^[a-z0-9_-]{1,32}$/', $tone)) {
+          $tone = 'muted';
+        }
+        $chips_out[] = [
+          'label' => $label,
+          'tone' => $tone,
+        ];
+      }
+      $rm = strtolower(trim((string) ($pres['readiness_mode'] ?? '')));
+      if ($rm !== '') {
+        $readiness_modes[$rm] = TRUE;
+      }
+      if ($visibility === '' && isset($pres['customer_visibility'])) {
+        $visibility = (string) $pres['customer_visibility'];
+      }
+    }
+
+    $title = match ($group_key) {
+      'merchandise' => (string) $this->t('Merch & pickup'),
+      'hospitality' => (string) $this->t('Hospitality'),
+      'timed_collection' => (string) $this->t('Timed collection'),
+      'bundles' => (string) $this->t('Packages'),
+      'parking' => (string) $this->t('Parking & access'),
+      default => (string) $this->t('Add-ons'),
+    };
+
+    $next_step = $this->nextStepForGroup($group_key, $checkout_bodies);
+    $collection_hint = (string) $this->t('Collect at the event when the organiser opens pickup or check-in.');
+
+    $readiness = '';
+    if (count($readiness_modes) === 1) {
+      $readiness = array_key_first($readiness_modes);
+    }
+    elseif ($readiness_modes !== []) {
+      $readiness = 'mixed';
+    }
+
+    return [
+      'group_key' => $group_key,
+      'title' => $title,
+      'summary_lines' => $summaries,
+      'chips' => $chips_out,
+      'next_step' => $next_step,
+      'collection_hint' => $collection_hint,
+      'visibility' => $visibility,
+      'readiness' => $readiness,
+    ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function extractCheckoutGuidanceBodies(?array $checkout_document): array {
+    if ($checkout_document === NULL) {
+      return [];
+    }
+    $rows = is_array($checkout_document['customer_guidance'] ?? NULL) ? $checkout_document['customer_guidance'] : [];
+    $out = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $body = trim((string) ($row['body'] ?? ''));
+      if ($body !== '') {
+        $out[] = $body;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param list<string> $checkout_bodies
+   */
+  private function nextStepForGroup(string $group_key, array $checkout_bodies): string {
+    $base = match ($group_key) {
+      'hospitality' => (string) $this->t('Hospitality access is linked to this booking — bring your confirmation and follow organiser instructions.'),
+      'timed_collection' => (string) $this->t('Timed collection windows are for planning; final times are confirmed on site.'),
+      'parking' => (string) $this->t('Parking add-ons follow venue access rules — arrive with this booking visible on your phone or email.'),
+      'bundles' => (string) $this->t('Package items are fulfilled together at the event when the organiser is ready.'),
+      default => (string) $this->t('Bring this booking confirmation — staff may ask before handing over items.'),
+    };
+    $extra = $this->pickCheckoutBodyForGroup($group_key, $checkout_bodies);
+    if ($extra === '') {
+      return $base;
+    }
+    return $base . ' ' . $extra;
+  }
+
+  /**
+   * @param list<string> $bodies
+   */
+  private function pickCheckoutBodyForGroup(string $group_key, array $bodies): string {
+    $want = match ($group_key) {
+      'hospitality' => 'hospitality',
+      'timed_collection' => 'timed_collection',
+      'merchandise', 'bundles', 'parking' => 'pickup',
+      default => '',
+    };
+    if ($want === '' || $bodies === []) {
+      return '';
+    }
+    foreach ($bodies as $body) {
+      $lower = strtolower($body);
+      if ($want === 'hospitality' && str_contains($lower, 'hospitality')) {
+        return $body;
+      }
+      if ($want === 'timed_collection' && str_contains($lower, 'timed')) {
+        return $body;
+      }
+      if ($want === 'pickup' && str_contains($lower, 'pickup')) {
+        return $body;
+      }
+    }
+    return '';
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  public function stripForbiddenRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_GUIDANCE_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
@@ -119,7 +119,7 @@ final class OperationalAddonGuidanceBuilder {
       ],
       '#cache' => [
         'tags' => $order->getCacheTags(),
-        'contexts' => ['languages:language_interface'],
+        'contexts' => ['languages:language_interface', 'user'],
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalCheckoutOrchestrationManager.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalCheckoutOrchestrationManager.php
@@ -51,8 +51,22 @@ final class OperationalCheckoutOrchestrationManager {
    *   Full checkout contract, or NULL when no operational composition exists.
    */
   public function buildCheckoutContractForOrder(OrderInterface $order): ?array {
-    $composition = $this->purchaseCompositionManager->composeForOrder($order);
-    return $this->finalizeContractFromComposition($composition, (int) $order->id(), NULL);
+    return $this->buildCheckoutContractFromComposition(
+      $this->purchaseCompositionManager->composeForOrder($order),
+      (int) $order->id(),
+      NULL,
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $composition
+   *   Output of {@see OperationalPurchaseCompositionManager::composeForOrder()}
+   *   or {@see OperationalPurchaseCompositionManager::composePreviewFromEvent()}.
+   *
+   * @return array<string, mixed>|null
+   */
+  public function buildCheckoutContractFromComposition(array $composition, ?int $order_id, ?int $event_id): ?array {
+    return $this->finalizeContractFromComposition($composition, $order_id, $event_id);
   }
 
   /**
@@ -67,7 +81,20 @@ final class OperationalCheckoutOrchestrationManager {
    * @return array<string, mixed>|null
    */
   public function buildOrderRenderArray(OrderInterface $order): ?array {
-    $contract = $this->buildCheckoutContractForOrder($order);
+    return $this->buildOrderRenderArrayFromComposition(
+      $order,
+      $this->purchaseCompositionManager->composeForOrder($order),
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $composition
+   *   Output of {@see OperationalPurchaseCompositionManager::composeForOrder()}.
+   *
+   * @return array<string, mixed>|null
+   */
+  public function buildOrderRenderArrayFromComposition(OrderInterface $order, array $composition): ?array {
+    $contract = $this->finalizeContractFromComposition($composition, (int) $order->id(), NULL);
     if ($contract === NULL) {
       return NULL;
     }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalPurchaseCompositionManager.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalPurchaseCompositionManager.php
@@ -99,9 +99,19 @@ final class OperationalPurchaseCompositionManager {
    * @return array<string, mixed>|null
    */
   public function buildOrderRenderArray(OrderInterface $order): ?array {
-    $document = $this->composeForOrder($order);
+    return $this->buildOrderRenderArrayFromDocument($order, $this->composeForOrder($order));
+  }
+
+  /**
+   * @param array<string, mixed> $document
+   *   Output of {@see self::composeForOrder()}.
+   *
+   * @return array<string, mixed>|null
+   */
+  public function buildOrderRenderArrayFromDocument(OrderInterface $order, array $document): ?array {
+    $groups = is_array($document['groups'] ?? NULL) ? $document['groups'] : [];
     $empty = TRUE;
-    foreach ($document['groups'] as $items) {
+    foreach ($groups as $items) {
       if (is_array($items) && $items !== []) {
         $empty = FALSE;
         break;

--- a/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
@@ -1,0 +1,667 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+/**
+ * Read-only vendor summaries of operational add-on purchases for an event.
+ *
+ * Order discovery and state filtering align with
+ * {@see \Drupal\myeventlane_vendor\Controller\VendorEventOrdersController}.
+ * Line grouping uses {@see OperationalPurchaseCompositionManager::composeForOrder()}
+ * without re-classifying bundles.
+ *
+ * Callers must enforce event management access before invoking
+ * {@see self::buildForEvent()} or {@see self::buildForOrder()}.
+ */
+final class VendorOperationalAddonOrderBuilder {
+
+  use StringTranslationTrait;
+
+  public const CONTRACT_FLAG = 'mel_vendor_operational_addon_orders';
+
+  /**
+   * @var list<string>
+   */
+  public const FORBIDDEN_VENDOR_ORDER_KEYS = [
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_secret',
+    'device_fingerprint',
+    'payload_sha256',
+    'inventory_quantity',
+    'stock_count',
+    'warehouse_ids',
+    'shipment_provider',
+    'internal_cost',
+    'vendor_margin',
+    'private_notes',
+    'attendee_answers',
+    'raw_email',
+  ];
+
+  /**
+   * Order states included in vendor order surfaces.
+   *
+   * @see \Drupal\myeventlane_vendor\Controller\VendorEventOrdersController::INCLUDED_STATES
+   *
+   * @var list<string>
+   */
+  private const INCLUDED_STATES = [
+    'completed',
+    'partially_refunded',
+    'refunded',
+    'placed',
+    'fulfilled',
+    'fulfillment',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OperationalPurchaseCompositionManager $purchaseCompositionManager,
+    private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    private readonly DateFormatterInterface $dateFormatter,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Whether the event workspace should surface the add-on orders tab/link.
+   *
+   * True when linked operational catalog exists or at least one qualifying
+   * order contains operational add-on lines for this event.
+   */
+  public function shouldSurfaceVendorAddonsTab(NodeInterface $event): bool {
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+    if ($this->eventHasConfiguredOperationalCatalog($event)) {
+      return TRUE;
+    }
+    return $this->eventHasPurchasedOperationalAddons($event);
+  }
+
+  public function eventHasConfiguredOperationalCatalog(NodeInterface $event): bool {
+    $built = $this->eventOperationalAddonBuilder->buildForEvent($event);
+    return ($built['addons'] ?? []) !== [];
+  }
+
+  /**
+   * Lightweight signal: any placed order for this event includes operational
+   * Commerce lines (by product bundle), without building full composition.
+   */
+  public function eventHasPurchasedOperationalAddons(NodeInterface $event): bool {
+    $eventId = (int) $event->id();
+    foreach ($this->loadOrdersForEvent($event) as $order) {
+      if ($this->orderHasOperationalAddons($order, $eventId)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  public function orderHasOperationalAddons(OrderInterface $order, ?int $eventId = NULL): bool {
+    $composition = $this->purchaseCompositionManager->composeForOrder($order);
+    $groups = is_array($composition['groups'] ?? NULL) ? $composition['groups'] : [];
+    foreach (['merchandise', 'hospitality', 'timed_collection', 'bundles', 'parking'] as $key) {
+      $lines = is_array($groups[$key] ?? NULL) ? $groups[$key] : [];
+      foreach ($lines as $line) {
+        if (!is_array($line)) {
+          continue;
+        }
+        if ($eventId !== NULL && !$this->compositionLineIsForEvent($line, $eventId, $order)) {
+          continue;
+        }
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   Render-safe document for mel_vendor_operational_addon_orders.
+   */
+  public function buildForEvent(NodeInterface $event, AccountInterface $account): array {
+    unset($account);
+    $eventId = (int) $event->id();
+    if ($event->bundle() !== 'event' || $eventId < 1) {
+      return $this->emptyDocument(TRUE);
+    }
+
+    $orders = $this->loadOrdersForEvent($event);
+    $rows = [];
+    $groupTotals = [
+      'merchandise' => 0,
+      'hospitality' => 0,
+      'timed_collection' => 0,
+      'bundles' => 0,
+      'parking' => 0,
+    ];
+    $itemTotal = 0;
+
+    foreach ($orders as $order) {
+      if (!$this->orderHasOperationalAddons($order, $eventId)) {
+        continue;
+      }
+      $row = $this->buildOrderRow($order, $eventId);
+      if ($row === NULL) {
+        continue;
+      }
+      $rows[] = $row;
+      foreach ($groupTotals as $gk => $_) {
+        $groupTotals[$gk] += (int) ($row['group_counts'][$gk] ?? 0);
+      }
+      $itemTotal += (int) ($row['addon_item_count'] ?? 0);
+    }
+
+    $doc = [
+      self::CONTRACT_FLAG => TRUE,
+      'schema_version' => 1,
+      'empty' => $rows === [],
+      'page_title' => (string) $this->t('Add-on orders'),
+      'page_intro' => (string) $this->t('Merch, hospitality, timed collection and other add-ons purchased for this event.'),
+      'empty_message' => (string) $this->t('No add-ons have been purchased for this event yet.'),
+      'orders' => $rows,
+      'totals' => [
+        'order_count' => count($rows),
+        'item_count' => $itemTotal,
+        'group_count' => count(array_filter($groupTotals, static fn(int $c): bool => $c > 0)),
+        'group_counts' => $groupTotals,
+      ],
+    ];
+
+    return $this->stripForbiddenRecursive($doc);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildForOrder(OrderInterface $order, AccountInterface $account, int $eventId): array {
+    unset($account);
+    if (!$this->orderHasOperationalAddons($order, $eventId)) {
+      return $this->emptyDocument(TRUE);
+    }
+    $row = $this->buildOrderRow($order, $eventId);
+    if ($row === NULL) {
+      return $this->emptyDocument(TRUE);
+    }
+    $doc = [
+      self::CONTRACT_FLAG => TRUE,
+      'schema_version' => 1,
+      'empty' => FALSE,
+      'page_title' => (string) $this->t('Add-on orders'),
+      'page_intro' => (string) $this->t('Operational add-ons on this order for your event.'),
+      'empty_message' => (string) $this->t('No add-ons on this order for this event.'),
+      'orders' => [$row],
+      'totals' => [
+        'order_count' => 1,
+        'item_count' => (int) ($row['addon_item_count'] ?? 0),
+        'group_count' => count(array_filter($row['group_counts'] ?? [])),
+        'group_counts' => $row['group_counts'] ?? [],
+      ],
+    ];
+    return $this->stripForbiddenRecursive($doc);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function emptyDocument(bool $empty): array {
+    return $this->stripForbiddenRecursive([
+      self::CONTRACT_FLAG => TRUE,
+      'schema_version' => 1,
+      'empty' => $empty,
+      'page_title' => (string) $this->t('Add-on orders'),
+      'page_intro' => (string) $this->t('Merch, hospitality, timed collection and other add-ons purchased for this event.'),
+      'empty_message' => (string) $this->t('No add-ons have been purchased for this event yet.'),
+      'orders' => [],
+      'totals' => [
+        'order_count' => 0,
+        'item_count' => 0,
+        'group_count' => 0,
+        'group_counts' => [
+          'merchandise' => 0,
+          'hospitality' => 0,
+          'timed_collection' => 0,
+          'bundles' => 0,
+          'parking' => 0,
+        ],
+      ],
+    ]);
+  }
+
+  /**
+   * @return list<OrderInterface>
+   */
+  private function loadOrdersForEvent(NodeInterface $event): array {
+    $eventId = (int) $event->id();
+    $orderItemStorage = $this->entityTypeManager->getStorage('commerce_order_item');
+    $orderStorage = $this->entityTypeManager->getStorage('commerce_order');
+
+    $storeId = $this->getEventStoreId($event);
+    if ($storeId === NULL) {
+      $defaultStore = $this->entityTypeManager->getStorage('commerce_store')->loadDefault();
+      $storeId = $defaultStore ? (int) $defaultStore->id() : NULL;
+    }
+    $allowedStoreIds = $storeId !== NULL ? [$storeId] : [];
+
+    $orderItemIds = $orderItemStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_target_event', $eventId)
+      ->execute();
+
+    $orderIds = [];
+    $foundViaEventLink = FALSE;
+    if (!empty($orderItemIds)) {
+      $items = $orderItemStorage->loadMultiple($orderItemIds);
+      foreach ($items as $item) {
+        if ($item instanceof OrderItemInterface && $item->getOrderId()) {
+          $orderIds[(int) $item->getOrderId()] = TRUE;
+        }
+      }
+      $orderIds = array_keys($orderIds);
+      $foundViaEventLink = $orderIds !== [];
+    }
+
+    if (empty($orderIds)) {
+      $orderIds = $this->findOrderIdsByVariationEvent($orderItemStorage, $eventId);
+      $foundViaEventLink = $orderIds !== [];
+    }
+
+    if (empty($orderIds) && $storeId !== NULL) {
+      $orderIds = $this->findOrderIdsByStoreAndState($orderStorage, $storeId);
+      $orderIds = $this->filterOrderIdsHavingEventItems($orderStorage, $orderIds, $eventId);
+      if (empty($orderIds)) {
+        $defaultStore = $this->entityTypeManager->getStorage('commerce_store')->loadDefault();
+        if ($defaultStore && (int) $defaultStore->id() !== $storeId) {
+          $orderIds = $this->findOrderIdsByStoreAndState($orderStorage, (int) $defaultStore->id());
+          $orderIds = $this->filterOrderIdsHavingEventItems($orderStorage, $orderIds, $eventId);
+          if (!empty($orderIds)) {
+            $allowedStoreIds = [$storeId, (int) $defaultStore->id()];
+          }
+        }
+      }
+    }
+
+    if (empty($orderIds)) {
+      return [];
+    }
+
+    $orders = $orderStorage->loadMultiple($orderIds);
+    $filtered = [];
+    foreach ($orders as $order) {
+      if (!$order instanceof OrderInterface) {
+        continue;
+      }
+      if (!$foundViaEventLink && $allowedStoreIds !== [] && !in_array((int) $order->getStoreId(), $allowedStoreIds, TRUE)) {
+        continue;
+      }
+      $state = $order->getState()->getId();
+      if (!in_array($state, self::INCLUDED_STATES, TRUE)) {
+        continue;
+      }
+      $hasEventItem = FALSE;
+      foreach ($order->getItems() as $it) {
+        if ($this->orderItemIsForEvent($it, $eventId)) {
+          $hasEventItem = TRUE;
+          break;
+        }
+      }
+      if (!$hasEventItem) {
+        continue;
+      }
+      $filtered[] = $order;
+    }
+
+    usort($filtered, static function (OrderInterface $a, OrderInterface $b): int {
+      $ta = $a->getPlacedTime() ?? 0;
+      $tb = $b->getPlacedTime() ?? 0;
+      return $tb <=> $ta;
+    });
+
+    return $filtered;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildOrderRow(OrderInterface $order, int $eventId): ?array {
+    $composition = $this->purchaseCompositionManager->composeForOrder($order);
+    $groups = is_array($composition['groups'] ?? NULL) ? $composition['groups'] : [];
+    $outGroups = [];
+    $groupCounts = [
+      'merchandise' => 0,
+      'hospitality' => 0,
+      'timed_collection' => 0,
+      'bundles' => 0,
+      'parking' => 0,
+    ];
+    $addonItemCount = 0;
+
+    foreach (['merchandise', 'hospitality', 'timed_collection', 'bundles', 'parking'] as $gkey) {
+      $lines = is_array($groups[$gkey] ?? NULL) ? $groups[$gkey] : [];
+      $vendorLines = [];
+      foreach ($lines as $line) {
+        if (!is_array($line) || !$this->compositionLineIsForEvent($line, $eventId, $order)) {
+          continue;
+        }
+        $vendorLine = $this->buildVendorLine($line, $order);
+        if ($vendorLine === NULL) {
+          continue;
+        }
+        $vendorLines[] = $vendorLine;
+        $qty = (int) ($vendorLine['quantity'] ?? 0);
+        $addonItemCount += max(1, $qty);
+        $groupCounts[$gkey]++;
+      }
+      if ($vendorLines !== []) {
+        $qtySum = 0;
+        foreach ($vendorLines as $vl) {
+          $qtySum += (int) ($vl['quantity'] ?? 0);
+        }
+        $outGroups[$gkey] = [
+          'group_key' => $gkey,
+          'label' => $this->groupLabel($gkey),
+          'lines' => $vendorLines,
+          'item_count' => count($vendorLines),
+          'quantity' => $qtySum,
+        ];
+      }
+    }
+
+    if ($outGroups === []) {
+      return NULL;
+    }
+
+    $placed = $order->getPlacedTime();
+    $placedTs = $placed ? (int) $placed : 0;
+    $placedDisplay = $placedTs > 0 ? $this->dateFormatter->format($placedTs, 'medium') : '';
+
+    $cid = $order->getCustomerId();
+    if ($cid) {
+      $customerLabel = (string) $this->t('Customer #@id', ['@id' => (string) $cid]);
+    }
+    elseif ($order->getEmail()) {
+      $customerLabel = (string) $order->getEmail();
+    }
+    else {
+      $customerLabel = (string) $this->t('Guest customer');
+    }
+
+    return [
+      'order_id' => (int) $order->id(),
+      'order_number' => (string) ($order->getOrderNumber() ?: ('#' . $order->id())),
+      'placed_timestamp' => $placedTs,
+      'placed_display' => $placedDisplay,
+      'customer_display_label' => $customerLabel,
+      'groups' => $outGroups,
+      'group_counts' => $groupCounts,
+      'addon_item_count' => $addonItemCount,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $line
+   *   Composition line from {@see OperationalPurchaseCompositionManager}.
+   *
+   * @return array<string, mixed>|null
+   */
+  private function buildVendorLine(array $line, OrderInterface $order): ?array {
+    $oid = (int) ($line['order_item_id'] ?? 0);
+    if ($oid < 1) {
+      return NULL;
+    }
+    $item = NULL;
+    foreach ($order->getItems() as $candidate) {
+      if ((int) $candidate->id() === $oid) {
+        $item = $candidate;
+        break;
+      }
+    }
+    if (!$item instanceof OrderItemInterface) {
+      return NULL;
+    }
+
+    $pres = is_array($line['presentation'] ?? NULL) ? $line['presentation'] : [];
+    $pres = $this->stripForbiddenRecursive($pres);
+
+    $pe = $item->getPurchasedEntity();
+    $variationLabel = $pe instanceof ProductVariationInterface ? $pe->label() : '';
+    $productLabel = '';
+    if ($pe instanceof ProductVariationInterface) {
+      $product = $pe->getProduct();
+      $productLabel = $product ? $product->label() : '';
+    }
+
+    $chips = [];
+    foreach (is_array($pres['operational_chips'] ?? NULL) ? $pres['operational_chips'] : [] as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = trim((string) ($chip['label'] ?? ''));
+      if ($label === '') {
+        continue;
+      }
+      $tone = strtolower(trim((string) ($chip['tone'] ?? 'muted')));
+      if (!preg_match('/^[a-z0-9_-]{1,32}$/', $tone)) {
+        $tone = 'muted';
+      }
+      $chips[] = ['label' => $label, 'tone' => $tone];
+    }
+
+    return [
+      'order_item_id' => $oid,
+      'quantity' => (int) $item->getQuantity(),
+      'product_label' => $productLabel,
+      'variation_label' => $variationLabel,
+      'operational_summary' => trim((string) ($pres['operational_summary'] ?? '')),
+      'readiness_mode' => trim((string) ($pres['readiness_mode'] ?? '')),
+      'pickup_mode' => trim((string) ($pres['pickup_mode'] ?? '')),
+      'customer_visibility' => trim((string) ($pres['customer_visibility'] ?? '')),
+      'chips' => $chips,
+    ];
+  }
+
+  private function groupLabel(string $groupKey): string {
+    return match ($groupKey) {
+      'merchandise' => (string) $this->t('Merch & pickup'),
+      'hospitality' => (string) $this->t('Hospitality'),
+      'timed_collection' => (string) $this->t('Timed collection'),
+      'bundles' => (string) $this->t('Packages'),
+      'parking' => (string) $this->t('Parking & access'),
+      default => (string) $this->t('Add-ons'),
+    };
+  }
+
+  /**
+   * @param array<string, mixed> $line
+   */
+  private function compositionLineIsForEvent(array $line, int $eventId, OrderInterface $order): bool {
+    $oid = (int) ($line['order_item_id'] ?? 0);
+    if ($oid < 1) {
+      return FALSE;
+    }
+    foreach ($order->getItems() as $item) {
+      if ((int) $item->id() === $oid) {
+        return $this->orderItemIsForEvent($item, $eventId);
+      }
+    }
+    return FALSE;
+  }
+
+  private function orderItemIsForEvent(OrderItemInterface $item, int $eventId): bool {
+    if ($item->bundle() === 'boost') {
+      return FALSE;
+    }
+    if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+      if ((int) $item->get('field_target_event')->target_id === $eventId) {
+        return TRUE;
+      }
+    }
+    $var = $item->getPurchasedEntity();
+    if ($var) {
+      if ($var->hasField('field_event') && !$var->get('field_event')->isEmpty()) {
+        if ((int) $var->get('field_event')->target_id === $eventId) {
+          return TRUE;
+        }
+      }
+      if ($var->hasField('field_event_ref') && !$var->get('field_event_ref')->isEmpty()) {
+        if ((int) $var->get('field_event_ref')->target_id === $eventId) {
+          return TRUE;
+        }
+      }
+      try {
+        $product = $var->getProduct();
+        if ($product && $product->hasField('field_event') && !$product->get('field_event')->isEmpty()) {
+          if ((int) $product->get('field_event')->target_id === $eventId) {
+            return TRUE;
+          }
+        }
+      }
+      catch (\Throwable) {
+      }
+    }
+    return FALSE;
+  }
+
+  private function getEventStoreId(NodeInterface $event): ?int {
+    if (!$event->hasField('field_product_target') || $event->get('field_product_target')->isEmpty()) {
+      return NULL;
+    }
+    $product = $event->get('field_product_target')->entity;
+    if (!$product) {
+      return NULL;
+    }
+    $stores = $product->getStores();
+    if ($stores === []) {
+      return NULL;
+    }
+    return (int) $stores[0]->id();
+  }
+
+  /**
+   * @param \Drupal\Core\Entity\EntityStorageInterface $orderItemStorage
+   * @return int[]
+   */
+  private function findOrderIdsByVariationEvent($orderItemStorage, int $eventId): array {
+    $varStorage = $this->entityTypeManager->getStorage('commerce_product_variation');
+    $vids = [];
+    $ids = $varStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_event', $eventId)
+      ->execute();
+    if ($ids) {
+      $vids = array_merge($vids, array_map('intval', (array) $ids));
+    }
+    try {
+      $ids2 = $varStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('field_event_ref', $eventId)
+        ->execute();
+      if ($ids2) {
+        $vids = array_merge($vids, array_map('intval', (array) $ids2));
+      }
+    }
+    catch (\Throwable) {
+    }
+    $vids = array_values(array_unique(array_filter($vids)));
+    if ($vids === []) {
+      return [];
+    }
+    $itemIds = $orderItemStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('purchased_entity', $vids, 'IN')
+      ->execute();
+    if (empty($itemIds)) {
+      return [];
+    }
+    $items = $orderItemStorage->loadMultiple($itemIds);
+    $orderIds = [];
+    foreach ($items as $item) {
+      if ($item instanceof OrderItemInterface && $item->getOrderId()) {
+        $orderIds[(int) $item->getOrderId()] = TRUE;
+      }
+    }
+    return array_keys($orderIds);
+  }
+
+  /**
+   * @return int[]
+   */
+  private function findOrderIdsByStoreAndState($orderStorage, int $storeId): array {
+    $ids = $orderStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('store_id', $storeId)
+      ->condition('state', self::INCLUDED_STATES, 'IN')
+      ->execute();
+    return array_map('intval', (array) $ids);
+  }
+
+  /**
+   * @param int[] $orderIds
+   *
+   * @return int[]
+   */
+  private function filterOrderIdsHavingEventItems($orderStorage, array $orderIds, int $eventId): array {
+    $out = [];
+    foreach ($orderStorage->loadMultiple($orderIds) as $order) {
+      if (!$order instanceof OrderInterface) {
+        continue;
+      }
+      foreach ($order->getItems() as $item) {
+        if ($this->orderItemIsForEvent($item, $eventId)) {
+          $out[] = (int) $order->id();
+          break;
+        }
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  public function stripForbiddenRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_VENDOR_ORDER_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
@@ -49,7 +49,16 @@ final class VendorOperationalAddonOrderBuilder {
     'private_notes',
     'attendee_answers',
     'raw_email',
+    'email',
+    'mail',
+    'billing_profile',
+    'customer_email',
   ];
+
+  /**
+   * Conservative max-age when order entity tags are impractical to enumerate.
+   */
+  public const VENDOR_ADDON_ORDERS_MAX_AGE = 300;
 
   /**
    * Order states included in vendor order surfaces.
@@ -96,6 +105,37 @@ final class VendorOperationalAddonOrderBuilder {
   public function eventHasConfiguredOperationalCatalog(NodeInterface $event): bool {
     $built = $this->eventOperationalAddonBuilder->buildForEvent($event);
     return ($built['addons'] ?? []) !== [];
+  }
+
+  /**
+   * Cache tags for vendor add-on order surfaces (event, catalog products, orders).
+   *
+   * Order tags are collected only for qualifying orders with operational lines.
+   * When many orders exist, callers should also set
+   * {@see self::VENDOR_ADDON_ORDERS_MAX_AGE} as a conservative bound.
+   *
+   * @return list<string>
+   */
+  public function collectCacheTagsForEvent(NodeInterface $event): array {
+    $eventId = (int) $event->id();
+    if ($event->bundle() !== 'event' || $eventId < 1) {
+      return [];
+    }
+
+    $tags = $event->getCacheTags();
+    $built = $this->eventOperationalAddonBuilder->buildForEvent($event);
+    foreach ($built['product_ids'] ?? [] as $pid) {
+      $tags[] = 'commerce_product:' . (int) $pid;
+    }
+
+    foreach ($this->loadOrdersForEvent($event) as $order) {
+      if (!$this->orderHasOperationalAddons($order, $eventId)) {
+        continue;
+      }
+      $tags = array_merge($tags, $order->getCacheTags());
+    }
+
+    return array_values(array_unique($tags));
   }
 
   /**
@@ -173,6 +213,7 @@ final class VendorOperationalAddonOrderBuilder {
       'empty' => $rows === [],
       'page_title' => (string) $this->t('Add-on orders'),
       'page_intro' => (string) $this->t('Merch, hospitality, timed collection and other add-ons purchased for this event.'),
+      'vendor_prepare_hint' => (string) $this->t('Prepare these add-ons before check-in. This list is read-only — collection and scanning tools are not available here yet.'),
       'empty_message' => (string) $this->t('No add-ons have been purchased for this event yet.'),
       'orders' => $rows,
       'totals' => [
@@ -204,6 +245,7 @@ final class VendorOperationalAddonOrderBuilder {
       'empty' => FALSE,
       'page_title' => (string) $this->t('Add-on orders'),
       'page_intro' => (string) $this->t('Operational add-ons on this order for your event.'),
+      'vendor_prepare_hint' => (string) $this->t('Prepare these add-ons before check-in. This list is read-only — collection and scanning tools are not available here yet.'),
       'empty_message' => (string) $this->t('No add-ons on this order for this event.'),
       'orders' => [$row],
       'totals' => [
@@ -226,6 +268,7 @@ final class VendorOperationalAddonOrderBuilder {
       'empty' => $empty,
       'page_title' => (string) $this->t('Add-on orders'),
       'page_intro' => (string) $this->t('Merch, hospitality, timed collection and other add-ons purchased for this event.'),
+      'vendor_prepare_hint' => (string) $this->t('Prepare these add-ons before check-in. This list is read-only — collection and scanning tools are not available here yet.'),
       'empty_message' => (string) $this->t('No add-ons have been purchased for this event yet.'),
       'orders' => [],
       'totals' => [
@@ -390,16 +433,7 @@ final class VendorOperationalAddonOrderBuilder {
     $placedTs = $placed ? (int) $placed : 0;
     $placedDisplay = $placedTs > 0 ? $this->dateFormatter->format($placedTs, 'medium') : '';
 
-    $cid = $order->getCustomerId();
-    if ($cid) {
-      $customerLabel = (string) $this->t('Customer #@id', ['@id' => (string) $cid]);
-    }
-    elseif ($order->getEmail()) {
-      $customerLabel = (string) $order->getEmail();
-    }
-    else {
-      $customerLabel = (string) $this->t('Guest customer');
-    }
+    $customerLabel = $this->buildCustomerDisplayLabel($order);
 
     return [
       'order_id' => (int) $order->id(),
@@ -473,6 +507,24 @@ final class VendorOperationalAddonOrderBuilder {
       'customer_visibility' => trim((string) ($pres['customer_visibility'] ?? '')),
       'chips' => $chips,
     ];
+  }
+
+  /**
+   * Privacy-safe purchaser label (no raw email; aligns with vendor orders name).
+   */
+  private function buildCustomerDisplayLabel(OrderInterface $order): string {
+    $customer = $order->getCustomer();
+    if ($customer && !$customer->isAnonymous()) {
+      $name = trim($customer->getDisplayName());
+      if ($name !== '') {
+        return $name;
+      }
+      $uid = (int) $customer->id();
+      if ($uid > 0) {
+        return (string) $this->t('Customer #@id', ['@id' => (string) $uid]);
+      }
+    }
+    return (string) $this->t('Guest customer');
   }
 
   private function groupLabel(string $groupKey): string {

--- a/web/modules/custom/myeventlane_commerce/templates/mel-operational-addon-guidance.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-operational-addon-guidance.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Compact customer add-on guidance (mel_operational_addon_guidance).
+ *
+ * Variables are pre-built in PHP; no calculations here.
+ *
+ * @see \Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder
+ */
+#}
+{% set g = guidance|default({}) %}
+{% if g.mel_operational_addon_guidance %}
+  <div class="mel-addon-guidance" role="region" aria-labelledby="mel-addon-guidance-title">
+    <div class="mel-addon-guidance__header">
+      <h2 id="mel-addon-guidance-title" class="mel-addon-guidance__title">{{ g.page_title }}</h2>
+      {% if g.page_intro %}
+        <p class="mel-addon-guidance__intro">{{ g.page_intro }}</p>
+      {% endif %}
+    </div>
+
+    {% if g.sections is defined and g.sections|length > 0 %}
+      <ul class="mel-addon-guidance__sections">
+        {% for section in g.sections %}
+          <li class="mel-addon-guidance__section">
+            <h3 class="mel-addon-guidance__section-title">{{ section.title }}</h3>
+            {% if section.summary_lines is defined and section.summary_lines|length > 0 %}
+              <ul class="mel-addon-guidance__summaries">
+                {% for line in section.summary_lines %}
+                  <li>{{ line }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if section.chips is defined and section.chips|length > 0 %}
+              <ul class="mel-addon-guidance__chips">
+                {% for chip in section.chips %}
+                  <li>
+                    <span class="mel-addon-guidance__chip mel-addon-guidance__chip--{{ chip.tone|default('muted') }}">{{ chip.label }}</span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if section.next_step %}
+              <p class="mel-addon-guidance__next">{{ section.next_step }}</p>
+            {% endif %}
+            {% if section.collection_hint %}
+              <p class="mel-addon-guidance__hint">{{ section.collection_hint }}</p>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if g.footer_note %}
+      <p class="mel-addon-guidance__footer">{{ g.footer_note }}</p>
+    {% endif %}
+    {% if g.support_hint %}
+      <p class="mel-addon-guidance__support mel-text--muted">{{ g.support_hint }}</p>
+    {% endif %}
+  </div>
+{% endif %}

--- a/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
@@ -11,6 +11,9 @@
   {% if doc.page_intro %}
     <p class="mel-vendor-addon-orders__intro">{{ doc.page_intro }}</p>
   {% endif %}
+  {% if doc.vendor_prepare_hint %}
+    <p class="mel-vendor-addon-orders__prepare-hint">{{ doc.vendor_prepare_hint }}</p>
+  {% endif %}
 
   {% if doc.empty %}
     <div class="mel-vendor-addon-orders__empty mel-card">

--- a/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
@@ -1,0 +1,106 @@
+{#
+/**
+ * @file
+ * Vendor read-only list of operational add-on purchases for an event.
+ *
+ * @see \Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder
+ */
+#}
+{% set doc = document|default({}) %}
+<div class="mel-vendor-addon-orders">
+  {% if doc.page_intro %}
+    <p class="mel-vendor-addon-orders__intro">{{ doc.page_intro }}</p>
+  {% endif %}
+
+  {% if doc.empty %}
+    <div class="mel-vendor-addon-orders__empty mel-card">
+      <div class="mel-card-body">
+        <p class="mel-vendor-addon-orders__empty-text">{{ doc.empty_message|default('') }}</p>
+      </div>
+    </div>
+  {% else %}
+    {% set totals = doc.totals|default({}) %}
+    <div class="mel-vendor-addon-orders__summary mel-card mel-mb-4">
+      <div class="mel-card-body">
+        <h2 class="mel-vendor-addon-orders__summary-title">{{ 'Summary'|t }}</h2>
+        <ul class="mel-vendor-addon-orders__stat-grid">
+          <li class="mel-vendor-addon-orders__stat">
+            <span class="mel-vendor-addon-orders__stat-label">{{ 'Orders with add-ons'|t }}</span>
+            <span class="mel-vendor-addon-orders__stat-value">{{ totals.order_count|default(0) }}</span>
+          </li>
+          <li class="mel-vendor-addon-orders__stat">
+            <span class="mel-vendor-addon-orders__stat-label">{{ 'Add-on line items'|t }}</span>
+            <span class="mel-vendor-addon-orders__stat-value">{{ totals.item_count|default(0) }}</span>
+          </li>
+        </ul>
+        {% set gc = totals.group_counts|default({}) %}
+        {% if gc is iterable %}
+          <ul class="mel-vendor-addon-orders__group-counts">
+            {% for key, count in gc %}
+              {% if count > 0 %}
+                <li><span class="mel-vendor-addon-orders__chip">{{ key|replace({'_': ' '})|title }}: {{ count }}</span></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="mel-vendor-addon-orders__list">
+      {% for order in doc.orders %}
+        <article class="mel-vendor-addon-orders__order mel-card mel-mb-3">
+          <div class="mel-card-body">
+            <header class="mel-vendor-addon-orders__order-head">
+              <div>
+                <h3 class="mel-vendor-addon-orders__order-title">{{ order.order_number|default('') }}</h3>
+                <p class="mel-vendor-addon-orders__order-meta">
+                  {% if order.placed_display %}
+                    <span>{{ 'Placed'|t }}: {{ order.placed_display }}</span>
+                  {% endif %}
+                </p>
+              </div>
+              <div class="mel-vendor-addon-orders__customer">
+                <span class="mel-vendor-addon-orders__customer-label">{{ order.customer_display_label|default('') }}</span>
+              </div>
+            </header>
+
+            {% for gkey, group in order.groups %}
+              <section class="mel-vendor-addon-orders__group" aria-labelledby="mel-vendor-addon-group-{{ order.order_id }}-{{ gkey }}">
+                <h4 id="mel-vendor-addon-group-{{ order.order_id }}-{{ gkey }}" class="mel-vendor-addon-orders__group-title">{{ group.label|default(gkey) }}</h4>
+                <ul class="mel-vendor-addon-orders__lines">
+                  {% for line in group.lines %}
+                    <li class="mel-vendor-addon-orders__line">
+                      <div class="mel-vendor-addon-orders__line-main">
+                        <span class="mel-vendor-addon-orders__line-product">{{ line.product_label|default('') }}</span>
+                        {% if line.variation_label %}
+                          <span class="mel-vendor-addon-orders__line-variation">{{ line.variation_label }}</span>
+                        {% endif %}
+                        <span class="mel-vendor-addon-orders__line-qty">× {{ line.quantity|default(0) }}</span>
+                      </div>
+                      {% if line.operational_summary %}
+                        <p class="mel-vendor-addon-orders__line-summary">{{ line.operational_summary }}</p>
+                      {% endif %}
+                      {% if line.readiness_mode or line.pickup_mode %}
+                        <p class="mel-vendor-addon-orders__line-modes">
+                          {% if line.readiness_mode %}<span class="mel-vendor-addon-orders__pill">{{ line.readiness_mode }}</span>{% endif %}
+                          {% if line.pickup_mode %}<span class="mel-vendor-addon-orders__pill">{{ line.pickup_mode }}</span>{% endif %}
+                        </p>
+                      {% endif %}
+                      {% if line.chips is defined and line.chips|length > 0 %}
+                        <ul class="mel-vendor-addon-orders__chips">
+                          {% for chip in line.chips %}
+                            <li><span class="mel-vendor-addon-orders__chip mel-vendor-addon-orders__chip--{{ chip.tone|default('muted') }}">{{ chip.label }}</span></li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </section>
+            {% endfor %}
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -118,6 +118,13 @@
               {% endif %}
             </div>
           </div>
+
+          {% if addons_available and operational_addon_form %}
+            <section class="mel-operational-addons-section" aria-labelledby="mel-operational-addons-title">
+              <h2 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ 'Add something extra'|t }}</h2>
+              {{ operational_addon_form }}
+            </section>
+          {% endif %}
         </div>
 
         {% if event_mode == 'paid' %}

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -122,6 +122,7 @@
           {% if addons_available and operational_addon_form %}
             <section class="mel-operational-addons-section" aria-labelledby="mel-operational-addons-title">
               <h2 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ 'Add something extra'|t }}</h2>
+              <p class="mel-operational-addons-section__lede">{{ 'Optional extras stay on this booking — collect at the event after purchase.'|t }}</p>
               {{ operational_addon_form }}
             </section>
           {% endif %}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -18,6 +18,7 @@ use Drupal\commerce_store\Entity\Store;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager;
@@ -328,6 +329,104 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $doc = $this->compositionManager()->composePreviewFromEvent(Node::load($this->event->id()));
     $this->assertCount(1, $doc['groups']['timed_collection']);
     $this->assertSame('elevated', $doc['governance']['severity']);
+  }
+
+  public function testEventOperationalAddonBuilderReturnsLinkedOperationalProducts(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-K1');
+    $product->set('field_mel_operational_product', json_encode([
+      'operational_product_type' => 'merch_pickup',
+      'operational_summary' => 'Pick up at desk',
+      'inventory_quantity' => 50,
+      'qr_payload' => 'nope',
+      'operational_chips' => [
+        ['label' => 'After entry', 'tone' => 'info'],
+      ],
+    ], JSON_THROW_ON_ERROR));
+    $product->save();
+
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertNotSame([], $built['addons']);
+    $first = $built['addons'][0];
+    $this->assertSame((int) $product->id(), (int) ($first['product_id'] ?? 0));
+    $this->assertArrayHasKey('operational', $first);
+    $this->assertArrayNotHasKey('inventory_quantity', $first['operational']);
+    $this->assertArrayNotHasKey('qr_payload', $first['operational']);
+    $this->assertSame('Pick up at desk', $first['operational']['operational_summary']);
+    $this->assertNotEmpty($first['variations']);
+  }
+
+  public function testEventOperationalAddonBuilderExcludesUnpublishedProduct(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-OFF');
+    $product->set('status', 0);
+    $product->save();
+
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderExcludesUnpublishedVariation(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-VAROFF');
+    foreach ($product->getVariations() as $variation) {
+      $variation->set('status', 0);
+      $variation->save();
+    }
+    $product->save();
+
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderEmptyWhenWrongEvent(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-OTHER');
+    $other = Node::create([
+      'type' => 'event',
+      'title' => 'Other event',
+      'uid' => $this->event->getOwnerId(),
+      'status' => 1,
+    ]);
+    $other->save();
+    $product->set('field_event', ['target_id' => $other->id()]);
+    $product->set('status', 1);
+    $product->save();
+
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
+  public function testEventOperationalAddonBuilderHasAddonsFalseWhenNoProducts(): void {
+    $empty_event = Node::create([
+      'type' => 'event',
+      'title' => 'No merch',
+      'uid' => $this->event->getOwnerId(),
+      'status' => 1,
+    ]);
+    $empty_event->save();
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $this->assertFalse($builder->hasAddons($empty_event));
   }
 
   protected function merchandiseManager(): OperationalMerchandiseManager {

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -391,6 +391,20 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $this->assertSame([], $built['addons']);
   }
 
+  public function testEventOperationalAddonBuilderExcludesProductWithoutStore(): void {
+    $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-NOSTORE');
+    $product->set('stores', []);
+    $product->save();
+
+    $builder = new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      $this->container->get('string_translation'),
+    );
+    $built = $builder->buildForEvent($this->event);
+    $this->assertSame([], $built['addons']);
+  }
+
   public function testEventOperationalAddonBuilderEmptyWhenWrongEvent(): void {
     $product = $this->createOperationalProduct('operational_merchandise', 'operational_merchandise_var', 'ADDON-OTHER');
     $other = Node::create([

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class EventOperationalAddonBuilderTest extends UnitTestCase {
+
+  private function builder(): EventOperationalAddonBuilder {
+    $etm = $this->createMock(\Drupal\Core\Entity\EntityTypeManagerInterface::class);
+    $logger = $this->createMock(LoggerInterface::class);
+    $merch = new OperationalMerchandiseManager(
+      $etm,
+      $this->getStringTranslationStub(),
+      $logger,
+    );
+    return new EventOperationalAddonBuilder(
+      $etm,
+      $merch,
+      $this->getStringTranslationStub(),
+    );
+  }
+
+  public function testSanitizeAddonStripsForbiddenKeys(): void {
+    $dirty = [
+      'title' => 'Tee',
+      'qr_payload' => 'secret',
+      'nested' => [
+        'scanner_secret' => 'x',
+        'ok' => 1,
+      ],
+    ];
+    $clean = $this->builder()->sanitizeAddon($dirty);
+    $this->assertSame('Tee', $clean['title']);
+    $this->assertArrayNotHasKey('qr_payload', $clean);
+    $this->assertArrayNotHasKey('scanner_secret', $clean['nested']);
+    $this->assertSame(1, $clean['nested']['ok']);
+  }
+
+  public function testSanitizeAddonStripsStockAndWarehouseKeys(): void {
+    $dirty = [
+      'stock_count' => 5,
+      'warehouse_ids' => [1],
+      'vendor_margin' => '10',
+    ];
+    $clean = $this->builder()->sanitizeAddon($dirty);
+    $this->assertSame([], $clean);
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class OperationalAddonGuidanceBuilderTest extends UnitTestCase {
+
+  private function builder(): OperationalAddonGuidanceBuilder {
+    return new OperationalAddonGuidanceBuilder($this->getStringTranslationStub());
+  }
+
+  public function testReturnsEmptyWhenNoOperationalGroups(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $this->assertSame([], $this->builder()->buildFromComposition($composition));
+  }
+
+  public function testBuildsMerchGuidance(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [
+          [
+            'presentation' => [
+              'operational_summary' => 'Pickup at merch tent',
+              'operational_chips' => [
+                ['label' => 'After doors', 'tone' => 'info'],
+              ],
+              'readiness_mode' => 'nominal',
+            ],
+          ],
+        ],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $out = $this->builder()->buildFromComposition($composition);
+    $this->assertNotEmpty($out);
+    $this->assertArrayHasKey('sections', $out);
+    $this->assertCount(1, $out['sections']);
+    $this->assertSame('merchandise', $out['sections'][0]['group_key']);
+    $this->assertContains('Pickup at merch tent', $out['sections'][0]['summary_lines']);
+    $this->assertCount(1, $out['sections'][0]['chips']);
+    $this->assertSame('After doors', $out['sections'][0]['chips'][0]['label']);
+    $this->assertSame('info', $out['sections'][0]['chips'][0]['tone']);
+    $this->assertSame('nominal', $out['sections'][0]['readiness']);
+  }
+
+  public function testBuildsHospitalityGuidance(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [],
+        'hospitality' => [
+          [
+            'presentation' => [
+              'operational_summary' => 'Lounge access included',
+              'readiness_mode' => 'attention',
+            ],
+          ],
+        ],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $checkout = [
+      'customer_guidance' => [
+        ['type' => 'hospitality', 'body' => 'Hospitality benefits activate according to organiser instructions—usually after admission.'],
+      ],
+    ];
+    $out = $this->builder()->buildFromComposition($composition, $checkout);
+    $this->assertCount(1, $out['sections']);
+    $this->assertSame('hospitality', $out['sections'][0]['group_key']);
+    $this->assertStringContainsString('Hospitality', $out['sections'][0]['next_step']);
+    $this->assertStringContainsString('Hospitality benefits activate', $out['sections'][0]['next_step']);
+  }
+
+  public function testBuildsTimedCollectionGuidance(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [],
+        'hospitality' => [],
+        'timed_collection' => [
+          [
+            'presentation' => [
+              'operational_summary' => 'Window 2–3pm',
+            ],
+          ],
+        ],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $checkout = [
+      'customer_guidance' => [
+        ['type' => 'timed_collection', 'body' => 'Timed collection windows are shown for planning.'],
+      ],
+    ];
+    $out = $this->builder()->buildFromComposition($composition, $checkout);
+    $this->assertCount(1, $out['sections']);
+    $this->assertSame('timed_collection', $out['sections'][0]['group_key']);
+    $this->assertStringContainsString('Timed collection', $out['sections'][0]['next_step']);
+  }
+
+  public function testStripsForbiddenKeysRecursively(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [
+          [
+            'presentation' => [
+              'operational_summary' => 'Visible',
+              'qr_payload' => ['secret' => 'x'],
+              'nested' => [
+                'scanner_secret' => 'no',
+                'inventory_quantity' => 99,
+              ],
+            ],
+          ],
+        ],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $out = $this->builder()->buildFromComposition($composition);
+    $encoded = json_encode($out);
+    $this->assertIsString($encoded);
+    $this->assertStringNotContainsString('qr_payload', $encoded);
+    $this->assertStringNotContainsString('scanner_secret', $encoded);
+    $this->assertStringNotContainsString('inventory_quantity', $encoded);
+    $this->assertStringContainsString('Visible', $encoded);
+  }
+
+  public function testStripRecursivePreservesListKeys(): void {
+    $nested = [
+      'chips' => [
+        0 => ['label' => 'A', 'tone' => 'info'],
+        1 => ['label' => 'B', 'tone' => 'muted'],
+      ],
+    ];
+    $stripped = $this->builder()->stripForbiddenRecursive($nested);
+    $this->assertSame([0, 1], array_keys($stripped['chips']));
+  }
+
+  public function testDoesNotInventShippingQrScannerCopyInMerchSection(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [
+          ['presentation' => ['operational_summary' => 'Hat']],
+        ],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $out = $this->builder()->buildFromComposition($composition);
+    $step = (string) ($out['sections'][0]['next_step'] ?? '');
+    $this->assertStringNotContainsStringIgnoringCase('QR', $step);
+    $this->assertStringNotContainsStringIgnoringCase('scanner', $step);
+    $this->assertStringNotContainsStringIgnoringCase('ship', $step);
+    $hint = (string) ($out['support_hint'] ?? '');
+    $this->assertStringContainsStringIgnoringCase('Shipping', $hint);
+    $this->assertStringContainsStringIgnoringCase('QR', $hint);
+  }
+
+  public function testBuildRenderArrayReturnsNullWhenEmpty(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCacheTags')->willReturn(['commerce_order:1']);
+    $composition = [
+      'groups' => [
+        'merchandise' => [],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $this->assertNull($this->builder()->buildRenderArray($order, $composition));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php
@@ -19,6 +19,22 @@ final class OperationalAddonGuidanceBuilderTest extends UnitTestCase {
     return new OperationalAddonGuidanceBuilder($this->getStringTranslationStub());
   }
 
+  public function testOmitsGuidanceForTicketOnlyComposition(): void {
+    $composition = [
+      'groups' => [
+        'merchandise' => [],
+        'hospitality' => [],
+        'timed_collection' => [],
+        'bundles' => [],
+        'parking' => [],
+      ],
+    ];
+    $this->assertSame([], $this->builder()->buildFromComposition($composition));
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCacheTags')->willReturn(['commerce_order:99']);
+    $this->assertNull($this->builder()->buildRenderArray($order, $composition));
+  }
+
   public function testReturnsEmptyWhenNoOperationalGroups(): void {
     $composition = [
       'groups' => [

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class VendorOperationalAddonOrderBuilderTest extends UnitTestCase {
+
+  private function stripHelper(): VendorOperationalAddonOrderBuilder {
+    $ref = new \ReflectionClass(VendorOperationalAddonOrderBuilder::class);
+    /** @var \Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder $o */
+    $o = $ref->newInstanceWithoutConstructor();
+    return $o;
+  }
+
+  public function testForbiddenKeysListIncludesVendorFields(): void {
+    $keys = VendorOperationalAddonOrderBuilder::FORBIDDEN_VENDOR_ORDER_KEYS;
+    $this->assertContains('attendee_answers', $keys);
+    $this->assertContains('qr_payload', $keys);
+    $this->assertContains('warehouse_ids', $keys);
+  }
+
+  public function testStripForbiddenRemovesNestedKeys(): void {
+    $data = [
+      'a' => 1,
+      'qr_payload' => ['x' => 1],
+      'nested' => [
+        'scanner_secret' => 'nope',
+        'attendee_answers' => ['q' => 'a'],
+        'ok' => 'yes',
+      ],
+    ];
+    $out = $this->stripHelper()->stripForbiddenRecursive($data);
+    $json = json_encode($out);
+    $this->assertStringNotContainsString('qr_payload', (string) $json);
+    $this->assertStringNotContainsString('scanner_secret', (string) $json);
+    $this->assertStringNotContainsString('attendee_answers', (string) $json);
+    $this->assertStringContainsString('yes', (string) $json);
+  }
+
+  public function testStripPreservesListKeysForChips(): void {
+    $data = [
+      'chips' => [
+        0 => ['label' => 'A', 'tone' => 'info'],
+        1 => ['label' => 'B', 'tone' => 'muted'],
+      ],
+    ];
+    $out = $this->stripHelper()->stripForbiddenRecursive($data);
+    $this->assertSame([0, 1], array_keys($out['chips']));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/VendorOperationalAddonOrderBuilderTest.php
@@ -26,6 +26,21 @@ final class VendorOperationalAddonOrderBuilderTest extends UnitTestCase {
     $this->assertContains('attendee_answers', $keys);
     $this->assertContains('qr_payload', $keys);
     $this->assertContains('warehouse_ids', $keys);
+    $this->assertContains('email', $keys);
+    $this->assertContains('customer_email', $keys);
+  }
+
+  public function testStripRemovesEmailKeys(): void {
+    $data = [
+      'customer_display_label' => 'Alex',
+      'email' => 'secret@example.com',
+      'nested' => ['mail' => 'also-secret@example.com', 'ok' => 1],
+    ];
+    $out = $this->stripHelper()->stripForbiddenRecursive($data);
+    $this->assertSame('Alex', $out['customer_display_label']);
+    $this->assertArrayNotHasKey('email', $out);
+    $this->assertArrayNotHasKey('mail', $out['nested']);
+    $this->assertSame(1, $out['nested']['ok']);
   }
 
   public function testStripForbiddenRemovesNestedKeys(): void {

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
@@ -38,6 +38,12 @@ myeventlane_vendor.event_workspace.orders:
   base_route: myeventlane_vendor.console.event_overview
   weight: -12
 
+myeventlane_vendor.event_workspace.addon_orders:
+  title: 'Add-on orders'
+  route_name: myeventlane_vendor.console.event_operational_addon_orders
+  base_route: myeventlane_vendor.console.event_overview
+  weight: -11
+
 myeventlane_vendor.event_workspace.attendees:
   title: 'Attendees'
   route_name: myeventlane_event_attendees.vendor_list

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -570,6 +570,21 @@ myeventlane_vendor.console.event_orders:
         bundle:
           - event
 
+myeventlane_vendor.console.event_operational_addon_orders:
+  path: '/vendor/events/{event}/addons'
+  defaults:
+    _controller: 'myeventlane_vendor.controller.vendor_operational_addon_orders:addons'
+    _title: 'Add-on orders'
+  requirements:
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: '\d+'
+  options:
+    parameters:
+      event:
+        type: entity:node
+        bundle:
+          - event
+
 myeventlane_vendor.console.event_order_view:
   path: '/vendor/events/{event}/orders/{order}'
   defaults:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -284,6 +284,7 @@ services:
       - '@router.route_provider'
       - '@access_manager'
       - '@current_user'
+      - '@myeventlane_commerce.vendor_operational_addon_order_builder'
 
   myeventlane_vendor.event_workspace_view_model_builder:
     class: Drupal\myeventlane_vendor\Service\VendorEventWorkspaceViewModelBuilder
@@ -301,6 +302,7 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_commerce.vendor_operational_addon_order_builder'
 
   # Vendor console controllers as services for DI.
   myeventlane_vendor.controller.vendor_dashboard:
@@ -385,6 +387,17 @@ services:
       - '@entity_type.manager'
       - '@config.factory'
       - '@datetime.time'
+    tags:
+      - { name: controller.service_arguments }
+
+  myeventlane_vendor.controller.vendor_operational_addon_orders:
+    class: Drupal\myeventlane_vendor\Controller\VendorOperationalAddonOrdersController
+    arguments:
+      - '@myeventlane_core.domain_detector'
+      - '@current_user'
+      - '@messenger'
+      - '@myeventlane_commerce.vendor_operational_addon_order_builder'
+      - '@myeventlane_vendor.service.event_tabs'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOperationalAddonOrdersController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOperationalAddonOrdersController.php
@@ -36,6 +36,7 @@ final class VendorOperationalAddonOrdersController extends VendorConsoleBaseCont
     $this->assertEventOwnership($event);
     $tabs = $this->eventTabsService->getTabs($event, 'addon_orders');
     $document = $this->vendorOperationalAddonOrderBuilder->buildForEvent($event, $this->currentUser);
+    $cache_tags = $this->vendorOperationalAddonOrderBuilder->collectCacheTagsForEvent($event);
 
     $content = [
       '#theme' => 'mel_vendor_operational_addon_orders',
@@ -45,8 +46,9 @@ final class VendorOperationalAddonOrdersController extends VendorConsoleBaseCont
       ],
       '#cache' => [
         'keys' => ['mel_vendor_operational_addon_orders', 'event', (string) $event->id()],
-        'tags' => $event->getCacheTags(),
-        'contexts' => ['user', 'languages:language_interface'],
+        'tags' => $cache_tags,
+        'contexts' => ['user', 'user.permissions', 'languages:language_interface'],
+        'max-age' => VendorOperationalAddonOrderBuilder::VENDOR_ADDON_ORDERS_MAX_AGE,
       ],
     ];
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOperationalAddonOrdersController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOperationalAddonOrdersController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Controller;
+
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
+use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_vendor\Service\VendorEventTabsService;
+use Drupal\node\NodeInterface;
+
+/**
+ * Vendor console: operational add-on orders for an event (read-only).
+ */
+final class VendorOperationalAddonOrdersController extends VendorConsoleBaseController {
+
+  public function __construct(
+    DomainDetector $domain_detector,
+    AccountProxyInterface $current_user,
+    MessengerInterface $messenger,
+    private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
+    private readonly VendorEventTabsService $eventTabsService,
+  ) {
+    parent::__construct($domain_detector, $current_user, $messenger);
+  }
+
+  /**
+   * Lists operational add-on purchases for the event.
+   *
+   * @return array<string, mixed>
+   *   Render array.
+   */
+  public function addons(NodeInterface $event): array {
+    $this->assertEventOwnership($event);
+    $tabs = $this->eventTabsService->getTabs($event, 'addon_orders');
+    $document = $this->vendorOperationalAddonOrderBuilder->buildForEvent($event, $this->currentUser);
+
+    $content = [
+      '#theme' => 'mel_vendor_operational_addon_orders',
+      '#document' => $document,
+      '#attached' => [
+        'library' => ['myeventlane_commerce/vendor_operational_addon_orders'],
+      ],
+      '#cache' => [
+        'keys' => ['mel_vendor_operational_addon_orders', 'event', (string) $event->id()],
+        'tags' => $event->getCacheTags(),
+        'contexts' => ['user', 'languages:language_interface'],
+      ],
+    ];
+
+    return $this->buildVendorPage('mel_event_workspace', [
+      'event' => $event,
+      'tabs' => $tabs,
+      'actions' => [],
+      'meta' => NULL,
+      'sidebar' => NULL,
+      'content' => $content,
+    ]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -11,6 +11,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
 use Drupal\myeventlane_event\Service\EventModeManager;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -32,6 +33,7 @@ final class VendorEventTabsService {
     private readonly RouteProviderInterface $routeProvider,
     private readonly AccessManagerInterface $accessManager,
     private readonly AccountInterface $currentUser,
+    private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -156,6 +158,18 @@ final class VendorEventTabsService {
         'disabled_reason' => (string) $t->translate('Turn on paid tickets for this event to use this section.'),
       ],
     ];
+
+    if ($this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')) {
+      $showAddons = $isTickets && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event);
+      $rows[] = [
+        'key' => 'addon_orders',
+        'label' => (string) $t->translate('Add-on orders'),
+        'route' => 'myeventlane_vendor.console.event_operational_addon_orders',
+        'params' => ['event' => $id],
+        'disabled' => !$showAddons,
+        'disabled_reason' => (string) $t->translate('Add-on orders appear when this event has operational extras configured or purchased.'),
+      ];
+    }
 
     if ($this->moduleHandler->moduleExists('myeventlane_refunds')) {
       $rows[] = [

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -14,6 +14,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\node\NodeInterface;
@@ -40,6 +41,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly MelReadinessHelper $readinessHelper,
+    private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -177,11 +179,19 @@ final class VendorEventWorkspaceViewModelBuilder {
 
     $previewUrl = $this->routeUrlIfAccessible('entity.node.canonical', ['node' => $nid], $account);
 
+    $addonOrdersUrl = NULL;
+    if (($eventType === 'paid' || $eventType === 'both')
+      && $this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')
+      && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event)) {
+      $addonOrdersUrl = $this->routeUrlIfAccessible('myeventlane_vendor.console.event_operational_addon_orders', ['event' => $nid], $account);
+    }
+
     $actions = [
       'edit' => $editUrl,
       'advanced_tickets' => $advancedTicketsUrl,
       'rsvps' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_rsvps', ['event' => $nid], $account),
       'orders' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account),
+      'addon_orders' => $addonOrdersUrl,
       'attendees' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account),
       'checkin' => $this->routeUrlIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account),
       'analytics' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_analytics', ['event' => $nid], $account),
@@ -288,6 +298,7 @@ final class VendorEventWorkspaceViewModelBuilder {
         'advanced_tickets' => NULL,
         'rsvps' => NULL,
         'orders' => NULL,
+        'addon_orders' => NULL,
         'attendees' => NULL,
         'checkin' => NULL,
         'analytics' => NULL,

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -668,6 +668,7 @@ function myeventlane_theme_preprocess_commerce_order(array &$variables): void {
   _myeventlane_theme_attach_mel_operational_fulfillment_execution_customer($variables);
   _myeventlane_theme_attach_mel_operational_purchase_composition($variables);
   _myeventlane_theme_attach_mel_operational_checkout($variables);
+  _myeventlane_theme_attach_operational_addon_guidance($variables);
 }
 
 /**
@@ -689,6 +690,7 @@ function myeventlane_theme_preprocess_myeventlane_my_tickets(array &$variables):
       $variables[$orders_key][$idx]['mel_operational_fulfillment_execution_customer'] = _myeventlane_theme_mel_operational_fulfillment_execution_customer_for_order($order);
       $variables[$orders_key][$idx]['mel_operational_purchase_composition'] = _myeventlane_theme_mel_operational_purchase_composition_for_order($order);
       $variables[$orders_key][$idx]['mel_operational_checkout'] = _myeventlane_theme_mel_operational_checkout_for_order($order);
+      $variables[$orders_key][$idx]['operational_addon_guidance'] = _myeventlane_theme_mel_operational_addon_guidance_for_order($order);
     }
   }
 
@@ -763,6 +765,7 @@ function myeventlane_theme_preprocess_myeventlane_order_detail(array &$variables
   _myeventlane_theme_attach_mel_operational_fulfillment_execution_customer($variables);
   _myeventlane_theme_attach_mel_operational_purchase_composition($variables);
   _myeventlane_theme_attach_mel_operational_checkout($variables);
+  _myeventlane_theme_attach_operational_addon_guidance($variables);
 
   if (!\Drupal::moduleHandler()->moduleExists('myeventlane_event_studio')
     || !\Drupal::hasService('myeventlane_event_studio.customer_operational_commerce_experience_builder')) {
@@ -1091,6 +1094,7 @@ function myeventlane_theme_preprocess_commerce_checkout_form(array &$variables):
   _myeventlane_theme_attach_mel_operational_fulfillment_execution_customer($variables);
   _myeventlane_theme_attach_mel_operational_purchase_composition($variables);
   _myeventlane_theme_attach_mel_operational_checkout($variables);
+  _myeventlane_theme_attach_operational_addon_guidance($variables);
 }
 
 /**
@@ -1140,6 +1144,84 @@ function _myeventlane_theme_set_mel_customer_operational_block(array &$variables
   }
   $render['#cache']['tags'] = array_values(array_unique(array_merge($cache_tags, $render['#cache']['tags'] ?? [])));
   $variables['mel_customer_operational_experience'] = $render;
+}
+
+/**
+ * Composition document per order, static-cached for the current request.
+ *
+ * @return array<string, mixed>
+ */
+function _myeventlane_theme_mel_operational_composition_document(OrderInterface $order): array {
+  static $by_order = [];
+  $oid = (int) $order->id();
+  if (array_key_exists($oid, $by_order)) {
+    return $by_order[$oid];
+  }
+  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_commerce')
+    || !\Drupal::hasService('myeventlane_commerce.operational_purchase_composition_manager')) {
+    $by_order[$oid] = _myeventlane_theme_mel_operational_composition_empty_groups();
+    return $by_order[$oid];
+  }
+  try {
+    /** @var \Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager $pcm */
+    $pcm = \Drupal::service('myeventlane_commerce.operational_purchase_composition_manager');
+    $by_order[$oid] = $pcm->composeForOrder($order);
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_theme')->notice('MEL operational composition document skipped for order @oid: @message', [
+      '@oid' => (string) $order->id(),
+      '@message' => $e->getMessage(),
+    ]);
+    $by_order[$oid] = _myeventlane_theme_mel_operational_composition_empty_groups();
+  }
+  return $by_order[$oid];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function _myeventlane_theme_mel_operational_composition_empty_groups(): array {
+  return [
+    'groups' => [
+      'merchandise' => [],
+      'hospitality' => [],
+      'timed_collection' => [],
+      'bundles' => [],
+      'parking' => [],
+    ],
+  ];
+}
+
+/**
+ * Cached checkout render array for an order (single orchestration finalize per request).
+ *
+ * @return array<string, mixed>|null
+ */
+function _myeventlane_theme_mel_operational_checkout_render_for_order(OrderInterface $order): ?array {
+  static $cache = [];
+  $oid = (int) $order->id();
+  if (array_key_exists($oid, $cache)) {
+    return $cache[$oid];
+  }
+  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_commerce')
+    || !\Drupal::hasService('myeventlane_commerce.operational_checkout_orchestration_manager')) {
+    $cache[$oid] = NULL;
+    return NULL;
+  }
+  try {
+    $composition = _myeventlane_theme_mel_operational_composition_document($order);
+    /** @var \Drupal\myeventlane_commerce\Service\OperationalCheckoutOrchestrationManager $oco */
+    $oco = \Drupal::service('myeventlane_commerce.operational_checkout_orchestration_manager');
+    $cache[$oid] = $oco->buildOrderRenderArrayFromComposition($order, $composition);
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_theme')->notice('MEL operational checkout orchestration skipped for order @oid: @message', [
+      '@oid' => (string) $order->id(),
+      '@message' => $e->getMessage(),
+    ]);
+    $cache[$oid] = NULL;
+  }
+  return $cache[$oid];
 }
 
 /**
@@ -1196,7 +1278,8 @@ function _myeventlane_theme_attach_mel_operational_purchase_composition(array &$
   try {
     /** @var \Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager $pcm */
     $pcm = \Drupal::service('myeventlane_commerce.operational_purchase_composition_manager');
-    $variables['mel_operational_purchase_composition'] = $pcm->buildOrderRenderArray($order);
+    $composition = _myeventlane_theme_mel_operational_composition_document($order);
+    $variables['mel_operational_purchase_composition'] = $pcm->buildOrderRenderArrayFromDocument($order, $composition);
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_theme')->notice('MEL operational purchase composition skipped: @message', ['@message' => $e->getMessage()]);
@@ -1215,7 +1298,8 @@ function _myeventlane_theme_mel_operational_purchase_composition_for_order(Order
   try {
     /** @var \Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager $pcm */
     $pcm = \Drupal::service('myeventlane_commerce.operational_purchase_composition_manager');
-    return $pcm->buildOrderRenderArray($order);
+    $composition = _myeventlane_theme_mel_operational_composition_document($order);
+    return $pcm->buildOrderRenderArrayFromDocument($order, $composition);
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_theme')->notice('MEL operational purchase composition (My Tickets) skipped for order @oid: @message', [
@@ -1249,13 +1333,50 @@ function _myeventlane_theme_attach_mel_operational_checkout(array &$variables): 
     return;
   }
   try {
-    /** @var \Drupal\myeventlane_commerce\Service\OperationalCheckoutOrchestrationManager $oco */
-    $oco = \Drupal::service('myeventlane_commerce.operational_checkout_orchestration_manager');
-    $variables['mel_operational_checkout'] = $oco->buildOrderRenderArray($order);
+    $variables['mel_operational_checkout'] = _myeventlane_theme_mel_operational_checkout_render_for_order($order);
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_theme')->notice('MEL operational checkout orchestration skipped: @message', ['@message' => $e->getMessage()]);
     $variables['mel_operational_checkout'] = NULL;
+  }
+}
+
+/**
+ * Compact post-purchase add-on guidance (read-only).
+ */
+function _myeventlane_theme_attach_operational_addon_guidance(array &$variables): void {
+  $variables['operational_addon_guidance'] = NULL;
+  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_commerce')
+    || !\Drupal::hasService('myeventlane_commerce.operational_addon_guidance_builder')) {
+    return;
+  }
+  $order = $variables['order_entity'] ?? NULL;
+  if (!$order instanceof OrderInterface && isset($variables['form']['#order'])) {
+    $candidate = $variables['form']['#order'];
+    $order = $candidate instanceof OrderInterface ? $candidate : NULL;
+  }
+  if (!$order instanceof OrderInterface && isset($variables['form']['#order_entity'])) {
+    $candidate = $variables['form']['#order_entity'];
+    $order = $candidate instanceof OrderInterface ? $candidate : NULL;
+  }
+  if (!$order instanceof OrderInterface) {
+    return;
+  }
+  try {
+    $composition = _myeventlane_theme_mel_operational_composition_document($order);
+    $checkout_render = _myeventlane_theme_mel_operational_checkout_render_for_order($order);
+    $contract = is_array($checkout_render) ? ($checkout_render['#checkout'] ?? NULL) : NULL;
+    /** @var \Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder $builder */
+    $builder = \Drupal::service('myeventlane_commerce.operational_addon_guidance_builder');
+    $variables['operational_addon_guidance'] = $builder->buildRenderArray(
+      $order,
+      $composition,
+      is_array($contract) ? $contract : NULL,
+    );
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_theme')->notice('MEL operational add-on guidance skipped: @message', ['@message' => $e->getMessage()]);
+    $variables['operational_addon_guidance'] = NULL;
   }
 }
 
@@ -1268,12 +1389,39 @@ function _myeventlane_theme_mel_operational_checkout_for_order(OrderInterface $o
     return NULL;
   }
   try {
-    /** @var \Drupal\myeventlane_commerce\Service\OperationalCheckoutOrchestrationManager $oco */
-    $oco = \Drupal::service('myeventlane_commerce.operational_checkout_orchestration_manager');
-    return $oco->buildOrderRenderArray($order);
+    return _myeventlane_theme_mel_operational_checkout_render_for_order($order);
   }
   catch (\Throwable $e) {
     \Drupal::logger('myeventlane_theme')->notice('MEL operational checkout (My Tickets) skipped for order @oid: @message', [
+      '@oid' => (string) $order->id(),
+      '@message' => $e->getMessage(),
+    ]);
+    return NULL;
+  }
+}
+
+/**
+ * @return array<string, mixed>|null
+ */
+function _myeventlane_theme_mel_operational_addon_guidance_for_order(OrderInterface $order): ?array {
+  if (!\Drupal::moduleHandler()->moduleExists('myeventlane_commerce')
+    || !\Drupal::hasService('myeventlane_commerce.operational_addon_guidance_builder')) {
+    return NULL;
+  }
+  try {
+    $composition = _myeventlane_theme_mel_operational_composition_document($order);
+    $checkout_render = _myeventlane_theme_mel_operational_checkout_render_for_order($order);
+    $contract = is_array($checkout_render) ? ($checkout_render['#checkout'] ?? NULL) : NULL;
+    /** @var \Drupal\myeventlane_commerce\Service\OperationalAddonGuidanceBuilder $builder */
+    $builder = \Drupal::service('myeventlane_commerce.operational_addon_guidance_builder');
+    return $builder->buildRenderArray(
+      $order,
+      $composition,
+      is_array($contract) ? $contract : NULL,
+    );
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_theme')->notice('MEL operational add-on guidance (My Tickets) skipped for order @oid: @message', [
       '@oid' => (string) $order->id(),
       '@message' => $e->getMessage(),
     ]);

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -174,6 +174,12 @@
       </section>
     {% endif %}
 
+    {% if operational_addon_guidance %}
+      <div class="mel-confirmation__addon-guidance mel-confirmation__main-pad" role="region" aria-label="{{ 'Your add-ons'|t }}">
+        {{ operational_addon_guidance }}
+      </div>
+    {% endif %}
+
     {% if mel_donation_total_formatted %}
       <div class="mel-confirmation-card mel-confirmation-card--donation">
         <div class="mel-confirmation-card__body">

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-order--user.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-order--user.html.twig
@@ -93,6 +93,15 @@
     </div>
   {% endif %}
 
+  {% if operational_addon_guidance %}
+    <div class="mel-order-detail__section mel-order-detail__addon-guidance mel-card mel-mb-4" role="region" aria-label="{{ 'Your add-ons'|t }}">
+      <div class="mel-card-body">
+        <h2 class="mel-order-detail__section-title">{{ 'Your add-ons'|t }}</h2>
+        {{ operational_addon_guidance }}
+      </div>
+    </div>
+  {% endif %}
+
   {# Order items table #}
   {% if order.order_items is defined and order.order_items|render|striptags|trim %}
     <div class="mel-order-detail__section mel-order-detail__items mel-card mel-mb-4">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -277,6 +277,9 @@
           {% if model.actions.orders is not null %}
             <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.orders }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View orders'|t }}</span></a>
           {% endif %}
+          {% if model.actions.addon_orders is not null %}
+            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.addon_orders }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View add-on orders'|t }}</span></a>
+          {% endif %}
           {% if model.actions.attendees is not null %}
             <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.attendees }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View attendees'|t }}</span></a>
           {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new customer-facing and vendor-facing order surfaces derived from Commerce order data, plus new caching logic and a vendor route/tab; mistakes could leak sensitive fields or cause stale/incorrect order visibility.
> 
> **Overview**
> Adds a new **post-purchase “Your add-ons” guidance strip** for customer surfaces (checkout completion, My Tickets, order detail, and `commerce_order` user view), built via `OperationalAddonGuidanceBuilder` from purchase composition (optionally enriched by the checkout orchestration contract) and rendered with a new theme hook/library and CSS.
> 
> Introduces a new **vendor console “Add-on orders”** page at `/vendor/events/{event}/addons`, including routing/controller, tab + workspace shortcut gating, and a `VendorOperationalAddonOrderBuilder` read model that discovers qualifying event orders, groups operational lines via composition, strips private fields (incl. emails/QR/scanner/warehouse keys), and applies conservative cache metadata.
> 
> Hardens and refactors operational add-on plumbing: excludes operational products with no store from booking add-ons, adds language cache contexts in booking/add-on form and book controller, reuses composition/orchestration via new `*FromComposition/*FromDocument` methods with request-local caching, and adds unit/kernel test coverage plus updated QA docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73486b786c7e7d7bc7d5db399fa79867bbc8c64c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->