### PR TITLE
Fix/workspace addon orders double scan

### DIFF
--- a/web/modules/custom/myeventlane_capacity/src/Service/CapacityOrderInspector.php
+++ b/web/modules/custom/myeventlane_capacity/src/Service/CapacityOrderInspector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_capacity\Service;
 
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 
@@ -119,8 +120,30 @@ final class CapacityOrderInspector {
       return TRUE;
     }
 
+    // Operational merchandise add-ons (event-scoped, not ticket matrix lines).
+    // @see \Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES
+    $purchased = $item->getPurchasedEntity();
+    if ($purchased instanceof ProductVariationInterface) {
+      $product = $purchased->getProduct();
+      if ($product !== NULL && $this->isOperationalMerchandiseProductBundle($product->bundle())) {
+        return TRUE;
+      }
+    }
+
     // All other items are considered tickets and subject to capacity checks.
     return FALSE;
+  }
+
+  /**
+   * Mirrors operational product bundles in myeventlane_commerce (cross-module).
+   */
+  private function isOperationalMerchandiseProductBundle(string $bundle): bool {
+    return in_array($bundle, [
+      'operational_merchandise',
+      'operational_bundle',
+      'hospitality_package',
+      'timed_collection_product',
+    ], TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
@@ -45,6 +45,7 @@ services:
       - '@myeventlane_commerce.order_item_classifier'
       - '@myeventlane_surface.state_readiness_helper'
       - '@file_url_generator'
+      - '@?myeventlane_commerce.operational_order_item_display_builder'
 
   myeventlane_checkout_flow.tax_invoice_presentation:
     class: Drupal\myeventlane_checkout_flow\Service\TaxInvoicePresentationBuilder
@@ -82,6 +83,7 @@ services:
       - '@myeventlane_tickets.universal_ticket_view_model_builder'
       - '@myeventlane_core.ticket_label_resolver'
       - '@string_translation'
+      - '@?myeventlane_commerce.operational_order_item_display_builder'
 
   logger.channel.myeventlane_checkout_flow:
     parent: logger.channel_base

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
@@ -12,6 +12,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder;
 use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_core\MelReadinessHelper;
@@ -31,6 +32,7 @@ final class CheckoutGroupedSummaryBuilder implements CheckoutGroupedSummaryBuild
     private readonly OrderItemClassifier $orderItemClassifier,
     private readonly MelReadinessHelper $readinessHelper,
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly ?OperationalOrderItemDisplayBuilder $operationalOrderItemDisplayBuilder = NULL,
   ) {}
 
   /**
@@ -61,7 +63,10 @@ final class CheckoutGroupedSummaryBuilder implements CheckoutGroupedSummaryBuild
       $line_key = $purchased ? 'p:' . $purchased->id() : 'i:' . $item->id();
       $bucket_key = ($event_id ?? 'other') . ':' . $line_key;
 
-      $ticket_type = $purchased ? $purchased->label() : $item->label();
+      $operational_display = $this->operationalOrderItemDisplayBuilder?->buildForOrderItem($item);
+      $ticket_type = is_array($operational_display)
+        ? (string) ($operational_display['title'] ?? '')
+        : ($purchased ? $purchased->label() : $item->label());
 
       if (!isset($line_buckets[$bucket_key])) {
         $line_buckets[$bucket_key] = [
@@ -69,6 +74,7 @@ final class CheckoutGroupedSummaryBuilder implements CheckoutGroupedSummaryBuild
           'ticket_type' => $ticket_type,
           'quantity' => 0,
           'total' => NULL,
+          'operational_addon_display' => $operational_display,
         ];
       }
 
@@ -158,6 +164,7 @@ final class CheckoutGroupedSummaryBuilder implements CheckoutGroupedSummaryBuild
         'quantity' => $bucket['quantity'],
         'ticket_type' => $bucket['ticket_type'],
         'total_price' => $total_price,
+        'operational_addon_display' => $bucket['operational_addon_display'] ?? NULL,
       ];
     }
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder;
 use Drupal\myeventlane_core\Service\TicketLabelResolver;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\UniversalTicketViewModelBuilder;
@@ -40,6 +41,7 @@ final class MyTicketsOrderViewModelBuilder {
     private readonly UniversalTicketViewModelBuilder $ticketViewModelBuilder,
     private readonly TicketLabelResolver $ticketLabelResolver,
     TranslationInterface $string_translation,
+    private readonly ?OperationalOrderItemDisplayBuilder $operationalOrderItemDisplayBuilder = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -281,11 +283,15 @@ final class MyTicketsOrderViewModelBuilder {
    *   Legacy ticket line display data.
    */
   private function legacyTicketItem(OrderItemInterface $item, bool $includeDetails): array {
+    $operational_display = $this->operationalOrderItemDisplayBuilder?->buildForOrderItem($item);
     $ticketItem = [
-      'title' => $this->ticketLabelResolver->getTicketLabel($item),
+      'title' => is_array($operational_display)
+        ? (string) ($operational_display['title'] ?? '')
+        : $this->ticketLabelResolver->getTicketLabel($item),
       'quantity' => (int) $item->getQuantity(),
       'price' => $item->getTotalPrice() ? $item->getTotalPrice()->getNumber() : 0.0,
       'attendees' => [],
+      'operational_addon_display' => $operational_display,
     ];
 
     if ($includeDetails && $item->hasField('field_ticket_holder') && !$item->get('field_ticket_holder')->isEmpty()) {

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
@@ -217,10 +217,14 @@
       <div class="mel-card mel-mt-4">
         <div class="mel-card-body">
           {% for ticket in order.ticket_items %}
-            <div class="mel-ticket-item mel-mt-4{% if not loop.first %} mel-pt-4 mel-border-top{% endif %}">
+            <div class="mel-ticket-item mel-mt-4{% if not loop.first %} mel-pt-4 mel-border-top{% endif %}{% if ticket.operational_addon_display|default(null) %} mel-ticket-item--operational-addon{% endif %}">
               <div class="mel-ticket-header">
                 <div class="mel-ticket-title">
-                  <strong>{{ ticket.title }}</strong>
+                  {% if ticket.operational_addon_display|default(null) %}
+                    {% include '@myeventlane_commerce/mel-operational-order-item-line.html.twig' with { display: ticket.operational_addon_display } only %}
+                  {% else %}
+                    <strong>{{ ticket.title }}</strong>
+                  {% endif %}
                 </div>
                 <div class="mel-ticket-price">
                   ${{ ticket.price|number_format(2) }}

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
@@ -281,6 +281,9 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
       $this->container->get('myeventlane_tickets.universal_ticket_view_model_builder'),
       $this->container->get('myeventlane_core.ticket_label_resolver'),
       $this->container->get('string_translation'),
+      $this->container->has('myeventlane_commerce.operational_order_item_display_builder')
+        ? $this->container->get('myeventlane_commerce.operational_order_item_display_builder')
+        : NULL,
     );
   }
 

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -10,7 +10,11 @@
   overflow-x: hidden;
 }
 
-.mel-operational-addons-section--embedded {
+.mel-booking-flow__addons {
+  margin-top: 1.25rem;
+}
+
+.mel-booking-flow__checkout {
   margin-top: 1.25rem;
 }
 

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -10,6 +10,10 @@
   overflow-x: hidden;
 }
 
+.mel-operational-addons-section--embedded {
+  margin-top: 1.25rem;
+}
+
 .mel-operational-addons-section__title {
   margin: 0 0 0.35rem;
   font-size: 1.125rem;

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -135,3 +135,82 @@
     width: auto;
   }
 }
+
+/**
+ * Operational add-on line items in cart, checkout summary, and order tables.
+ */
+.mel-operational-order-item-line {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.mel-operational-order-item-line__title {
+  font-weight: 700;
+  font-size: 0.98rem;
+  line-height: 1.35;
+  color: rgba(15, 23, 42, 0.92);
+}
+
+.mel-operational-order-item-line__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: rgba(15, 23, 42, 0.68);
+}
+
+.mel-operational-order-item-line__variation {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-operational-order-item-line__description {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.62);
+}
+
+.mel-operational-order-item-line__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.15rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-operational-order-item-line__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: rgba(15, 23, 42, 0.06);
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.mel-operational-order-item-line__chip--pickup {
+  background: rgba(14, 116, 144, 0.12);
+  color: rgba(14, 116, 144, 0.95);
+}
+
+.mel-summary-item--operational-addon .mel-summary-item__label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.mel-summary-item--operational-addon .mel-operational-order-item-line {
+  margin-top: 0.1rem;
+}
+
+.mel-ticket-item--operational-addon .mel-ticket-title .mel-operational-order-item-line__title {
+  font-size: 1rem;
+}

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -302,6 +302,8 @@ function myeventlane_commerce_theme(): array {
         'mel_operational_checkout' => NULL,
         'addons_available' => FALSE,
         'operational_addon_form' => [],
+        'ticket_form' => [],
+        'ticket_form_actions' => [],
       ],
       'template' => 'myeventlane-event-book',
     ],

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
@@ -15,8 +16,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\node\NodeInterface;
-use Drupal\views\ViewExecutable;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ResultRow;
+use Drupal\views\ViewExecutable;
 
 /**
  * Helper: find the quantity number element in ATC form (various widget shapes).
@@ -331,6 +334,12 @@ function myeventlane_commerce_theme(): array {
       ],
       'template' => 'mel-vendor-operational-addon-orders',
     ],
+    'mel_operational_order_item_line' => [
+      'variables' => [
+        'display' => [],
+      ],
+      'template' => 'mel-operational-order-item-line',
+    ],
     'mel_waitlist_offer_countdown' => [
       'variables' => [
         'expires_timestamp' => 0,
@@ -411,7 +420,7 @@ function myeventlane_commerce_theme_registry_alter(array &$registry): void {
   $theme = \Drupal::theme()->getActiveTheme()->getName();
   $theme_path = \Drupal::service('extension.list.theme')->getPath($theme);
   $commerce_tpl_dir = $theme_path . '/templates/commerce';
-  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout', 'mel_operational_addon_guidance', 'mel_vendor_operational_addon_orders'] as $hook) {
+  foreach (['mel_operational_purchase_composition', 'mel_operational_checkout', 'mel_operational_addon_guidance', 'mel_vendor_operational_addon_orders', 'mel_operational_order_item_line'] as $hook) {
     if (!isset($registry[$hook])) {
       continue;
     }
@@ -661,6 +670,133 @@ function myeventlane_commerce_checkout_form_submit_safety_check(array &$form, Fo
       }
     }
   }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for commerce_cart_form.
+ *
+ * Maps operational add-on display metadata by order item ID for Twig/Views.
+ */
+function myeventlane_commerce_preprocess_commerce_cart_form(array &$variables): void {
+  $variables['operational_order_item_display'] = _myeventlane_commerce_operational_order_item_display_map(
+    _myeventlane_commerce_order_items_from_cart_form($variables['form'] ?? []),
+  );
+}
+
+/**
+ * Implements hook_preprocess_views_view_field().
+ *
+ * Replaces purchased-entity cell output for operational add-ons on the cart form.
+ */
+function myeventlane_commerce_preprocess_views_view_field(array &$variables): void {
+  $view = $variables['view'] ?? NULL;
+  if (!$view instanceof ViewExecutable) {
+    return;
+  }
+  $view_id = $view->id();
+  $field = $variables['field'] ?? NULL;
+  if (!$field instanceof FieldPluginBase) {
+    return;
+  }
+  $field_id = (string) ($field->options['id'] ?? '');
+  if ($view_id === 'commerce_cart_form' && $field_id !== 'purchased_entity') {
+    return;
+  }
+  if ($view_id === 'commerce_order_item_table' && $field_id !== 'title') {
+    return;
+  }
+  if (!in_array($view_id, ['commerce_cart_form', 'commerce_order_item_table'], TRUE)) {
+    return;
+  }
+  $order_item = _myeventlane_commerce_order_item_from_views_row($variables['row'] ?? NULL);
+  if ($order_item === NULL) {
+    return;
+  }
+  $render = _myeventlane_commerce_operational_order_item_line_render($order_item);
+  if ($render !== NULL) {
+    $variables['output'] = $render;
+  }
+}
+
+/**
+ * @param array<string, mixed> $form
+ *
+ * @return list<\Drupal\commerce_order\Entity\OrderItemInterface>
+ */
+function _myeventlane_commerce_order_items_from_cart_form(array $form): array {
+  $items = $form['#order_items'] ?? NULL;
+  if (!is_array($items)) {
+    return [];
+  }
+  $out = [];
+  foreach ($items as $item) {
+    if ($item instanceof OrderItemInterface) {
+      $out[] = $item;
+    }
+  }
+  return $out;
+}
+
+/**
+ * @param \Drupal\views\ResultRow|null $row
+ */
+function _myeventlane_commerce_order_item_from_views_row($row): ?OrderItemInterface {
+  if (!$row instanceof ResultRow) {
+    return NULL;
+  }
+  if (isset($row->_relationship_entities['order_items'])
+    && $row->_relationship_entities['order_items'] instanceof OrderItemInterface) {
+    return $row->_relationship_entities['order_items'];
+  }
+  if (isset($row->_entity) && $row->_entity instanceof OrderItemInterface) {
+    return $row->_entity;
+  }
+  return NULL;
+}
+
+/**
+ * @param list<\Drupal\commerce_order\Entity\OrderItemInterface> $order_items
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function _myeventlane_commerce_operational_order_item_display_map(array $order_items): array {
+  if (!\Drupal::hasService('myeventlane_commerce.operational_order_item_display_builder')) {
+    return [];
+  }
+  $builder = \Drupal::service('myeventlane_commerce.operational_order_item_display_builder');
+  $map = [];
+  foreach ($order_items as $order_item) {
+    $display = $builder->buildForOrderItem($order_item);
+    if ($display !== NULL) {
+      $map[(int) $order_item->id()] = $display;
+    }
+  }
+  return $map;
+}
+
+/**
+ * @return array<string, mixed>|null
+ */
+function _myeventlane_commerce_operational_order_item_line_render(OrderItemInterface $order_item): ?array {
+  if (!\Drupal::hasService('myeventlane_commerce.operational_order_item_display_builder')) {
+    return NULL;
+  }
+  $display = \Drupal::service('myeventlane_commerce.operational_order_item_display_builder')
+    ->buildForOrderItem($order_item);
+  if ($display === NULL) {
+    return NULL;
+  }
+  return [
+    '#theme' => 'mel_operational_order_item_line',
+    '#display' => $display,
+    '#attached' => [
+      'library' => ['myeventlane_commerce/operational_addons'],
+    ],
+    '#cache' => [
+      'tags' => array_merge($order_item->getCacheTags(), ['commerce_product_variation:' . (int) ($order_item->getPurchasedEntityId() ?? 0)]),
+      'contexts' => ['languages:language_interface'],
+    ],
+  ];
 }
 
 /**

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -204,6 +204,13 @@ services:
       - '@myeventlane_commerce.operational_merchandise_manager'
       - '@string_translation'
 
+  myeventlane_commerce.operational_order_item_display_builder:
+    class: Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder
+    arguments:
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@entity_type.manager'
+      - '@string_translation'
+
   myeventlane_commerce.operational_merchandise_governance_manager:
     class: Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager
     arguments:

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
@@ -134,6 +135,8 @@ final class BookController extends ControllerBase {
       '#event' => $node,
       '#addons_available' => FALSE,
       '#operational_addon_form' => [],
+      '#ticket_form' => [],
+      '#ticket_form_actions' => [],
       '#cache' => [
         'contexts' => ['route', 'user.roles', 'url.query_args', 'session', 'languages:language_interface'],
         'tags' => $node->getCacheTags(),
@@ -150,7 +153,7 @@ final class BookController extends ControllerBase {
     $formClass = $this->bookingFlowResolver->resolveBookingForm($node);
     switch ($formClass) {
       case TicketSelectionForm::class:
-        $build['#matrix_form'] = $this->buildPaidForm($node);
+        $this->attachPaidTicketBookingForms($build, $node);
         break;
 
       case RsvpPublicForm::class:
@@ -162,19 +165,49 @@ final class BookController extends ControllerBase {
         break;
     }
 
-    if ($isPaid) {
-      $addon_catalog = $this->eventOperationalAddonBuilder->buildForEvent($node);
-      if ($addon_catalog['addons'] !== []) {
-        $build['#addons_available'] = TRUE;
-        foreach ($addon_catalog['product_ids'] as $pid) {
-          $build['#cache']['tags'][] = 'commerce_product:' . $pid;
-        }
-      }
-    }
-
     $build['#cache']['tags'] = array_values(array_unique($build['#cache']['tags']));
 
     return $build;
+  }
+
+  /**
+   * Paid book page: ticket form, optional add-ons, then checkout CTA (sibling forms).
+   *
+   * @param array<string, mixed> $build
+   *   Page render array (altered in place).
+   */
+  private function attachPaidTicketBookingForms(array &$build, NodeInterface $node): void {
+    $form = $this->buildPaidForm($node);
+    if (isset($form['#type']) && $form['#type'] === 'container' && !isset($form['#form_id'])) {
+      $build['#matrix_form'] = $form;
+      return;
+    }
+
+    $form['#attributes']['id'] = 'mel-ticket-selection-form';
+    $actions = $form['actions'] ?? NULL;
+    unset($form['actions']);
+    if (is_array($actions) && isset($actions['submit']) && is_array($actions['submit'])) {
+      $actions['submit']['#attributes']['form'] = 'mel-ticket-selection-form';
+    }
+
+    $build['#ticket_form'] = $form;
+    $build['#matrix_form'] = $form;
+    if ($actions !== NULL) {
+      $build['#ticket_form_actions'] = $actions;
+    }
+
+    $addon_catalog = $this->eventOperationalAddonBuilder->buildForEvent($node);
+    if ($addon_catalog['addons'] === []) {
+      return;
+    }
+    $build['#addons_available'] = TRUE;
+    foreach ($addon_catalog['product_ids'] as $pid) {
+      $build['#cache']['tags'][] = 'commerce_product:' . $pid;
+    }
+    $build['#operational_addon_form'] = $this->formBuilderService->getForm(
+      EventOperationalAddonCartForm::class,
+      $node,
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -8,7 +8,6 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
-use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
@@ -170,10 +169,6 @@ final class BookController extends ControllerBase {
         foreach ($addon_catalog['product_ids'] as $pid) {
           $build['#cache']['tags'][] = 'commerce_product:' . $pid;
         }
-        $build['#operational_addon_form'] = $this->formBuilderService->getForm(
-          EventOperationalAddonCartForm::class,
-          $node,
-        );
       }
     }
 

--- a/web/modules/custom/myeventlane_commerce/src/EventSubscriber/TicketAvailabilityCommerceSubscriber.php
+++ b/web/modules/custom/myeventlane_commerce/src/EventSubscriber/TicketAvailabilityCommerceSubscriber.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_commerce\EventSubscriber;
 
+use Drupal\commerce\PurchasableEntityInterface;
 use Drupal\commerce_cart\Event\CartEntityAddEvent;
 use Drupal\commerce_cart\Event\CartEvents;
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Lock\LockBackendInterface;
@@ -14,6 +16,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
 use Drupal\myeventlane_capacity\Service\CapacityOrderInspector;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\node\NodeInterface;
 use Drupal\state_machine\Event\WorkflowTransitionEvent;
@@ -75,12 +78,10 @@ final class TicketAvailabilityCommerceSubscriber implements EventSubscriberInter
     $order_item = $event->getOrderItem();
     $cart = $event->getCart();
 
-    if ($this->orderInspector->isNonTicketItem($order_item)) {
+    if (!$this->shouldValidateAsTicket($order_item)) {
       return;
     }
-    if (!$order_item->hasField('field_target_event') || $order_item->get('field_target_event')->isEmpty()) {
-      return;
-    }
+
     $purchased = $order_item->get('purchased_entity')->entity;
     if (!$purchased instanceof ProductVariationInterface) {
       return;
@@ -159,6 +160,37 @@ final class TicketAvailabilityCommerceSubscriber implements EventSubscriberInter
       $request->attributes->set(self::PLACEMENT_LOCK_ATTR, $lock_name);
     }
     // Per-event capacity validation runs in TicketCapacityOrderSubscriber (priority 50).
+  }
+
+  /**
+   * Whether ticket availability rules apply to this cart line.
+   */
+  private function shouldValidateAsTicket(OrderItemInterface $order_item): bool {
+    if ($this->orderInspector->isNonTicketItem($order_item)) {
+      return FALSE;
+    }
+    if (!$order_item->hasField('field_target_event') || $order_item->get('field_target_event')->isEmpty()) {
+      return FALSE;
+    }
+    $purchased = $order_item->get('purchased_entity')->entity;
+    if (!$purchased instanceof PurchasableEntityInterface) {
+      return FALSE;
+    }
+    return !$this->isOperationalAddonVariation($purchased);
+  }
+
+  /**
+   * Operational add-ons are event-scoped but not ticket matrix variations.
+   */
+  private function isOperationalAddonVariation(PurchasableEntityInterface $entity): bool {
+    if (!$entity instanceof ProductVariationInterface) {
+      return FALSE;
+    }
+    $product = $entity->getProduct();
+    if ($product === NULL) {
+      return FALSE;
+    }
+    return OperationalMerchandiseManager::isOperationalProductBundle($product->bundle());
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/EventSubscriber/TicketCapacityOrderSubscriber.php
+++ b/web/modules/custom/myeventlane_commerce/src/EventSubscriber/TicketCapacityOrderSubscriber.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
 use Drupal\myeventlane_capacity\Service\CapacityOrderInspector;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\node\NodeInterface;
 use Drupal\state_machine\Event\WorkflowTransitionEvent;
@@ -101,6 +102,13 @@ final class TicketCapacityOrderSubscriber implements EventSubscriberInterface {
         $requested_total = (int) ($event_totals[$event_id] ?? 0);
         foreach ($variations as $variation_id => $qty) {
           $variation = $variation_storage->load($variation_id);
+          if ($variation instanceof ProductVariationInterface) {
+            $variation_product = $variation->getProduct();
+            if ($variation_product !== NULL
+              && OperationalMerchandiseManager::isOperationalProductBundle($variation_product->bundle())) {
+              continue;
+            }
+          }
           if (!$variation instanceof ProductVariationInterface) {
             $this->logger->error(
               'Orphan ticket variation @vid on order @oid (event @eid): variation entity missing.',

--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -27,8 +27,11 @@ use Drupal\mel_ticket\Entity\TicketType;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\TicketTypeManager;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -62,6 +65,8 @@ final class TicketSelectionForm extends FormBase {
     protected TimeInterface $time,
     protected CapacityOrderInspector $orderInspector,
     protected TicketTypeManager $ticketTypeManager,
+    protected EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    protected FormBuilderInterface $formBuilder,
     protected ?EventCapacityServiceInterface $capacityService = NULL,
   ) {}
 
@@ -82,6 +87,8 @@ final class TicketSelectionForm extends FormBase {
       $container->get('datetime.time'),
       $container->get('myeventlane_capacity.order_inspector'),
       $container->get('myeventlane_event.ticket_type_manager'),
+      $container->get('myeventlane_commerce.event_operational_addon_builder'),
+      $container->get('form_builder'),
       $container->has('myeventlane_capacity.service')
         ? $container->get('myeventlane_capacity.service')
         : NULL,
@@ -347,6 +354,35 @@ final class TicketSelectionForm extends FormBase {
       }
 
       $this->appendMelDonationField($form, $node, $estimated_total);
+
+      if ($this->eventOperationalAddonBuilder->hasAddons($node)) {
+        $form['operational_addons'] = [
+          '#type' => 'container',
+          '#weight' => 18,
+          '#attributes' => [
+            'class' => [
+              'mel-operational-addons-section',
+              'mel-operational-addons-section--embedded',
+            ],
+          ],
+        ];
+        $form['operational_addons']['title'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Add something extra'),
+          '#attributes' => ['class' => ['mel-operational-addons-section__title']],
+        ];
+        $form['operational_addons']['lede'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Optional extras stay on this booking — collect at the event after purchase.'),
+          '#attributes' => ['class' => ['mel-operational-addons-section__lede']],
+        ];
+        $form['operational_addons']['form'] = $this->formBuilder->getForm(
+          EventOperationalAddonCartForm::class,
+          $node,
+        );
+      }
 
       $form['actions'] = [
         '#type' => 'actions',

--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -27,11 +27,8 @@ use Drupal\mel_ticket\Entity\TicketType;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\myeventlane_commerce\Form\EventOperationalAddonCartForm;
-use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_event\Service\TicketTypeManager;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -65,8 +62,6 @@ final class TicketSelectionForm extends FormBase {
     protected TimeInterface $time,
     protected CapacityOrderInspector $orderInspector,
     protected TicketTypeManager $ticketTypeManager,
-    protected EventOperationalAddonBuilder $eventOperationalAddonBuilder,
-    protected FormBuilderInterface $formBuilder,
     protected ?EventCapacityServiceInterface $capacityService = NULL,
   ) {}
 
@@ -87,8 +82,6 @@ final class TicketSelectionForm extends FormBase {
       $container->get('datetime.time'),
       $container->get('myeventlane_capacity.order_inspector'),
       $container->get('myeventlane_event.ticket_type_manager'),
-      $container->get('myeventlane_commerce.event_operational_addon_builder'),
-      $container->get('form_builder'),
       $container->has('myeventlane_capacity.service')
         ? $container->get('myeventlane_capacity.service')
         : NULL,
@@ -354,35 +347,6 @@ final class TicketSelectionForm extends FormBase {
       }
 
       $this->appendMelDonationField($form, $node, $estimated_total);
-
-      if ($this->eventOperationalAddonBuilder->hasAddons($node)) {
-        $form['operational_addons'] = [
-          '#type' => 'container',
-          '#weight' => 18,
-          '#attributes' => [
-            'class' => [
-              'mel-operational-addons-section',
-              'mel-operational-addons-section--embedded',
-            ],
-          ],
-        ];
-        $form['operational_addons']['title'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'h3',
-          '#value' => $this->t('Add something extra'),
-          '#attributes' => ['class' => ['mel-operational-addons-section__title']],
-        ];
-        $form['operational_addons']['lede'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $this->t('Optional extras stay on this booking — collect at the event after purchase.'),
-          '#attributes' => ['class' => ['mel-operational-addons-section__lede']],
-        ];
-        $form['operational_addons']['form'] = $this->formBuilder->getForm(
-          EventOperationalAddonCartForm::class,
-          $node,
-        );
-      }
 
       $form['actions'] = [
         '#type' => 'actions',

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalMerchandiseManager.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalMerchandiseManager.php
@@ -38,6 +38,13 @@ final class OperationalMerchandiseManager {
   ];
 
   /**
+   * Whether a Commerce product bundle is operational merchandise architecture.
+   */
+  public static function isOperationalProductBundle(string $bundle): bool {
+    return in_array($bundle, self::OPERATIONAL_PRODUCT_BUNDLES, TRUE);
+  }
+
+  /**
    * @var list<string>
    */
   public const FORBIDDEN_PRODUCT_KEYS = [

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalOrderItemDisplayBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalOrderItemDisplayBuilder.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Customer-safe labels for operational add-on Commerce order line items.
+ *
+ * Read-only projection for cart, checkout, orders, and My Tickets surfaces.
+ */
+final class OperationalOrderItemDisplayBuilder {
+
+  use StringTranslationTrait;
+
+  public const CONTRACT_FLAG = 'is_operational_addon';
+
+  /**
+   * @var list<string>
+   */
+  public const FORBIDDEN_DISPLAY_KEYS = [
+    'qr_payload',
+    'replay_token',
+    'scanner_action',
+    'scanner_secret',
+    'device_fingerprint',
+    'inventory_quantity',
+    'stock_count',
+    'warehouse_ids',
+    'shipment_provider',
+    'shipment_state',
+    'fingerprint',
+    'operational_fingerprint',
+  ];
+
+  /**
+   * Variation titles that must not be used as the primary customer label.
+   *
+   * @var list<string>
+   */
+  private const GENERIC_VARIATION_LABELS = [
+    'price',
+    'unit price',
+    'default',
+    'variation',
+    'product',
+  ];
+
+  public function __construct(
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   *   Sanitized display document, or NULL when the line is not operational.
+   */
+  public function buildForOrderItem(OrderItemInterface $order_item): ?array {
+    $purchased = $order_item->getPurchasedEntity();
+    if (!$purchased instanceof ProductVariationInterface) {
+      return NULL;
+    }
+    $product = $purchased->getProduct();
+    if (!$product instanceof ProductInterface) {
+      return NULL;
+    }
+    if (!OperationalMerchandiseManager::isOperationalProductBundle($product->bundle())) {
+      return NULL;
+    }
+
+    $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+
+    $event = $this->resolveEvent($product, $order_item);
+    $event_id = $event instanceof NodeInterface ? (int) $event->id() : 0;
+    $event_title = $event instanceof NodeInterface ? (string) $event->label() : '';
+
+    $product_title = $this->customerProductTitle((string) $product->label());
+    $variation_label = $this->meaningfulVariationLabel((string) $purchased->label(), $product_title);
+
+    $description = trim((string) ($presentation['operational_summary'] ?? ''));
+    if ($description === '') {
+      $description = $this->descriptionFromPickupMode((string) ($presentation['pickup_mode'] ?? ''));
+    }
+
+    $chips = $this->normalizeChips(is_array($presentation['operational_chips'] ?? NULL) ? $presentation['operational_chips'] : []);
+
+    $doc = [
+      self::CONTRACT_FLAG => TRUE,
+      'title' => $product_title,
+      'subtitle' => $event_title !== ''
+        ? (string) $this->t('For: @event', ['@event' => $event_title])
+        : '',
+      'description' => $description,
+      'variation_label' => $variation_label,
+      'chips' => $chips,
+      'pickup_mode' => (string) ($presentation['pickup_mode'] ?? ''),
+      'event_id' => $event_id,
+      'event_title' => $event_title,
+    ];
+
+    return $this->stripForbiddenRecursive($doc);
+  }
+
+  /**
+   * @param array<int|string, mixed> $data
+   *
+   * @return array<int|string, mixed>
+   */
+  public function stripForbiddenRecursive(array $data): array {
+    if (array_is_list($data)) {
+      $out = [];
+      foreach ($data as $item) {
+        if (is_array($item)) {
+          $out[] = $this->stripForbiddenRecursive($item);
+        }
+        elseif (is_scalar($item) || $item === NULL) {
+          $out[] = $item;
+        }
+      }
+      return $out;
+    }
+    $out = [];
+    foreach ($data as $key => $value) {
+      if (!is_string($key) || in_array($key, self::FORBIDDEN_DISPLAY_KEYS, TRUE)) {
+        continue;
+      }
+      if (is_array($value)) {
+        $out[$key] = $this->stripForbiddenRecursive($value);
+      }
+      elseif (is_scalar($value) || $value === NULL) {
+        $out[$key] = $value;
+      }
+    }
+    return $out;
+  }
+
+  private function resolveEvent(ProductInterface $product, OrderItemInterface $order_item): ?NodeInterface {
+    if ($product->hasField('field_event') && !$product->get('field_event')->isEmpty()) {
+      $event = $product->get('field_event')->entity;
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        return $event;
+      }
+    }
+    if ($order_item->hasField('field_target_event') && !$order_item->get('field_target_event')->isEmpty()) {
+      $event = $order_item->get('field_target_event')->entity;
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        return $event;
+      }
+      $event_id = (int) $order_item->get('field_target_event')->target_id;
+      if ($event_id > 0) {
+        $loaded = $this->entityTypeManager->getStorage('node')->load($event_id);
+        if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+          return $loaded;
+        }
+      }
+    }
+    return NULL;
+  }
+
+  private function customerProductTitle(string $raw): string {
+    $raw = trim($raw);
+    if ($raw === '') {
+      return (string) $this->t('Add-on');
+    }
+    $stripped = preg_replace('/\s*-\s*Node\s+\d+$/i', '', $raw);
+    return is_string($stripped) && trim($stripped) !== '' ? trim($stripped) : $raw;
+  }
+
+  private function meaningfulVariationLabel(string $variation_label, string $product_title): string {
+    $variation_label = trim($variation_label);
+    if ($variation_label === '') {
+      return '';
+    }
+    $lower = strtolower($variation_label);
+    if (in_array($lower, self::GENERIC_VARIATION_LABELS, TRUE)) {
+      return '';
+    }
+    if (strcasecmp($variation_label, $product_title) === 0) {
+      return '';
+    }
+    if (str_starts_with(strtolower($product_title), strtolower($variation_label))) {
+      return '';
+    }
+    return $variation_label;
+  }
+
+  /**
+   * @param list<array<string, string>> $chips
+   *
+   * @return list<array{label: string, tone: string}>
+   */
+  private function normalizeChips(array $chips): array {
+    $out = [];
+    $seen = [];
+    foreach ($chips as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = trim((string) ($chip['label'] ?? ''));
+      if ($label === '' || isset($seen[$label])) {
+        continue;
+      }
+      $seen[$label] = TRUE;
+      $tone = strtolower(trim((string) ($chip['tone'] ?? 'muted')));
+      if (!preg_match('/^[a-z0-9_-]{1,32}$/', $tone)) {
+        $tone = 'muted';
+      }
+      $out[] = [
+        'label' => $label,
+        'tone' => $tone,
+      ];
+    }
+    if ($out === []) {
+      $out[] = [
+        'label' => (string) $this->t('Add-on'),
+        'tone' => 'muted',
+      ];
+    }
+    return $out;
+  }
+
+  private function descriptionFromPickupMode(string $pickup_mode): string {
+    return match ($pickup_mode) {
+      'venue_pickup', 'counter', 'timed_window' => (string) $this->t('Collect at the venue after purchase.'),
+      'none' => (string) $this->t('Follow organiser instructions for this add-on.'),
+      default => (string) $this->t('Collect at the venue after purchase.'),
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/templates/mel-operational-order-item-line.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-operational-order-item-line.html.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Customer line label for an operational add-on order item (cart / summaries).
+ *
+ * Variables:
+ * - display: sanitized array from OperationalOrderItemDisplayBuilder.
+ */
+#}
+{% set d = display|default({}) %}
+<div class="mel-operational-order-item-line">
+  {% if d.title|default('') %}
+    <div class="mel-operational-order-item-line__title">{{ d.title }}</div>
+  {% endif %}
+  {% if d.subtitle|default('') %}
+    <p class="mel-operational-order-item-line__subtitle">{{ d.subtitle }}</p>
+  {% endif %}
+  {% if d.variation_label|default('') %}
+    <p class="mel-operational-order-item-line__variation">{{ d.variation_label }}</p>
+  {% endif %}
+  {% if d.description|default('') %}
+    <p class="mel-operational-order-item-line__description">{{ d.description }}</p>
+  {% endif %}
+  {% if d.chips|default([])|length > 0 %}
+    <ul class="mel-operational-order-item-line__chips" aria-label="{{ 'Add-on details'|t }}">
+      {% for chip in d.chips %}
+        <li class="mel-operational-order-item-line__chip mel-operational-order-item-line__chip--{{ chip.tone|default('muted')|clean_class }}">{{ chip.label|default('') }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -102,8 +102,10 @@
               {% endif %}
             </h2>
 
-            <div class="mel-ticket-panel__body mel-event-book__form-body">
-              {% if matrix_form is not empty %}
+            <div class="mel-ticket-panel__body mel-event-book__form-body mel-booking-flow" data-mel-booking-flow>
+              {% if ticket_form is not empty %}
+                {{ ticket_form }}
+              {% elseif matrix_form is not empty %}
                 {{ matrix_form }}
               {% elseif rsvp_form is not empty %}
                 {{ rsvp_form }}
@@ -116,10 +118,29 @@
                   {% endif %}
                 </div>
               {% endif %}
+
+              {% if addons_available and operational_addon_form %}
+                <section class="mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title">
+                  <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ 'Add something extra'|t }}</h3>
+                  <p class="mel-operational-addons-section__lede">{{ 'Optional extras stay on this booking — collect at the event after purchase.'|t }}</p>
+                  {{ operational_addon_form }}
+                </section>
+              {% endif %}
+
+              {% if ticket_form_actions is not empty %}
+                <div class="mel-booking__cta mel-booking-flow__checkout" role="region" aria-label="{{ 'Reserve tickets'|t }}">
+                  <div class="mel-mobile-booking-bar" data-mel-mobile-booking-bar>
+                    <span class="mel-mobile-booking-bar__count" data-mel-booking-count></span>
+                    <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
+                  </div>
+                  <p class="mel-booking__cta-note">
+                    {{ "Tickets will be added to your cart — checkout when you're ready."|t }}
+                  </p>
+                  {{ ticket_form_actions }}
+                </div>
+              {% endif %}
             </div>
           </div>
-
-          {# Operational add-ons render inside TicketSelectionForm (matrix_form) before checkout. #}
         </div>
 
         {% if event_mode == 'paid' %}

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -119,13 +119,7 @@
             </div>
           </div>
 
-          {% if addons_available and operational_addon_form %}
-            <section class="mel-operational-addons-section" aria-labelledby="mel-operational-addons-title">
-              <h2 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ 'Add something extra'|t }}</h2>
-              <p class="mel-operational-addons-section__lede">{{ 'Optional extras stay on this booking — collect at the event after purchase.'|t }}</p>
-              {{ operational_addon_form }}
-            </section>
-          {% endif %}
+          {# Operational add-ons render inside TicketSelectionForm (matrix_form) before checkout. #}
         </div>
 
         {% if event_mode == 'paid' %}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class OperationalOrderItemDisplayBuilderTest extends UnitTestCase {
+
+  /**
+   * @covers ::buildForOrderItem
+   */
+  public function testReturnsNullForNonOperationalProduct(): void {
+    $builder = $this->builder();
+    $order_item = $this->orderItemFixture('default', 'Price', 'Regular ticket');
+    $this->assertNull($builder->buildForOrderItem($order_item));
+  }
+
+  /**
+   * @covers ::buildForOrderItem
+   */
+  public function testOperationalProductUsesProductLabelNotGenericVariationTitle(): void {
+    $builder = $this->builder();
+    $order_item = $this->orderItemFixture(
+      'operational_merchandise',
+      'Price',
+      'Event T-shirt',
+      operational_payload: [
+        'operational_product_type' => 'merch_pickup',
+        'operational_summary' => 'Collect your T-shirt at the venue after purchase.',
+        'operational_chips' => [
+          ['label' => 'Add-on', 'tone' => 'muted'],
+          ['label' => 'Venue pickup', 'tone' => 'pickup'],
+        ],
+        'pickup_mode' => 'venue_pickup',
+        'customer_visibility' => 'visible',
+        'readiness_mode' => 'authoring',
+      ],
+      event_title: 'Night of Live Music at the Ritz',
+    );
+    $display = $builder->buildForOrderItem($order_item);
+    $this->assertIsArray($display);
+    $this->assertTrue($display[OperationalOrderItemDisplayBuilder::CONTRACT_FLAG]);
+    $this->assertSame('Event T-shirt', $display['title']);
+    $this->assertSame('', $display['variation_label']);
+    $this->assertStringContainsString('Night of Live Music at the Ritz', (string) $display['subtitle']);
+  }
+
+  /**
+   * @covers ::buildForOrderItem
+   */
+  public function testEventTitleResolvesFromProductFieldEvent(): void {
+    $builder = $this->builder();
+    $order_item = $this->orderItemFixture(
+      'operational_merchandise',
+      'Price',
+      'Event T-shirt',
+      event_title: 'Ritz Live Music Night',
+      event_id: 1584,
+    );
+    $display = $builder->buildForOrderItem($order_item);
+    $this->assertIsArray($display);
+    $this->assertSame(1584, $display['event_id']);
+    $this->assertSame('Ritz Live Music Night', $display['event_title']);
+  }
+
+  /**
+   * @covers ::buildForOrderItem
+   */
+  public function testDescriptionResolvesFromOperationalPresentation(): void {
+    $builder = $this->builder();
+    $order_item = $this->orderItemFixture(
+      'operational_merchandise',
+      'Price',
+      'Event T-shirt',
+      operational_payload: [
+        'operational_product_type' => 'merch_pickup',
+        'operational_summary' => 'Collect your T-shirt at the venue after purchase.',
+        'operational_chips' => [],
+        'pickup_mode' => 'venue_pickup',
+        'customer_visibility' => 'visible',
+        'readiness_mode' => 'authoring',
+      ],
+    );
+    $display = $builder->buildForOrderItem($order_item);
+    $this->assertIsArray($display);
+    $this->assertSame('Collect your T-shirt at the venue after purchase.', $display['description']);
+  }
+
+  /**
+   * @covers ::stripForbiddenRecursive
+   */
+  public function testForbiddenKeysAreStrippedRecursively(): void {
+    $builder = $this->builder();
+    $out = $builder->stripForbiddenRecursive([
+      'title' => 'Event T-shirt',
+      'chips' => [
+        ['label' => 'Add-on', 'qr_payload' => 'secret'],
+      ],
+      'scanner_secret' => 'nope',
+    ]);
+    $this->assertSame('Event T-shirt', $out['title']);
+    $this->assertArrayNotHasKey('scanner_secret', $out);
+    $this->assertArrayNotHasKey('qr_payload', $out['chips'][0]);
+    $this->assertSame('Add-on', $out['chips'][0]['label']);
+  }
+
+  /**
+   * @covers ::buildForOrderItem
+   */
+  public function testChipsRemainListShaped(): void {
+    $builder = $this->builder();
+    $order_item = $this->orderItemFixture(
+      'operational_merchandise',
+      'Price',
+      'Event T-shirt',
+      operational_payload: [
+        'operational_product_type' => 'merch_pickup',
+        'operational_chips' => [
+          ['label' => 'Add-on', 'tone' => 'muted'],
+          ['label' => 'Venue pickup', 'tone' => 'pickup'],
+        ],
+        'pickup_mode' => 'venue_pickup',
+        'customer_visibility' => 'visible',
+        'readiness_mode' => 'authoring',
+      ],
+    );
+    $display = $builder->buildForOrderItem($order_item);
+    $this->assertIsArray($display);
+    $this->assertIsList($display['chips']);
+    $this->assertGreaterThanOrEqual(2, count($display['chips']));
+    $this->assertSame('Add-on', $display['chips'][0]['label']);
+  }
+
+  private function builder(): OperationalOrderItemDisplayBuilder {
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $manager = new OperationalMerchandiseManager(
+      $etm,
+      $this->getStringTranslationStub(),
+      $this->createMock(LoggerInterface::class),
+    );
+    return new OperationalOrderItemDisplayBuilder(
+      $manager,
+      $etm,
+      $this->getStringTranslationStub(),
+    );
+  }
+
+  /**
+   * @param array<string, mixed>|null $operational_payload
+   */
+  private function orderItemFixture(
+    string $product_bundle,
+    string $variation_label,
+    string $product_label,
+    ?array $operational_payload = NULL,
+    ?string $event_title = NULL,
+    int $event_id = 0,
+  ): OrderItemInterface {
+    $event = NULL;
+    if ($event_title !== NULL) {
+      $event = $this->createMock(NodeInterface::class);
+      $event->method('id')->willReturn((string) $event_id);
+      $event->method('label')->willReturn($event_title);
+      $event->method('bundle')->willReturn('event');
+    }
+
+    $event_field = new TestFieldItemList($event);
+    $operational_field = new TestOperationalFieldItemList($operational_payload);
+
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn($product_bundle);
+    $product->method('label')->willReturn($product_label);
+    $product->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => in_array($field, ['field_event', 'field_mel_operational_product'], TRUE),
+    );
+    $product->method('get')->willReturnCallback(
+      static fn (string $field) => match ($field) {
+        'field_event' => $event_field,
+        'field_mel_operational_product' => $operational_field,
+        default => $event_field,
+      },
+    );
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('label')->willReturn($variation_label);
+    $variation->method('getProduct')->willReturn($product);
+
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('getPurchasedEntity')->willReturn($variation);
+
+    return $order_item;
+  }
+
+}
+
+/**
+ * Minimal field list stub for entity reference fields in unit tests.
+ */
+final class TestFieldItemList {
+
+  public function __construct(public readonly ?NodeInterface $entity) {}
+
+  public function isEmpty(): bool {
+    return $this->entity === NULL;
+  }
+
+}
+
+/**
+ * Minimal operational product field stub.
+ */
+final class TestOperationalFieldItemList {
+
+  /**
+   * @param array<string, mixed>|null $payload
+   */
+  public function __construct(private readonly ?array $payload) {}
+
+  public function isEmpty(): bool {
+    return $this->payload === NULL;
+  }
+
+  public function __get(string $name): mixed {
+    if ($name === 'value') {
+      return json_encode($this->payload ?? [], JSON_THROW_ON_ERROR);
+    }
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/TicketAvailabilityCommerceSubscriberTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/TicketAvailabilityCommerceSubscriberTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\myeventlane_capacity\Service\CapacityOrderInspector;
+use Drupal\myeventlane_commerce\EventSubscriber\TicketAvailabilityCommerceSubscriber;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\EventSubscriber\TicketAvailabilityCommerceSubscriber
+ *
+ * @group myeventlane_commerce
+ */
+final class TicketAvailabilityCommerceSubscriberTest extends UnitTestCase {
+
+  /**
+   * @return array<string, bool>
+   */
+  public static function operationalBundleProvider(): array {
+    $cases = [];
+    foreach (OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES as $bundle) {
+      $cases[$bundle] = [$bundle, TRUE];
+    }
+    $cases['default_ticket_product'] = ['default', FALSE];
+    return $cases;
+  }
+
+  /**
+   * @covers ::shouldValidateAsTicket
+   * @dataProvider operationalBundleProvider
+   */
+  public function testShouldValidateAsTicketSkipsOperationalMerchandise(string $bundle, bool $skip_ticket_rules): void {
+    $subscriber = $this->subscriber();
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('bundle')->willReturn('default');
+    $order_item->method('hasField')->with('field_target_event')->willReturn(TRUE);
+    $order_item->method('get')->willReturnCallback(function (string $field) {
+      if ($field === 'field_target_event') {
+        $field_item = new class {
+
+          public bool $isEmpty = FALSE;
+
+          public int $target_id = 1584;
+
+        };
+        return $field_item;
+      }
+      if ($field === 'purchased_entity') {
+        $field_item = new class($this->variation($bundle)) {
+
+          public function __construct(public object $entity) {}
+
+        };
+        return $field_item;
+      }
+      return NULL;
+    });
+
+    $should_validate = $this->invokeShouldValidateAsTicket($subscriber, $order_item);
+    $this->assertSame(!$skip_ticket_rules, $should_validate);
+  }
+
+  public function testShouldValidateAsTicketStillAppliesToTicketLines(): void {
+    $subscriber = $this->subscriber();
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $order_item->method('bundle')->willReturn('default');
+    $order_item->method('hasField')->with('field_target_event')->willReturn(TRUE);
+    $order_item->method('get')->willReturnCallback(function (string $field) {
+      if ($field === 'field_target_event') {
+        $field_item = new class {
+
+          public bool $isEmpty = FALSE;
+
+          public int $target_id = 1584;
+
+        };
+        return $field_item;
+      }
+      if ($field === 'purchased_entity') {
+        $field_item = new class($this->variation('default')) {
+
+          public function __construct(public object $entity) {}
+
+        };
+        return $field_item;
+      }
+      return NULL;
+    });
+
+    $this->assertTrue($this->invokeShouldValidateAsTicket($subscriber, $order_item));
+  }
+
+  private function subscriber(): TicketAvailabilityCommerceSubscriber {
+    return new TicketAvailabilityCommerceSubscriber(
+      $this->createMock(TicketAvailabilityService::class),
+      new CapacityOrderInspector(),
+      $this->createMock(\Drupal\Core\Entity\EntityTypeManagerInterface::class),
+      $this->createMock(LockBackendInterface::class),
+      $this->createMock(RequestStack::class),
+      $this->getStringTranslationStub(),
+      $this->createMock(LoggerInterface::class),
+    );
+  }
+
+  private function variation(string $product_bundle): ProductVariationInterface&MockObject {
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn($product_bundle);
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getProduct')->willReturn($product);
+    return $variation;
+  }
+
+  private function invokeShouldValidateAsTicket(
+    TicketAvailabilityCommerceSubscriber $subscriber,
+    OrderItemInterface $order_item,
+  ): bool {
+    $method = new \ReflectionMethod($subscriber, 'shouldValidateAsTicket');
+    $method->setAccessible(TRUE);
+    return (bool) $method->invoke($subscriber, $order_item);
+  }
+
+}

--- a/web/phpunit-governance.xml
+++ b/web/phpunit-governance.xml
@@ -47,6 +47,7 @@
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalCheckoutGovernanceManagerTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalCustomerGuidanceBuilderTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalCartProjectionBuilderTest.php</file>
+      <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
@@ -145,20 +145,22 @@
    * @returns {{ container: Document|HTMLElement, empty: HTMLElement|null, items: HTMLElement|null, subtotalWrap: HTMLElement|null, subtotalValue: HTMLElement|null, mobileBar: HTMLElement|null, countEl: HTMLElement|null, totalEl: HTMLElement|null, submit: HTMLElement|null }}
    */
   function getTargets(form) {
+    const flow = form.closest('[data-mel-booking-flow]');
     const root =
       form.closest('.mel-booking-v2') ||
       document.querySelector('.mel-booking-v2') ||
       document;
+    const scope = flow || form;
     return {
       container: root,
       empty: root.querySelector('[data-mel-summary-empty]'),
       items: root.querySelector('[data-mel-summary-items]'),
       subtotalWrap: root.querySelector('[data-mel-summary-subtotal]'),
       subtotalValue: root.querySelector('[data-mel-summary-subtotal-value]'),
-      mobileBar: form.querySelector('[data-mel-mobile-booking-bar]'),
-      countEl: form.querySelector('[data-mel-booking-count]'),
-      totalEl: form.querySelector('[data-mel-booking-total]'),
-      submit: form.querySelector('.mel-add-to-cart-button, input[type="submit"].button--primary, button[type="submit"].button--primary'),
+      mobileBar: scope.querySelector('[data-mel-mobile-booking-bar]'),
+      countEl: scope.querySelector('[data-mel-booking-count]'),
+      totalEl: scope.querySelector('[data-mel-booking-total]'),
+      submit: scope.querySelector('.mel-add-to-cart-button, input[type="submit"].button--primary, button[type="submit"].button--primary'),
     };
   }
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
@@ -31,10 +31,15 @@
         {% endif %}
 
         {% for item in event.items %}
-          <div class="mel-summary-item">
+          <div class="mel-summary-item{% if item.operational_addon_display|default(null) %} mel-summary-item--operational-addon{% endif %}">
             <span class="mel-summary-item__label">
-              <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
-              <span class="mel-summary-item__ticket-type">{{ item.ticket_type }}</span>
+              {% if item.operational_addon_display|default(null) %}
+                <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
+                {% include '@myeventlane_commerce/mel-operational-order-item-line.html.twig' with { display: item.operational_addon_display } only %}
+              {% else %}
+                <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
+                <span class="mel-summary-item__ticket-type">{{ item.ticket_type }}</span>
+              {% endif %}
             </span>
             <span class="mel-summary-item__price">{{ item.total_price }}</span>
           </div>

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-ticket-selection-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-ticket-selection-form.html.twig
@@ -45,16 +45,5 @@
     {{ form.empty }}
   </div>
 
-  {% if form.actions is defined %}
-    <div class="mel-booking__cta" role="region" aria-label="{{ 'Reserve tickets'|t }}">
-      <div class="mel-mobile-booking-bar" data-mel-mobile-booking-bar>
-        <span class="mel-mobile-booking-bar__count" data-mel-booking-count></span>
-        <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
-      </div>
-      <p class="mel-booking__cta-note">
-        {{ "Tickets will be added to your cart — checkout when you're ready."|t }}
-      </p>
-      {{ form.actions }}
-    </div>
-  {% endif %}
+  {# Checkout CTA renders on the book page after the operational add-on form (sibling forms). #}
 </form>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts ticket/capacity validation logic to explicitly exclude operational add-on products and changes how order items are rendered in cart/checkout/My Tickets, which could affect purchase eligibility checks and customer-facing summaries if misclassified.
> 
> **Overview**
> **Operational merchandise add-ons are now treated as first-class order lines (but not tickets).** Capacity/ticket-availability inspection and order-placement validation now exclude operational add-on product bundles so they don’t consume event ticket capacity or trigger ticket rules.
> 
> **Customer-facing surfaces now render a dedicated operational add-on line display.** Adds `OperationalOrderItemDisplayBuilder`, a new `mel_operational_order_item_line` theme, and Twig/CSS updates so cart views, grouped checkout summaries, and legacy My Tickets rows show sanitized add-on titles/subtitles/chips instead of generic variation labels.
> 
> **Paid booking page layout is reorganized.** The ticket selection form actions are split out so add-ons render between the ticket matrix and the checkout CTA, with JS updated to scope summary elements to the new booking-flow container; includes new/updated unit and kernel tests and service wiring (optional DI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2750c355f4a4a707dc334799bf5dd01e083f240a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->