### PR TITLE
feat(commerce): make event extras visual and variant-aware

### DIFF
--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_images.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_images.yml
@@ -1,0 +1,25 @@
+uuid: d79cbbfc-968a-4826-a3e6-ffbe89d313fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.storage.commerce_product.field_mel_extra_images
+    - media.type.image
+id: commerce_product.hospitality_package.field_mel_extra_images
+field_name: field_mel_extra_images
+entity_type: commerce_product
+bundle: hospitality_package
+label: 'Extra images'
+description: 'Upload product photos, detail shots, size charts, or collection reference images. The first image is shown as the main image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_pickup_note.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_pickup_note.yml
@@ -1,0 +1,19 @@
+uuid: d1b06ec4-efd9-48f3-a13c-19bef65ee508
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.storage.commerce_product.field_mel_extra_pickup_note
+id: commerce_product.hospitality_package.field_mel_extra_pickup_note
+field_name: field_mel_extra_pickup_note
+entity_type: commerce_product
+bundle: hospitality_package
+label: 'Pickup note'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_description.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_description.yml
@@ -1,0 +1,19 @@
+uuid: 4ed5a126-0431-46cc-b627-4c8f98a4bb98
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.storage.commerce_product.field_mel_extra_short_description
+id: commerce_product.hospitality_package.field_mel_extra_short_description
+field_name: field_mel_extra_short_description
+entity_type: commerce_product
+bundle: hospitality_package
+label: 'Short customer description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_images.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_images.yml
@@ -1,0 +1,25 @@
+uuid: 482b50a9-beed-4a2d-8427-1cd609f05897
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.storage.commerce_product.field_mel_extra_images
+    - media.type.image
+id: commerce_product.operational_bundle.field_mel_extra_images
+field_name: field_mel_extra_images
+entity_type: commerce_product
+bundle: operational_bundle
+label: 'Extra images'
+description: 'Upload product photos, detail shots, size charts, or collection reference images. The first image is shown as the main image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_pickup_note.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_pickup_note.yml
@@ -1,0 +1,19 @@
+uuid: 579f12ab-fec8-48da-943d-c726ffeefa0d
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.storage.commerce_product.field_mel_extra_pickup_note
+id: commerce_product.operational_bundle.field_mel_extra_pickup_note
+field_name: field_mel_extra_pickup_note
+entity_type: commerce_product
+bundle: operational_bundle
+label: 'Pickup note'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_description.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_description.yml
@@ -1,0 +1,19 @@
+uuid: 28779f50-58cd-4fef-bfc2-ad4d30323ce1
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.storage.commerce_product.field_mel_extra_short_description
+id: commerce_product.operational_bundle.field_mel_extra_short_description
+field_name: field_mel_extra_short_description
+entity_type: commerce_product
+bundle: operational_bundle
+label: 'Short customer description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_images.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_images.yml
@@ -1,0 +1,25 @@
+uuid: 268fd402-7aa8-4124-944b-0732343e7892
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.storage.commerce_product.field_mel_extra_images
+    - media.type.image
+id: commerce_product.operational_merchandise.field_mel_extra_images
+field_name: field_mel_extra_images
+entity_type: commerce_product
+bundle: operational_merchandise
+label: 'Extra images'
+description: 'Upload product photos, detail shots, size charts, or collection reference images. The first image is shown as the main image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_pickup_note.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_pickup_note.yml
@@ -1,0 +1,19 @@
+uuid: ccd70b20-c07e-4551-a397-676528792339
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.storage.commerce_product.field_mel_extra_pickup_note
+id: commerce_product.operational_merchandise.field_mel_extra_pickup_note
+field_name: field_mel_extra_pickup_note
+entity_type: commerce_product
+bundle: operational_merchandise
+label: 'Pickup note'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_description.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_description.yml
@@ -1,0 +1,19 @@
+uuid: 11870ec3-1900-4f18-819d-e36602b0ba57
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.storage.commerce_product.field_mel_extra_short_description
+id: commerce_product.operational_merchandise.field_mel_extra_short_description
+field_name: field_mel_extra_short_description
+entity_type: commerce_product
+bundle: operational_merchandise
+label: 'Short customer description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_images.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_images.yml
@@ -1,0 +1,25 @@
+uuid: 628fba83-efdb-44c5-b9ab-299897da1660
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.storage.commerce_product.field_mel_extra_images
+    - media.type.image
+id: commerce_product.timed_collection_product.field_mel_extra_images
+field_name: field_mel_extra_images
+entity_type: commerce_product
+bundle: timed_collection_product
+label: 'Extra images'
+description: 'Upload product photos, detail shots, size charts, or collection reference images. The first image is shown as the main image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+
+field_type: entity_reference

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_pickup_note.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_pickup_note.yml
@@ -1,0 +1,19 @@
+uuid: 624bb2bf-ecae-4424-9ec9-803b34fa1219
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.storage.commerce_product.field_mel_extra_pickup_note
+id: commerce_product.timed_collection_product.field_mel_extra_pickup_note
+field_name: field_mel_extra_pickup_note
+entity_type: commerce_product
+bundle: timed_collection_product
+label: 'Pickup note'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_description.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_description.yml
@@ -1,0 +1,19 @@
+uuid: 58da2fa7-7633-4097-98e3-037eba1b5cd2
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.storage.commerce_product.field_mel_extra_short_description
+id: commerce_product.timed_collection_product.field_mel_extra_short_description
+field_name: field_mel_extra_short_description
+entity_type: commerce_product
+bundle: timed_collection_product
+label: 'Short customer description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_size.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_size.yml
@@ -1,0 +1,21 @@
+uuid: ab91203c-c622-47b2-8f5e-448cb8bd2416
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_merchandise_var
+    - field.storage.commerce_product_variation.field_mel_size
+  module:
+    - options
+id: commerce_product_variation.operational_merchandise_var.field_mel_size
+field_name: field_mel_size
+entity_type: commerce_product_variation
+bundle: operational_merchandise_var
+label: Size
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.commerce_product.field_mel_extra_images.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_extra_images.yml
@@ -1,0 +1,20 @@
+uuid: e80c261d-ef01-4d36-a814-6a63a96a934d
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+    - media
+id: commerce_product.field_mel_extra_images
+field_name: field_mel_extra_images
+entity_type: commerce_product
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 6
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product.field_mel_extra_pickup_note.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_extra_pickup_note.yml
@@ -1,0 +1,19 @@
+uuid: b2e36ced-fed8-4e1d-9849-1217819bb8fd
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product.field_mel_extra_pickup_note
+field_name: field_mel_extra_pickup_note
+entity_type: commerce_product
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product.field_mel_extra_short_description.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_extra_short_description.yml
@@ -1,0 +1,19 @@
+uuid: cbb21a86-8b85-4326-8dcc-db03e9e84ac7
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product.field_mel_extra_short_description
+field_name: field_mel_extra_short_description
+entity_type: commerce_product
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product_variation.field_mel_size.yml
+++ b/config/sync/field.storage.commerce_product_variation.field_mel_size.yml
@@ -1,0 +1,42 @@
+uuid: bca75731-4b92-4866-ab06-911e567bd72e
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+    - options
+id: commerce_product_variation.field_mel_size
+field_name: field_mel_size
+entity_type: commerce_product_variation
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: xs
+      label: XS
+    -
+      value: s
+      label: S
+    -
+      value: m
+      label: M
+    -
+      value: l
+      label: L
+    -
+      value: xl
+      label: XL
+    -
+      value: 2xl
+      label: 2XL
+    -
+      value: 3xl
+      label: 3XL
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.mel_extra_square.yml
+++ b/config/sync/image.style.mel_extra_square.yml
@@ -1,0 +1,19 @@
+uuid: f5fa6d9d-7242-4d40-aa60-38c6fa817c84
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.focal_point
+  module:
+    - focal_point
+name: mel_extra_square
+label: 'MEL Event extra (square)'
+effects:
+  6bd98da5-6fe6-4444-bfaf-82a42da0d0eb:
+    uuid: 6bd98da5-6fe6-4444-bfaf-82a42da0d0eb
+    id: focal_point_scale_and_crop
+    weight: 0
+    data:
+      width: 400
+      height: 400
+      crop_type: focal_point

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -214,3 +214,274 @@
 .mel-ticket-item--operational-addon .mel-ticket-title .mel-operational-order-item-line__title {
   font-size: 1rem;
 }
+
+/* Event Extras — booking cards */
+.mel-event-extras-form__heading {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.mel-event-extras-form__intro {
+  margin: 0 0 1rem;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.mel-event-extras-form__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mel-event-extra-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, rgba(255, 247, 250, 0.95), rgba(245, 240, 255, 0.92));
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+@media (min-width: 640px) {
+  .mel-event-extra-card {
+    grid-template-columns: 140px minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.mel-event-extra-card__media {
+  min-width: 0;
+}
+
+.mel-event-extra-card__image {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.mel-event-extra-card__thumbs {
+  display: flex;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.15rem;
+}
+
+.mel-event-extra-card__thumb {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.mel-event-extra-card__thumb.is-active {
+  border-color: #e57373;
+}
+
+.mel-event-extra-card__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0.35rem;
+  display: block;
+}
+
+.mel-event-extra-card__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.mel-event-extra-card__description,
+.mel-event-extra-card__pickup {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.mel-event-extra-card__price {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.mel-event-extra-card__sizes-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.mel-event-extra-card__size-radios {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.mel-event-extra-card__size-radios .form-item {
+  margin: 0;
+}
+
+.mel-event-extra-card__size-radios input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mel-event-extra-card__size-radios label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mel-event-extra-card__size-radios input:focus-visible + label {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.mel-event-extra-card__size-radios input:checked + label {
+  background: rgba(229, 115, 115, 0.15);
+  border-color: #e57373;
+  color: rgba(15, 23, 42, 0.92);
+}
+
+.mel-event-extra-card__qty {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.65rem;
+}
+
+.mel-event-extra-card__qty-btn {
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #fff;
+  font-size: 1.2rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.mel-event-extra-card__qty-btn:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.mel-event-extra-card__qty-value {
+  min-width: 1.5rem;
+  text-align: center;
+  font-weight: 700;
+}
+
+.mel-event-extra-card__qty-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Compact line with thumbnail (cart / checkout / orders) */
+.mel-event-extra-line {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.mel-event-extra-line__thumb {
+  flex: 0 0 64px;
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.05);
+}
+
+.mel-event-extra-line__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.mel-event-extra-line__title {
+  font-weight: 700;
+  font-size: 0.98rem;
+}
+
+.mel-event-extra-line__size,
+.mel-event-extra-line__pickup,
+.mel-event-extra-line__description {
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.mel-event-extra-line__price {
+  margin: 0.15rem 0 0;
+  font-weight: 700;
+}
+
+.mel-summary-item--operational-addon .mel-event-extra-line,
+.mel-ticket-item--operational-addon .mel-event-extra-line {
+  width: 100%;
+}
+
+/* Vendor add-on order rows */
+.mel-vendor-addon-orders__line {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.mel-vendor-addon-orders__thumb {
+  flex: 0 0 56px;
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.mel-vendor-addon-orders__line-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.mel-vendor-addon-orders__line-size,
+.mel-vendor-addon-orders__line-paid {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.mel-vendor-addon-orders__line-pickup {
+  margin: 0.25rem 0 0;
+  font-size: 0.88rem;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-extra-card__thumb,
+  .mel-event-extra-card__qty-btn {
+    transition: none;
+  }
+}

--- a/web/modules/custom/myeventlane_commerce/js/mel-event-extras-booking.js
+++ b/web/modules/custom/myeventlane_commerce/js/mel-event-extras-booking.js
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * Event Extras booking cards: gallery thumbs, quantity stepper sync.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  function syncQtyDisplay(card, value) {
+    const display = card.querySelector('.mel-event-extra-card__qty-value');
+    const input = card.querySelector('.mel-event-extra-card__qty-input');
+    const v = String(value);
+    if (display) {
+      display.textContent = v;
+    }
+    if (input) {
+      input.value = v;
+    }
+  }
+
+  Drupal.behaviors.melEventExtrasBooking = {
+    attach(context) {
+      once('mel-event-extra-card', '.mel-event-extra-card', context).forEach((card) => {
+        const input = card.querySelector('.mel-event-extra-card__qty-input');
+        const dec = card.querySelector('.mel-event-extra-card__qty-btn--dec');
+        const inc = card.querySelector('.mel-event-extra-card__qty-btn--inc');
+        const max = input ? parseInt(input.getAttribute('max') || '10', 10) : 10;
+
+        if (input) {
+          syncQtyDisplay(card, input.value || '0');
+          input.addEventListener('change', () => {
+            let v = parseInt(input.value || '0', 10);
+            if (Number.isNaN(v) || v < 0) {
+              v = 0;
+            }
+            if (v > max) {
+              v = max;
+            }
+            syncQtyDisplay(card, v);
+          });
+        }
+
+        if (dec) {
+          dec.addEventListener('click', (e) => {
+            e.preventDefault();
+            const cur = parseInt(input?.value || '0', 10) || 0;
+            syncQtyDisplay(card, Math.max(0, cur - 1));
+          });
+        }
+
+        if (inc) {
+          inc.addEventListener('click', (e) => {
+            e.preventDefault();
+            const cur = parseInt(input?.value || '0', 10) || 0;
+            syncQtyDisplay(card, Math.min(max, cur + 1));
+          });
+        }
+
+        once('mel-event-extra-thumb', '.mel-event-extra-card__thumb', card).forEach((btn) => {
+          btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const url = btn.getAttribute('data-image-url');
+            const alt = btn.getAttribute('data-image-alt') || '';
+            const img = card.querySelector('.mel-event-extra-card__image');
+            if (img && url) {
+              img.setAttribute('src', url);
+              img.setAttribute('alt', alt);
+            }
+            card.querySelectorAll('.mel-event-extra-card__thumb').forEach((t) => {
+              t.classList.remove('is-active');
+            });
+            btn.classList.add('is-active');
+          });
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -59,3 +59,14 @@ operational_addons:
       css/mel-operational-addons.css: {}
   dependencies:
     - core/drupal
+
+event_extras_booking:
+  version: 1.0
+  css:
+    theme:
+      css/mel-operational-addons.css: {}
+  js:
+    js/mel-event-extras-booking.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -208,18 +208,29 @@ services:
       - '@string_translation'
       - '@logger.channel.myeventlane_commerce'
 
+  myeventlane_commerce.operational_extra_visual_presenter:
+    class: Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter
+    arguments:
+      - '@entity_type.manager'
+      - '@file_url_generator'
+      - '@extension.path.resolver'
+      - '@string_translation'
+
   myeventlane_commerce.event_operational_addon_builder:
     class: Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
     arguments:
       - '@entity_type.manager'
       - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@string_translation'
 
   myeventlane_commerce.operational_order_item_display_builder:
     class: Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder
     arguments:
       - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@entity_type.manager'
+      - '@commerce_price.currency_formatter'
       - '@string_translation'
 
   myeventlane_commerce.operational_merchandise_governance_manager:
@@ -270,5 +281,6 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_commerce.operational_purchase_composition_manager'
       - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@date.formatter'
       - '@string_translation'

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -12,6 +12,7 @@ use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
@@ -19,7 +20,7 @@ use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Customer form: add event-linked operational add-ons to the Commerce cart.
+ * Customer form: add event-linked Event Extras to the Commerce cart.
  */
 final class EventOperationalAddonCartForm extends FormBase {
 
@@ -75,8 +76,8 @@ final class EventOperationalAddonCartForm extends FormBase {
 
     $form['#node'] = $event;
     $form['#tree'] = TRUE;
-    $form['#attributes']['class'][] = 'mel-operational-addons-form';
-    $form['#attached']['library'][] = 'myeventlane_commerce/operational_addons';
+    $form['#attributes']['class'][] = 'mel-event-extras-form';
+    $form['#attached']['library'][] = 'myeventlane_commerce/event_extras_booking';
 
     $cache_tags = $event->getCacheTags();
     foreach ($built['product_ids'] ?? [] as $pid) {
@@ -85,165 +86,314 @@ final class EventOperationalAddonCartForm extends FormBase {
     $form['#cache']['tags'] = array_values(array_unique($cache_tags));
     $form['#cache']['contexts'] = ['user', 'session', 'languages:language_interface'];
 
+    $form['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $this->t('Add something extra'),
+      '#attributes' => ['class' => ['mel-event-extras-form__heading']],
+    ];
+
     $form['intro'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('Optional extras for this event — add to your booking, then collect on site after checkout. Quantities are not stock guarantees.'),
-      '#attributes' => ['class' => ['mel-operational-addons-form__intro']],
+      '#value' => $this->t('Optional Event extras for this booking — collect on site after checkout.'),
+      '#attributes' => ['class' => ['mel-event-extras-form__intro']],
     ];
 
     $form['lines'] = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-operational-addons-form__lines']],
+      '#attributes' => ['class' => ['mel-event-extras-form__cards']],
     ];
 
     foreach ($addons as $index => $addon) {
       if (!is_array($addon)) {
         continue;
       }
-      $pid = (int) ($addon['product_id'] ?? 0);
-      $title = (string) ($addon['title'] ?? '');
-      $operational = is_array($addon['operational'] ?? NULL) ? $addon['operational'] : [];
-      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
-
-      $card = [
-        '#type' => 'container',
-        '#attributes' => [
-          'class' => ['mel-operational-addon-card'],
-          'data-product-id' => (string) $pid,
-        ],
-      ];
-
-      $card['title'] = [
-        '#type' => 'html_tag',
-        '#tag' => 'h3',
-        '#value' => $title !== '' ? $title : $this->t('Add-on'),
-        '#attributes' => ['class' => ['mel-operational-addon-card__title']],
-      ];
-
-      if ($operational !== []) {
-        $card['summary'] = [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-operational-addon-card__summary']],
-        ];
-        $summary_text = trim((string) ($operational['operational_summary'] ?? ''));
-        if ($summary_text !== '') {
-          $card['summary']['text'] = [
-            '#type' => 'html_tag',
-            '#tag' => 'p',
-            '#value' => $summary_text,
-            '#attributes' => ['class' => ['mel-operational-addon-card__summary-text']],
-          ];
-        }
-        $chips = is_array($operational['operational_chips'] ?? NULL) ? $operational['operational_chips'] : [];
-        if ($chips !== []) {
-          $card['summary']['chips'] = [
-            '#type' => 'container',
-            '#attributes' => ['class' => ['mel-operational-addon-card__chips']],
-          ];
-          foreach ($chips as $chip) {
-            if (!is_array($chip)) {
-              continue;
-            }
-            $label = trim((string) ($chip['label'] ?? ''));
-            if ($label === '') {
-              continue;
-            }
-            $tone = $this->chipToneClass((string) ($chip['tone'] ?? 'muted'));
-            $card['summary']['chips'][] = [
-              '#type' => 'html_tag',
-              '#tag' => 'span',
-              '#value' => $label,
-              '#attributes' => [
-                'class' => [
-                  'mel-pill',
-                  'mel-pill--operational',
-                  'mel-pill--tone-' . $tone,
-                ],
-              ],
-            ];
-          }
-        }
-      }
-
-      $card['variations'] = [
-        '#type' => 'container',
-        '#tree' => TRUE,
-        '#attributes' => ['class' => ['mel-operational-addon-card__variations']],
-      ];
-
-      foreach ($variations as $v) {
-        if (!is_array($v)) {
-          continue;
-        }
-        $vid = (int) ($v['variation_id'] ?? 0);
-        if ($vid < 1) {
-          continue;
-        }
-        $v_label = (string) ($v['label'] ?? '');
-        $price_number = (string) ($v['price_number'] ?? '');
-        $currency = (string) ($v['price_currency_code'] ?? '');
-        $price_display = '';
-        if ($price_number !== '' && $currency !== '') {
-          $price_display = $this->currencyFormatter->format($price_number, $currency);
-        }
-
-        $row = [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-operational-addon-card__row']],
-        ];
-        $row['meta'] = [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-operational-addon-card__row-meta']],
-        ];
-        $row['meta']['variation_title'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          '#value' => $v_label !== '' ? $v_label : $this->t('Option'),
-          '#attributes' => ['class' => ['mel-operational-addon-card__variation-title']],
-        ];
-        if ($price_display !== '') {
-          $row['meta']['price'] = [
-            '#type' => 'html_tag',
-            '#tag' => 'div',
-            '#value' => $price_display,
-            '#attributes' => ['class' => ['mel-operational-addon-card__price']],
-          ];
-        }
-
-        $row['qty'] = [
-          '#type' => 'number',
-          '#title' => $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $this->t('this option')]),
-          '#title_display' => 'invisible',
-          '#min' => 0,
-          '#max' => self::UI_QTY_MAX,
-          '#step' => 1,
-          '#default_value' => 0,
-          '#attributes' => [
-            'class' => ['mel-operational-addon-card__qty'],
-            'inputmode' => 'numeric',
-            'aria-label' => (string) $this->t('Quantity for @label', ['@label' => $v_label !== '' ? $v_label : $title]),
-          ],
-        ];
-
-        $card['variations'][$vid] = $row;
-      }
-
-      $form['lines'][$index] = $card;
+      $form['lines'][$index] = $this->buildAddonCard($addon, (int) $index);
     }
 
     $form['actions'] = [
       '#type' => 'actions',
-      '#attributes' => ['class' => ['mel-operational-addons-form__actions']],
+      '#attributes' => ['class' => ['mel-event-extras-form__actions']],
     ];
     $form['actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Add extras to cart'),
       '#button_type' => 'primary',
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-btn--xl']],
+      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-btn--xl', 'mel-event-extras-form__submit']],
     ];
 
     return $form;
+  }
+
+  /**
+   * @param array<string, mixed> $addon
+   *
+   * @return array<string, mixed>
+   */
+  private function buildAddonCard(array $addon, int $index): array {
+    $pid = (int) ($addon['product_id'] ?? 0);
+    $title = (string) ($addon['title'] ?? '');
+    $short = trim((string) ($addon['short_description'] ?? ''));
+    $pickup = trim((string) ($addon['pickup_note'] ?? ''));
+    $gallery = is_array($addon['gallery_images'] ?? NULL) ? $addon['gallery_images'] : [];
+    $primary = is_array($addon['primary_image'] ?? NULL) ? $addon['primary_image'] : [];
+    $size_options = is_array($addon['size_options'] ?? NULL) ? $addon['size_options'] : [];
+    $requires_size = !empty($addon['requires_size_selection']);
+    $default_vid = (int) ($addon['default_variation_id'] ?? 0);
+
+    $price_display = $this->resolveDisplayPrice($addon, $size_options);
+
+    $card = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-event-extra-card'],
+        'data-product-id' => (string) $pid,
+        'data-requires-size' => $requires_size ? '1' : '0',
+        'data-default-variation' => $default_vid > 0 ? (string) $default_vid : '',
+      ],
+    ];
+
+    $card['product_id'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $pid,
+    ];
+
+    $card['media'] = $this->buildGalleryRenderArray($gallery, $primary, (string) ($addon['image_alt'] ?? $title));
+
+    $card['body'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extra-card__body']],
+    ];
+    $card['body']['title'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h3',
+      '#value' => $title !== '' ? $title : $this->t('Event extra'),
+      '#attributes' => ['class' => ['mel-event-extra-card__title']],
+    ];
+    if ($short !== '') {
+      $card['body']['description'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $short,
+        '#attributes' => ['class' => ['mel-event-extra-card__description']],
+      ];
+    }
+    if ($pickup !== '') {
+      $card['body']['pickup'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $pickup,
+        '#attributes' => ['class' => ['mel-event-extra-card__pickup']],
+      ];
+    }
+    if ($price_display !== '') {
+      $card['body']['price'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $price_display,
+        '#attributes' => ['class' => ['mel-event-extra-card__price']],
+      ];
+    }
+
+    $chips = is_array($addon['chips'] ?? NULL) ? $addon['chips'] : [];
+    if ($chips !== []) {
+      $card['body']['chips'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-card__chips']],
+      ];
+      foreach ($chips as $chip) {
+        if (!is_array($chip)) {
+          continue;
+        }
+        $label = trim((string) ($chip['label'] ?? ''));
+        if ($label === '') {
+          continue;
+        }
+        $tone = $this->chipToneClass((string) ($chip['tone'] ?? 'muted'));
+        $card['body']['chips'][] = [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $label,
+          '#attributes' => [
+            'class' => [
+              'mel-pill',
+              'mel-pill--extra',
+              'mel-pill--tone-' . $tone,
+            ],
+          ],
+        ];
+      }
+    }
+
+    if ($requires_size && $size_options !== []) {
+      $card['size_fieldset'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-card__sizes']],
+        'label' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $this->t('Size'),
+          '#attributes' => ['class' => ['mel-event-extra-card__sizes-label']],
+        ],
+      ];
+      $card['selected_size'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Size'),
+        '#title_display' => 'invisible',
+        '#options' => $this->sizeRadioOptions($size_options),
+        '#default_value' => '',
+        '#attributes' => ['class' => ['mel-event-extra-card__size-radios']],
+      ];
+    }
+    else {
+      $card['selected_size'] = [
+        '#type' => 'hidden',
+        '#value' => '',
+      ];
+    }
+
+    $card['quantity'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Quantity'),
+      '#title_display' => 'invisible',
+      '#min' => 0,
+      '#max' => self::UI_QTY_MAX,
+      '#step' => 1,
+      '#default_value' => 0,
+      '#attributes' => [
+        'class' => ['mel-event-extra-card__qty-input'],
+        'inputmode' => 'numeric',
+        'aria-label' => (string) $this->t('Quantity for @title', ['@title' => $title !== '' ? $title : $this->t('this extra')]),
+      ],
+    ];
+
+    $card['qty_controls'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extra-card__qty']],
+      'decrease' => [
+        '#type' => 'html_tag',
+        '#tag' => 'button',
+        '#value' => Markup::create('&minus;'),
+        '#attributes' => [
+          'type' => 'button',
+          'class' => ['mel-event-extra-card__qty-btn', 'mel-event-extra-card__qty-btn--dec'],
+          'aria-label' => (string) $this->t('Decrease quantity'),
+        ],
+      ],
+      'quantity_display' => [
+        '#markup' => '<span class="mel-event-extra-card__qty-value" aria-hidden="true">0</span>',
+      ],
+      'increase' => [
+        '#type' => 'html_tag',
+        '#tag' => 'button',
+        '#value' => Markup::create('+'),
+        '#attributes' => [
+          'type' => 'button',
+          'class' => ['mel-event-extra-card__qty-btn', 'mel-event-extra-card__qty-btn--inc'],
+          'aria-label' => (string) $this->t('Increase quantity'),
+        ],
+      ],
+    ];
+
+    return $card;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $gallery
+   * @param array<string, mixed> $primary
+   */
+  private function buildGalleryRenderArray(array $gallery, array $primary, string $alt): array {
+    $images = $gallery !== [] ? $gallery : [$primary];
+    $main_url = (string) ($images[0]['url'] ?? '');
+    $main_alt = (string) ($images[0]['alt'] ?? $alt);
+
+    $safe_url = htmlspecialchars($main_url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $safe_alt = htmlspecialchars($main_alt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $media = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extra-card__media']],
+      'primary' => [
+        '#markup' => '<img class="mel-event-extra-card__image" src="' . $safe_url . '" alt="' . $safe_alt . '" loading="lazy" width="400" height="400" decoding="async" />',
+      ],
+    ];
+
+    if (count($images) > 1) {
+      $media['thumbs'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-card__thumbs']],
+      ];
+      foreach ($images as $idx => $image) {
+        if (!is_array($image)) {
+          continue;
+        }
+        $url = (string) ($image['url'] ?? '');
+        if ($url === '') {
+          continue;
+        }
+        $thumb_alt = (string) ($image['alt'] ?? $alt);
+        $media['thumbs'][] = [
+          '#type' => 'html_tag',
+          '#tag' => 'button',
+          '#value' => Markup::create('<img src="' . htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '" alt="" loading="lazy" width="72" height="72" />'),
+          '#attributes' => [
+            'type' => 'button',
+            'class' => ['mel-event-extra-card__thumb', $idx === 0 ? 'is-active' : ''],
+            'data-image-url' => $url,
+            'data-image-alt' => $thumb_alt,
+            'aria-label' => (string) $this->t('Show image @num', ['@num' => (string) ($idx + 1)]),
+          ],
+        ];
+      }
+    }
+
+    return $media;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $size_options
+   *
+   * @return array<string, string>
+   */
+  private function sizeRadioOptions(array $size_options): array {
+    $options = [];
+    foreach ($size_options as $opt) {
+      if (!is_array($opt)) {
+        continue;
+      }
+      $key = (string) ($opt['size_key'] ?? '');
+      if ($key === '') {
+        continue;
+      }
+      $label = (string) ($opt['size_label'] ?? $key);
+      $options[$key] = $label;
+    }
+    return $options;
+  }
+
+  /**
+   * @param array<string, mixed> $addon
+   * @param list<array<string, mixed>> $size_options
+   */
+  private function resolveDisplayPrice(array $addon, array $size_options): string {
+    if ($size_options !== []) {
+      $first = $size_options[0];
+      $number = (string) ($first['price_number'] ?? '');
+      $currency = (string) ($first['price_currency_code'] ?? '');
+      if ($number !== '' && $currency !== '') {
+        return $this->currencyFormatter->format($number, $currency);
+      }
+    }
+    $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+    $first_var = $variations[0] ?? NULL;
+    if (is_array($first_var)) {
+      $number = (string) ($first_var['price_number'] ?? '');
+      $currency = (string) ($first_var['price_currency_code'] ?? '');
+      if ($number !== '' && $currency !== '') {
+        return $this->currencyFormatter->format($number, $currency);
+      }
+    }
+    return '';
   }
 
   private function chipToneClass(string $tone): string {
@@ -256,30 +406,52 @@ final class EventOperationalAddonCartForm extends FormBase {
    *
    * @return array<int, array<string, mixed>>
    */
-  private function buildAllowlistFromAddons(array $addons): array {
-    $map = [];
+  private function buildProductCatalogFromAddons(array $addons): array {
+    $catalog = [];
     foreach ($addons as $addon) {
       if (!is_array($addon)) {
         continue;
       }
-      $product_id = (int) ($addon['product_id'] ?? 0);
-      $bundle = (string) ($addon['bundle'] ?? '');
-      $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
-      foreach ($variations as $v) {
-        if (!is_array($v)) {
-          continue;
-        }
-        $vid = (int) ($v['variation_id'] ?? 0);
-        if ($vid < 1) {
-          continue;
-        }
-        $map[$vid] = [
-          'product_id' => $product_id,
-          'bundle' => $bundle,
-        ];
+      $pid = (int) ($addon['product_id'] ?? 0);
+      if ($pid < 1) {
+        continue;
       }
+      $variations_by_size = [];
+      $variation_ids = [];
+      $size_options = is_array($addon['size_options'] ?? NULL) ? $addon['size_options'] : [];
+      foreach ($size_options as $opt) {
+        if (!is_array($opt)) {
+          continue;
+        }
+        $vid = (int) ($opt['variation_id'] ?? 0);
+        $size_key = (string) ($opt['size_key'] ?? '');
+        if ($vid < 1 || $size_key === '') {
+          continue;
+        }
+        $variations_by_size[$size_key] = $vid;
+        $variation_ids[$vid] = TRUE;
+      }
+      if ($variations_by_size === []) {
+        foreach (is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [] as $v) {
+          if (!is_array($v)) {
+            continue;
+          }
+          $vid = (int) ($v['variation_id'] ?? 0);
+          if ($vid > 0) {
+            $variation_ids[$vid] = TRUE;
+          }
+        }
+      }
+      $catalog[$pid] = [
+        'product_id' => $pid,
+        'bundle' => (string) ($addon['bundle'] ?? ''),
+        'requires_size_selection' => !empty($addon['requires_size_selection']),
+        'variations_by_size' => $variations_by_size,
+        'variation_ids' => array_map('intval', array_keys($variation_ids)),
+        'default_variation_id' => (int) ($addon['default_variation_id'] ?? 0),
+      ];
     }
-    return $map;
+    return $catalog;
   }
 
   /**
@@ -293,7 +465,7 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
 
     $fresh = $this->addonBuilder->buildForEvent($event);
-    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+    $catalog = $this->buildProductCatalogFromAddons($fresh['addons'] ?? []);
 
     $lines = $form_state->getValue('lines');
     if (!is_array($lines)) {
@@ -304,39 +476,58 @@ final class EventOperationalAddonCartForm extends FormBase {
       if (!is_array($line)) {
         continue;
       }
-      $variations = $line['variations'] ?? NULL;
-      if (!is_array($variations)) {
+      $pid = (int) ($line['product_id'] ?? 0);
+      $qty = (int) ($line['quantity'] ?? 0);
+      if ($qty < 1) {
         continue;
       }
-      foreach ($variations as $vid_key => $row) {
-        $vid = (int) $vid_key;
-        if ($vid < 1) {
-          $this->getLogger('myeventlane_commerce')->warning('Operational add-on submit ignored malformed variation key @key.', ['@key' => (string) $vid_key]);
+      if ($pid < 1 || !isset($catalog[$pid])) {
+        $form_state->setErrorByName('lines', $this->t('One or more selected extras are not available for this event.'));
+        return;
+      }
+      if ($qty > self::UI_QTY_MAX || $qty < 0) {
+        $form_state->setErrorByName('lines', $this->t('Please choose a smaller quantity for extras.'));
+        return;
+      }
+
+      $entry = $catalog[$pid];
+      $vid = $this->resolveVariationIdForLine($line, $entry);
+      if ($vid < 1) {
+        if (!empty($entry['requires_size_selection'])) {
+          $form_state->setErrorByName('lines', $this->t('Please choose a size for each extra you add.'));
+        }
+        else {
           $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));
-          return;
         }
-        if (!isset($allowlist[$vid])) {
-          $this->getLogger('myeventlane_commerce')->notice('Operational add-on validation rejected variation @vid for event @eid (not allowlisted).', [
-            '@vid' => (string) $vid,
-            '@eid' => (string) $event->id(),
-          ]);
-          $form_state->setErrorByName('lines', $this->t('One or more selected add-ons are not available for this event.'));
-          return;
-        }
-        if (!is_array($row)) {
-          continue;
-        }
-        $qty = (int) ($row['qty'] ?? 0);
-        if ($qty < 0) {
-          $form_state->setErrorByName('lines', $this->t('Quantities cannot be negative.'));
-          return;
-        }
-        if ($qty > self::UI_QTY_MAX) {
-          $form_state->setErrorByName('lines', $this->t('Please choose a smaller quantity for add-ons.'));
-          return;
-        }
+        return;
+      }
+      if (!in_array($vid, $entry['variation_ids'], TRUE)) {
+        $form_state->setErrorByName('lines', $this->t('One or more selected extras are not available for this event.'));
+        return;
       }
     }
+  }
+
+  /**
+   * @param array<string, mixed> $line
+   * @param array<string, mixed> $entry
+   */
+  private function resolveVariationIdForLine(array $line, array $entry): int {
+    $requires_size = !empty($entry['requires_size_selection']);
+    $by_size = is_array($entry['variations_by_size'] ?? NULL) ? $entry['variations_by_size'] : [];
+    if ($requires_size && $by_size !== []) {
+      $size_key = (string) ($line['selected_size'] ?? '');
+      if ($size_key === '' || !isset($by_size[$size_key])) {
+        return 0;
+      }
+      return (int) $by_size[$size_key];
+    }
+    $default = (int) ($entry['default_variation_id'] ?? 0);
+    if ($default > 0) {
+      return $default;
+    }
+    $ids = is_array($entry['variation_ids'] ?? NULL) ? $entry['variation_ids'] : [];
+    return $ids !== [] ? (int) $ids[0] : 0;
   }
 
   /**
@@ -349,7 +540,7 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
 
     $fresh = $this->addonBuilder->buildForEvent($event);
-    $allowlist = $this->buildAllowlistFromAddons($fresh['addons'] ?? []);
+    $catalog = $this->buildProductCatalogFromAddons($fresh['addons'] ?? []);
 
     $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
 
@@ -363,26 +554,16 @@ final class EventOperationalAddonCartForm extends FormBase {
       if (!is_array($line)) {
         continue;
       }
-      $variations = $line['variations'] ?? NULL;
-      if (!is_array($variations)) {
+      $pid = (int) ($line['product_id'] ?? 0);
+      $qty = (int) ($line['quantity'] ?? 0);
+      if ($qty < 1 || $pid < 1 || !isset($catalog[$pid])) {
         continue;
       }
-      foreach ($variations as $vid => $row) {
-        $vid = (int) $vid;
-        if ($vid < 1 || !is_array($row)) {
-          continue;
-        }
-        $qty = (int) ($row['qty'] ?? 0);
-        if ($qty < 1) {
-          continue;
-        }
-        if (!isset($allowlist[$vid])) {
-          $this->messenger()->addError($this->t('Add-ons could not be updated. Please refresh the page.'));
-          $this->getLogger('myeventlane_commerce')->error('Operational add-on submit aborted: variation @vid not allowlisted post-validate.', ['@vid' => (string) $vid]);
-          return;
-        }
-        $to_add[$vid] = $qty;
+      $vid = $this->resolveVariationIdForLine($line, $catalog[$pid]);
+      if ($vid < 1) {
+        continue;
       }
+      $to_add[$vid] = ($to_add[$vid] ?? 0) + $qty;
     }
 
     if ($to_add === []) {
@@ -394,53 +575,46 @@ final class EventOperationalAddonCartForm extends FormBase {
       /** @var \Drupal\commerce_product\Entity\ProductVariationInterface|null $variation */
       $variation = $variation_storage->load($variation_id);
       if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
-        $this->messenger()->addError($this->t('An add-on is no longer available.'));
-        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
+        $this->messenger()->addError($this->t('An extra is no longer available.'));
+        $this->getLogger('myeventlane_commerce')->notice('Event extra submit rejected missing or unpublished variation @vid.', ['@vid' => (string) $variation_id]);
         return;
       }
 
       $product = $variation->getProduct();
       if (!$product instanceof ProductInterface) {
-        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        $this->messenger()->addError($this->t('An extra is no longer available.'));
         return;
       }
 
       if (!$product->isPublished()) {
-        $this->messenger()->addError($this->t('An add-on is no longer available.'));
+        $this->messenger()->addError($this->t('An extra is no longer available.'));
         return;
       }
 
       if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
-        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
-        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected bundle @bundle for variation @vid.', [
-          '@bundle' => $product->bundle(),
-          '@vid' => (string) $variation_id,
-        ]);
+        $this->messenger()->addError($this->t('An extra is not valid for this event.'));
         return;
       }
 
       if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()
         || (int) $product->get('field_event')->target_id !== (int) $event->id()) {
-        $this->messenger()->addError($this->t('An add-on is not linked to this event.'));
-        $this->getLogger('myeventlane_commerce')->notice('Operational add-on submit rejected event mismatch for product @pid.', ['@pid' => (string) $product->id()]);
+        $this->messenger()->addError($this->t('An extra is not linked to this event.'));
         return;
       }
 
-      $expected_pid = (int) ($allowlist[$variation_id]['product_id'] ?? 0);
-      if ($expected_pid > 0 && (int) $product->id() !== $expected_pid) {
-        $this->messenger()->addError($this->t('An add-on is not valid for this event.'));
+      if ((int) $product->id() !== (int) ($catalog[(int) $product->id()]['product_id'] ?? 0)) {
+        $this->messenger()->addError($this->t('An extra is not valid for this event.'));
         return;
       }
 
       $stores = $product->getStores();
       if ($stores === []) {
-        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
-        $this->getLogger('myeventlane_commerce')->error('Operational add-on submit failed: product @pid has no stores.', ['@pid' => (string) $product->id()]);
+        $this->messenger()->addError($this->t('No store is configured for an extra. Please contact the organiser.'));
         return;
       }
       $store = reset($stores);
       if (!$store) {
-        $this->messenger()->addError($this->t('No store is configured for an add-on. Please contact the organiser.'));
+        $this->messenger()->addError($this->t('No store is configured for an extra. Please contact the organiser.'));
         return;
       }
 
@@ -454,7 +628,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       }
     }
 
-    $this->messenger()->addStatus($this->t('Add-ons added to your booking.'));
+    $this->messenger()->addStatus($this->t('Event extras added to your booking.'));
     $form_state->setRedirectUrl(Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event->id()]));
   }
 

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
@@ -43,11 +43,23 @@ final class EventOperationalAddonBuilder {
     'private_notes',
     'internal_cost',
     'vendor_margin',
+    'operational_product_type',
+    'fulfillment_mode',
+    'reservation_mode',
+    'readiness_mode',
+    'continuity_mode',
+    'capability_reference',
+    'customer_visibility',
+    'collection_rules',
+    'hospitality_rules',
+    'pickup_mode',
+    'readiness_mode',
   ];
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly OperationalExtraVisualPresenter $visualPresenter,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -103,7 +115,14 @@ final class EventOperationalAddonBuilder {
         continue;
       }
 
+      $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+      $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+      $visual = $this->visualPresenter->buildProductVisualDocument($product, $presentation);
+
       $variations = [];
+      $size_options = [];
+      $product_title = (string) $product->label();
+
       foreach ($product->getVariations() as $variation) {
         if (!$variation instanceof ProductVariationInterface) {
           continue;
@@ -112,30 +131,78 @@ final class EventOperationalAddonBuilder {
           continue;
         }
         $price = $variation->getPrice();
-        $variations[] = [
+        $size = $this->visualPresenter->resolveVariationSize($variation);
+        $meaningful = $this->visualPresenter->meaningfulVariationLabel((string) $variation->label(), $product_title);
+        $display_label = $size['size_label'] !== '' ? $size['size_label'] : $meaningful;
+
+        $row = [
           'variation_id' => (int) $variation->id(),
-          'label' => (string) $variation->label(),
+          'label' => $display_label,
           'price_number' => $price ? (string) $price->getNumber() : '',
           'price_currency_code' => $price ? (string) $price->getCurrencyCode() : '',
+          'size_key' => $size['size_key'],
+          'size_label' => $size['size_label'],
         ];
+        $variations[] = $row;
+
+        if ($size['size_key'] !== '') {
+          $size_options[] = [
+            'variation_id' => (int) $variation->id(),
+            'size_key' => $size['size_key'],
+            'size_label' => $size['size_label'],
+            'price_number' => $row['price_number'],
+            'price_currency_code' => $row['price_currency_code'],
+          ];
+        }
       }
 
       if ($variations === []) {
         continue;
       }
 
-      $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
-      $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+      if ($size_options === [] && count($variations) > 1) {
+        foreach ($variations as $v) {
+          $label = trim((string) ($v['label'] ?? ''));
+          if ($label === '') {
+            continue;
+          }
+          $size_options[] = [
+            'variation_id' => (int) $v['variation_id'],
+            'size_key' => 'v' . (string) $v['variation_id'],
+            'size_label' => $label,
+            'price_number' => (string) ($v['price_number'] ?? ''),
+            'price_currency_code' => (string) ($v['price_currency_code'] ?? ''),
+          ];
+        }
+      }
 
-      $row = $this->sanitizeAddon([
+      $requires_size = count($size_options) > 1;
+      $default_variation_id = count($variations) === 1 ? (int) $variations[0]['variation_id'] : NULL;
+
+      $chips = $this->buildCustomerChips($visual, $presentation);
+
+      $addon_row = [
         'product_id' => (int) $product->id(),
         'bundle' => $product->bundle(),
-        'title' => (string) $product->label(),
+        'title' => $product_title,
         'variations' => $variations,
-        'operational' => $presentation,
-      ]);
+        'primary_image' => $visual['primary_image'],
+        'gallery_images' => $visual['gallery_images'],
+        'image_alt' => $visual['image_alt'],
+        'has_images' => (bool) $visual['has_images'],
+        'short_description' => $visual['short_description'],
+        'pickup_note' => $visual['pickup_note'],
+        'size_options' => $size_options,
+        'requires_size_selection' => $requires_size,
+        'default_variation_id' => $default_variation_id,
+        'chips' => $chips,
+        'operational' => [
+          'operational_summary' => $visual['short_description'],
+          'operational_chips' => $chips,
+        ],
+      ];
 
-      $addons[] = $row;
+      $addons[] = $this->sanitizeAddon($addon_row);
       $product_ids[] = (int) $product->id();
     }
 
@@ -156,6 +223,48 @@ final class EventOperationalAddonBuilder {
    */
   public function sanitizeAddon(array $addon): array {
     return $this->stripForbiddenKeysRecursive($addon);
+  }
+
+  /**
+   * @param array<string, mixed> $visual
+   * @param array<string, mixed> $presentation
+   *
+   * @return list<array{label: string, tone: string}>
+   */
+  private function buildCustomerChips(array $visual, array $presentation): array {
+    $chips = [];
+    $pickup = trim((string) ($visual['pickup_note'] ?? ''));
+    if ($pickup !== '') {
+      $chips[] = ['label' => $pickup, 'tone' => 'pickup'];
+    }
+
+    $from_json = is_array($presentation['operational_chips'] ?? NULL) ? $presentation['operational_chips'] : [];
+    foreach ($from_json as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = trim((string) ($chip['label'] ?? ''));
+      if ($label === '') {
+        continue;
+      }
+      $tone = strtolower(trim((string) ($chip['tone'] ?? 'muted')));
+      if (in_array($tone, ['pickup', 'info'], TRUE) && $pickup !== '' && strcasecmp($label, $pickup) === 0) {
+        continue;
+      }
+      if (!preg_match('/^[a-z0-9_-]{1,32}$/', $tone)) {
+        $tone = 'muted';
+      }
+      $chips[] = ['label' => $label, 'tone' => $tone];
+    }
+
+    if ($chips === []) {
+      $chips[] = [
+        'label' => (string) $this->t('Collect at the event'),
+        'tone' => 'pickup',
+      ];
+    }
+
+    return $chips;
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalAddonGuidanceBuilder.php
@@ -91,8 +91,8 @@ final class OperationalAddonGuidanceBuilder {
     $out = [
       self::CONTRACT_FLAG => TRUE,
       'schema_version' => 1,
-      'page_title' => (string) $this->t('Your add-ons'),
-      'page_intro' => (string) $this->t('Merch, hospitality, and collection items linked to this booking are shown below. Collect at the event when the organiser is ready.'),
+      'page_title' => (string) $this->t('Your extras'),
+      'page_intro' => (string) $this->t('Extras linked to this booking are shown below. Collect at the event when the organiser is ready.'),
       'sections' => $sections,
       'footer_note' => (string) $this->t('Show your order confirmation if staff ask. Hospitality access stays linked to this booking — follow organiser instructions on the day.'),
       'support_hint' => (string) $this->t('Shipping and QR wallet collection are not shown here yet; use your confirmation email and organiser updates for the latest details.'),

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ExtensionPathResolver;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\file\FileInterface;
+use Drupal\image\ImageStyleInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Field-first visual metadata for Event Extras (customer-safe, no stock/shipping).
+ */
+class OperationalExtraVisualPresenter {
+
+  use StringTranslationTrait;
+
+  public const IMAGE_STYLE = 'mel_extra_square';
+
+  /**
+   * @var array<string, string>
+   */
+  public const SIZE_LABELS = [
+    'xs' => 'XS',
+    's' => 'S',
+    'm' => 'M',
+    'l' => 'L',
+    'xl' => 'XL',
+    '2xl' => '2XL',
+    '3xl' => '3XL',
+  ];
+
+  /**
+   * @var list<string>
+   */
+  private const GENERIC_VARIATION_LABELS = [
+    'price',
+    'unit price',
+    'default',
+    'variation',
+    'product',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly ExtensionPathResolver $extensionPathResolver,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildProductVisualDocument(ProductInterface $product, array $presentation = []): array {
+    $images = $this->buildGalleryFromProduct($product);
+    $primary = $images[0] ?? $this->buildPlaceholderImage();
+    $short = $this->resolveShortDescription($product, $presentation);
+    $pickup = $this->resolvePickupNote($product, $presentation);
+
+    return [
+      'primary_image' => $primary,
+      'gallery_images' => $images !== [] ? $images : [$primary],
+      'image_alt' => (string) ($primary['alt'] ?? $product->label()),
+      'has_images' => $images !== [],
+      'short_description' => $short,
+      'pickup_note' => $pickup,
+      'placeholder_url' => $this->placeholderUrl(),
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $presentation
+   */
+  public function resolveShortDescription(ProductInterface $product, array $presentation): string {
+    if ($product->hasField('field_mel_extra_short_description') && !$product->get('field_mel_extra_short_description')->isEmpty()) {
+      $text = trim((string) $product->get('field_mel_extra_short_description')->value);
+      if ($text !== '') {
+        return $this->sanitizePlainText($text, 600);
+      }
+    }
+    $from_json = trim((string) ($presentation['operational_summary'] ?? ''));
+    return $from_json !== '' ? $this->sanitizePlainText($from_json, 600) : '';
+  }
+
+  /**
+   * @param array<string, mixed> $presentation
+   */
+  public function resolvePickupNote(ProductInterface $product, array $presentation): string {
+    if ($product->hasField('field_mel_extra_pickup_note') && !$product->get('field_mel_extra_pickup_note')->isEmpty()) {
+      $text = trim((string) $product->get('field_mel_extra_pickup_note')->value);
+      if ($text !== '') {
+        return $this->sanitizePlainText($text, 400);
+      }
+    }
+    $chips = is_array($presentation['operational_chips'] ?? NULL) ? $presentation['operational_chips'] : [];
+    foreach ($chips as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = trim((string) ($chip['label'] ?? ''));
+      $tone = strtolower(trim((string) ($chip['tone'] ?? '')));
+      if ($label !== '' && in_array($tone, ['pickup', 'info'], TRUE)) {
+        return $label;
+      }
+    }
+    return $this->pickupNoteFromMode((string) ($presentation['pickup_mode'] ?? ''));
+  }
+
+  /**
+   * @return array{size_key: string, size_label: string}
+   */
+  public function resolveVariationSize(ProductVariationInterface $variation): array {
+    if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+      $key = strtolower(trim((string) $variation->get('field_mel_size')->value));
+      if ($key !== '' && isset(self::SIZE_LABELS[$key])) {
+        return ['size_key' => $key, 'size_label' => self::SIZE_LABELS[$key]];
+      }
+    }
+    $label = trim((string) $variation->label());
+    $lower = strtolower($label);
+    if (isset(self::SIZE_LABELS[$lower])) {
+      return ['size_key' => $lower, 'size_label' => self::SIZE_LABELS[$lower]];
+    }
+    foreach (self::SIZE_LABELS as $key => $human) {
+      if (strcasecmp($label, $human) === 0) {
+        return ['size_key' => $key, 'size_label' => $human];
+      }
+    }
+    return ['size_key' => '', 'size_label' => ''];
+  }
+
+  public function meaningfulVariationLabel(string $variation_label, string $product_title): string {
+    $variation_label = trim($variation_label);
+    if ($variation_label === '') {
+      return '';
+    }
+    $lower = strtolower($variation_label);
+    if (in_array($lower, self::GENERIC_VARIATION_LABELS, TRUE)) {
+      return '';
+    }
+    if (strcasecmp($variation_label, $product_title) === 0) {
+      return '';
+    }
+    if (str_starts_with(strtolower($product_title), strtolower($variation_label))) {
+      return '';
+    }
+    return $variation_label;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function buildGalleryFromProduct(ProductInterface $product): array {
+    if (!$product->hasField('field_mel_extra_images') || $product->get('field_mel_extra_images')->isEmpty()) {
+      return [];
+    }
+    $out = [];
+    foreach ($product->get('field_mel_extra_images')->referencedEntities() as $media) {
+      if (!$media instanceof MediaInterface) {
+        continue;
+      }
+      $built = $this->buildImageFromMedia($media, (string) $product->label());
+      if ($built !== NULL) {
+        $out[] = $built;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  public function buildPrimaryThumbnailForProduct(ProductInterface $product): ?array {
+    $gallery = $this->buildGalleryFromProduct($product);
+    if ($gallery !== []) {
+      return $gallery[0];
+    }
+    return $this->buildPlaceholderImage();
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  public function buildPrimaryThumbnailForVariation(ProductVariationInterface $variation): ?array {
+    $product = $variation->getProduct();
+    if ($product instanceof ProductInterface) {
+      return $this->buildPrimaryThumbnailForProduct($product);
+    }
+    return $this->buildPlaceholderImage();
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildPlaceholderImage(): array {
+    return [
+      'url' => $this->placeholderUrl(),
+      'alt' => (string) $this->t('Event extra'),
+      'is_placeholder' => TRUE,
+      'media_id' => 0,
+    ];
+  }
+
+  public function placeholderUrl(): string {
+    $theme_path = $this->extensionPathResolver->getPath('theme', 'myeventlane_theme');
+    $relative = $theme_path . '/images/mel/placeholders/mel-placeholder-default.svg';
+    return $this->fileUrlGenerator->generateAbsoluteString($relative);
+  }
+
+  public function formatPrice(?Price $price): string {
+    if (!$price instanceof Price) {
+      return '';
+    }
+    $number = $price->getNumber();
+    $currency = $price->getCurrencyCode();
+    if ($number === '' || $currency === '') {
+      return '';
+    }
+    return $currency . $number;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildImageFromMedia(MediaInterface $media, string $fallback_alt): ?array {
+    if (!$media->hasField('field_media_image') || $media->get('field_media_image')->isEmpty()) {
+      return NULL;
+    }
+    $item = $media->get('field_media_image')->first();
+    if ($item === NULL) {
+      return NULL;
+    }
+    $file = $item->entity;
+    if (!$file instanceof FileInterface) {
+      return NULL;
+    }
+    $alt = trim((string) ($item->alt ?? ''));
+    if ($alt === '') {
+      $alt = $fallback_alt;
+    }
+    $style = $this->loadImageStyle();
+    $uri = $file->getFileUri();
+    $url = $style instanceof ImageStyleInterface
+      ? $style->buildUrl($uri)
+      : $this->fileUrlGenerator->generateAbsoluteString($uri);
+
+    return [
+      'url' => $url,
+      'alt' => $this->sanitizePlainText($alt, 255),
+      'is_placeholder' => FALSE,
+      'media_id' => (int) $media->id(),
+    ];
+  }
+
+  private function loadImageStyle(): ?ImageStyleInterface {
+    $style = $this->entityTypeManager->getStorage('image_style')->load(self::IMAGE_STYLE);
+    return $style instanceof ImageStyleInterface ? $style : NULL;
+  }
+
+  private function pickupNoteFromMode(string $pickup_mode): string {
+    return match ($pickup_mode) {
+      'venue_pickup', 'counter', 'timed_window' => (string) $this->t('Collect at the venue'),
+      default => '',
+    };
+  }
+
+  private function sanitizePlainText(string $text, int $max): string {
+    $text = trim(strip_tags($text));
+    if (mb_strlen($text, 'UTF-8') > $max) {
+      return mb_substr($text, 0, $max - 1, 'UTF-8') . '…';
+    }
+    return $text;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalOrderItemDisplayBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalOrderItemDisplayBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_commerce\Service;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\CurrencyFormatter;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -13,7 +14,7 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
 
 /**
- * Customer-safe labels for operational add-on Commerce order line items.
+ * Customer-safe labels for Event Extra Commerce order line items.
  *
  * Read-only projection for cart, checkout, orders, and My Tickets surfaces.
  */
@@ -39,24 +40,16 @@ final class OperationalOrderItemDisplayBuilder {
     'shipment_state',
     'fingerprint',
     'operational_fingerprint',
-  ];
-
-  /**
-   * Variation titles that must not be used as the primary customer label.
-   *
-   * @var list<string>
-   */
-  private const GENERIC_VARIATION_LABELS = [
-    'price',
-    'unit price',
-    'default',
-    'variation',
-    'product',
+    'pickup_mode',
+    'readiness_mode',
+    'operational_product_type',
   ];
 
   public function __construct(
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly OperationalExtraVisualPresenter $visualPresenter,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CurrencyFormatter $currencyFormatter,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -81,20 +74,43 @@ final class OperationalOrderItemDisplayBuilder {
 
     $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
     $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+    $visual = $this->visualPresenter->buildProductVisualDocument($product, $presentation);
 
     $event = $this->resolveEvent($product, $order_item);
     $event_id = $event instanceof NodeInterface ? (int) $event->id() : 0;
     $event_title = $event instanceof NodeInterface ? (string) $event->label() : '';
 
     $product_title = $this->customerProductTitle((string) $product->label());
-    $variation_label = $this->meaningfulVariationLabel((string) $purchased->label(), $product_title);
+    $size = $this->visualPresenter->resolveVariationSize($purchased);
+    $size_label = $size['size_label'] !== ''
+      ? $size['size_label']
+      : $this->visualPresenter->meaningfulVariationLabel((string) $purchased->label(), $product_title);
 
-    $description = trim((string) ($presentation['operational_summary'] ?? ''));
+    $short_description = trim((string) ($visual['short_description'] ?? ''));
+    $pickup_note = trim((string) ($visual['pickup_note'] ?? ''));
+    $description = $short_description !== '' ? $short_description : $pickup_note;
+    if ($description === '') {
+      $description = trim((string) ($presentation['operational_summary'] ?? ''));
+    }
     if ($description === '') {
       $description = $this->descriptionFromPickupMode((string) ($presentation['pickup_mode'] ?? ''));
     }
 
+    $thumbnail = $this->visualPresenter->buildPrimaryThumbnailForProduct($product);
+    $thumb_url = is_array($thumbnail) ? (string) ($thumbnail['url'] ?? '') : '';
+    $thumb_alt = is_array($thumbnail) ? (string) ($thumbnail['alt'] ?? $product_title) : $product_title;
+
+    $price = $order_item->getTotalPrice() ?? $purchased->getPrice();
+    $price_display = '';
+    if ($price !== NULL) {
+      $price_display = $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode());
+    }
+
     $chips = $this->normalizeChips(is_array($presentation['operational_chips'] ?? NULL) ? $presentation['operational_chips'] : []);
+    if ($pickup_note !== '') {
+      array_unshift($chips, ['label' => $pickup_note, 'tone' => 'pickup']);
+      $chips = $this->dedupeChips($chips);
+    }
 
     $doc = [
       self::CONTRACT_FLAG => TRUE,
@@ -103,9 +119,14 @@ final class OperationalOrderItemDisplayBuilder {
         ? (string) $this->t('For: @event', ['@event' => $event_title])
         : '',
       'description' => $description,
-      'variation_label' => $variation_label,
+      'short_description' => $short_description,
+      'pickup_note' => $pickup_note,
+      'variation_label' => $size_label,
+      'size_label' => $size_label,
+      'thumbnail_url' => $thumb_url,
+      'thumbnail_alt' => $thumb_alt,
+      'price_display' => $price_display,
       'chips' => $chips,
-      'pickup_mode' => (string) ($presentation['pickup_mode'] ?? ''),
       'event_id' => $event_id,
       'event_title' => $event_title,
     ];
@@ -172,28 +193,10 @@ final class OperationalOrderItemDisplayBuilder {
   private function customerProductTitle(string $raw): string {
     $raw = trim($raw);
     if ($raw === '') {
-      return (string) $this->t('Add-on');
+      return (string) $this->t('Event extra');
     }
     $stripped = preg_replace('/\s*-\s*Node\s+\d+$/i', '', $raw);
     return is_string($stripped) && trim($stripped) !== '' ? trim($stripped) : $raw;
-  }
-
-  private function meaningfulVariationLabel(string $variation_label, string $product_title): string {
-    $variation_label = trim($variation_label);
-    if ($variation_label === '') {
-      return '';
-    }
-    $lower = strtolower($variation_label);
-    if (in_array($lower, self::GENERIC_VARIATION_LABELS, TRUE)) {
-      return '';
-    }
-    if (strcasecmp($variation_label, $product_title) === 0) {
-      return '';
-    }
-    if (str_starts_with(strtolower($product_title), strtolower($variation_label))) {
-      return '';
-    }
-    return $variation_label;
   }
 
   /**
@@ -224,9 +227,28 @@ final class OperationalOrderItemDisplayBuilder {
     }
     if ($out === []) {
       $out[] = [
-        'label' => (string) $this->t('Add-on'),
+        'label' => (string) $this->t('Event extra'),
         'tone' => 'muted',
       ];
+    }
+    return $out;
+  }
+
+  /**
+   * @param list<array{label: string, tone: string}> $chips
+   *
+   * @return list<array{label: string, tone: string}>
+   */
+  private function dedupeChips(array $chips): array {
+    $out = [];
+    $seen = [];
+    foreach ($chips as $chip) {
+      $label = $chip['label'] ?? '';
+      if ($label === '' || isset($seen[$label])) {
+        continue;
+      }
+      $seen[$label] = TRUE;
+      $out[] = $chip;
     }
     return $out;
   }
@@ -234,7 +256,7 @@ final class OperationalOrderItemDisplayBuilder {
   private function descriptionFromPickupMode(string $pickup_mode): string {
     return match ($pickup_mode) {
       'venue_pickup', 'counter', 'timed_window' => (string) $this->t('Collect at the venue after purchase.'),
-      'none' => (string) $this->t('Follow organiser instructions for this add-on.'),
+      'none' => (string) $this->t('Follow organiser instructions for this extra.'),
       default => (string) $this->t('Collect at the venue after purchase.'),
     };
   }

--- a/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_commerce\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -80,6 +81,7 @@ final class VendorOperationalAddonOrderBuilder {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly OperationalPurchaseCompositionManager $purchaseCompositionManager,
     private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    private readonly OperationalExtraVisualPresenter $visualPresenter,
     private readonly DateFormatterInterface $dateFormatter,
     TranslationInterface $string_translation,
   ) {
@@ -475,9 +477,28 @@ final class VendorOperationalAddonOrderBuilder {
     $pe = $item->getPurchasedEntity();
     $variationLabel = $pe instanceof ProductVariationInterface ? $pe->label() : '';
     $productLabel = '';
+    $product = NULL;
+    $thumbnail_url = '';
+    $thumbnail_alt = '';
+    $pickup_note = '';
+    $short_description = '';
+    $size_label = '';
     if ($pe instanceof ProductVariationInterface) {
       $product = $pe->getProduct();
       $productLabel = $product ? $product->label() : '';
+      $size = $this->visualPresenter->resolveVariationSize($pe);
+      $size_label = $size['size_label'] !== ''
+        ? $size['size_label']
+        : $this->visualPresenter->meaningfulVariationLabel($variationLabel, $productLabel);
+      if ($product instanceof ProductInterface) {
+        $payload = is_array($line['presentation'] ?? NULL) ? $line['presentation'] : [];
+        $visual = $this->visualPresenter->buildProductVisualDocument($product, $payload);
+        $thumb = $this->visualPresenter->buildPrimaryThumbnailForProduct($product);
+        $thumbnail_url = (string) ($thumb['url'] ?? '');
+        $thumbnail_alt = (string) ($thumb['alt'] ?? $productLabel);
+        $pickup_note = (string) ($visual['pickup_note'] ?? '');
+        $short_description = (string) ($visual['short_description'] ?? '');
+      }
     }
 
     $chips = [];
@@ -501,9 +522,13 @@ final class VendorOperationalAddonOrderBuilder {
       'quantity' => (int) $item->getQuantity(),
       'product_label' => $productLabel,
       'variation_label' => $variationLabel,
+      'size_label' => $size_label,
+      'thumbnail_url' => $thumbnail_url,
+      'thumbnail_alt' => $thumbnail_alt,
+      'pickup_note' => $pickup_note,
+      'short_description' => $short_description !== '' ? $short_description : trim((string) ($pres['operational_summary'] ?? '')),
       'operational_summary' => trim((string) ($pres['operational_summary'] ?? '')),
-      'readiness_mode' => trim((string) ($pres['readiness_mode'] ?? '')),
-      'pickup_mode' => trim((string) ($pres['pickup_mode'] ?? '')),
+      'payment_status_label' => $this->paymentStatusLabel($order),
       'customer_visibility' => trim((string) ($pres['customer_visibility'] ?? '')),
       'chips' => $chips,
     ];
@@ -525,6 +550,17 @@ final class VendorOperationalAddonOrderBuilder {
       }
     }
     return (string) $this->t('Guest customer');
+  }
+
+  private function paymentStatusLabel(OrderInterface $order): string {
+    $state = $order->getState()->getId();
+    return match ($state) {
+      'completed', 'fulfilled', 'fulfillment' => (string) $this->t('Paid'),
+      'placed' => (string) $this->t('Payment received'),
+      'refunded' => (string) $this->t('Refunded'),
+      'partially_refunded' => (string) $this->t('Partially refunded'),
+      default => (string) $this->t('In progress'),
+    };
   }
 
   private function groupLabel(string $groupKey): string {

--- a/web/modules/custom/myeventlane_commerce/templates/mel-operational-order-item-line.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-operational-order-item-line.html.twig
@@ -1,31 +1,43 @@
 {#
 /**
  * @file
- * Customer line label for an operational add-on order item (cart / summaries).
+ * Customer line label for an Event Extra order item (cart / summaries).
  *
  * Variables:
  * - display: sanitized array from OperationalOrderItemDisplayBuilder.
  */
 #}
 {% set d = display|default({}) %}
-<div class="mel-operational-order-item-line">
-  {% if d.title|default('') %}
-    <div class="mel-operational-order-item-line__title">{{ d.title }}</div>
+<div class="mel-event-extra-line">
+  {% if d.thumbnail_url|default('') %}
+    <img class="mel-event-extra-line__thumb" src="{{ d.thumbnail_url }}" alt="{{ d.thumbnail_alt|default(d.title|default('')) }}" loading="lazy" width="64" height="64" />
   {% endif %}
-  {% if d.subtitle|default('') %}
-    <p class="mel-operational-order-item-line__subtitle">{{ d.subtitle }}</p>
-  {% endif %}
-  {% if d.variation_label|default('') %}
-    <p class="mel-operational-order-item-line__variation">{{ d.variation_label }}</p>
-  {% endif %}
-  {% if d.description|default('') %}
-    <p class="mel-operational-order-item-line__description">{{ d.description }}</p>
-  {% endif %}
-  {% if d.chips|default([])|length > 0 %}
-    <ul class="mel-operational-order-item-line__chips" aria-label="{{ 'Add-on details'|t }}">
-      {% for chip in d.chips %}
-        <li class="mel-operational-order-item-line__chip mel-operational-order-item-line__chip--{{ chip.tone|default('muted')|clean_class }}">{{ chip.label|default('') }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+  <div class="mel-event-extra-line__content">
+    {% if d.title|default('') %}
+      <div class="mel-event-extra-line__title">{{ d.title }}</div>
+    {% endif %}
+    {% if d.size_label|default('') %}
+      <p class="mel-event-extra-line__size">{{ 'Size: @size'|t({'@size': d.size_label}) }}</p>
+    {% elseif d.variation_label|default('') %}
+      <p class="mel-event-extra-line__size">{{ 'Size: @size'|t({'@size': d.variation_label}) }}</p>
+    {% endif %}
+    {% if d.pickup_note|default('') %}
+      <p class="mel-event-extra-line__pickup">{{ d.pickup_note }}</p>
+    {% elseif d.description|default('') %}
+      <p class="mel-event-extra-line__description">{{ d.description }}</p>
+    {% endif %}
+    {% if d.price_display|default('') %}
+      <p class="mel-event-extra-line__price">{{ d.price_display }}</p>
+    {% endif %}
+    {% if d.subtitle|default('') %}
+      <p class="mel-event-extra-line__subtitle mel-text--muted">{{ d.subtitle }}</p>
+    {% endif %}
+    {% if d.chips|default([])|length > 0 %}
+      <ul class="mel-event-extra-line__chips" aria-label="{{ 'Extra details'|t }}">
+        {% for chip in d.chips %}
+          <li class="mel-event-extra-line__chip mel-event-extra-line__chip--{{ chip.tone|default('muted')|clean_class }}">{{ chip.label|default('') }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
 </div>

--- a/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/mel-vendor-operational-addon-orders.html.twig
@@ -73,22 +73,29 @@
                 <ul class="mel-vendor-addon-orders__lines">
                   {% for line in group.lines %}
                     <li class="mel-vendor-addon-orders__line">
-                      <div class="mel-vendor-addon-orders__line-main">
-                        <span class="mel-vendor-addon-orders__line-product">{{ line.product_label|default('') }}</span>
-                        {% if line.variation_label %}
-                          <span class="mel-vendor-addon-orders__line-variation">{{ line.variation_label }}</span>
+                      {% if line.thumbnail_url|default('') %}
+                        <img class="mel-vendor-addon-orders__thumb" src="{{ line.thumbnail_url }}" alt="{{ line.thumbnail_alt|default(line.product_label|default('')) }}" loading="lazy" width="56" height="56" />
+                      {% endif %}
+                      <div class="mel-vendor-addon-orders__line-body">
+                        <div class="mel-vendor-addon-orders__line-main">
+                          <span class="mel-vendor-addon-orders__line-product">{{ line.product_label|default('') }}</span>
+                          {% if line.size_label|default('') %}
+                            <span class="mel-vendor-addon-orders__line-size">{{ 'Size @size'|t({'@size': line.size_label}) }}</span>
+                          {% elseif line.variation_label %}
+                            <span class="mel-vendor-addon-orders__line-variation">{{ line.variation_label }}</span>
+                          {% endif %}
+                          <span class="mel-vendor-addon-orders__line-qty">× {{ line.quantity|default(0) }}</span>
+                          {% if line.payment_status_label|default('') %}
+                            <span class="mel-vendor-addon-orders__line-paid">{{ line.payment_status_label }}</span>
+                          {% endif %}
+                        </div>
+                        {% if line.pickup_note|default('') %}
+                          <p class="mel-vendor-addon-orders__line-pickup">{{ line.pickup_note }}</p>
+                        {% elseif line.short_description|default('') %}
+                          <p class="mel-vendor-addon-orders__line-summary">{{ line.short_description }}</p>
+                        {% elseif line.operational_summary %}
+                          <p class="mel-vendor-addon-orders__line-summary">{{ line.operational_summary }}</p>
                         {% endif %}
-                        <span class="mel-vendor-addon-orders__line-qty">× {{ line.quantity|default(0) }}</span>
-                      </div>
-                      {% if line.operational_summary %}
-                        <p class="mel-vendor-addon-orders__line-summary">{{ line.operational_summary }}</p>
-                      {% endif %}
-                      {% if line.readiness_mode or line.pickup_mode %}
-                        <p class="mel-vendor-addon-orders__line-modes">
-                          {% if line.readiness_mode %}<span class="mel-vendor-addon-orders__pill">{{ line.readiness_mode }}</span>{% endif %}
-                          {% if line.pickup_mode %}<span class="mel-vendor-addon-orders__pill">{{ line.pickup_mode }}</span>{% endif %}
-                        </p>
-                      {% endif %}
                       {% if line.chips is defined and line.chips|length > 0 %}
                         <ul class="mel-vendor-addon-orders__chips">
                           {% for chip in line.chips %}
@@ -96,6 +103,7 @@
                           {% endfor %}
                         </ul>
                       {% endif %}
+                      </div>
                     </li>
                   {% endfor %}
                 </ul>

--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -19,6 +19,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager;
@@ -344,11 +345,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     ], JSON_THROW_ON_ERROR));
     $product->save();
 
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $built = $builder->buildForEvent($this->event);
     $this->assertNotSame([], $built['addons']);
     $first = $built['addons'][0];
@@ -365,11 +362,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $product->set('status', 0);
     $product->save();
 
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $built = $builder->buildForEvent($this->event);
     $this->assertSame([], $built['addons']);
   }
@@ -382,11 +375,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     }
     $product->save();
 
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $built = $builder->buildForEvent($this->event);
     $this->assertSame([], $built['addons']);
   }
@@ -396,11 +385,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $product->set('stores', []);
     $product->save();
 
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $built = $builder->buildForEvent($this->event);
     $this->assertSame([], $built['addons']);
   }
@@ -418,11 +403,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     $product->set('status', 1);
     $product->save();
 
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $built = $builder->buildForEvent($this->event);
     $this->assertSame([], $built['addons']);
   }
@@ -435,11 +416,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
       'status' => 1,
     ]);
     $empty_event->save();
-    $builder = new EventOperationalAddonBuilder(
-      $this->container->get('entity_type.manager'),
-      $this->merchandiseManager(),
-      $this->container->get('string_translation'),
-    );
+    $builder = $this->eventOperationalAddonBuilder();
     $this->assertFalse($builder->hasAddons($empty_event));
   }
 
@@ -448,6 +425,20 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $this->container->get('string_translation'),
       $this->container->get('logger.factory')->get('operational_merchandise_kernel'),
+    );
+  }
+
+  protected function eventOperationalAddonBuilder(): EventOperationalAddonBuilder {
+    return new EventOperationalAddonBuilder(
+      $this->container->get('entity_type.manager'),
+      $this->merchandiseManager(),
+      new OperationalExtraVisualPresenter(
+        $this->container->get('entity_type.manager'),
+        $this->container->get('file_url_generator'),
+        $this->container->get('extension.path.resolver'),
+        $this->container->get('string_translation'),
+      ),
+      $this->container->get('string_translation'),
     );
   }
 

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_commerce\Unit;
 
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -16,17 +21,24 @@ use Psr\Log\LoggerInterface;
  */
 final class EventOperationalAddonBuilderTest extends UnitTestCase {
 
-  private function builder(): EventOperationalAddonBuilder {
-    $etm = $this->createMock(\Drupal\Core\Entity\EntityTypeManagerInterface::class);
+  private function builder(?OperationalExtraVisualPresenter $visual = NULL): EventOperationalAddonBuilder {
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
     $logger = $this->createMock(LoggerInterface::class);
     $merch = new OperationalMerchandiseManager(
       $etm,
       $this->getStringTranslationStub(),
       $logger,
     );
+    $visual ??= new OperationalExtraVisualPresenter(
+      $etm,
+      $this->createMock(\Drupal\Core\File\FileUrlGeneratorInterface::class),
+      $this->createMock(\Drupal\Core\Extension\ExtensionPathResolver::class),
+      $this->getStringTranslationStub(),
+    );
     return new EventOperationalAddonBuilder(
       $etm,
       $merch,
+      $visual,
       $this->getStringTranslationStub(),
     );
   }
@@ -55,6 +67,92 @@ final class EventOperationalAddonBuilderTest extends UnitTestCase {
     ];
     $clean = $this->builder()->sanitizeAddon($dirty);
     $this->assertSame([], $clean);
+  }
+
+  public function testSanitizeAddonIncludesGalleryMetadataKeys(): void {
+    $addon = $this->builder()->sanitizeAddon([
+      'title' => 'Event T-shirt',
+      'has_images' => FALSE,
+      'primary_image' => ['url' => '/placeholder.svg', 'is_placeholder' => TRUE],
+      'gallery_images' => [['url' => '/placeholder.svg']],
+      'short_description' => 'Soft cotton tee',
+      'pickup_note' => 'Collect at the merch table',
+      'size_options' => [
+        ['variation_id' => 10, 'size_key' => 'l', 'size_label' => 'L'],
+      ],
+    ]);
+    $this->assertFalse($addon['has_images']);
+    $this->assertSame('Soft cotton tee', $addon['short_description']);
+    $this->assertSame('Collect at the merch table', $addon['pickup_note']);
+    $this->assertCount(1, $addon['size_options']);
+    $this->assertArrayNotHasKey('warehouse_ids', $addon);
+  }
+
+  public function testVisualPresenterFieldFirstDescriptionFallback(): void {
+    $visual = $this->createMock(OperationalExtraVisualPresenter::class);
+    $visual->method('buildProductVisualDocument')->willReturn([
+      'short_description' => 'From field',
+      'pickup_note' => 'Desk pickup',
+      'primary_image' => ['url' => '/x.jpg'],
+      'gallery_images' => [],
+      'has_images' => TRUE,
+      'image_alt' => 'Tee',
+      'placeholder_url' => '/p.svg',
+    ]);
+    $visual->method('resolveVariationSize')->willReturn(['size_key' => 'm', 'size_label' => 'M']);
+    $visual->method('meaningfulVariationLabel')->willReturn('');
+
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_merchandise');
+    $product->method('isPublished')->willReturn(TRUE);
+    $product->method('label')->willReturn('Tee');
+    $product->method('id')->willReturn('1');
+    $product->method('getStores')->willReturn([$this->createMock(\Drupal\commerce_store\Entity\StoreInterface::class)]);
+    $product->method('hasField')->willReturnCallback(
+      static fn (string $f): bool => in_array($f, ['field_event', 'field_mel_operational_product'], TRUE),
+    );
+    $event_field = $this->createMock(FieldItemListInterface::class);
+    $event_field->method('isEmpty')->willReturn(FALSE);
+    $event_field->method('__get')->willReturnMap([['target_id', '99']]);
+    $op_field = $this->createMock(FieldItemListInterface::class);
+    $op_field->method('isEmpty')->willReturn(FALSE);
+    $op_field->method('__get')->willReturnMap([['value', '{"operational_summary":"JSON summary"}']]);
+    $product->method('get')->willReturnCallback(
+      static fn (string $f) => match ($f) {
+        'field_event' => $event_field,
+        default => $op_field,
+      },
+    );
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('isPublished')->willReturn(TRUE);
+    $variation->method('id')->willReturn('5');
+    $variation->method('label')->willReturn('Price');
+    $variation->method('getPrice')->willReturn(NULL);
+    $product->method('getVariations')->willReturn([$variation]);
+
+    $storage = $this->createMock(\Drupal\Core\Entity\EntityStorageInterface::class);
+    $storage->method('getQuery')->willReturn($query = $this->createMock(\Drupal\Core\Entity\Query\QueryInterface::class));
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('sort')->willReturnSelf();
+    $query->method('execute')->willReturn([1]);
+    $storage->method('loadMultiple')->willReturn([1 => $product]);
+
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getStorage')->willReturn($storage);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $merch = new OperationalMerchandiseManager($etm, $this->getStringTranslationStub(), $logger);
+    $builder = new EventOperationalAddonBuilder($etm, $merch, $visual, $this->getStringTranslationStub());
+
+    $event = $this->createMock(\Drupal\node\NodeInterface::class);
+    $event->method('id')->willReturn('99');
+    $event->method('bundle')->willReturn('event');
+
+    $built = $builder->buildForEvent($event);
+    $this->assertSame('From field', $built['addons'][0]['short_description']);
+    $this->assertSame('m', $built['addons'][0]['variations'][0]['size_key']);
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php
@@ -8,6 +8,7 @@ use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder;
 use Drupal\node\NodeInterface;
@@ -122,6 +123,63 @@ final class OperationalOrderItemDisplayBuilderTest extends UnitTestCase {
   /**
    * @covers ::buildForOrderItem
    */
+  public function testDisplayIncludesThumbnailSizeAndPickupNote(): void {
+    $visual = $this->createMock(OperationalExtraVisualPresenter::class);
+    $visual->method('buildProductVisualDocument')->willReturn([
+      'short_description' => 'Soft tee',
+      'pickup_note' => 'Collect at the merch table',
+      'primary_image' => ['url' => 'https://example.test/tee.jpg', 'alt' => 'Tee'],
+      'gallery_images' => [],
+      'has_images' => TRUE,
+      'image_alt' => 'Tee',
+      'placeholder_url' => '',
+    ]);
+    $visual->method('buildPrimaryThumbnailForProduct')->willReturn([
+      'url' => 'https://example.test/tee.jpg',
+      'alt' => 'Tee',
+    ]);
+    $visual->method('resolveVariationSize')->willReturn(['size_key' => 'l', 'size_label' => 'L']);
+    $visual->method('meaningfulVariationLabel')->willReturn('');
+
+    $builder = $this->builder($visual);
+    $order_item = $this->orderItemFixture(
+      'operational_merchandise',
+      'Price',
+      'Event T-shirt',
+    );
+    $display = $builder->buildForOrderItem($order_item);
+    $this->assertIsArray($display);
+    $this->assertSame('L', $display['size_label']);
+    $this->assertSame('Collect at the merch table', $display['pickup_note']);
+    $this->assertStringContainsString('tee.jpg', (string) $display['thumbnail_url']);
+  }
+
+  public function testPlaceholderWhenNoImages(): void {
+    $visual = $this->createMock(OperationalExtraVisualPresenter::class);
+    $visual->method('buildProductVisualDocument')->willReturn([
+      'short_description' => '',
+      'pickup_note' => '',
+      'primary_image' => ['url' => '/themes/custom/myeventlane_theme/images/mel/placeholders/mel-placeholder-default.svg', 'is_placeholder' => TRUE],
+      'gallery_images' => [],
+      'has_images' => FALSE,
+      'image_alt' => 'Event extra',
+      'placeholder_url' => '/themes/custom/myeventlane_theme/images/mel/placeholders/mel-placeholder-default.svg',
+    ]);
+    $visual->method('buildPrimaryThumbnailForProduct')->willReturn([
+      'url' => '/themes/custom/myeventlane_theme/images/mel/placeholders/mel-placeholder-default.svg',
+      'alt' => 'Event extra',
+      'is_placeholder' => TRUE,
+    ]);
+    $visual->method('resolveVariationSize')->willReturn(['size_key' => '', 'size_label' => '']);
+    $visual->method('meaningfulVariationLabel')->willReturn('');
+
+    $display = $this->builder($visual)->buildForOrderItem(
+      $this->orderItemFixture('operational_merchandise', 'Price', 'Hat'),
+    );
+    $this->assertIsArray($display);
+    $this->assertStringContainsString('placeholder', (string) $display['thumbnail_url']);
+  }
+
   public function testChipsRemainListShaped(): void {
     $builder = $this->builder();
     $order_item = $this->orderItemFixture(
@@ -143,19 +201,30 @@ final class OperationalOrderItemDisplayBuilderTest extends UnitTestCase {
     $this->assertIsArray($display);
     $this->assertIsList($display['chips']);
     $this->assertGreaterThanOrEqual(2, count($display['chips']));
-    $this->assertSame('Add-on', $display['chips'][0]['label']);
+    $labels = array_column($display['chips'], 'label');
+    $this->assertContains('Add-on', $labels);
   }
 
-  private function builder(): OperationalOrderItemDisplayBuilder {
+  private function builder(?OperationalExtraVisualPresenter $visual = NULL): OperationalOrderItemDisplayBuilder {
     $etm = $this->createMock(EntityTypeManagerInterface::class);
     $manager = new OperationalMerchandiseManager(
       $etm,
       $this->getStringTranslationStub(),
       $this->createMock(LoggerInterface::class),
     );
+    $visual ??= new OperationalExtraVisualPresenter(
+      $etm,
+      $this->createMock(\Drupal\Core\File\FileUrlGeneratorInterface::class),
+      $this->createMock(\Drupal\Core\Extension\ExtensionPathResolver::class),
+      $this->getStringTranslationStub(),
+    );
+    $currency = $this->createMock(\Drupal\commerce_price\CurrencyFormatter::class);
+    $currency->method('format')->willReturn('$35.00');
     return new OperationalOrderItemDisplayBuilder(
       $manager,
+      $visual,
       $etm,
+      $currency,
       $this->getStringTranslationStub(),
     );
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioProductisationForm.php
@@ -14,6 +14,7 @@ use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\OperationalCapabilityCommerceLinkManager;
 use Drupal\myeventlane_event_studio\Service\OperationalCapabilityStudioManager;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
 use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioBuilder;
 use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
@@ -272,15 +273,22 @@ final class EventStudioProductisationForm extends FormBase {
       VendorProductisationStudioManager::TYPE_MERCHANDISE => [
         'title' => [
           '#type' => 'textfield',
-          '#title' => $this->t('Title'),
+          '#title' => $this->t('Extra title'),
           '#default_value' => (string) ($row['title'] ?? ''),
           '#maxlength' => 180,
         ],
         'customer_summary' => [
           '#type' => 'textarea',
-          '#title' => $this->t('Short customer summary'),
+          '#title' => $this->t('Short customer description'),
           '#default_value' => (string) ($row['customer_summary'] ?? ''),
           '#rows' => 3,
+        ],
+        'pickup_note' => [
+          '#type' => 'textarea',
+          '#title' => $this->t('Pickup note'),
+          '#default_value' => (string) ($row['pickup_note'] ?? ''),
+          '#rows' => 2,
+          '#description' => $this->t('Shown to customers, e.g. “Collect at the merch table after check-in.”'),
         ],
         'customer_visibility' => [
           '#type' => 'select',
@@ -293,11 +301,8 @@ final class EventStudioProductisationForm extends FormBase {
           '#default_value' => (string) ($row['customer_visibility'] ?? 'visible'),
         ],
         'pickup_mode' => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Pickup mode token'),
-          '#default_value' => (string) ($row['pickup_mode'] ?? 'counter'),
-          '#maxlength' => 64,
-          '#description' => $this->t('Authoring hint only — venue pickup is enforced by your operational capability settings.'),
+          '#type' => 'hidden',
+          '#value' => 'venue_pickup',
         ],
       ],
       VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => [
@@ -438,33 +443,42 @@ final class EventStudioProductisationForm extends FormBase {
       'notice' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Stock counts, warehouse routing, shipping labels, scanners, QR payloads, and entitlement issuance are <strong>not</strong> configured here — they are handled later in Commerce and operations tooling.'),
+        '#value' => $this->t('Extras are saved when you press Save. Add product photos from the linked catalog product after creation if needed.'),
         '#attributes' => ['class' => ['mel-productisation-wizard-warning']],
-      ],
-      'readiness_chips' => [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $this->t('Operational readiness: authoring · pricing · customer copy'),
-        '#attributes' => ['class' => ['mel-productisation-wizard-chips']],
       ],
       'customer_preview_label' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Customer sees this (from your summary fields and the product title below).'),
+        '#value' => $this->t('Customers see a card with image, title, price, description, and pickup note.'),
         '#attributes' => ['class' => ['mel-productisation-wizard-preview-hint']],
       ],
       'commerce_create_title' => [
         '#type' => 'textfield',
-        '#title' => $this->t('Catalog title'),
+        '#title' => $this->t('Extra title'),
         '#default_value' => '',
         '#maxlength' => 255,
         '#description' => $this->t('Plain text only. Defaults from the fields above when left blank.'),
       ],
       'commerce_create_customer_summary' => [
         '#type' => 'textarea',
-        '#title' => $this->t('Short customer summary'),
+        '#title' => $this->t('Short customer description'),
         '#rows' => 3,
         '#default_value' => '',
+      ],
+      'commerce_create_pickup_note' => [
+        '#type' => 'textarea',
+        '#title' => $this->t('Pickup note'),
+        '#rows' => 2,
+        '#default_value' => '',
+        '#access' => $type === VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      ],
+      'commerce_create_sizes' => [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Sizes offered'),
+        '#options' => OperationalExtraVisualPresenter::SIZE_LABELS,
+        '#default_value' => [],
+        '#access' => $type === VendorProductisationStudioManager::TYPE_MERCHANDISE,
+        '#description' => $this->t('Creates one purchasable option per size. Leave empty for a single one-size option.'),
       ],
       'commerce_create_price' => [
         '#type' => 'number',

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -12,6 +12,7 @@ use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
@@ -156,6 +157,8 @@ final class VendorOperationalProductCreationManager {
     $metadata = $this->buildOperationalMetadata($type, $payload, $summary);
     $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
+    $pickup_note = $this->sanitizePlainText((string) ($payload['pickup_note'] ?? ''), 400);
+
     $product = CommerceProduct::create([
       'type' => $bundles['product_type'],
       'title' => $title,
@@ -165,20 +168,22 @@ final class VendorOperationalProductCreationManager {
       'field_event' => ['target_id' => (int) $event->id()],
       'field_mel_operational_product' => $encoded,
     ]);
+    if ($product->hasField('field_mel_extra_short_description')) {
+      $product->set('field_mel_extra_short_description', $summary);
+    }
+    if ($product->hasField('field_mel_extra_pickup_note') && $pickup_note !== '') {
+      $product->set('field_mel_extra_pickup_note', $pickup_note);
+    }
     $product->save();
 
     $price = new Price($amount, strtoupper($currency));
-
-    $variation = ProductVariation::create([
-      'type' => $bundles['variation_type'],
-      'sku' => $sku,
-      'title' => $title,
-      'status' => 1,
-      'price' => $price,
-    ]);
-    $variation->save();
-
-    $product->addVariation($variation);
+    $variation_ids = $this->createVariationsForProduct($product, $bundles, $payload, $title, $sku, $price);
+    foreach ($variation_ids as $vid) {
+      $loaded = $this->entityTypeManager->getStorage('commerce_product_variation')->load($vid);
+      if ($loaded instanceof ProductVariation) {
+        $product->addVariation($loaded);
+      }
+    }
     $product->save();
 
     $reloaded = $this->entityTypeManager->getStorage('commerce_product')->load($product->id());
@@ -290,8 +295,79 @@ final class VendorOperationalProductCreationManager {
       'hospitality_benefits_summary' => (string) ($row['benefits_summary'] ?? ''),
       'parking_guidance' => (string) ($row['parking_guidance'] ?? ''),
       'bundle_capability_types' => $bundle_caps,
+      'pickup_note' => (string) ($row['commerce_create_pickup_note'] ?? $row['pickup_note'] ?? ''),
+      'sizes' => $this->normalizeSizeKeys($row['commerce_create_sizes'] ?? $row['sizes'] ?? []),
     ];
     return $this->stripForbiddenFromPayload($payload);
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function createVariationsForProduct(
+    ProductInterface $product,
+    array $bundles,
+    array $payload,
+    string $title,
+    string $sku_base,
+    Price $price,
+  ): array {
+    $size_keys = $this->normalizeSizeKeys($payload['sizes'] ?? []);
+    $variation_type = $bundles['variation_type'];
+    $ids = [];
+
+    if ($size_keys !== [] && $variation_type === 'operational_merchandise_var') {
+      foreach ($size_keys as $size_key) {
+        $label = OperationalExtraVisualPresenter::SIZE_LABELS[$size_key] ?? strtoupper($size_key);
+        $variation = ProductVariation::create([
+          'type' => $variation_type,
+          'sku' => $this->sanitizePlainText($sku_base . '-' . $size_key, 128),
+          'title' => $title . ' — ' . $label,
+          'status' => 1,
+          'price' => $price,
+        ]);
+        if ($variation->hasField('field_mel_size')) {
+          $variation->set('field_mel_size', $size_key);
+        }
+        $variation->save();
+        $ids[] = (int) $variation->id();
+      }
+      return $ids;
+    }
+
+    $variation = ProductVariation::create([
+      'type' => $variation_type,
+      'sku' => $sku_base,
+      'title' => $title,
+      'status' => 1,
+      'price' => $price,
+    ]);
+    $variation->save();
+    return [(int) $variation->id()];
+  }
+
+  /**
+   * @param mixed $raw
+   *
+   * @return list<string>
+   */
+  private function normalizeSizeKeys(mixed $raw): array {
+    if (!is_array($raw)) {
+      return [];
+    }
+    $out = [];
+    foreach ($raw as $key => $value) {
+      $candidate = is_string($key) && !is_numeric($key) ? $key : $value;
+      if (!is_string($candidate) && !is_int($candidate)) {
+        continue;
+      }
+      $size = strtolower(trim((string) $candidate));
+      if ($size === '' || !isset(OperationalExtraVisualPresenter::SIZE_LABELS[$size])) {
+        continue;
+      }
+      $out[$size] = $size;
+    }
+    return array_values($out);
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the booking/cart add-extras flow and order-item/vendor display projections, so mistakes could break adding extras or render incorrect variation/price/media details. Mostly presentation/read-model changes, but backed by new Drupal fields/config that require correct deployment.
> 
> **Overview**
> **Event extras are now rendered as visual, variant-aware cards** on the booking page, with a new `event_extras_booking` library (CSS + JS) providing image gallery thumbs and a quantity stepper UI.
> 
> Adds new Drupal config for extra-specific product fields (`field_mel_extra_images`, `field_mel_extra_short_description`, `field_mel_extra_pickup_note`) across operational/hospitality/timed bundles, plus a variation `field_mel_size` and a new square image style `mel_extra_square`.
> 
> Introduces `OperationalExtraVisualPresenter` and wires it into the add-on builder and display builders to surface thumbnails, pickup notes, short descriptions, size labels, and formatted prices in customer and vendor order line templates; vendor rows also gain a derived payment-status label. Event Studio product creation now supports pickup notes and optional per-size variation creation (setting `field_mel_size`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeafda000589f8e2bd7422e8bb415fbdd4670bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->