### PR TITLE
Cursor/2026 05 17 agu4 bb7cd

### DIFF
--- a/config/sync/crop.type.event_hero.yml
+++ b/config/sync/crop.type.event_hero.yml
@@ -2,8 +2,8 @@ uuid: 14cf33ec-dd08-4fec-a713-ef8586e2d88f
 langcode: en
 status: true
 dependencies: {  }
-id: event_hero
 label: 'Event hero (1200×630)'
+id: event_hero
 description: 'Fixed framing for event cover images in Event Studio branding (listings and social previews).'
 aspect_ratio: '1200:630'
 soft_limit_width: null

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -28,6 +28,48 @@ MEL_CURRENT_SWITCHED=0
 MEL_MM_ENABLED_ATTEMPTED=0
 MEL_PREVIOUS_CURRENT=""
 
+mel_drush_maintenance_mode() {
+  # state:set (alias sset) requires a bootstrapped site; use integer for 0/1.
+  local mode="$1"
+  vendor/bin/drush state:set system.maintenance_mode "$mode" \
+    --input-format=integer \
+    --uri="$SITE_URI"
+}
+
+mel_db_connection_hint() {
+  cat >&2 <<'EOF'
+Database connection failed before deploy could continue.
+
+On the staging host, check:
+  1. MariaDB/MySQL is running:
+       sudo systemctl status mariadb || sudo systemctl status mysql
+       sudo systemctl start mariadb
+  2. Credentials in ~/staging/shared/settings.php match the live database.
+  3. Host vs socket: if host is 127.0.0.1 but MySQL only listens on a Unix socket,
+     set 'host' => 'localhost' in $databases['default']['default'] (or enable TCP bind).
+  4. Manual test from the release directory:
+       cd ~/staging/current && vendor/bin/drush sql:query "SELECT 1" --uri="$SITE_URI"
+EOF
+}
+
+mel_verify_drush_bootstrap() {
+  local label="${1:-Preflight}"
+  echo "${label}: verifying Drupal bootstrap (Drush)..."
+  local out
+  set +e
+  out="$(vendor/bin/drush status --uri="$SITE_URI" 2>&1)"
+  local rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] || ! echo "$out" | grep -qE 'Drupal bootstrap\s*:\s*Successful'; then
+    echo "ERROR: Drupal did not bootstrap (${label})." >&2
+    printf '%s\n' "$out" >&2
+    mel_db_connection_hint
+    return 1
+  fi
+  echo "${label}: Drupal bootstrap OK"
+  return 0
+}
+
 mel_deploy_cleanup() {
   if [ "${DEPLOY_SUCCEEDED:-0}" = "1" ]; then
     return 0
@@ -42,7 +84,7 @@ mel_deploy_cleanup() {
   drush_cwd="$(readlink -f "$CURRENT_PATH" 2>/dev/null || true)"
   if [ -n "$drush_cwd" ] && [ -x "$drush_cwd/vendor/bin/drush" ]; then
     if [ "${MEL_MM_ENABLED_ATTEMPTED:-0}" = "1" ]; then
-      ( cd "$drush_cwd" && vendor/bin/drush sset system.maintenance_mode 0 --uri="$SITE_URI" 2>/dev/null || true )
+      ( cd "$drush_cwd" && mel_drush_maintenance_mode 0 2>/dev/null || true )
     fi
     ( cd "$drush_cwd" && vendor/bin/drush cr --uri="$SITE_URI" 2>/dev/null || true )
   fi
@@ -191,15 +233,19 @@ if [ ! -x "vendor/bin/drush" ]; then
   exit 1
 fi
 
-# ---- MAINTENANCE MODE ----
-MEL_MM_ENABLED_ATTEMPTED=1
-vendor/bin/drush sset system.maintenance_mode 1 --uri="$SITE_URI" || true
-vendor/bin/drush cr --uri="$SITE_URI" || true
+# Fail fast before switching current/: new code + shared settings must bootstrap and reach MySQL.
+mel_verify_drush_bootstrap "Preflight (new release, before symlink switch)"
 
 # Capture previous live release before switching (for rollback).
 if [ -e "$CURRENT_PATH" ]; then
   MEL_PREVIOUS_CURRENT="$(readlink -f "$CURRENT_PATH" 2>/dev/null || true)"
 fi
+
+# ---- MAINTENANCE MODE ----
+MEL_MM_ENABLED_ATTEMPTED=1
+echo "Enabling maintenance mode..."
+mel_drush_maintenance_mode 1
+vendor/bin/drush cr --uri="$SITE_URI"
 
 # ---- SWITCH RELEASE (ATOMIC) ----
 ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
@@ -207,14 +253,7 @@ MEL_CURRENT_SWITCHED=1
 
 cd "$CURRENT_PATH"
 
-# Fail fast after switching current: use full status output (not only --field) so stderr is visible if Drush warns.
-echo "Verifying Drupal bootstrap (Drush against new release)..."
-DRUSH_STATUS_OUT="$(vendor/bin/drush status --uri="$SITE_URI" 2>&1)" || true
-if ! echo "$DRUSH_STATUS_OUT" | grep -qE 'Drupal bootstrap\s*:\s*Successful'; then
-  echo "ERROR: Drupal did not bootstrap after release switch." >&2
-  echo "$DRUSH_STATUS_OUT" >&2
-  exit 1
-fi
+mel_verify_drush_bootstrap "Post-switch (current release)"
 
 # ---- CONFIG SYNC: mirror artifact → shared sync directory (single source of truth per release) ----
 # Staging uses a shared path (e.g. /home/mel/staging/config/sync) referenced by settings.php.
@@ -320,14 +359,14 @@ if [ "$_mel_drush_cr_rc" -ne 0 ]; then
   exit "$_mel_drush_cr_rc"
 fi
 
-echo "Finalize: drush sset system.maintenance_mode 0..."
+echo "Finalize: drush state:set system.maintenance_mode 0..."
 set +e
-_mel_drush_mm_out="$(vendor/bin/drush sset system.maintenance_mode 0 --uri="$SITE_URI" 2>&1)"
+_mel_drush_mm_out="$(mel_drush_maintenance_mode 0 2>&1)"
 _mel_drush_mm_rc=$?
 set -e
 printf '%s\n' "$_mel_drush_mm_out"
 if [ "$_mel_drush_mm_rc" -ne 0 ]; then
-  echo "ERROR: drush sset system.maintenance_mode 0 failed during finalize (exit $_mel_drush_mm_rc)." >&2
+  echo "ERROR: drush state:set system.maintenance_mode 0 failed during finalize (exit $_mel_drush_mm_rc)." >&2
   exit "$_mel_drush_mm_rc"
 fi
 

--- a/scripts/deploy/verify-staging-database.sh
+++ b/scripts/deploy/verify-staging-database.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run on the staging host (SSH) to diagnose deploy failures:
+#   SQLSTATE[HY000] [2002] Connection refused
+#
+# Usage:
+#   bash scripts/deploy/verify-staging-database.sh
+#   SITE_URI=https://staging.myeventlane.com.au bash scripts/deploy/verify-staging-database.sh /home/mel/staging/current
+set -euo pipefail
+
+ROOT="${1:-${HOME}/staging/current}"
+SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "ERROR: release directory not found: $ROOT"
+  exit 1
+fi
+
+if [[ ! -x "$ROOT/vendor/bin/drush" ]]; then
+  echo "ERROR: drush not found under $ROOT"
+  exit 1
+fi
+
+cd "$ROOT"
+
+echo "Release: $(readlink -f .)"
+echo "SITE_URI: $SITE_URI"
+echo ""
+
+echo "=== Drush status ==="
+vendor/bin/drush status --uri="$SITE_URI" || true
+echo ""
+
+echo "=== SQL connectivity (SELECT 1) ==="
+set +e
+SQL_OUT="$(vendor/bin/drush sql:query "SELECT 1" --uri="$SITE_URI" 2>&1)"
+SQL_RC=$?
+set -e
+printf '%s\n' "$SQL_OUT"
+if [[ "$SQL_RC" -ne 0 ]]; then
+  echo ""
+  echo "FAIL: database not reachable from CLI."
+  echo "If the public site loads but this fails, check whether settings.php uses"
+  echo "host 127.0.0.1 (TCP) vs localhost (socket) and whether MariaDB listens on TCP."
+  echo ""
+  echo "Suggested host checks:"
+  command -v systemctl >/dev/null 2>&1 && systemctl is-active mariadb 2>/dev/null || systemctl is-active mysql 2>/dev/null || true
+  exit "$SQL_RC"
+fi
+
+echo "OK: database reachable"

--- a/web/themes/custom/myeventlane_theme/js/mel-cards.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-cards.js
@@ -6,7 +6,8 @@
   'use strict';
 
   // Perceived luminance (0–255). Single source of truth for all event cards.
-  var MEL_CARD_BRIGHTNESS_THRESHOLD = 128;
+  // Matches the former featured-carousel inline threshold (140).
+  var MEL_CARD_BRIGHTNESS_THRESHOLD = 140;
 
   function applyBrightness(img, card) {
     var canvas = document.createElement('canvas');

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -892,6 +892,8 @@
   @include mel-event-card-content-glass;
 
   .mel-event-card__link {
+    position: relative;
+    display: block;
     aspect-ratio: 4 / 5;
     height: auto;
     min-height: 0;
@@ -1070,6 +1072,8 @@
   min-height: 300px;
 
   .mel-event-card__link {
+    position: relative;
+    display: block;
     aspect-ratio: auto;
     height: 100%;
     min-height: 100%;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the deployment flow (maintenance mode handling and preflight checks), which could affect release cutover/rollback behavior if misconfigured. Frontend/theme and config tweaks are low risk but will change UI contrast and card layout.
> 
> **Overview**
> **Deploy hardening:** `remote-deploy.sh` now fails fast with a reusable `mel_verify_drush_bootstrap` check *before and after* switching the `current` symlink, centralizes maintenance-mode toggling via `mel_drush_maintenance_mode` (using `drush state:set` with integer input), and prints actionable MySQL/MariaDB troubleshooting hints on bootstrap failure.
> 
> **New ops utility:** adds `verify-staging-database.sh` to quickly confirm Drush bootstrap and run a `SELECT 1` via `drush sql:query` on the staging host.
> 
> **UI/config tweaks:** adjusts event card brightness threshold (128→140), ensures `.mel-event-card__link` is `position: relative; display: block` for featured/standard variants, and fixes `crop.type.event_hero.yml` to include the `id` field in the correct place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913ec58782283e4eb16033d4ed87a27d5d98349b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->