### PR TITLE
refactor(tickets): enhance operational summaries and diagnostics hand…

### DIFF
--- a/scripts/dev/create-operational-tshirt-addon.php
+++ b/scripts/dev/create-operational-tshirt-addon.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * @file
+ * One-off dev script: published operational T-shirt add-on for an event.
+ *
+ * Usage (local/staging only):
+ *   ddev drush php:script scripts/dev/create-operational-tshirt-addon.php -- 1540
+ */
+
+declare(strict_types=1);
+
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\node\NodeInterface;
+
+$event_id = isset($extra[0]) ? (int) $extra[0] : 0;
+if ($event_id < 1) {
+  throw new \InvalidArgumentException('Pass an event node ID, e.g. ddev drush php:script scripts/dev/create-operational-tshirt-addon.php -- 1540');
+}
+
+$entity_type_manager = \Drupal::entityTypeManager();
+$node_storage = $entity_type_manager->getStorage('node');
+$event = $node_storage->load($event_id);
+if (!$event instanceof NodeInterface) {
+  $hint = '';
+  $recent = $node_storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'event')
+    ->condition('status', 1)
+    ->sort('nid', 'DESC')
+    ->range(0, 5)
+    ->execute();
+  if ($recent !== []) {
+    $hint = ' Recent published event IDs in this database: ' . implode(', ', $recent) . '.';
+  }
+  throw new \InvalidArgumentException("Node {$event_id} was not found in this database.{$hint} Use an event ID that exists here, or run this script against staging where event 1540 lives.");
+}
+if ($event->bundle() !== 'event') {
+  throw new \InvalidArgumentException("Node {$event_id} exists but bundle is \"{$event->bundle()}\" (expected \"event\").");
+}
+
+$store = NULL;
+if ($event->hasField('field_event_store') && !$event->get('field_event_store')->isEmpty()) {
+  $store = $event->get('field_event_store')->entity;
+}
+if (!$store && $event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
+  $ticket_product = $event->get('field_product_target')->entity;
+  if ($ticket_product && method_exists($ticket_product, 'getStores')) {
+    $stores = $ticket_product->getStores();
+    $store = reset($stores) ?: NULL;
+  }
+}
+if (!$store) {
+  throw new \RuntimeException("Could not resolve Commerce store for event {$event_id}. Set field_event_store or link a ticket product first.");
+}
+
+$product_type_storage = $entity_type_manager->getStorage('commerce_product_type');
+$variation_type_storage = $entity_type_manager->getStorage('commerce_product_variation_type');
+if (!$product_type_storage->load('operational_merchandise')) {
+  throw new \RuntimeException('Missing product type: operational_merchandise. Import config before running this script.');
+}
+if (!$variation_type_storage->load('operational_merchandise_var')) {
+  throw new \RuntimeException('Missing variation type: operational_merchandise_var. Import config before running this script.');
+}
+
+$product_storage = $entity_type_manager->getStorage('commerce_product');
+$variation_storage = $entity_type_manager->getStorage('commerce_product_variation');
+
+$sku = "MEL-{$event_id}-TSHIRT";
+$existing_variations = $variation_storage->loadByProperties([
+  'sku' => $sku,
+  'type' => 'operational_merchandise_var',
+]);
+$variation = reset($existing_variations);
+if (!$variation instanceof ProductVariation) {
+  $variation = ProductVariation::create([
+    'type' => 'operational_merchandise_var',
+    'sku' => $sku,
+    'title' => 'T-shirt',
+    'price' => new Price('35.00', 'AUD'),
+    'status' => TRUE,
+  ]);
+  $variation->save();
+}
+
+$product_title = "Event T-shirt - Node {$event_id}";
+$query = $product_storage->getQuery()
+  ->accessCheck(FALSE)
+  ->condition('type', 'operational_merchandise')
+  ->condition('title', $product_title)
+  ->range(0, 1);
+$pids = $query->execute();
+$product = $pids ? $product_storage->load(reset($pids)) : NULL;
+
+$payload = [
+  'operational_product_type' => 'merch_pickup',
+  'fulfillment_mode' => 'pickup',
+  'reservation_mode' => 'commerce_cart',
+  'pickup_mode' => 'venue_pickup',
+  'readiness_mode' => 'ready',
+  'continuity_mode' => 'collect_after_entry',
+  'capability_reference' => 'operational_merchandise',
+  'customer_visibility' => 'visible',
+  'collection_rules' => [],
+  'hospitality_rules' => [],
+  'operational_summary' => 'Collect your T-shirt at the venue.',
+  'operational_chips' => [
+    ['label' => 'Venue pickup', 'tone' => 'info'],
+    ['label' => 'Add-on', 'tone' => 'muted'],
+  ],
+];
+
+if (!$product instanceof Product) {
+  $product = Product::create([
+    'type' => 'operational_merchandise',
+    'title' => $product_title,
+    'stores' => [$store],
+    'variations' => [$variation],
+    'status' => TRUE,
+  ]);
+}
+else {
+  $product->set('stores', [$store]);
+  $product->set('variations', [$variation]);
+  $product->set('status', TRUE);
+}
+
+if (!$product->hasField('field_event')) {
+  throw new \RuntimeException('Product bundle is missing field_event.');
+}
+$product->set('field_event', ['target_id' => $event_id]);
+
+if (!$product->hasField('field_mel_operational_product')) {
+  throw new \RuntimeException('Product bundle is missing field_mel_operational_product.');
+}
+$product->set('field_mel_operational_product', json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+$product->save();
+$variation->save();
+
+$book_path = '/event/' . $event_id . '/book';
+echo "Created/reused operational T-shirt add-on\n";
+echo "Event ID: {$event_id}\n";
+echo "Store ID: {$store->id()}\n";
+echo "Product ID: {$product->id()}\n";
+echo "Variation ID: {$variation->id()}\n";
+echo "SKU: {$sku}\n";
+echo "Product edit: /admin/commerce/products/{$product->id()}/edit\n";
+echo "QA booking URL: {$book_path}\n";
+echo "Node URL: /node/{$event_id}\n";

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -12,7 +12,6 @@ use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
@@ -26,13 +25,18 @@ final class EventOperationalAddonCartForm extends FormBase {
 
   private const UI_QTY_MAX = 10;
 
+  /**
+   * Promoted protected properties (not private readonly).
+   *
+   * FormBase serializes forms via DependencySerializationTrait; private readonly
+   * properties are not reliably rehydrated on cache rebuild.
+   */
   public function __construct(
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly CartProviderInterface $cartProvider,
-    private readonly CartManagerInterface $cartManager,
-    private readonly EventOperationalAddonBuilder $addonBuilder,
-    private readonly CurrencyFormatter $currencyFormatter,
-    private readonly LoggerChannelFactoryInterface $loggerFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected CartProviderInterface $cartProvider,
+    protected CartManagerInterface $cartManager,
+    protected EventOperationalAddonBuilder $addonBuilder,
+    protected CurrencyFormatter $currencyFormatter,
   ) {}
 
   /**
@@ -45,7 +49,6 @@ final class EventOperationalAddonCartForm extends FormBase {
       $container->get('commerce_cart.cart_manager'),
       $container->get('myeventlane_commerce.event_operational_addon_builder'),
       $container->get('commerce_price.currency_formatter'),
-      $container->get('logger.factory'),
     );
   }
 
@@ -308,12 +311,12 @@ final class EventOperationalAddonCartForm extends FormBase {
       foreach ($variations as $vid_key => $row) {
         $vid = (int) $vid_key;
         if ($vid < 1) {
-          $this->loggerFactory->get('myeventlane_commerce')->warning('Operational add-on submit ignored malformed variation key @key.', ['@key' => (string) $vid_key]);
+          $this->getLogger('myeventlane_commerce')->warning('Operational add-on submit ignored malformed variation key @key.', ['@key' => (string) $vid_key]);
           $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));
           return;
         }
         if (!isset($allowlist[$vid])) {
-          $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on validation rejected variation @vid for event @eid (not allowlisted).', [
+          $this->getLogger('myeventlane_commerce')->notice('Operational add-on validation rejected variation @vid for event @eid (not allowlisted).', [
             '@vid' => (string) $vid,
             '@eid' => (string) $event->id(),
           ]);
@@ -375,7 +378,7 @@ final class EventOperationalAddonCartForm extends FormBase {
         }
         if (!isset($allowlist[$vid])) {
           $this->messenger()->addError($this->t('Add-ons could not be updated. Please refresh the page.'));
-          $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit aborted: variation @vid not allowlisted post-validate.', ['@vid' => (string) $vid]);
+          $this->getLogger('myeventlane_commerce')->error('Operational add-on submit aborted: variation @vid not allowlisted post-validate.', ['@vid' => (string) $vid]);
           return;
         }
         $to_add[$vid] = $qty;
@@ -392,7 +395,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $variation = $variation_storage->load($variation_id);
       if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
         $this->messenger()->addError($this->t('An add-on is no longer available.'));
-        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
+        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
         return;
       }
 
@@ -409,7 +412,7 @@ final class EventOperationalAddonCartForm extends FormBase {
 
       if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
         $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
-        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected bundle @bundle for variation @vid.', [
+        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected bundle @bundle for variation @vid.', [
           '@bundle' => $product->bundle(),
           '@vid' => (string) $variation_id,
         ]);
@@ -419,7 +422,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()
         || (int) $product->get('field_event')->target_id !== (int) $event->id()) {
         $this->messenger()->addError($this->t('An add-on is not linked to this event.'));
-        $this->loggerFactory->get('myeventlane_commerce')->notice('Operational add-on submit rejected event mismatch for product @pid.', ['@pid' => (string) $product->id()]);
+        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected event mismatch for product @pid.', ['@pid' => (string) $product->id()]);
         return;
       }
 
@@ -432,7 +435,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $stores = $product->getStores();
       if ($stores === []) {
         $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
-        $this->loggerFactory->get('myeventlane_commerce')->error('Operational add-on submit failed: product @pid has no stores.', ['@pid' => (string) $product->id()]);
+        $this->getLogger('myeventlane_commerce')->error('Operational add-on submit failed: product @pid has no stores.', ['@pid' => (string) $product->id()]);
         return;
       }
       $store = reset($stores);

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalFulfillmentExecutionManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalFulfillmentExecutionManager.php
@@ -96,7 +96,7 @@ final class OperationalFulfillmentExecutionManager {
       $normalized = (string) ($row['normalized_lifecycle_state'] ?? '');
       $execution_type = $this->mapToExecutionType($fulfillment_type, $row);
       $redemption_state = $this->truncateSummary(
-        $this->stripScannerExecutionProjectionMaterial((string) ($row['redemption_execution_summary'] ?? '')),
+        $this->customerRedemptionStateLabel((string) ($row['redemption_execution_summary'] ?? '')),
       );
       $exec = [
         'execution_id' => $this->stableExecutionId((int) ($row['ticket_ordinal'] ?? 0), $execution_type, $normalized),
@@ -222,33 +222,124 @@ final class OperationalFulfillmentExecutionManager {
   }
 
   /**
-   * Removes scanner-policy tokens from execution projection strings.
-   *
-   * Lifecycle read-models may include `scanner_action=` diagnostics for staff
-   * fulfillment cards; execution orchestration strips those for all execution
-   * bundle consumers (customer strips and execution governance projections).
-   */
-  private function stripScannerExecutionProjectionMaterial(string $text): string {
-    if ($text === '') {
-      return '';
-    }
-    $out = preg_replace('/\bscanner_action=[^;]*\s*(;\s*|\s*|$)/', '', $text) ?? $text;
-    $out = trim((string) $out);
-    $out = preg_replace('/;\s*;/', '; ', $out) ?? $out;
-    return trim((string) $out, " \t\n\r\0\x0B;");
-  }
-
-  /**
    * @param array<string, mixed> $row
    */
   private function composeRowSummary(array $row, string $execution_type): string {
-    $pickup = $this->stripScannerExecutionProjectionMaterial(trim((string) ($row['pickup_lifecycle_summary'] ?? '')));
-    $redeem = $this->stripScannerExecutionProjectionMaterial(trim((string) ($row['redemption_execution_summary'] ?? '')));
-    $parts = array_filter([$pickup, $redeem]);
+    $pickup = $this->customerPickupSummary(trim((string) ($row['pickup_lifecycle_summary'] ?? '')));
+    $redeem = $this->customerRedemptionSummary(trim((string) ($row['redemption_execution_summary'] ?? '')));
+    $parts = array_values(array_filter([$pickup, $redeem]));
     if ($parts !== []) {
       return implode(' — ', $parts);
     }
-    return (string) $this->t('Operational execution projection for @type.', ['@type' => $execution_type]);
+    return $this->defaultCustomerExecutionSummary($execution_type);
+  }
+
+  private function customerPickupSummary(string $raw): string {
+    if ($raw === '') {
+      return '';
+    }
+    if (str_contains($raw, 'pickup_lane=not_required')) {
+      return (string) $this->t('No pickup is required for this item. Follow organiser instructions at the venue.');
+    }
+    if (str_contains($raw, 'pickup_lane=required')) {
+      return (string) $this->t('Collect this item at the venue when advised by the organiser.');
+    }
+    $stripped = $this->stripInternalExecutionDiagnostics($raw);
+    if ($stripped !== '' && !$this->containsInternalDiagnosticTokens($stripped)) {
+      return $stripped;
+    }
+    return (string) $this->t('This item will be handled at the venue. Check your confirmation and organiser instructions before arrival.');
+  }
+
+  private function customerRedemptionSummary(string $raw): string {
+    if ($raw === '') {
+      return '';
+    }
+    if (str_contains($raw, 'redemption_lane=validation_only')) {
+      return (string) $this->t('Entry validation applies at the venue. Follow organiser signage and staff instructions.');
+    }
+    if (str_contains($raw, 'redemption_lane=redeemable')) {
+      return (string) $this->t('Redemption may be available at the venue per organiser rules.');
+    }
+    $stripped = $this->stripInternalExecutionDiagnostics($raw);
+    if ($stripped !== '' && !$this->containsInternalDiagnosticTokens($stripped)) {
+      return $stripped;
+    }
+    return (string) $this->t('Your ticket will be handled at the venue. Check your confirmation before arrival.');
+  }
+
+  private function customerRedemptionStateLabel(string $raw): string {
+    if ($raw === '') {
+      return '';
+    }
+    if (str_contains($raw, 'redemption_lane=validation_only')) {
+      return (string) $this->t('Validation at venue');
+    }
+    if (str_contains($raw, 'redemption_lane=redeemable')) {
+      return (string) $this->t('Redemption at venue');
+    }
+    $stripped = $this->stripInternalExecutionDiagnostics($raw);
+    return $stripped !== '' && !$this->containsInternalDiagnosticTokens($stripped)
+      ? $stripped
+      : (string) $this->t('At venue');
+  }
+
+  private function defaultCustomerExecutionSummary(string $execution_type): string {
+    return match ($execution_type) {
+      'merch_pickup', 'timed_collection' => (string) $this->t('This item will be handled at the venue. Check your confirmation and organiser instructions before arrival.'),
+      'hospitality_redemption' => (string) $this->t('Hospitality access is coordinated at the venue. Follow organiser instructions on arrival.'),
+      'parking_access' => (string) $this->t('Parking access follows the organiser rules shown in your confirmation.'),
+      'admission_access' => (string) $this->t('Admission is validated at the venue. Have your ticket ready when you arrive.'),
+      default => (string) $this->t('On-site steps for this item are handled at the venue. Check your confirmation before arrival.'),
+    };
+  }
+
+  /**
+   * Strips internal lifecycle diagnostics from customer execution projections.
+   *
+   * Staff lifecycle read-models retain key=value diagnostics; execution bundles
+   * for customer surfaces must not echo those tokens.
+   */
+  private function stripInternalExecutionDiagnostics(string $text): string {
+    if ($text === '') {
+      return '';
+    }
+    $patterns = [
+      '/\bscanner_action=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bpickup_lane=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bredemption_lane=[^;]*\s*(;\s*|\s*|$)/',
+      '/\btimed=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bsession=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bredemptions=\d+\/\d+\s*(;\s*|\s*|$)/',
+      '/\blifecycle=[^;]*\s*(;\s*|\s*|$)/',
+      '/\brequires_fulfilment=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bpdf=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bstate=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bfulfilment_row=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bqr_payload=[^;]*\s*(;\s*|\s*|$)/',
+      '/\breplay_token=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bfingerprint=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bdevice_fingerprint=[^;]*\s*(;\s*|\s*|$)/',
+      '/\binventory_quantity=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bstock_count=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bwarehouse_ids=[^;]*\s*(;\s*|\s*|$)/',
+      '/\bshipment_provider=[^;]*\s*(;\s*|\s*|$)/',
+    ];
+    $out = $text;
+    foreach ($patterns as $pattern) {
+      $out = preg_replace($pattern, '', $out) ?? $out;
+    }
+    $out = trim((string) $out);
+    $out = preg_replace('/;\s*;/', '; ', $out) ?? $out;
+    $out = preg_replace('/\s+—\s+—/', ' — ', $out) ?? $out;
+    return trim((string) $out, " \t\n\r\0\x0B;—");
+  }
+
+  private function containsInternalDiagnosticTokens(string $text): bool {
+    return (bool) preg_match(
+      '/\b(pickup_lane|redemption_lane|scanner_action|qr_payload|replay_token|fingerprint|device_fingerprint|inventory_quantity|stock_count|warehouse_ids|shipment_provider)=/',
+      $text,
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/src/Service/OperationalFulfillmentExecutionProjectionBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/OperationalFulfillmentExecutionProjectionBuilder.php
@@ -195,9 +195,13 @@ final class OperationalFulfillmentExecutionProjectionBuilder {
       if (!is_array($row)) {
         continue;
       }
-      $lines[] = (string) ($row['operational_summary'] ?? '');
+      $line = trim((string) ($row['operational_summary'] ?? ''));
+      if ($line === '' || $this->lineContainsInternalDiagnosticTokens($line)) {
+        continue;
+      }
+      $lines[] = $line;
     }
-    $lines = array_values(array_filter(array_map('trim', $lines)));
+    $lines = array_values(array_unique($lines));
 
     return [
       'continuity_chips' => $chips,
@@ -211,6 +215,13 @@ final class OperationalFulfillmentExecutionProjectionBuilder {
    *
    * @return list<array{label: string, tone: string}>
    */
+  private function lineContainsInternalDiagnosticTokens(string $line): bool {
+    return (bool) preg_match(
+      '/\b(pickup_lane|redemption_lane|scanner_action|qr_payload|replay_token|fingerprint|device_fingerprint|inventory_quantity|stock_count|warehouse_ids|shipment_provider)=/',
+      $line,
+    );
+  }
+
   private function dedupeChips(array $chips): array {
     $seen = [];
     $out = [];

--- a/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
@@ -51,7 +51,6 @@ final class UniversalTicketViewModelBuilder {
     $remaining_redemptions = $this->capabilityManager->getRemainingRedemptions($ticket);
     $is_expired = $this->capabilityManager->isExpired($ticket);
     $can_scan = $this->capabilityManager->canBeScanned($ticket);
-    $timed_entry = $this->venueOperationPolicyManager->buildTimedEntryPolicy($ticket);
     $scanner_status = $this->scannerStatus($ticket, $entitlement_type, $can_scan, $is_expired, $fulfilment_status);
 
     $now = $this->time->getCurrentTime();

--- a/web/modules/custom/myeventlane_tickets/tests/src/Unit/OperationalFulfillmentExecutionManagerTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Unit/OperationalFulfillmentExecutionManagerTest.php
@@ -64,7 +64,7 @@ final class OperationalFulfillmentExecutionManagerTest extends UnitTestCase {
     $this->assertSame('z', $clean['nested']['ok']);
   }
 
-  public function testExecutionBundleOmitsScannerActionTokens(): void {
+  public function testExecutionBundleUsesCustomerFriendlyOperationalSummaries(): void {
     $merged = [
       'issuance' => ['worst_quantity_alignment_status' => 'valid'],
       'recovery' => ['recovery_mismatch_observed' => FALSE],
@@ -85,8 +85,14 @@ final class OperationalFulfillmentExecutionManagerTest extends UnitTestCase {
     ];
     $out = $this->manager()->composeExecutionBundleFromMerged($merged, 500);
     $first = $out['executions'][0];
-    $this->assertStringNotContainsString('scanner_action', (string) ($first['operational_summary'] ?? ''));
-    $this->assertStringNotContainsString('scanner_action', (string) ($first['redemption_state'] ?? ''));
+    $summary = (string) ($first['operational_summary'] ?? '');
+    $redemption_state = (string) ($first['redemption_state'] ?? '');
+    foreach (['pickup_lane=', 'redemption_lane=', 'scanner_action=', 'timed=', 'session=', 'redemptions='] as $forbidden) {
+      $this->assertStringNotContainsString($forbidden, $summary);
+      $this->assertStringNotContainsString($forbidden, $redemption_state);
+    }
+    $this->assertStringContainsString('pickup', strtolower($summary));
+    $this->assertStringContainsString(' — ', $summary, 'Pickup and redemption summaries should be separated by an em dash.');
   }
 
 }


### PR DESCRIPTION
…ling

- Removed unused timed entry policy from UniversalTicketViewModelBuilder.
- Improved operational fulfillment execution summaries to use customer-friendly language and removed internal diagnostic tokens.
- Updated tests to ensure operational summaries do not contain forbidden tokens and validate the format of summaries.

This refactor aims to enhance the clarity of operational messages presented to customers while ensuring internal diagnostics are not exposed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes customer-visible fulfillment summaries/projections and adjusts a Drupal form’s dependency injection/serialization behavior, which could affect cart submission and post-purchase messaging.
> 
> **Overview**
> **Customer-facing fulfillment messaging is cleaned up and made safer.** `OperationalFulfillmentExecutionManager` now generates customer-friendly pickup/redemption summaries/state labels and strips a broader set of internal diagnostic tokens; the projection builder also filters out any summaries that still contain those tokens and dedupes lines.
> 
> **Operational add-on cart form DI is adjusted for Drupal form serialization.** `EventOperationalAddonCartForm` removes the injected `logger.factory`, switches to `getLogger()`, and changes constructor-promoted dependencies from `private readonly` to `protected` to avoid cache rebuild/rehydration issues.
> 
> Adds a one-off dev Drush script (`create-operational-tshirt-addon.php`) to create or reuse an event-linked operational merchandise product/variation (T-shirt) with a prefilled operational payload, and updates unit tests to assert forbidden tokens are absent and summaries are formatted as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e6607ccdcc99306cb3781ca0a44f158e2f8410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->