### PR TITLE
fix(theme): attach event card brightness behaviour to listings

### DIFF
--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -30,6 +30,14 @@ home-hero-rotator:
     - core/drupal
     - core/once
 
+# Event card image brightness (light/dark text contrast classes on .mel-event-card).
+mel-card-behaviors:
+  js:
+    js/mel-cards.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Branded 403/404 (standalone CSS; source SCSS in mel_maintenance/scss/errors.scss).
 mel-error-pages:
   version: VERSION
@@ -64,11 +72,8 @@ front:
   css:
     theme:
       dist/css/front.css: {}
-  js:
-    js/mel-cards.js: {}
   dependencies:
-    - core/drupal
-    - core/once
+    - myeventlane_theme/mel-card-behaviors
     - myeventlane_theme/home-hero-rotator
 
 # Help Centre search (/help/search) — compiled into dist/main.scss via Vite.
@@ -84,11 +89,13 @@ mel-listing-header:
       dist/css/front.css: {}
   dependencies:
     - core/drupal
+    - myeventlane_theme/mel-card-behaviors
 
 # /events listing: date pills + exposed filter bar (bundled in main.css via Vite).
 mel-events-discovery:
   dependencies:
     - myeventlane_theme/global-styling
+    - myeventlane_theme/mel-card-behaviors
     - core/drupal
 
 # Category discovery chip bar (AJAX, no full page reload).


### PR DESCRIPTION
Event card brightness (mel-cards.js) is now a dedicated reusable library and is attached to public listing/discovery surfaces, not only the homepage front bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only refactors Drupal theme library wiring to load an existing JS behavior on additional listing pages; primary risk is missing/duplicate asset attachment affecting styling/contrast.
> 
> **Overview**
> Introduces a dedicated `mel-card-behaviors` library for the event-card image brightness/contrast behavior (`js/mel-cards.js`), instead of attaching it directly via the `front` library.
> 
> Updates `front`, `mel-listing-header`, and `mel-events-discovery` to depend on `myeventlane_theme/mel-card-behaviors`, ensuring the contrast classes are applied across public listing/discovery surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef4f42201be1dc134e86186be0c45d22356dc4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->