### PR TITLE
Unify vendor Event Extras editor

### DIFF
--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -255,6 +255,29 @@
   min-width: 0;
 }
 
+.mel-event-extra-card__image-open {
+  display: block;
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+  border-radius: 0.85rem;
+}
+
+.mel-event-extra-card__image-open:hover .mel-event-extra-card__image,
+.mel-event-extra-card__image-open:focus-visible .mel-event-extra-card__image {
+  opacity: 0.92;
+}
+
+.mel-event-extra-card__image-open:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
 .mel-event-extra-card__image {
   display: block;
   width: 100%;
@@ -263,6 +286,17 @@
   object-fit: cover;
   border-radius: 0.85rem;
   background: rgba(15, 23, 42, 0.04);
+}
+
+.mel-event-extra-card__image-zoom {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.62) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 3h6v6M14 10l7-7M9 21H3v-6M10 14l-7 7'/%3E%3C/svg%3E") center / 1rem no-repeat;
+  pointer-events: none;
 }
 
 .mel-event-extra-card__thumbs {
@@ -317,6 +351,10 @@
   color: rgba(15, 23, 42, 0.9);
 }
 
+.mel-event-extra-card__sizes {
+  margin-top: 0.35rem;
+}
+
 .mel-event-extra-card__sizes-label {
   display: block;
   font-size: 0.85rem;
@@ -324,52 +362,122 @@
   margin-bottom: 0.35rem;
 }
 
-.mel-event-extra-card__size-radios {
+/* Radios without #title avoid a fieldset; legacy fieldset markup is still supported. */
+.mel-event-extras-form fieldset.mel-event-extra-card__size-radios {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.mel-event-extras-form fieldset.mel-event-extra-card__size-radios legend {
+  display: none;
+}
+
+.mel-event-extras-form fieldset.mel-event-extra-card__size-radios .fieldset-wrapper {
+  margin: 0;
+  padding: 0;
+}
+
+.mel-event-extras-form .mel-event-extra-card__size-radios,
+.mel-event-extras-form .mel-event-extra-card__size-radios > div[id$='-selected-size'],
+.mel-event-extras-form fieldset.mel-event-extra-card__size-radios .fieldset-wrapper > div {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
 }
 
-.mel-event-extra-card__size-radios .form-item {
+.mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio {
   margin: 0;
+  position: relative;
 }
 
-.mel-event-extra-card__size-radios input {
+.mel-event-extras-form .mel-event-extra-card__sizes input[type='radio'] {
   position: absolute;
-  opacity: 0;
-  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.mel-event-extra-card__size-radios label {
+/* Booking page sets labels to display:block — override for size chips only. */
+.mel-booking-v2 .mel-event-extras-form .mel-event-extra-card__sizes label.option,
+.mel-booking-v2 .mel-event-extras-form .mel-event-extra-card__sizes .mel-event-extra-card__size-chip-label,
+.mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 44px;
   min-height: 44px;
+  margin: 0;
   padding: 0 0.65rem;
   border-radius: 999px;
-  border: 1px solid rgba(99, 102, 241, 0.35);
+  border: 2px solid rgba(99, 102, 241, 0.4);
   background: #fff;
+  color: rgba(15, 23, 42, 0.88);
   font-weight: 600;
   cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.mel-event-extra-card__size-radios input:focus-visible + label {
+.mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio.is-selected label,
+.mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio:has(input:checked) label,
+.mel-event-extras-form .mel-event-extra-card__sizes .mel-event-extra-card__size-chip-label.is-selected {
+  background: #f26d5b;
+  border-color: #e55c49;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(242, 109, 91, 0.35);
+}
+
+.mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio:has(input:focus-visible) label {
   outline: 2px solid #6366f1;
   outline-offset: 2px;
 }
 
-.mel-event-extra-card__size-radios input:checked + label {
-  background: rgba(229, 115, 115, 0.15);
-  border-color: #e57373;
-  color: rgba(15, 23, 42, 0.92);
+.mel-event-extras-form .mel-event-extra-card__size-selected {
+  margin: 0.35rem 0 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.82);
+}
+
+.mel-event-extras-form .mel-event-extra-card__size-selected[hidden] {
+  display: none;
 }
 
 .mel-event-extra-card__qty {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  margin-top: 0.65rem;
+  margin-top: 0.5rem;
+}
+
+.mel-event-extra-card__footer {
+  grid-column: 1 / -1;
+  margin-top: 0.75rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.mel-event-extra-card__add-to-cart {
+  display: block;
+  width: 100%;
+  min-height: 48px;
+  margin: 0;
+  padding: 0.65rem 1.25rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(242, 109, 91, 0.28);
+}
+
+.mel-event-extra-card__add-to-cart:hover,
+.mel-event-extra-card__add-to-cart:focus-visible {
+  box-shadow: 0 6px 18px rgba(242, 109, 91, 0.36);
 }
 
 .mel-event-extra-card__qty-btn {
@@ -477,6 +585,166 @@
   margin: 0.25rem 0 0;
   font-size: 0.88rem;
   color: rgba(15, 23, 42, 0.72);
+}
+
+/* Full-size gallery lightbox (booking extras). */
+.mel-event-extra-lightbox {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  padding: 1rem;
+  align-items: center;
+  justify-items: center;
+}
+
+.mel-event-extra-lightbox.is-open {
+  display: grid;
+}
+
+.mel-event-extra-lightbox[hidden] {
+  display: none !important;
+}
+
+.mel-event-extra-lightbox__overlay {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: rgba(15, 23, 42, 0.72);
+  cursor: pointer;
+}
+
+.mel-event-extra-lightbox__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 52rem);
+  max-height: min(92vh, 48rem);
+  padding: 1rem 1.25rem 1.25rem;
+  overflow: auto;
+}
+
+.mel-event-extra-lightbox__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.mel-event-extra-lightbox__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.mel-event-extra-lightbox__close {
+  position: relative;
+  z-index: 2;
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.06);
+  color: rgba(15, 23, 42, 0.88);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.mel-event-extra-lightbox__close:hover,
+.mel-event-extra-lightbox__close:focus-visible {
+  background: rgba(15, 23, 42, 0.1);
+}
+
+.mel-event-extra-lightbox__stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+}
+
+.mel-event-extra-lightbox__image {
+  display: block;
+  max-width: 100%;
+  max-height: min(70vh, 36rem);
+  width: auto;
+  height: auto;
+  margin: 0 auto;
+  object-fit: contain;
+  border-radius: 0.5rem;
+}
+
+.mel-event-extra-lightbox__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.18);
+  color: rgba(15, 23, 42, 0.9);
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mel-event-extra-lightbox__nav--prev {
+  left: 0.35rem;
+}
+
+.mel-event-extra-lightbox__nav--next {
+  right: 0.35rem;
+}
+
+.mel-event-extra-lightbox__nav:hover,
+.mel-event-extra-lightbox__nav:focus-visible {
+  background: #fff;
+}
+
+.mel-event-extra-lightbox__counter {
+  margin: 0.65rem 0 0;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.mel-event-extra-lightbox__thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: center;
+  margin-top: 0.85rem;
+}
+
+.mel-event-extra-lightbox__thumb {
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.mel-event-extra-lightbox__thumb.is-active {
+  border-color: #f26d5b;
+}
+
+.mel-event-extra-lightbox__thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/modules/custom/myeventlane_commerce/js/mel-event-extras-booking.js
+++ b/web/modules/custom/myeventlane_commerce/js/mel-event-extras-booking.js
@@ -1,10 +1,25 @@
 /**
  * @file
- * Event Extras booking cards: gallery thumbs, quantity stepper sync.
+ * Event Extras booking cards: gallery thumbs, quantity stepper, size chips.
  */
 (function (Drupal, once) {
   'use strict';
 
+  const SELECTION_EVENT = 'mel-booking-selection-change';
+
+  /**
+   * @param {HTMLElement} card
+   */
+  function notifyBookingSelectionChange(card) {
+    const flow = card.closest('[data-mel-booking-flow]');
+    if (flow) {
+      flow.dispatchEvent(new CustomEvent(SELECTION_EVENT, { bubbles: true }));
+    }
+  }
+
+  /**
+   * @param {HTMLElement} card
+   */
   function syncQtyDisplay(card, value) {
     const display = card.querySelector('.mel-event-extra-card__qty-value');
     const input = card.querySelector('.mel-event-extra-card__qty-input');
@@ -13,7 +28,424 @@
       display.textContent = v;
     }
     if (input) {
+      const prev = input.value;
       input.value = v;
+      if (prev !== v) {
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        notifyBookingSelectionChange(card);
+      }
+    }
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @returns {string}
+   */
+  function getSelectedSizeLabel(card) {
+    const checked = card.querySelector(
+      '.mel-event-extra-card__sizes input[type="radio"][name*="selected_size"]:checked',
+    );
+    if (!(checked instanceof HTMLInputElement)) {
+      return '';
+    }
+    const wrap = checked.closest('.form-type-radio');
+    const label = wrap?.querySelector('label');
+    return label?.textContent?.trim() || checked.value.toUpperCase();
+  }
+
+  /**
+   * @param {HTMLElement} card
+   */
+  function syncSizeChips(card) {
+    const requiresSize = card.getAttribute('data-requires-size') === '1';
+    if (!requiresSize) {
+      return;
+    }
+
+    card.querySelectorAll('.mel-event-extra-card__sizes .form-type-radio').forEach((wrap) => {
+      const radio = wrap.querySelector('input[type="radio"]');
+      const label = wrap.querySelector('label');
+      const selected = radio instanceof HTMLInputElement && radio.checked;
+      wrap.classList.toggle('is-selected', selected);
+      if (label) {
+        label.classList.toggle('is-selected', selected);
+        label.setAttribute('aria-pressed', selected ? 'true' : 'false');
+      }
+    });
+
+    const hint = card.querySelector('[data-mel-extra-size-selected]');
+    const sizeLabel = getSelectedSizeLabel(card);
+    if (hint instanceof HTMLElement) {
+      if (sizeLabel !== '') {
+        hint.hidden = false;
+        hint.textContent = Drupal.t('Size: @size', { '@size': sizeLabel });
+      }
+      else {
+        hint.hidden = true;
+        hint.textContent = '';
+      }
+    }
+  }
+
+  /**
+   * @param {HTMLElement} card
+   */
+  function bindSizeChips(card) {
+    if (card.getAttribute('data-requires-size') !== '1') {
+      return;
+    }
+
+    const sizeGroup = card.querySelector('.mel-event-extra-card__size-radios');
+    if (sizeGroup) {
+      sizeGroup.setAttribute('role', 'radiogroup');
+    }
+
+    card.querySelectorAll('.mel-event-extra-card__sizes .form-type-radio').forEach((wrap) => {
+      const radio = wrap.querySelector('input[type="radio"]');
+      const label = wrap.querySelector('label');
+      if (!(radio instanceof HTMLInputElement) || !label) {
+        return;
+      }
+
+      wrap.classList.add('mel-event-extra-card__size-chip');
+      label.classList.add('mel-event-extra-card__size-chip-label');
+      label.setAttribute('role', 'button');
+      label.setAttribute('tabindex', '0');
+
+      const selectChip = () => {
+        radio.checked = true;
+        card.querySelectorAll('.mel-event-extra-card__sizes input[type="radio"]').forEach((other) => {
+          if (other !== radio) {
+            other.checked = false;
+          }
+        });
+        syncSizeChips(card);
+        const qtyInput = card.querySelector('.mel-event-extra-card__qty-input');
+        const cur = parseInt(qtyInput?.value || '0', 10) || 0;
+        if (cur < 1) {
+          syncQtyDisplay(card, 1);
+        }
+        radio.dispatchEvent(new Event('change', { bubbles: true }));
+        notifyBookingSelectionChange(card);
+      };
+
+      label.addEventListener('click', (e) => {
+        e.preventDefault();
+        selectChip();
+      });
+
+      label.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          selectChip();
+        }
+      });
+
+      radio.addEventListener('change', () => {
+        syncSizeChips(card);
+        notifyBookingSelectionChange(card);
+      });
+    });
+
+    syncSizeChips(card);
+  }
+
+  /** @type {HTMLElement|null} */
+  let sharedLightbox = null;
+
+  /** @type {(e: KeyboardEvent) => void} */
+  let documentKeydownHandler = null;
+
+  /**
+   * @param {HTMLElement} card
+   * @returns {{url: string, full_url: string, alt: string}[]}
+   */
+  function collectGallery(card) {
+    const media = card.querySelector('.mel-event-extra-card__media');
+    const raw = media?.getAttribute('data-extra-gallery');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((item) => item && (item.url || item.full_url));
+        }
+      } catch (e) {
+        // Fall through to thumb-derived gallery.
+      }
+    }
+    /** @type {{url: string, full_url: string, alt: string}[]} */
+    const fromThumbs = [];
+    card.querySelectorAll('.mel-event-extra-card__thumb').forEach((btn) => {
+      const url = btn.getAttribute('data-image-url') || '';
+      if (url === '') {
+        return;
+      }
+      fromThumbs.push({
+        url,
+        full_url: btn.getAttribute('data-image-full-url') || url,
+        alt: btn.getAttribute('data-image-alt') || '',
+      });
+    });
+    if (fromThumbs.length > 0) {
+      return fromThumbs;
+    }
+    const img = card.querySelector('.mel-event-extra-card__image');
+    if (img instanceof HTMLImageElement && img.src) {
+      return [{ url: img.src, full_url: img.src, alt: img.alt || '' }];
+    }
+    return [];
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @param {{url: string, full_url: string, alt: string}[]} gallery
+   * @returns {number}
+   */
+  function getActiveGalleryIndex(card, gallery) {
+    const activeThumb = card.querySelector('.mel-event-extra-card__thumb.is-active');
+    if (activeThumb) {
+      const idx = parseInt(activeThumb.getAttribute('data-gallery-index') || '0', 10);
+      if (Number.isFinite(idx) && idx >= 0 && idx < gallery.length) {
+        return idx;
+      }
+    }
+    const img = card.querySelector('.mel-event-extra-card__image');
+    const src = img instanceof HTMLImageElement ? img.getAttribute('src') || '' : '';
+    const found = gallery.findIndex((item) => item.url === src || item.full_url === src);
+    return found >= 0 ? found : 0;
+  }
+
+  /**
+   * @returns {HTMLElement}
+   */
+  function ensureLightbox() {
+    if (sharedLightbox) {
+      return sharedLightbox;
+    }
+
+    const root = document.createElement('div');
+    root.className = 'mel-event-extra-lightbox';
+    root.id = 'mel-event-extra-lightbox';
+    root.setAttribute('hidden', 'hidden');
+    root.setAttribute('aria-hidden', 'true');
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-modal', 'true');
+    root.setAttribute('aria-label', Drupal.t('Product image viewer'));
+    root.innerHTML = [
+      '<button type="button" class="mel-event-extra-lightbox__overlay" data-mel-lightbox-close aria-label="',
+      Drupal.t('Close'),
+      '"></button>',
+      '<div class="mel-event-extra-lightbox__dialog" data-mel-lightbox-dialog>',
+      '<header class="mel-event-extra-lightbox__header">',
+      '<p class="mel-event-extra-lightbox__title" data-mel-lightbox-title></p>',
+      '<button type="button" class="mel-event-extra-lightbox__close" data-mel-lightbox-close aria-label="',
+      Drupal.t('Close'),
+      '">&times;</button>',
+      '</header>',
+      '<div class="mel-event-extra-lightbox__stage">',
+      '<button type="button" class="mel-event-extra-lightbox__nav mel-event-extra-lightbox__nav--prev" data-mel-lightbox-prev aria-label="',
+      Drupal.t('Previous image'),
+      '">&lsaquo;</button>',
+      '<img class="mel-event-extra-lightbox__image" data-mel-lightbox-image alt="" />',
+      '<button type="button" class="mel-event-extra-lightbox__nav mel-event-extra-lightbox__nav--next" data-mel-lightbox-next aria-label="',
+      Drupal.t('Next image'),
+      '">&rsaquo;</button>',
+      '</div>',
+      '<p class="mel-event-extra-lightbox__counter" data-mel-lightbox-counter hidden></p>',
+      '<div class="mel-event-extra-lightbox__thumbs" data-mel-lightbox-thumbs hidden></div>',
+      '</div>',
+    ].join('');
+
+    document.body.appendChild(root);
+    sharedLightbox = root;
+
+    const onCloseClick = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      closeLightbox();
+    };
+    root.querySelectorAll('[data-mel-lightbox-close]').forEach((btn) => {
+      btn.addEventListener('click', onCloseClick);
+    });
+
+    documentKeydownHandler = (e) => {
+      if (!sharedLightbox || !sharedLightbox.classList.contains('is-open')) {
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeLightbox();
+      }
+      else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        sharedLightbox.dispatchEvent(new CustomEvent('mel-lightbox:prev'));
+      }
+      else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        sharedLightbox.dispatchEvent(new CustomEvent('mel-lightbox:next'));
+      }
+    };
+
+    const prev = root.querySelector('[data-mel-lightbox-prev]');
+    const next = root.querySelector('[data-mel-lightbox-next]');
+    if (prev) {
+      prev.addEventListener('click', (e) => {
+        e.preventDefault();
+        root.dispatchEvent(new CustomEvent('mel-lightbox:prev'));
+      });
+    }
+    if (next) {
+      next.addEventListener('click', (e) => {
+        e.preventDefault();
+        root.dispatchEvent(new CustomEvent('mel-lightbox:next'));
+      });
+    }
+
+    return root;
+  }
+
+  function closeLightbox() {
+    if (!sharedLightbox) {
+      return;
+    }
+    sharedLightbox.classList.remove('is-open');
+    sharedLightbox.setAttribute('hidden', 'hidden');
+    sharedLightbox.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('mel-modal-open');
+    if (documentKeydownHandler) {
+      document.removeEventListener('keydown', documentKeydownHandler);
+    }
+    const trigger = sharedLightbox._melTrigger;
+    if (trigger && typeof trigger.focus === 'function') {
+      trigger.focus();
+    }
+    sharedLightbox._melTrigger = null;
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @param {number} startIndex
+   */
+  function openLightbox(card, startIndex) {
+    const gallery = collectGallery(card);
+    if (gallery.length === 0) {
+      return;
+    }
+
+    const lb = ensureLightbox();
+    let index = Math.max(0, Math.min(startIndex, gallery.length - 1));
+    const title = card.getAttribute('data-extra-title') || '';
+    const imgEl = lb.querySelector('[data-mel-lightbox-image]');
+    const titleEl = lb.querySelector('[data-mel-lightbox-title]');
+    const counterEl = lb.querySelector('[data-mel-lightbox-counter]');
+    const thumbsEl = lb.querySelector('[data-mel-lightbox-thumbs]');
+    const prevBtn = lb.querySelector('[data-mel-lightbox-prev]');
+    const nextBtn = lb.querySelector('[data-mel-lightbox-next]');
+    const opener = card.querySelector('.mel-event-extra-card__image-open');
+
+    const render = () => {
+      const item = gallery[index];
+      const displayUrl = item.full_url || item.url;
+      if (imgEl instanceof HTMLImageElement) {
+        imgEl.src = displayUrl;
+        imgEl.alt = item.alt || title;
+      }
+      if (titleEl) {
+        titleEl.textContent = title;
+      }
+      if (counterEl instanceof HTMLElement) {
+        if (gallery.length > 1) {
+          counterEl.hidden = false;
+          counterEl.textContent = Drupal.t('Image @current of @total', {
+            '@current': String(index + 1),
+            '@total': String(gallery.length),
+          });
+        }
+        else {
+          counterEl.hidden = true;
+          counterEl.textContent = '';
+        }
+      }
+      if (prevBtn instanceof HTMLButtonElement) {
+        prevBtn.hidden = gallery.length <= 1;
+      }
+      if (nextBtn instanceof HTMLButtonElement) {
+        nextBtn.hidden = gallery.length <= 1;
+      }
+      if (thumbsEl instanceof HTMLElement) {
+        thumbsEl.innerHTML = '';
+        if (gallery.length > 1) {
+          thumbsEl.hidden = false;
+          gallery.forEach((thumb, thumbIndex) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'mel-event-extra-lightbox__thumb';
+            if (thumbIndex === index) {
+              btn.classList.add('is-active');
+            }
+            btn.setAttribute('aria-label', Drupal.t('Show image @num', {
+              '@num': String(thumbIndex + 1),
+            }));
+            const thumbImg = document.createElement('img');
+            thumbImg.src = thumb.url || thumb.full_url;
+            thumbImg.alt = '';
+            thumbImg.loading = 'lazy';
+            btn.appendChild(thumbImg);
+            btn.addEventListener('click', (e) => {
+              e.preventDefault();
+              index = thumbIndex;
+              render();
+            });
+            thumbsEl.appendChild(btn);
+          });
+        }
+        else {
+          thumbsEl.hidden = true;
+        }
+      }
+    };
+
+    const onPrev = () => {
+      index = (index - 1 + gallery.length) % gallery.length;
+      render();
+    };
+    const onNext = () => {
+      index = (index + 1) % gallery.length;
+      render();
+    };
+
+    lb.removeEventListener('mel-lightbox:prev', onPrev);
+    lb.removeEventListener('mel-lightbox:next', onNext);
+    lb.addEventListener('mel-lightbox:prev', onPrev);
+    lb.addEventListener('mel-lightbox:next', onNext);
+
+    render();
+    lb.classList.add('is-open');
+    lb.removeAttribute('hidden');
+    lb.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('mel-modal-open');
+    if (documentKeydownHandler) {
+      document.addEventListener('keydown', documentKeydownHandler);
+    }
+    lb._melTrigger = opener instanceof HTMLElement ? opener : null;
+    const closeBtn = lb.querySelector('.mel-event-extra-lightbox__close');
+    if (closeBtn instanceof HTMLElement) {
+      closeBtn.focus();
+    }
+  }
+
+  /**
+   * @param {HTMLElement} card
+   */
+  function bindGalleryLightbox(card) {
+    const opener = card.querySelector('.mel-event-extra-card__image-open');
+    if (opener) {
+      opener.addEventListener('click', (e) => {
+        e.preventDefault();
+        const gallery = collectGallery(card);
+        openLightbox(card, getActiveGalleryIndex(card, gallery));
+      });
     }
   }
 
@@ -24,6 +456,9 @@
         const dec = card.querySelector('.mel-event-extra-card__qty-btn--dec');
         const inc = card.querySelector('.mel-event-extra-card__qty-btn--inc');
         const max = input ? parseInt(input.getAttribute('max') || '10', 10) : 10;
+
+        bindSizeChips(card);
+        bindGalleryLightbox(card);
 
         if (input) {
           syncQtyDisplay(card, input.value || '0');
@@ -36,6 +471,9 @@
               v = max;
             }
             syncQtyDisplay(card, v);
+          });
+          input.addEventListener('input', () => {
+            notifyBookingSelectionChange(card);
           });
         }
 
@@ -69,6 +507,12 @@
               t.classList.remove('is-active');
             });
             btn.classList.add('is-active');
+          });
+          btn.addEventListener('dblclick', (e) => {
+            e.preventDefault();
+            const gallery = collectGallery(card);
+            const idx = parseInt(btn.getAttribute('data-gallery-index') || '0', 10);
+            openLightbox(card, Number.isFinite(idx) ? idx : 0);
           });
         });
       });

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -61,7 +61,7 @@ operational_addons:
     - core/drupal
 
 event_extras_booking:
-  version: 1.0
+  version: 1.7
   css:
     theme:
       css/mel-operational-addons.css: {}

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.module
@@ -86,16 +86,21 @@ function myeventlane_commerce_page_attachments(array &$attachments): void {
     $locale = 'en-AU';
   }
 
+  $cart_extras = \Drupal::service('myeventlane_commerce.event_booking_summary_cart_extras_builder')
+    ->buildForEvent($node);
+
   $attachments['#attached']['library'][] = 'myeventlane_theme/mel_booking_summary';
   $attachments['#attached']['drupalSettings']['melBookingSummary'] = [
     'enabled' => TRUE,
     'currencyCode' => $currency,
     'locale' => $locale,
+    'cartExtras' => $cart_extras,
     'strings' => [
       'subtotal' => (string) t('Subtotal'),
       'ticketCount' => (string) t('@count tickets'),
       'noTicketsYet' => (string) t('No tickets selected'),
       'ticketFallback' => (string) t('Ticket'),
+      'extraFallback' => (string) t('Event extra'),
       'donationLine' => (string) t('Optional support (estimate)'),
     ],
   ];

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -224,6 +224,15 @@ services:
       - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@string_translation'
 
+  myeventlane_commerce.event_booking_summary_cart_extras_builder:
+    class: Drupal\myeventlane_commerce\Service\EventBookingSummaryCartExtrasBuilder
+    arguments:
+      - '@commerce_cart.cart_provider'
+      - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@myeventlane_commerce.operational_order_item_display_builder'
+      - '@myeventlane_commerce.operational_extra_visual_presenter'
+      - '@entity_type.manager'
+
   myeventlane_commerce.operational_order_item_display_builder:
     class: Drupal\myeventlane_commerce\Service\OperationalOrderItemDisplayBuilder
     arguments:

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -112,17 +112,6 @@ final class EventOperationalAddonCartForm extends FormBase {
       $form['lines'][$index] = $this->buildAddonCard($addon, (int) $index);
     }
 
-    $form['actions'] = [
-      '#type' => 'actions',
-      '#attributes' => ['class' => ['mel-event-extras-form__actions']],
-    ];
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Add extras to cart'),
-      '#button_type' => 'primary',
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary', 'mel-btn--xl', 'mel-event-extras-form__submit']],
-    ];
-
     return $form;
   }
 
@@ -143,15 +132,16 @@ final class EventOperationalAddonCartForm extends FormBase {
     $default_vid = (int) ($addon['default_variation_id'] ?? 0);
 
     $price_display = $this->resolveDisplayPrice($addon, $size_options);
+    $summary_attrs = $this->buildExtraSummaryDataAttributes($addon, $size_options);
 
     $card = [
       '#type' => 'container',
-      '#attributes' => [
+      '#attributes' => array_merge([
         'class' => ['mel-event-extra-card'],
         'data-product-id' => (string) $pid,
         'data-requires-size' => $requires_size ? '1' : '0',
         'data-default-variation' => $default_vid > 0 ? (string) $default_vid : '',
-      ],
+      ], $summary_attrs),
     ];
 
     $card['product_id'] = [
@@ -227,23 +217,45 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
 
     if ($requires_size && $size_options !== []) {
-      $card['size_fieldset'] = [
+      $size_id = 'mel-extra-size-' . $index;
+      $card['body']['sizes'] = [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-event-extra-card__sizes']],
         'label' => [
           '#type' => 'html_tag',
           '#tag' => 'span',
           '#value' => $this->t('Size'),
-          '#attributes' => ['class' => ['mel-event-extra-card__sizes-label']],
+          '#attributes' => [
+            'class' => ['mel-event-extra-card__sizes-label'],
+            'id' => $size_id,
+          ],
         ],
-      ];
-      $card['selected_size'] = [
-        '#type' => 'radios',
-        '#title' => $this->t('Size'),
-        '#title_display' => 'invisible',
-        '#options' => $this->sizeRadioOptions($size_options),
-        '#default_value' => '',
-        '#attributes' => ['class' => ['mel-event-extra-card__size-radios']],
+        'options' => [
+          '#type' => 'container',
+          '#attributes' => [
+            'class' => ['mel-event-extra-card__size-radios'],
+            'role' => 'radiogroup',
+            'aria-labelledby' => $size_id,
+          ],
+          'selected_size' => [
+            '#type' => 'radios',
+            '#options' => $this->sizeRadioOptions($size_options),
+            '#default_value' => '',
+            '#parents' => ['lines', (string) $index, 'selected_size'],
+          ],
+        ],
+        'selected' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => '',
+          '#attributes' => [
+            'class' => ['mel-event-extra-card__size-selected'],
+            'data-mel-extra-size-selected' => 'true',
+            'aria-live' => 'polite',
+            'aria-atomic' => 'true',
+            'hidden' => 'hidden',
+          ],
+        ],
       ];
     }
     else {
@@ -296,6 +308,29 @@ final class EventOperationalAddonCartForm extends FormBase {
       ],
     ];
 
+    $card['footer'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extra-card__footer']],
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Add to Cart'),
+        '#button_type' => 'primary',
+        '#name' => 'add_extra_' . $index,
+        '#line_index' => $index,
+        '#attributes' => [
+          'class' => [
+            'mel-btn',
+            'mel-btn--primary',
+            'mel-event-extra-card__add-to-cart',
+          ],
+          'data-line-index' => (string) $index,
+        ],
+        '#limit_validation_errors' => [
+          ['lines', $index],
+        ],
+      ],
+    ];
+
     return $card;
   }
 
@@ -305,32 +340,67 @@ final class EventOperationalAddonCartForm extends FormBase {
    */
   private function buildGalleryRenderArray(array $gallery, array $primary, string $alt): array {
     $images = $gallery !== [] ? $gallery : [$primary];
-    $main_url = (string) ($images[0]['url'] ?? '');
-    $main_alt = (string) ($images[0]['alt'] ?? $alt);
+    $gallery_payload = [];
+    foreach ($images as $image) {
+      if (!is_array($image)) {
+        continue;
+      }
+      $url = (string) ($image['url'] ?? '');
+      if ($url === '') {
+        continue;
+      }
+      $gallery_payload[] = [
+        'url' => $url,
+        'full_url' => (string) ($image['full_url'] ?? $url),
+        'alt' => (string) ($image['alt'] ?? $alt),
+      ];
+    }
+    if ($gallery_payload === []) {
+      $gallery_payload[] = [
+        'url' => '',
+        'full_url' => '',
+        'alt' => $alt,
+      ];
+    }
 
+    $main = $gallery_payload[0];
+    $main_url = (string) ($main['url'] ?? '');
+    $main_alt = (string) ($main['alt'] ?? $alt);
     $safe_url = htmlspecialchars($main_url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $safe_alt = htmlspecialchars($main_alt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $open_label = htmlspecialchars(
+      (string) $this->t('View larger product image'),
+      ENT_QUOTES | ENT_SUBSTITUTE,
+      'UTF-8',
+    );
+
     $media = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-extra-card__media']],
+      '#attributes' => [
+        'class' => ['mel-event-extra-card__media'],
+        'data-extra-gallery' => (string) json_encode($gallery_payload, JSON_THROW_ON_ERROR),
+      ],
       'primary' => [
-        '#markup' => '<img class="mel-event-extra-card__image" src="' . $safe_url . '" alt="' . $safe_alt . '" loading="lazy" width="400" height="400" decoding="async" />',
+        '#markup' => Markup::create(
+          '<button type="button" class="mel-event-extra-card__image-open" aria-label="' . $open_label . '">'
+          . '<img class="mel-event-extra-card__image" src="' . $safe_url . '" alt="' . $safe_alt . '" loading="lazy" width="400" height="400" decoding="async" />'
+          . '<span class="mel-event-extra-card__image-zoom" aria-hidden="true"></span>'
+          . '</button>'
+        ),
       ],
     ];
 
-    if (count($images) > 1) {
+    if (count($gallery_payload) > 1) {
       $media['thumbs'] = [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-event-extra-card__thumbs']],
       ];
-      foreach ($images as $idx => $image) {
-        if (!is_array($image)) {
-          continue;
-        }
+      foreach ($gallery_payload as $idx => $image) {
         $url = (string) ($image['url'] ?? '');
         if ($url === '') {
           continue;
         }
+        $full_url = (string) ($image['full_url'] ?? $url);
         $thumb_alt = (string) ($image['alt'] ?? $alt);
         $media['thumbs'][] = [
           '#type' => 'html_tag',
@@ -340,7 +410,9 @@ final class EventOperationalAddonCartForm extends FormBase {
             'type' => 'button',
             'class' => ['mel-event-extra-card__thumb', $idx === 0 ? 'is-active' : ''],
             'data-image-url' => $url,
+            'data-image-full-url' => $full_url,
             'data-image-alt' => $thumb_alt,
+            'data-gallery-index' => (string) $idx,
             'aria-label' => (string) $this->t('Show image @num', ['@num' => (string) ($idx + 1)]),
           ],
         ];
@@ -348,6 +420,63 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
 
     return $media;
+  }
+
+  /**
+   * Data attributes for the live booking sidebar summary (JS reads these).
+   *
+   * @param array<string, mixed> $addon
+   * @param list<array<string, mixed>> $size_options
+   *
+   * @return array<string, string>
+   */
+  private function buildExtraSummaryDataAttributes(array $addon, array $size_options): array {
+    $title = trim((string) ($addon['title'] ?? ''));
+    $attrs = [
+      'data-extra-title' => $title !== '' ? $title : (string) $this->t('Event extra'),
+    ];
+
+    $prices_by_size = [];
+    foreach ($size_options as $opt) {
+      if (!is_array($opt)) {
+        continue;
+      }
+      $key = (string) ($opt['size_key'] ?? '');
+      $number = (string) ($opt['price_number'] ?? '');
+      if ($key === '' || $number === '') {
+        continue;
+      }
+      $prices_by_size[$key] = [
+        'number' => $number,
+        'currency' => (string) ($opt['price_currency_code'] ?? ''),
+        'label' => (string) ($opt['size_label'] ?? $key),
+      ];
+    }
+
+    if ($prices_by_size !== []) {
+      $attrs['data-extra-prices'] = (string) json_encode($prices_by_size, JSON_THROW_ON_ERROR);
+      $first = reset($prices_by_size);
+      if (is_array($first)) {
+        $attrs['data-extra-price-number'] = (string) ($first['number'] ?? '');
+        $attrs['data-extra-price-currency'] = (string) ($first['currency'] ?? '');
+      }
+      return $attrs;
+    }
+
+    $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+    $first_var = $variations[0] ?? NULL;
+    if (is_array($first_var)) {
+      $number = (string) ($first_var['price_number'] ?? '');
+      $currency = (string) ($first_var['price_currency_code'] ?? '');
+      if ($number !== '') {
+        $attrs['data-extra-price-number'] = $number;
+        if ($currency !== '') {
+          $attrs['data-extra-price-currency'] = $currency;
+        }
+      }
+    }
+
+    return $attrs;
   }
 
   /**
@@ -472,13 +601,20 @@ final class EventOperationalAddonCartForm extends FormBase {
       return;
     }
 
-    foreach ($lines as $line) {
+    $line_index = $this->triggeredLineIndex($form_state);
+    foreach ($lines as $index => $line) {
+      if ($line_index !== NULL && $index !== $line_index) {
+        continue;
+      }
       if (!is_array($line)) {
         continue;
       }
       $pid = (int) ($line['product_id'] ?? 0);
       $qty = (int) ($line['quantity'] ?? 0);
       if ($qty < 1) {
+        if ($line_index !== NULL) {
+          $form_state->setErrorByName('lines][' . $index . '][quantity', $this->t('Choose a quantity of at least 1.'));
+        }
         continue;
       }
       if ($pid < 1 || !isset($catalog[$pid])) {
@@ -494,7 +630,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $vid = $this->resolveVariationIdForLine($line, $entry);
       if ($vid < 1) {
         if (!empty($entry['requires_size_selection'])) {
-          $form_state->setErrorByName('lines', $this->t('Please choose a size for each extra you add.'));
+          $form_state->setErrorByName('lines][' . $index . '][selected_size', $this->t('Please choose a size before adding to cart.'));
         }
         else {
           $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));
@@ -549,8 +685,13 @@ final class EventOperationalAddonCartForm extends FormBase {
       return;
     }
 
+    $line_index = $this->triggeredLineIndex($form_state);
+
     $to_add = [];
-    foreach ($lines as $line) {
+    foreach ($lines as $index => $line) {
+      if ($line_index !== NULL && $index !== $line_index) {
+        continue;
+      }
       if (!is_array($line)) {
         continue;
       }
@@ -567,7 +708,7 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
 
     if ($to_add === []) {
-      $this->messenger()->addStatus($this->t('Choose a quantity greater than zero to add extras.'));
+      $this->messenger()->addWarning($this->t('Choose a size and quantity, then tap Add to Cart.'));
       return;
     }
 
@@ -628,8 +769,26 @@ final class EventOperationalAddonCartForm extends FormBase {
       }
     }
 
-    $this->messenger()->addStatus($this->t('Event extras added to your booking.'));
+    $added_count = count($to_add);
+    if ($added_count === 1) {
+      $this->messenger()->addStatus($this->t('Added to your cart.'));
+    }
+    else {
+      $this->messenger()->addStatus($this->t('@count extras added to your cart.', ['@count' => $added_count]));
+    }
     $form_state->setRedirectUrl(Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event->id()]));
+  }
+
+  /**
+   * Line index when submit came from a per-card Add to Cart button.
+   */
+  private function triggeredLineIndex(FormStateInterface $form_state): ?int {
+    $trigger = $form_state->getTriggeringElement();
+    if (!is_array($trigger) || !array_key_exists('#line_index', $trigger)) {
+      return NULL;
+    }
+    $index = (int) $trigger['#line_index'];
+    return $index >= 0 ? $index : NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventBookingSummaryCartExtrasBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventBookingSummaryCartExtrasBuilder.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_cart\CartProviderInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Cart-backed extras for the paid event book page "Your selection" sidebar.
+ */
+final class EventBookingSummaryCartExtrasBuilder {
+
+  public function __construct(
+    private readonly CartProviderInterface $cartProvider,
+    private readonly EventOperationalAddonBuilder $addonBuilder,
+    private readonly OperationalOrderItemDisplayBuilder $orderItemDisplayBuilder,
+    private readonly OperationalExtraVisualPresenter $visualPresenter,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Builds cart-backed extra lines for the booking summary sidebar.
+   *
+   * @return list<array{
+   *   merge_key: string,
+   *     product_id: int,
+   *     size_key: string,
+   *     title: string,
+   *     qty: int,
+   *     unit_number: string,
+   *     currency: string,
+   *   }>
+   *   Sanitized extra lines keyed for client-side merge with in-form preview.
+   */
+  public function buildForEvent(NodeInterface $event): array {
+    if ($event->bundle() !== 'event') {
+      return [];
+    }
+
+    $event_id = (int) $event->id();
+    $stores = $this->collectStoresForEvent($event);
+    if ($stores === []) {
+      return [];
+    }
+
+    $lines = [];
+    $seen_order_items = [];
+    foreach ($stores as $store) {
+      $cart = $this->cartProvider->getCart('default', $store);
+      if (!$cart instanceof OrderInterface) {
+        continue;
+      }
+      foreach ($cart->getItems() as $order_item) {
+        if (!$order_item instanceof OrderItemInterface) {
+          continue;
+        }
+        $oid = (int) $order_item->id();
+        if ($oid > 0 && isset($seen_order_items[$oid])) {
+          continue;
+        }
+        $line = $this->buildLineFromOrderItem($order_item, $event_id);
+        if ($line === NULL) {
+          continue;
+        }
+        if ($oid > 0) {
+          $seen_order_items[$oid] = TRUE;
+        }
+        $lines[] = $line;
+      }
+    }
+
+    return $lines;
+  }
+
+  /**
+   * Collects stores for ticket and operational products on the event.
+   *
+   * @return array<string, \Drupal\commerce_store\Entity\StoreInterface>
+   *   Store entities keyed by store ID.
+   */
+  private function collectStoresForEvent(NodeInterface $event): array {
+    /** @var array<string, StoreInterface> $stores */
+    $stores = [];
+
+    if ($event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
+      $product = $event->get('field_product_target')->entity;
+      if ($product instanceof ProductInterface) {
+        foreach ($product->getStores() as $store) {
+          if ($store instanceof StoreInterface) {
+            $stores[(string) $store->id()] = $store;
+          }
+        }
+      }
+    }
+
+    $built = $this->addonBuilder->buildForEvent($event);
+    $product_ids = is_array($built['product_ids'] ?? NULL) ? $built['product_ids'] : [];
+    if ($product_ids === []) {
+      return $stores;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('commerce_product');
+    foreach ($product_ids as $pid) {
+      $pid = (int) $pid;
+      if ($pid < 1) {
+        continue;
+      }
+      $product = $storage->load($pid);
+      if (!$product instanceof ProductInterface) {
+        continue;
+      }
+      foreach ($product->getStores() as $store) {
+        if ($store instanceof StoreInterface) {
+          $stores[(string) $store->id()] = $store;
+        }
+      }
+    }
+
+    return $stores;
+  }
+
+  /**
+   * Builds one summary line from a cart order item for this event.
+   *
+   * @return array{
+   *   merge_key: string,
+   *     product_id: int,
+   *     size_key: string,
+   *     title: string,
+   *     qty: int,
+   *     unit_number: string,
+   *     currency: string,
+   *   }|null
+   *   Summary line document, or NULL when the item is not an event extra.
+   */
+  private function buildLineFromOrderItem(OrderItemInterface $order_item, int $event_id): ?array {
+    $display = $this->orderItemDisplayBuilder->buildForOrderItem($order_item);
+    if ($display === NULL) {
+      return NULL;
+    }
+    if ((int) ($display['event_id'] ?? 0) !== $event_id) {
+      return NULL;
+    }
+
+    $purchased = $order_item->getPurchasedEntity();
+    if (!$purchased instanceof ProductVariationInterface) {
+      return NULL;
+    }
+    $product = $purchased->getProduct();
+    if (!$product instanceof ProductInterface) {
+      return NULL;
+    }
+
+    $qty = (int) round((float) $order_item->getQuantity());
+    if ($qty < 1) {
+      return NULL;
+    }
+
+    $unit_price = $order_item->getUnitPrice() ?? $purchased->getPrice();
+    if ($unit_price === NULL) {
+      return NULL;
+    }
+
+    $title = trim((string) ($display['title'] ?? ''));
+    if ($title === '') {
+      $title = trim((string) $product->label());
+    }
+
+    $size = $this->visualPresenter->resolveVariationSize($purchased);
+    $size_key = (string) ($size['size_key'] ?? '');
+    $size_label = trim((string) ($display['size_label'] ?? ''));
+    if ($size_label === '' && $size_key !== '') {
+      $size_label = (string) ($size['size_label'] ?? strtoupper($size_key));
+    }
+    if ($size_label !== '') {
+      $title = $title . ' (' . $size_label . ')';
+    }
+
+    $product_id = (int) $product->id();
+    $merge_key = $product_id . ':' . ($size_key !== '' ? $size_key : 'default');
+
+    return [
+      'merge_key' => $merge_key,
+      'product_id' => $product_id,
+      'size_key' => $size_key,
+      'title' => $title,
+      'qty' => $qty,
+      'unit_number' => (string) $unit_price->getNumber(),
+      'currency' => (string) $unit_price->getCurrencyCode(),
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalExtraVisualPresenter.php
@@ -203,8 +203,10 @@ class OperationalExtraVisualPresenter {
    * @return array<string, mixed>
    */
   public function buildPlaceholderImage(): array {
+    $placeholder = $this->placeholderUrl();
     return [
-      'url' => $this->placeholderUrl(),
+      'url' => $placeholder,
+      'full_url' => $placeholder,
       'alt' => (string) $this->t('Event extra'),
       'is_placeholder' => TRUE,
       'media_id' => 0,
@@ -250,12 +252,14 @@ class OperationalExtraVisualPresenter {
     }
     $style = $this->loadImageStyle();
     $uri = $file->getFileUri();
+    $full_url = $this->fileUrlGenerator->generateAbsoluteString($uri);
     $url = $style instanceof ImageStyleInterface
       ? $style->buildUrl($uri)
-      : $this->fileUrlGenerator->generateAbsoluteString($uri);
+      : $full_url;
 
     return [
       'url' => $url,
+      'full_url' => $full_url,
       'alt' => $this->sanitizePlainText($alt, 255),
       'is_placeholder' => FALSE,
       'media_id' => (int) $media->id(),

--- a/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-booking-summary.js
@@ -141,47 +141,259 @@
   }
 
   /**
-   * @param {HTMLFormElement} form
+   * @param {HTMLElement} flow
    * @returns {{ container: Document|HTMLElement, empty: HTMLElement|null, items: HTMLElement|null, subtotalWrap: HTMLElement|null, subtotalValue: HTMLElement|null, mobileBar: HTMLElement|null, countEl: HTMLElement|null, totalEl: HTMLElement|null, submit: HTMLElement|null }}
    */
-  function getTargets(form) {
-    const flow = form.closest('[data-mel-booking-flow]');
+  function getTargets(flow) {
     const root =
-      form.closest('.mel-booking-v2') ||
+      flow.closest('.mel-booking-v2') ||
       document.querySelector('.mel-booking-v2') ||
       document;
-    const scope = flow || form;
     return {
       container: root,
       empty: root.querySelector('[data-mel-summary-empty]'),
       items: root.querySelector('[data-mel-summary-items]'),
       subtotalWrap: root.querySelector('[data-mel-summary-subtotal]'),
       subtotalValue: root.querySelector('[data-mel-summary-subtotal-value]'),
-      mobileBar: scope.querySelector('[data-mel-mobile-booking-bar]'),
-      countEl: scope.querySelector('[data-mel-booking-count]'),
-      totalEl: scope.querySelector('[data-mel-booking-total]'),
-      submit: scope.querySelector('.mel-add-to-cart-button, input[type="submit"].button--primary, button[type="submit"].button--primary'),
+      mobileBar: flow.querySelector('[data-mel-mobile-booking-bar]'),
+      countEl: flow.querySelector('[data-mel-booking-count]'),
+      totalEl: flow.querySelector('[data-mel-booking-total]'),
+      submit: flow.querySelector('.mel-add-to-cart-button, input[type="submit"].button--primary, button[type="submit"].button--primary'),
     };
   }
 
   /**
-   * @param {HTMLFormElement} form
+   * @param {HTMLElement} card
+   * @returns {Record<string, {number?: string, currency?: string, label?: string}>}
+   */
+  function getExtraPricesBySize(card) {
+    const raw = card.getAttribute('data-extra-prices');
+    if (!raw) {
+      return {};
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @returns {string}
+   */
+  function getSelectedExtraSizeKey(card) {
+    const checked = card.querySelector('input[type="radio"][name*="selected_size"]:checked');
+    if (checked instanceof HTMLInputElement) {
+      return checked.value;
+    }
+    const selectedChip = card.querySelector(
+      '.mel-event-extra-card__sizes .form-type-radio.is-selected input[type="radio"]',
+    );
+    if (selectedChip instanceof HTMLInputElement) {
+      return selectedChip.value;
+    }
+    return '';
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @returns {number}
+   */
+  function getExtraQuantity(card) {
+    const input = card.querySelector('.mel-event-extra-card__qty-input');
+    if (input && !input.disabled) {
+      const raw = parseInt(String(input.value), 10);
+      if (Number.isFinite(raw) && raw > 0) {
+        return raw;
+      }
+    }
+    const display = card.querySelector('.mel-event-extra-card__qty-value');
+    if (display) {
+      const raw = parseInt(String(display.textContent || '').trim(), 10);
+      if (Number.isFinite(raw) && raw > 0) {
+        return raw;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @param {string} sizeKey
+   * @returns {string}
+   */
+  function getExtraMergeKey(card, sizeKey) {
+    const productId = card.getAttribute('data-product-id') || '';
+    return `${productId}:${sizeKey || 'default'}`;
+  }
+
+  /**
+   * @param {HTMLElement} card
+   * @returns {number}
+   */
+  function getExtraUnitPrice(card) {
+    const sizeKey = getSelectedExtraSizeKey(card);
+    const prices = getExtraPricesBySize(card);
+    if (sizeKey && prices[sizeKey] && prices[sizeKey].number) {
+      const n = parseFloat(String(prices[sizeKey].number).replace(/,/g, ''), 10);
+      if (Number.isFinite(n)) {
+        return n;
+      }
+    }
+    const attr = card.getAttribute('data-extra-price-number');
+    if (attr) {
+      const n = parseFloat(String(attr).replace(/,/g, ''), 10);
+      if (Number.isFinite(n)) {
+        return n;
+      }
+    }
+    const priceEl = card.querySelector('.mel-event-extra-card__price');
+    if (priceEl) {
+      return parsePriceFromText(priceEl.textContent || '');
+    }
+    return 0;
+  }
+
+  /**
+   * @param {HTMLElement} flow
+   * @param {object} strings
+   * @returns {{ title: string, qty: number, line: number }[]}
+   */
+  function getExtraSummaryLines(flow, strings) {
+    /** @type {{ title: string, qty: number, line: number, mergeKey: string }[]} */
+    const lines = [];
+    flow.querySelectorAll('.mel-event-extra-card').forEach((card) => {
+      const qty = getExtraQuantity(card);
+      if (qty <= 0) {
+        return;
+      }
+      const requiresSize = card.getAttribute('data-requires-size') === '1';
+      const sizeKey = getSelectedExtraSizeKey(card);
+      if (requiresSize && !sizeKey) {
+        return;
+      }
+      const title =
+        card.getAttribute('data-extra-title') ||
+        card.querySelector('.mel-event-extra-card__title')?.textContent?.trim() ||
+        strings.extraFallback ||
+        'Event extra';
+      let label = title;
+      if (sizeKey) {
+        const prices = getExtraPricesBySize(card);
+        const sizeLabel = prices[sizeKey]?.label || sizeKey.toUpperCase();
+        label = `${title} (${sizeLabel})`;
+      }
+      const unit = getExtraUnitPrice(card);
+      lines.push({
+        title: label,
+        qty,
+        line: qty * unit,
+        mergeKey: getExtraMergeKey(card, sizeKey),
+      });
+    });
+    return lines;
+  }
+
+  /**
+   * @param {object} settings
+   * @returns {{ title: string, qty: number, line: number, mergeKey: string }[]}
+   */
+  function getCartExtraSummaryLines(settings) {
+    const raw = settings.cartExtras;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      return [];
+    }
+    /** @type {{ title: string, qty: number, line: number, mergeKey: string }[]} */
+    const lines = [];
+    raw.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const qty = parseInt(String(entry.qty ?? ''), 10);
+      if (!Number.isFinite(qty) || qty < 1) {
+        return;
+      }
+      const unit = parseFloat(String(entry.unit_number ?? '').replace(/,/g, ''), 10);
+      if (!Number.isFinite(unit)) {
+        return;
+      }
+      const title = String(entry.title ?? '').trim();
+      if (title === '') {
+        return;
+      }
+      const mergeKey = String(entry.merge_key ?? '').trim();
+      lines.push({
+        title,
+        qty,
+        line: qty * unit,
+        mergeKey: mergeKey !== '' ? mergeKey : `cart:${title}`,
+      });
+    });
+    return lines;
+  }
+
+  /**
+   * @param {{ title: string, qty: number, line: number, mergeKey: string }[]} cartLines
+   * @param {{ title: string, qty: number, line: number, mergeKey: string }[]} formLines
+   * @returns {{ title: string, qty: number, line: number }[]}
+   */
+  function mergeExtraSummaryLines(cartLines, formLines) {
+    /** @type {Map<string, { title: string, qty: number, line: number }>} */
+    const merged = new Map();
+    cartLines.forEach((line) => {
+      merged.set(line.mergeKey, {
+        title: line.title,
+        qty: line.qty,
+        line: line.line,
+      });
+    });
+    formLines.forEach((line) => {
+      merged.set(line.mergeKey, {
+        title: line.title,
+        qty: line.qty,
+        line: line.line,
+      });
+    });
+    return Array.from(merged.values());
+  }
+
+  /**
+   * @param {HTMLElement} flow
+   * @param {HTMLFormElement} ticketForm
    * @param {object} settings
    */
-  function bindForm(form, settings) {
+  function bindBookingFlow(flow, ticketForm, settings) {
     const fmt = getMoneyFormatter(settings.currencyCode, settings.locale);
-    const targets = getTargets(form);
+    const targets = getTargets(flow);
     let announceTimer = null;
     let lastAnnounce = '';
 
     const strings = settings.strings || {};
 
+    const appendSummaryLine = (ul, line, extraClass) => {
+      const li = document.createElement('li');
+      li.className = extraClass
+        ? `mel-booking-summary__item ${extraClass}`
+        : 'mel-booking-summary__item';
+      const label = document.createElement('span');
+      label.className = 'mel-booking-summary__item-label';
+      label.textContent = `${line.qty} × ${line.title}`;
+      const amt = document.createElement('span');
+      amt.className = 'mel-booking-summary__item-amount';
+      amt.textContent = fmt.format(line.line);
+      li.appendChild(label);
+      li.appendChild(amt);
+      ul.appendChild(li);
+    };
+
     const sync = () => {
-      const rows = getTicketRows(form);
-      let totalQty = 0;
+      const rows = getTicketRows(ticketForm);
+      let ticketQty = 0;
       let subtotal = 0;
       /** @type {{ title: string, qty: number, line: number }[]} */
-      const lines = [];
+      const ticketLines = [];
 
       rows.forEach((row) => {
         const qty = getQuantity(row);
@@ -194,14 +406,25 @@
           row.querySelector('.mel-ticket-label')?.textContent?.trim() ||
           strings.ticketFallback ||
           'Ticket';
-        totalQty += qty;
+        ticketQty += qty;
         const line = qty * unit;
         subtotal += line;
-        lines.push({ title, qty, line });
+        ticketLines.push({ title, qty, line });
       });
 
-      const hasSelection = totalQty > 0;
-      const donationLine = hasSelection ? getOptionalDonation(form) : 0;
+      const formExtraLines = getExtraSummaryLines(flow, strings);
+      const cartExtraLines = getCartExtraSummaryLines(settings);
+      const extraLines = mergeExtraSummaryLines(cartExtraLines, formExtraLines);
+      let extraQty = 0;
+      extraLines.forEach((l) => {
+        extraQty += l.qty;
+        subtotal += l.line;
+      });
+
+      const hasTickets = ticketQty > 0;
+      const hasExtras = extraLines.length > 0;
+      const hasSelection = hasTickets || hasExtras;
+      const donationLine = hasTickets ? getOptionalDonation(ticketForm) : 0;
       const displayTotal = subtotal + donationLine;
 
       if (targets.empty) {
@@ -213,31 +436,14 @@
         } else {
           const ul = document.createElement('ul');
           ul.className = 'mel-booking-summary__list';
-          lines.forEach((l) => {
-            const li = document.createElement('li');
-            li.className = 'mel-booking-summary__item';
-            const label = document.createElement('span');
-            label.className = 'mel-booking-summary__item-label';
-            label.textContent = `${l.qty} × ${l.title}`;
-            const amt = document.createElement('span');
-            amt.className = 'mel-booking-summary__item-amount';
-            amt.textContent = fmt.format(l.line);
-            li.appendChild(label);
-            li.appendChild(amt);
-            ul.appendChild(li);
-          });
+          ticketLines.forEach((l) => appendSummaryLine(ul, l, ''));
+          extraLines.forEach((l) => appendSummaryLine(ul, l, 'mel-booking-summary__item--extra'));
           if (donationLine > 0) {
-            const dli = document.createElement('li');
-            dli.className = 'mel-booking-summary__item mel-booking-summary__item--donation';
-            const dlabel = document.createElement('span');
-            dlabel.className = 'mel-booking-summary__item-label';
-            dlabel.textContent = strings.donationLine || 'Contribution';
-            const damt = document.createElement('span');
-            damt.className = 'mel-booking-summary__item-amount';
-            damt.textContent = fmt.format(donationLine);
-            dli.appendChild(dlabel);
-            dli.appendChild(damt);
-            ul.appendChild(dli);
+            appendSummaryLine(
+              ul,
+              { title: strings.donationLine || 'Contribution', qty: 1, line: donationLine },
+              'mel-booking-summary__item--donation',
+            );
           }
           targets.items.innerHTML = '';
           targets.items.appendChild(ul);
@@ -249,12 +455,13 @@
         targets.subtotalValue.textContent = hasSelection ? fmt.format(displayTotal) : '';
       }
 
+      const totalItemQty = ticketQty + extraQty;
       if (targets.countEl) {
-        if (totalQty === 0) {
+        if (totalItemQty === 0) {
           targets.countEl.textContent = strings.noTicketsYet || '';
         } else {
           const tpl = strings.ticketCount || '@count tickets';
-          targets.countEl.textContent = tpl.replace('@count', String(totalQty));
+          targets.countEl.textContent = tpl.replace('@count', String(totalItemQty));
         }
       }
       if (targets.totalEl) {
@@ -262,7 +469,7 @@
       }
 
       if (targets.submit) {
-        targets.submit.classList.toggle('mel-booking-submit--soft-idle', !hasSelection);
+        targets.submit.classList.toggle('mel-booking-submit--soft-idle', !hasTickets);
       }
 
       rows.forEach((row) => {
@@ -285,7 +492,8 @@
         if (!targets.items || !hasSelection) {
           return;
         }
-        let summary = lines.map((l) => `${l.qty} ${l.title}`).join(', ');
+        const allLines = ticketLines.concat(extraLines);
+        let summary = allLines.map((l) => `${l.qty} ${l.title}`).join(', ');
         if (donationLine > 0) {
           summary += `. ${strings.donationLine || 'Contribution'} ${fmt.format(donationLine)}`;
         }
@@ -303,7 +511,7 @@
     });
 
     const onChange = () => sync();
-    getTicketRows(form).forEach((row) => {
+    getTicketRows(ticketForm).forEach((row) => {
       const input = getQtyInput(row);
       if (input) {
         input.addEventListener('input', onChange);
@@ -311,13 +519,13 @@
       }
     });
 
-    const donationInput = form.querySelector('[name="mel_donation"]');
+    const donationInput = ticketForm.querySelector('[name="mel_donation"]');
     if (donationInput) {
       donationInput.addEventListener('input', onChange);
       donationInput.addEventListener('change', onChange);
     }
 
-    form.querySelectorAll('.mel-donation-chip[data-amount]').forEach((chip) => {
+    ticketForm.querySelectorAll('.mel-donation-chip[data-amount]').forEach((chip) => {
       chip.addEventListener('click', (e) => {
         e.preventDefault();
         const amount = parseFloat(chip.getAttribute('data-amount') || '', 10);
@@ -331,7 +539,7 @@
       });
     });
 
-    form.addEventListener(
+    ticketForm.addEventListener(
       'input',
       (e) => {
         if (isQuantityControl(e.target) || isDonationControl(e.target)) {
@@ -340,7 +548,7 @@
       },
       false,
     );
-    form.addEventListener(
+    ticketForm.addEventListener(
       'change',
       (e) => {
         if (isQuantityControl(e.target) || isDonationControl(e.target)) {
@@ -350,9 +558,29 @@
       false,
     );
 
-    form.addEventListener('submit', () => {
+    ticketForm.addEventListener('submit', () => {
       window.setTimeout(sync, 0);
     });
+
+    flow.addEventListener('mel-booking-selection-change', onChange, false);
+    flow.addEventListener(
+      'change',
+      (e) => {
+        if (e.target instanceof HTMLElement && e.target.closest('.mel-event-extra-card')) {
+          onChange();
+        }
+      },
+      false,
+    );
+    flow.addEventListener(
+      'input',
+      (e) => {
+        if (e.target instanceof HTMLElement && e.target.closest('.mel-event-extra-card')) {
+          onChange();
+        }
+      },
+      false,
+    );
   }
 
   Drupal.behaviors.melBookingSummary = {
@@ -368,8 +596,12 @@
         ...raw,
         enabled: true,
       };
-      once('mel-booking-summary', '.mel-booking-form[data-mel-booking-form]', context).forEach((el) => {
-        bindForm(el, settings);
+      once('mel-booking-summary', '[data-mel-booking-flow]', context).forEach((flow) => {
+        const ticketForm = flow.querySelector('.mel-booking-form[data-mel-booking-form]');
+        if (!(ticketForm instanceof HTMLFormElement)) {
+          return;
+        }
+        bindBookingFlow(flow, ticketForm, settings);
       });
     },
   };

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -216,9 +216,11 @@ mel_confirmation:
 
 # Live order summary + mobile totals on /event/{nid}/book (paid ticket matrix only).
 mel_booking_summary:
+  version: 1.3
   js:
     js/mel-booking-summary.js: {}
   dependencies:
     - core/drupal
     - core/drupalSettings
     - core/once
+    - myeventlane_commerce/event_extras_booking

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
@@ -633,6 +633,12 @@
     }
   }
 
+  .mel-booking-summary__item--extra {
+    .mel-booking-summary__item-label {
+      font-weight: typography.$mel-font-semibold;
+    }
+  }
+
   .mel-ticket-row {
     position: relative;
     display: grid;


### PR DESCRIPTION
Adds a unified vendor-facing Event Studio Extras editor so organisers can create and manage event extras such as merch, hospitality, pickup items, and bundles without using raw Commerce product admin pages.

Includes:
- /vendor/events/{event}/studio/extras route
- redirects/aliases from legacy merchandise/add-ons routes
- vendor-owned create/update flow for operational Commerce products
- visual Event Extras UI with preview cards
- size-aware merchandise variation handling
- admin-only advanced Commerce edit fallback
- contract rendering fix for EventStudioEventExtrasForm autoloading
- tests for section contract and vendor product creation manager

No stock, warehouse, shipping orchestration, scanner, QR, entitlement, checkout, or order mutation logic was added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the event booking purchase flow to add per-card submissions, size-selection UI, and cart-backed extras in the live summary; mistakes could cause incorrect quantities/sizes or confusing booking totals.
> 
> **Overview**
> Enhances Event Extras on the booking page with **size chip selection**, **per-card “Add to Cart” actions**, and a **click-to-zoom image lightbox** (including full-size gallery navigation).
> 
> Updates the live booking sidebar summary to include extras (merged from both current form selections and existing cart items via new `EventBookingSummaryCartExtrasBuilder` + `drupalSettings.melBookingSummary.cartExtras`), and adjusts UI/validation so only the triggered extra line is validated/submitted with clearer messages and size-required errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0e07bdb92961eb0c51dda558f02a89f449dae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->