### PR TITLE
Refactor image brightness handling in mel-cards.js to use a constant …

### DIFF
--- a/web/themes/custom/myeventlane_theme/js/mel-cards.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-cards.js
@@ -5,6 +5,9 @@
 (function (Drupal, once) {
   'use strict';
 
+  // Perceived luminance (0–255). Single source of truth for all event cards.
+  var MEL_CARD_BRIGHTNESS_THRESHOLD = 128;
+
   function applyBrightness(img, card) {
     var canvas = document.createElement('canvas');
     var ctx = canvas.getContext('2d');
@@ -31,7 +34,7 @@
       }
 
       var avg = total / (data.length / 4);
-      var isLight = avg > 128;
+      var isLight = avg > MEL_CARD_BRIGHTNESS_THRESHOLD;
 
       card.classList.remove('mel-event-card--light-bg', 'mel-event-card--dark-bg');
       card.classList.add(isLight ? 'mel-event-card--light-bg' : 'mel-event-card--dark-bg');

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig
@@ -75,72 +75,7 @@
         });
       }
 
-      // --- Adaptive text contrast based on image brightness ---
-      // Samples the bottom 40% of each card image (where the glass overlay sits)
-      // and toggles between light/dark text for readability.
-      function getImageBrightness(img, card) {
-        const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        // Sample at reduced resolution for performance
-        const sampleW = 100;
-        const sampleH = 60;
-        canvas.width = sampleW;
-        canvas.height = sampleH;
-
-        try {
-          // Draw only the bottom 40% of the image (where overlay sits)
-          const srcY = img.naturalHeight * 0.6;
-          const srcH = img.naturalHeight * 0.4;
-          ctx.drawImage(img, 0, srcY, img.naturalWidth, srcH, 0, 0, sampleW, sampleH);
-
-          const data = ctx.getImageData(0, 0, sampleW, sampleH).data;
-          let totalBrightness = 0;
-          const pixelCount = data.length / 4;
-
-          for (let i = 0; i < data.length; i += 4) {
-            // Perceived brightness formula (ITU-R BT.601)
-            totalBrightness += (data[i] * 0.299 + data[i+1] * 0.587 + data[i+2] * 0.114);
-          }
-
-          const avgBrightness = totalBrightness / pixelCount;
-
-          // Threshold: 0-255 scale. Below 140 = dark image = white text
-          if (avgBrightness > 140) {
-            card.classList.add('mel-event-card--light-bg');
-            card.classList.remove('mel-event-card--dark-bg');
-          } else {
-            card.classList.add('mel-event-card--dark-bg');
-            card.classList.remove('mel-event-card--light-bg');
-          }
-        } catch (e) {
-          // CORS or other error — default to white text (dark-bg)
-          card.classList.add('mel-event-card--dark-bg');
-        }
-      }
-
-      // Process featured carousel cards (compact/legacy only — overlay cards use fixed glass tokens).
-      document.querySelectorAll('.mel-featured-carousel__slide .mel-event-card').forEach(function(card) {
-        if (
-          card.classList.contains('mel-event-card--standard')
-          || card.classList.contains('mel-event-card--hero')
-          || card.classList.contains('mel-event-card--featured')
-        ) {
-          return;
-        }
-
-        const img = card.querySelector('.mel-event-card__image img, .mel-event-card__image-element');
-        if (!img) return;
-
-        if (img.complete && img.naturalWidth > 0) {
-          getImageBrightness(img, card);
-        } else {
-          img.addEventListener('load', function() {
-            getImageBrightness(img, card);
-          });
-        }
-      });
+      // Adaptive text contrast: mel-cards.js (Drupal.behaviors.melCardBrightness, front library).
     })();
   </script>
 {% endif %}


### PR DESCRIPTION
…threshold for light/dark background determination. Removed redundant getImageBrightness function from the template file, streamlining the code for adaptive text contrast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: consolidates existing brightness/contrast logic into a shared constant and removes redundant inline JS; main impact is a small behavior change in the light/dark cutoff value.
> 
> **Overview**
> Centralizes event-card image brightness detection in `mel-cards.js` by introducing `MEL_CARD_BRIGHTNESS_THRESHOLD` and using it for the light/dark class decision.
> 
> Removes the duplicated inline `getImageBrightness` logic from the featured events carousel Twig template, leaving contrast handling to the existing `Drupal.behaviors.melCardBrightness` front-end library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57b413b041b666a15508684ae356238b9093d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->