### PR TITLE
Feature/event page style themes

### DIFF
--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -38,6 +38,8 @@ dependencies:
     - field.field.node.event.field_location_latitude
     - field.field.node.event.field_location_longitude
     - field.field.node.event.field_location_place_id
+    - field.field.node.event.field_mel_page_style
+    - field.field.node.event.field_mel_theme_colour
     - field.field.node.event.field_product_target
     - field.field.node.event.field_promo_expires
     - field.field.node.event.field_promoted
@@ -122,6 +124,8 @@ hidden:
   field_location_longitude: true
   field_location_place_id: true
   field_mel_op_capabilities: true
+  field_mel_page_style: true
+  field_mel_theme_colour: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true

--- a/config/sync/field.field.node.event.field_mel_page_style.yml
+++ b/config/sync/field.field.node.event.field_mel_page_style.yml
@@ -1,0 +1,23 @@
+uuid: c3d4e5f6-a7b8-4901-c234-56789abcdef0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_mel_page_style
+    - node.type.event
+  module:
+    - options
+id: node.event.field_mel_page_style
+field_name: field_mel_page_style
+entity_type: node
+bundle: event
+label: 'Event page style'
+description: 'Public event page layout style (Classic or Immersive).'
+required: false
+translatable: true
+default_value:
+  -
+    value: classic
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.event.field_mel_theme_colour.yml
+++ b/config/sync/field.field.node.event.field_mel_theme_colour.yml
@@ -1,0 +1,23 @@
+uuid: d4e5f6a7-b8c9-4012-d345-6789abcdef01
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_mel_theme_colour
+    - node.type.event
+  module:
+    - options
+id: node.event.field_mel_theme_colour
+field_name: field_mel_theme_colour
+entity_type: node
+bundle: event
+label: 'Event theme colour'
+description: 'Accent colour preset for the public event page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: coral
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_mel_page_style.yml
+++ b/config/sync/field.storage.node.field_mel_page_style.yml
@@ -13,10 +13,10 @@ settings:
   allowed_values:
     -
       value: classic
-      label: 'MEL Classic'
+      label: 'Warm & Energetic'
     -
       value: immersive
-      label: 'MEL Immersive'
+      label: 'Bold & Immersive'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/field.storage.node.field_mel_page_style.yml
+++ b/config/sync/field.storage.node.field_mel_page_style.yml
@@ -1,0 +1,27 @@
+uuid: a1b2c3d4-e5f6-4789-a012-3456789abcde
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_mel_page_style
+field_name: field_mel_page_style
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: classic
+      label: 'MEL Classic'
+    -
+      value: immersive
+      label: 'MEL Immersive'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_mel_theme_colour.yml
+++ b/config/sync/field.storage.node.field_mel_theme_colour.yml
@@ -1,0 +1,36 @@
+uuid: b2c3d4e5-f6a7-4890-b123-456789abcdef
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_mel_theme_colour
+field_name: field_mel_theme_colour
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: coral
+      label: Coral
+    -
+      value: purple
+      label: Purple
+    -
+      value: mint
+      label: Mint
+    -
+      value: gold
+      label: Gold
+    -
+      value: blue
+      label: 'Deep Blue'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_mel_theme_colour.yml
+++ b/config/sync/field.storage.node.field_mel_theme_colour.yml
@@ -13,19 +13,19 @@ settings:
   allowed_values:
     -
       value: coral
-      label: Coral
+      label: 'Coral Pop'
     -
       value: purple
-      label: Purple
+      label: 'Violet Pulse'
     -
       value: mint
-      label: Mint
+      label: 'Mint Night'
     -
       value: gold
-      label: Gold
+      label: 'Golden Hour'
     -
       value: blue
-      label: 'Deep Blue'
+      label: 'Ocean Blue'
   allowed_values_function: ''
 module: options
 locked: false

--- a/docs/event-page-style-and-colour-themes.md
+++ b/docs/event-page-style-and-colour-themes.md
@@ -2,16 +2,30 @@
 
 ## Product decision
 
-- **MEL Classic** is the default public event page style for all vendors.
-- **MEL Immersive** is a premium layout for organisers with Pro capability (or admin).
-- Vendors choose a **safe colour preset** (no custom hex in this slice).
-- Billing, checkout, and subscription purchase are **out of scope** here; capability is gated via a dedicated service seam.
+- **Mockup 1 — Warm & Energetic** (`classic` + `coral`) is the default public event page for everyone.
+- **Non-Pro vendors** always publish and render `classic` / `coral` (stored Pro-only values do not leak to the public page).
+- **Pro organisers** (or admin) may choose **Bold & Immersive** (`immersive`) and any curated colour mood preset.
+- Vendors choose from **MEL-designed presets only** (no custom hex picker).
+- **Clean & Modern** (Mockup 2) is deferred to a future slice.
+- Billing, checkout, and subscription purchase are **out of scope**; capability is gated via `EventStyleAccessManager` + `ProAccessService`.
+
+## Vendor-facing labels
+
+| Machine | Label |
+|---------|--------|
+| `classic` | Warm & Energetic |
+| `immersive` | Bold & Immersive |
+| `coral` | Coral Pop |
+| `purple` | Violet Pulse |
+| `mint` | Mint Night |
+| `gold` | Golden Hour |
+| `blue` | Ocean Blue |
 
 ## Classic vs Immersive
 
-| | MEL Classic | MEL Immersive |
+| | Warm & Energetic (`classic`) | Bold & Immersive (`immersive`) |
 |---|-------------|----------------|
-| Access | All vendors | Pro (`event_immersive_style`) or `administer nodes` |
+| Public render | All vendors (default) | Pro (`event_immersive_style`) or `administer nodes` |
 | Feel | Warm, community-first, bright cards | Dark cinematic hero, bold contrast |
 | Best for | Workshops, markets, community | Music, nightlife, launches |
 
@@ -29,9 +43,10 @@ Allowed colours: `coral`, `purple`, `mint`, `gold`, `blue`.
 
 - **Service ID:** `myeventlane_event_studio.event_style_access`
 - **Class:** `Drupal\myeventlane_event_studio\Service\EventStyleAccessManager`
-- **Method:** `canUseImmersiveStyle(NodeInterface $event, AccountInterface $account): bool`
+- **Methods:** `canCustomizeEventPage()`, `canUseStyle()`, `canUseColour()`, `canUseImmersiveStyle()`
 - **Pro feature key:** `event_immersive_style` (listed in `ProAccessService` gated features)
 - **Admin bypass:** `administer nodes`
+- Non-Pro: `classic` + `coral` only.
 - Future: subscription state, boost purchase, or admin override can extend this service without changing Event Studio save paths.
 
 ## Public render resolver
@@ -39,13 +54,14 @@ Allowed colours: `coral`, `purple`, `mint`, `gold`, `blue`.
 - **Service ID:** `myeventlane_event_studio.event_page_style_resolver`
 - **Class:** `Drupal\myeventlane_event_studio\Service\EventPageStyleResolver`
 - Sanitizes stored values; builds modifier classes for Twig.
-- **This slice:** public pages trust stored style when valid; Studio blocks unauthorized Immersive saves. When Pro expires, a future job should downgrade stored `field_mel_page_style` using entitlement state.
+- **Public render:** uses event owner capability; non-Pro owners always resolve to `classic` / `coral` regardless of stored values.
+- **Studio save:** validation errors for Pro-only style/colour; `resolveForPersistence()` downgrades defense-in-depth.
 
 ## Event Studio UX
 
 - **Form:** `EventBrandingForm` (Branding workspace)
-- **Probe:** “What feeling should this event page have?”
-- **Present:** Classic and Immersive option cards (`#mel_option_cards`)
+- **Section:** “Choose your event page style”
+- **Present:** Warm & Energetic and Bold & Immersive option cards (`#mel_option_cards`)
 - **Listen:** Selected style + colour radios reflect current node values
 - **Ask:** Save writes `field_mel_page_style` and `field_mel_theme_colour` via `EventStudioSaveService::saveBrandingHero()`
 - **Invite:** Non-Pro vendors see Immersive disabled with upgrade copy (no billing link in this slice)
@@ -74,7 +90,7 @@ SCSS: `web/themes/custom/myeventlane_theme/src/scss/components/_event-page-theme
 
 ## QA checklist
 
-- [ ] Vendor without Pro: Classic + colours save; Immersive locked; tampered POST rejected
+- [ ] Vendor without Pro: public page classic/coral; Immersive and non-coral moods locked; tampered POST rejected
 - [ ] Pro vendor: Immersive saves and public page shows Immersive classes
 - [ ] Admin: Immersive available
 - [ ] Invalid style/colour values sanitize to classic/coral on public render

--- a/docs/event-page-style-and-colour-themes.md
+++ b/docs/event-page-style-and-colour-themes.md
@@ -1,0 +1,95 @@
+# Event page style and colour themes
+
+## Product decision
+
+- **MEL Classic** is the default public event page style for all vendors.
+- **MEL Immersive** is a premium layout for organisers with Pro capability (or admin).
+- Vendors choose a **safe colour preset** (no custom hex in this slice).
+- Billing, checkout, and subscription purchase are **out of scope** here; capability is gated via a dedicated service seam.
+
+## Classic vs Immersive
+
+| | MEL Classic | MEL Immersive |
+|---|-------------|----------------|
+| Access | All vendors | Pro (`event_immersive_style`) or `administer nodes` |
+| Feel | Warm, community-first, bright cards | Dark cinematic hero, bold contrast |
+| Best for | Workshops, markets, community | Music, nightlife, launches |
+
+## Fields (config/sync)
+
+| Field | Machine name | Default |
+|-------|----------------|---------|
+| Event page style | `field_mel_page_style` | `classic` |
+| Event theme colour | `field_mel_theme_colour` | `coral` |
+
+Allowed style values: `classic`, `immersive`.  
+Allowed colours: `coral`, `purple`, `mint`, `gold`, `blue`.
+
+## Capability service
+
+- **Service ID:** `myeventlane_event_studio.event_style_access`
+- **Class:** `Drupal\myeventlane_event_studio\Service\EventStyleAccessManager`
+- **Method:** `canUseImmersiveStyle(NodeInterface $event, AccountInterface $account): bool`
+- **Pro feature key:** `event_immersive_style` (listed in `ProAccessService` gated features)
+- **Admin bypass:** `administer nodes`
+- Future: subscription state, boost purchase, or admin override can extend this service without changing Event Studio save paths.
+
+## Public render resolver
+
+- **Service ID:** `myeventlane_event_studio.event_page_style_resolver`
+- **Class:** `Drupal\myeventlane_event_studio\Service\EventPageStyleResolver`
+- Sanitizes stored values; builds modifier classes for Twig.
+- **This slice:** public pages trust stored style when valid; Studio blocks unauthorized Immersive saves. When Pro expires, a future job should downgrade stored `field_mel_page_style` using entitlement state.
+
+## Event Studio UX
+
+- **Form:** `EventBrandingForm` (Branding workspace)
+- **Probe:** “What feeling should this event page have?”
+- **Present:** Classic and Immersive option cards (`#mel_option_cards`)
+- **Listen:** Selected style + colour radios reflect current node values
+- **Ask:** Save writes `field_mel_page_style` and `field_mel_theme_colour` via `EventStudioSaveService::saveBrandingHero()`
+- **Invite:** Non-Pro vendors see Immersive disabled with upgrade copy (no billing link in this slice)
+- **Validation:** Unauthorized Immersive submission returns a form error (not silent downgrade)
+
+## Public CSS / classes
+
+Applied on the full event `<article>` (single template: `node--event--full.html.twig`):
+
+- `mel-event-page--classic` | `mel-event-page--immersive`
+- `mel-event-page--colour-{coral|purple|mint|gold|blue}`
+
+CSS variables per colour:
+
+- `--mel-event-accent`
+- `--mel-event-accent-soft`
+- `--mel-event-accent-contrast`
+
+SCSS: `web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss`
+
+## Accessibility
+
+- WCAG-minded contrast on Immersive cards and CTAs
+- Minimum **44px** tap targets on primary actions
+- `prefers-reduced-motion: reduce` respected (no motion-heavy effects)
+
+## QA checklist
+
+- [ ] Vendor without Pro: Classic + colours save; Immersive locked; tampered POST rejected
+- [ ] Pro vendor: Immersive saves and public page shows Immersive classes
+- [ ] Admin: Immersive available
+- [ ] Invalid style/colour values sanitize to classic/coral on public render
+- [ ] Each colour preset updates CTA/accent on Classic and Immersive
+- [ ] `npm run mel:lint` and `npm run mel:build` pass
+- [ ] `config:status` clean after `drush cim`
+
+## Non-goals (this slice)
+
+- No duplicate event Twig templates per style
+- No custom colour picker / arbitrary hex
+- No billing or checkout for Pro upgrade
+- No stock, warehouse, shipping, scanner, QR, entitlement, cart, or order changes
+
+## Future work
+
+- Persist event-level entitlement when subscription/boost ends and downgrade stored style
+- Cross-link: prior audit notes in `docs/event-page-style-and-colour-audit.md` when present on branch

--- a/docs/event-page-style-and-colour-themes.md
+++ b/docs/event-page-style-and-colour-themes.md
@@ -89,6 +89,30 @@ SCSS: `web/themes/custom/myeventlane_theme/src/scss/components/_event-page-theme
 - No billing or checkout for Pro upgrade
 - No stock, warehouse, shipping, scanner, QR, entitlement, cart, or order changes
 
+## Config notes (pre-PR audit)
+
+### `field_mel_extras_book_placement`
+
+**Classification: B — local-only drift (not required on `main` or this branch).**
+
+| Check | Result |
+|-------|--------|
+| `config/sync` YAML | Not present on `main` or `feature/event-page-style-themes` |
+| Custom module / theme code references | None on current branch |
+| Active Drupal config | Does not exist (removed when `drush cim` aligned DB with sync during style-themes verification) |
+
+The field appeared only on unmerged work (`85125b64` on `feature/event-studio-extras-editor`, not an ancestor of `main`) with `EventExtrasBookPlacementResolver` and booking-placement UI. That commit is **not** in `main` or PR #403’s merged tree. A copy existed in the local database only (“Only in DB” before `cim`).
+
+**Action for this PR:** Do not recreate the field. Restoring it belongs in a separate PR if/when extras book-placement code and config are merged to `main`.
+
+### `core.entity_form_display.node.event.studio_branding` drift
+
+**Classification: benign ordering only.** Active vs sync differ only in YAML key order under `hidden:` (`field_mel_theme_colour` position). Both hide the same fields including `field_mel_page_style` and `field_mel_theme_colour`. No missing or extra fields.
+
+### `crop.type.event_hero` drift
+
+**Classification: pre-existing, unrelated.** Active vs sync differ only in key order (`id` / `label`). Not introduced by Event Page Style Themes.
+
 ## Future work
 
 - Persist event-level entitlement when subscription/boost ends and downgrade stored style

--- a/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
+++ b/web/modules/custom/myeventlane_commerce/css/mel-operational-addons.css
@@ -3,11 +3,36 @@
  *
  * Mobile-first cards; coral primary CTA uses theme `.mel-btn--primary`.
  */
+.mel-booking-extras {
+  overflow-x: hidden;
+}
+
+.mel-booking-extras--inline {
+  margin-top: 1.25rem;
+}
+
+.mel-booking-extras--sidebar {
+  margin-top: 1rem;
+}
+
 .mel-operational-addons-section {
   margin-top: 1.75rem;
   padding-top: 1.5rem;
   border-top: 1px solid rgba(15, 23, 42, 0.08);
   overflow-x: hidden;
+}
+
+.mel-booking-extras--inline.mel-operational-addons-section {
+  margin-top: 1.25rem;
+}
+
+.mel-booking-extras--sidebar.mel-operational-addons-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.mel-booking-extras--sidebar .mel-operational-addons-form__lines {
+  gap: 0.75rem;
 }
 
 .mel-booking-flow__addons {

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.libraries.yml
@@ -69,7 +69,7 @@ mel_operational_addon_teaser:
     - core/drupal
 
 event_extras_booking:
-  version: 1.7
+  version: 1.8
   css:
     theme:
       css/mel-operational-addons.css: {}

--- a/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/BookController.php
@@ -224,7 +224,10 @@ final class BookController extends ControllerBase {
       return;
     }
     $build['#addons_available'] = TRUE;
-    $build['#extras_book_placement'] = $this->extrasBookPlacementResolver->getPlacement($node);
+    $placement = $this->extrasBookPlacementResolver->resolve($node);
+    $build['#extras_book_placement'] = $placement;
+    $build['#extras_inline_before_access_code'] = $this->extrasBookPlacementResolver->isInline($node);
+    $build['#extras_sidebar_selection'] = $this->extrasBookPlacementResolver->isSidebar($node);
     foreach ($addon_catalog['product_ids'] as $pid) {
       $build['#cache']['tags'][] = 'commerce_product:' . $pid;
     }

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventExtrasBookPlacementResolver.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventExtrasBookPlacementResolver.php
@@ -22,6 +22,11 @@ final class EventExtrasBookPlacementResolver {
 
   public const PLACEMENT_SIDEBAR = 'sidebar';
 
+  /**
+   * Default placement when the field is empty or invalid.
+   */
+  public const DEFAULT_PLACEMENT = self::PLACEMENT_MAIN_BEFORE_ACCESS;
+
   public const FIELD_NAME = 'field_mel_extras_book_placement';
 
   /**
@@ -36,16 +41,42 @@ final class EventExtrasBookPlacementResolver {
   }
 
   /**
+   * @return list<string>
+   */
+  public function allowedPlacements(): array {
+    return [
+      self::PLACEMENT_MAIN_BEFORE_ACCESS,
+      self::PLACEMENT_SIDEBAR,
+    ];
+  }
+
+  /**
+   * Human labels for vendor placement radios.
+   *
+   * @return array<string, string>
+   */
+  public function labels(): array {
+    return [
+      self::PLACEMENT_MAIN_BEFORE_ACCESS => (string) $this->t('Under ticket choices, before the access code'),
+      self::PLACEMENT_SIDEBAR => (string) $this->t('In the sidebar next to “Your selection”'),
+    ];
+  }
+
+  /**
    * Options for vendor placement radios.
    *
    * @return array<string, string>
    *   Machine value => label for vendor forms.
    */
   public function getOptions(): array {
-    return [
-      self::PLACEMENT_MAIN_BEFORE_ACCESS => (string) t('Under ticket choices, before the access code'),
-      self::PLACEMENT_SIDEBAR => (string) t('In the sidebar next to “Your selection”'),
-    ];
+    return $this->labels();
+  }
+
+  /**
+   * Returns the placement for an event (defaults to main column).
+   */
+  public function resolve(NodeInterface $event): string {
+    return $this->getPlacement($event);
   }
 
   /**
@@ -53,13 +84,20 @@ final class EventExtrasBookPlacementResolver {
    */
   public function getPlacement(NodeInterface $event): string {
     if ($event->bundle() !== 'event' || !$event->hasField(self::FIELD_NAME)) {
-      return self::PLACEMENT_MAIN_BEFORE_ACCESS;
+      return self::DEFAULT_PLACEMENT;
     }
     if ($event->get(self::FIELD_NAME)->isEmpty()) {
-      return self::PLACEMENT_MAIN_BEFORE_ACCESS;
+      return self::DEFAULT_PLACEMENT;
     }
     $value = (string) $event->get(self::FIELD_NAME)->value;
-    return $this->isValid($value) ? $value : self::PLACEMENT_MAIN_BEFORE_ACCESS;
+    return $this->isValid($value) ? $value : self::DEFAULT_PLACEMENT;
+  }
+
+  /**
+   * Whether extras render inline in the main ticket column.
+   */
+  public function isInline(NodeInterface $event): bool {
+    return $this->resolve($event) === self::PLACEMENT_MAIN_BEFORE_ACCESS;
   }
 
   /**
@@ -73,7 +111,7 @@ final class EventExtrasBookPlacementResolver {
    * Whether extras render in the main column before the access code.
    */
   public function isMainBeforeAccess(NodeInterface $event): bool {
-    return $this->getPlacement($event) === self::PLACEMENT_MAIN_BEFORE_ACCESS;
+    return $this->isInline($event);
   }
 
   /**
@@ -84,7 +122,7 @@ final class EventExtrasBookPlacementResolver {
       throw new \RuntimeException('Extras book placement field is not available on this event.');
     }
     if (!$this->isValid($placement)) {
-      $placement = self::PLACEMENT_MAIN_BEFORE_ACCESS;
+      $placement = self::DEFAULT_PLACEMENT;
     }
     $storage = $this->entityTypeManager->getStorage('node');
     $fresh = $storage->load($event->id());
@@ -114,10 +152,7 @@ final class EventExtrasBookPlacementResolver {
    * Whether a placement machine name is allowed.
    */
   public function isValid(string $placement): bool {
-    return in_array($placement, [
-      self::PLACEMENT_MAIN_BEFORE_ACCESS,
-      self::PLACEMENT_SIDEBAR,
-    ], TRUE);
+    return in_array($placement, $this->allowedPlacements(), TRUE);
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -15,8 +15,8 @@
  * templates/commerce/myeventlane-event-book.html.twig extending this file.
  */
 #}
-{% set extras_in_sidebar = addons_available and extras_book_placement|default('main_before_access') == 'sidebar' %}
-{% set extras_in_main = addons_available and not extras_in_sidebar %}
+{% set extras_in_sidebar = addons_available and (extras_sidebar_selection|default(false) or extras_book_placement|default('main_before_access') == 'sidebar') %}
+{% set extras_in_main = addons_available and (extras_inline_before_access_code|default(false) or not extras_in_sidebar) %}
 <article class="mel-booking-v2 mel-booking mel-event-book mel-event--v2" data-event-mode="{{ event_mode }}">
   <div class="mel-container mel-container--event">
     <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-booking-event-title">
@@ -122,7 +122,7 @@
               {% endif %}
 
               {% if extras_in_main and operational_addon_form %}
-                <section id="mel-operational-addons" class="mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
+                <section id="mel-operational-addons" class="mel-booking-extras mel-booking-extras--inline mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
                   <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
                   <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
                   {{ operational_addon_form }}
@@ -187,7 +187,7 @@
             {% endif %}
 
             {% if extras_in_sidebar and operational_addon_form %}
-              <section id="mel-operational-addons" class="mel-operational-addons-section mel-operational-addons-section--sidebar mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
+              <section id="mel-operational-addons" class="mel-booking-extras mel-booking-extras--sidebar mel-operational-addons-section mel-operational-addons-section--sidebar mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
                 <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
                 <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
                 {{ operational_addon_form }}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventExtrasBookPlacementResolverTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventExtrasBookPlacementResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver
+ *
+ * @group myeventlane_commerce
+ */
+final class EventExtrasBookPlacementResolverTest extends UnitTestCase {
+
+  private EventExtrasBookPlacementResolver $resolver;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $string_translation = $this->getStringTranslationStub();
+    $this->resolver = new EventExtrasBookPlacementResolver(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(AccountProxyInterface::class),
+      $string_translation,
+    );
+  }
+
+  /**
+   * @covers ::resolve
+   */
+  public function testMissingFieldReturnsDefault(): void {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('hasField')->willReturn(FALSE);
+
+    $this->assertSame(
+      EventExtrasBookPlacementResolver::DEFAULT_PLACEMENT,
+      $this->resolver->resolve($event),
+    );
+    $this->assertTrue($this->resolver->isInline($event));
+    $this->assertFalse($this->resolver->isSidebar($event));
+  }
+
+  /**
+   * @covers ::resolve
+   */
+  public function testEmptyFieldReturnsDefault(): void {
+    $field = new class () {
+      public function isEmpty(): bool {
+        return TRUE;
+      }
+    };
+    $event = $this->createEventWithField($field);
+
+    $this->assertSame(EventExtrasBookPlacementResolver::PLACEMENT_MAIN_BEFORE_ACCESS, $this->resolver->resolve($event));
+  }
+
+  /**
+   * @covers ::resolve
+   */
+  public function testInvalidValueReturnsDefault(): void {
+    $field = $this->createFieldValue('not-valid');
+    $event = $this->createEventWithField($field);
+
+    $this->assertSame(EventExtrasBookPlacementResolver::DEFAULT_PLACEMENT, $this->resolver->resolve($event));
+  }
+
+  /**
+   * @covers ::resolve
+   * @covers ::isInline
+   */
+  public function testInlineValueResolves(): void {
+    $event = $this->createEventWithField($this->createFieldValue(EventExtrasBookPlacementResolver::PLACEMENT_MAIN_BEFORE_ACCESS));
+
+    $this->assertSame(EventExtrasBookPlacementResolver::PLACEMENT_MAIN_BEFORE_ACCESS, $this->resolver->resolve($event));
+    $this->assertTrue($this->resolver->isInline($event));
+    $this->assertFalse($this->resolver->isSidebar($event));
+  }
+
+  /**
+   * @covers ::resolve
+   * @covers ::isSidebar
+   */
+  public function testSidebarValueResolves(): void {
+    $event = $this->createEventWithField($this->createFieldValue(EventExtrasBookPlacementResolver::PLACEMENT_SIDEBAR));
+
+    $this->assertSame(EventExtrasBookPlacementResolver::PLACEMENT_SIDEBAR, $this->resolver->resolve($event));
+    $this->assertFalse($this->resolver->isInline($event));
+    $this->assertTrue($this->resolver->isSidebar($event));
+  }
+
+  /**
+   * @covers ::labels
+   */
+  public function testLabelsIncludeBothOptions(): void {
+    $labels = $this->resolver->labels();
+    $this->assertArrayHasKey(EventExtrasBookPlacementResolver::PLACEMENT_MAIN_BEFORE_ACCESS, $labels);
+    $this->assertArrayHasKey(EventExtrasBookPlacementResolver::PLACEMENT_SIDEBAR, $labels);
+  }
+
+  private function createEventWithField(object $field): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('hasField')->with(EventExtrasBookPlacementResolver::FIELD_NAME)->willReturn(TRUE);
+    $event->method('get')->with(EventExtrasBookPlacementResolver::FIELD_NAME)->willReturn($field);
+    return $event;
+  }
+
+  private function createFieldValue(string $value): object {
+    return new class ($value) {
+      public function __construct(public string $value) {}
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1229,3 +1229,82 @@ textarea.mel-input--body {
   z-index: 2;
 }
 
+/* Event page style (Classic / Immersive) + colour presets */
+.mel-event-studio .mel-es-field-group--page-style {
+  margin-top: 1.5rem;
+}
+
+.mel-event-studio .mel-option-card--locked {
+  opacity: 0.72;
+}
+
+.mel-event-studio .mel-option-card--locked .mel-option-card__label::after {
+  content: ' · Pro';
+  font-weight: 600;
+  color: #7c83fd;
+}
+
+.mel-event-studio .mel-page-style-upgrade {
+  margin: 0.5rem 0 0;
+}
+
+.mel-event-studio .mel-page-style-colour-block {
+  margin-top: 1.25rem;
+}
+
+.mel-event-studio .mel-page-style-colour-block__title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.mel-event-studio .mel-page-style-colours.mel-option-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
+  gap: 0.65rem;
+}
+
+.mel-event-studio .mel-page-style-colour-card .form-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mel-event-studio .mel-page-style-colour-card .mel-option-card__content {
+  padding-top: 2rem;
+}
+
+.mel-event-studio .mel-page-style-colour-card .mel-option-card__content::before {
+  content: '';
+  position: absolute;
+  top: 0.85rem;
+  left: 1rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  border: 2px solid rgba(36, 48, 58, 0.12);
+}
+
+.mel-event-studio .mel-page-style-colour-card--coral .mel-option-card__content::before {
+  background: #f26d5b;
+}
+
+.mel-event-studio .mel-page-style-colour-card--purple .mel-option-card__content::before {
+  background: #7c83fd;
+}
+
+.mel-event-studio .mel-page-style-colour-card--mint .mel-option-card__content::before {
+  background: #5eead4;
+}
+
+.mel-event-studio .mel-page-style-colour-card--gold .mel-option-card__content::before {
+  background: #f5a04c;
+}
+
+.mel-event-studio .mel-page-style-colour-card--blue .mel-option-card__content::before {
+  background: #3b82f6;
+}
+
+.mel-event-studio .mel-page-style-colour-card.form-item--error {
+  border-color: #ef4444;
+}
+

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -284,6 +284,7 @@ services:
     class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager
     arguments:
       - '@?myeventlane_pro.pro_access'
+      - '@entity_type.manager'
 
   myeventlane_event_studio.event_page_style_resolver:
     class: Drupal\myeventlane_event_studio\Service\EventPageStyleResolver

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -280,6 +280,14 @@ services:
       - '@entity_type.manager'
       - '@string_translation'
 
+  myeventlane_event_studio.event_style_access:
+    class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager
+    arguments:
+      - '@?myeventlane_pro.pro_access'
+
+  myeventlane_event_studio.event_page_style_resolver:
+    class: Drupal\myeventlane_event_studio\Service\EventPageStyleResolver
+
   myeventlane_event_studio.save:
     class: Drupal\myeventlane_event_studio\Service\EventStudioSaveService
     arguments:
@@ -296,6 +304,7 @@ services:
       - '@file_system'
       - '@?myeventlane_questions.template_cloner'
       - '@myeventlane_event_studio.operational_capability_studio_manager'
+      - '@myeventlane_event_studio.event_page_style_resolver'
 
   myeventlane_event_studio.readiness:
     class: Drupal\myeventlane_event_studio\Service\EventReadinessService

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -287,6 +287,9 @@ services:
 
   myeventlane_event_studio.event_page_style_resolver:
     class: Drupal\myeventlane_event_studio\Service\EventPageStyleResolver
+    arguments:
+      - '@myeventlane_event_studio.event_style_access'
+      - '@entity_type.manager'
 
   myeventlane_event_studio.save:
     class: Drupal\myeventlane_event_studio\Service\EventStudioSaveService

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -280,7 +280,6 @@ final class EventBrandingForm extends EventStudioBaseForm {
    */
   private function buildPageStyleFields(array &$form, NodeInterface $node, array $melDefaults): void {
     $can_customize = $this->eventStyleAccess->canCustomizeEventPage($this->currentUser);
-    $style_labels = $this->eventPageStyleResolver->styleOptions();
     $colour_labels = $this->eventPageStyleResolver->colourOptions();
 
     if ($can_customize) {
@@ -306,26 +305,26 @@ final class EventBrandingForm extends EventStudioBaseForm {
         '<section class="mel-es-field-group mel-es-field-group--page-style" aria-labelledby="mel-es-page-style-title">'
         . '<header class="mel-es-field-group__header">'
         . '<h3 class="mel-es-field-group__title" id="mel-es-page-style-title">' . Html::escape((string) $this->t('Choose your event page style')) . '</h3>'
-        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Warm & Energetic is the standard MyEventLane event page — bright, readable, and community-first. Pro organisers can unlock Bold & Immersive and curated colour moods that stay accessible and on-brand.')) . '</p>'
+        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Every event uses the Classic MyEventLane page by default. Pro organisers can unlock Immersive styling and approved colour palettes.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body mel-es-field-group__body--page-style">'
       ),
       '#weight' => 15,
     ];
 
-    $style_options = [];
-    foreach ($style_labels as $key => $label) {
-      $style_options[$key] = $this->t($label);
-    }
+    $style_options = [
+      EventPageStyleResolver::STYLE_CLASSIC => $this->t('Classic MyEventLane page'),
+      EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Immersive page'),
+    ];
 
     $form['mel']['field_mel_page_style'] = [
       '#type' => 'radios',
-      '#title' => $this->t('Page style (Warm & Energetic is included for everyone)'),
+      '#title' => $this->t('Page style'),
       '#mel_option_cards' => TRUE,
       '#mel_option_cards_tickets_layout' => TRUE,
       '#mel_option_descriptions' => [
-        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Friendly, bright and community-first. Best for local events, workshops, gigs and gatherings.'),
-        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('A high-impact dark event page for music, nightlife, launches and premium experiences.'),
+        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Warm, clear and conversion-focused. Included for every event.'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Bold visual page style for Pro organisers.'),
       ],
       '#options' => $style_options,
       '#default_value' => $style_default,
@@ -365,10 +364,10 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#attributes' => ['class' => ['mel-page-style-colours']],
       '#prefix' => '<div class="mel-page-style-colour-block" aria-labelledby="mel-es-theme-colour-title">'
         . '<h4 class="mel-es-field-group__title mel-page-style-colour-block__title" id="mel-es-theme-colour-title">'
-        . Html::escape((string) $this->t('Colour mood (curated presets — no custom hex colours)'))
+        . Html::escape((string) $this->t('Choose an approved colour palette'))
         . '</h4>'
         . '<p class="mel-es-field-group__hint mel-page-style-colour-block__hint">'
-        . Html::escape((string) $this->t('Coral Pop is the default. Pro presets are designed for contrast and readability on your public event page.'))
+        . Html::escape((string) $this->t('Curated palettes keep your event page accessible and on-brand. Coral Pop is included for every event.'))
         . '</p>',
       '#suffix' => '</div>',
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -8,13 +8,30 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
+use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Isolated Event Studio form for event branding.
  */
 final class EventBrandingForm extends EventStudioBaseForm {
+
+  private EventStyleAccessManager $eventStyleAccess;
+
+  private EventPageStyleResolver $eventPageStyleResolver;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->eventStyleAccess = $container->get('myeventlane_event_studio.event_style_access');
+    $instance->eventPageStyleResolver = $container->get('myeventlane_event_studio.event_page_style_resolver');
+    return $instance;
+  }
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_branding_form';
@@ -63,6 +80,59 @@ final class EventBrandingForm extends EventStudioBaseForm {
     $merged = $this->mergeMel($baseline, $submitted);
 
     return $this->saveService->saveBrandingHero($loaded, $merged, $form_state, $draft);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    parent::validateForm($form, $form_state);
+
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid < 1) {
+      return;
+    }
+    $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
+    if (!$loaded instanceof NodeInterface) {
+      return;
+    }
+
+    $mel = $form_state->getValue('mel') ?? [];
+    if (!is_array($mel)) {
+      return;
+    }
+
+    $style = isset($mel['field_mel_page_style']) && is_scalar($mel['field_mel_page_style'])
+      ? (string) $mel['field_mel_page_style']
+      : '';
+    $colour = isset($mel['field_mel_theme_colour']) && is_scalar($mel['field_mel_theme_colour'])
+      ? (string) $mel['field_mel_theme_colour']
+      : '';
+
+    $sanitized_style = $this->eventPageStyleResolver->sanitizeStyle($style !== '' ? $style : NULL);
+    $sanitized_colour = $this->eventPageStyleResolver->sanitizeColour($colour !== '' ? $colour : NULL);
+
+    if ($style !== '' && $sanitized_style !== $style) {
+      $form_state->setErrorByName(
+        'mel][field_mel_page_style',
+        $this->t('Choose a valid event page style.')
+      );
+    }
+
+    if ($colour !== '' && $sanitized_colour !== $colour) {
+      $form_state->setErrorByName(
+        'mel][field_mel_theme_colour',
+        $this->t('Choose a valid event theme colour.')
+      );
+    }
+
+    if ($sanitized_style === EventPageStyleResolver::STYLE_IMMERSIVE
+      && !$this->eventStyleAccess->canUseImmersiveStyle($loaded, $this->currentUser)) {
+      $form_state->setErrorByName(
+        'mel][field_mel_page_style',
+        $this->t('MEL Immersive requires MyEventLane Pro. Choose MEL Classic or upgrade to unlock Immersive styling.')
+      );
+    }
   }
 
   /**
@@ -195,13 +265,113 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#weight' => 5,
     ];
 
-    $form['unavailable'] = [
-      '#type' => 'container',
-      '#weight' => 20,
-      '#attributes' => ['class' => ['mel-event-studio-section__placeholder']],
-      'copy' => [
-        '#markup' => '<p>' . $this->t('More brand controls will appear here only when they are ready for creators. For now, the hero image and focal point are enough for most events.') . '</p>',
+    $this->buildPageStyleFields($form, $node, $melDefaults);
+  }
+
+  /**
+   * @param array<string, mixed> $form
+   * @param array<string, mixed> $melDefaults
+   */
+  private function buildPageStyleFields(array &$form, NodeInterface $node, array $melDefaults): void {
+    $can_immersive = $this->eventStyleAccess->canUseImmersiveStyle($node, $this->currentUser);
+
+    $style_default = $melDefaults['field_mel_page_style'] ?? EventPageStyleResolver::STYLE_CLASSIC;
+    if ($node->hasField('field_mel_page_style') && !$node->get('field_mel_page_style')->isEmpty()) {
+      $style_default = (string) $node->get('field_mel_page_style')->value;
+    }
+    $style_default = $this->eventPageStyleResolver->sanitizeStyle((string) $style_default);
+
+    $colour_default = $melDefaults['field_mel_theme_colour'] ?? EventPageStyleResolver::COLOUR_CORAL;
+    if ($node->hasField('field_mel_theme_colour') && !$node->get('field_mel_theme_colour')->isEmpty()) {
+      $colour_default = (string) $node->get('field_mel_theme_colour')->value;
+    }
+    $colour_default = $this->eventPageStyleResolver->sanitizeColour((string) $colour_default);
+
+    $form['mel']['page_style_shell'] = [
+      '#type' => 'markup',
+      '#markup' => Markup::create(
+        '<section class="mel-es-field-group mel-es-field-group--page-style" aria-labelledby="mel-es-page-style-title">'
+        . '<header class="mel-es-field-group__header">'
+        . '<h3 class="mel-es-field-group__title" id="mel-es-page-style-title">' . Html::escape((string) $this->t('Event page style')) . '</h3>'
+        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('What feeling should this event page have?')) . '</p>'
+        . '</header>'
+        . '<div class="mel-es-field-group__body mel-es-field-group__body--page-style">'
+      ),
+      '#weight' => 15,
+    ];
+
+    $classic_desc = $this->t('Included — friendly, bright, community-first. Best for workshops, markets, and community events.');
+    $immersive_desc = $can_immersive
+      ? $this->t('Pro — bold, image-led, high-impact. Best for music, nightlife, launches, and premium events.')
+      : $this->t('Pro — bold, image-led, high-impact. Best for music, nightlife, launches, and premium events. Unlock Immersive styling with MyEventLane Pro.');
+
+    $form['mel']['field_mel_page_style'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Page style'),
+      '#mel_option_cards' => TRUE,
+      '#mel_option_cards_tickets_layout' => TRUE,
+      '#mel_option_descriptions' => [
+        EventPageStyleResolver::STYLE_CLASSIC => $classic_desc,
+        EventPageStyleResolver::STYLE_IMMERSIVE => $immersive_desc,
       ],
+      '#options' => [
+        EventPageStyleResolver::STYLE_CLASSIC => $this->t('MEL Classic'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('MEL Immersive'),
+      ],
+      '#default_value' => $style_default,
+      '#attributes' => ['class' => ['mel-page-style-radios']],
+    ];
+
+    if (!$can_immersive) {
+      $form['mel']['field_mel_page_style'][EventPageStyleResolver::STYLE_IMMERSIVE]['#disabled'] = TRUE;
+      $form['mel']['field_mel_page_style'][EventPageStyleResolver::STYLE_IMMERSIVE]['#attributes']['class'][] = 'mel-option-card--locked';
+    }
+
+    if (!$can_immersive) {
+      $form['mel']['immersive_upgrade'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => Html::escape((string) $this->t('Unlock Immersive styling with MyEventLane Pro.')),
+        '#attributes' => [
+          'class' => ['mel-page-style-upgrade', 'mel-es-field-group__reassurance'],
+          'role' => 'note',
+        ],
+        '#weight' => 16,
+      ];
+    }
+
+    $colour_options = [
+      EventPageStyleResolver::COLOUR_CORAL => $this->t('Coral'),
+      EventPageStyleResolver::COLOUR_PURPLE => $this->t('Purple'),
+      EventPageStyleResolver::COLOUR_MINT => $this->t('Mint'),
+      EventPageStyleResolver::COLOUR_GOLD => $this->t('Gold'),
+      EventPageStyleResolver::COLOUR_BLUE => $this->t('Deep Blue'),
+    ];
+
+    $form['mel']['field_mel_theme_colour'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Theme colour'),
+      '#title_display' => 'invisible',
+      '#mel_option_cards' => TRUE,
+      '#options' => $colour_options,
+      '#default_value' => $colour_default,
+      '#attributes' => ['class' => ['mel-page-style-colours']],
+      '#prefix' => '<div class="mel-page-style-colour-block" aria-labelledby="mel-es-theme-colour-title">'
+        . '<h4 class="mel-es-field-group__title mel-page-style-colour-block__title" id="mel-es-theme-colour-title">'
+        . Html::escape((string) $this->t('Theme colour'))
+        . '</h4>',
+      '#suffix' => '</div>',
+    ];
+
+    foreach (array_keys($colour_options) as $colour_key) {
+      $form['mel']['field_mel_theme_colour'][$colour_key]['#wrapper_attributes']['class'][] = 'mel-page-style-colour-card';
+      $form['mel']['field_mel_theme_colour'][$colour_key]['#wrapper_attributes']['class'][] = 'mel-page-style-colour-card--' . $colour_key;
+    }
+
+    $form['mel']['page_style_close'] = [
+      '#type' => 'markup',
+      '#markup' => Markup::create('</div></div></section>'),
+      '#weight' => 17,
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -306,7 +306,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
         '<section class="mel-es-field-group mel-es-field-group--page-style" aria-labelledby="mel-es-page-style-title">'
         . '<header class="mel-es-field-group__header">'
         . '<h3 class="mel-es-field-group__title" id="mel-es-page-style-title">' . Html::escape((string) $this->t('Choose your event page style')) . '</h3>'
-        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Your event page uses the MyEventLane Warm & Energetic style by default. Pro organisers can unlock extra styles and colour moods.')) . '</p>'
+        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Warm & Energetic is the standard MyEventLane event page — bright, readable, and community-first. Pro organisers can unlock Bold & Immersive and curated colour moods that stay accessible and on-brand.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body mel-es-field-group__body--page-style">'
       ),
@@ -320,7 +320,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
 
     $form['mel']['field_mel_page_style'] = [
       '#type' => 'radios',
-      '#title' => $this->t('Page style'),
+      '#title' => $this->t('Page style (Warm & Energetic is included for everyone)'),
       '#mel_option_cards' => TRUE,
       '#mel_option_cards_tickets_layout' => TRUE,
       '#mel_option_descriptions' => [
@@ -365,8 +365,11 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#attributes' => ['class' => ['mel-page-style-colours']],
       '#prefix' => '<div class="mel-page-style-colour-block" aria-labelledby="mel-es-theme-colour-title">'
         . '<h4 class="mel-es-field-group__title mel-page-style-colour-block__title" id="mel-es-theme-colour-title">'
-        . Html::escape((string) $this->t('Colour mood'))
-        . '</h4>',
+        . Html::escape((string) $this->t('Colour mood (curated presets — no custom hex colours)'))
+        . '</h4>'
+        . '<p class="mel-es-field-group__hint mel-page-style-colour-block__hint">'
+        . Html::escape((string) $this->t('Coral Pop is the default. Pro presets are designed for contrast and readability on your public event page.'))
+        . '</p>',
       '#suffix' => '</div>',
     ];
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -126,11 +126,17 @@ final class EventBrandingForm extends EventStudioBaseForm {
       );
     }
 
-    if ($sanitized_style === EventPageStyleResolver::STYLE_IMMERSIVE
-      && !$this->eventStyleAccess->canUseImmersiveStyle($loaded, $this->currentUser)) {
+    if ($style !== '' && !$this->eventStyleAccess->canUseStyle($sanitized_style, $this->currentUser)) {
       $form_state->setErrorByName(
         'mel][field_mel_page_style',
-        $this->t('MEL Immersive requires MyEventLane Pro. Choose MEL Classic or upgrade to unlock Immersive styling.')
+        $this->t('Custom page styles are a Pro feature.')
+      );
+    }
+
+    if ($colour !== '' && !$this->eventStyleAccess->canUseColour($sanitized_colour, $this->currentUser)) {
+      $form_state->setErrorByName(
+        'mel][field_mel_theme_colour',
+        $this->t('Custom colour palettes are a Pro feature.')
       );
     }
   }
@@ -273,18 +279,25 @@ final class EventBrandingForm extends EventStudioBaseForm {
    * @param array<string, mixed> $melDefaults
    */
   private function buildPageStyleFields(array &$form, NodeInterface $node, array $melDefaults): void {
-    $can_immersive = $this->eventStyleAccess->canUseImmersiveStyle($node, $this->currentUser);
+    $can_customize = $this->eventStyleAccess->canCustomizeEventPage($this->currentUser);
+    $style_labels = $this->eventPageStyleResolver->styleOptions();
+    $colour_labels = $this->eventPageStyleResolver->colourOptions();
 
-    $style_default = $melDefaults['field_mel_page_style'] ?? EventPageStyleResolver::STYLE_CLASSIC;
-    if ($node->hasField('field_mel_page_style') && !$node->get('field_mel_page_style')->isEmpty()) {
-      $style_default = (string) $node->get('field_mel_page_style')->value;
+    if ($can_customize) {
+      $style_default = $melDefaults['field_mel_page_style'] ?? EventPageStyleResolver::STYLE_CLASSIC;
+      if ($node->hasField('field_mel_page_style') && !$node->get('field_mel_page_style')->isEmpty()) {
+        $style_default = (string) $node->get('field_mel_page_style')->value;
+      }
+      $colour_default = $melDefaults['field_mel_theme_colour'] ?? EventPageStyleResolver::COLOUR_CORAL;
+      if ($node->hasField('field_mel_theme_colour') && !$node->get('field_mel_theme_colour')->isEmpty()) {
+        $colour_default = (string) $node->get('field_mel_theme_colour')->value;
+      }
+    }
+    else {
+      $style_default = EventPageStyleResolver::STYLE_CLASSIC;
+      $colour_default = EventPageStyleResolver::COLOUR_CORAL;
     }
     $style_default = $this->eventPageStyleResolver->sanitizeStyle((string) $style_default);
-
-    $colour_default = $melDefaults['field_mel_theme_colour'] ?? EventPageStyleResolver::COLOUR_CORAL;
-    if ($node->hasField('field_mel_theme_colour') && !$node->get('field_mel_theme_colour')->isEmpty()) {
-      $colour_default = (string) $node->get('field_mel_theme_colour')->value;
-    }
     $colour_default = $this->eventPageStyleResolver->sanitizeColour((string) $colour_default);
 
     $form['mel']['page_style_shell'] = [
@@ -292,18 +305,18 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#markup' => Markup::create(
         '<section class="mel-es-field-group mel-es-field-group--page-style" aria-labelledby="mel-es-page-style-title">'
         . '<header class="mel-es-field-group__header">'
-        . '<h3 class="mel-es-field-group__title" id="mel-es-page-style-title">' . Html::escape((string) $this->t('Event page style')) . '</h3>'
-        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('What feeling should this event page have?')) . '</p>'
+        . '<h3 class="mel-es-field-group__title" id="mel-es-page-style-title">' . Html::escape((string) $this->t('Choose your event page style')) . '</h3>'
+        . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Your event page uses the MyEventLane Warm & Energetic style by default. Pro organisers can unlock extra styles and colour moods.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body mel-es-field-group__body--page-style">'
       ),
       '#weight' => 15,
     ];
 
-    $classic_desc = $this->t('Included — friendly, bright, community-first. Best for workshops, markets, and community events.');
-    $immersive_desc = $can_immersive
-      ? $this->t('Pro — bold, image-led, high-impact. Best for music, nightlife, launches, and premium events.')
-      : $this->t('Pro — bold, image-led, high-impact. Best for music, nightlife, launches, and premium events. Unlock Immersive styling with MyEventLane Pro.');
+    $style_options = [];
+    foreach ($style_labels as $key => $label) {
+      $style_options[$key] = $this->t($label);
+    }
 
     $form['mel']['field_mel_page_style'] = [
       '#type' => 'radios',
@@ -311,27 +324,24 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#mel_option_cards' => TRUE,
       '#mel_option_cards_tickets_layout' => TRUE,
       '#mel_option_descriptions' => [
-        EventPageStyleResolver::STYLE_CLASSIC => $classic_desc,
-        EventPageStyleResolver::STYLE_IMMERSIVE => $immersive_desc,
+        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Friendly, bright and community-first. Best for local events, workshops, gigs and gatherings.'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('A high-impact dark event page for music, nightlife, launches and premium experiences.'),
       ],
-      '#options' => [
-        EventPageStyleResolver::STYLE_CLASSIC => $this->t('MEL Classic'),
-        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('MEL Immersive'),
-      ],
+      '#options' => $style_options,
       '#default_value' => $style_default,
       '#attributes' => ['class' => ['mel-page-style-radios']],
     ];
 
-    if (!$can_immersive) {
+    if (!$can_customize) {
       $form['mel']['field_mel_page_style'][EventPageStyleResolver::STYLE_IMMERSIVE]['#disabled'] = TRUE;
       $form['mel']['field_mel_page_style'][EventPageStyleResolver::STYLE_IMMERSIVE]['#attributes']['class'][] = 'mel-option-card--locked';
     }
 
-    if (!$can_immersive) {
-      $form['mel']['immersive_upgrade'] = [
+    if (!$can_customize) {
+      $form['mel']['page_style_upgrade'] = [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => Html::escape((string) $this->t('Unlock Immersive styling with MyEventLane Pro.')),
+        '#value' => Html::escape((string) $this->t('Upgrade to Pro to customise your event page.')),
         '#attributes' => [
           'class' => ['mel-page-style-upgrade', 'mel-es-field-group__reassurance'],
           'role' => 'note',
@@ -340,17 +350,14 @@ final class EventBrandingForm extends EventStudioBaseForm {
       ];
     }
 
-    $colour_options = [
-      EventPageStyleResolver::COLOUR_CORAL => $this->t('Coral'),
-      EventPageStyleResolver::COLOUR_PURPLE => $this->t('Purple'),
-      EventPageStyleResolver::COLOUR_MINT => $this->t('Mint'),
-      EventPageStyleResolver::COLOUR_GOLD => $this->t('Gold'),
-      EventPageStyleResolver::COLOUR_BLUE => $this->t('Deep Blue'),
-    ];
+    $colour_options = [];
+    foreach ($colour_labels as $key => $label) {
+      $colour_options[$key] = $this->t($label);
+    }
 
     $form['mel']['field_mel_theme_colour'] = [
       '#type' => 'radios',
-      '#title' => $this->t('Theme colour'),
+      '#title' => $this->t('Colour mood'),
       '#title_display' => 'invisible',
       '#mel_option_cards' => TRUE,
       '#options' => $colour_options,
@@ -358,12 +365,16 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#attributes' => ['class' => ['mel-page-style-colours']],
       '#prefix' => '<div class="mel-page-style-colour-block" aria-labelledby="mel-es-theme-colour-title">'
         . '<h4 class="mel-es-field-group__title mel-page-style-colour-block__title" id="mel-es-theme-colour-title">'
-        . Html::escape((string) $this->t('Theme colour'))
+        . Html::escape((string) $this->t('Colour mood'))
         . '</h4>',
       '#suffix' => '</div>',
     ];
 
     foreach (array_keys($colour_options) as $colour_key) {
+      if ($colour_key !== EventPageStyleResolver::COLOUR_CORAL && !$can_customize) {
+        $form['mel']['field_mel_theme_colour'][$colour_key]['#disabled'] = TRUE;
+        $form['mel']['field_mel_theme_colour'][$colour_key]['#attributes']['class'][] = 'mel-option-card--locked';
+      }
       $form['mel']['field_mel_theme_colour'][$colour_key]['#wrapper_attributes']['class'][] = 'mel-page-style-colour-card';
       $form['mel']['field_mel_theme_colour'][$colour_key]['#wrapper_attributes']['class'][] = 'mel-page-style-colour-card--' . $colour_key;
     }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -367,7 +367,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
         . Html::escape((string) $this->t('Choose an approved colour palette'))
         . '</h4>'
         . '<p class="mel-es-field-group__hint mel-page-style-colour-block__hint">'
-        . Html::escape((string) $this->t('Curated palettes keep your event page accessible and on-brand. Coral Pop is included for every event.'))
+        . Html::escape((string) $this->t('Curated palettes keep your event page accessible and on-brand.'))
         . '</p>',
       '#suffix' => '</div>',
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -236,6 +236,21 @@ final class EventStudioEventExtrasForm extends FormBase {
    * @return array<string, mixed>
    */
   private function buildBookingPlacement(NodeInterface $event): array {
+    if (!$event->hasField(EventExtrasBookPlacementResolver::FIELD_NAME)) {
+      if ($this->currentUser()->hasPermission('administer nodes')) {
+        return [
+          'booking_placement_wrapper' => [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['messages', 'messages--warning']],
+            'message' => [
+              '#markup' => '<p>' . $this->t('Extras booking placement is not configured on this site. Import the <code>field_mel_extras_book_placement</code> field configuration, then reload this page.') . '</p>',
+            ],
+          ],
+        ];
+      }
+      return ['booking_placement_wrapper' => ['#access' => FALSE]];
+    }
+
     $cards = $this->extrasBuilder->loadExtrasForEvent($event);
     $published = array_filter($cards, static fn (array $card): bool => !empty($card['show_on_booking']));
     if ($published === []) {
@@ -263,8 +278,9 @@ final class EventStudioEventExtrasForm extends FormBase {
           '#title' => $this->t('Placement'),
           '#title_display' => 'invisible',
           '#options' => $this->extrasBookPlacementResolver->getOptions(),
-          '#default_value' => $this->extrasBookPlacementResolver->getPlacement($event),
+          '#default_value' => $this->extrasBookPlacementResolver->resolve($event),
           '#required' => TRUE,
+          '#parents' => ['extras_book_placement'],
         ],
         'save_extras_placement' => [
           '#type' => 'submit',
@@ -590,14 +606,15 @@ final class EventStudioEventExtrasForm extends FormBase {
       $this->messenger()->addError($this->t('The event could not be loaded.'));
       return;
     }
+    $this->assertCanManageEvent($event);
     $placement = $this->getSubmittedExtrasBookPlacement($form_state);
     if (!$this->extrasBookPlacementResolver->isValid($placement)) {
-      $this->messenger()->addError($this->t('Choose a valid placement option.'));
+      $form_state->setErrorByName('extras_book_placement', $this->t('Choose a valid placement option.'));
       return;
     }
     try {
       $this->extrasBookPlacementResolver->savePlacement($event, $placement);
-      $this->messenger()->addStatus($this->t('Booking page placement saved.'));
+      $this->messenger()->addStatus($this->t('Extras placement saved.'));
     }
     catch (\Throwable $e) {
       $this->logger->error('Extras book placement save failed for event @nid: @message', [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
@@ -13,7 +13,8 @@ use Drupal\user\UserInterface;
  * Resolves and sanitizes public event page style/colour for theme render.
  *
  * Stored field values may reflect Pro-only choices; public render and save
- * paths must enforce capability so non-Pro events never show Immersive.
+ * paths must enforce capability so non-Pro events always show Mockup 1
+ * (classic + coral).
  */
 final class EventPageStyleResolver {
 
@@ -56,6 +57,33 @@ final class EventPageStyleResolver {
   ) {}
 
   /**
+   * Vendor-facing style labels (machine value => label).
+   *
+   * @return array<string, string>
+   */
+  public function styleOptions(): array {
+    return [
+      self::STYLE_CLASSIC => 'Warm & Energetic',
+      self::STYLE_IMMERSIVE => 'Bold & Immersive',
+    ];
+  }
+
+  /**
+   * Vendor-facing colour mood labels (machine value => label).
+   *
+   * @return array<string, string>
+   */
+  public function colourOptions(): array {
+    return [
+      self::COLOUR_CORAL => 'Coral Pop',
+      self::COLOUR_PURPLE => 'Violet Pulse',
+      self::COLOUR_MINT => 'Mint Night',
+      self::COLOUR_GOLD => 'Golden Hour',
+      self::COLOUR_BLUE => 'Ocean Blue',
+    ];
+  }
+
+  /**
    * Resolves style/colour for anonymous/public full-page render.
    *
    * Uses the event owner's Pro capability (not the current viewer). Does not
@@ -66,6 +94,7 @@ final class EventPageStyleResolver {
    *   colour: string,
    *   classes: list<string>,
    *   is_pro_style: bool,
+   *   is_customized: bool,
    *   stored_style: string,
    *   stored_colour: string,
    * }
@@ -77,21 +106,30 @@ final class EventPageStyleResolver {
     return $this->buildResolved(
       $stored_style,
       $stored_colour,
-      $this->canEventUseImmersive($event),
+      $this->canEventCustomize($event),
     );
   }
 
   /**
    * Resolves style/colour for Event Studio persistence.
    *
+   * @param array{field_mel_page_style?: string|null, field_mel_theme_colour?: string|null} $submitted
+   *   Mel fragment keys from the branding form.
+   *
    * @return array{style: string, colour: string}
    */
   public function resolveForPersistence(
     NodeInterface $event,
-    ?string $submitted_style,
-    ?string $submitted_colour,
+    array $submitted,
     AccountInterface $account,
   ): array {
+    $submitted_style = isset($submitted['field_mel_page_style']) && is_scalar($submitted['field_mel_page_style'])
+      ? (string) $submitted['field_mel_page_style']
+      : NULL;
+    $submitted_colour = isset($submitted['field_mel_theme_colour']) && is_scalar($submitted['field_mel_theme_colour'])
+      ? (string) $submitted['field_mel_theme_colour']
+      : NULL;
+
     $stored_style = $submitted_style !== NULL && $submitted_style !== ''
       ? $this->sanitizeStyle($submitted_style)
       : $this->readStoredStyle($event);
@@ -99,10 +137,10 @@ final class EventPageStyleResolver {
       ? $this->sanitizeColour($submitted_colour)
       : $this->readStoredColour($event);
 
-    $can_immersive = $this->styleAccess instanceof EventStyleAccessManager
-      && $this->styleAccess->canUseImmersiveStyle($event, $account);
+    $can_customize = $this->styleAccess instanceof EventStyleAccessManager
+      && $this->styleAccess->canCustomizeEventPage($account);
 
-    $resolved = $this->buildResolved($stored_style, $stored_colour, $can_immersive);
+    $resolved = $this->buildResolved($stored_style, $stored_colour, $can_customize);
 
     return [
       'style' => $resolved['style'],
@@ -158,9 +196,9 @@ final class EventPageStyleResolver {
   }
 
   /**
-   * Whether the event owner may use Immersive on the public page.
+   * Whether the event owner may customise page style and colour on the public page.
    */
-  public function canEventUseImmersive(NodeInterface $event): bool {
+  public function canEventCustomize(NodeInterface $event): bool {
     if (!$this->styleAccess instanceof EventStyleAccessManager) {
       return FALSE;
     }
@@ -170,7 +208,14 @@ final class EventPageStyleResolver {
       return FALSE;
     }
 
-    return $this->styleAccess->canUseImmersiveStyle($event, $owner);
+    return $this->styleAccess->canCustomizeEventPage($owner);
+  }
+
+  /**
+   * @deprecated Use canEventCustomize(). Kept for existing call sites.
+   */
+  public function canEventUseImmersive(NodeInterface $event): bool {
+    return $this->canEventCustomize($event);
   }
 
   /**
@@ -179,23 +224,33 @@ final class EventPageStyleResolver {
    *   colour: string,
    *   classes: list<string>,
    *   is_pro_style: bool,
+   *   is_customized: bool,
    *   stored_style: string,
    *   stored_colour: string,
    * }
    */
-  private function buildResolved(string $stored_style, string $stored_colour, bool $can_immersive): array {
+  private function buildResolved(string $stored_style, string $stored_colour, bool $can_customize): array {
+    if (!$can_customize) {
+      return [
+        'style' => self::STYLE_CLASSIC,
+        'colour' => self::COLOUR_CORAL,
+        'classes' => $this->buildPageClasses(self::STYLE_CLASSIC, self::COLOUR_CORAL),
+        'is_pro_style' => FALSE,
+        'is_customized' => FALSE,
+        'stored_style' => $stored_style,
+        'stored_colour' => $stored_colour,
+      ];
+    }
+
     $style = $this->sanitizeStyle($stored_style);
     $colour = $this->sanitizeColour($stored_colour);
-
-    if ($style === self::STYLE_IMMERSIVE && !$can_immersive) {
-      $style = self::STYLE_CLASSIC;
-    }
 
     return [
       'style' => $style,
       'colour' => $colour,
       'classes' => $this->buildPageClasses($style, $colour),
-      'is_pro_style' => $style === self::STYLE_IMMERSIVE,
+      'is_pro_style' => $style !== self::STYLE_CLASSIC || $colour !== self::COLOUR_CORAL,
+      'is_customized' => $style !== self::STYLE_CLASSIC || $colour !== self::COLOUR_CORAL,
       'stored_style' => $stored_style,
       'stored_colour' => $stored_colour,
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Resolves and sanitizes public event page style/colour for theme render.
+ *
+ * Stored field values may reflect Pro-only choices; public render and save
+ * paths must enforce capability so non-Pro events never show Immersive.
  */
 final class EventPageStyleResolver {
 
@@ -44,23 +50,63 @@ final class EventPageStyleResolver {
     self::COLOUR_BLUE,
   ];
 
+  public function __construct(
+    private readonly ?EventStyleAccessManager $styleAccess = NULL,
+    private readonly ?EntityTypeManagerInterface $entityTypeManager = NULL,
+  ) {}
+
   /**
-   * Resolves stored values for anonymous/public full-page render.
+   * Resolves style/colour for anonymous/public full-page render.
    *
-   * Capability enforcement on save happens in Event Studio; public render only
-   * sanitizes allowed values. Future Pro expiry should use persisted entitlement
-   * state and downgrade stored style when subscription lapses.
+   * Uses the event owner's Pro capability (not the current viewer). Does not
+   * mutate the node.
    *
-   * @return array{style: string, colour: string, classes: list<string>}
+   * @return array{
+   *   style: string,
+   *   colour: string,
+   *   classes: list<string>,
+   *   is_pro_style: bool,
+   *   stored_style: string,
+   *   stored_colour: string,
+   * }
    */
   public function resolveForPublicRender(NodeInterface $event): array {
-    $style = $this->readStoredStyle($event);
-    $colour = $this->readStoredColour($event);
+    $stored_style = $this->readStoredStyle($event);
+    $stored_colour = $this->readStoredColour($event);
+
+    return $this->buildResolved(
+      $stored_style,
+      $stored_colour,
+      $this->canEventUseImmersive($event),
+    );
+  }
+
+  /**
+   * Resolves style/colour for Event Studio persistence.
+   *
+   * @return array{style: string, colour: string}
+   */
+  public function resolveForPersistence(
+    NodeInterface $event,
+    ?string $submitted_style,
+    ?string $submitted_colour,
+    AccountInterface $account,
+  ): array {
+    $stored_style = $submitted_style !== NULL && $submitted_style !== ''
+      ? $this->sanitizeStyle($submitted_style)
+      : $this->readStoredStyle($event);
+    $stored_colour = $submitted_colour !== NULL && $submitted_colour !== ''
+      ? $this->sanitizeColour($submitted_colour)
+      : $this->readStoredColour($event);
+
+    $can_immersive = $this->styleAccess instanceof EventStyleAccessManager
+      && $this->styleAccess->canUseImmersiveStyle($event, $account);
+
+    $resolved = $this->buildResolved($stored_style, $stored_colour, $can_immersive);
 
     return [
-      'style' => $style,
-      'colour' => $colour,
-      'classes' => $this->buildPageClasses($style, $colour),
+      'style' => $resolved['style'],
+      'colour' => $resolved['colour'],
     ];
   }
 
@@ -111,6 +157,50 @@ final class EventPageStyleResolver {
     return self::ALLOWED_COLOURS;
   }
 
+  /**
+   * Whether the event owner may use Immersive on the public page.
+   */
+  public function canEventUseImmersive(NodeInterface $event): bool {
+    if (!$this->styleAccess instanceof EventStyleAccessManager) {
+      return FALSE;
+    }
+
+    $owner = $this->loadEventOwnerAccount($event);
+    if ($owner === NULL) {
+      return FALSE;
+    }
+
+    return $this->styleAccess->canUseImmersiveStyle($event, $owner);
+  }
+
+  /**
+   * @return array{
+   *   style: string,
+   *   colour: string,
+   *   classes: list<string>,
+   *   is_pro_style: bool,
+   *   stored_style: string,
+   *   stored_colour: string,
+   * }
+   */
+  private function buildResolved(string $stored_style, string $stored_colour, bool $can_immersive): array {
+    $style = $this->sanitizeStyle($stored_style);
+    $colour = $this->sanitizeColour($stored_colour);
+
+    if ($style === self::STYLE_IMMERSIVE && !$can_immersive) {
+      $style = self::STYLE_CLASSIC;
+    }
+
+    return [
+      'style' => $style,
+      'colour' => $colour,
+      'classes' => $this->buildPageClasses($style, $colour),
+      'is_pro_style' => $style === self::STYLE_IMMERSIVE,
+      'stored_style' => $stored_style,
+      'stored_colour' => $stored_colour,
+    ];
+  }
+
   private function readStoredStyle(NodeInterface $event): string {
     if (!$event->hasField('field_mel_page_style') || $event->get('field_mel_page_style')->isEmpty()) {
       return self::STYLE_CLASSIC;
@@ -123,6 +213,20 @@ final class EventPageStyleResolver {
       return self::COLOUR_CORAL;
     }
     return $this->sanitizeColour((string) $event->get('field_mel_theme_colour')->value);
+  }
+
+  private function loadEventOwnerAccount(NodeInterface $event): ?AccountInterface {
+    if (!$this->entityTypeManager instanceof EntityTypeManagerInterface) {
+      return NULL;
+    }
+
+    $uid = (int) $event->getOwnerId();
+    if ($uid < 1) {
+      return NULL;
+    }
+
+    $user = $this->entityTypeManager->getStorage('user')->load($uid);
+    return $user instanceof UserInterface ? $user : NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventPageStyleResolver.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Resolves and sanitizes public event page style/colour for theme render.
+ */
+final class EventPageStyleResolver {
+
+  public const STYLE_CLASSIC = 'classic';
+
+  public const STYLE_IMMERSIVE = 'immersive';
+
+  public const COLOUR_CORAL = 'coral';
+
+  public const COLOUR_PURPLE = 'purple';
+
+  public const COLOUR_MINT = 'mint';
+
+  public const COLOUR_GOLD = 'gold';
+
+  public const COLOUR_BLUE = 'blue';
+
+  /**
+   * @var list<string>
+   */
+  private const ALLOWED_STYLES = [
+    self::STYLE_CLASSIC,
+    self::STYLE_IMMERSIVE,
+  ];
+
+  /**
+   * @var list<string>
+   */
+  private const ALLOWED_COLOURS = [
+    self::COLOUR_CORAL,
+    self::COLOUR_PURPLE,
+    self::COLOUR_MINT,
+    self::COLOUR_GOLD,
+    self::COLOUR_BLUE,
+  ];
+
+  /**
+   * Resolves stored values for anonymous/public full-page render.
+   *
+   * Capability enforcement on save happens in Event Studio; public render only
+   * sanitizes allowed values. Future Pro expiry should use persisted entitlement
+   * state and downgrade stored style when subscription lapses.
+   *
+   * @return array{style: string, colour: string, classes: list<string>}
+   */
+  public function resolveForPublicRender(NodeInterface $event): array {
+    $style = $this->readStoredStyle($event);
+    $colour = $this->readStoredColour($event);
+
+    return [
+      'style' => $style,
+      'colour' => $colour,
+      'classes' => $this->buildPageClasses($style, $colour),
+    ];
+  }
+
+  /**
+   * Sanitizes a style machine name for render or persistence.
+   */
+  public function sanitizeStyle(?string $style): string {
+    $style = strtolower(trim((string) $style));
+    return in_array($style, self::ALLOWED_STYLES, TRUE)
+      ? $style
+      : self::STYLE_CLASSIC;
+  }
+
+  /**
+   * Sanitizes a colour machine name for render or persistence.
+   */
+  public function sanitizeColour(?string $colour): string {
+    $colour = strtolower(trim((string) $colour));
+    return in_array($colour, self::ALLOWED_COLOURS, TRUE)
+      ? $colour
+      : self::COLOUR_CORAL;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function buildPageClasses(string $style, string $colour): array {
+    $style = $this->sanitizeStyle($style);
+    $colour = $this->sanitizeColour($colour);
+
+    return [
+      'mel-event-page--' . $style,
+      'mel-event-page--colour-' . $colour,
+    ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function getAllowedStyles(): array {
+    return self::ALLOWED_STYLES;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function getAllowedColours(): array {
+    return self::ALLOWED_COLOURS;
+  }
+
+  private function readStoredStyle(NodeInterface $event): string {
+    if (!$event->hasField('field_mel_page_style') || $event->get('field_mel_page_style')->isEmpty()) {
+      return self::STYLE_CLASSIC;
+    }
+    return $this->sanitizeStyle((string) $event->get('field_mel_page_style')->value);
+  }
+
+  private function readStoredColour(NodeInterface $event): string {
+    if (!$event->hasField('field_mel_theme_colour') || $event->get('field_mel_theme_colour')->isEmpty()) {
+      return self::COLOUR_CORAL;
+    }
+    return $this->sanitizeColour((string) $event->get('field_mel_theme_colour')->value);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1014,26 +1014,16 @@ final class EventStudioSaveService {
       return [];
     }
 
-    $submitted_style = array_key_exists('field_mel_page_style', $mel_values) && is_scalar($mel_values['field_mel_page_style'])
-      ? (string) $mel_values['field_mel_page_style']
-      : NULL;
-    $submitted_colour = array_key_exists('field_mel_theme_colour', $mel_values) && is_scalar($mel_values['field_mel_theme_colour'])
-      ? (string) $mel_values['field_mel_theme_colour']
-      : NULL;
-
     $account = \Drupal::currentUser();
-    $resolved = $this->eventPageStyleResolver->resolveForPersistence(
-      $node,
-      $submitted_style,
-      $submitted_colour,
-      $account,
-    );
+    $resolved = $this->eventPageStyleResolver->resolveForPersistence($node, $mel_values, $account);
 
-    if ($node->hasField('field_mel_page_style') && $submitted_style !== NULL) {
+    if ($node->hasField('field_mel_page_style')
+      && array_key_exists('field_mel_page_style', $mel_values)) {
       $node->set('field_mel_page_style', $resolved['style']);
     }
 
-    if ($node->hasField('field_mel_theme_colour') && $submitted_colour !== NULL) {
+    if ($node->hasField('field_mel_theme_colour')
+      && array_key_exists('field_mel_theme_colour', $mel_values)) {
       $node->set('field_mel_theme_colour', $resolved['colour']);
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1014,16 +1014,27 @@ final class EventStudioSaveService {
       return [];
     }
 
-    if ($node->hasField('field_mel_page_style') && array_key_exists('field_mel_page_style', $mel_values)) {
-      $node->set('field_mel_page_style', $this->eventPageStyleResolver->sanitizeStyle(
-        is_scalar($mel_values['field_mel_page_style']) ? (string) $mel_values['field_mel_page_style'] : NULL
-      ));
+    $submitted_style = array_key_exists('field_mel_page_style', $mel_values) && is_scalar($mel_values['field_mel_page_style'])
+      ? (string) $mel_values['field_mel_page_style']
+      : NULL;
+    $submitted_colour = array_key_exists('field_mel_theme_colour', $mel_values) && is_scalar($mel_values['field_mel_theme_colour'])
+      ? (string) $mel_values['field_mel_theme_colour']
+      : NULL;
+
+    $account = \Drupal::currentUser();
+    $resolved = $this->eventPageStyleResolver->resolveForPersistence(
+      $node,
+      $submitted_style,
+      $submitted_colour,
+      $account,
+    );
+
+    if ($node->hasField('field_mel_page_style') && $submitted_style !== NULL) {
+      $node->set('field_mel_page_style', $resolved['style']);
     }
 
-    if ($node->hasField('field_mel_theme_colour') && array_key_exists('field_mel_theme_colour', $mel_values)) {
-      $node->set('field_mel_theme_colour', $this->eventPageStyleResolver->sanitizeColour(
-        is_scalar($mel_values['field_mel_theme_colour']) ? (string) $mel_values['field_mel_theme_colour'] : NULL
-      ));
+    if ($node->hasField('field_mel_theme_colour') && $submitted_colour !== NULL) {
+      $node->set('field_mel_theme_colour', $resolved['colour']);
     }
 
     return [];

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -60,6 +60,7 @@ final class EventStudioSaveService {
     private readonly FileSystemInterface $fileSystem,
     private readonly ?QuestionTemplateCloner $questionTemplateCloner = NULL,
     private readonly ?OperationalCapabilityStudioManager $operationalCapabilityStudioManager = NULL,
+    private readonly ?EventPageStyleResolver $eventPageStyleResolver = NULL,
   ) {}
 
   /**
@@ -981,6 +982,11 @@ final class EventStudioSaveService {
       }
     }
 
+    $style_errors = $this->applyBrandingPageStyleFields($node, $mel_values);
+    if ($style_errors !== []) {
+      return ['node' => NULL, 'errors' => $style_errors, 'warnings' => []];
+    }
+
     EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio branding draft.' : 'Event Studio branding save.');
     try {
       $node->save();
@@ -994,6 +1000,33 @@ final class EventStudioSaveService {
     }
 
     return ['node' => $node, 'errors' => [], 'warnings' => $warnings];
+  }
+
+  /**
+   * Persists page style and theme colour from the branding mel fragment.
+   *
+   * @param array<string, mixed> $mel_values
+   *
+   * @return list<string>
+   */
+  private function applyBrandingPageStyleFields(NodeInterface $node, array $mel_values): array {
+    if (!$this->eventPageStyleResolver instanceof EventPageStyleResolver) {
+      return [];
+    }
+
+    if ($node->hasField('field_mel_page_style') && array_key_exists('field_mel_page_style', $mel_values)) {
+      $node->set('field_mel_page_style', $this->eventPageStyleResolver->sanitizeStyle(
+        is_scalar($mel_values['field_mel_page_style']) ? (string) $mel_values['field_mel_page_style'] : NULL
+      ));
+    }
+
+    if ($node->hasField('field_mel_theme_colour') && array_key_exists('field_mel_theme_colour', $mel_values)) {
+      $node->set('field_mel_theme_colour', $this->eventPageStyleResolver->sanitizeColour(
+        is_scalar($mel_values['field_mel_theme_colour']) ? (string) $mel_values['field_mel_theme_colour'] : NULL
+      ));
+    }
+
+    return [];
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStyleAccessManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStyleAccessManager.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_pro\Service\ProAccessService;
+use Drupal\node\NodeInterface;
+
+/**
+ * Capability gate for Immersive event page styling.
+ *
+ * This service is the seam for future Pro subscription, boost purchase, or admin
+ * override without hard-coding billing in Event Studio forms or theme render.
+ */
+final class EventStyleAccessManager {
+
+  /**
+   * Pro feature key for Immersive page style (see ProAccessService::PRO_FEATURES).
+   */
+  public const FEATURE_IMMERSIVE_STYLE = 'event_immersive_style';
+
+  public function __construct(
+    private readonly ?ProAccessService $proAccess = NULL,
+  ) {}
+
+  /**
+   * Whether the account may select or persist Immersive styling for an event.
+   */
+  public function canUseImmersiveStyle(NodeInterface $event, AccountInterface $account): bool {
+    if ($account->hasPermission('administer nodes')) {
+      return TRUE;
+    }
+
+    if ($this->proAccess instanceof ProAccessService) {
+      return $this->proAccess->canAccessFeature($account, self::FEATURE_IMMERSIVE_STYLE);
+    }
+
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStyleAccessManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStyleAccessManager.php
@@ -4,31 +4,39 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_pro\Service\ProAccessService;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
 
 /**
- * Capability gate for Immersive event page styling.
+ * Capability gate for event page style and colour customisation.
  *
- * This service is the seam for future Pro subscription, boost purchase, or admin
- * override without hard-coding billing in Event Studio forms or theme render.
+ * Non-Pro vendors always use Mockup 1 (classic + coral). Pro and admin may
+ * choose curated MEL presets. Billing is enforced via ProAccessService only.
  */
 final class EventStyleAccessManager {
 
   /**
-   * Pro feature key for Immersive page style (see ProAccessService::PRO_FEATURES).
+   * Pro feature key for event page customisation (see ProAccessService::PRO_FEATURES).
    */
   public const FEATURE_IMMERSIVE_STYLE = 'event_immersive_style';
 
   public function __construct(
     private readonly ?ProAccessService $proAccess = NULL,
+    private readonly ?EntityTypeManagerInterface $entityTypeManager = NULL,
   ) {}
 
   /**
-   * Whether the account may select or persist Immersive styling for an event.
+   * Whether the account may customise event page style and colour presets.
    */
-  public function canUseImmersiveStyle(NodeInterface $event, AccountInterface $account): bool {
+  public function canCustomizeEventPage(AccountInterface|int $account): bool {
+    $account = $this->resolveAccount($account);
+    if ($account === NULL) {
+      return FALSE;
+    }
+
     if ($account->hasPermission('administer nodes')) {
       return TRUE;
     }
@@ -38,6 +46,54 @@ final class EventStyleAccessManager {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Whether the account may use a given page style machine name.
+   */
+  public function canUseStyle(string $style, AccountInterface|int $account): bool {
+    $style = strtolower(trim($style));
+    if ($style === EventPageStyleResolver::STYLE_CLASSIC || $style === '') {
+      return TRUE;
+    }
+
+    if ($style === EventPageStyleResolver::STYLE_IMMERSIVE) {
+      return $this->canCustomizeEventPage($account);
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Whether the account may use a given colour preset machine name.
+   */
+  public function canUseColour(string $colour, AccountInterface|int $account): bool {
+    $colour = strtolower(trim($colour));
+    if ($colour === EventPageStyleResolver::COLOUR_CORAL || $colour === '') {
+      return TRUE;
+    }
+
+    return $this->canCustomizeEventPage($account);
+  }
+
+  /**
+   * Whether the account may select or persist Immersive styling for an event.
+   */
+  public function canUseImmersiveStyle(NodeInterface $event, AccountInterface $account): bool {
+    return $this->canUseStyle(EventPageStyleResolver::STYLE_IMMERSIVE, $account);
+  }
+
+  private function resolveAccount(AccountInterface|int $account): ?AccountInterface {
+    if ($account instanceof AccountInterface) {
+      return $account;
+    }
+
+    if ($account < 1 || !$this->entityTypeManager instanceof EntityTypeManagerInterface) {
+      return NULL;
+    }
+
+    $user = $this->entityTypeManager->getStorage('user')->load($account);
+    return $user instanceof UserInterface ? $user : NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventPageStyleResolver
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventPageStyleResolverTest extends UnitTestCase {
+
+  private EventPageStyleResolver $resolver;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->resolver = new EventPageStyleResolver();
+  }
+
+  /**
+   * @covers ::sanitizeStyle
+   * @covers ::sanitizeColour
+   */
+  public function testInvalidValuesSanitizeToDefaults(): void {
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $this->resolver->sanitizeStyle('not-a-style'));
+    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $this->resolver->sanitizeColour('neon'));
+  }
+
+  /**
+   * @covers ::resolveForPublicRender
+   */
+  public function testMissingFieldsDefaultClassicCoral(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->willReturn(FALSE);
+
+    $resolved = $this->resolver->resolveForPublicRender($node);
+
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $resolved['colour']);
+    $this->assertSame(
+      ['mel-event-page--classic', 'mel-event-page--colour-coral'],
+      $resolved['classes']
+    );
+  }
+
+  /**
+   * @covers ::resolveForPublicRender
+   */
+  public function testStoredValuesResolveToClasses(): void {
+    $style_field = new class () {
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+      public string $value = 'immersive';
+    };
+
+    $colour_field = new class () {
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+      public string $value = 'purple';
+    };
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->willReturnMap([
+      ['field_mel_page_style', TRUE],
+      ['field_mel_theme_colour', TRUE],
+    ]);
+    $node->method('get')->willReturnMap([
+      ['field_mel_page_style', $style_field],
+      ['field_mel_theme_colour', $colour_field],
+    ]);
+
+    $resolved = $this->resolver->resolveForPublicRender($node);
+
+    $this->assertSame('immersive', $resolved['style']);
+    $this->assertSame('purple', $resolved['colour']);
+    $this->assertContains('mel-event-page--immersive', $resolved['classes']);
+    $this->assertContains('mel-event-page--colour-purple', $resolved['classes']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
@@ -47,12 +47,13 @@ final class EventPageStyleResolverTest extends UnitTestCase {
       $resolved['classes']
     );
     $this->assertFalse($resolved['is_pro_style']);
+    $this->assertFalse($resolved['is_customized']);
   }
 
   /**
    * @covers ::resolveForPublicRender
    */
-  public function testImmersiveDeniedFallsBackToClassicOnPublicRender(): void {
+  public function testNonProOwnerStoredImmersivePurpleResolvesClassicCoral(): void {
     $owner = $this->createVendorAccount(FALSE);
     $node = $this->createEventNodeWithStyle('immersive', 'purple', 42);
 
@@ -63,16 +64,17 @@ final class EventPageStyleResolverTest extends UnitTestCase {
     $resolved = $resolver->resolveForPublicRender($node);
 
     $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
-    $this->assertSame(EventPageStyleResolver::COLOUR_PURPLE, $resolved['colour']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $resolved['colour']);
     $this->assertContains('mel-event-page--classic', $resolved['classes']);
+    $this->assertContains('mel-event-page--colour-coral', $resolved['classes']);
     $this->assertNotContains('mel-event-page--immersive', $resolved['classes']);
-    $this->assertFalse($resolved['is_pro_style']);
+    $this->assertNotContains('mel-event-page--colour-purple', $resolved['classes']);
   }
 
   /**
    * @covers ::resolveForPublicRender
    */
-  public function testImmersiveAllowedForProOwnerOnPublicRender(): void {
+  public function testProOwnerStoredImmersivePurpleResolvesImmersivePurple(): void {
     $owner = $this->createVendorAccount(TRUE);
     $node = $this->createEventNodeWithStyle('immersive', 'purple', 99);
 
@@ -91,57 +93,56 @@ final class EventPageStyleResolverTest extends UnitTestCase {
   /**
    * @covers ::resolveForPersistence
    */
-  public function testPersistenceDowngradesImmersiveWhenAccessDenied(): void {
+  public function testPersistenceDowngradesProChoicesForNonPro(): void {
     $node = $this->createMock(NodeInterface::class);
     $account = $this->createVendorAccount(FALSE);
 
     $resolver = new EventPageStyleResolver(new EventStyleAccessManager(NULL));
-    $resolved = $resolver->resolveForPersistence(
-      $node,
-      EventPageStyleResolver::STYLE_IMMERSIVE,
-      EventPageStyleResolver::COLOUR_PURPLE,
-      $account,
-    );
+    $resolved = $resolver->resolveForPersistence($node, [
+      'field_mel_page_style' => EventPageStyleResolver::STYLE_IMMERSIVE,
+      'field_mel_theme_colour' => EventPageStyleResolver::COLOUR_PURPLE,
+    ], $account);
 
     $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
-    $this->assertSame(EventPageStyleResolver::COLOUR_PURPLE, $resolved['colour']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $resolved['colour']);
   }
 
   /**
    * @covers ::resolveForPersistence
    */
-  public function testPersistenceAllowsImmersiveWhenAccessGranted(): void {
+  public function testPersistenceAllowsProChoicesForAdmin(): void {
     $node = $this->createMock(NodeInterface::class);
     $account = $this->createVendorAccount(TRUE);
 
     $resolver = new EventPageStyleResolver(new EventStyleAccessManager());
-    $resolved = $resolver->resolveForPersistence(
-      $node,
-      EventPageStyleResolver::STYLE_IMMERSIVE,
-      EventPageStyleResolver::COLOUR_MINT,
-      $account,
-    );
+    $resolved = $resolver->resolveForPersistence($node, [
+      'field_mel_page_style' => EventPageStyleResolver::STYLE_IMMERSIVE,
+      'field_mel_theme_colour' => EventPageStyleResolver::COLOUR_MINT,
+    ], $account);
 
     $this->assertSame(EventPageStyleResolver::STYLE_IMMERSIVE, $resolved['style']);
     $this->assertSame(EventPageStyleResolver::COLOUR_MINT, $resolved['colour']);
   }
 
   /**
-   * @covers ::resolveForPublicRender
+   * @covers ::colourOptions
    */
-  public function testNonProVendorKeepsColourPresetOnClassicFallback(): void {
-    $owner = $this->createVendorAccount(FALSE);
-    $node = $this->createEventNodeWithStyle('immersive', 'gold', 7);
+  public function testColourLabelsIncludeFriendlyNames(): void {
+    $labels = (new EventPageStyleResolver())->colourOptions();
 
-    $resolver = new EventPageStyleResolver(
-      new EventStyleAccessManager(NULL),
-      $this->createOwnerEntityTypeManager($owner, 7),
-    );
-    $resolved = $resolver->resolveForPublicRender($node);
+    $this->assertSame('Coral Pop', $labels[EventPageStyleResolver::COLOUR_CORAL]);
+    $this->assertSame('Violet Pulse', $labels[EventPageStyleResolver::COLOUR_PURPLE]);
+    $this->assertArrayHasKey(EventPageStyleResolver::COLOUR_MINT, $labels);
+  }
 
-    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
-    $this->assertSame(EventPageStyleResolver::COLOUR_GOLD, $resolved['colour']);
-    $this->assertContains('mel-event-page--colour-gold', $resolved['classes']);
+  /**
+   * @covers ::styleOptions
+   */
+  public function testStyleLabelsIncludeFriendlyNames(): void {
+    $labels = (new EventPageStyleResolver())->styleOptions();
+
+    $this->assertSame('Warm & Energetic', $labels[EventPageStyleResolver::STYLE_CLASSIC]);
+    $this->assertSame('Bold & Immersive', $labels[EventPageStyleResolver::STYLE_IMMERSIVE]);
   }
 
   private function createEventNodeWithStyle(string $style, string $colour, int $uid): NodeInterface {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventPageStyleResolverTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_event_studio\Unit;
 
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
+use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
 
 /**
  * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventPageStyleResolver
@@ -15,20 +20,15 @@ use Drupal\Tests\UnitTestCase;
  */
 final class EventPageStyleResolverTest extends UnitTestCase {
 
-  private EventPageStyleResolver $resolver;
-
-  protected function setUp(): void {
-    parent::setUp();
-    $this->resolver = new EventPageStyleResolver();
-  }
-
   /**
    * @covers ::sanitizeStyle
    * @covers ::sanitizeColour
    */
   public function testInvalidValuesSanitizeToDefaults(): void {
-    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $this->resolver->sanitizeStyle('not-a-style'));
-    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $this->resolver->sanitizeColour('neon'));
+    $resolver = new EventPageStyleResolver();
+
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolver->sanitizeStyle('not-a-style'));
+    $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $resolver->sanitizeColour('neon'));
   }
 
   /**
@@ -38,7 +38,7 @@ final class EventPageStyleResolverTest extends UnitTestCase {
     $node = $this->createMock(NodeInterface::class);
     $node->method('hasField')->willReturn(FALSE);
 
-    $resolved = $this->resolver->resolveForPublicRender($node);
+    $resolved = (new EventPageStyleResolver())->resolveForPublicRender($node);
 
     $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
     $this->assertSame(EventPageStyleResolver::COLOUR_CORAL, $resolved['colour']);
@@ -46,24 +46,117 @@ final class EventPageStyleResolverTest extends UnitTestCase {
       ['mel-event-page--classic', 'mel-event-page--colour-coral'],
       $resolved['classes']
     );
+    $this->assertFalse($resolved['is_pro_style']);
   }
 
   /**
    * @covers ::resolveForPublicRender
    */
-  public function testStoredValuesResolveToClasses(): void {
-    $style_field = new class () {
+  public function testImmersiveDeniedFallsBackToClassicOnPublicRender(): void {
+    $owner = $this->createVendorAccount(FALSE);
+    $node = $this->createEventNodeWithStyle('immersive', 'purple', 42);
+
+    $resolver = new EventPageStyleResolver(
+      new EventStyleAccessManager(NULL),
+      $this->createOwnerEntityTypeManager($owner, 42),
+    );
+    $resolved = $resolver->resolveForPublicRender($node);
+
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_PURPLE, $resolved['colour']);
+    $this->assertContains('mel-event-page--classic', $resolved['classes']);
+    $this->assertNotContains('mel-event-page--immersive', $resolved['classes']);
+    $this->assertFalse($resolved['is_pro_style']);
+  }
+
+  /**
+   * @covers ::resolveForPublicRender
+   */
+  public function testImmersiveAllowedForProOwnerOnPublicRender(): void {
+    $owner = $this->createVendorAccount(TRUE);
+    $node = $this->createEventNodeWithStyle('immersive', 'purple', 99);
+
+    $resolver = new EventPageStyleResolver(
+      new EventStyleAccessManager(),
+      $this->createOwnerEntityTypeManager($owner, 99),
+    );
+    $resolved = $resolver->resolveForPublicRender($node);
+
+    $this->assertSame(EventPageStyleResolver::STYLE_IMMERSIVE, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_PURPLE, $resolved['colour']);
+    $this->assertContains('mel-event-page--immersive', $resolved['classes']);
+    $this->assertTrue($resolved['is_pro_style']);
+  }
+
+  /**
+   * @covers ::resolveForPersistence
+   */
+  public function testPersistenceDowngradesImmersiveWhenAccessDenied(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $account = $this->createVendorAccount(FALSE);
+
+    $resolver = new EventPageStyleResolver(new EventStyleAccessManager(NULL));
+    $resolved = $resolver->resolveForPersistence(
+      $node,
+      EventPageStyleResolver::STYLE_IMMERSIVE,
+      EventPageStyleResolver::COLOUR_PURPLE,
+      $account,
+    );
+
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_PURPLE, $resolved['colour']);
+  }
+
+  /**
+   * @covers ::resolveForPersistence
+   */
+  public function testPersistenceAllowsImmersiveWhenAccessGranted(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $account = $this->createVendorAccount(TRUE);
+
+    $resolver = new EventPageStyleResolver(new EventStyleAccessManager());
+    $resolved = $resolver->resolveForPersistence(
+      $node,
+      EventPageStyleResolver::STYLE_IMMERSIVE,
+      EventPageStyleResolver::COLOUR_MINT,
+      $account,
+    );
+
+    $this->assertSame(EventPageStyleResolver::STYLE_IMMERSIVE, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_MINT, $resolved['colour']);
+  }
+
+  /**
+   * @covers ::resolveForPublicRender
+   */
+  public function testNonProVendorKeepsColourPresetOnClassicFallback(): void {
+    $owner = $this->createVendorAccount(FALSE);
+    $node = $this->createEventNodeWithStyle('immersive', 'gold', 7);
+
+    $resolver = new EventPageStyleResolver(
+      new EventStyleAccessManager(NULL),
+      $this->createOwnerEntityTypeManager($owner, 7),
+    );
+    $resolved = $resolver->resolveForPublicRender($node);
+
+    $this->assertSame(EventPageStyleResolver::STYLE_CLASSIC, $resolved['style']);
+    $this->assertSame(EventPageStyleResolver::COLOUR_GOLD, $resolved['colour']);
+    $this->assertContains('mel-event-page--colour-gold', $resolved['classes']);
+  }
+
+  private function createEventNodeWithStyle(string $style, string $colour, int $uid): NodeInterface {
+    $style_field = new class ($style) {
+      public function __construct(public string $value) {}
       public function isEmpty(): bool {
         return FALSE;
       }
-      public string $value = 'immersive';
     };
 
-    $colour_field = new class () {
+    $colour_field = new class ($colour) {
+      public function __construct(public string $value) {}
       public function isEmpty(): bool {
         return FALSE;
       }
-      public string $value = 'purple';
     };
 
     $node = $this->createMock(NodeInterface::class);
@@ -75,13 +168,27 @@ final class EventPageStyleResolverTest extends UnitTestCase {
       ['field_mel_page_style', $style_field],
       ['field_mel_theme_colour', $colour_field],
     ]);
+    $node->method('getOwnerId')->willReturn($uid);
 
-    $resolved = $this->resolver->resolveForPublicRender($node);
+    return $node;
+  }
 
-    $this->assertSame('immersive', $resolved['style']);
-    $this->assertSame('purple', $resolved['colour']);
-    $this->assertContains('mel-event-page--immersive', $resolved['classes']);
-    $this->assertContains('mel-event-page--colour-purple', $resolved['classes']);
+  private function createOwnerEntityTypeManager(UserInterface $owner, int $uid): EntityTypeManagerInterface {
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->with($uid)->willReturn($owner);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('user')->willReturn($storage);
+
+    return $entity_type_manager;
+  }
+
+  private function createVendorAccount(bool $is_admin): AccountInterface&UserInterface {
+    $account = $this->createMock(UserInterface::class);
+    $account->method('hasPermission')
+      ->willReturnCallback(static fn (string $permission): bool => $is_admin && $permission === 'administer nodes');
+
+    return $account;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStyleAccessManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStyleAccessManagerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStyleAccessManager
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStyleAccessManagerTest extends UnitTestCase {
+
+  /**
+   * @covers ::canUseImmersiveStyle
+   */
+  public function testDefaultFalseForNormalVendorAccount(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('hasPermission')->with('administer nodes')->willReturn(FALSE);
+
+    $event = $this->createMock(NodeInterface::class);
+    $manager = new EventStyleAccessManager(NULL);
+
+    $this->assertFalse($manager->canUseImmersiveStyle($event, $account));
+  }
+
+  /**
+   * @covers ::canUseImmersiveStyle
+   */
+  public function testTrueForAdminPermission(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('hasPermission')->with('administer nodes')->willReturn(TRUE);
+
+    $event = $this->createMock(NodeInterface::class);
+    $manager = new EventStyleAccessManager();
+
+    $this->assertTrue($manager->canUseImmersiveStyle($event, $account));
+  }
+
+  /**
+   * @covers ::canUseImmersiveStyle
+   */
+  public function testUnknownFeatureDoesNotGrantViaMissingProService(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('hasPermission')->willReturn(FALSE);
+
+    $event = $this->createMock(NodeInterface::class);
+    $manager = new EventStyleAccessManager(NULL);
+
+    $this->assertFalse($manager->canUseImmersiveStyle($event, $account));
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStyleAccessManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStyleAccessManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\myeventlane_event_studio\Unit;
 
 use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
 use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
@@ -17,6 +18,7 @@ use Drupal\Tests\UnitTestCase;
 final class EventStyleAccessManagerTest extends UnitTestCase {
 
   /**
+   * @covers ::canCustomizeEventPage
    * @covers ::canUseImmersiveStyle
    */
   public function testDefaultFalseForNormalVendorAccount(): void {
@@ -26,11 +28,14 @@ final class EventStyleAccessManagerTest extends UnitTestCase {
     $event = $this->createMock(NodeInterface::class);
     $manager = new EventStyleAccessManager(NULL);
 
+    $this->assertFalse($manager->canCustomizeEventPage($account));
     $this->assertFalse($manager->canUseImmersiveStyle($event, $account));
   }
 
   /**
-   * @covers ::canUseImmersiveStyle
+   * @covers ::canCustomizeEventPage
+   * @covers ::canUseStyle
+   * @covers ::canUseColour
    */
   public function testTrueForAdminPermission(): void {
     $account = $this->createMock(AccountInterface::class);
@@ -39,20 +44,25 @@ final class EventStyleAccessManagerTest extends UnitTestCase {
     $event = $this->createMock(NodeInterface::class);
     $manager = new EventStyleAccessManager();
 
-    $this->assertTrue($manager->canUseImmersiveStyle($event, $account));
+    $this->assertTrue($manager->canCustomizeEventPage($account));
+    $this->assertTrue($manager->canUseStyle(EventPageStyleResolver::STYLE_IMMERSIVE, $account));
+    $this->assertTrue($manager->canUseColour(EventPageStyleResolver::COLOUR_PURPLE, $account));
   }
 
   /**
-   * @covers ::canUseImmersiveStyle
+   * @covers ::canUseStyle
+   * @covers ::canUseColour
    */
-  public function testUnknownFeatureDoesNotGrantViaMissingProService(): void {
+  public function testNonProMayUseClassicAndCoralOnly(): void {
     $account = $this->createMock(AccountInterface::class);
     $account->method('hasPermission')->willReturn(FALSE);
 
-    $event = $this->createMock(NodeInterface::class);
     $manager = new EventStyleAccessManager(NULL);
 
-    $this->assertFalse($manager->canUseImmersiveStyle($event, $account));
+    $this->assertTrue($manager->canUseStyle(EventPageStyleResolver::STYLE_CLASSIC, $account));
+    $this->assertFalse($manager->canUseStyle(EventPageStyleResolver::STYLE_IMMERSIVE, $account));
+    $this->assertTrue($manager->canUseColour(EventPageStyleResolver::COLOUR_CORAL, $account));
+    $this->assertFalse($manager->canUseColour(EventPageStyleResolver::COLOUR_PURPLE, $account));
   }
 
 }

--- a/web/modules/custom/myeventlane_pro/src/Service/ProAccessService.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProAccessService.php
@@ -28,6 +28,7 @@ final class ProAccessService {
     'advanced_analytics',
     'audience_messaging',
     'boost_priority',
+    'event_immersive_style',
   ];
 
   /**

--- a/web/phpunit-event-studio.xml
+++ b/web/phpunit-event-studio.xml
@@ -12,6 +12,7 @@
   <testsuites>
     <testsuite name="event_studio">
       <directory>modules/custom/myeventlane_event_studio/tests/src</directory>
+      <file>modules/custom/myeventlane_commerce/tests/src/Unit/EventExtrasBookPlacementResolverTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -4116,6 +4116,32 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
     }
   }
 
+  // Event page style themes (Classic / Immersive + colour preset).
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_event_studio')
+    && \Drupal::hasService('myeventlane_event_studio.event_page_style_resolver')) {
+    /** @var \Drupal\myeventlane_event_studio\Service\EventPageStyleResolver $page_style_resolver */
+    $page_style_resolver = \Drupal::service('myeventlane_event_studio.event_page_style_resolver');
+    $resolved = $page_style_resolver->resolveForPublicRender($node);
+    $variables['event_page_style'] = $resolved['style'];
+    $variables['event_theme_colour'] = $resolved['colour'];
+    $variables['event_page_classes'] = $resolved['classes'];
+    if (!isset($variables['attributes']) || !is_array($variables['attributes'])) {
+      $variables['attributes'] = [];
+    }
+    $variables['attributes']['class'] ??= [];
+    if (!is_array($variables['attributes']['class'])) {
+      $variables['attributes']['class'] = [];
+    }
+    foreach ($resolved['classes'] as $class) {
+      $variables['attributes']['class'][] = $class;
+    }
+  }
+  else {
+    $variables['event_page_style'] = 'classic';
+    $variables['event_theme_colour'] = 'coral';
+    $variables['event_page_classes'] = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
+  }
+
   // Calendar URLs for event full template (same builder as checkout confirmation).
   $variables['apple_ics_url'] = '';
   $variables['outlook_ics_url'] = '';

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2815,6 +2815,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
     }
 
     if ($view_mode === 'full' && $node?->bundle() === 'event') {
+      _myeventlane_theme_apply_event_page_style_theme_variables($variables, $node);
       $variables['mel_event_selling_fast'] = FALSE;
       if (\Drupal::hasService('myeventlane_capacity.service')) {
         $capacity = \Drupal::service('myeventlane_capacity.service');
@@ -3796,8 +3797,38 @@ function myeventlane_theme_form_alter(array &$form, \Drupal\Core\Form\FormStateI
 }
 
 /**
- * Preprocess variables for event nodes only.
+ * Applies Classic/Immersive page style classes to event node template variables.
  */
+function _myeventlane_theme_apply_event_page_style_theme_variables(array &$variables, NodeInterface $node): void {
+  if (($variables['view_mode'] ?? '') !== 'full') {
+    return;
+  }
+
+  $classes = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
+  $style = 'classic';
+  $colour = 'coral';
+
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_event_studio')
+    && \Drupal::hasService('myeventlane_event_studio.event_page_style_resolver')) {
+    /** @var \Drupal\myeventlane_event_studio\Service\EventPageStyleResolver $resolver */
+    $resolver = \Drupal::service('myeventlane_event_studio.event_page_style_resolver');
+    $resolved = $resolver->resolveForPublicRender($node);
+    $style = $resolved['style'];
+    $colour = $resolved['colour'];
+    $classes = $resolved['classes'];
+  }
+
+  $variables['event_page_style'] = $style;
+  $variables['event_theme_colour'] = $colour;
+  $variables['event_page_classes'] = $classes;
+
+  if (!isset($variables['attributes']) || !$variables['attributes'] instanceof Attribute) {
+    $existing = $variables['attributes'] ?? [];
+    $variables['attributes'] = new Attribute(is_array($existing) ? $existing : []);
+  }
+  $variables['attributes']->addClass($classes);
+}
+
 /**
  * Preprocess event nodes to resolve hero image safely.
  */
@@ -4114,32 +4145,6 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
         $variables['mel_booking_action_label'] = new TranslatableMarkup('Get your tickets');
       }
     }
-  }
-
-  // Event page style themes (Classic / Immersive + colour preset).
-  if (\Drupal::moduleHandler()->moduleExists('myeventlane_event_studio')
-    && \Drupal::hasService('myeventlane_event_studio.event_page_style_resolver')) {
-    /** @var \Drupal\myeventlane_event_studio\Service\EventPageStyleResolver $page_style_resolver */
-    $page_style_resolver = \Drupal::service('myeventlane_event_studio.event_page_style_resolver');
-    $resolved = $page_style_resolver->resolveForPublicRender($node);
-    $variables['event_page_style'] = $resolved['style'];
-    $variables['event_theme_colour'] = $resolved['colour'];
-    $variables['event_page_classes'] = $resolved['classes'];
-    if (!isset($variables['attributes']) || !is_array($variables['attributes'])) {
-      $variables['attributes'] = [];
-    }
-    $variables['attributes']['class'] ??= [];
-    if (!is_array($variables['attributes']['class'])) {
-      $variables['attributes']['class'] = [];
-    }
-    foreach ($resolved['classes'] as $class) {
-      $variables['attributes']['class'][] = $class;
-    }
-  }
-  else {
-    $variables['event_page_style'] = 'classic';
-    $variables['event_theme_colour'] = 'coral';
-    $variables['event_page_classes'] = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
   }
 
   // Calendar URLs for event full template (same builder as checkout confirmation).

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -43,18 +43,24 @@
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
 }
 
-// Classic — warm MEL default (Mockup 1): light page, white cards, coral/accent CTAs.
+// Page shell warmth when Classic event is present (article bg alone leaves white gutters).
+body:has(.mel-event-page--classic.mel-event--v2),
+main.mel-main:has(.mel-event-page--classic.mel-event--v2) {
+  background-color: #fff8f4;
+}
+
+// Classic — warm MEL default (Mockup 1): light page, white cards, preset accent CTAs.
+// Accent colours come from mel-event-page--colour-* on <article> (coral default).
 .mel-event-page--classic.mel-event--v2 {
   --mel-event-page-bg: #fff8f4;
   --mel-event-surface: #ffffff;
   --mel-event-surface-soft: #fff1ec;
   --mel-event-border: rgba(242, 109, 91, 0.18);
   --mel-event-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
-  --mel-event-accent: #f26d5b;
-  --mel-event-accent-strong: #ef4f3f;
-  --mel-event-accent-soft: rgba(242, 109, 91, 0.12);
   --mel-event-text: #1f2933;
   --mel-event-muted: #6b7280;
+  --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 88%, #1f2933 12%);
+  --mel-event-accent-soft: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 12%, #fff 88%);
   // Aliases used elsewhere in this file.
   --mel-event-card-bg: var(--mel-event-surface);
   --mel-event-card-border: var(--mel-event-border);
@@ -62,6 +68,8 @@
   --mel-event-surface-raised: var(--mel-event-surface);
   --mel-event-text-muted: var(--mel-event-muted);
 
+  display: block;
+  width: 100%;
   background: var(--mel-event-page-bg);
   color: var(--mel-event-text);
   min-height: 100vh;
@@ -95,11 +103,28 @@
     color: #fff;
   }
 
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__category,
   .mel-event-hero--featured-style .mel-event__category,
   .mel-event-hero--featured-style .mel-pill--on-image {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     border: none;
+    box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
+  }
+
+  // Intelligence / popularity chip in hero content (Twig uses mel_event_signal, not hero__chip).
+  .mel-event-hero--featured-style .mel-event-hero__content .mel-event__signal {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    margin: 0;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.2;
     box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
   }
 
@@ -150,14 +175,20 @@
     color: var(--mel-event-text);
   }
 
-  .mel-event__signal {
-    background: var(--mel-event-accent-soft, colors.$mel-color-surface-alt);
+  .mel-event-layout__main .mel-event__signal,
+  .mel-event-layout__sidebar .mel-event__signal {
+    background: var(--mel-event-accent-soft);
     color: var(--mel-event-text);
   }
 
-  .mel-event__signal--strong {
+  .mel-card--sticky .mel-event__signal--strong,
+  .mel-event-layout__sidebar .mel-event__signal--strong {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 13px;
+    font-weight: 600;
   }
 
   .mel-event-meta-bar,
@@ -235,13 +266,13 @@
     border-radius: radii.$mel-radius-md;
   }
 
-  // Warm “Grab the extras” panel.
-  .mel-event-section--extras {
+  // Warm “Grab the extras” panel (outer section card).
+  .mel-event-section--extras.mel-card--surface {
     background: var(--mel-event-surface-soft);
     border-color: var(--mel-event-border);
 
-    .mel-card__header,
-    .mel-card__body {
+    > .mel-card__header,
+    > .mel-card__body {
       background: transparent;
     }
   }
@@ -249,6 +280,16 @@
   .mel-event-section--extras .mel-card__title,
   .mel-event-section--extras .mel-event-section__title {
     color: var(--mel-event-accent);
+  }
+
+  // Nested operational teaser — do not double as a white inner card (_event-full + module CSS).
+  .mel-event-section--extras .mel-addon-teaser.mel-card--surface {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
   }
 
   .mel-event-section--extras .mel-addon-teaser__list {
@@ -271,6 +312,12 @@
     box-shadow: none;
   }
 
+  // Beat _event-full.scss lavender tint on extras rows.
+  .mel-event--v2.mel-event-page--classic .mel-event-section--extras .mel-addon-teaser__item {
+    background: var(--mel-event-surface);
+    border-color: var(--mel-event-border);
+  }
+
   .mel-event-section--extras .mel-addon-teaser__thumb {
     flex: 0 0 auto;
     width: 56px;
@@ -285,16 +332,20 @@
   }
 
   .mel-event-section--extras .mel-addon-teaser__cta,
-  .mel-event-section--extras .mel-addon-teaser__scroll {
+  .mel-event-section--extras .mel-addon-teaser__scroll,
+  .mel-event-section--extras .mel-addon-teaser__cta.mel-btn--secondary,
+  .mel-event-section--extras .mel-addon-teaser__scroll.mel-btn--secondary {
     background: transparent;
     border: 2px solid var(--mel-event-accent);
     color: var(--mel-event-accent-strong);
     min-height: 44px;
     font-weight: 600;
+    border-radius: radii.$mel-radius-lg;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
         background: var(--mel-event-accent-soft);
+        color: var(--mel-event-accent-strong);
       }
     }
   }
@@ -323,7 +374,8 @@
 
   .mel-btn--primary,
   .button--primary,
-  .mel-event--v2 .mel-btn--primary {
+  .mel-event--v2 .mel-btn--primary,
+  .mel-event--v2 .mel-btn--coral-cta {
     background-color: var(--mel-event-accent, colors.$mel-color-primary);
     border-color: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
@@ -338,6 +390,14 @@
     border-color: var(--mel-event-card-border);
     color: var(--mel-event-text);
     min-height: 44px;
+  }
+
+  // Preserve coral pill CTA from _event-full (do not let generic primary rule flatten radius).
+  .mel-card--sticky .mel-btn--coral-cta,
+  .mel-mobile-cta .mel-btn--coral-cta {
+    border-radius: 16px;
+    background: var(--mel-coral, var(--mel-event-accent, #{colors.$mel-color-primary}));
+    color: colors.$mel-color-on-primary;
   }
 
   .mel-mobile-cta {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -42,9 +42,23 @@
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
 }
 
-// Classic — warm MEL default with visible accent from colour preset.
+// Classic — warm MEL default (Mockup 1): light page, white cards, coral/accent CTAs.
 .mel-event-page--classic.mel-event--v2 {
-  background-color: colors.$mel-color-bg;
+  --mel-event-surface: #{colors.$mel-color-surface};
+  --mel-event-surface-raised: #{colors.$mel-color-surface};
+  --mel-event-text: #{colors.$mel-color-text};
+  --mel-event-text-muted: #{colors.$mel-color-text-muted};
+
+  background-color: color.mix(colors.$mel-color-bg, #fff8f4, 72%);
+  color: var(--mel-event-text);
+
+  .mel-event-layout__main,
+  .mel-event-layout__sidebar,
+  .mel-event-meta-bar,
+  .mel-event-info__body,
+  .mel-event-section__body {
+    color: var(--mel-event-text);
+  }
 
   .mel-event__signal {
     background: var(--mel-event-accent-soft, colors.$mel-color-surface-alt);
@@ -58,22 +72,30 @@
 
   .mel-event-meta-bar,
   .mel-event__card,
-  .mel-card--sticky {
-    background: colors.$mel-color-surface;
+  .mel-card--sticky,
+  .mel-event-layout__main .mel-card {
+    background: var(--mel-event-surface);
     border-radius: radii.$mel-radius-xl;
     box-shadow: shadows.$mel-shadow-md;
     border: 1px solid colors.$mel-color-border;
+    color: var(--mel-event-text);
   }
 
   .mel-event-info__title,
   .mel-event-section__title,
   .mel-card__title {
-    color: colors.$mel-color-text;
+    color: var(--mel-event-text);
   }
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
     background: var(--mel-event-accent, colors.$mel-color-primary);
+  }
+
+  .mel-card--sticky .mel-booking-panel__chip,
+  .mel-event__meta,
+  .mel-event-info__label {
+    color: var(--mel-event-text-muted);
   }
 
   .mel-btn--primary,
@@ -84,6 +106,21 @@
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
     font-weight: 600;
+    box-shadow: shadows.$mel-shadow-sm;
+  }
+
+  .mel-btn--secondary,
+  .button--secondary {
+    background: colors.$mel-color-surface;
+    border-color: colors.$mel-color-border;
+    color: colors.$mel-color-text;
+    min-height: 44px;
+  }
+
+  .mel-mobile-cta {
+    background: colors.$mel-color-surface;
+    border-top: 1px solid colors.$mel-color-border;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.08);
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -42,47 +42,79 @@
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
 }
 
-// Classic — warm default (inherits existing .mel-event--v2 look; accent-driven CTAs).
+// Classic — warm MEL default with visible accent from colour preset.
 .mel-event-page--classic.mel-event--v2 {
   background-color: colors.$mel-color-bg;
 
-  .mel-event__card,
+  .mel-event__signal {
+    background: var(--mel-event-accent-soft, colors.$mel-color-surface-alt);
+    color: colors.$mel-color-text;
+  }
+
+  .mel-event__signal--strong {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+  }
+
   .mel-event-meta-bar,
+  .mel-event__card,
   .mel-card--sticky {
     background: colors.$mel-color-surface;
     border-radius: radii.$mel-radius-xl;
     box-shadow: shadows.$mel-shadow-md;
+    border: 1px solid colors.$mel-color-border;
   }
 
-  .mel-event--v2 .mel-btn--primary,
-  .mel-event--v2 .button--primary {
+  .mel-event-info__title,
+  .mel-event-section__title,
+  .mel-card__title {
+    color: colors.$mel-color-text;
+  }
+
+  .mel-event-info__title::after,
+  .mel-event-section__title::after {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+  }
+
+  .mel-btn--primary,
+  .button--primary,
+  .mel-event--v2 .mel-btn--primary {
     background-color: var(--mel-event-accent, colors.$mel-color-primary);
     border-color: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
+    font-weight: 600;
   }
 }
 
-// Immersive — dark cinematic treatment; readable cards and CTAs.
+// Immersive — cinematic full-page treatment (obvious vs Classic).
 .mel-event-page--immersive.mel-event--v2 {
   --mel-event-surface: #{color.mix(colors.$mel-color-navy, #0d1117, 88%)};
   --mel-event-surface-raised: #{color.mix(colors.$mel-color-navy, #1a2330, 72%)};
   --mel-event-text: #{colors.$mel-color-text-inverse};
   --mel-event-text-muted: #{color.mix(#fff, colors.$mel-color-navy, 62%)};
 
-  background: linear-gradient(
-    180deg,
-    color.mix(colors.$mel-color-navy, #000, 92%) 0%,
-    color.mix(colors.$mel-color-navy, #1a2330, 72%) 100%
-  );
+  background:
+    radial-gradient(120% 80% at 50% -10%, rgba(255, 255, 255, 0.08) 0%, transparent 55%),
+    linear-gradient(
+      180deg,
+      color.mix(colors.$mel-color-navy, #000, 92%) 0%,
+      color.mix(colors.$mel-color-navy, #1a2330, 72%) 100%
+    );
   color: var(--mel-event-text);
+
+  .mel-event-hero--featured-style {
+    border-radius: radii.$mel-radius-xl;
+    overflow: hidden;
+    box-shadow: 0 24px 56px rgba(0, 0, 0, 0.45);
+  }
 
   .mel-event-hero--featured-style .mel-event-hero__overlay {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.15) 0%,
-      rgba(13, 17, 23, 0.72) 55%,
-      rgba(13, 17, 23, 0.92) 100%
+      rgba(0, 0, 0, 0.05) 0%,
+      rgba(13, 17, 23, 0.55) 42%,
+      rgba(13, 17, 23, 0.94) 100%
     );
   }
 
@@ -90,7 +122,8 @@
   .mel-event-hero-card__title,
   #mel-event-title {
     color: var(--mel-event-text);
-    text-shadow: 0 2px 18px rgba(0, 0, 0, 0.45);
+    text-shadow: 0 2px 24px rgba(0, 0, 0, 0.55);
+    letter-spacing: -0.02em;
   }
 
   .mel-event-meta-bar,
@@ -98,14 +131,17 @@
   .mel-card--sticky,
   .mel-event-layout__main .mel-card {
     background: var(--mel-event-surface-raised);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
     color: var(--mel-event-text);
+    backdrop-filter: blur(6px);
   }
 
   .mel-event-meta-bar,
   .mel-event-layout__main,
-  .mel-event-layout__sidebar {
+  .mel-event-layout__sidebar,
+  .mel-event-info__body,
+  .mel-event-section__body {
     color: var(--mel-event-text);
   }
 
@@ -125,6 +161,22 @@
     color: var(--mel-event-text-muted);
   }
 
+  .mel-event__signal--strong {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  }
+
+  .mel-event-info__title,
+  .mel-event-section__title {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-info__title::after,
+  .mel-event-section__title::after {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+  }
+
   .mel-btn--primary,
   .button--primary,
   .mel-event--v2 .mel-btn--primary {
@@ -132,29 +184,33 @@
     border-color: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
+    font-weight: 700;
+    box-shadow: 0 10px 28px color.mix(#000, colors.$mel-color-primary, 35%);
   }
 
   .mel-btn--secondary,
   .button--secondary {
     background: transparent;
-    border-color: rgba(255, 255, 255, 0.35);
+    border-color: rgba(255, 255, 255, 0.38);
     color: var(--mel-event-text);
     min-height: 44px;
   }
 
-  .mel-event__signal--strong {
-    background: var(--mel-event-accent, colors.$mel-color-primary);
-    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
-  }
-
   .mel-mobile-cta {
     background: var(--mel-event-surface-raised);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.35);
   }
 
   @media (prefers-reduced-motion: reduce) {
     .mel-event-hero--featured-style .mel-event-hero__overlay {
       transition: none;
+    }
+
+    .mel-event-meta-bar,
+    .mel-event__card,
+    .mel-card--sticky {
+      backdrop-filter: none;
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -1,0 +1,160 @@
+// ==========================================================================
+// Event page style themes — Classic (default) + Immersive (Pro-capable)
+// Scoped to public full event pages via modifier classes on <article>.
+// ==========================================================================
+
+@use 'sass:color';
+@use '../tokens/colors';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/spacing' as space-tokens;
+@use '../tokens/breakpoints';
+@use '../tokens/motion' as melmotion;
+
+// Colour presets — CSS custom properties consumed by Classic and Immersive.
+.mel-event-page--colour-coral {
+  --mel-event-accent: #{colors.$mel-color-primary};
+  --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #fff, 18%)};
+  --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+}
+
+.mel-event-page--colour-purple {
+  --mel-event-accent: #{colors.$mel-color-accent};
+  --mel-event-accent-soft: #{colors.$mel-color-pastel-lavender};
+  --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+}
+
+.mel-event-page--colour-mint {
+  --mel-event-accent: #{color.adjust(colors.$mel-color-success, $lightness: -8%)};
+  --mel-event-accent-soft: #{colors.$mel-color-pastel-mint};
+  --mel-event-accent-contrast: #{colors.$mel-color-text};
+}
+
+.mel-event-page--colour-gold {
+  --mel-event-accent: #{colors.$mel-color-orange};
+  --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #fff, 22%)};
+  --mel-event-accent-contrast: #{colors.$mel-color-text};
+}
+
+.mel-event-page--colour-blue {
+  --mel-event-accent: #{colors.$mel-color-info};
+  --mel-event-accent-soft: #{colors.$mel-color-info-bg};
+  --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+}
+
+// Classic — warm default (inherits existing .mel-event--v2 look; accent-driven CTAs).
+.mel-event-page--classic.mel-event--v2 {
+  background-color: colors.$mel-color-bg;
+
+  .mel-event__card,
+  .mel-event-meta-bar,
+  .mel-card--sticky {
+    background: colors.$mel-color-surface;
+    border-radius: radii.$mel-radius-xl;
+    box-shadow: shadows.$mel-shadow-md;
+  }
+
+  .mel-event--v2 .mel-btn--primary,
+  .mel-event--v2 .button--primary {
+    background-color: var(--mel-event-accent, colors.$mel-color-primary);
+    border-color: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    min-height: 44px;
+  }
+}
+
+// Immersive — dark cinematic treatment; readable cards and CTAs.
+.mel-event-page--immersive.mel-event--v2 {
+  --mel-event-surface: #{color.mix(colors.$mel-color-navy, #0d1117, 88%)};
+  --mel-event-surface-raised: #{color.mix(colors.$mel-color-navy, #1a2330, 72%)};
+  --mel-event-text: #{colors.$mel-color-text-inverse};
+  --mel-event-text-muted: #{color.mix(#fff, colors.$mel-color-navy, 62%)};
+
+  background: linear-gradient(
+    180deg,
+    color.mix(colors.$mel-color-navy, #000, 92%) 0%,
+    color.mix(colors.$mel-color-navy, #1a2330, 72%) 100%
+  );
+  color: var(--mel-event-text);
+
+  .mel-event-hero--featured-style .mel-event-hero__overlay {
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.15) 0%,
+      rgba(13, 17, 23, 0.72) 55%,
+      rgba(13, 17, 23, 0.92) 100%
+    );
+  }
+
+  .mel-event-hero__content,
+  .mel-event-hero-card__title,
+  #mel-event-title {
+    color: var(--mel-event-text);
+    text-shadow: 0 2px 18px rgba(0, 0, 0, 0.45);
+  }
+
+  .mel-event-meta-bar,
+  .mel-event__card,
+  .mel-card--sticky,
+  .mel-event-layout__main .mel-card {
+    background: var(--mel-event-surface-raised);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-meta-bar,
+  .mel-event-layout__main,
+  .mel-event-layout__sidebar {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-meta-bar a,
+  .mel-event-layout__main a:not(.mel-btn) {
+    color: color.mix(#fff, colors.$mel-color-accent, 70%);
+  }
+
+  .mel-card--sticky .mel-booking-panel__price,
+  .mel-event__signal {
+    color: var(--mel-event-text);
+  }
+
+  .mel-card--sticky .mel-booking-panel__chip,
+  .mel-event__meta,
+  .mel-event-info__label {
+    color: var(--mel-event-text-muted);
+  }
+
+  .mel-btn--primary,
+  .button--primary,
+  .mel-event--v2 .mel-btn--primary {
+    background-color: var(--mel-event-accent, colors.$mel-color-primary);
+    border-color: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    min-height: 44px;
+  }
+
+  .mel-btn--secondary,
+  .button--secondary {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.35);
+    color: var(--mel-event-text);
+    min-height: 44px;
+  }
+
+  .mel-event__signal--strong {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+  }
+
+  .mel-mobile-cta {
+    background: var(--mel-event-surface-raised);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mel-event-hero--featured-style .mel-event-hero__overlay {
+      transition: none;
+    }
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -49,6 +49,11 @@ main.mel-main:has(.mel-event-page--classic.mel-event--v2) {
   background-color: #fff8f4;
 }
 
+body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
+  background-color: #fff8f4;
+  color: #1f2933;
+}
+
 // Classic — warm MEL default (Mockup 1): light page, white cards, preset accent CTAs.
 // Accent colours come from mel-event-page--colour-* on <article> (coral default).
 .mel-event-page--classic.mel-event--v2 {
@@ -60,7 +65,7 @@ main.mel-main:has(.mel-event-page--classic.mel-event--v2) {
   --mel-event-text: #1f2933;
   --mel-event-muted: #6b7280;
   --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 88%, #1f2933 12%);
-  --mel-event-accent-soft: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 12%, #fff 88%);
+  // --mel-event-accent-soft comes from mel-event-page--colour-* (coral default).
   // Aliases used elsewhere in this file.
   --mel-event-card-bg: var(--mel-event-surface);
   --mel-event-card-border: var(--mel-event-border);
@@ -212,6 +217,19 @@ main.mel-main:has(.mel-event-page--classic.mel-event--v2) {
     @include breakpoints.mel-break(lg) {
       padding: space-tokens.mel-space(5);
     }
+  }
+
+  // Beat _event-full.scss tinted highlights / expect cards on Mockup 1.
+  .mel-card--highlights,
+  .mel-card--expect {
+    background: var(--mel-event-surface);
+    border: 1px solid var(--mel-event-border);
+    box-shadow: var(--mel-event-shadow);
+  }
+
+  .mel-event-highlights__icon {
+    background: var(--mel-event-accent-soft);
+    color: var(--mel-event-accent);
   }
 
   .mel-card__title,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -46,18 +46,26 @@
 // Classic — warm MEL default (Mockup 1): light page, white cards, coral/accent CTAs.
 .mel-event-page--classic.mel-event--v2 {
   --mel-event-page-bg: #fff8f4;
-  --mel-event-card-bg: #ffffff;
-  --mel-event-card-border: rgba(242, 109, 91, 0.16);
-  --mel-event-card-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
+  --mel-event-surface: #ffffff;
+  --mel-event-surface-soft: #fff1ec;
+  --mel-event-border: rgba(242, 109, 91, 0.18);
+  --mel-event-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
+  --mel-event-accent: #f26d5b;
+  --mel-event-accent-strong: #ef4f3f;
+  --mel-event-accent-soft: rgba(242, 109, 91, 0.12);
   --mel-event-text: #1f2933;
   --mel-event-muted: #6b7280;
-  --mel-event-surface: var(--mel-event-card-bg);
-  --mel-event-surface-raised: var(--mel-event-card-bg);
+  // Aliases used elsewhere in this file.
+  --mel-event-card-bg: var(--mel-event-surface);
+  --mel-event-card-border: var(--mel-event-border);
+  --mel-event-card-shadow: var(--mel-event-shadow);
+  --mel-event-surface-raised: var(--mel-event-surface);
   --mel-event-text-muted: var(--mel-event-muted);
 
-  background-color: var(--mel-event-page-bg);
+  background: var(--mel-event-page-bg);
   color: var(--mel-event-text);
-  min-height: 100%;
+  min-height: 100vh;
+  overflow-x: clip;
 
   .mel-container {
     color: var(--mel-event-text);
@@ -78,6 +86,13 @@
       rgba(31, 41, 51, 0.45) 55%,
       rgba(31, 41, 51, 0.82) 100%
     );
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__title,
+  .mel-event-hero--featured-style #mel-event-title,
+  .mel-event-hero--featured-style .mel-event-hero__datetime,
+  .mel-event-hero--featured-style .mel-event-hero__venue {
+    color: #fff;
   }
 
   .mel-event-hero--featured-style .mel-event__category,
@@ -150,11 +165,22 @@
   .mel-card--sticky,
   .mel-event-layout__main .mel-card,
   .mel-card--surface {
-    background: var(--mel-event-card-bg);
+    background: var(--mel-event-surface);
     border-radius: radii.$mel-radius-xl;
-    box-shadow: var(--mel-event-card-shadow);
-    border: 1px solid var(--mel-event-card-border);
+    box-shadow: var(--mel-event-shadow);
+    border: 1px solid var(--mel-event-border);
     color: var(--mel-event-text);
+  }
+
+  .mel-card--surface .mel-card__header,
+  .mel-card--surface .mel-card__body,
+  .mel-card--sticky .mel-card__header,
+  .mel-card--sticky .mel-card__body {
+    padding: space-tokens.mel-space(4);
+
+    @include breakpoints.mel-break(lg) {
+      padding: space-tokens.mel-space(5);
+    }
   }
 
   .mel-card__title,
@@ -184,10 +210,35 @@
     color: var(--mel-event-muted);
   }
 
+  // Ticket sidebar — coral chips, save tint, trust accents.
+  .mel-card--sticky .mel-chip--filled,
+  .mel-card--sticky .mel-chip {
+    background: var(--mel-event-accent-soft);
+    border: 1px solid var(--mel-event-accent);
+    color: var(--mel-event-accent-strong);
+  }
+
+  .mel-card--sticky .mel-booking-panel__save,
+  .mel-card--sticky .mel-booking-panel__save--fav {
+    background: var(--mel-event-surface-soft);
+    border-color: var(--mel-event-border);
+  }
+
+  .mel-card--sticky .mel-booking-panel__item-icon,
+  .mel-card--sticky .mel-booking-panel__item--highlight .mel-icon,
+  .mel-card--sticky .mel-trust-item__text {
+    color: var(--mel-event-accent);
+  }
+
+  .mel-card--sticky .mel-booking-panel__item--highlight {
+    background: var(--mel-event-accent-soft);
+    border-radius: radii.$mel-radius-md;
+  }
+
   // Warm “Grab the extras” panel.
   .mel-event-section--extras {
-    background: var(--mel-event-accent-soft, color.mix(colors.$mel-color-primary, #fff, 18%));
-    border-color: var(--mel-event-card-border);
+    background: var(--mel-event-surface-soft);
+    border-color: var(--mel-event-border);
 
     .mel-card__header,
     .mel-card__body {
@@ -195,9 +246,75 @@
     }
   }
 
+  .mel-event-section--extras .mel-card__title,
+  .mel-event-section--extras .mel-event-section__title {
+    color: var(--mel-event-accent);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__list {
+    display: flex;
+    flex-direction: column;
+    gap: space-tokens.mel-space(2);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
   .mel-event-section--extras .mel-addon-teaser__item {
-    background: var(--mel-event-card-bg);
-    border: 1px solid var(--mel-event-card-border);
+    display: flex;
+    align-items: center;
+    gap: space-tokens.mel-space(3);
+    padding: space-tokens.mel-space(3);
+    background: var(--mel-event-surface);
+    border: 1px solid var(--mel-event-border);
+    border-radius: radii.$mel-radius-lg;
+    box-shadow: none;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__thumb {
+    flex: 0 0 auto;
+    width: 56px;
+    height: 56px;
+    border-radius: radii.$mel-radius-md;
+    object-fit: cover;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__body {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__cta,
+  .mel-event-section--extras .mel-addon-teaser__scroll {
+    background: transparent;
+    border: 2px solid var(--mel-event-accent);
+    color: var(--mel-event-accent-strong);
+    min-height: 44px;
+    font-weight: 600;
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: var(--mel-event-accent-soft);
+      }
+    }
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__more {
+    color: var(--mel-event-accent-strong);
+    font-weight: 600;
+  }
+
+  // Map + share on warm page.
+  .mel-event-map-embed {
+    border-radius: radii.$mel-radius-lg;
+    border-color: var(--mel-event-border);
+    overflow: hidden;
+  }
+
+  .mel-event-share--panel .mel-event-share__chip-icon {
+    background: var(--mel-event-accent-soft);
+    border-color: var(--mel-event-border);
+    color: var(--mel-event-accent-strong);
   }
 
   .mel-event-layout__main a:not(.mel-btn):not(.mel-social) {
@@ -236,6 +353,22 @@
   .mel-organiser-card,
   .mel-return-block {
     color: var(--mel-event-text);
+  }
+
+  .mel-event-support-zone {
+    border-top: 1px solid var(--mel-event-border);
+    padding-top: space-tokens.mel-space(4);
+  }
+
+  @include breakpoints.mel-break(md, max) {
+    .mel-event-meta-bar__items {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .mel-event-meta-bar__cluster {
+      width: 100%;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -1,5 +1,5 @@
 // ==========================================================================
-// Event page style themes — Mockup 1 Classic (default) + Mockup 3 Immersive (Pro-capable).
+// Event page style themes — Mockup 1 Classic (default) + Mockup 3 Immersive (Pro).
 // Mockup 2 Clean & Modern deferred.
 // Scoped to public full event pages via modifier classes on <article>.
 // ==========================================================================
@@ -45,17 +45,91 @@
 
 // Classic — warm MEL default (Mockup 1): light page, white cards, coral/accent CTAs.
 .mel-event-page--classic.mel-event--v2 {
-  --mel-event-surface: #{colors.$mel-color-surface};
-  --mel-event-surface-raised: #{colors.$mel-color-surface};
-  --mel-event-text: #{colors.$mel-color-text};
-  --mel-event-text-muted: #{colors.$mel-color-text-muted};
+  --mel-event-page-bg: #fff8f4;
+  --mel-event-card-bg: #ffffff;
+  --mel-event-card-border: rgba(242, 109, 91, 0.16);
+  --mel-event-card-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
+  --mel-event-text: #1f2933;
+  --mel-event-muted: #6b7280;
+  --mel-event-surface: var(--mel-event-card-bg);
+  --mel-event-surface-raised: var(--mel-event-card-bg);
+  --mel-event-text-muted: var(--mel-event-muted);
 
-  background-color: color.mix(colors.$mel-color-bg, #fff8f4, 72%);
+  background-color: var(--mel-event-page-bg);
   color: var(--mel-event-text);
+  min-height: 100%;
+
+  .mel-container {
+    color: var(--mel-event-text);
+  }
+
+  // Hero — rounded featured image, dark overlay, white title (base _event-hero.scss).
+  .mel-event-hero--featured-style {
+    border-radius: radii.$mel-radius-xl;
+    border: none;
+    box-shadow: var(--mel-event-card-shadow);
+    overflow: hidden;
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__overlay {
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.08) 0%,
+      rgba(31, 41, 51, 0.45) 55%,
+      rgba(31, 41, 51, 0.82) 100%
+    );
+  }
+
+  .mel-event-hero--featured-style .mel-event__category,
+  .mel-event-hero--featured-style .mel-pill--on-image {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    border: none;
+    box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
+  }
+
+  // Floating meta strip — white card overlapping hero foot.
+  .mel-event-meta-bar {
+    position: relative;
+    z-index: 4;
+    margin-top: calc(-1 * #{space-tokens.mel-space(5)});
+    background: var(--mel-event-card-bg);
+    border: 1px solid var(--mel-event-card-border);
+    border-radius: radii.$mel-radius-xl;
+    box-shadow: var(--mel-event-card-shadow);
+    color: var(--mel-event-text);
+
+    @include breakpoints.mel-break(md, max) {
+      margin-top: space-tokens.mel-space(3);
+    }
+  }
+
+  .mel-event-meta__primary {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-meta__secondary,
+  .mel-event-meta__icon {
+    color: var(--mel-event-muted);
+  }
+
+  .mel-event-layout {
+    margin-top: space-tokens.mel-space(5);
+  }
+
+  @include breakpoints.mel-break(lg) {
+    .mel-event-layout__sidebar {
+      align-self: start;
+    }
+
+    .mel-event-layout__sidebar > .mel-card--sticky {
+      position: sticky;
+      top: space-tokens.mel-space(4);
+    }
+  }
 
   .mel-event-layout__main,
   .mel-event-layout__sidebar,
-  .mel-event-meta-bar,
   .mel-event-info__body,
   .mel-event-section__body {
     color: var(--mel-event-text);
@@ -63,7 +137,7 @@
 
   .mel-event__signal {
     background: var(--mel-event-accent-soft, colors.$mel-color-surface-alt);
-    color: colors.$mel-color-text;
+    color: var(--mel-event-text);
   }
 
   .mel-event__signal--strong {
@@ -74,17 +148,18 @@
   .mel-event-meta-bar,
   .mel-event__card,
   .mel-card--sticky,
-  .mel-event-layout__main .mel-card {
-    background: var(--mel-event-surface);
+  .mel-event-layout__main .mel-card,
+  .mel-card--surface {
+    background: var(--mel-event-card-bg);
     border-radius: radii.$mel-radius-xl;
-    box-shadow: shadows.$mel-shadow-md;
-    border: 1px solid colors.$mel-color-border;
+    box-shadow: var(--mel-event-card-shadow);
+    border: 1px solid var(--mel-event-card-border);
     color: var(--mel-event-text);
   }
 
+  .mel-card__title,
   .mel-event-info__title,
-  .mel-event-section__title,
-  .mel-card__title {
+  .mel-event-section__title {
     color: var(--mel-event-text);
   }
 
@@ -93,10 +168,40 @@
     background: var(--mel-event-accent, colors.$mel-color-primary);
   }
 
+  .mel-text--muted,
+  .mel-event-section__lede,
+  .mel-muted {
+    color: var(--mel-event-muted);
+  }
+
+  .mel-card--sticky .mel-booking-panel__price {
+    color: var(--mel-event-text);
+  }
+
   .mel-card--sticky .mel-booking-panel__chip,
   .mel-event__meta,
   .mel-event-info__label {
-    color: var(--mel-event-text-muted);
+    color: var(--mel-event-muted);
+  }
+
+  // Warm “Grab the extras” panel.
+  .mel-event-section--extras {
+    background: var(--mel-event-accent-soft, color.mix(colors.$mel-color-primary, #fff, 18%));
+    border-color: var(--mel-event-card-border);
+
+    .mel-card__header,
+    .mel-card__body {
+      background: transparent;
+    }
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__item {
+    background: var(--mel-event-card-bg);
+    border: 1px solid var(--mel-event-card-border);
+  }
+
+  .mel-event-layout__main a:not(.mel-btn):not(.mel-social) {
+    color: color.mix(colors.$mel-color-primary, colors.$mel-color-navy, 35%);
   }
 
   .mel-btn--primary,
@@ -107,21 +212,36 @@
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
     font-weight: 600;
-    box-shadow: shadows.$mel-shadow-sm;
+    box-shadow: 0 8px 22px color.mix(#000, colors.$mel-color-primary, 12%);
   }
 
   .mel-btn--secondary,
   .button--secondary {
-    background: colors.$mel-color-surface;
-    border-color: colors.$mel-color-border;
-    color: colors.$mel-color-text;
+    background: var(--mel-event-card-bg);
+    border-color: var(--mel-event-card-border);
+    color: var(--mel-event-text);
     min-height: 44px;
   }
 
   .mel-mobile-cta {
-    background: colors.$mel-color-surface;
-    border-top: 1px solid colors.$mel-color-border;
-    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.08);
+    background: var(--mel-event-card-bg);
+    border-top: 1px solid var(--mel-event-card-border);
+    box-shadow: 0 -6px 24px rgba(41, 50, 65, 0.1);
+  }
+
+  .mel-event-support-zone__link {
+    color: var(--mel-event-text);
+  }
+
+  .mel-organiser-card,
+  .mel-return-block {
+    color: var(--mel-event-text);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mel-event-hero--featured-style .mel-event-hero__overlay {
+      transition: none;
+    }
   }
 }
 
@@ -164,10 +284,8 @@
     letter-spacing: -0.02em;
   }
 
-  .mel-event-meta-bar,
-  .mel-event__card,
-  .mel-card--sticky,
-  .mel-event-layout__main .mel-card {
+  .mel-event-meta-bar {
+    margin-top: space-tokens.mel-space(3);
     background: var(--mel-event-surface-raised);
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
@@ -175,7 +293,17 @@
     backdrop-filter: blur(6px);
   }
 
-  .mel-event-meta-bar,
+  .mel-event__card,
+  .mel-card--sticky,
+  .mel-event-layout__main .mel-card,
+  .mel-card--surface {
+    background: var(--mel-event-surface-raised);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+    color: var(--mel-event-text);
+    backdrop-filter: blur(6px);
+  }
+
   .mel-event-layout__main,
   .mel-event-layout__sidebar,
   .mel-event-info__body,
@@ -206,13 +334,19 @@
   }
 
   .mel-event-info__title,
-  .mel-event-section__title {
+  .mel-event-section__title,
+  .mel-card__title {
     color: var(--mel-event-text);
   }
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
     background: var(--mel-event-accent, colors.$mel-color-primary);
+  }
+
+  .mel-event-section--extras {
+    background: color.mix(colors.$mel-color-navy, colors.$mel-color-primary, 92%);
+    border-color: rgba(255, 255, 255, 0.12);
   }
 
   .mel-btn--primary,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -1,5 +1,6 @@
 // ==========================================================================
-// Event page style themes — Classic (default) + Immersive (Pro-capable)
+// Event page style themes — Mockup 1 Classic (default) + Mockup 3 Immersive (Pro-capable).
+// Mockup 2 Clean & Modern deferred.
 // Scoped to public full event pages via modifier classes on <article>.
 // ==========================================================================
 

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -149,6 +149,7 @@
 @use 'components/live-operations';
 @use 'components/event-page';
 @use 'components/event-full' as event_full_component;
+@use 'components/event-page-themes';
 @use 'components/mel-calendar';
 @use 'components/event-node';
 @use 'components/event' as event-component;

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -67,7 +67,7 @@
   and mel_show_booking_cta
   and (mel_cta_text|striptags|trim|length > 0) %}
 
-<article{{ attributes.addClass('mel-event', 'mel-event--v2') }}>
+<article{{ attributes.addClass('mel-event', 'mel-event--v2', event_page_classes|default([])) }}>
   <div class="mel-container">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
     <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -67,7 +67,7 @@
   and mel_show_booking_cta
   and (mel_cta_text|striptags|trim|length > 0) %}
 
-<article{{ attributes.addClass('mel-event', 'mel-event--v2', event_page_classes|default([])) }}>
+<article{{ attributes.addClass('mel-event', 'mel-event--v2') }}>
   <div class="mel-container">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
     <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes public event page rendering and Event Studio save/validation paths by introducing new style/colour fields and Pro-gated capability checks; mistakes could affect how events render publicly or allow unintended styling for non-Pro vendors.
> 
> **Overview**
> Adds two new translatable `event` fields (`field_mel_page_style`, `field_mel_theme_colour`) with curated allowed values/defaults, and documents the intended behavior and gating.
> 
> Introduces `EventStyleAccessManager` (Pro feature key `event_immersive_style`) and `EventPageStyleResolver` to sanitize/resolve stored values for **public render** based on the *event owner* capability and for **persistence** on save; Event Studio branding now renders radios for style/colour, disables Pro-only options for non-Pro users, and validates tampered submissions.
> 
> Updates the theme to apply resolved modifier classes (`mel-event-page--{classic|immersive}` + `mel-event-page--colour-*`) and adds substantial SCSS for Classic/Immersive visual treatments; also refines booking-page extras placement plumbing/styling (resolver API tweaks, controller/twig vars, CSS adjustments) and adds unit tests plus a Pro feature list entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fdc708f42822c6c4ff6a6bcbd064a94dfa67ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->