### PR TITLE
fix(commerce): expose event extras fields on product forms

### DIFF
--- a/config/sync/core.entity_form_display.commerce_product.hospitality_package.default.yml
+++ b/config/sync/core.entity_form_display.commerce_product.hospitality_package.default.yml
@@ -1,0 +1,119 @@
+uuid: d17750f2-85c9-40d3-8dcd-f0f9080645e4
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.hospitality_package
+    - field.field.commerce_product.hospitality_package.field_event
+    - field.field.commerce_product.hospitality_package.field_mel_extra_images
+    - field.field.commerce_product.hospitality_package.field_mel_extra_pickup_note
+    - field.field.commerce_product.hospitality_package.field_mel_extra_short_desc
+    - field.field.commerce_product.hospitality_package.field_mel_operational_product
+  module:
+    - commerce
+    - media_library
+    - path
+id: commerce_product.hospitality_package.default
+targetEntityType: commerce_product
+bundle: hospitality_package
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event:
+    type: entity_reference_autocomplete
+    weight: 91
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_images:
+    type: media_library_widget
+    weight: 20
+    region: content
+    settings:
+      media_types:
+        image: image
+    third_party_settings: {  }
+  field_mel_extra_pickup_note:
+    type: string_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_short_desc:
+    type: string_textarea
+    weight: 21
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_operational_product:
+    type: string_textarea
+    weight: 92
+    region: hidden
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 90
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  stores:
+    type: commerce_entity_select
+    weight: -10
+    region: content
+    settings:
+      hide_single_entity: true
+      autocomplete_threshold: 7
+      autocomplete_size: 60
+      autocomplete_placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  variations: true
+

--- a/config/sync/core.entity_form_display.commerce_product.operational_bundle.default.yml
+++ b/config/sync/core.entity_form_display.commerce_product.operational_bundle.default.yml
@@ -1,0 +1,119 @@
+uuid: 70c37d3e-2083-447d-be80-a28b6dffb88f
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_bundle
+    - field.field.commerce_product.operational_bundle.field_event
+    - field.field.commerce_product.operational_bundle.field_mel_extra_images
+    - field.field.commerce_product.operational_bundle.field_mel_extra_pickup_note
+    - field.field.commerce_product.operational_bundle.field_mel_extra_short_desc
+    - field.field.commerce_product.operational_bundle.field_mel_operational_product
+  module:
+    - commerce
+    - media_library
+    - path
+id: commerce_product.operational_bundle.default
+targetEntityType: commerce_product
+bundle: operational_bundle
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event:
+    type: entity_reference_autocomplete
+    weight: 91
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_images:
+    type: media_library_widget
+    weight: 20
+    region: content
+    settings:
+      media_types:
+        image: image
+    third_party_settings: {  }
+  field_mel_extra_pickup_note:
+    type: string_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_short_desc:
+    type: string_textarea
+    weight: 21
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_operational_product:
+    type: string_textarea
+    weight: 92
+    region: hidden
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 90
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  stores:
+    type: commerce_entity_select
+    weight: -10
+    region: content
+    settings:
+      hide_single_entity: true
+      autocomplete_threshold: 7
+      autocomplete_size: 60
+      autocomplete_placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  variations: true
+

--- a/config/sync/core.entity_form_display.commerce_product.operational_merchandise.default.yml
+++ b/config/sync/core.entity_form_display.commerce_product.operational_merchandise.default.yml
@@ -1,0 +1,119 @@
+uuid: abeb646a-7e6b-41e2-ba7b-08f0070afef5
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.operational_merchandise
+    - field.field.commerce_product.operational_merchandise.field_event
+    - field.field.commerce_product.operational_merchandise.field_mel_extra_images
+    - field.field.commerce_product.operational_merchandise.field_mel_extra_pickup_note
+    - field.field.commerce_product.operational_merchandise.field_mel_extra_short_desc
+    - field.field.commerce_product.operational_merchandise.field_mel_operational_product
+  module:
+    - commerce
+    - media_library
+    - path
+id: commerce_product.operational_merchandise.default
+targetEntityType: commerce_product
+bundle: operational_merchandise
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event:
+    type: entity_reference_autocomplete
+    weight: 91
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_images:
+    type: media_library_widget
+    weight: 20
+    region: content
+    settings:
+      media_types:
+        image: image
+    third_party_settings: {  }
+  field_mel_extra_pickup_note:
+    type: string_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_short_desc:
+    type: string_textarea
+    weight: 21
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_operational_product:
+    type: string_textarea
+    weight: 92
+    region: hidden
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 90
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  stores:
+    type: commerce_entity_select
+    weight: -10
+    region: content
+    settings:
+      hide_single_entity: true
+      autocomplete_threshold: 7
+      autocomplete_size: 60
+      autocomplete_placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  variations: true
+

--- a/config/sync/core.entity_form_display.commerce_product.timed_collection_product.default.yml
+++ b/config/sync/core.entity_form_display.commerce_product.timed_collection_product.default.yml
@@ -1,0 +1,119 @@
+uuid: 521fff7a-4bb7-4b1e-bae2-40a15bf9a720
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.timed_collection_product
+    - field.field.commerce_product.timed_collection_product.field_event
+    - field.field.commerce_product.timed_collection_product.field_mel_extra_images
+    - field.field.commerce_product.timed_collection_product.field_mel_extra_pickup_note
+    - field.field.commerce_product.timed_collection_product.field_mel_extra_short_desc
+    - field.field.commerce_product.timed_collection_product.field_mel_operational_product
+  module:
+    - commerce
+    - media_library
+    - path
+id: commerce_product.timed_collection_product.default
+targetEntityType: commerce_product
+bundle: timed_collection_product
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event:
+    type: entity_reference_autocomplete
+    weight: 91
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_images:
+    type: media_library_widget
+    weight: 20
+    region: content
+    settings:
+      media_types:
+        image: image
+    third_party_settings: {  }
+  field_mel_extra_pickup_note:
+    type: string_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_extra_short_desc:
+    type: string_textarea
+    weight: 21
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_mel_operational_product:
+    type: string_textarea
+    weight: 92
+    region: hidden
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 90
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  stores:
+    type: commerce_entity_select
+    weight: -10
+    region: content
+    settings:
+      hide_single_entity: true
+      autocomplete_threshold: 7
+      autocomplete_size: 60
+      autocomplete_placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  variations: true
+

--- a/config/sync/core.entity_form_display.commerce_product_variation.operational_merchandise_var.default.yml
+++ b/config/sync/core.entity_form_display.commerce_product_variation.operational_merchandise_var.default.yml
@@ -1,0 +1,72 @@
+uuid: 746b961c-b5a2-4b68-b860-760ad4b3d773
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_merchandise_var
+    - field.field.commerce_product_variation.operational_merchandise_var.field_mel_size
+  module:
+    - commerce_price
+id: commerce_product_variation.operational_merchandise_var.default
+targetEntityType: commerce_product_variation
+bundle: operational_merchandise_var
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 91
+    region: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_mel_size:
+    type: options_select
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 9
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  list_price:
+    type: commerce_list_price
+    weight: -1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  price:
+    type: commerce_price_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  sku:
+    type: string_textfield
+    weight: -4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 90
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 92
+    region: hidden
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }
+


### PR DESCRIPTION
Add entity form displays for operational Commerce product bundles and operational_merchandise_var so admins can edit extra images, customer copy, pickup notes, and size on standard product/variation edit forms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts Drupal Commerce admin form displays; primary risk is unintended field visibility/layout changes for product editors.
> 
> **Overview**
> Adds new Drupal config in `config/sync` defining default entity form displays for several Commerce product bundles (`hospitality_package`, `operational_bundle`, `operational_merchandise`, `timed_collection_product`) so admins can edit extra images and customer-facing copy/pickup note fields directly on product edit forms.
> 
> Also adds an entity form display for the `operational_merchandise_var` variation type to expose the `field_mel_size` selector alongside standard SKU/price fields (with some operational/event fields kept hidden).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0cbfe7d4f9bf314ec42c3de736353f176765c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->