### PR TITLE
Canonical event card visual convergence

### DIFF
--- a/web/themes/custom/myeventlane_theme/js/mel-cards.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-cards.js
@@ -5,6 +5,9 @@
 (function (Drupal, once) {
   'use strict';
 
+  // Perceived luminance (0–255). Single source of truth for all event cards.
+  var MEL_CARD_BRIGHTNESS_THRESHOLD = 128;
+
   function applyBrightness(img, card) {
     var canvas = document.createElement('canvas');
     var ctx = canvas.getContext('2d');
@@ -31,7 +34,7 @@
       }
 
       var avg = total / (data.length / 4);
-      var isLight = avg > 128;
+      var isLight = avg > MEL_CARD_BRIGHTNESS_THRESHOLD;
 
       card.classList.remove('mel-event-card--light-bg', 'mel-event-card--dark-bg');
       card.classList.add(isLight ? 'mel-event-card--light-bg' : 'mel-event-card--dark-bg');

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig
@@ -75,72 +75,7 @@
         });
       }
 
-      // --- Adaptive text contrast based on image brightness ---
-      // Samples the bottom 40% of each card image (where the glass overlay sits)
-      // and toggles between light/dark text for readability.
-      function getImageBrightness(img, card) {
-        const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        // Sample at reduced resolution for performance
-        const sampleW = 100;
-        const sampleH = 60;
-        canvas.width = sampleW;
-        canvas.height = sampleH;
-
-        try {
-          // Draw only the bottom 40% of the image (where overlay sits)
-          const srcY = img.naturalHeight * 0.6;
-          const srcH = img.naturalHeight * 0.4;
-          ctx.drawImage(img, 0, srcY, img.naturalWidth, srcH, 0, 0, sampleW, sampleH);
-
-          const data = ctx.getImageData(0, 0, sampleW, sampleH).data;
-          let totalBrightness = 0;
-          const pixelCount = data.length / 4;
-
-          for (let i = 0; i < data.length; i += 4) {
-            // Perceived brightness formula (ITU-R BT.601)
-            totalBrightness += (data[i] * 0.299 + data[i+1] * 0.587 + data[i+2] * 0.114);
-          }
-
-          const avgBrightness = totalBrightness / pixelCount;
-
-          // Threshold: 0-255 scale. Below 140 = dark image = white text
-          if (avgBrightness > 140) {
-            card.classList.add('mel-event-card--light-bg');
-            card.classList.remove('mel-event-card--dark-bg');
-          } else {
-            card.classList.add('mel-event-card--dark-bg');
-            card.classList.remove('mel-event-card--light-bg');
-          }
-        } catch (e) {
-          // CORS or other error — default to white text (dark-bg)
-          card.classList.add('mel-event-card--dark-bg');
-        }
-      }
-
-      // Process featured carousel cards (compact/legacy only — overlay cards use fixed glass tokens).
-      document.querySelectorAll('.mel-featured-carousel__slide .mel-event-card').forEach(function(card) {
-        if (
-          card.classList.contains('mel-event-card--standard')
-          || card.classList.contains('mel-event-card--hero')
-          || card.classList.contains('mel-event-card--featured')
-        ) {
-          return;
-        }
-
-        const img = card.querySelector('.mel-event-card__image img, .mel-event-card__image-element');
-        if (!img) return;
-
-        if (img.complete && img.naturalWidth > 0) {
-          getImageBrightness(img, card);
-        } else {
-          img.addEventListener('load', function() {
-            getImageBrightness(img, card);
-          });
-        }
-      });
+      // Adaptive text contrast: mel-cards.js (Drupal.behaviors.melCardBrightness, front library).
     })();
   </script>
 {% endif %}


### PR DESCRIPTION
## Summary

This PR completes the public event card convergence work.

It makes `.mel-event-card` the canonical public discovery card visual system, keeps `--promoted` as the source-of-truth promotion state, and treats `--boosted` only as a visual alias where present.

It also tunes the shared card visual language so standard, featured, hero, and promoted cards feel like the same product family across homepage, discovery, carousel, and listing surfaces.

## Key changes

- Consolidated public event card styling around `.mel-event-card`.
- Preserved `featured_hero` as an accepted variant while rendering through the canonical card contract.
- Tuned glass panel styling, image crop, carousel sizing, save button hit target, and mobile overflow.
- Added shared liquid-glass styling used by event cards and related hero surfaces.
- Centralised card image brightness handling in `mel-cards.js` using `MEL_CARD_BRIGHTNESS_THRESHOLD = 128`.
- Removed duplicate inline brightness sampling from the featured events carousel template.
- Carousel wrapper now handles carousel navigation only; card contrast is handled by the shared card behaviour.

## Validation

- `composer validate --no-check-publish` — pass
- `git diff --check` — pass
- `ddev drush cr` — pass
- `npm run mel:lint` — pass
- `npm run mel:build` — pass

## Manual QA

Prior browser QA on this branch passed for:

- Homepage featured carousel
- Homepage discovery / upcoming grid
- Mobile around 390px
- Desktop around 1440px

Recommended reviewer check:

- Hard-refresh any page using `views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig`
- Confirm contrast remains correct now that the old inline threshold `140` has been removed and the shared threshold is `128`.

## Explicit exclusions

No changes to:

- Commerce
- Checkout
- Cart/order logic
- Ticketing
- QR/scanner/entitlement
- Stock/warehouse/shipping/fulfilment
- Vendor operational dashboards
- Account operational cards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small front-end refactor that removes duplicate brightness sampling and standardizes a single luminance threshold; potential impact is limited to card text contrast styling.
> 
> **Overview**
> Standardizes event-card text contrast by introducing a shared `MEL_CARD_BRIGHTNESS_THRESHOLD` (128) in `mel-cards.js` and using it for the light/dark background class toggle.
> 
> Removes the featured carousel’s inline image-brightness sampling/threshold logic from `views-view-unformatted--featured-events-carousel--featured-events-carousel.html.twig`, leaving the template script to handle only carousel navigation and relying on the shared Drupal behavior for contrast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25a45734c62d40ecf1751c3ce1e17296d5be82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->