### PR TITLE
Feature/event studio extras editor

### DIFF
--- a/docs/event-extras-studio-audit.md
+++ b/docs/event-extras-studio-audit.md
@@ -1,0 +1,58 @@
+# Event Extras Studio — Phase 0 audit
+
+**Date:** 2026-05-18  
+**Git:** clean working tree, no merge in progress.
+
+## 1. Routes
+
+| Path | Route name | Controller | Section | Access |
+|------|------------|------------|---------|--------|
+| `/vendor/events/{node}/studio/merchandise` | `myeventlane_event_studio.workspace_merchandise` | `EventStudioController::workspace` | `merchandise` | `EventStudioAccess::access` |
+| `/vendor/events/{node}/studio/addons` | `myeventlane_event_studio.workspace_addons` | same | `addons` | same |
+| `/vendor/events/{node}/studio/add-ons` | `myeventlane_event_studio.workspace_add_ons` | same | `addons` | same |
+| `/vendor/events/{node}/studio/fulfilment` | `myeventlane_event_studio.workspace_fulfilment` | same | `fulfilment` | same |
+| `/vendor/events/{node}/studio/extras` | — | — | — | **Did not exist** |
+
+All workspace routes use theme `mel_event_studio_workspace`; section content from `EventStudioSectionRenderer` + section plugins.
+
+## 2. Section plugins
+
+| Section | State | Render target | Nav |
+|---------|-------|---------------|-----|
+| `merchandise` | active | `EventStudioProductisationForm` | visible |
+| `addons` | deferred | `deferred_empty` | visible (shows “Planned”) |
+| `fulfilment` | active | `EventStudioOperationalCapabilityForm` | visible |
+
+**Merchandise vs add-ons:** Not duplicate logic. Merchandise is the full productisation studio; add-ons is a deferred placeholder only.
+
+## 3. Services / forms
+
+- `EventStudioProductisationForm` — multi-type productisation (5 types), link-or-create Commerce, autosave key `merchandise`.
+- `VendorOperationalProductCreationManager` — **create-only** on explicit save; strips forbidden keys; sizes on create; **no update**, **no images** on create.
+- `EventOperationalAddonBuilder` — booking page reads products via `field_event` + published status (not productisation JSON).
+- `OperationalExtraVisualPresenter` — gallery, sizes, pickup note from entity fields.
+- `VendorProductisationStudioBuilder` — cards + preview strip.
+
+## 4. CRUD capabilities (pre-unification)
+
+| Capability | Supported? |
+|------------|------------|
+| Create product | Yes (`createOperationalProductForEvent`) |
+| Update product | **No** dedicated method |
+| Multiple size variations | Yes on **create** only |
+| Update variations / preserve IDs | **No** |
+| Unpublish removed sizes | **No** |
+| Vendor/event/store ownership on create | Yes |
+| `field_mel_extra_images` in Studio | **No** (Commerce admin form display only) |
+
+## 5. Raw Commerce product edit
+
+No vendor-facing links to `entity.commerce_product.edit_form` found in custom modules. Admin `/admin/commerce/products/{id}/edit` remains debug path.
+
+## 6. Config
+
+Confirmed in `config/sync`: `field_mel_extra_images`, `field_mel_extra_short_desc`, `field_mel_extra_pickup_note`, `field_mel_operational_product`, `field_event` on operational bundles; `field_mel_size` on `operational_merchandise_var`; form displays use `media_library_widget` for images.
+
+## 7. Proceed / stop
+
+**Proceed:** access (`EventStudioAccess`, `EventVendorAccessChecker`), services exist, ownership patterns clear. Gaps (update, images, unified UX) are the implementation target.

--- a/docs/event-extras-studio-editor.md
+++ b/docs/event-extras-studio-editor.md
@@ -1,0 +1,89 @@
+# Event Extras Studio editor
+
+## Purpose
+
+Single vendor-facing surface to create and manage **event extras** (merch, food & drink, VIP, pickup items, bundles) inside Event Studio, backed by Drupal Commerce operational products.
+
+**Route:** `/vendor/events/{event}/studio/extras`  
+**Route name:** `myeventlane_event_studio.workspace_extras`
+
+Legacy URLs `/studio/merchandise`, `/studio/addons`, and `/studio/add-ons` redirect here (bookmarks preserved).
+
+## Architecture
+
+| Layer | Responsibility |
+|-------|----------------|
+| `EventStudioEventExtrasForm` | Vendor UI (probe → edit → list), no Commerce jargon |
+| `EventStudioEventExtrasBuilder` | List cards + customer preview rows |
+| `VendorOperationalProductCreationManager::saveEventExtraForVendor()` | Create/update products, variations, fields, access |
+| `EventOperationalAddonBuilder` | Customer booking page (unchanged) |
+| `OperationalExtraVisualPresenter` | Images, sizes, pickup note presentation |
+
+Commerce remains authoritative for catalog, carts, checkout, and orders. **No** stock, warehouse, shipping, scanner, QR, entitlement, or checkout mutation in this flow.
+
+## Vendor flow (Probe → Present → Listen → Ask → Invite)
+
+1. **Probe** — choice cards: Merchandise, Food & drink, VIP / hospitality, Pickup item, Bundle / package.
+2. **Present** — editor: name, description, price, sizes (merch), pickup note, show on booking, images (after first save or on edit).
+3. **Listen** — guest preview card on edit.
+4. **Ask** — save, save & add another, list actions (edit, hide/show on booking).
+5. **Invite** — footer CTAs: preview booking page, continue to publish.
+
+## Access rules
+
+- `EventStudioAccess` + `EventVendorAccessChecker::accountHasWorkspaceParityForEvent()`
+- Product must have `field_event` = current event
+- Product bundle ∈ `OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES`
+- Product store must match resolved vendor/event store
+- Ticket products and other vendors’ products are rejected
+
+## Field mapping
+
+| Vendor field | Commerce |
+|--------------|----------|
+| Extra name | `commerce_product.title` |
+| Short description | `field_mel_extra_short_desc` |
+| Pickup note | `field_mel_extra_pickup_note` |
+| Images | `field_mel_extra_images` (media) |
+| Show on booking | `status` (published) |
+| Sizes | `field_mel_size` per `operational_merchandise_var` variation |
+| Price | variation `price` |
+| Event link | `field_event` (set automatically, not editable) |
+| Store | `stores` (set automatically) |
+
+Internal operational JSON: `field_mel_operational_product` (sanitized; vendors cannot submit forbidden keys).
+
+## Extra type → Commerce bundle
+
+| UI type | Productisation type | Commerce product bundle |
+|---------|---------------------|-------------------------|
+| Merchandise | `merchandise` | `operational_merchandise` |
+| Food & drink | `timed_collection` | `timed_collection_product` |
+| Pickup item | `timed_collection` | `timed_collection_product` |
+| VIP / hospitality | `hospitality_package` | `hospitality_package` |
+| Bundle / package | `operational_bundle` | `operational_bundle` |
+
+## Navigation
+
+- Sidebar: **Extras** (unified), **Collection** (formerly Fulfilment label only).
+- **Merchandise** and **Add-ons** hidden from navigation; old routes redirect.
+
+## Admin
+
+Users with `administer commerce_product` see **Advanced Commerce edit** on the extra editor only.
+
+## QA checklist
+
+See task spec: vendor create T-shirt with sizes → booking page → cart → checkout → tickets/order → cross-vendor denial.
+
+## Non-goals
+
+- Fulfilment execution, scanners, inventory decrement
+- Shipping / warehouse orchestration
+- Replacing Commerce checkout or cart APIs
+- Removing admin Commerce product edit globally
+
+## Related docs
+
+- [event-extras-studio-audit.md](event-extras-studio-audit.md) — Phase 0 audit
+- [vendor-productisation-studio.md](vendor-productisation-studio.md) — legacy productisation studio (still available at merchandise route redirect target)

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
@@ -1,0 +1,139 @@
+/**
+ * Unified Event Extras Studio (vendor).
+ */
+
+.mel-event-extras-studio {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mel-event-extras-studio__probe {
+  margin-top: 0.5rem;
+}
+
+.mel-event-extra-choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.mel-event-extra-choice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  font-weight: 600;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-extra-choice {
+    transition: none;
+  }
+}
+
+.mel-event-extra-choice:hover,
+.mel-event-extra-choice:focus-visible {
+  border-color: var(--mel-accent, #7c6cf0);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mel-accent, #7c6cf0) 25%, transparent);
+  outline: none;
+}
+
+.mel-event-extras-studio__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mel-event-extra-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mel-event-extra-card__inner {
+  display: grid;
+  grid-template-columns: 7.5rem 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.mel-event-extra-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .mel-event-extra-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mel-event-extra-card__media img,
+.mel-event-extra-card__placeholder {
+  width: 7.5rem;
+  height: 7.5rem;
+  object-fit: cover;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-muted, #f4f1fa);
+}
+
+.mel-event-extra-size-chip {
+  display: inline-block;
+  margin: 0 0.25rem 0.25rem 0;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  background: var(--mel-surface-muted, #f4f1fa);
+}
+
+.mel-event-extra-actions .button {
+  min-height: 2.75rem;
+}
+
+.mel-event-extra-editor .form-actions .button {
+  min-height: 2.75rem;
+}
+
+.mel-event-extras-studio__footer-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.mel-event-extra-preview {
+  margin-top: 1rem;
+}
+
+.mel-event-extra-preview__card {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-extra-preview__image {
+  width: 6rem;
+  height: 6rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.mel-event-extras-studio__admin-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -25,6 +25,14 @@ mel_operational_capability_studio:
     - core/drupal
     - core/once
 
+mel_event_extras_studio:
+  version: 1.0
+  css:
+    theme:
+      css/mel-event-extras-studio.css: {}
+  dependencies:
+    - core/drupal
+
 mel_vendor_productisation_studio:
   version: 1.0
   css:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -126,6 +126,25 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-productisation',
     ],
+    'mel_event_studio_extras_list' => [
+      'variables' => [
+        'cards' => [],
+        'empty' => FALSE,
+      ],
+      'template' => 'mel-event-studio-extras-list',
+    ],
+    'mel_event_studio_extra_card' => [
+      'variables' => [
+        'card' => [],
+      ],
+      'template' => 'mel-event-studio-extra-card',
+    ],
+    'mel_event_studio_extra_preview' => [
+      'variables' => [
+        'preview' => [],
+      ],
+      'template' => 'mel-event-studio-extra-preview',
+    ],
     'mel_customer_operational_experience' => [
       'variables' => [
         'experience' => [],
@@ -230,6 +249,7 @@ function _myeventlane_event_studio_is_event_studio_route(?string $route_name = N
     'myeventlane_event_studio.workspace_tickets',
     'myeventlane_event_studio.workspace_questions',
     'myeventlane_event_studio.workspace_capacity',
+    'myeventlane_event_studio.workspace_extras',
     'myeventlane_event_studio.workspace_merchandise',
     'myeventlane_event_studio.workspace_addons',
     'myeventlane_event_studio.workspace_promotions',

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -119,12 +119,24 @@ myeventlane_event_studio.workspace_capacity:
       node:
         type: entity:node
 
-myeventlane_event_studio.workspace_merchandise:
-  path: '/vendor/events/{node}/studio/merchandise'
+myeventlane_event_studio.workspace_extras:
+  path: '/vendor/events/{node}/studio/extras'
   defaults:
     _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
     _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
-    section: 'merchandise'
+    section: 'extras'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_merchandise:
+  path: '/vendor/events/{node}/studio/merchandise'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::redirectToExtrasWorkspace'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+
@@ -136,9 +148,7 @@ myeventlane_event_studio.workspace_merchandise:
 myeventlane_event_studio.workspace_addons:
   path: '/vendor/events/{node}/studio/addons'
   defaults:
-    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
-    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
-    section: 'addons'
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::redirectToExtrasWorkspace'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+
@@ -150,9 +160,7 @@ myeventlane_event_studio.workspace_addons:
 myeventlane_event_studio.workspace_add_ons:
   path: '/vendor/events/{node}/studio/add-ons'
   defaults:
-    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
-    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
-    section: 'addons'
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::redirectToExtrasWorkspace'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -222,6 +222,15 @@ services:
       - '@string_translation'
       - '@logger.channel.myeventlane_event_studio'
 
+  myeventlane_event_studio.event_extras_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@myeventlane_commerce.operational_extra_visual_presenter'
+      - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@string_translation'
+
   myeventlane_event_studio.vendor_productisation_studio_builder:
     class: Drupal\myeventlane_event_studio\Service\VendorProductisationStudioBuilder
     arguments:

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -120,6 +120,26 @@ final class EventStudioController extends ControllerBase {
   }
 
   /**
+   * Preserves bookmarked merchandise / add-ons URLs while routing to unified Extras.
+   */
+  public function redirectToExtrasWorkspace(NodeInterface $node): RedirectResponse {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    $account = $this->currentUser();
+    if (!$account->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+      throw new AccessDeniedHttpException();
+    }
+    $request = $this->requestStack->getCurrentRequest();
+    $options = [];
+    if ($request !== NULL && $request->query->count() > 0) {
+      $options['query'] = $request->query->all();
+    }
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $node->id()], $options)->toString());
+  }
+
+  /**
    * Builds the canonical operational Event Studio shell.
    *
    * @return array<string, mixed>

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -18,7 +18,6 @@ use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -34,7 +33,6 @@ final class EventStudioEventExtrasForm extends FormBase {
     private readonly EventStudioEventExtrasBuilder $extrasBuilder,
     private readonly AccountProxyInterface $currentUser,
     private readonly LoggerInterface $logger,
-    private readonly RequestStack $requestStack,
   ) {}
 
   public static function create(ContainerInterface $container): static {
@@ -45,7 +43,6 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('myeventlane_event_studio.event_extras_builder'),
       $container->get('current_user'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
-      $container->get('request_stack'),
     );
   }
 
@@ -57,7 +54,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     $event = $this->getRouteEvent($node);
     $this->assertCanManageEvent($event);
 
-    $request = $this->requestStack->getCurrentRequest();
+    $request = $this->getRequest();
     $edit_id = (int) ($request?->query->get('extra') ?? 0);
     $add_type = (string) ($request?->query->get('add') ?? '');
     $action = (string) ($form_state->get('mel_extras_mode') ?? '');

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -1,0 +1,596 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
+use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Unified vendor Event Extras editor (Commerce-backed, vendor-language UI).
+ */
+final class EventStudioEventExtrasForm extends FormBase {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly VendorOperationalProductCreationManager $productCreationManager,
+    private readonly EventStudioEventExtrasBuilder $extrasBuilder,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly LoggerInterface $logger,
+    private readonly RequestStack $requestStack,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
+      $container->get('myeventlane_event_studio.event_extras_builder'),
+      $container->get('current_user'),
+      $container->get('logger.factory')->get('myeventlane_event_studio'),
+      $container->get('request_stack'),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_event_extras';
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    $event = $this->getRouteEvent($node);
+    $this->assertCanManageEvent($event);
+
+    $request = $this->requestStack->getCurrentRequest();
+    $edit_id = (int) ($request?->query->get('extra') ?? 0);
+    $add_type = (string) ($request?->query->get('add') ?? '');
+    $action = (string) ($form_state->get('mel_extras_mode') ?? '');
+    if ($action === '') {
+      if ($edit_id > 0) {
+        $action = 'edit';
+      }
+      elseif ($add_type !== '') {
+        $action = 'add';
+        $form_state->set('mel_extras_extra_type', $add_type);
+      }
+      else {
+        $action = 'list';
+      }
+      $form_state->set('mel_extras_mode', $action);
+    }
+
+    $form['#attributes']['class'][] = 'mel-event-extras-studio';
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_extras_studio';
+
+    $form['event_id'] = [
+      '#type' => 'hidden',
+      '#value' => (string) $event->id(),
+    ];
+
+    $form['intro'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-event-extras-studio__intro']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h2',
+        '#value' => $this->t('Event extras'),
+        '#attributes' => ['class' => ['mel-es-card__title']],
+      ],
+      'copy' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Offer merch, food vouchers, VIP packages, or pickup items guests can add when booking.'),
+        '#attributes' => ['class' => ['mel-es-card__hint']],
+      ],
+    ];
+
+    $mode = (string) $form_state->get('mel_extras_mode');
+    if ($mode === 'edit' || $mode === 'add') {
+      $form['editor'] = $this->buildEditor($form_state, $event, $mode, $edit_id);
+    }
+    else {
+      $form['list'] = $this->buildList($event);
+      $form['probe'] = $this->buildProbe($event);
+    }
+
+    $form['footer_cta'] = $this->buildFooterCta($event);
+
+    return $form;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildList(NodeInterface $event): array {
+    $cards = $this->extrasBuilder->loadExtrasForEvent($event);
+    $list = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extras-studio__list']],
+    ];
+    if ($cards === []) {
+      $list['empty'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No extras yet. Choose a type below to add your first one.'),
+        '#attributes' => ['class' => ['mel-event-extras-studio__empty', 'mel-text--muted']],
+      ];
+      return $list;
+    }
+    foreach ($cards as $card) {
+      $pid = (int) ($card['product_id'] ?? 0);
+      if ($pid < 1) {
+        continue;
+      }
+      $show = !empty($card['show_on_booking']);
+      $list['card_' . $pid] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-card', 'mel-es-card']],
+        'content' => [
+          '#theme' => 'mel_event_studio_extra_card',
+          '#card' => $card,
+        ],
+        'actions' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-extra-actions']],
+          'edit' => [
+            '#type' => 'link',
+            '#title' => $this->t('Edit'),
+            '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+              'query' => ['extra' => $pid],
+            ]),
+            '#attributes' => ['class' => ['button', 'mel-event-extra-card__edit']],
+          ],
+          'toggle_' . $pid => [
+            '#type' => 'submit',
+            '#value' => $show ? $this->t('Hide from booking') : $this->t('Show on booking'),
+            '#name' => 'toggle_' . $pid,
+            '#submit' => ['::submitToggleVisibility'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-event-extra-card__toggle', 'button']],
+            '#product_id' => $pid,
+          ],
+        ],
+      ];
+    }
+    return $list;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildProbe(NodeInterface $event): array {
+    $choices = $this->extrasBuilder->extraTypeChoices();
+    $items = [];
+    foreach ($choices as $key => $label) {
+      $items[$key] = [
+        '#type' => 'link',
+        '#title' => $label,
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+          'query' => ['add' => $key],
+        ]),
+        '#attributes' => [
+          'class' => ['mel-event-extra-choice', 'mel-event-extra-choice--' . $key],
+        ],
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extras-studio__probe', 'mel-es-card']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('What would you like to offer?'),
+        '#attributes' => ['class' => ['mel-es-card__title']],
+      ],
+      'choices' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-choices']],
+        '#children' => $items,
+      ],
+      'none' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No extras yet? You can skip this and add them later.'),
+        '#attributes' => ['class' => ['mel-text--muted']],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildEditor(FormStateInterface $form_state, NodeInterface $event, string $mode, int $edit_id): array {
+    $product = NULL;
+    $defaults = [
+      'extra_type' => (string) ($form_state->get('mel_extras_extra_type') ?? ''),
+      'title' => '',
+      'customer_summary' => '',
+      'pickup_note' => '',
+      'price_amount' => '',
+      'show_on_booking' => 1,
+      'sizes' => [],
+    ];
+    if ($mode === 'edit' && $edit_id > 0) {
+      $product = $this->productCreationManager->assertVendorCanManageProduct($this->currentUser(), $event, $edit_id);
+      $defaults = $this->defaultsFromProduct($product);
+    }
+
+    $editor = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extra-editor', 'mel-es-card']],
+      'back' => [
+        '#type' => 'link',
+        '#title' => $this->t('← All extras'),
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]),
+        '#attributes' => ['class' => ['mel-event-extras-studio__back']],
+      ],
+      'product_id' => [
+        '#type' => 'hidden',
+        '#value' => $product instanceof ProductInterface ? (string) $product->id() : '',
+      ],
+    ];
+
+    if ($product === NULL) {
+      $editor['extra_type'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Extra type'),
+        '#options' => $this->extrasBuilder->extraTypeChoices(),
+        '#default_value' => $defaults['extra_type'] !== '' ? $defaults['extra_type'] : 'merchandise',
+        '#required' => TRUE,
+        '#attributes' => ['class' => ['mel-event-extra-type-radios']],
+      ];
+    }
+
+    $editor['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Extra name'),
+      '#default_value' => $defaults['title'],
+      '#required' => TRUE,
+      '#maxlength' => 255,
+    ];
+    $editor['customer_summary'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Short customer description'),
+      '#default_value' => $defaults['customer_summary'],
+      '#required' => TRUE,
+      '#rows' => 3,
+    ];
+    $editor['pickup_note'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Pickup / venue collection note'),
+      '#default_value' => $defaults['pickup_note'],
+      '#rows' => 2,
+      '#description' => $this->t('E.g. “Collect at the merch desk after check-in.”'),
+    ];
+    $editor['price_amount'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Price'),
+      '#default_value' => $defaults['price_amount'],
+      '#required' => TRUE,
+      '#min' => 0,
+      '#step' => 0.01,
+    ];
+    $editor['sizes'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Sizes (merchandise)'),
+      '#options' => OperationalExtraVisualPresenter::SIZE_LABELS,
+      '#default_value' => $defaults['sizes'],
+      '#description' => $this->t('Creates one purchasable option per size. Leave empty for a single option.'),
+    ];
+    $editor['show_on_booking'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show on booking page'),
+      '#default_value' => (bool) $defaults['show_on_booking'],
+    ];
+
+    if ($product instanceof ProductInterface) {
+      $editor += $this->buildImagesWidget($product, $form_state);
+      $editor['preview'] = [
+        '#theme' => 'mel_event_studio_extra_preview',
+        '#preview' => $this->extrasBuilder->buildPreviewRow($product, $event),
+      ];
+    }
+    else {
+      $editor['images_notice'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('You can add photos after saving this extra.'),
+        '#attributes' => ['class' => ['mel-text--muted']],
+      ];
+    }
+
+    if ($this->currentUser()->hasPermission('administer commerce_product')) {
+      $pid = $product instanceof ProductInterface ? (int) $product->id() : 0;
+      if ($pid > 0) {
+        $editor['admin_commerce'] = [
+          '#type' => 'link',
+          '#title' => $this->t('Advanced Commerce edit'),
+          '#url' => Url::fromRoute('entity.commerce_product.edit_form', ['commerce_product' => $pid]),
+          '#attributes' => [
+            'class' => ['mel-event-extras-studio__admin-link'],
+            'target' => '_blank',
+            'rel' => 'noopener noreferrer',
+          ],
+        ];
+      }
+    }
+
+    $editor['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Save extra'),
+        '#button_type' => 'primary',
+      ],
+      'add_another' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Save and add another'),
+        '#submit' => ['::submitAddAnother'],
+      ],
+    ];
+
+    return $editor;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildImagesWidget(ProductInterface $product, FormStateInterface $form_state): array {
+    $display_id = 'commerce_product.' . $product->bundle() . '.default';
+    $form_display = EntityFormDisplay::load($display_id);
+    if ($form_display === NULL || !$product->hasField('field_mel_extra_images')) {
+      return [];
+    }
+    $widget = $form_display->getRenderer('field_mel_extra_images');
+    if ($widget === NULL) {
+      return [];
+    }
+    $element = $widget->form($product->get('field_mel_extra_images'), [], $form_state);
+    $element['#title'] = $this->t('Images');
+    $element['#attributes']['class'][] = 'mel-event-extra-gallery';
+    return ['images' => $element];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildFooterCta(NodeInterface $event): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extras-studio__footer-cta']],
+      'preview_booking' => [
+        '#type' => 'link',
+        '#title' => $this->t('Preview booking page'),
+        '#url' => Url::fromRoute('entity.node.canonical', ['node' => $event->id()]),
+        '#attributes' => ['class' => ['button', 'mel-event-extras-studio__cta']],
+      ],
+      'publish' => [
+        '#type' => 'link',
+        '#title' => $this->t('Continue to publish'),
+        '#url' => Url::fromRoute('myeventlane_event_studio.edit_publish', ['node' => $event->id()]),
+        '#attributes' => ['class' => ['button', 'button--primary', 'mel-event-extras-studio__cta']],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function defaultsFromProduct(ProductInterface $product): array {
+    $sizes = [];
+    foreach ($product->getVariations() as $variation) {
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty() && $variation->isPublished()) {
+        $key = strtolower((string) $variation->get('field_mel_size')->value);
+        $sizes[$key] = $key;
+      }
+    }
+    $price = '';
+    foreach ($product->getVariations() as $variation) {
+      if ($variation->isPublished() && $variation->getPrice() !== NULL) {
+        $price = $variation->getPrice()->getNumber();
+        break;
+      }
+    }
+    $short = $product->hasField('field_mel_extra_short_desc') && !$product->get('field_mel_extra_short_desc')->isEmpty()
+      ? (string) $product->get('field_mel_extra_short_desc')->value
+      : '';
+    $pickup = $product->hasField('field_mel_extra_pickup_note') && !$product->get('field_mel_extra_pickup_note')->isEmpty()
+      ? (string) $product->get('field_mel_extra_pickup_note')->value
+      : '';
+    return [
+      'extra_type' => '',
+      'title' => $product->label(),
+      'customer_summary' => $short,
+      'pickup_note' => $pickup,
+      'price_amount' => $price,
+      'show_on_booking' => $product->isPublished() ? 1 : 0,
+      'sizes' => $sizes,
+    ];
+  }
+
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $form_state->setErrorByName('', $this->t('The event could not be loaded.'));
+      return;
+    }
+    $trigger = $form_state->getTriggeringElement();
+    if (!is_array($trigger)) {
+      return;
+    }
+    if (str_starts_with((string) ($trigger['#name'] ?? ''), 'toggle_')) {
+      return;
+    }
+    if (($trigger['#type'] ?? '') !== 'submit') {
+      return;
+    }
+    $input = $this->collectInput($form_state);
+    foreach ($this->productCreationManager->validateEventExtraInput($this->currentUser(), $event, $input) as $error) {
+      $form_state->setErrorByName('', $error);
+    }
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->saveExtra($form_state, FALSE);
+  }
+
+  public function submitAddAnother(array &$form, FormStateInterface $form_state): void {
+    $this->saveExtra($form_state, TRUE);
+  }
+
+  public function submitToggleVisibility(array &$form, FormStateInterface $form_state): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      return;
+    }
+    $trigger = $form_state->getTriggeringElement();
+    $pid = (int) ($trigger['#product_id'] ?? 0);
+    if ($pid < 1) {
+      return;
+    }
+    try {
+      $product = $this->productCreationManager->assertVendorCanManageProduct($this->currentUser(), $event, $pid);
+      $show = !$product->isPublished();
+      $product->setPublished($show);
+      $product->save();
+      $this->messenger()->addStatus($show
+        ? $this->t('“@title” is now shown on the booking page.', ['@title' => $product->label()])
+        : $this->t('“@title” is hidden from the booking page.', ['@title' => $product->label()]));
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->messenger()->addError($e->getMessage());
+    }
+    $form_state->setRedirect('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]);
+  }
+
+  private function saveExtra(FormStateInterface $form_state, bool $add_another): void {
+    $event = $this->loadSubmittedEvent($form_state);
+    if (!$event instanceof NodeInterface) {
+      $this->messenger()->addError($this->t('The event could not be loaded.'));
+      return;
+    }
+    try {
+      $input = $this->collectInput($form_state);
+      $product = $this->productCreationManager->saveEventExtraForVendor($this->currentUser(), $event, $input);
+      $this->messenger()->addStatus($this->t('Your extra “@title” is saved. Guests can add it when booking.', [
+        '@title' => $product->label(),
+      ]));
+      if ($add_another) {
+        $form_state->setRedirect('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+          'query' => ['add' => 'merchandise'],
+        ]);
+        return;
+      }
+      $form_state->setRedirect('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+        'query' => ['extra' => (int) $product->id()],
+      ]);
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->messenger()->addError($e->getMessage());
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event extra save failed for event @nid: @message', [
+        '@nid' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('Could not save this extra.'));
+    }
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function collectInput(FormStateInterface $form_state): array {
+    $sizes = [];
+    foreach ((array) ($form_state->getValue('sizes') ?? []) as $key => $on) {
+      if (!empty($on)) {
+        $sizes[] = (string) $key;
+      }
+    }
+    $image_media_ids = $this->extractImageMediaIds($form_state);
+    return [
+      'product_id' => (int) ($form_state->getValue('product_id') ?? 0),
+      'extra_type' => (string) ($form_state->getValue('extra_type') ?? ''),
+      'title' => (string) ($form_state->getValue('title') ?? ''),
+      'customer_summary' => (string) ($form_state->getValue('customer_summary') ?? ''),
+      'pickup_note' => (string) ($form_state->getValue('pickup_note') ?? ''),
+      'price_amount' => $form_state->getValue('price_amount'),
+      'sizes' => $sizes,
+      'show_on_booking' => !empty($form_state->getValue('show_on_booking')),
+      'image_media_ids' => $image_media_ids,
+    ];
+  }
+
+  private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {
+    if ($node instanceof NodeInterface) {
+      return $node;
+    }
+    $route_node = $this->getRouteMatch()->getParameter('node');
+    if ($route_node instanceof NodeInterface) {
+      return $route_node;
+    }
+    throw new NotFoundHttpException();
+  }
+
+  private function assertCanManageEvent(NodeInterface $event): void {
+    if ($event->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    if (!$this->currentUser->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $this->currentUser())) {
+      throw new AccessDeniedHttpException();
+    }
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function extractImageMediaIds(FormStateInterface $form_state): array {
+    $images_value = $form_state->getValue('images');
+    $ids = [];
+    if (!is_array($images_value)) {
+      return $ids;
+    }
+    $walker = function (mixed $value) use (&$walker, &$ids): void {
+      if (is_array($value)) {
+        if (isset($value['target_id']) && is_numeric($value['target_id'])) {
+          $id = (int) $value['target_id'];
+          if ($id > 0) {
+            $ids[$id] = $id;
+          }
+        }
+        foreach ($value as $child) {
+          $walker($child);
+        }
+      }
+    };
+    $walker($images_value);
+    return array_values($ids);
+  }
+
+  private function loadSubmittedEvent(FormStateInterface $form_state): ?NodeInterface {
+    $event_id = (int) ($form_state->getValue('event_id') ?? 0);
+    if ($event_id < 1) {
+      return NULL;
+    }
+    $event = $this->entityTypeManager->getStorage('node')->load($event_id);
+    return $event instanceof NodeInterface && $event->bundle() === 'event' ? $event : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -9,7 +9,6 @@ use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
@@ -26,14 +25,34 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class EventStudioEventExtrasForm extends FormBase {
 
+  /**
+   * Protected (not private readonly) so form cache unserialization can restore services.
+   *
+   * @see EventStudioOperationalTicketsForm::ensureInjectedServices()
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  protected EventVendorAccessChecker $eventVendorAccessChecker;
+
+  protected VendorOperationalProductCreationManager $productCreationManager;
+
+  protected EventStudioEventExtrasBuilder $extrasBuilder;
+
+  protected LoggerInterface $logger;
+
   public function __construct(
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly EventVendorAccessChecker $eventVendorAccessChecker,
-    private readonly VendorOperationalProductCreationManager $productCreationManager,
-    private readonly EventStudioEventExtrasBuilder $extrasBuilder,
-    private readonly AccountProxyInterface $currentUser,
-    private readonly LoggerInterface $logger,
-  ) {}
+    EntityTypeManagerInterface $entity_type_manager,
+    EventVendorAccessChecker $event_vendor_access_checker,
+    VendorOperationalProductCreationManager $product_creation_manager,
+    EventStudioEventExtrasBuilder $extras_builder,
+    LoggerInterface $logger,
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->eventVendorAccessChecker = $event_vendor_access_checker;
+    $this->productCreationManager = $product_creation_manager;
+    $this->extrasBuilder = $extras_builder;
+    $this->logger = $logger;
+  }
 
   public static function create(ContainerInterface $container): static {
     return new static(
@@ -41,9 +60,41 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
       $container->get('myeventlane_event_studio.event_extras_builder'),
-      $container->get('current_user'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __wakeup(): void {
+    parent::__wakeup();
+    $this->ensureInjectedServices();
+  }
+
+  /**
+   * Ensures services are present after form cache unserialization.
+   */
+  private function ensureInjectedServices(): void {
+    if (isset($this->entityTypeManager, $this->eventVendorAccessChecker, $this->productCreationManager, $this->extrasBuilder, $this->logger)) {
+      return;
+    }
+    $container = \Drupal::getContainer();
+    if (!isset($this->entityTypeManager)) {
+      $this->entityTypeManager = $container->get('entity_type.manager');
+    }
+    if (!isset($this->eventVendorAccessChecker)) {
+      $this->eventVendorAccessChecker = $container->get('myeventlane_vendor.event_access_checker');
+    }
+    if (!isset($this->productCreationManager)) {
+      $this->productCreationManager = $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager');
+    }
+    if (!isset($this->extrasBuilder)) {
+      $this->extrasBuilder = $container->get('myeventlane_event_studio.event_extras_builder');
+    }
+    if (!isset($this->logger)) {
+      $this->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
+    }
   }
 
   public function getFormId(): string {
@@ -51,6 +102,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   }
 
   public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    $this->ensureInjectedServices();
     $event = $this->getRouteEvent($node);
     $this->assertCanManageEvent($event);
 
@@ -439,6 +491,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   }
 
   public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $this->ensureInjectedServices();
     $event = $this->loadSubmittedEvent($form_state);
     if (!$event instanceof NodeInterface) {
       $form_state->setErrorByName('', $this->t('The event could not be loaded.'));
@@ -469,6 +522,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   }
 
   public function submitToggleVisibility(array &$form, FormStateInterface $form_state): void {
+    $this->ensureInjectedServices();
     $event = $this->loadSubmittedEvent($form_state);
     if (!$event instanceof NodeInterface) {
       return;
@@ -494,6 +548,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   }
 
   private function saveExtra(FormStateInterface $form_state, bool $add_another): void {
+    $this->ensureInjectedServices();
     $event = $this->loadSubmittedEvent($form_state);
     if (!$event instanceof NodeInterface) {
       $this->messenger()->addError($this->t('The event could not be loaded.'));
@@ -581,8 +636,9 @@ final class EventStudioEventExtrasForm extends FormBase {
     if ($event->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
-    if (!$this->currentUser->hasPermission('administer nodes')
-      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $this->currentUser())) {
+    $account = $this->currentUser();
+    if (!$account->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
       throw new AccessDeniedHttpException();
     }
   }
@@ -601,9 +657,6 @@ final class EventStudioEventExtrasForm extends FormBase {
     $product->save();
   }
 
-  /**
-   * @return list<int>
-   */
   /**
    * @param string|list<string> $key
    *

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -99,7 +99,7 @@ final class EventStudioEventExtrasForm extends FormBase {
 
     $mode = (string) $form_state->get('mel_extras_mode');
     if ($mode === 'edit' || $mode === 'add') {
-      $form['editor'] = $this->buildEditor($form_state, $event, $mode, $edit_id);
+      $form['editor'] = $this->buildEditor($form, $form_state, $event, $mode, $edit_id);
     }
     else {
       $form['list'] = $this->buildList($event);
@@ -212,7 +212,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   /**
    * @return array<string, mixed>
    */
-  private function buildEditor(FormStateInterface $form_state, NodeInterface $event, string $mode, int $edit_id): array {
+  private function buildEditor(array &$form, FormStateInterface $form_state, NodeInterface $event, string $mode, int $edit_id): array {
     $product = NULL;
     $defaults = [
       'extra_type' => (string) ($form_state->get('mel_extras_extra_type') ?? ''),
@@ -230,6 +230,8 @@ final class EventStudioEventExtrasForm extends FormBase {
 
     $editor = [
       '#type' => 'container',
+      '#tree' => TRUE,
+      '#parents' => ['editor'],
       '#attributes' => ['class' => ['mel-event-extra-editor', 'mel-es-card']],
       'back' => [
         '#type' => 'link',
@@ -297,7 +299,6 @@ final class EventStudioEventExtrasForm extends FormBase {
     ];
 
     if ($product instanceof ProductInterface) {
-      $editor += $this->buildImagesWidget($product, $form_state);
       $editor['preview'] = [
         '#theme' => 'mel_event_studio_extra_preview',
         '#preview' => $this->extrasBuilder->buildPreviewRow($product, $event),
@@ -342,26 +343,42 @@ final class EventStudioEventExtrasForm extends FormBase {
       ],
     ];
 
+    if ($product instanceof ProductInterface) {
+      $this->attachImagesWidget($product, $form, $editor, $form_state);
+    }
+
     return $editor;
   }
 
   /**
-   * @return array<string, mixed>
+   * Attaches the Commerce media_library widget (EntityFormDisplay pattern).
    */
-  private function buildImagesWidget(ProductInterface $product, FormStateInterface $form_state): array {
+  private function attachImagesWidget(ProductInterface $product, array &$form, array &$editor, FormStateInterface $form_state): void {
     $display_id = 'commerce_product.' . $product->bundle() . '.default';
     $form_display = EntityFormDisplay::load($display_id);
     if ($form_display === NULL || !$product->hasField('field_mel_extra_images')) {
-      return [];
+      return;
     }
     $widget = $form_display->getRenderer('field_mel_extra_images');
     if ($widget === NULL) {
-      return [];
+      return;
     }
-    $element = $widget->form($product->get('field_mel_extra_images'), [], $form_state);
-    $element['#title'] = $this->t('Images');
-    $element['#attributes']['class'][] = 'mel-event-extra-gallery';
-    return ['images' => $element];
+    if (!isset($form['#parents'])) {
+      $form['#parents'] = [];
+    }
+    if (!isset($editor['#parents'])) {
+      $editor['#parents'] = ['editor'];
+    }
+    if (!isset($editor['#tree'])) {
+      $editor['#tree'] = TRUE;
+    }
+    $editor['field_mel_extra_images'] = $widget->form(
+      $product->get('field_mel_extra_images'),
+      $editor,
+      $form_state,
+    );
+    $editor['field_mel_extra_images']['#title'] = $this->t('Images');
+    $editor['field_mel_extra_images']['#attributes']['class'][] = 'mel-event-extra-gallery';
   }
 
   /**
@@ -485,6 +502,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     try {
       $input = $this->collectInput($form_state);
       $product = $this->productCreationManager->saveEventExtraForVendor($this->currentUser(), $event, $input);
+      $this->extractImagesOntoProduct($form_state, $product);
       $this->messenger()->addStatus($this->t('Your extra “@title” is saved. Guests can add it when booking.', [
         '@title' => $product->label(),
       ]));
@@ -515,23 +533,37 @@ final class EventStudioEventExtrasForm extends FormBase {
    */
   private function collectInput(FormStateInterface $form_state): array {
     $sizes = [];
-    foreach ((array) ($form_state->getValue('sizes') ?? []) as $key => $on) {
+    foreach ((array) ($this->editorValue($form_state, 'sizes') ?? []) as $key => $on) {
       if (!empty($on)) {
         $sizes[] = (string) $key;
       }
     }
-    $image_media_ids = $this->extractImageMediaIds($form_state);
+    $image_media_ids = $this->extractImageMediaIds($form_state, ['editor', 'field_mel_extra_images']);
+    if ($image_media_ids === []) {
+      $image_media_ids = $this->extractImageMediaIds($form_state, 'field_mel_extra_images');
+    }
     return [
-      'product_id' => (int) ($form_state->getValue('product_id') ?? 0),
-      'extra_type' => (string) ($form_state->getValue('extra_type') ?? ''),
-      'title' => (string) ($form_state->getValue('title') ?? ''),
-      'customer_summary' => (string) ($form_state->getValue('customer_summary') ?? ''),
-      'pickup_note' => (string) ($form_state->getValue('pickup_note') ?? ''),
-      'price_amount' => $form_state->getValue('price_amount'),
+      'product_id' => (int) ($this->editorValue($form_state, 'product_id') ?? 0),
+      'extra_type' => (string) ($this->editorValue($form_state, 'extra_type') ?? ''),
+      'title' => (string) ($this->editorValue($form_state, 'title') ?? ''),
+      'customer_summary' => (string) ($this->editorValue($form_state, 'customer_summary') ?? ''),
+      'pickup_note' => (string) ($this->editorValue($form_state, 'pickup_note') ?? ''),
+      'price_amount' => $this->editorValue($form_state, 'price_amount'),
       'sizes' => $sizes,
-      'show_on_booking' => !empty($form_state->getValue('show_on_booking')),
+      'show_on_booking' => !empty($this->editorValue($form_state, 'show_on_booking')),
       'image_media_ids' => $image_media_ids,
     ];
+  }
+
+  /**
+   * Reads a value from the editor subtree (#tree + #parents).
+   */
+  private function editorValue(FormStateInterface $form_state, string $key): mixed {
+    $editor = $form_state->getValue('editor');
+    if (is_array($editor) && array_key_exists($key, $editor)) {
+      return $editor[$key];
+    }
+    return $form_state->getValue($key);
   }
 
   private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {
@@ -555,11 +587,30 @@ final class EventStudioEventExtrasForm extends FormBase {
     }
   }
 
+  private function extractImagesOntoProduct(FormStateInterface $form_state, ProductInterface $product): void {
+    $display_id = 'commerce_product.' . $product->bundle() . '.default';
+    $form_display = EntityFormDisplay::load($display_id);
+    if ($form_display === NULL || !$product->hasField('field_mel_extra_images')) {
+      return;
+    }
+    $complete = $form_state->getCompleteForm();
+    if (!is_array($complete) || !isset($complete['editor']['field_mel_extra_images'])) {
+      return;
+    }
+    $form_display->extractFormValues($product, $complete['editor'], $form_state);
+    $product->save();
+  }
+
   /**
    * @return list<int>
    */
-  private function extractImageMediaIds(FormStateInterface $form_state): array {
-    $images_value = $form_state->getValue('images');
+  /**
+   * @param string|list<string> $key
+   *
+   * @return list<int>
+   */
+  private function extractImageMediaIds(FormStateInterface $form_state, string|array $key = 'field_mel_extra_images'): array {
+    $images_value = $form_state->getValue($key);
     $ids = [];
     if (!is_array($images_value)) {
       return $ids;

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AddonsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AddonsSection.php
@@ -24,5 +24,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'deferred',
   mobile_priority: 170,
   operationalArea: 'commerce_product',
+  navigationVisible: FALSE,
 )]
 final class AddonsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Unified Event Extras authoring section.
+ */
+#[EventStudioSection(
+  id: 'extras',
+  title: 'Extras',
+  group: 'Commerce',
+  routeName: 'myeventlane_event_studio.workspace_extras',
+  section_state: 'active',
+  weight: 125,
+  icon: 'extras',
+  renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventStudioEventExtrasForm',
+  writable: TRUE,
+  supports_autosave: FALSE,
+  readiness_participant: FALSE,
+  empty_state_type: 'none',
+  mobile_priority: 155,
+  operationalArea: 'commerce_product',
+)]
+final class ExtrasSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
@@ -11,7 +11,7 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
  */
 #[EventStudioSection(
   id: 'fulfilment',
-  title: 'Fulfilment',
+  title: 'Collection',
   group: 'Operations',
   routeName: 'myeventlane_event_studio.workspace_fulfilment',
   section_state: 'active',

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MerchandiseSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MerchandiseSection.php
@@ -24,5 +24,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 160,
   operationalArea: 'commerce_product',
+  navigationVisible: FALSE,
 )]
 final class MerchandiseSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\node\NodeInterface;
+
+/**
+ * Presentation builder for the unified Event Extras Studio editor.
+ */
+final class EventStudioEventExtrasBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly OperationalExtraVisualPresenter $visualPresenter,
+    private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function loadExtrasForEvent(NodeInterface $event): array {
+    $storage = $this->entityTypeManager->getStorage('commerce_product');
+    $ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, 'IN')
+      ->condition('field_event', (int) $event->id())
+      ->sort('title', 'ASC')
+      ->execute();
+    if ($ids === []) {
+      return [];
+    }
+    $cards = [];
+    foreach ($storage->loadMultiple($ids) as $product) {
+      if ($product instanceof ProductInterface) {
+        $cards[] = $this->buildExtraCard($product, $event);
+      }
+    }
+    return $cards;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildExtraCard(ProductInterface $product, NodeInterface $event): array {
+    $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+    $visual = $this->visualPresenter->buildProductVisualDocument($product, $presentation);
+    $sizes = $this->summarizeSizes($product);
+    $price_label = $this->formatPriceRange($product);
+
+    return [
+      'product_id' => (int) $product->id(),
+      'title' => $product->label(),
+      'short_description' => (string) ($visual['short_description'] ?? ''),
+      'pickup_note' => (string) ($visual['pickup_note'] ?? ''),
+      'primary_image' => $visual['primary_image'] ?? [],
+      'sizes_summary' => $sizes,
+      'price_label' => $price_label,
+      'show_on_booking' => $product->isPublished(),
+      'bundle' => $product->bundle(),
+      'edit_url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', [
+        'node' => $event->id(),
+      ], [
+        'query' => ['extra' => (int) $product->id()],
+      ])->toString(),
+      'preview' => $this->buildPreviewRow($product, $event),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildPreviewRow(ProductInterface $product, NodeInterface $event): array {
+    $built = $this->eventOperationalAddonBuilder->buildForEvent($event);
+    foreach ($built['addons'] as $addon) {
+      if ((int) ($addon['product_id'] ?? 0) === (int) $product->id()) {
+        return $addon;
+      }
+    }
+    $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $presentation = $this->operationalMerchandiseManager->buildCustomerSafeProductPresentation($payload);
+    $visual = $this->visualPresenter->buildProductVisualDocument($product, $presentation);
+    return [
+      'product_id' => (int) $product->id(),
+      'title' => $product->label(),
+      'short_description' => (string) ($visual['short_description'] ?? ''),
+      'pickup_note' => (string) ($visual['pickup_note'] ?? ''),
+      'primary_image' => $visual['primary_image'] ?? [],
+      'variations' => [],
+    ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function extraTypeChoices(): array {
+    return [
+      'merchandise' => (string) $this->t('Merchandise'),
+      'food_drink' => (string) $this->t('Food & drink'),
+      'vip_hospitality' => (string) $this->t('VIP / hospitality'),
+      'pickup_item' => (string) $this->t('Pickup item'),
+      'bundle' => (string) $this->t('Bundle / package'),
+    ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function summarizeSizes(ProductInterface $product): array {
+    $out = [];
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        continue;
+      }
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+        $key = strtolower((string) $variation->get('field_mel_size')->value);
+        $out[] = OperationalExtraVisualPresenter::SIZE_LABELS[$key] ?? strtoupper($key);
+      }
+    }
+    return array_values(array_unique($out));
+  }
+
+  private function formatPriceRange(ProductInterface $product): string {
+    $amounts = [];
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        continue;
+      }
+      $price = $variation->getPrice();
+      if ($price !== NULL) {
+        $amounts[] = (float) $price->getNumber();
+      }
+    }
+    if ($amounts === []) {
+      return '';
+    }
+    $min = min($amounts);
+    $max = max($amounts);
+    $currency = '';
+    foreach ($product->getVariations() as $variation) {
+      if ($variation instanceof ProductVariationInterface && $variation->getPrice() !== NULL) {
+        $currency = $variation->getPrice()->getCurrencyCode();
+        break;
+      }
+    }
+    $symbol = $currency !== '' ? $currency . ' ' : '';
+    if ($min === $max) {
+      return $symbol . number_format($min, 2);
+    }
+    return $symbol . number_format($min, 2) . ' – ' . number_format($max, 2);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -8,6 +8,7 @@ use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\Product as CommerceProduct;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -29,6 +30,30 @@ final class VendorOperationalProductCreationManager {
   /**
    * @var list<string>
    */
+  /**
+   * Vendor-facing extra type keys (UI) mapped internally to productisation types.
+   *
+   * @var array<string, string>
+   */
+  public const VENDOR_EXTRA_TYPE_MAP = [
+    'merchandise' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+    'food_drink' => VendorProductisationStudioManager::TYPE_TIMED_COLLECTION,
+    'vip_hospitality' => VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+    'pickup_item' => VendorProductisationStudioManager::TYPE_TIMED_COLLECTION,
+    'bundle' => VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE,
+  ];
+
+  /**
+   * @var list<string>
+   */
+  public const VENDOR_EXTRA_TYPE_KEYS = [
+    'merchandise',
+    'food_drink',
+    'vip_hospitality',
+    'pickup_item',
+    'bundle',
+  ];
+
   public const FORBIDDEN_CREATION_KEYS = [
     'inventory_quantity',
     'stock_count',
@@ -115,6 +140,181 @@ final class VendorOperationalProductCreationManager {
    *
    * @throws \InvalidArgumentException
    */
+  /**
+   * Creates or updates an event extra Commerce product for a vendor (explicit save only).
+   *
+   * @param array<string, mixed> $input
+   *   Keys: extra_type, title, customer_summary, pickup_note, price_amount, currency_code,
+   *   sizes (list), show_on_booking (bool), product_id (optional), image_media_ids (list<int>).
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function saveEventExtraForVendor(AccountInterface $account, NodeInterface $event, array $input): ProductInterface {
+    $input = $this->stripForbiddenFromPayload($input);
+    $product_id = (int) ($input['product_id'] ?? 0);
+    if ($product_id > 0) {
+      return $this->updateEventExtraForVendor($account, $event, $product_id, $input);
+    }
+    $payload = $this->buildEventExtraCreationPayload($event, $input);
+    $created = $this->createOperationalProductForEvent($account, $event, $payload);
+    $product = $this->entityTypeManager->getStorage('commerce_product')->load((int) $created['product_id']);
+    if (!$product instanceof ProductInterface) {
+      throw new \RuntimeException('Event extra product could not be loaded after create.');
+    }
+    $this->applyEventExtraFieldUpdates($product, $input);
+    $product->save();
+    return $product;
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return array<string, mixed>
+   */
+  public function buildEventExtraCreationPayload(NodeInterface $event, array $input): array {
+    $extra_type = $this->normalizeVendorExtraType((string) ($input['extra_type'] ?? ''));
+    if ($extra_type === '') {
+      throw new \InvalidArgumentException('A valid extra type is required.');
+    }
+    $productisation_type = self::VENDOR_EXTRA_TYPE_MAP[$extra_type];
+    $store_id = $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+    $currency = 'AUD';
+    if ($store_id !== NULL && $store_id > 0) {
+      $store = $this->entityTypeManager->getStorage('commerce_store')->load($store_id);
+      if (is_object($store) && method_exists($store, 'getDefaultCurrencyCode')) {
+        $currency = (string) $store->getDefaultCurrencyCode();
+      }
+    }
+    $currency_in = $this->normalizeCurrencyCode((string) ($input['currency_code'] ?? $currency));
+    if ($currency_in === '') {
+      $currency_in = $currency;
+    }
+    $show = !array_key_exists('show_on_booking', $input) || !empty($input['show_on_booking']);
+    $pickup_mode = match ($extra_type) {
+      'pickup_item' => 'collect',
+      'food_drink' => 'counter',
+      default => 'counter',
+    };
+    $fulfillment = match ($productisation_type) {
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => 'redeem',
+      VendorProductisationStudioManager::TYPE_TIMED_COLLECTION => 'collect',
+      default => 'collect',
+    };
+    return $this->stripForbiddenFromPayload([
+      'productisation_type' => $productisation_type,
+      'event_id' => (int) $event->id(),
+      'title' => (string) ($input['title'] ?? ''),
+      'customer_summary' => (string) ($input['customer_summary'] ?? ''),
+      'price_amount' => $input['price_amount'] ?? NULL,
+      'currency_code' => $currency_in,
+      'customer_visibility' => $show ? 'visible' : 'hidden',
+      'fulfillment_mode' => $fulfillment,
+      'reservation_mode' => 'operational_projection',
+      'pickup_mode' => $pickup_mode,
+      'pickup_note' => (string) ($input['pickup_note'] ?? ''),
+      'sizes' => $this->normalizeSizeKeys($input['sizes'] ?? []),
+      'timed_collection_window_copy' => $extra_type === 'pickup_item' ? (string) ($input['pickup_note'] ?? '') : '',
+      'hospitality_benefits_summary' => $productisation_type === VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE
+        ? (string) ($input['customer_summary'] ?? '') : '',
+    ]);
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return list<string>
+   */
+  public function validateEventExtraInput(AccountInterface $account, NodeInterface $event, array $input): array {
+    $input = $this->stripForbiddenFromPayload($input);
+    $errors = [];
+    if ($account->isAnonymous()) {
+      return ['Authentication is required.'];
+    }
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)
+      && !$account->hasPermission('administer nodes')) {
+      return ['You do not have permission to manage extras for this event.'];
+    }
+    $product_id = (int) ($input['product_id'] ?? 0);
+    if ($product_id > 0) {
+      try {
+        $this->assertVendorCanManageProduct($account, $event, $product_id);
+      }
+      catch (\InvalidArgumentException $e) {
+        return [$e->getMessage()];
+      }
+    }
+    else {
+      $extra_type = $this->normalizeVendorExtraType((string) ($input['extra_type'] ?? ''));
+      if ($extra_type === '') {
+        $errors[] = 'Choose what kind of extra you are offering.';
+      }
+    }
+    $title = trim((string) ($input['title'] ?? ''));
+    if ($title === '') {
+      $errors[] = 'Extra name is required.';
+    }
+    $summary = trim((string) ($input['customer_summary'] ?? ''));
+    if ($summary === '') {
+      $errors[] = 'Short customer description is required.';
+    }
+    $amount = $this->normalizePriceAmount($input['price_amount'] ?? NULL);
+    if ($amount === NULL) {
+      $errors[] = 'A valid price is required.';
+    }
+    return $errors;
+  }
+
+  /**
+   * @throws \InvalidArgumentException
+   */
+  public function assertVendorCanManageProduct(AccountInterface $account, NodeInterface $event, int $product_id): ProductInterface {
+    if ($product_id < 1) {
+      throw new \InvalidArgumentException('Invalid extra reference.');
+    }
+    if ($account->isAnonymous()) {
+      throw new \InvalidArgumentException('Authentication is required.');
+    }
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)
+      && !$account->hasPermission('administer nodes')) {
+      throw new \InvalidArgumentException('You do not have permission to manage extras for this event.');
+    }
+    $product = $this->entityTypeManager->getStorage('commerce_product')->load($product_id);
+    if (!$product instanceof ProductInterface) {
+      throw new \InvalidArgumentException('Extra was not found.');
+    }
+    if (!in_array($product->bundle(), OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES, TRUE)) {
+      throw new \InvalidArgumentException('This item is not an event extra.');
+    }
+    if ($product->bundle() === 'ticket') {
+      throw new \InvalidArgumentException('Ticket products cannot be edited here.');
+    }
+    if (!$product->hasField('field_event') || $product->get('field_event')->isEmpty()) {
+      throw new \InvalidArgumentException('Extra is not linked to an event.');
+    }
+    if ((int) $product->get('field_event')->target_id !== (int) $event->id()) {
+      throw new \InvalidArgumentException('Extra does not belong to this event.');
+    }
+    $store_id = $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+    if ($store_id === NULL || !$this->productInStore($product, $store_id)) {
+      throw new \InvalidArgumentException('Extra is not available in the store for this event.');
+    }
+    if (!$account->hasPermission('administer nodes')) {
+      $vendor_store = $this->commerceLinkManager->resolveVendorStoreIdForEvent($event);
+      if ($vendor_store !== NULL && $vendor_store !== $store_id) {
+        throw new \InvalidArgumentException('Extra store does not match your vendor store.');
+      }
+    }
+    return $product;
+  }
+
+  public function normalizeVendorExtraType(string $raw): string {
+    $key = strtolower(trim($raw));
+    return in_array($key, self::VENDOR_EXTRA_TYPE_KEYS, TRUE) ? $key : '';
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
   public function createOperationalProductForEvent(AccountInterface $account, NodeInterface $event, array $payload): array {
     $payload = $this->stripForbiddenFromPayload($payload);
     $errors = $this->validateCreationPayload($account, $event, $payload);
@@ -158,11 +358,12 @@ final class VendorOperationalProductCreationManager {
     $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
     $pickup_note = $this->sanitizePlainText((string) ($payload['pickup_note'] ?? ''), 400);
+    $visibility = $this->normalizeVisibility((string) ($payload['customer_visibility'] ?? 'visible'));
 
     $product = CommerceProduct::create([
       'type' => $bundles['product_type'],
       'title' => $title,
-      'status' => 1,
+      'status' => $visibility === 'visible' ? 1 : 0,
       'stores' => [$store_id],
       'uid' => (int) $account->id(),
       'field_event' => ['target_id' => (int) $event->id()],
@@ -633,6 +834,184 @@ final class VendorOperationalProductCreationManager {
       'customer_summary' => (string) ($presentation['operational_summary'] ?? ''),
       'product_bundle' => $product->bundle(),
     ];
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
+  private function updateEventExtraForVendor(AccountInterface $account, NodeInterface $event, int $product_id, array $input): ProductInterface {
+    $product = $this->assertVendorCanManageProduct($account, $event, $product_id);
+    $errors = $this->validateEventExtraInput($account, $event, $input);
+    if ($errors !== []) {
+      throw new \InvalidArgumentException(implode(' ', $errors));
+    }
+
+    $title = $this->sanitizePlainText((string) ($input['title'] ?? ''), 255);
+    $summary = $this->sanitizePlainText((string) ($input['customer_summary'] ?? ''), 600);
+    $pickup_note = $this->sanitizePlainText((string) ($input['pickup_note'] ?? ''), 400);
+    $show = !array_key_exists('show_on_booking', $input) || !empty($input['show_on_booking']);
+    $currency = $this->normalizeCurrencyCode((string) ($input['currency_code'] ?? ''));
+    if ($currency === '') {
+      $store_id = $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
+      if ($store_id !== NULL && $store_id > 0) {
+        $store = $this->entityTypeManager->getStorage('commerce_store')->load($store_id);
+        if (is_object($store) && method_exists($store, 'getDefaultCurrencyCode')) {
+          $currency = (string) $store->getDefaultCurrencyCode();
+        }
+      }
+      if ($currency === '') {
+        $currency = 'AUD';
+      }
+    }
+    $amount = (string) $this->normalizePriceAmount($input['price_amount'] ?? NULL);
+    $price = new Price($amount, $currency);
+
+    $product->setTitle($title);
+    $product->setPublished($show);
+    if ($product->hasField('field_mel_extra_short_desc')) {
+      $product->set('field_mel_extra_short_desc', $summary);
+    }
+    if ($product->hasField('field_mel_extra_pickup_note')) {
+      $product->set('field_mel_extra_pickup_note', $pickup_note);
+    }
+
+    $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $metadata['operational_summary'] = $summary;
+    $metadata['customer_visibility'] = $show ? 'visible' : 'hidden';
+    $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    if ($product->hasField('field_mel_operational_product')) {
+      $product->set('field_mel_operational_product', $encoded);
+    }
+
+    $this->applyEventExtraFieldUpdates($product, $input);
+    $this->syncVariationsForEventExtra($product, $input, $title, $price);
+    $product->save();
+
+    $this->logger->notice('Vendor event extra @pid updated for event @eid.', [
+      '@pid' => (string) $product->id(),
+      '@eid' => (string) $event->id(),
+    ]);
+
+    return $product;
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
+  private function applyEventExtraFieldUpdates(ProductInterface $product, array $input): void {
+    if (!$product->hasField('field_mel_extra_images')) {
+      return;
+    }
+    $media_ids = $input['image_media_ids'] ?? $input['images'] ?? [];
+    if (!is_array($media_ids)) {
+      return;
+    }
+    $values = [];
+    foreach ($media_ids as $mid) {
+      $id = (int) $mid;
+      if ($id > 0) {
+        $values[] = ['target_id' => $id];
+      }
+    }
+    $product->set('field_mel_extra_images', $values);
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
+  private function syncVariationsForEventExtra(ProductInterface $product, array $input, string $title, Price $price): void {
+    $bundles = $this->mapProductBundleToVariationType($product->bundle());
+    $variation_type = $bundles['variation_type'];
+    $size_keys = $variation_type === 'operational_merchandise_var'
+      ? $this->normalizeSizeKeys($input['sizes'] ?? [])
+      : [];
+
+    $storage = $this->entityTypeManager->getStorage('commerce_product_variation');
+    $existing = [];
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface) {
+        continue;
+      }
+      $size = '';
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+        $size = strtolower((string) $variation->get('field_mel_size')->value);
+      }
+      $key = $size !== '' ? $size : '_default';
+      $existing[$key] = $variation;
+    }
+
+    $desired_keys = $size_keys !== [] ? $size_keys : ['_default'];
+    $sku_base = 'mel-extra-' . (int) $product->id();
+
+    foreach ($desired_keys as $size_key) {
+      $lookup = $size_key === '_default' ? '_default' : $size_key;
+      $label = $size_key === '_default'
+        ? $title
+        : $title . ' — ' . (OperationalExtraVisualPresenter::SIZE_LABELS[$size_key] ?? strtoupper($size_key));
+      $sku = $size_key === '_default'
+        ? $this->sanitizePlainText($sku_base, 128)
+        : $this->sanitizePlainText($sku_base . '-' . $size_key, 128);
+
+      if (isset($existing[$lookup])) {
+        $variation = $existing[$lookup];
+        $variation->setTitle($label);
+        $variation->setPrice($price);
+        $variation->setPublished(TRUE);
+        if ($size_key !== '_default' && $variation->hasField('field_mel_size')) {
+          $variation->set('field_mel_size', $size_key);
+        }
+        $variation->save();
+        unset($existing[$lookup]);
+        continue;
+      }
+
+      $variation = ProductVariation::create([
+        'type' => $variation_type,
+        'sku' => $sku,
+        'title' => $label,
+        'status' => 1,
+        'price' => $price,
+      ]);
+      if ($size_key !== '_default' && $variation->hasField('field_mel_size')) {
+        $variation->set('field_mel_size', $size_key);
+      }
+      $variation->save();
+      $product->addVariation($variation);
+    }
+
+    foreach ($existing as $orphan) {
+      if ($orphan instanceof ProductVariationInterface && $orphan->isPublished()) {
+        $orphan->setPublished(FALSE);
+        $orphan->save();
+        $this->logger->notice('Unpublished event extra variation @vid (size removed or consolidated).', [
+          '@vid' => (string) $orphan->id(),
+        ]);
+      }
+    }
+  }
+
+  /**
+   * @return array{product_type: string, variation_type: string}
+   */
+  private function mapProductBundleToVariationType(string $bundle): array {
+    return match ($bundle) {
+      'hospitality_package' => [
+        'product_type' => 'hospitality_package',
+        'variation_type' => 'hospitality_package_var',
+      ],
+      'timed_collection_product' => [
+        'product_type' => 'timed_collection_product',
+        'variation_type' => 'timed_collection_var',
+      ],
+      'operational_bundle' => [
+        'product_type' => 'operational_bundle',
+        'variation_type' => 'operational_bundle_var',
+      ],
+      default => [
+        'product_type' => 'operational_merchandise',
+        'variation_type' => 'operational_merchandise_var',
+      ],
+    };
   }
 
   private function productInStore(ProductInterface $product, int $store_id): bool {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Single event extra card (vendor list).
+ */
+#}
+<div class="mel-event-extra-card__inner">
+  <div class="mel-event-extra-card__media">
+    {% if card.primary_image.url|default('') %}
+      <img src="{{ card.primary_image.url }}" alt="{{ card.primary_image.alt|default(card.title) }}" class="mel-event-extra-card__image" loading="lazy" />
+    {% else %}
+      <div class="mel-event-extra-card__placeholder" aria-hidden="true"></div>
+    {% endif %}
+  </div>
+  <div class="mel-event-extra-card__body">
+    <h3 class="mel-event-extra-card__title">{{ card.title }}</h3>
+    {% if card.short_description %}
+      <p class="mel-event-extra-card__desc">{{ card.short_description }}</p>
+    {% endif %}
+    {% if card.price_label %}
+      <p class="mel-event-extra-card__price">{{ card.price_label }}</p>
+    {% endif %}
+    {% if card.sizes_summary is not empty %}
+      <p class="mel-event-extra-card__sizes">
+        {% for size in card.sizes_summary %}
+          <span class="mel-event-extra-size-chip">{{ size }}</span>
+        {% endfor %}
+      </p>
+    {% endif %}
+    {% if card.pickup_note %}
+      <p class="mel-event-extra-card__pickup mel-text--muted">{{ card.pickup_note }}</p>
+    {% endif %}
+    <p class="mel-event-extra-card__status">
+      {{ card.show_on_booking ? 'Shown on booking page'|t : 'Hidden from booking page'|t }}
+    </p>
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-preview.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Customer-style preview for one event extra (studio editor).
+ */
+#}
+{% set img = preview.primary_image|default({}) %}
+<aside class="mel-event-extra-preview mel-es-card" aria-label="{{ 'Customer preview'|t }}">
+  <h3 class="mel-event-extra-preview__heading">{{ 'Guest preview'|t }}</h3>
+  <div class="mel-event-extra-preview__card">
+    {% if img.url|default('') %}
+      <img class="mel-event-extra-preview__image" src="{{ img.url }}" alt="{{ img.alt|default(preview.title) }}" loading="lazy" />
+    {% endif %}
+    <div class="mel-event-extra-preview__body">
+      <h4 class="mel-event-extra-preview__title">{{ preview.title|default('') }}</h4>
+      {% if preview.short_description|default('') %}
+        <p class="mel-event-extra-preview__desc">{{ preview.short_description }}</p>
+      {% endif %}
+      {% if preview.pickup_note|default('') %}
+        <p class="mel-event-extra-preview__pickup">{{ preview.pickup_note }}</p>
+      {% endif %}
+      <p class="mel-event-extra-preview__cta mel-text--muted">{{ 'Add to booking (preview only)'|t }}</p>
+    </div>
+  </div>
+</aside>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-list.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-list.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Event Extras list (vendor studio).
+ */
+#}
+<div class="mel-event-extras-studio__list" role="list">
+  {% if empty %}
+    <p class="mel-event-extras-studio__empty mel-text--muted">{{ 'No extras yet. Choose a type below to add your first one.'|t }}</p>
+  {% else %}
+    {% for card in cards %}
+      <article class="mel-event-extra-card mel-es-card" role="listitem">
+        <div class="mel-event-extra-card__media">
+          {% if card.primary_image.url|default('') %}
+            <img src="{{ card.primary_image.url }}" alt="{{ card.primary_image.alt|default(card.title) }}" width="120" height="120" loading="lazy" />
+          {% else %}
+            <div class="mel-event-extra-card__placeholder" aria-hidden="true"></div>
+          {% endif %}
+        </div>
+        <div class="mel-event-extra-card__body">
+          <h3 class="mel-event-extra-card__title">{{ card.title }}</h3>
+          {% if card.short_description %}
+            <p class="mel-event-extra-card__desc">{{ card.short_description }}</p>
+          {% endif %}
+          {% if card.price_label %}
+            <p class="mel-event-extra-card__price">{{ card.price_label }}</p>
+          {% endif %}
+          {% if card.sizes_summary is not empty %}
+            <p class="mel-event-extra-card__sizes">
+              {% for size in card.sizes_summary %}
+                <span class="mel-event-extra-size-chip">{{ size }}</span>
+              {% endfor %}
+            </p>
+          {% endif %}
+          {% if card.pickup_note %}
+            <p class="mel-event-extra-card__pickup mel-text--muted">{{ card.pickup_note }}</p>
+          {% endif %}
+          <p class="mel-event-extra-card__status">
+            {{ card.show_on_booking ? 'Shown on booking page'|t : 'Hidden from booking page'|t }}
+          </p>
+        </div>
+        <div class="mel-event-extra-card__actions mel-event-extra-actions">
+          <a href="{{ card.edit_url }}" class="button mel-event-extra-card__edit">{{ 'Edit'|t }}</a>
+        </div>
+      </article>
+    {% endfor %}
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSectionContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSectionContractTest.php
@@ -41,6 +41,19 @@ final class EventStudioSectionContractTest extends TestCase {
   }
 
   /**
+   * Extras must reference a loadable form class or the workspace shows the governed fallback.
+   */
+  public function testExtrasSectionFormClassIsLoadable(): void {
+    $formClass = 'Drupal\myeventlane_event_studio\Form\EventStudioEventExtrasForm';
+    $this->assertTrue(class_exists($formClass), 'EventStudioEventExtrasForm must autoload for the extras section contract.');
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Plugin/EventStudioSection/ExtrasSection.php');
+    $this->assertIsString($contents);
+    $this->assertStringContainsString('form:' . $formClass, $contents);
+    $this->assertStringContainsString("routeName: 'myeventlane_event_studio.workspace_extras'", $contents);
+    $this->assertStringContainsString("id: 'extras'", $contents);
+  }
+
+  /**
    * @covers \Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder::deferredSection
    */
   public function testDeferredSectionsUseGovernedCopy(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\myeventlane_event_studio\Unit;
 
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -20,6 +21,58 @@ final class VendorOperationalProductCreationManagerTest extends TestCase {
     $this->assertContains('inventory_quantity', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
     $this->assertContains('qr_payload', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
     $this->assertContains('entitlement_id', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+    $this->assertContains('scanner_action', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+    $this->assertContains('warehouse_ids', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+    $this->assertContains('shipment_state', VendorOperationalProductCreationManager::FORBIDDEN_CREATION_KEYS);
+  }
+
+  public function testVendorExtraTypeMapCoversProductisationTypes(): void {
+    $this->assertSame(
+      VendorProductisationStudioManager::TYPE_MERCHANDISE,
+      VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['merchandise'],
+    );
+    $this->assertSame(
+      VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+      VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['vip_hospitality'],
+    );
+    $this->assertSame(
+      VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE,
+      VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['bundle'],
+    );
+  }
+
+  public function testStripForbiddenFromPayloadRemovesOperationalKeys(): void {
+    $manager = $this->createPartialManager();
+    $out = $manager->stripForbiddenFromPayload([
+      'title' => 'T-shirt',
+      'qr_payload' => 'secret',
+      'scanner_action' => 'x',
+      'entitlement_id' => '1',
+      'warehouse_ids' => ['w1'],
+      'shipment_state' => 'ship',
+      'nested' => ['scanner_tokens' => ['a']],
+    ]);
+    $this->assertSame('T-shirt', $out['title']);
+    $this->assertArrayNotHasKey('qr_payload', $out);
+    $this->assertArrayNotHasKey('scanner_action', $out);
+    $this->assertArrayNotHasKey('entitlement_id', $out);
+    $this->assertArrayNotHasKey('warehouse_ids', $out);
+    $this->assertArrayNotHasKey('shipment_state', $out);
+    $this->assertArrayHasKey('nested', $out);
+    $this->assertArrayNotHasKey('scanner_tokens', $out['nested']);
+  }
+
+  public function testNormalizeVendorExtraTypeRejectsUnknown(): void {
+    $manager = $this->createPartialManager();
+    $this->assertSame('', $manager->normalizeVendorExtraType('operational_product'));
+    $this->assertSame('merchandise', $manager->normalizeVendorExtraType('Merchandise'));
+  }
+
+  private function createPartialManager(): VendorOperationalProductCreationManager {
+    $ref = new \ReflectionClass(VendorOperationalProductCreationManager::class);
+    /** @var VendorOperationalProductCreationManager $manager */
+    $manager = $ref->newInstanceWithoutConstructor();
+    return $manager;
   }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new vendor-facing CRUD for Commerce products/variations (including publish state and images) and changes routing/navigation, which could affect access control and product catalog integrity if edge cases are missed.
> 
> **Overview**
> Adds a new **unified “Extras” workspace** at `/vendor/events/{node}/studio/extras`, with legacy `merchandise`/`addons` URLs now redirecting there and those sections hidden from navigation (and `Fulfilment` renamed to **Collection**).
> 
> Implements a new `EventStudioEventExtrasForm` + `EventStudioEventExtrasBuilder` to list, create, edit, preview, and toggle booking visibility for event extras, including attaching the Commerce `media_library` images widget.
> 
> Extends `VendorOperationalProductCreationManager` from create-only to **create/update** extras: validates vendor access/event/store ownership, maps vendor extra types to Commerce bundles, syncs variations (create/update, unpublish removed sizes), updates operational JSON + fields (incl. images), and sets product publish status from “show on booking”. Includes new CSS/templates, service wiring, and unit tests for the new section and type/forbidden-key contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e563049bfaab08b81516a98ded332d5bfcd5ff5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->