### PR TITLE
Fix/workspace addon orders double scan

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -302,7 +302,6 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_surface.state_readiness_helper'
-      - '@myeventlane_commerce.vendor_operational_addon_order_builder'
 
   # Vendor console controllers as services for DI.
   myeventlane_vendor.controller.vendor_dashboard:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -285,6 +285,7 @@ services:
       - '@access_manager'
       - '@current_user'
       - '@myeventlane_commerce.vendor_operational_addon_order_builder'
+      - '@myeventlane_core.event_state_resolver'
 
   myeventlane_vendor.event_workspace_view_model_builder:
     class: Drupal\myeventlane_vendor\Service\VendorEventWorkspaceViewModelBuilder

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -12,6 +12,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
+use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_event\Service\EventModeManager;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -34,6 +35,7 @@ final class VendorEventTabsService {
     private readonly AccessManagerInterface $accessManager,
     private readonly AccountInterface $currentUser,
     private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
+    private readonly EventStateResolver $eventStateResolver,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -160,7 +162,10 @@ final class VendorEventTabsService {
     ];
 
     if ($this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')) {
-      $showAddons = $isTickets && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event);
+      // Match workspace paid/both gate: linked ticket product, not MODE_PAID alone
+      // (RSVP events with a non-hybrid product still surface operational add-ons).
+      $showAddons = $this->eventStateResolver->hasProductTarget($event)
+        && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event);
       $rows[] = [
         'key' => 'addon_orders',
         'label' => (string) $t->translate('Add-on orders'),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -14,7 +14,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\node\NodeInterface;
@@ -41,7 +40,6 @@ final class VendorEventWorkspaceViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly MelReadinessHelper $readinessHelper,
-    private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -179,12 +177,8 @@ final class VendorEventWorkspaceViewModelBuilder {
 
     $previewUrl = $this->routeUrlIfAccessible('entity.node.canonical', ['node' => $nid], $account);
 
-    $addonOrdersUrl = NULL;
-    if (($eventType === 'paid' || $eventType === 'both')
-      && $this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')
-      && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event)) {
-      $addonOrdersUrl = $this->routeUrlIfAccessible('myeventlane_vendor.console.event_operational_addon_orders', ['event' => $nid], $account);
-    }
+    // Reuse tab availability so add-on order gating runs once per request.
+    $addonOrdersUrl = $this->addonOrdersUrlFromWorkspaceTabs($tabs);
 
     $actions = [
       'edit' => $editUrl,
@@ -595,6 +589,25 @@ final class VendorEventWorkspaceViewModelBuilder {
     }
 
     return $metrics;
+  }
+
+  /**
+   * Resolves the add-on orders shortcut from workspace tabs.
+   *
+   * @param list<array<string, mixed>> $tabs
+   */
+  private function addonOrdersUrlFromWorkspaceTabs(array $tabs): ?Url {
+    foreach ($tabs as $tab) {
+      if (($tab['key'] ?? '') !== 'addon_orders') {
+        continue;
+      }
+      if (empty($tab['available'])) {
+        return NULL;
+      }
+      $url = $tab['url'] ?? NULL;
+      return $url instanceof Url ? $url : NULL;
+    }
+    return NULL;
   }
 
   private function routeExists(string $name): bool {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small dependency-injection and conditional-logic changes that only affect whether the vendor UI surfaces the add-on orders tab/shortcut for certain event types.
> 
> **Overview**
> Aligns the **Add-on orders** tab availability with workspace rules by switching the gating check from “ticket mode” to `EventStateResolver::hasProductTarget()` (while still respecting `VendorOperationalAddonOrderBuilder::shouldSurfaceVendorAddonsTab()`).
> 
> Removes duplicate add-on orders eligibility checks in the workspace view model by deriving the add-on orders action URL directly from the already-built workspace tabs, and updates service wiring accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0d35a2c5287f2b6aed241a520abe1a4a5d5c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->