### PR TITLE
fix(commerce): shorten extra short description field name for Drupal …

### DIFF
--- a/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.hospitality_package.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.hospitality_package
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.hospitality_package.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.hospitality_package.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: hospitality_package
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.operational_bundle.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.operational_bundle
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.operational_bundle.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.operational_bundle.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: operational_bundle
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.operational_merchandise.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.operational_merchandise
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.operational_merchandise.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.operational_merchandise.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: operational_merchandise
 label: 'Short customer description'

--- a/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_desc.yml
+++ b/config/sync/field.field.commerce_product.timed_collection_product.field_mel_extra_short_desc.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - commerce_product.commerce_product_type.timed_collection_product
-    - field.storage.commerce_product.field_mel_extra_short_description
-id: commerce_product.timed_collection_product.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+    - field.storage.commerce_product.field_mel_extra_short_desc
+id: commerce_product.timed_collection_product.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 bundle: timed_collection_product
 label: 'Short customer description'

--- a/config/sync/field.storage.commerce_product.field_mel_extra_short_desc.yml
+++ b/config/sync/field.storage.commerce_product.field_mel_extra_short_desc.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   module:
     - commerce_product
-id: commerce_product.field_mel_extra_short_description
-field_name: field_mel_extra_short_description
+id: commerce_product.field_mel_extra_short_desc
+field_name: field_mel_extra_short_desc
 entity_type: commerce_product
 type: string_long
 settings:

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
@@ -82,8 +82,8 @@ class OperationalExtraVisualPresenter {
    * @param array<string, mixed> $presentation
    */
   public function resolveShortDescription(ProductInterface $product, array $presentation): string {
-    if ($product->hasField('field_mel_extra_short_description') && !$product->get('field_mel_extra_short_description')->isEmpty()) {
-      $text = trim((string) $product->get('field_mel_extra_short_description')->value);
+    if ($product->hasField('field_mel_extra_short_desc') && !$product->get('field_mel_extra_short_desc')->isEmpty()) {
+      $text = trim((string) $product->get('field_mel_extra_short_desc')->value);
       if ($text !== '') {
         return $this->sanitizePlainText($text, 600);
       }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -168,8 +168,8 @@ final class VendorOperationalProductCreationManager {
       'field_event' => ['target_id' => (int) $event->id()],
       'field_mel_operational_product' => $encoded,
     ]);
-    if ($product->hasField('field_mel_extra_short_description')) {
-      $product->set('field_mel_extra_short_description', $summary);
+    if ($product->hasField('field_mel_extra_short_desc')) {
+      $product->set('field_mel_extra_short_desc', $summary);
     }
     if ($product->hasField('field_mel_extra_pickup_note') && $pickup_note !== '') {
       $product->set('field_mel_extra_pickup_note', $pickup_note);


### PR DESCRIPTION
…limit

Drupal field machine names must be <= 32 characters. Replace field_mel_extra_short_description (33 chars) with field_mel_extra_short_desc. Remove the invalid storage and field instance config from the branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames a Commerce product field at the Drupal config and PHP usage level, which can break existing content/config sync if the old field exists in environments or data needs migration.
> 
> **Overview**
> Fixes an invalid Drupal field machine name by renaming `field_mel_extra_short_description` to the shorter `field_mel_extra_short_desc`.
> 
> Updates field storage + per-bundle field instance config for multiple Commerce product bundles, and switches custom services (`OperationalExtraVisualPresenter`, `VendorOperationalProductCreationManager`) to read/write the new field name when resolving/setting the customer short description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e0b2b9a0986d5cb5f89d4e60653e42aeac5630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->