### PR TITLE
fix(theme): centralise event card brightness handling

### DIFF
--- a/config/sync/crop.type.event_hero.yml
+++ b/config/sync/crop.type.event_hero.yml
@@ -2,8 +2,8 @@ uuid: 14cf33ec-dd08-4fec-a713-ef8586e2d88f
 langcode: en
 status: true
 dependencies: {  }
-id: event_hero
 label: 'Event hero (1200×630)'
+id: event_hero
 description: 'Fixed framing for event cover images in Event Studio branding (listings and social previews).'
 aspect_ratio: '1200:630'
 soft_limit_width: null

--- a/web/themes/custom/myeventlane_theme/js/mel-cards.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-cards.js
@@ -6,7 +6,8 @@
   'use strict';
 
   // Perceived luminance (0–255). Single source of truth for all event cards.
-  var MEL_CARD_BRIGHTNESS_THRESHOLD = 128;
+  // Matches the former featured-carousel inline threshold (140).
+  var MEL_CARD_BRIGHTNESS_THRESHOLD = 140;
 
   function applyBrightness(img, card) {
     var canvas = document.createElement('canvas');

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -892,6 +892,8 @@
   @include mel-event-card-content-glass;
 
   .mel-event-card__link {
+    position: relative;
+    display: block;
     aspect-ratio: 4 / 5;
     height: auto;
     min-height: 0;
@@ -1070,6 +1072,8 @@
   min-height: 300px;
 
   .mel-event-card__link {
+    position: relative;
+    display: block;
     aspect-ratio: auto;
     height: 100%;
     min-height: 100%;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk visual-only changes: adjusts the luminance threshold used to pick light/dark card contrast classes and tweaks link positioning/sizing in featured/featured-carousel cards.
> 
> **Overview**
> Updates event card adaptive-contrast behavior by changing the shared `mel-cards.js` brightness threshold from `128` to `140`, aligning contrast decisions across card variants.
> 
> Adjusts event card SCSS so featured cards/carousel variants set `.mel-event-card__link` to `position: relative` and `display: block`, improving overlay/media layout consistency.
> 
> Fixes the `event_hero` crop config YAML formatting so `id: event_hero` is correctly placed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e633f191c23de4da5792f282708240be2af882b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->