### PR TITLE
fix(commerce): field_mel_extra_short_desc for Drupal 32-char limit (staging cim)

### DIFF
--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.hospitality_package
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.hospitality_package.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.hospitality_package.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: hospitality_package
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.operational_bundle
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.operational_bundle.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.operational_bundle.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: operational_bundle
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.operational_merchandise
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.operational_merchandise.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.operational_merchandise.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: operational_merchandise
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.timed_collection_product
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.timed_collection_product.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.timed_collection_product.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: timed_collection_product
 label: 'Short customer description'

--- a/config/sync/field.storage.commerce_product.field_mel_extra_short_desc.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_extra_short_desc.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   module:
     - commerce_product
-id: commerce_product.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+id: commerce_product.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 type: string_long
 settings:

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
@@ -82,8 +82,8 @@ class OperationalExtraVisualPresenter {
    * @param array<string, mixed> $presentation
    */
   public function resolveShortDescription(ProductInterface $product, array $presentation): string {
-    if ($product->hasField('field_mel_extra_short_description') && !$product->get('field_mel_extra_short_description')->isEmpty()) {
-      $text = trim((string) $product->get('field_mel_extra_short_description')->value);
+    if ($product->hasField('field_mel_extra_short_desc') && !$product->get('field_mel_extra_short_desc')->isEmpty()) {
+      $text = trim((string) $product->get('field_mel_extra_short_desc')->value);
       if ($text !== '') {
         return $this->sanitizePlainText($text, 600);
       }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -168,8 +168,8 @@ final class VendorOperationalProductCreationManager {
       'field_event' => ['target_id' => (int) $event->id()],
       'field_mel_operational_product' => $encoded,
     ]);
-    if ($product->hasField('field_mel_extra_short_description')) {
-      $product->set('field_mel_extra_short_description', $summary);
+    if ($product->hasField('field_mel_extra_short_desc')) {
+      $product->set('field_mel_extra_short_desc', $summary);
     }
     if ($product->hasField('field_mel_extra_pickup_note') && $pickup_note !== '') {
       $product->set('field_mel_extra_pickup_note', $pickup_note);


### PR DESCRIPTION
## Summary
- Staging `drush deploy` fails because `main` merged Event Extras with `field_mel_extra_short_description` (33 chars; Drupal max is 32).
- Renames to `field_mel_extra_short_desc` and removes invalid config from the tree.

## Why staging still fails
- `.github/workflows/deploy-staging.yml` deploys on push to **`main`** only.
- `main` at `390e235a` includes the feature without this fix.

## Test plan
- [ ] Merge PR
- [ ] Wait for / re-run staging deploy from `main`
- [ ] `drush config:import -y` succeeds (creates `field_mel_extra_short_desc` only)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a straightforward Drupal field rename across config and two call sites; main risk is data/config migration alignment if the old field existed in an environment.
> 
> **Overview**
> Renames the Commerce product field `field_mel_extra_short_description` to `field_mel_extra_short_desc` to comply with Drupal’s 32-character field name limit, updating field storage and bundle field configs accordingly.
> 
> Updates custom services to read/write the new field name when presenting and creating operational products (`OperationalExtraVisualPresenter::resolveShortDescription` and `VendorOperationalProductCreationManager::createOperationalProductForEvent`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3ed790daa77a32ec9f7ac4d49d16484017c4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->