### PR TITLE
Feature/event page style themes

### DIFF
--- a/docs/event-hero-focal-and-gallery.md
+++ b/docs/event-hero-focal-and-gallery.md
@@ -1,0 +1,32 @@
+# Event hero focal point and future gallery
+
+## Current hero stack (do not replace)
+
+| Layer | Role |
+|-------|------|
+| `field_event_image` | Single cover file + alt on the event node |
+| **Event Studio branding** | `image_widget_crop` + crop type `event_hero` (1200×630) — vendor sets a fixed crop in Studio |
+| **Public event + book hero** | Image style `mel_event_hero_featured` (1600×900) via `focal_point_scale_and_crop` on crop type `focal_point` |
+| **Focal point storage** | `focal_point` module persists focus on the file crop entity; branding save copies `focal_point` from the mel widget into the field item |
+
+Focal shortcuts in Branding (`mel-branding-hero-tools.js`) set the `focal_point` form value. They do **not** move the `event_hero` crop box — that remains the Crop API widget. Public framing follows **focal_point**, not the event_hero crop rectangle.
+
+## Branding UX (this slice)
+
+- `BrandingHeroFocalAugmenter` injects `focal_point` + indicator into the crop widget delta so focal_point JS and shortcuts work together.
+- Active shortcut state, `aria-pressed`, status copy, and 16:9 framing preview reflect the same focal values used on the public page.
+
+## Future gallery (recommendation only — not built here)
+
+**Keep** `field_event_image` as the single required hero (cardinality 1).
+
+**Add later** a separate optional field, e.g. `field_mel_event_gallery` — multi-value `image` or `entity_reference` to `media` — for venue, artists, sponsors, immersive carousels. Do not overload the hero field.
+
+Benefits:
+
+- No migration of existing hero data
+- Clear product semantics (cover vs gallery)
+- Event full / immersive templates can render hero + gallery independently
+- Crop/focal rules stay on hero; gallery can use lighter card crops
+
+Avoid a parallel hero system or custom image entity.

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -17,7 +17,7 @@
 #}
 {% set extras_in_sidebar = addons_available and (extras_sidebar_selection|default(false) or extras_book_placement|default('main_before_access') == 'sidebar') %}
 {% set extras_in_main = addons_available and (extras_inline_before_access_code|default(false) or not extras_in_sidebar) %}
-<article class="mel-booking-v2 mel-booking mel-event-book mel-event--v2" data-event-mode="{{ event_mode }}">
+<article class="mel-booking-v2 mel-booking mel-event-book mel-event--v2{% if event_page_classes is defined and event_page_classes %} {{ event_page_classes|join(' ') }}{% else %} mel-event-page--classic mel-event-page--colour-coral{% endif %}" data-event-mode="{{ event_mode }}">
   <div class="mel-container mel-container--event">
     <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-booking-event-title">
       <div class="mel-event-hero__media">

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1234,77 +1234,252 @@ textarea.mel-input--body {
   margin-top: 1.5rem;
 }
 
+.mel-event-studio .mel-page-style-radios.mel-option-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .mel-event-studio .mel-page-style-radios.mel-option-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-event-studio .mel-page-style-card.mel-option-card {
+  min-width: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.mel-event-studio .mel-page-style-card .form-radio {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  pointer-events: none;
+}
+
+.mel-event-studio .mel-page-style-card .mel-option-card__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+  min-height: 11.5rem;
+  padding: 0.85rem 1rem 1rem;
+  padding-top: 5.75rem;
+  border-inline-start: none;
+  box-sizing: border-box;
+}
+
+.mel-event-studio .mel-page-style-card .mel-option-card__content::before {
+  content: '';
+  position: absolute;
+  top: 0.85rem;
+  left: 1rem;
+  right: 1rem;
+  height: 4.25rem;
+  border-radius: 10px;
+  border: 1px solid rgba(36, 48, 58, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.mel-event-studio .mel-page-style-card--classic .mel-option-card__content::before {
+  background:
+    linear-gradient(180deg, rgba(31, 41, 51, 0.15) 0%, rgba(31, 41, 51, 0.55) 100%),
+    linear-gradient(135deg, #ffd4c8 0%, #f26d5b 55%, #fff8f4 100%);
+}
+
+.mel-event-studio .mel-page-style-card--immersive .mel-option-card__content::before {
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(13, 17, 23, 0.92) 100%),
+    linear-gradient(145deg, #1a2330 0%, #0d1117 48%, #7c83fd 100%);
+}
+
+.mel-event-studio .mel-page-style-card .mel-option-card__badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  line-height: 1.2;
+}
+
+.mel-event-studio .mel-page-style-card--classic .mel-option-card__badge {
+  background: rgba(242, 109, 91, 0.14);
+  color: #c94f3f;
+}
+
+.mel-event-studio .mel-page-style-card--immersive .mel-option-card__badge {
+  background: rgba(124, 131, 253, 0.18);
+  color: #5b63e8;
+}
+
+.mel-event-studio .mel-page-style-card input:checked + .mel-option-card__content {
+  border: 2px solid #5b63e8;
+  border-radius: 12px;
+  box-shadow: 0 0 0 3px rgba(91, 99, 232, 0.14);
+}
+
+.mel-event-studio .mel-page-style-card input:focus-visible + .mel-option-card__content {
+  outline: 2px solid #5b63e8;
+  outline-offset: 2px;
+}
+
 .mel-event-studio .mel-option-card--locked {
-  opacity: 0.72;
+  opacity: 0.82;
 }
 
 .mel-event-studio .mel-option-card--locked .mel-option-card__label::after {
-  content: ' · Pro';
-  font-weight: 600;
-  color: #7c83fd;
+  content: none;
+}
+
+.mel-event-studio .mel-option-card--locked .mel-option-card__content::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.42);
+  pointer-events: none;
 }
 
 .mel-event-studio .mel-page-style-upgrade {
-  margin: 0.5rem 0 0;
+  margin: 0.65rem 0 0;
+  font-size: 0.875rem;
 }
 
 .mel-event-studio .mel-page-style-colour-block {
-  margin-top: 1.25rem;
+  margin-top: 1.35rem;
 }
 
 .mel-event-studio .mel-page-style-colour-block__title {
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.35rem;
   font-size: 1rem;
+}
+
+.mel-event-studio .mel-page-style-colour-block__hint {
+  margin: 0 0 0.85rem;
 }
 
 .mel-event-studio .mel-page-style-colours.mel-option-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .mel-event-studio .mel-page-style-colours.mel-option-cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .mel-event-studio .mel-page-style-colours.mel-option-cards {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.mel-event-studio .mel-page-style-colour-card.mel-option-card {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .mel-event-studio .mel-page-style-colour-card .form-radio {
   position: absolute;
   opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
   pointer-events: none;
 }
 
 .mel-event-studio .mel-page-style-colour-card .mel-option-card__content {
-  padding-top: 2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+  width: 100%;
+  min-height: 7.25rem;
+  padding: 0.65rem 0.65rem 0.75rem;
+  padding-top: 3.35rem;
+  border-inline-start: none;
+  text-align: left;
 }
 
 .mel-event-studio .mel-page-style-colour-card .mel-option-card__content::before {
   content: '';
   position: absolute;
-  top: 0.85rem;
-  left: 1rem;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 999px;
-  border: 2px solid rgba(36, 48, 58, 0.12);
+  top: 0.65rem;
+  left: 0.65rem;
+  right: 0.65rem;
+  height: 2.35rem;
+  border-radius: 10px;
+  border: 1px solid rgba(36, 48, 58, 0.12);
+  box-shadow: 0 6px 16px rgba(41, 50, 65, 0.12);
 }
 
 .mel-event-studio .mel-page-style-colour-card--coral .mel-option-card__content::before {
-  background: #f26d5b;
+  background: linear-gradient(135deg, #fff1ec 0%, #f26d5b 52%, #ffd4c8 100%);
 }
 
 .mel-event-studio .mel-page-style-colour-card--purple .mel-option-card__content::before {
-  background: #7c83fd;
+  background: linear-gradient(135deg, #f3f0ff 0%, #7c83fd 55%, #c4b5fd 100%);
 }
 
 .mel-event-studio .mel-page-style-colour-card--mint .mel-option-card__content::before {
-  background: #5eead4;
+  background: linear-gradient(135deg, #ecfeff 0%, #2dd4bf 50%, #5eead4 100%);
 }
 
 .mel-event-studio .mel-page-style-colour-card--gold .mel-option-card__content::before {
-  background: #f5a04c;
+  background: linear-gradient(135deg, #fff7ed 0%, #f5a04c 52%, #fde68a 100%);
 }
 
 .mel-event-studio .mel-page-style-colour-card--blue .mel-option-card__content::before {
-  background: #3b82f6;
+  background: linear-gradient(135deg, #eff6ff 0%, #3b82f6 55%, #93c5fd 100%);
+}
+
+.mel-event-studio .mel-page-style-colour-card input:checked + .mel-option-card__content {
+  border: 2px solid #5b63e8;
+  border-radius: 12px;
+  box-shadow:
+    0 0 0 3px rgba(91, 99, 232, 0.14),
+    0 10px 22px rgba(41, 50, 65, 0.1);
+}
+
+.mel-event-studio .mel-page-style-colour-card input:checked + .mel-option-card__content::before {
+  box-shadow:
+    0 8px 20px rgba(41, 50, 65, 0.16),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.45);
+}
+
+.mel-event-studio .mel-page-style-colour-card .mel-option-card__label strong {
+  font-size: 0.8125rem;
 }
 
 .mel-event-studio .mel-page-style-colour-card.form-item--error {
   border-color: #ef4444;
+}
+
+@media (max-width: 767px) {
+  .mel-es-branding-hero-focal-presets__buttons .button {
+    min-height: 44px;
+    padding-inline: 0.85rem;
+  }
+
+  .mel-event-studio .mel-page-style-card .mel-option-card__content,
+  .mel-event-studio .mel-page-style-colour-card .mel-option-card__content {
+    min-height: auto;
+  }
 }
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1176,12 +1176,57 @@ textarea.mel-input--body {
   }
 }
 
-/* Branding hero: size hint, focal presets, remove (EventBrandingForm). */
+/* Branding hero: focal, framing preview, remove (EventBrandingForm). */
 .mel-es-branding-hero-tools {
-  margin-top: 0.75rem;
+  margin-top: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(36, 48, 58, 0.1);
+  background: linear-gradient(180deg, rgba(255, 248, 244, 0.65) 0%, rgba(255, 255, 255, 0.92) 100%);
+}
+
+.mel-es-branding-hero-framing {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.mel-es-branding-hero-framing__title {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--mel-studio-text);
+}
+
+.mel-es-branding-hero-framing__frame {
+  position: relative;
+  width: 100%;
+  max-width: 28rem;
+  aspect-ratio: 16 / 9;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(36, 48, 58, 0.14);
+  box-shadow: 0 10px 28px rgba(41, 50, 65, 0.12);
+  background: #1a2330;
+}
+
+.mel-es-branding-hero-framing__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 50% 50%;
+}
+
+.mel-es-branding-hero-framing__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
 }
 
 .mel-es-branding-hero-size-hint {
@@ -1193,9 +1238,8 @@ textarea.mel-input--body {
 
 .mel-es-branding-hero-focal-presets {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .mel-es-branding-hero-focal-presets__label {
@@ -1207,21 +1251,51 @@ textarea.mel-input--body {
 .mel-es-branding-hero-focal-presets__buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: 0.4rem;
+}
+
+.mel-es-branding-focal-preset.is-active,
+.mel-es-branding-focal-preset[aria-pressed="true"] {
+  border-color: #5b63e8;
+  background: rgba(91, 99, 232, 0.12);
+  color: #3d45c4;
+  box-shadow: 0 0 0 2px rgba(91, 99, 232, 0.2);
+}
+
+.mel-es-branding-focal-preset:focus-visible {
+  outline: 2px solid #5b63e8;
+  outline-offset: 2px;
+}
+
+.mel-es-branding-hero-focal-status {
+  margin: 0;
+  min-height: 1.25rem;
+  font-size: 0.8125rem;
+  color: var(--mel-studio-muted);
+  line-height: 1.4;
 }
 
 .mel-es-field-group--branding .js-mel-branding-hero-remove:not(:disabled) {
   align-self: flex-start;
 }
 
-/* Branding: image_focal_point — click preview to set focal point. */
-.mel-event-studio .mel-es-field-group--branding .focal-point-indicator,
-.mel-event-studio .mel-es-field-group--branding .image-widget .preview,
+/* Branding: focal_point augment on image_widget_crop — click preview to set focus. */
 .mel-event-studio .mel-es-field-group--branding .focal-point-wrapper {
   pointer-events: auto;
 }
 
-.mel-event-studio .mel-es-field-group--branding .image-widget .preview {
+.mel-event-studio .mel-es-field-group--branding .focal-point-wrapper .focal-point {
+  max-width: 8rem;
+}
+
+.mel-event-studio .mel-es-field-group--branding .focal-point-indicator,
+.mel-event-studio .mel-es-field-group--branding .image-widget .preview img,
+.mel-event-studio .mel-es-field-group--branding .focal-point-wrapper + img {
+  pointer-events: auto;
+}
+
+.mel-event-studio .mel-es-field-group--branding .image-widget .preview,
+.mel-event-studio .mel-es-field-group--branding .focal-point-wrapper {
   cursor: crosshair;
 }
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1288,14 +1288,47 @@ textarea.mel-input--body {
 
 .mel-event-studio .mel-page-style-card--classic .mel-option-card__content::before {
   background:
-    linear-gradient(180deg, rgba(31, 41, 51, 0.15) 0%, rgba(31, 41, 51, 0.55) 100%),
-    linear-gradient(135deg, #ffd4c8 0%, #f26d5b 55%, #fff8f4 100%);
+    linear-gradient(180deg, rgba(31, 41, 51, 0.12) 0%, rgba(31, 41, 51, 0.45) 100%),
+    linear-gradient(135deg, #ffe8e0 0%, #f26d5b 48%, #fff8f4 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+/* Mini layout mock: content card + coral CTA (Classic). */
+.mel-event-studio .mel-page-style-card--classic .mel-option-card__content::after {
+  content: '';
+  position: absolute;
+  top: 2.35rem;
+  left: 1.35rem;
+  width: 42%;
+  height: 2rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 2px 6px rgba(41, 50, 65, 0.12);
+  pointer-events: none;
 }
 
 .mel-event-studio .mel-page-style-card--immersive .mel-option-card__content::before {
   background:
-    linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(13, 17, 23, 0.92) 100%),
-    linear-gradient(145deg, #1a2330 0%, #0d1117 48%, #7c83fd 100%);
+    linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(13, 17, 23, 0.88) 100%),
+    linear-gradient(145deg, #1a2330 0%, #0d1117 42%, #5b63e8 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 24px rgba(91, 99, 232, 0.25);
+}
+
+/* Mini layout mock: sidebar + accent glow (Immersive). */
+.mel-event-studio .mel-page-style-card--immersive .mel-option-card__content::after {
+  content: '';
+  position: absolute;
+  top: 2.4rem;
+  right: 1.2rem;
+  width: 28%;
+  height: 2.35rem;
+  border-radius: 6px;
+  background: rgba(35, 45, 61, 0.95);
+  border: 1px solid rgba(124, 131, 253, 0.45);
+  box-shadow: 0 0 14px rgba(124, 131, 253, 0.35);
+  pointer-events: none;
 }
 
 .mel-event-studio .mel-page-style-card .mel-option-card__badge {
@@ -1320,8 +1353,9 @@ textarea.mel-input--body {
 }
 
 .mel-event-studio .mel-page-style-card--immersive .mel-option-card__badge {
-  background: rgba(124, 131, 253, 0.18);
-  color: #5b63e8;
+  background: linear-gradient(135deg, rgba(124, 131, 253, 0.28) 0%, rgba(91, 99, 232, 0.18) 100%);
+  color: #e8eaff;
+  box-shadow: 0 0 12px rgba(124, 131, 253, 0.35);
 }
 
 .mel-event-studio .mel-page-style-card input:checked + .mel-option-card__content {
@@ -1430,37 +1464,44 @@ textarea.mel-input--body {
 }
 
 .mel-event-studio .mel-page-style-colour-card--coral .mel-option-card__content::before {
-  background: linear-gradient(135deg, #fff1ec 0%, #f26d5b 52%, #ffd4c8 100%);
+  background: linear-gradient(135deg, #fff5f0 0%, #f26d5b 45%, #ff8a75 85%, #ffd4c8 100%);
+  box-shadow: 0 6px 18px rgba(242, 109, 91, 0.35);
 }
 
 .mel-event-studio .mel-page-style-colour-card--purple .mel-option-card__content::before {
-  background: linear-gradient(135deg, #f3f0ff 0%, #7c83fd 55%, #c4b5fd 100%);
+  background: linear-gradient(135deg, #f0edff 0%, #7c83fd 48%, #a78bfa 100%);
+  box-shadow: 0 6px 18px rgba(124, 131, 253, 0.35);
 }
 
 .mel-event-studio .mel-page-style-colour-card--mint .mel-option-card__content::before {
-  background: linear-gradient(135deg, #ecfeff 0%, #2dd4bf 50%, #5eead4 100%);
+  background: linear-gradient(135deg, #e6fffa 0%, #14b8a6 50%, #5eead4 100%);
+  box-shadow: 0 6px 18px rgba(20, 184, 166, 0.32);
 }
 
 .mel-event-studio .mel-page-style-colour-card--gold .mel-option-card__content::before {
-  background: linear-gradient(135deg, #fff7ed 0%, #f5a04c 52%, #fde68a 100%);
+  background: linear-gradient(135deg, #fff8eb 0%, #f5a04c 50%, #fcd34d 100%);
+  box-shadow: 0 6px 18px rgba(245, 160, 76, 0.34);
 }
 
 .mel-event-studio .mel-page-style-colour-card--blue .mel-option-card__content::before {
-  background: linear-gradient(135deg, #eff6ff 0%, #3b82f6 55%, #93c5fd 100%);
+  background: linear-gradient(135deg, #eff6ff 0%, #3b82f6 50%, #60a5fa 100%);
+  box-shadow: 0 6px 18px rgba(59, 130, 246, 0.32);
 }
 
 .mel-event-studio .mel-page-style-colour-card input:checked + .mel-option-card__content {
   border: 2px solid #5b63e8;
   border-radius: 12px;
   box-shadow:
-    0 0 0 3px rgba(91, 99, 232, 0.14),
+    0 0 0 3px rgba(91, 99, 232, 0.18),
+    0 0 20px rgba(91, 99, 232, 0.12),
     0 10px 22px rgba(41, 50, 65, 0.1);
 }
 
 .mel-event-studio .mel-page-style-colour-card input:checked + .mel-option-card__content::before {
   box-shadow:
-    0 8px 20px rgba(41, 50, 65, 0.16),
-    inset 0 0 0 2px rgba(255, 255, 255, 0.45);
+    0 8px 22px rgba(41, 50, 65, 0.2),
+    0 0 16px rgba(91, 99, 232, 0.2),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.5);
 }
 
 .mel-event-studio .mel-page-style-colour-card .mel-option-card__label strong {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
@@ -1,9 +1,17 @@
 /**
  * @file
- * Branding hero: focal presets and remove cover (delegates to core Remove).
+ * Branding hero: focal presets, public framing preview, remove cover.
  */
 
 (function ($, Drupal, once) {
+  const PRESETS = [
+    { value: "50,50" },
+    { value: "50,18" },
+    { value: "50,82" },
+    { value: "18,50" },
+    { value: "82,50" },
+  ];
+
   /**
    * @param {HTMLElement} root
    * @returns {HTMLInputElement|null}
@@ -23,20 +31,175 @@
   }
 
   /**
+   * @param {string} value
+   * @returns {{ x: number, y: number }}
+   */
+  function parseFocal(value) {
+    const parts = String(value || "50,50").split(",");
+    const x = parseInt(parts[0], 10);
+    const y = parseInt(parts[1], 10);
+    return {
+      x: Number.isFinite(x) ? x : 50,
+      y: Number.isFinite(y) ? y : 50,
+    };
+  }
+
+  /**
+   * @param {string} a
+   * @param {string} b
+   * @returns {boolean}
+   */
+  function focalMatches(a, b) {
+    const left = parseFocal(a);
+    const right = parseFocal(b);
+    return left.x === right.x && left.y === right.y;
+  }
+
+  /**
+   * @param {string} value
+   * @returns {string|null}
+   */
+  function matchingPresetValue(value) {
+    for (let i = 0; i < PRESETS.length; i += 1) {
+      if (focalMatches(PRESETS[i].value, value)) {
+        return PRESETS[i].value;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {HTMLInputElement|null} field
+   */
+  function syncPresetButtons(root, field) {
+    const value = field ? String(field.value || "").trim() : "";
+    const match = matchingPresetValue(value);
+    root.querySelectorAll(".mel-es-branding-focal-preset").forEach((btn) => {
+      const preset = btn.getAttribute("data-focal-preset") || "";
+      const active = match !== null && preset === match;
+      btn.classList.toggle("is-active", active);
+      btn.setAttribute("aria-pressed", active ? "true" : "false");
+    });
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {string} message
+   */
+  function setFocalStatus(root, message) {
+    const status = root.querySelector("#mel-es-branding-focal-status");
+    if (status) {
+      status.textContent = message;
+    }
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {HTMLImageElement|null}
+   */
+  function findWidgetPreviewImage(root) {
+    const thumb = root.querySelector(
+      ".image-widget .preview img, .image-widget .preview .thumbnail img, .focal-point-wrapper + img, .image-widget img",
+    );
+    return thumb instanceof HTMLImageElement ? thumb : null;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {string} focalValue
+   */
+  function syncFramingPreview(root, focalValue) {
+    const frame = root.querySelector(".js-mel-branding-hero-framing-frame");
+    if (!frame) {
+      return;
+    }
+    const source = findWidgetPreviewImage(root);
+    const { x, y } = parseFocal(focalValue);
+    let img = frame.querySelector("img.mel-es-branding-hero-framing__img");
+    if (!source || !source.getAttribute("src")) {
+      frame.hidden = true;
+      if (img) {
+        img.removeAttribute("src");
+      }
+      return;
+    }
+    frame.hidden = false;
+    if (!img) {
+      img = document.createElement("img");
+      img.className = "mel-es-branding-hero-framing__img";
+      img.alt = "";
+      img.decoding = "async";
+      img.loading = "lazy";
+      frame.appendChild(img);
+    }
+    if (img.getAttribute("src") !== source.src) {
+      img.src = source.src;
+    }
+    img.style.objectPosition = `${x}% ${y}%`;
+  }
+
+  /**
    * @param {HTMLElement} root
    */
   function syncHeroToolStrip(root) {
     const focal = findFocalField(root);
     const presets = root.querySelector(".mel-es-branding-hero-focal-presets");
+    const framing = root.querySelector(".mel-es-branding-hero-framing");
+    const hasImage = !!findWidgetPreviewImage(root);
+
     if (presets) {
       presets.hidden = !focal;
     }
+    if (framing) {
+      framing.hidden = !hasImage;
+    }
+
+    if (focal) {
+      syncPresetButtons(root, focal);
+      syncFramingPreview(root, focal.value);
+      if (!focal.dataset.melFocalInitial) {
+        focal.dataset.melFocalInitial = focal.value || "50,50";
+        setFocalStatus(
+          root,
+          Drupal.t("Focal point loaded. Save branding to publish changes on your event page."),
+        );
+      }
+    }
+
     const custom = root.querySelector(".js-mel-branding-hero-remove");
     const native = findNativeRemove(root);
     if (custom) {
       const enable = !!native;
       custom.disabled = !enable;
       custom.setAttribute("aria-disabled", enable ? "false" : "true");
+    }
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {HTMLInputElement} field
+   * @param {boolean} fromPreset
+   */
+  function onFocalChanged(root, field, fromPreset) {
+    syncPresetButtons(root, field);
+    syncFramingPreview(root, field.value);
+    const initial = field.dataset.melFocalInitial || "50,50";
+    if (focalMatches(field.value, initial)) {
+      setFocalStatus(
+        root,
+        Drupal.t("Focal point matches your saved cover. Save branding after any change."),
+      );
+    } else if (fromPreset) {
+      setFocalStatus(
+        root,
+        Drupal.t("Shortcut applied — save branding to update your public hero."),
+      );
+    } else {
+      setFocalStatus(
+        root,
+        Drupal.t("Focal point updated — save branding to update your public hero."),
+      );
     }
   }
 
@@ -49,6 +212,16 @@
           syncHeroToolStrip(root);
         });
     });
+    $(document).on("drupalFocalPointSet.melBrandingHeroTools", () => {
+      document
+        .querySelectorAll(".mel-es-field-group--branding")
+        .forEach((root) => {
+          const field = findFocalField(root);
+          if (field) {
+            onFocalChanged(root, field, false);
+          }
+        });
+    });
   }
 
   Drupal.behaviors.melBrandingHeroTools = {
@@ -56,6 +229,13 @@
       once("mel-branding-hero-tools", ".mel-es-field-group--branding", context).forEach(
         (root) => {
           syncHeroToolStrip(root);
+
+          const focal = findFocalField(root);
+          if (focal) {
+            focal.addEventListener("change", () => {
+              onFocalChanged(root, focal, false);
+            });
+          }
 
           root.addEventListener("click", (event) => {
             const presetBtn = event.target.closest(".mel-es-branding-focal-preset");
@@ -71,6 +251,7 @@
               }
               field.value = value;
               $(field).trigger("change");
+              onFocalChanged(root, field, true);
               return;
             }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.16
+  version: 1.17
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.15
+  version: 1.16
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.17
+  version: 1.18
   css:
     theme:
       css/mel-event-studio.css: {}
@@ -61,7 +61,7 @@ mel_customer_operational_experience:
     - core/drupal
 
 mel_branding_hero_tools:
-  version: 1.0
+  version: 1.1
   js:
     js/mel-branding-hero-tools.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -206,6 +206,10 @@ function myeventlane_event_studio_preprocess_form_element__mel_option_card(array
   if (isset($variables['label']) && is_array($variables['label'])) {
     $variables['label']['#mel_option_card_label'] = TRUE;
   }
+  $element = $variables['element'] ?? [];
+  if (is_array($element) && !empty($element['#mel_option_badge'])) {
+    $variables['mel_option_badge'] = $element['#mel_option_badge'];
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -286,6 +286,7 @@ services:
       - '@focal_point.manager'
       - '@config.factory'
       - '@image.factory'
+      - '@entity_type.manager'
       - '@string_translation'
 
   myeventlane_event_studio.event_style_access:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -280,6 +280,14 @@ services:
       - '@entity_type.manager'
       - '@string_translation'
 
+  myeventlane_event_studio.branding_hero_focal_augmenter:
+    class: Drupal\myeventlane_event_studio\Service\BrandingHeroFocalAugmenter
+    arguments:
+      - '@focal_point.manager'
+      - '@config.factory'
+      - '@image.factory'
+      - '@string_translation'
+
   myeventlane_event_studio.event_style_access:
     class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager
     arguments:

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioMelOptionCards.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioMelOptionCards.php
@@ -29,6 +29,8 @@ final class EventStudioMelOptionCards {
 
     /** @var array<string, mixed> $descriptions */
     $descriptions = $element['#mel_option_descriptions'] ?? [];
+    /** @var array<string, mixed> $badges */
+    $badges = $element['#mel_option_badges'] ?? [];
 
     foreach (Element::children($element) as $key) {
       if (($element[$key]['#type'] ?? '') !== 'radio') {
@@ -43,6 +45,10 @@ final class EventStudioMelOptionCards {
       if (array_key_exists($key, $descriptions) && $descriptions[$key] !== NULL && $descriptions[$key] !== '') {
         $element[$key]['#description'] = $descriptions[$key];
         $element[$key]['#description_display'] = 'after';
+      }
+
+      if (array_key_exists($key, $badges) && $badges[$key] !== NULL && $badges[$key] !== '') {
+        $element[$key]['#mel_option_badge'] = $badges[$key];
       }
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -226,13 +226,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
     $form['mel']['branding_hero_tools'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-es-branding-hero-tools']],
-      '#weight' => 2,
-      'size_hint' => [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#attributes' => ['class' => ['mel-es-branding-hero-size-hint']],
-        '#value' => Html::escape((string) $this->t('For the clearest hero on event and book pages, use at least 1600×900 pixels (16:9). We warn after save if the file is under 1280×720; very small images may look soft when scaled up. Minimum upload size enforced by the field is 400×200.')),
-      ],
+      '#weight' => 10,
       'presets' => [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-es-branding-hero-focal-presets']],
@@ -252,6 +246,13 @@ final class EventBrandingForm extends EventStudioBaseForm {
           'r' => $this->buildFocalPresetButton($this->t('Right'), '82,50'),
         ],
       ],
+      'size_hint' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => ['class' => ['mel-es-branding-hero-size-hint']],
+        '#value' => Html::escape((string) $this->t('For the clearest hero on event and book pages, use at least 1600×900 pixels (16:9). We warn after save if the file is under 1280×720; very small images may look soft when scaled up. Minimum upload size enforced by the field is 400×200.')),
+        '#weight' => 5,
+      ],
       'remove' => [
         '#type' => 'button',
         '#value' => $this->t('Remove cover image'),
@@ -268,7 +269,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
     $form['mel']['branding_hero_close'] = [
       '#type' => 'markup',
       '#markup' => Markup::create('</div></div></div></section>'),
-      '#weight' => 5,
+      '#weight' => 12,
     ];
 
     $this->buildPageStyleFields($form, $node, $melDefaults);
@@ -313,23 +314,36 @@ final class EventBrandingForm extends EventStudioBaseForm {
     ];
 
     $style_options = [
-      EventPageStyleResolver::STYLE_CLASSIC => $this->t('Classic MyEventLane page'),
-      EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Immersive page'),
+      EventPageStyleResolver::STYLE_CLASSIC => $this->t('Classic MyEventLane'),
+      EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Immersive'),
     ];
 
     $form['mel']['field_mel_page_style'] = [
       '#type' => 'radios',
       '#title' => $this->t('Page style'),
+      '#weight' => 20,
       '#mel_option_cards' => TRUE,
-      '#mel_option_cards_tickets_layout' => TRUE,
       '#mel_option_descriptions' => [
-        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Warm, clear and conversion-focused. Included for every event.'),
-        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Bold visual page style for Pro organisers.'),
+        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Warm, clear and conversion-focused. Included with every event.'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Bold cinematic layout for Pro organisers.'),
+      ],
+      '#mel_option_badges' => [
+        EventPageStyleResolver::STYLE_CLASSIC => $this->t('Included'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Pro'),
       ],
       '#options' => $style_options,
       '#default_value' => $style_default,
       '#attributes' => ['class' => ['mel-page-style-radios']],
     ];
+
+    foreach (array_keys($style_options) as $style_key) {
+      $form['mel']['field_mel_page_style'][$style_key]['#wrapper_attributes'] = [
+        'class' => [
+          'mel-page-style-card',
+          'mel-page-style-card--' . $style_key,
+        ],
+      ];
+    }
 
     if (!$can_customize) {
       $form['mel']['field_mel_page_style'][EventPageStyleResolver::STYLE_IMMERSIVE]['#disabled'] = TRUE;
@@ -358,6 +372,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#type' => 'radios',
       '#title' => $this->t('Colour mood'),
       '#title_display' => 'invisible',
+      '#weight' => 22,
       '#mel_option_cards' => TRUE,
       '#options' => $colour_options,
       '#default_value' => $colour_default,

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -325,11 +325,11 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#mel_option_cards' => TRUE,
       '#mel_option_descriptions' => [
         EventPageStyleResolver::STYLE_CLASSIC => $this->t('Warm, clear and conversion-focused. Included with every event.'),
-        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Bold cinematic layout for Pro organisers.'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Premium cinematic layout with rich colour palettes. Built for Pro organisers.'),
       ],
       '#mel_option_badges' => [
         EventPageStyleResolver::STYLE_CLASSIC => $this->t('Included'),
-        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Pro'),
+        EventPageStyleResolver::STYLE_IMMERSIVE => $this->t('Pro Experience'),
       ],
       '#options' => $style_options,
       '#default_value' => $style_default,

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -8,6 +8,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\myeventlane_event_studio\Service\BrandingHeroFocalAugmenter;
 use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
@@ -23,14 +24,45 @@ final class EventBrandingForm extends EventStudioBaseForm {
 
   private EventPageStyleResolver $eventPageStyleResolver;
 
+  private BrandingHeroFocalAugmenter $brandingHeroFocalAugmenter;
+
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
     $instance = parent::create($container);
-    $instance->eventStyleAccess = $container->get('myeventlane_event_studio.event_style_access');
-    $instance->eventPageStyleResolver = $container->get('myeventlane_event_studio.event_page_style_resolver');
+    $instance->ensureInjectedServices($container);
     return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __wakeup(): void {
+    parent::__wakeup();
+    $this->ensureInjectedServices();
+  }
+
+  /**
+   * Ensures services are present after form cache unserialization.
+   *
+   * Cached form state restores the form object in build_info. Properties assigned
+   * after parent::create() are not re-initialized unless restored here.
+   */
+  private function ensureInjectedServices(?ContainerInterface $container = NULL): void {
+    if (isset($this->eventStyleAccess, $this->eventPageStyleResolver, $this->brandingHeroFocalAugmenter)) {
+      return;
+    }
+    $container ??= \Drupal::getContainer();
+    if (!isset($this->eventStyleAccess)) {
+      $this->eventStyleAccess = $container->get('myeventlane_event_studio.event_style_access');
+    }
+    if (!isset($this->eventPageStyleResolver)) {
+      $this->eventPageStyleResolver = $container->get('myeventlane_event_studio.event_page_style_resolver');
+    }
+    if (!isset($this->brandingHeroFocalAugmenter)) {
+      $this->brandingHeroFocalAugmenter = $container->get('myeventlane_event_studio.branding_hero_focal_augmenter');
+    }
   }
 
   public function getFormId(): string {
@@ -86,6 +118,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $this->ensureInjectedServices();
     parent::validateForm($form, $form_state);
 
     $nid = (int) ($form_state->getValue('nid') ?? 0);
@@ -153,15 +186,22 @@ final class EventBrandingForm extends EventStudioBaseForm {
       $target->set('field_event_image', []);
       return;
     }
-    $target->set('field_event_image', [
-      [
-        'target_id' => $hero['fid'],
-        'alt' => $hero['alt'],
-      ],
-    ]);
+    $row = [
+      'target_id' => $hero['fid'],
+      'alt' => $hero['alt'],
+    ];
+    $raw = $melDefaults['field_event_image'] ?? [];
+    if (is_array($raw)) {
+      $delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($raw);
+      if (isset($delta['focal_point']) && trim((string) $delta['focal_point']) !== '') {
+        $row['focal_point'] = trim((string) $delta['focal_point']);
+      }
+    }
+    $target->set('field_event_image', [$row]);
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $this->ensureInjectedServices();
     $request = $this->requestStack->getCurrentRequest();
     $restoreDraft = $request !== NULL && $request->query->getBoolean('restore_draft');
 
@@ -183,7 +223,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
         . '<header class="mel-es-field-group__header">'
         . '<h3 class="mel-es-field-group__title" id="mel-es-branding-title">' . Html::escape((string) $this->t('Branding')) . '</h3>'
         . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Shape how your event appears across MyEventLane and social sharing.')) . '</p>'
-        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('Click the image preview to set the focal point, or use the shortcuts below. Alt text in the image field is required when a cover image is present.')) . '</p>'
+        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('Set where the hero should focus for your public event and book pages. Click the image or use the shortcuts, then save branding. Alt text is required when a cover image is present.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body">'
         . '<div class="mel-identity-media mel-identity-media--compact">'
@@ -220,6 +260,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
       else {
         $form['mel']['field_event_image'] = $widget->form($formNode->get('field_event_image'), $form['mel'], $form_state);
         $form['mel']['field_event_image']['#weight'] = 0;
+        $this->brandingHeroFocalAugmenter->attachAfterBuild($form['mel']['field_event_image'], $formNode);
       }
     }
 
@@ -227,6 +268,27 @@ final class EventBrandingForm extends EventStudioBaseForm {
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-es-branding-hero-tools']],
       '#weight' => 10,
+      'framing' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-es-branding-hero-framing']],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#attributes' => ['class' => ['mel-es-branding-hero-framing__title']],
+          '#value' => Html::escape((string) $this->t('Public hero framing (16:9)')),
+        ],
+        'frame' => [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#attributes' => ['class' => ['mel-es-branding-hero-framing__frame', 'js-mel-branding-hero-framing-frame']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#attributes' => ['class' => ['mel-es-branding-hero-framing__hint', 'mel-text--muted']],
+          '#value' => Html::escape((string) $this->t('Matches how your cover appears on the event and book pages.')),
+        ],
+      ],
       'presets' => [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-es-branding-hero-focal-presets']],
@@ -238,12 +300,26 @@ final class EventBrandingForm extends EventStudioBaseForm {
         ],
         'buttons' => [
           '#type' => 'container',
-          '#attributes' => ['class' => ['mel-es-branding-hero-focal-presets__buttons']],
+          '#attributes' => [
+            'class' => ['mel-es-branding-hero-focal-presets__buttons'],
+            'role' => 'group',
+            'aria-label' => (string) $this->t('Focal shortcuts'),
+          ],
           'c' => $this->buildFocalPresetButton($this->t('Centre'), '50,50'),
           't' => $this->buildFocalPresetButton($this->t('Top'), '50,18'),
           'b' => $this->buildFocalPresetButton($this->t('Bottom'), '50,82'),
           'l' => $this->buildFocalPresetButton($this->t('Left'), '18,50'),
           'r' => $this->buildFocalPresetButton($this->t('Right'), '82,50'),
+        ],
+        'status' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#attributes' => [
+            'class' => ['mel-es-branding-hero-focal-status'],
+            'id' => 'mel-es-branding-focal-status',
+            'aria-live' => 'polite',
+          ],
+          '#value' => '',
         ],
       ],
       'size_hint' => [
@@ -414,6 +490,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
         'type' => 'button',
         'class' => ['button', 'button--small', 'button--secondary', 'mel-es-branding-focal-preset'],
         'data-focal-preset' => $preset,
+        'aria-pressed' => 'false',
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -186,18 +186,12 @@ final class EventBrandingForm extends EventStudioBaseForm {
       $target->set('field_event_image', []);
       return;
     }
-    $row = [
-      'target_id' => $hero['fid'],
-      'alt' => $hero['alt'],
-    ];
-    $raw = $melDefaults['field_event_image'] ?? [];
-    if (is_array($raw)) {
-      $delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($raw);
-      if (isset($delta['focal_point']) && trim((string) $delta['focal_point']) !== '') {
-        $row['focal_point'] = trim((string) $delta['focal_point']);
-      }
-    }
-    $target->set('field_event_image', [$row]);
+    $target->set('field_event_image', [
+      [
+        'target_id' => $hero['fid'],
+        'alt' => $hero['alt'],
+      ],
+    ]);
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
@@ -260,7 +254,14 @@ final class EventBrandingForm extends EventStudioBaseForm {
       else {
         $form['mel']['field_event_image'] = $widget->form($formNode->get('field_event_image'), $form['mel'], $form_state);
         $form['mel']['field_event_image']['#weight'] = 0;
-        $this->brandingHeroFocalAugmenter->attachAfterBuild($form['mel']['field_event_image'], $formNode);
+        $focal_override = NULL;
+        if ($restoreDraft && is_array($melDefaults['field_event_image'] ?? NULL)) {
+          $draft_delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($melDefaults['field_event_image']);
+          if (isset($draft_delta['focal_point']) && trim((string) $draft_delta['focal_point']) !== '') {
+            $focal_override = trim((string) $draft_delta['focal_point']);
+          }
+        }
+        $this->brandingHeroFocalAugmenter->attachAfterBuild($form['mel']['field_event_image'], $formNode, $focal_override);
       }
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Image\ImageFactory;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\crop\Entity\Crop;
 use Drupal\file\FileInterface;
 use Drupal\focal_point\FocalPointManagerInterface;
-use Drupal\focal_point\Plugin\Field\FieldWidget\FocalPointImageWidget;
 use Drupal\node\NodeInterface;
 
 /**
@@ -32,6 +33,7 @@ final class BrandingHeroFocalAugmenter {
     private readonly FocalPointManagerInterface $focalPointManager,
     private readonly ConfigFactoryInterface $configFactory,
     private readonly ImageFactory $imageFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -43,7 +45,10 @@ final class BrandingHeroFocalAugmenter {
    * @param array<string, mixed> $field_element
    *   The field_event_image form element from the entity form display widget.
    */
-  public function attachAfterBuild(array &$field_element, NodeInterface $node): void {
+  public function attachAfterBuild(array &$field_element, NodeInterface $node, ?string $focal_override = NULL): void {
+    if ($focal_override !== NULL && trim($focal_override) !== '') {
+      $field_element['#mel_branding_focal_override'] = trim($focal_override);
+    }
     $field_element['#after_build'][] = function (array $element, $form_state) use ($node): array {
       return $this->afterBuildField($element, $node);
     };
@@ -70,7 +75,10 @@ final class BrandingHeroFocalAugmenter {
       if (!isset($element['widget'][$delta_key]) || !is_array($element['widget'][$delta_key])) {
         continue;
       }
-      $this->augmentWidgetDelta($element['widget'][$delta_key], $node);
+      $override = isset($element['#mel_branding_focal_override'])
+        ? (string) $element['#mel_branding_focal_override']
+        : NULL;
+      $this->augmentWidgetDelta($element['widget'][$delta_key], $node, $override);
     }
 
     return $element;
@@ -81,12 +89,16 @@ final class BrandingHeroFocalAugmenter {
    *
    * @param array<string, mixed> $delta
    */
-  private function augmentWidgetDelta(array &$delta, NodeInterface $node): void {
-    if (isset($delta['focal_point'])) {
+  private function augmentWidgetDelta(array &$delta, NodeInterface $node, ?string $focal_override = NULL): void {
+    if (isset($delta['focal_point']) && is_array($delta['focal_point'])) {
+      // Cached or prior builds may still reference the core focal widget validator.
+      $delta['focal_point']['#element_validate'] = [[$this, 'validateFocalPointElement']];
       return;
     }
 
-    $focal_value = $this->resolveFocalPoint($node, $delta);
+    $focal_value = $focal_override !== NULL && $this->focalPointManager->validateFocalPoint($focal_override)
+      ? $focal_override
+      : $this->resolveFocalPoint($node, $delta);
     $selector = 'focal-point-mel-field-event-image-0';
 
     $delta['focal_point'] = [
@@ -94,7 +106,7 @@ final class BrandingHeroFocalAugmenter {
       '#title' => $this->t('Focal point'),
       '#description' => $this->t('Focus area for the public event and book page hero (16:9). Saved when you save branding.'),
       '#default_value' => $focal_value,
-      '#element_validate' => [[FocalPointImageWidget::class, 'validateFocalPoint']],
+      '#element_validate' => [[$this, 'validateFocalPointElement']],
       '#attributes' => [
         'class' => ['focal-point', $selector],
         'data-selector' => $selector,
@@ -149,27 +161,78 @@ final class BrandingHeroFocalAugmenter {
       }
     }
 
-    if ($node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()) {
-      $item = $node->get('field_event_image')->first();
-      if ($item !== NULL) {
-        $stored = $item->get('focal_point');
-        if ($stored !== NULL && !$stored->isEmpty()) {
-          $candidate = trim((string) $stored->value);
-          if ($this->focalPointManager->validateFocalPoint($candidate)) {
-            return $candidate;
-          }
-        }
-        $file = $item->entity;
-        if ($file instanceof FileInterface) {
-          $from_crop = $this->focalPointFromFileCrop($file);
-          if ($from_crop !== NULL) {
-            return $from_crop;
-          }
-        }
+    $file = $this->resolveHeroFile($node, $delta);
+    if ($file instanceof FileInterface) {
+      $from_crop = $this->focalPointFromFileCrop($file);
+      if ($from_crop !== NULL) {
+        return $from_crop;
       }
     }
 
     return self::DEFAULT_FOCAL;
+  }
+
+  /**
+   * Loads the hero file from the node field or an in-progress widget delta.
+   *
+   * Focal point is stored on the file's focal_point crop entity, not on the image
+   * field item (image fields do not expose a focal_point property).
+   *
+   * @param array<string, mixed> $delta
+   */
+  private function resolveHeroFile(NodeInterface $node, array $delta = []): ?FileInterface {
+    if ($node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()) {
+      $file = $node->get('field_event_image')->entity;
+      if ($file instanceof FileInterface) {
+        return $file;
+      }
+    }
+
+    $fid = 0;
+    if (isset($delta['fids']['#value'])) {
+      $fid = (int) $delta['fids']['#value'];
+    }
+    elseif (isset($delta['fids']) && is_numeric($delta['fids'])) {
+      $fid = (int) $delta['fids'];
+    }
+    elseif (isset($delta['target_id']['#value'])) {
+      $fid = (int) $delta['target_id']['#value'];
+    }
+    elseif (isset($delta['target_id']) && is_numeric($delta['target_id'])) {
+      $fid = (int) $delta['target_id'];
+    }
+
+    if ($fid > 0) {
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      return $file instanceof FileInterface ? $file : NULL;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Validates the augmented focal_point textfield on the branding form.
+   *
+   * Do not use FocalPointImageWidget::validateFocalPoint() here: it assumes a
+   * widget-integrated element tree and breaks when #parents is not an array.
+   * Empty values are allowed; save defaults to 50,50.
+   *
+   * @param array<string, mixed> $element
+   */
+  public function validateFocalPointElement(array &$element, FormStateInterface $form_state): void {
+    $value = trim((string) ($element['#value'] ?? ''));
+    if ($value === '') {
+      return;
+    }
+    if ($this->focalPointManager->validateFocalPoint($value)) {
+      return;
+    }
+    $parents = $element['#parents'] ?? [];
+    $name = is_array($parents) ? implode('][', $parents) : (string) $parents;
+    if ($name === '' && isset($element['#name'])) {
+      $name = (string) $element['#name'];
+    }
+    $form_state->setErrorByName($name, $this->t('Focal point must be percentages like 50,50 (horizontal, vertical).'));
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Image\ImageFactory;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\crop\Entity\Crop;
+use Drupal\file\FileInterface;
+use Drupal\focal_point\FocalPointManagerInterface;
+use Drupal\focal_point\Plugin\Field\FieldWidget\FocalPointImageWidget;
+use Drupal\node\NodeInterface;
+
+/**
+ * Adds focal point controls to the branding image_widget_crop hero field.
+ *
+ * Public event and book heroes use the focal_point crop (see mel_event_hero_featured).
+ * The studio branding form uses image_widget_crop for the fixed event_hero crop; this
+ * augmenter wires the focal_point form element and indicator expected by focal_point
+ * JS and mel-branding-hero-tools.js without replacing the crop widget.
+ */
+final class BrandingHeroFocalAugmenter {
+
+  use StringTranslationTrait;
+
+  public const DEFAULT_FOCAL = '50,50';
+
+  public function __construct(
+    private readonly FocalPointManagerInterface $focalPointManager,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly ImageFactory $imageFactory,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Registers #after_build to inject focal point UI into the hero widget.
+   *
+   * @param array<string, mixed> $field_element
+   *   The field_event_image form element from the entity form display widget.
+   */
+  public function attachAfterBuild(array &$field_element, NodeInterface $node): void {
+    $field_element['#after_build'][] = function (array $element, $form_state) use ($node): array {
+      return $this->afterBuildField($element, $node);
+    };
+  }
+
+  /**
+   * Form API #after_build callback.
+   *
+   * @param array<string, mixed> $element
+   *   The field_event_image element.
+   *
+   * @return array<string, mixed>
+   */
+  public function afterBuildField(array $element, NodeInterface $node): array {
+    if (!isset($element['widget']) || !is_array($element['widget'])) {
+      return $element;
+    }
+
+    foreach (array_keys($element['widget']) as $delta) {
+      if (!is_numeric($delta)) {
+        continue;
+      }
+      $delta_key = (int) $delta;
+      if (!isset($element['widget'][$delta_key]) || !is_array($element['widget'][$delta_key])) {
+        continue;
+      }
+      $this->augmentWidgetDelta($element['widget'][$delta_key], $node);
+    }
+
+    return $element;
+  }
+
+  /**
+   * Injects focal_point field + preview indicator into one widget delta.
+   *
+   * @param array<string, mixed> $delta
+   */
+  private function augmentWidgetDelta(array &$delta, NodeInterface $node): void {
+    if (isset($delta['focal_point'])) {
+      return;
+    }
+
+    $focal_value = $this->resolveFocalPoint($node, $delta);
+    $selector = 'focal-point-mel-field-event-image-0';
+
+    $delta['focal_point'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Focal point'),
+      '#description' => $this->t('Focus area for the public event and book page hero (16:9). Saved when you save branding.'),
+      '#default_value' => $focal_value,
+      '#element_validate' => [[FocalPointImageWidget::class, 'validateFocalPoint']],
+      '#attributes' => [
+        'class' => ['focal-point', $selector],
+        'data-selector' => $selector,
+        'data-field-name' => 'field_event_image',
+        'aria-describedby' => 'mel-es-branding-focal-status',
+      ],
+      '#wrapper_attributes' => [
+        'class' => ['focal-point-wrapper'],
+      ],
+      '#attached' => [
+        'library' => ['focal_point/drupal.focal_point'],
+      ],
+      '#weight' => 20,
+    ];
+
+    if (isset($delta['preview']) && is_array($delta['preview'])) {
+      $preview_weight = $delta['preview']['#weight'] ?? 0;
+      unset($delta['preview']['#weight']);
+      $delta['preview'] = [
+        'indicator' => [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#attributes' => [
+            'class' => ['focal-point-indicator'],
+            'data-selector' => $selector,
+            'data-delta' => 0,
+          ],
+        ],
+        'thumbnail' => $delta['preview'],
+        '#weight' => $preview_weight,
+      ];
+    }
+  }
+
+  /**
+   * Resolves a focal point string (x,y percentages) for the branding hero.
+   *
+   * @param array<string, mixed> $delta
+   *   Optional widget delta (may include focal_point from draft POST).
+   */
+  public function resolveFocalPoint(NodeInterface $node, array $delta = []): string {
+    if (isset($delta['focal_point']['#default_value'])) {
+      $candidate = trim((string) $delta['focal_point']['#default_value']);
+      if ($this->focalPointManager->validateFocalPoint($candidate)) {
+        return $candidate;
+      }
+    }
+    if (isset($delta['focal_point']) && is_string($delta['focal_point'])) {
+      $candidate = trim($delta['focal_point']);
+      if ($this->focalPointManager->validateFocalPoint($candidate)) {
+        return $candidate;
+      }
+    }
+
+    if ($node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()) {
+      $item = $node->get('field_event_image')->first();
+      if ($item !== NULL) {
+        $stored = $item->get('focal_point');
+        if ($stored !== NULL && !$stored->isEmpty()) {
+          $candidate = trim((string) $stored->value);
+          if ($this->focalPointManager->validateFocalPoint($candidate)) {
+            return $candidate;
+          }
+        }
+        $file = $item->entity;
+        if ($file instanceof FileInterface) {
+          $from_crop = $this->focalPointFromFileCrop($file);
+          if ($from_crop !== NULL) {
+            return $from_crop;
+          }
+        }
+      }
+    }
+
+    return self::DEFAULT_FOCAL;
+  }
+
+  /**
+   * Reads focal_point crop entity coordinates for a file.
+   */
+  private function focalPointFromFileCrop(FileInterface $file): ?string {
+    $crop_type = (string) $this->configFactory->get('focal_point.settings')->get('crop_type');
+    if ($crop_type === '') {
+      return NULL;
+    }
+    $crop = Crop::findCrop($file->getFileUri(), $crop_type);
+    if ($crop === NULL || $crop->get('x')->isEmpty() || $crop->get('y')->isEmpty()) {
+      return NULL;
+    }
+    $image = $this->imageFactory->get($file->getFileUri());
+    if (!$image->isValid()) {
+      return NULL;
+    }
+    $anchor = $this->focalPointManager->absoluteToRelative(
+      (float) $crop->get('x')->value,
+      (float) $crop->get('y')->value,
+      $image->getWidth(),
+      $image->getHeight(),
+    );
+    $value = ((int) $anchor['x']) . ',' . ((int) $anchor['y']);
+    return $this->focalPointManager->validateFocalPoint($value) ? $value : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/form-element--mel-option-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/form-element--mel-option-card.html.twig
@@ -52,6 +52,9 @@
   {% endif %}
   {% if label_display == 'after' %}
     <div class="mel-option-card__content">
+      {% if mel_option_badge is defined and mel_option_badge %}
+        <span class="mel-option-card__badge">{{ mel_option_badge }}</span>
+      {% endif %}
       {{ label }}
       {% if description_display in ['after', 'invisible'] and description.content %}
         <p{{ description.attributes.addClass(desc_card_classes) }}>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3797,13 +3797,11 @@ function myeventlane_theme_form_alter(array &$form, \Drupal\Core\Form\FormStateI
 }
 
 /**
- * Applies Classic/Immersive page style classes to event node template variables.
+ * Resolves public event page style + colour classes for a node.
+ *
+ * @return array{style: string, colour: string, classes: list<string>}
  */
-function _myeventlane_theme_apply_event_page_style_theme_variables(array &$variables, NodeInterface $node): void {
-  if (($variables['view_mode'] ?? '') !== 'full') {
-    return;
-  }
-
+function _myeventlane_theme_resolve_event_page_style_for_node(NodeInterface $node): array {
   $classes = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
   $style = 'classic';
   $colour = 'coral';
@@ -3818,9 +3816,25 @@ function _myeventlane_theme_apply_event_page_style_theme_variables(array &$varia
     $classes = $resolved['classes'];
   }
 
-  $variables['event_page_style'] = $style;
-  $variables['event_theme_colour'] = $colour;
-  $variables['event_page_classes'] = $classes;
+  return [
+    'style' => $style,
+    'colour' => $colour,
+    'classes' => $classes,
+  ];
+}
+
+/**
+ * Applies Classic/Immersive page style classes to event node template variables.
+ */
+function _myeventlane_theme_apply_event_page_style_theme_variables(array &$variables, NodeInterface $node): void {
+  if (($variables['view_mode'] ?? '') !== 'full') {
+    return;
+  }
+
+  $resolved = _myeventlane_theme_resolve_event_page_style_for_node($node);
+  $variables['event_page_style'] = $resolved['style'];
+  $variables['event_theme_colour'] = $resolved['colour'];
+  $variables['event_page_classes'] = $resolved['classes'];
 
   if (!isset($variables['attributes']) || !$variables['attributes'] instanceof Attribute) {
     $existing = $variables['attributes'] ?? [];
@@ -4344,6 +4358,9 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
   $variables['mel_signal_is_community'] = FALSE;
   $variables['mel_signal_trust_label'] = NULL;
   $variables['mel_signal_urgency_label'] = NULL;
+  $variables['event_page_style'] = 'classic';
+  $variables['event_theme_colour'] = 'coral';
+  $variables['event_page_classes'] = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
 
   $variables['label'] = $variables['title'] ?? '';
   $variables['hero_image'] = NULL;
@@ -4519,6 +4536,11 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
       $variables['mel_customer_operational_experience'] = NULL;
     }
   }
+
+  $pageStyle = _myeventlane_theme_resolve_event_page_style_for_node($event);
+  $variables['event_page_style'] = $pageStyle['style'];
+  $variables['event_theme_colour'] = $pageStyle['colour'];
+  $variables['event_page_classes'] = $pageStyle['classes'];
 
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
@@ -426,7 +426,7 @@
   min-width: 0;
 }
 
-.mel-booking-v2 .mel-access-code {
+.mel-booking-v2.mel-event-page--classic .mel-access-code {
   min-width: 0;
   padding: spacing.mel-space(3);
   border-radius: radii.$mel-radius-lg;
@@ -1352,36 +1352,235 @@
     opacity: 1;
   }
 
-  // Extras — match immersive event extras language.
+  // Extras — integrated immersive product cards (beats mel-operational-addons.css pale surfaces).
   .mel-booking-extras,
-  .mel-operational-addons-section {
+  .mel-operational-addons-section,
+  .mel-operational-addons-section--sidebar {
     margin-top: var(--mel-immersive-block-gap, #{spacing.mel-space(4)});
     padding: var(--mel-immersive-pad-secondary, #{spacing.mel-space(5)}) 0 0;
     border-top: 1px solid var(--mel-event-divider, rgba(255, 255, 255, 0.1));
-    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
-  }
-
-  .mel-booking-extras .mel-addon-teaser__item,
-  .mel-operational-addons-section .mel-addon-teaser__item {
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--mel-event-divider, rgba(255, 255, 255, 0.1));
     border-radius: 0;
+    background: transparent;
     box-shadow: none;
     color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
   }
 
-  .mel-booking-extras .mel-addon-teaser__name,
-  .mel-operational-addons-section .mel-addon-teaser__name {
-    color: var(--mel-immersive-text, #fff);
-    font-weight: 600;
-  }
-
-  .mel-booking-extras .mel-addon-teaser__intro,
-  .mel-booking-extras .mel-addon-teaser__hint,
-  .mel-operational-addons-section .mel-addon-teaser__intro {
+  .mel-event-extras-form__intro {
     color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
     opacity: 1;
+  }
+
+  .mel-event-extra-card,
+  .mel-operational-addon-card {
+    padding: var(--mel-immersive-pad-secondary, #{spacing.mel-space(5)});
+    border-radius: var(--mel-immersive-radius-inner, #{radii.$mel-radius-lg});
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 14%, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 86%);
+    border: 1px solid color-mix(in srgb, var(--mel-event-accent) 22%, transparent);
+    box-shadow: var(--mel-immersive-shadow-panel, 0 22px 52px rgba(0, 0, 0, 0.3));
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-event-extra-card__title,
+  .mel-operational-addon-card__title {
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-extra-card__description,
+  .mel-event-extra-card__pickup,
+  .mel-event-extra-card__size-selected,
+  .mel-operational-addon-card__summary-text {
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    opacity: 1;
+  }
+
+  .mel-event-extra-card__price,
+  .mel-operational-addon-card__price {
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-extra-card__sizes-label {
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-event-extra-card__media {
+    border-radius: var(--mel-immersive-radius-inner, #{radii.$mel-radius-lg});
+    overflow: hidden;
+  }
+
+  .mel-event-extra-card__image,
+  .mel-event-extra-card__image-open {
+    background: rgba(8, 12, 20, 0.55);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+  }
+
+  .mel-event-extra-card__thumb {
+    background: color-mix(in srgb, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 90%, transparent);
+    border-color: var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+
+    &.is-active {
+      border-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    }
+  }
+
+  .mel-event-extra-card__chips,
+  .mel-operational-addon-card__chips {
+    .mel-pill,
+    .mel-pill--extra {
+      background: color-mix(in srgb, var(--mel-event-accent-soft) 75%, transparent);
+      border: 1px solid color-mix(in srgb, var(--mel-event-accent) 32%, transparent);
+      color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+    }
+  }
+
+  .mel-event-extras-form .mel-event-extra-card__sizes label.option,
+  .mel-event-extras-form .mel-event-extra-card__sizes .mel-event-extra-card__size-chip-label,
+  .mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio label {
+    background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio.is-selected label,
+  .mel-event-extras-form .mel-event-extra-card__sizes .form-type-radio:has(input:checked) label,
+  .mel-event-extras-form .mel-event-extra-card__sizes .mel-event-extra-card__size-chip-label.is-selected {
+    background: var(--mel-event-accent, #{colors.$mel-color-primary});
+    border-color: color-mix(in srgb, var(--mel-event-accent) 88%, #fff 12%);
+    color: var(--mel-event-accent-contrast, #{colors.$mel-color-on-primary});
+    box-shadow: 0 6px 18px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.28));
+  }
+
+  .mel-event-extra-card__qty-btn {
+    background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 90%, transparent);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-extra-card__qty-value {
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-extra-card__footer,
+  .mel-operational-addon-card__row {
+    border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+  }
+
+  .mel-operational-addon-card__qty {
+    background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-extras-form .mel-event-extra-card__add-to-cart,
+  .mel-event-extras-form .mel-btn--primary.mel-event-extra-card__add-to-cart,
+  .mel-operational-addons-form__actions .mel-btn--primary {
+    background-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    border-color: transparent;
+    color: var(--mel-event-accent-contrast, #{colors.$mel-color-on-primary});
+    box-shadow:
+      0 12px 28px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.32)),
+      0 2px 8px rgba(0, 0, 0, 0.2);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        filter: brightness(1.06) saturate(1.04);
+        box-shadow:
+          0 16px 34px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.36)),
+          0 4px 12px rgba(0, 0, 0, 0.22);
+      }
+    }
+  }
+
+  // Access code — dark panel (beats default light .mel-access-code on classic).
+  .mel-access-code,
+  .mel-ticket-booking-access-wrap {
+    margin-top: var(--mel-immersive-block-gap, #{spacing.mel-space(4)});
+  }
+
+  .mel-access-code {
+    padding: var(--mel-immersive-pad-secondary, #{spacing.mel-space(5)});
+    border-radius: var(--mel-immersive-radius-inner, #{radii.$mel-radius-lg});
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 12%, rgba(12, 17, 26, 0.82) 88%);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+    box-shadow: var(--mel-immersive-shadow-quiet, 0 14px 36px rgba(0, 0, 0, 0.22));
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-access-code .mel-ticket-booking-access,
+  .mel-ticket-booking-access-wrap .mel-ticket-booking-access {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+  }
+
+  .mel-access-code .mel-ticket-booking-access legend,
+  .mel-ticket-booking-access-wrap .mel-ticket-booking-access legend {
+    float: none;
+    position: static;
+    display: block;
+    width: 100%;
+    margin: 0 0 spacing.mel-space(3);
+    padding: 0;
+    font-size: var(--mel-immersive-heading-secondary, 1.125rem);
+    font-weight: 700;
+    line-height: 1.25;
+    color: var(--mel-immersive-text, #fff);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+  }
+
+  .mel-access-code .mel-ticket-booking-access .fieldset-description,
+  .mel-ticket-booking-access-wrap .mel-ticket-booking-access .fieldset-description {
+    margin: 0 0 spacing.mel-space(3);
+    font-size: var(--mel-immersive-meta-size, 0.9375rem);
+    line-height: 1.5;
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    opacity: 1;
+  }
+
+  .mel-access-code .form-item,
+  .mel-ticket-booking-access-wrap .form-item {
+    margin-bottom: spacing.mel-space(3);
+  }
+
+  .mel-access-code label,
+  .mel-ticket-booking-access-wrap label {
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-access-code input[type='text'],
+  .mel-ticket-booking-access-wrap input[type='text'] {
+    min-height: 44px;
+    background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+    border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+    color: var(--mel-immersive-text, #fff);
+
+    &::placeholder {
+      color: var(--mel-immersive-text-helper, rgba(255, 255, 255, 0.64));
+    }
+
+    &:focus-visible {
+      border-color: var(--mel-event-accent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--mel-event-accent) 28%, transparent);
+    }
+  }
+
+  .mel-access-code .mel-btn,
+  .mel-access-code .button,
+  .mel-ticket-booking-access-wrap .mel-btn,
+  .mel-ticket-booking-access-wrap .button {
+    min-height: 44px;
+    background-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    border-color: transparent;
+    color: var(--mel-event-accent-contrast, #{colors.$mel-color-on-primary});
+    box-shadow: 0 10px 24px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.28));
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        filter: brightness(1.06);
+      }
+    }
   }
 
   // Ticket matrix rows.
@@ -1415,11 +1614,6 @@
         border-color: var(--mel-event-accent);
         box-shadow: 0 0 0 3px color-mix(in srgb, var(--mel-event-accent) 28%, transparent);
       }
-    }
-
-    .mel-access-code {
-      background: color-mix(in srgb, var(--mel-event-accent-soft) 40%, transparent);
-      border: none;
     }
 
     .mel-ticket-row {
@@ -1521,8 +1715,17 @@
     }
 
     .mel-ticket-panel,
-    .mel-booking-summary {
+    .mel-booking-summary,
+    .mel-event-extra-card {
       padding: spacing.mel-space(4);
+    }
+
+    .mel-event-extra-card {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .mel-event-extra-card__image {
+      max-width: 100%;
     }
   }
 
@@ -1530,6 +1733,7 @@
     .mel-event-info-strip,
     .mel-ticket-panel,
     .mel-booking-summary,
+    .mel-access-code,
     .mel-event-book__form-body .mel-booking__cta {
       backdrop-filter: none;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
@@ -1130,3 +1130,408 @@
     transition: none;
   }
 }
+
+// ==========================================================================
+// Book page ↔ event page visual convergence (Classic + Immersive)
+// Reuses mel-event-page--* classes + tokens from _event-page-themes.scss.
+// ==========================================================================
+
+.mel-booking-v2.mel-event-page--classic {
+  background: #fff8f4;
+  color: var(--mel-event-text, #{colors.$mel-color-text});
+
+  .mel-container {
+    max-width: min(100%, 76rem);
+  }
+
+  .mel-event-info-strip {
+    background: var(--mel-event-surface, #fff);
+    border: 1px solid var(--mel-event-border, rgba(242, 109, 91, 0.18));
+    border-radius: radii.$mel-radius-xl;
+    box-shadow: var(--mel-event-shadow, 0 18px 45px rgba(41, 50, 65, 0.08));
+    color: var(--mel-event-muted, #{colors.$mel-color-text-muted});
+  }
+
+  .mel-ticket-panel,
+  .mel-booking-summary,
+  .mel-event-description-card {
+    background: var(--mel-event-surface, #fff);
+    border: 1px solid var(--mel-event-border, rgba(242, 109, 91, 0.18));
+    border-radius: radii.$mel-radius-xl;
+    box-shadow: var(--mel-event-shadow, 0 18px 45px rgba(41, 50, 65, 0.08));
+  }
+
+  .mel-booking-summary {
+    background: linear-gradient(
+      165deg,
+      color.adjust(colors.$mel-color-surface, $lightness: 0.5%) 0%,
+      color.adjust(colors.$mel-color-bg, $lightness: 3%) 55%,
+      color.adjust(colors.$mel-color-surface, $lightness: 1%) 100%
+    );
+  }
+
+  .mel-ticket-panel__title,
+  .mel-booking-summary__title,
+  .mel-operational-addons-section__title {
+    color: var(--mel-event-text, #{colors.$mel-color-text});
+  }
+
+  .mel-ticket-panel__lead,
+  .mel-booking-summary__kicker,
+  .mel-booking-summary__cta-note,
+  .mel-booking-summary__empty-line--soft,
+  .mel-operational-addons-section__lede {
+    color: var(--mel-event-muted, #{colors.$mel-color-text-muted});
+  }
+
+  .mel-event-book__form-body .mel-btn--primary,
+  .mel-event-book__form-body .mel-add-to-cart-button {
+    background-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    border-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    box-shadow: 0 8px 22px var(--mel-event-accent-glow, rgba(41, 50, 65, 0.12));
+  }
+}
+
+.mel-booking-v2.mel-event-page--immersive.mel-event--v2 {
+  padding-top: spacing.mel-space(6);
+  padding-bottom: spacing.mel-space(8);
+  background: transparent;
+  color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+
+  .mel-container {
+    max-width: min(100%, 76rem);
+  }
+
+  .mel-event-layout {
+    gap: var(--mel-immersive-section-gap, #{spacing.mel-space(6)});
+
+    @include breakpoints.mel-break(lg) {
+      column-gap: var(--mel-immersive-section-gap, #{spacing.mel-space(6)});
+    }
+  }
+
+  // Hero — continuous with public immersive event page (no frosted box).
+  .mel-event-hero--featured-style {
+    min-height: clamp(18rem, 36vw, 28rem);
+    margin-bottom: var(--mel-immersive-block-gap, #{spacing.mel-space(4)});
+    border: none;
+    border-radius: var(--mel-immersive-radius, #{radii.$mel-radius-xl});
+    box-shadow: var(--mel-immersive-shadow-featured, 0 26px 60px rgba(0, 0, 0, 0.34));
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__overlay {
+    background:
+      radial-gradient(ellipse 90% 55% at 50% 100%, rgba(0, 0, 0, 0.5) 0%, transparent 68%),
+      radial-gradient(ellipse 60% 40% at 12% 18%, color-mix(in srgb, var(--mel-event-accent) 14%, transparent) 0%, transparent 55%),
+      linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(8, 11, 18, 0.5) 48%, rgba(6, 9, 15, 0.88) 100%);
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__content {
+    right: spacing.mel-space(6);
+    bottom: spacing.mel-space(6);
+    left: spacing.mel-space(6);
+    max-width: 44rem;
+  }
+
+  .mel-event-hero__glass {
+    max-width: none;
+    padding: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .mel-event-hero__glass .mel-event-hero__title,
+  .mel-event-hero__glass .mel-event-hero__datetime,
+  .mel-event-hero__glass .mel-event-hero__venue,
+  .mel-event-hero__glass .mel-event-hero__status {
+    color: var(--mel-immersive-text, #fff);
+    text-shadow: 0 2px 32px rgba(0, 0, 0, 0.7);
+  }
+
+  .mel-event-hero__glass .mel-event-hero__datetime,
+  .mel-event-hero__glass .mel-event-hero__venue {
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  // Trust strip — meta-bar sibling.
+  .mel-event-info-strip {
+    margin-bottom: var(--mel-immersive-section-gap, #{spacing.mel-space(6)});
+    padding: var(--mel-immersive-pad-secondary, #{spacing.mel-space(5)}) var(--mel-immersive-pad-primary, #{spacing.mel-space(6)});
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 12%, rgba(12, 17, 26, 0.78) 88%);
+    border: none;
+    border-radius: var(--mel-immersive-radius, #{radii.$mel-radius-xl});
+    box-shadow: var(--mel-immersive-shadow-quiet, 0 14px 36px rgba(0, 0, 0, 0.22));
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    font-size: var(--mel-immersive-meta-size, 0.9375rem);
+    font-weight: typography.$mel-font-semibold;
+    backdrop-filter: blur(12px);
+  }
+
+  .mel-event-info-strip__item {
+    opacity: 1;
+  }
+
+  // Primary panels — ticket matrix + order summary.
+  .mel-ticket-panel,
+  .mel-booking-summary {
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 16%, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 84%);
+    border: none;
+    border-radius: var(--mel-immersive-radius, #{radii.$mel-radius-xl});
+    box-shadow: var(--mel-immersive-shadow-panel, 0 22px 52px rgba(0, 0, 0, 0.3));
+    backdrop-filter: blur(8px);
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-booking-summary {
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 14%, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 86%);
+    box-shadow: var(--mel-immersive-shadow-sidebar, 0 18px 44px rgba(0, 0, 0, 0.32));
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-booking-summary__header,
+  .mel-booking-summary__footer {
+    border-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    background: transparent;
+  }
+
+  .mel-ticket-panel__title,
+  .mel-booking-summary__title,
+  .mel-operational-addons-section__title,
+  .mel-booking__intro h2 {
+    color: var(--mel-immersive-text, #fff);
+    font-size: var(--mel-immersive-heading-size, clamp(1.375rem, 2.1vw, 1.6rem));
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+
+  .mel-ticket-panel__lead,
+  .mel-booking-summary__kicker,
+  .mel-booking-summary__empty-line,
+  .mel-booking-summary__item,
+  .mel-booking-summary__cta-note,
+  .mel-booking__intro p,
+  .mel-booking__reassurance,
+  .mel-booking__cta-note,
+  .mel-operational-addons-section__lede {
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    opacity: 1;
+  }
+
+  .mel-booking-summary__empty-line--soft,
+  .mel-booking-summary__cta-note,
+  .mel-booking__cta-note {
+    color: var(--mel-immersive-text-helper, rgba(255, 255, 255, 0.64));
+  }
+
+  .mel-booking-summary__title,
+  .mel-booking-summary__subtotal,
+  .mel-booking-summary__item-amount,
+  .mel-booking-summary__subtotal-value,
+  .mel-mobile-booking-bar__total {
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-booking-summary__subtotal {
+    border-color: color-mix(in srgb, var(--mel-event-accent) 28%, transparent);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 35%, transparent);
+  }
+
+  .mel-booking-summary__item-amount,
+  .mel-booking-summary__subtotal-value,
+  .mel-mobile-booking-bar__total {
+    color: var(--mel-event-accent-strong, var(--mel-event-accent));
+  }
+
+  .mel-booking-confidence,
+  .mel-text--muted,
+  .mel-muted {
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    opacity: 1;
+  }
+
+  // Extras — match immersive event extras language.
+  .mel-booking-extras,
+  .mel-operational-addons-section {
+    margin-top: var(--mel-immersive-block-gap, #{spacing.mel-space(4)});
+    padding: var(--mel-immersive-pad-secondary, #{spacing.mel-space(5)}) 0 0;
+    border-top: 1px solid var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-booking-extras .mel-addon-teaser__item,
+  .mel-operational-addons-section .mel-addon-teaser__item {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    border-radius: 0;
+    box-shadow: none;
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-booking-extras .mel-addon-teaser__name,
+  .mel-operational-addons-section .mel-addon-teaser__name {
+    color: var(--mel-immersive-text, #fff);
+    font-weight: 600;
+  }
+
+  .mel-booking-extras .mel-addon-teaser__intro,
+  .mel-booking-extras .mel-addon-teaser__hint,
+  .mel-operational-addons-section .mel-addon-teaser__intro {
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+    opacity: 1;
+  }
+
+  // Ticket matrix rows.
+  .mel-event-book__form-body {
+    label,
+    legend {
+      color: var(--mel-immersive-text, #fff);
+    }
+
+    .fieldset-description,
+    .mel-ticket-description,
+    .mel-ticket-row__helper,
+    .mel-ticket-availability,
+    .mel-ticket-card__availability {
+      color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+      opacity: 1;
+    }
+
+    input[type='text'],
+    input[type='email'],
+    input[type='tel'],
+    input[type='number'],
+    select,
+    textarea,
+    .mel-ticket-quantity {
+      background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+      border: 1px solid var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+      color: var(--mel-immersive-text, #fff);
+
+      &:focus-visible {
+        border-color: var(--mel-event-accent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--mel-event-accent) 28%, transparent);
+      }
+    }
+
+    .mel-access-code {
+      background: color-mix(in srgb, var(--mel-event-accent-soft) 40%, transparent);
+      border: none;
+    }
+
+    .mel-ticket-row {
+      background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 10%, var(--mel-event-surface, rgba(28, 36, 50, 0.72)) 90%);
+      border: none;
+      box-shadow: var(--mel-immersive-shadow-quiet, 0 14px 36px rgba(0, 0, 0, 0.22));
+      color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+
+      &:hover {
+        border-color: transparent;
+        box-shadow: var(--mel-immersive-shadow-panel, 0 22px 52px rgba(0, 0, 0, 0.3));
+      }
+    }
+
+    .mel-ticket-row.mel-ticket-row--selected,
+    .mel-ticket-row.selected,
+    .mel-ticket-row.has-quantity,
+    .mel-ticket-row[data-selected='true'],
+    .mel-ticket-row--recommended {
+      background: color-mix(in srgb, var(--mel-event-accent-soft) 32%, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 68%);
+      border: 1px solid color-mix(in srgb, var(--mel-event-accent) 45%, transparent);
+      box-shadow: var(--mel-immersive-shadow-panel, 0 22px 52px rgba(0, 0, 0, 0.3));
+    }
+
+    .mel-ticket-label,
+    .mel-ticket-price,
+    .mel-ticket-row__top-price {
+      color: var(--mel-immersive-text, #fff);
+    }
+
+    .mel-ticket-price,
+    .mel-ticket-row__top-price {
+      color: var(--mel-event-accent-strong, var(--mel-event-accent));
+    }
+
+    .mel-ticket-row__meta {
+      border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    }
+
+    .form-actions {
+      border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    }
+  }
+
+  // Sticky checkout CTA — event sidebar CTA language.
+  .mel-event-book__form-body .mel-booking__cta {
+    background: color-mix(in srgb, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 94%, transparent);
+    border-top: none;
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.36);
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-event-book__form-body .mel-booking__cta .mel-mobile-booking-bar {
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 45%, transparent);
+    border: none;
+    color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+  }
+
+  .mel-event-book__form-body .mel-booking__cta .mel-mobile-booking-bar__count {
+    color: var(--mel-immersive-text, #fff);
+  }
+
+  .mel-event-book__form-body .mel-btn--primary,
+  .mel-event-book__form-body .mel-add-to-cart-button {
+    background-color: var(--mel-event-accent, #{colors.$mel-color-primary});
+    border-color: transparent;
+    color: var(--mel-event-accent-contrast, #{colors.$mel-color-on-primary});
+    box-shadow:
+      0 12px 28px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.32)),
+      0 2px 8px rgba(0, 0, 0, 0.2);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        transform: none;
+        filter: brightness(1.06) saturate(1.04);
+        box-shadow:
+          0 16px 34px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.36)),
+          0 4px 12px rgba(0, 0, 0, 0.22);
+      }
+    }
+  }
+
+  .mel-booking-nav__back {
+    color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+  }
+
+  @include breakpoints.mel-break(md, max) {
+    padding-top: spacing.mel-space(5);
+    padding-bottom: spacing.mel-space(7);
+
+    .mel-event-hero--featured-style {
+      min-height: 18rem;
+    }
+
+    .mel-event-hero--featured-style .mel-event-hero__content {
+      right: spacing.mel-space(4);
+      bottom: spacing.mel-space(4);
+      left: spacing.mel-space(4);
+    }
+
+    .mel-ticket-panel,
+    .mel-booking-summary {
+      padding: spacing.mel-space(4);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mel-event-info-strip,
+    .mel-ticket-panel,
+    .mel-booking-summary,
+    .mel-event-book__form-body .mel-booking__cta {
+      backdrop-filter: none;
+    }
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -488,24 +488,25 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   --mel-event-text: var(--mel-immersive-text-body);
   --mel-event-text-secondary: var(--mel-immersive-text-secondary);
   --mel-event-text-muted: var(--mel-immersive-text-muted);
-  --mel-event-divider: rgba(255, 255, 255, 0.22);
-  // Depth — lifted panels, softer OLED backdrop.
-  --mel-event-surface: rgba(26, 34, 48, 0.92);
-  --mel-event-surface-raised: rgba(35, 45, 61, 0.94);
-  --mel-event-surface-spotlight: rgba(43, 55, 73, 0.96);
-  --mel-event-border: rgba(255, 255, 255, 0.14);
-  --mel-event-border-strong: rgba(255, 255, 255, 0.22);
+  --mel-event-divider: rgba(255, 255, 255, 0.2);
+  // Depth — tonal layers (avoid identical navy panels + loud outlines).
+  --mel-event-surface-quiet: rgba(24, 31, 44, 0.72);
+  --mel-event-surface: rgba(30, 38, 52, 0.82);
+  --mel-event-surface-raised: rgba(38, 48, 64, 0.88);
+  --mel-event-surface-spotlight: rgba(44, 56, 74, 0.92);
+  --mel-event-border: rgba(255, 255, 255, 0.08);
+  --mel-event-border-strong: rgba(255, 255, 255, 0.12);
   --mel-event-shadow-elevated:
-    0 20px 48px rgba(0, 0, 0, 0.42),
-    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 24px 56px rgba(0, 0, 0, 0.36),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   --mel-event-shadow-sidebar:
-    0 20px 48px rgba(0, 0, 0, 0.42),
-    0 0 0 1px rgba(255, 255, 255, 0.08),
-    0 0 22px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.14));
+    0 28px 56px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
   --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 78%, #fff 22%);
   --mel-event-surface-tint: transparent;
-  --mel-immersive-section-gap: #{space-tokens.mel-space(6)};
+  --mel-immersive-section-gap: #{space-tokens.mel-space(7)};
+  --mel-immersive-heading-size: clamp(1.375rem, 2.2vw, 1.625rem);
+  --mel-immersive-body-size: 1.0625rem;
 
   background:
     radial-gradient(ellipse 100% 70% at 50% -12%, color-mix(in srgb, var(--mel-event-accent) 18%, transparent) 0%, transparent 62%),
@@ -521,69 +522,95 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   // Immersive-only palette tuning (Classic colour tokens above stay unchanged).
   &.mel-event-page--colour-coral {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #232d3d, 32%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.38)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 32%)};
-    --mel-event-surface-tint: #{color.mix(colors.$mel-color-primary, #161f2e, 12%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #283545, 36%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.32)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 28%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-primary, #121820, 10%)};
   }
 
   &.mel-event-page--colour-purple {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-accent, #232d3d, 34%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.4)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 34%)};
-    --mel-event-surface-tint: #{color.mix(colors.$mel-color-accent, #161f2e, 14%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-accent, #283545, 38%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.34)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 30%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-accent, #121820, 12%)};
   }
 
   &.mel-event-page--colour-mint {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-success, #232d3d, 32%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.36)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 34%)};
-    --mel-event-surface-tint: #{color.mix(colors.$mel-color-success, #161f2e, 12%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-success, #283545, 36%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.3)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 30%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-success, #121820, 10%)};
   }
 
   &.mel-event-page--colour-gold {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #232d3d, 32%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.38)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 32%)};
-    --mel-event-surface-tint: #{color.mix(colors.$mel-color-orange, #161f2e, 12%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #283545, 36%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.32)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 28%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-orange, #121820, 10%)};
   }
 
   &.mel-event-page--colour-blue {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-info, #232d3d, 32%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.36)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 34%)};
-    --mel-event-surface-tint: #{color.mix(colors.$mel-color-info, #161f2e, 12%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-info, #283545, 36%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.3)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 30%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-info, #121820, 10%)};
   }
 
+  padding-top: space-tokens.mel-space(5);
+  padding-bottom: space-tokens.mel-space(8);
+
+  .mel-container {
+    max-width: min(100%, 76rem);
+  }
+
+  .mel-event__hero {
+    margin-bottom: space-tokens.mel-space(5);
+  }
+
+  // Hero — cinematic scale, soft edge (no outlined rectangle).
   .mel-event-hero--featured-style {
-    margin-bottom: space-tokens.mel-space(2);
+    min-height: clamp(22rem, 42vw, 34rem);
+    margin-bottom: space-tokens.mel-space(5);
+    border: none;
     border-radius: radii.$mel-radius-xl;
     overflow: hidden;
-    box-shadow:
-      0 28px 64px rgba(0, 0, 0, 0.5),
-      0 0 36px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
+    box-shadow: 0 36px 80px rgba(0, 0, 0, 0.48);
   }
 
   .mel-event-hero--featured-style .mel-event-hero__overlay {
-    background: linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.08) 0%,
-      rgba(10, 14, 22, 0.52) 45%,
-      rgba(8, 11, 18, 0.9) 100%
-    );
+    background:
+      radial-gradient(ellipse 90% 55% at 50% 100%, rgba(0, 0, 0, 0.5) 0%, transparent 68%),
+      radial-gradient(ellipse 60% 40% at 12% 18%, color-mix(in srgb, var(--mel-event-accent) 14%, transparent) 0%, transparent 55%),
+      linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(8, 11, 18, 0.5) 48%, rgba(6, 9, 15, 0.88) 100%);
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__content {
+    right: space-tokens.mel-space(6);
+    bottom: space-tokens.mel-space(6);
+    left: space-tokens.mel-space(6);
+    max-width: 44rem;
+    gap: space-tokens.mel-space(3);
   }
 
   .mel-event-hero__content,
   .mel-event-hero-card__title,
   #mel-event-title {
-    color: var(--mel-event-heading);
-    text-shadow: 0 2px 28px rgba(0, 0, 0, 0.65);
-    letter-spacing: -0.02em;
+    color: var(--mel-immersive-text);
+    text-shadow: 0 2px 32px rgba(0, 0, 0, 0.7);
+    letter-spacing: -0.03em;
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__title,
+  #mel-event-title {
+    font-size: clamp(2rem, 4.8vw, 3.35rem);
+    font-weight: 800;
+    line-height: 1.06;
   }
 
   .mel-event-hero--featured-style .mel-event-hero__datetime,
   .mel-event-hero--featured-style .mel-event-hero__venue {
-    color: #f3f6fb;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 1rem;
     opacity: 1;
   }
 
@@ -593,36 +620,51 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__signal {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
-    box-shadow: 0 6px 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   }
 
+  // Meta strip — premium floating bar.
   .mel-event-meta-bar {
-    margin-top: space-tokens.mel-space(4);
-    margin-bottom: space-tokens.mel-space(2);
-    background: var(--mel-event-surface-raised);
-    border: 1px solid var(--mel-event-border-strong);
-    box-shadow: var(--mel-event-shadow-elevated);
+    margin-top: 0;
+    margin-bottom: space-tokens.mel-space(6);
+    padding: space-tokens.mel-space(4) space-tokens.mel-space(5);
+    background: rgba(14, 20, 30, 0.82);
+    border: 1px solid var(--mel-event-border);
+    border-radius: radii.$mel-radius-xl;
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.38);
     color: var(--mel-immersive-text-body);
-    backdrop-filter: blur(12px);
+    backdrop-filter: blur(14px);
+    gap: space-tokens.mel-space(4);
   }
 
   .mel-event-meta__primary {
     color: var(--mel-immersive-text);
+    font-size: 1.0625rem;
     font-weight: 600;
+    line-height: 1.3;
   }
 
   .mel-event-meta__secondary {
     color: var(--mel-immersive-text-meta);
+    font-size: 0.9375rem;
+    line-height: 1.45;
   }
 
   .mel-event-meta__icon {
-    color: var(--mel-event-accent-strong);
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 12px;
     opacity: 1;
+  }
+
+  .mel-event-meta__icon::after {
+    width: 0.875rem;
+    height: 0.875rem;
   }
 
   .mel-event-meta-bar a {
     color: var(--mel-immersive-text);
-    text-decoration-color: var(--mel-event-accent-strong);
+    text-decoration-color: color-mix(in srgb, var(--mel-event-accent) 55%, transparent);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
@@ -631,9 +673,15 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     }
   }
 
+  // Layout rhythm — editorial column spacing.
   .mel-event-layout {
-    margin-top: var(--mel-immersive-section-gap);
-    gap: space-tokens.mel-space(5);
+    margin-top: 0;
+    gap: space-tokens.mel-space(6);
+
+    @include breakpoints.mel-break(lg) {
+      grid-template-columns: minmax(0, 1fr) min(400px, 34vw);
+      column-gap: space-tokens.mel-space(6);
+    }
   }
 
   .mel-event-layout__main,
@@ -643,35 +691,61 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     gap: var(--mel-immersive-section-gap);
   }
 
-  .mel-event__card,
-  .mel-event-layout__main .mel-card,
-  .mel-card--surface {
-    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 35%, var(--mel-event-surface-raised) 65%);
-    border: 1px solid var(--mel-event-border-strong);
+  // Card system — shadow separation, neutral edges (accent on CTAs/chips only).
+  .mel-event-layout__main .mel-card--surface {
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 22%, var(--mel-event-surface-raised) 78%);
+    border: none;
     box-shadow: var(--mel-event-shadow-elevated);
-    color: var(--mel-immersive-text-body);
-    backdrop-filter: blur(12px);
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-card--highlights {
+    background: var(--mel-event-surface-quiet);
+    border: none;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+  }
+
+  .mel-card--expect {
+    background: var(--mel-event-surface);
+    border: none;
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.32);
+  }
+
+  .mel-event-section--share.mel-card--surface {
+    background: var(--mel-event-surface-quiet);
+    border: none;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.26);
   }
 
   .mel-card--sticky {
-    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 28%, var(--mel-event-surface-raised) 72%);
-    border: 1px solid var(--mel-event-border-strong);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 18%, var(--mel-event-surface-spotlight) 82%);
+    border: none;
     box-shadow: var(--mel-event-shadow-sidebar);
-    color: var(--mel-immersive-text-body);
     backdrop-filter: blur(12px);
   }
 
-  .mel-card--highlights,
-  .mel-card--expect {
-    background: var(--mel-event-surface-spotlight);
-    border-color: var(--mel-event-border-strong);
+  .mel-card--surface .mel-card__header,
+  .mel-card--surface .mel-card__body {
+    padding: space-tokens.mel-space(5) space-tokens.mel-space(6);
+
+    @include breakpoints.mel-break(lg) {
+      padding: space-tokens.mel-space(6) space-tokens.mel-space(7);
+    }
   }
 
-  .mel-card--surface .mel-card__header,
-  .mel-card--surface .mel-card__body,
+  .mel-card--highlights .mel-card__header,
+  .mel-card--highlights .mel-card__body {
+    padding: space-tokens.mel-space(4) space-tokens.mel-space(5);
+  }
+
+  .mel-card--expect .mel-card__header,
+  .mel-card--expect .mel-card__body {
+    padding: space-tokens.mel-space(5) space-tokens.mel-space(6);
+  }
+
   .mel-card--sticky .mel-card__header,
   .mel-card--sticky .mel-card__body {
-    padding: space-tokens.mel-space(5);
+    padding: space-tokens.mel-space(5) space-tokens.mel-space(5);
 
     @include breakpoints.mel-break(lg) {
       padding: space-tokens.mel-space(6);
@@ -718,7 +792,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     background: var(--mel-event-accent-soft);
     border: 1px solid var(--mel-event-chip-border, var(--mel-event-accent));
     color: var(--mel-event-accent-strong);
-    box-shadow: 0 4px 14px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.25));
+    box-shadow: none;
   }
 
   .mel-card--sticky .mel-booking-panel__item-icon,
@@ -735,8 +809,9 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   .mel-card--sticky .mel-booking-panel__save,
   .mel-card--sticky .mel-booking-panel__save--fav {
-    background: var(--mel-event-surface-spotlight);
-    border-color: var(--mel-event-border-strong);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--mel-event-border);
+    box-shadow: none;
     color: var(--mel-immersive-text-body);
   }
 
@@ -758,17 +833,27 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-section__title,
   .mel-card__title {
     color: var(--mel-immersive-text);
+    font-size: var(--mel-immersive-heading-size);
     font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
   }
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
+    height: 3px;
     background: linear-gradient(
       90deg,
       var(--mel-event-accent, colors.$mel-color-primary) 0%,
-      var(--mel-event-divider) 72%
+      var(--mel-event-divider) 80%
     );
     opacity: 1;
+  }
+
+  .mel-event-info__body,
+  .mel-event-section__body {
+    font-size: var(--mel-immersive-body-size);
+    line-height: 1.65;
   }
 
   // Typography — beat _event-full.scss dim hardcoded greys on dark surfaces.
@@ -845,11 +930,11 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-section--extras.mel-card--surface {
-    background: color-mix(in srgb, var(--mel-event-accent-soft) 42%, var(--mel-event-surface-spotlight) 58%);
-    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border-strong));
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 38%, var(--mel-event-surface-spotlight) 62%);
+    border: none;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      0 18px 42px rgba(0, 0, 0, 0.35);
+      inset 0 1px 0 rgba(255, 255, 255, 0.07),
+      0 24px 52px rgba(0, 0, 0, 0.38);
 
     > .mel-card__header,
     > .mel-card__body {
@@ -859,13 +944,24 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   .mel-event-section--extras .mel-card__title,
   .mel-event-section--extras .mel-event-section__title {
-    color: var(--mel-event-accent-strong);
+    color: var(--mel-immersive-text);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__list {
+    gap: space-tokens.mel-space(3);
   }
 
   .mel-event-section--extras .mel-addon-teaser__item {
-    background: var(--mel-event-surface-raised);
-    border: 1px solid var(--mel-event-border-strong);
-    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.28);
+    padding: space-tokens.mel-space(4);
+    background: rgba(22, 30, 42, 0.75);
+    border: none;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__thumb {
+    width: 64px;
+    height: 64px;
+    border-radius: radii.$mel-radius-lg;
   }
 
   .mel-event-section--extras .mel-addon-teaser__cta,
@@ -873,27 +969,30 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-section--extras .mel-addon-teaser__cta.mel-btn--secondary,
   .mel-event-section--extras .mel-addon-teaser__scroll.mel-btn--secondary {
     border-color: var(--mel-event-accent);
-    color: var(--mel-event-accent-strong);
-    background: color-mix(in srgb, var(--mel-event-accent-soft) 35%, transparent);
+    color: var(--mel-immersive-text);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 45%, transparent);
+    min-height: 44px;
+    font-weight: 600;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
         background: var(--mel-event-accent-soft);
-        box-shadow: 0 8px 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.3));
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
       }
     }
   }
 
   .mel-event-map-embed {
-    border: 1px solid var(--mel-event-border-strong);
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    border: none;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+    border-radius: radii.$mel-radius-lg;
   }
 
   .mel-event-share--panel .mel-event-share__chip-icon {
-    background: var(--mel-event-accent-soft);
-    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border-strong));
-    color: var(--mel-event-accent-strong);
-    box-shadow: 0 6px 18px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.28));
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--mel-event-border);
+    color: var(--mel-immersive-text);
+    box-shadow: none;
   }
 
   .mel-event-share--panel .mel-event-share__chip-label {
@@ -905,25 +1004,27 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     color: var(--mel-immersive-text-body);
   }
 
-  .mel-btn--primary,
-  .button--primary,
-  .mel-event--v2 .mel-btn--primary,
-  .mel-event--v2 .mel-btn--coral-cta {
+  // Primary CTA glow — sidebar + mobile bar only (not every panel).
+  .mel-card--sticky .mel-btn--primary,
+  .mel-card--sticky .mel-btn--coral-cta,
+  .mel-card--sticky .button--primary,
+  .mel-mobile-cta .mel-btn--primary,
+  .mel-mobile-cta .mel-btn--coral-cta {
     background-color: var(--mel-event-accent, colors.$mel-color-primary);
     border-color: color-mix(in srgb, var(--mel-event-accent) 88%, #fff 12%);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 48px;
     font-weight: 700;
     box-shadow:
-      0 12px 32px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.4)),
-      0 0 0 1px color-mix(in srgb, var(--mel-event-accent) 65%, #fff 35%);
+      0 14px 36px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.38)),
+      0 0 0 1px color-mix(in srgb, var(--mel-event-accent) 55%, #fff 45%);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        filter: brightness(1.06) saturate(1.08);
+        filter: brightness(1.08) saturate(1.06);
         box-shadow:
-          0 16px 38px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.48)),
-          0 0 24px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
+          0 18px 42px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.45)),
+          0 0 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.28));
       }
     }
   }
@@ -931,7 +1032,17 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-card--sticky .mel-btn--coral-cta,
   .mel-mobile-cta .mel-btn--coral-cta {
     border-radius: 16px;
-    min-height: 48px;
+  }
+
+  .mel-btn--primary,
+  .button--primary,
+  .mel-event-layout__main .mel-btn--primary {
+    background-color: var(--mel-event-accent, colors.$mel-color-primary);
+    border-color: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    min-height: 44px;
+    font-weight: 600;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
   }
 
   .mel-btn--secondary,
@@ -958,9 +1069,30 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   @include breakpoints.mel-break(md, max) {
     --mel-immersive-section-gap: #{space-tokens.mel-space(5)};
+    --mel-immersive-heading-size: 1.3125rem;
+
+    padding-top: space-tokens.mel-space(4);
+    padding-bottom: space-tokens.mel-space(6);
+
+    .mel-event-hero--featured-style {
+      min-height: 20rem;
+      margin-bottom: space-tokens.mel-space(4);
+    }
+
+    .mel-event-hero--featured-style .mel-event-hero__content {
+      right: space-tokens.mel-space(4);
+      bottom: space-tokens.mel-space(4);
+      left: space-tokens.mel-space(4);
+    }
+
+    .mel-event-hero--featured-style .mel-event-hero__title,
+    #mel-event-title {
+      font-size: clamp(1.625rem, 7vw, 2.25rem);
+    }
 
     .mel-event-meta-bar {
-      margin-top: space-tokens.mel-space(3);
+      margin-bottom: space-tokens.mel-space(5);
+      padding: space-tokens.mel-space(4);
     }
 
     .mel-event-meta-bar__items {
@@ -975,8 +1107,12 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
     .mel-event-meta__primary,
     .mel-event-meta__secondary {
-      font-size: 15px;
+      font-size: 1rem;
       line-height: 1.45;
+    }
+
+    .mel-event-layout {
+      gap: space-tokens.mel-space(5);
     }
 
     .mel-card--surface .mel-card__header,
@@ -986,10 +1122,10 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
       padding: space-tokens.mel-space(4);
     }
 
-    .mel-btn--primary,
-    .button--primary,
-    .mel-event--v2 .mel-btn--primary,
-    .mel-event--v2 .mel-btn--coral-cta,
+    .mel-card--sticky .mel-btn--primary,
+    .mel-card--sticky .mel-btn--coral-cta,
+    .mel-mobile-cta .mel-btn--primary,
+    .mel-mobile-cta .mel-btn--coral-cta,
     .mel-btn--secondary,
     .button--secondary {
       min-height: 44px;
@@ -1007,10 +1143,10 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
       backdrop-filter: none;
     }
 
-    .mel-btn--primary,
-    .button--primary,
-    .mel-event--v2 .mel-btn--primary,
-    .mel-event--v2 .mel-btn--coral-cta {
+    .mel-card--sticky .mel-btn--primary,
+    .mel-card--sticky .mel-btn--coral-cta,
+    .mel-mobile-cta .mel-btn--primary,
+    .mel-mobile-cta .mel-btn--coral-cta {
       &:hover {
         filter: none;
       }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -17,30 +17,40 @@
   --mel-event-accent: #{colors.$mel-color-primary};
   --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #fff, 18%)};
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+  --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.32)};
+  --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 35%)};
 }
 
 .mel-event-page--colour-purple {
   --mel-event-accent: #{colors.$mel-color-accent};
   --mel-event-accent-soft: #{colors.$mel-color-pastel-lavender};
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+  --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.34)};
+  --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 40%)};
 }
 
 .mel-event-page--colour-mint {
   --mel-event-accent: #{color.adjust(colors.$mel-color-success, $lightness: -8%)};
   --mel-event-accent-soft: #{colors.$mel-color-pastel-mint};
   --mel-event-accent-contrast: #{colors.$mel-color-text};
+  --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.28)};
+  --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 42%)};
 }
 
 .mel-event-page--colour-gold {
   --mel-event-accent: #{colors.$mel-color-orange};
   --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #fff, 22%)};
   --mel-event-accent-contrast: #{colors.$mel-color-text};
+  --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.3)};
+  --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 38%)};
 }
 
 .mel-event-page--colour-blue {
   --mel-event-accent: #{colors.$mel-color-info};
   --mel-event-accent-soft: #{colors.$mel-color-info-bg};
   --mel-event-accent-contrast: #{colors.$mel-color-on-primary};
+  --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.3)};
+  --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 40%)};
 }
 
 // Page shell warmth when Classic event is present (article bg alone leaves white gutters).
@@ -114,7 +124,7 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     border: none;
-    box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
+    box-shadow: 0 4px 14px var(--mel-event-accent-glow, rgba(41, 50, 65, 0.18));
   }
 
   // Popularity / intelligence pill in hero chip (Mockup 1 top-left).
@@ -130,7 +140,7 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     font-size: 13px;
     font-weight: 600;
     line-height: 1.2;
-    box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
+    box-shadow: 0 4px 14px var(--mel-event-accent-glow, rgba(41, 50, 65, 0.18));
   }
 
   // Floating meta strip — white card overlapping hero foot.
@@ -263,8 +273,9 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
   .mel-card--sticky .mel-chip--filled,
   .mel-card--sticky .mel-chip {
     background: var(--mel-event-accent-soft);
-    border: 1px solid var(--mel-event-accent);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-accent));
     color: var(--mel-event-accent-strong);
+    box-shadow: 0 2px 8px var(--mel-event-accent-glow, transparent);
   }
 
   .mel-card--sticky .mel-booking-panel__save,
@@ -286,8 +297,9 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 
   // Warm “Grab the extras” panel (outer section card).
   .mel-event-section--extras.mel-card--surface {
-    background: var(--mel-event-surface-soft);
-    border-color: var(--mel-event-border);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 55%, var(--mel-event-surface-soft) 45%);
+    border-color: var(--mel-event-chip-border, var(--mel-event-border));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 
     > .mel-card__header,
     > .mel-card__body {
@@ -382,12 +394,13 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 
   .mel-event-share--panel .mel-event-share__chip-icon {
     background: var(--mel-event-accent-soft);
-    border-color: var(--mel-event-border);
+    border-color: var(--mel-event-chip-border, var(--mel-event-border));
     color: var(--mel-event-accent-strong);
+    box-shadow: 0 4px 12px var(--mel-event-accent-glow, transparent);
   }
 
   .mel-event-layout__main a:not(.mel-btn):not(.mel-social) {
-    color: color.mix(colors.$mel-color-primary, colors.$mel-color-navy, 35%);
+    color: var(--mel-event-accent-strong);
   }
 
   .mel-btn--primary,
@@ -399,7 +412,7 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
     font-weight: 600;
-    box-shadow: 0 8px 22px color.mix(#000, colors.$mel-color-primary, 12%);
+    box-shadow: 0 8px 22px var(--mel-event-accent-glow, rgba(41, 50, 65, 0.12));
   }
 
   .mel-btn--secondary,
@@ -415,7 +428,8 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
   .mel-mobile-cta .mel-btn--coral-cta {
     border-radius: 16px;
     background: var(--mel-coral, var(--mel-event-accent, #{colors.$mel-color-primary}));
-    color: colors.$mel-color-on-primary;
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    box-shadow: 0 10px 26px var(--mel-event-accent-glow, rgba(41, 50, 65, 0.14));
   }
 
   .mel-mobile-cta {
@@ -568,7 +582,7 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 44px;
     font-weight: 700;
-    box-shadow: 0 10px 28px color.mix(#000, colors.$mel-color-primary, 35%);
+    box-shadow: 0 10px 28px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
   }
 
   .mel-btn--secondary,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -470,49 +470,70 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
   }
 }
 
-// Immersive shell — extend page gutters to match cinematic backdrop.
+// Immersive shell — atmospheric canvas (article carries local accents).
 body:has(.mel-event-page--immersive.mel-event--v2),
 main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
-  background-color: #0a0f18;
+  background-color: #080c14;
+  background-image:
+    radial-gradient(ellipse 120% 55% at 50% -8%, rgba(255, 255, 255, 0.04) 0%, transparent 58%),
+    radial-gradient(ellipse 70% 50% at 100% 50%, rgba(255, 255, 255, 0.02) 0%, transparent 52%),
+    radial-gradient(ellipse 55% 45% at 0% 100%, rgba(0, 0, 0, 0.35) 0%, transparent 50%),
+    linear-gradient(180deg, #080c14 0%, #0c121c 50%, #101826 100%);
 }
 
-// Immersive — cinematic Pro experience (readability, depth, editorial spacing).
+// Immersive — cinematic Pro experience (single authored visual system).
 .mel-event-page--immersive.mel-event--v2 {
-  // Typography scale (immersive-only).
+  // Typography scale.
   --mel-immersive-text: #fff;
-  --mel-immersive-text-body: rgba(255, 255, 255, 0.84);
-  --mel-immersive-text-secondary: rgba(255, 255, 255, 0.74);
-  --mel-immersive-text-muted: rgba(255, 255, 255, 0.62);
-  --mel-immersive-text-meta: rgba(255, 255, 255, 0.72);
+  --mel-immersive-text-body: rgba(255, 255, 255, 0.86);
+  --mel-immersive-text-secondary: rgba(255, 255, 255, 0.76);
+  --mel-immersive-text-muted: rgba(255, 255, 255, 0.64);
+  --mel-immersive-text-meta: rgba(255, 255, 255, 0.74);
+  --mel-immersive-text-label: rgba(255, 255, 255, 0.7);
   --mel-event-heading: var(--mel-immersive-text);
   --mel-event-text: var(--mel-immersive-text-body);
   --mel-event-text-secondary: var(--mel-immersive-text-secondary);
   --mel-event-text-muted: var(--mel-immersive-text-muted);
-  --mel-event-divider: rgba(255, 255, 255, 0.2);
-  // Depth — tonal layers (avoid identical navy panels + loud outlines).
-  --mel-event-surface-quiet: rgba(24, 31, 44, 0.72);
-  --mel-event-surface: rgba(30, 38, 52, 0.82);
-  --mel-event-surface-raised: rgba(38, 48, 64, 0.88);
-  --mel-event-surface-spotlight: rgba(44, 56, 74, 0.92);
-  --mel-event-border: rgba(255, 255, 255, 0.08);
-  --mel-event-border-strong: rgba(255, 255, 255, 0.12);
-  --mel-event-shadow-elevated:
-    0 24px 56px rgba(0, 0, 0, 0.36),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --mel-event-shadow-sidebar:
-    0 28px 56px rgba(0, 0, 0, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.07);
-  --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 78%, #fff 22%);
-  --mel-event-surface-tint: transparent;
-  --mel-immersive-section-gap: #{space-tokens.mel-space(7)};
-  --mel-immersive-heading-size: clamp(1.375rem, 2.2vw, 1.625rem);
+  --mel-event-divider: rgba(255, 255, 255, 0.14);
+  --mel-immersive-heading-size: clamp(1.375rem, 2.1vw, 1.6rem);
+  --mel-immersive-heading-secondary: clamp(1.125rem, 1.6vw, 1.25rem);
   --mel-immersive-body-size: 1.0625rem;
+  --mel-immersive-lede-size: 1rem;
+  --mel-immersive-meta-size: 0.9375rem;
+  --mel-immersive-label-size: 0.8125rem;
+  // Spacing rhythm.
+  --mel-immersive-section-gap: #{space-tokens.mel-space(6)};
+  --mel-immersive-block-gap: #{space-tokens.mel-space(4)};
+  --mel-immersive-pad-primary: #{space-tokens.mel-space(6)};
+  --mel-immersive-pad-secondary: #{space-tokens.mel-space(5)};
+  --mel-immersive-pad-tertiary: #{space-tokens.mel-space(4)};
+  // Surfaces — tonal layers, minimal outlines.
+  --mel-event-surface-quiet: rgba(22, 28, 40, 0.55);
+  --mel-event-surface: rgba(28, 36, 50, 0.72);
+  --mel-event-surface-raised: rgba(34, 44, 60, 0.78);
+  --mel-event-surface-spotlight: rgba(40, 52, 70, 0.85);
+  --mel-event-border: rgba(255, 255, 255, 0.06);
+  --mel-event-border-strong: rgba(255, 255, 255, 0.1);
+  --mel-immersive-radius: #{radii.$mel-radius-xl};
+  --mel-immersive-radius-inner: #{radii.$mel-radius-lg};
+  --mel-immersive-shadow-quiet: 0 14px 36px rgba(0, 0, 0, 0.22);
+  --mel-immersive-shadow-panel: 0 22px 52px rgba(0, 0, 0, 0.3);
+  --mel-immersive-shadow-featured: 0 26px 60px rgba(0, 0, 0, 0.34);
+  --mel-immersive-shadow-sidebar: 0 18px 44px rgba(0, 0, 0, 0.32);
+  --mel-immersive-inset-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  --mel-event-shadow-elevated: var(--mel-immersive-shadow-panel);
+  --mel-event-shadow-sidebar: var(--mel-immersive-shadow-sidebar);
+  --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 78%, #fff 22%);
+  --mel-event-accent-glow-cta: color-mix(in srgb, var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35)) 55%, transparent);
+  --mel-event-surface-tint: transparent;
 
   background:
-    radial-gradient(ellipse 100% 70% at 50% -12%, color-mix(in srgb, var(--mel-event-accent) 18%, transparent) 0%, transparent 62%),
-    radial-gradient(ellipse 50% 42% at 100% 8%, color-mix(in srgb, var(--mel-event-accent) 10%, transparent) 0%, transparent 55%),
-    radial-gradient(ellipse 40% 38% at 0% 92%, rgba(255, 255, 255, 0.03) 0%, transparent 58%),
-    linear-gradient(180deg, #0a0f18 0%, #101825 45%, #161f2e 100%);
+    radial-gradient(ellipse 95% 65% at 50% -10%, color-mix(in srgb, var(--mel-event-accent) 14%, transparent) 0%, transparent 60%),
+    radial-gradient(ellipse 48% 40% at 100% 6%, color-mix(in srgb, var(--mel-event-accent) 8%, transparent) 0%, transparent 52%),
+    radial-gradient(ellipse 42% 36% at 0% 88%, rgba(255, 255, 255, 0.025) 0%, transparent 55%),
+    radial-gradient(ellipse 80% 50% at 50% 100%, rgba(0, 0, 0, 0.25) 0%, transparent 62%),
+    linear-gradient(180deg, transparent 0%, rgba(12, 18, 28, 0.4) 100%);
+  background-color: transparent;
   color: var(--mel-event-text);
   min-height: 100vh;
 
@@ -556,25 +577,25 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     --mel-event-surface-tint: #{color.mix(colors.$mel-color-info, #121820, 10%)};
   }
 
-  padding-top: space-tokens.mel-space(5);
-  padding-bottom: space-tokens.mel-space(8);
+  padding-top: space-tokens.mel-space(6);
+  padding-bottom: space-tokens.mel-space(9);
 
   .mel-container {
     max-width: min(100%, 76rem);
   }
 
   .mel-event__hero {
-    margin-bottom: space-tokens.mel-space(5);
+    margin-bottom: var(--mel-immersive-block-gap);
   }
 
-  // Hero — cinematic scale, soft edge (no outlined rectangle).
+  // Hero — primary focal (soft edge, no outline box).
   .mel-event-hero--featured-style {
     min-height: clamp(22rem, 42vw, 34rem);
-    margin-bottom: space-tokens.mel-space(5);
+    margin-bottom: var(--mel-immersive-block-gap);
     border: none;
-    border-radius: radii.$mel-radius-xl;
+    border-radius: var(--mel-immersive-radius);
     overflow: hidden;
-    box-shadow: 0 36px 80px rgba(0, 0, 0, 0.48);
+    box-shadow: var(--mel-immersive-shadow-featured);
   }
 
   .mel-event-hero--featured-style .mel-event-hero__overlay {
@@ -623,37 +644,37 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   }
 
-  // Meta strip — premium floating bar.
+  // Meta strip — integrated bar (tonal, not a separate widget).
   .mel-event-meta-bar {
     margin-top: 0;
-    margin-bottom: space-tokens.mel-space(6);
-    padding: space-tokens.mel-space(4) space-tokens.mel-space(5);
-    background: rgba(14, 20, 30, 0.82);
-    border: 1px solid var(--mel-event-border);
-    border-radius: radii.$mel-radius-xl;
-    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.38);
+    margin-bottom: var(--mel-immersive-section-gap);
+    padding: var(--mel-immersive-pad-secondary) var(--mel-immersive-pad-primary);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 12%, rgba(12, 17, 26, 0.78) 88%);
+    border: none;
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-quiet);
     color: var(--mel-immersive-text-body);
-    backdrop-filter: blur(14px);
-    gap: space-tokens.mel-space(4);
+    backdrop-filter: blur(12px);
+    gap: var(--mel-immersive-block-gap);
   }
 
   .mel-event-meta__primary {
     color: var(--mel-immersive-text);
-    font-size: 1.0625rem;
+    font-size: var(--mel-immersive-body-size);
     font-weight: 600;
-    line-height: 1.3;
+    line-height: 1.35;
   }
 
   .mel-event-meta__secondary {
     color: var(--mel-immersive-text-meta);
-    font-size: 0.9375rem;
-    line-height: 1.45;
+    font-size: var(--mel-immersive-meta-size);
+    line-height: 1.5;
   }
 
   .mel-event-meta__icon {
-    width: 2.25rem;
-    height: 2.25rem;
-    border-radius: 12px;
+    width: 2.125rem;
+    height: 2.125rem;
+    border-radius: var(--mel-immersive-radius-inner);
     opacity: 1;
   }
 
@@ -673,14 +694,14 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     }
   }
 
-  // Layout rhythm — editorial column spacing.
+  // Layout rhythm — connected columns on one canvas.
   .mel-event-layout {
     margin-top: 0;
-    gap: space-tokens.mel-space(6);
+    gap: var(--mel-immersive-section-gap);
 
     @include breakpoints.mel-break(lg) {
-      grid-template-columns: minmax(0, 1fr) min(400px, 34vw);
-      column-gap: space-tokens.mel-space(6);
+      grid-template-columns: minmax(0, 1fr) min(392px, 33vw);
+      column-gap: var(--mel-immersive-section-gap);
     }
   }
 
@@ -691,65 +712,81 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     gap: var(--mel-immersive-section-gap);
   }
 
-  // Card system — shadow separation, neutral edges (accent on CTAs/chips only).
+  // Card hierarchy — primary / secondary / tertiary weight.
   .mel-event-layout__main .mel-card--surface {
-    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 22%, var(--mel-event-surface-raised) 78%);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 16%, var(--mel-event-surface-raised) 84%);
     border: none;
-    box-shadow: var(--mel-event-shadow-elevated);
-    backdrop-filter: blur(10px);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-panel);
+    backdrop-filter: blur(8px);
   }
 
   .mel-card--highlights {
     background: var(--mel-event-surface-quiet);
     border: none;
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-quiet);
+    backdrop-filter: none;
   }
 
   .mel-card--expect {
-    background: var(--mel-event-surface);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 8%, var(--mel-event-surface) 92%);
     border: none;
-    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.32);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-panel);
+    backdrop-filter: blur(6px);
   }
 
   .mel-event-section--share.mel-card--surface {
     background: var(--mel-event-surface-quiet);
     border: none;
-    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.26);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-quiet);
+    backdrop-filter: none;
   }
 
   .mel-card--sticky {
-    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 18%, var(--mel-event-surface-spotlight) 82%);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 14%, var(--mel-event-surface-spotlight) 86%);
     border: none;
-    box-shadow: var(--mel-event-shadow-sidebar);
-    backdrop-filter: blur(12px);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-sidebar);
+    backdrop-filter: blur(10px);
   }
 
   .mel-card--surface .mel-card__header,
   .mel-card--surface .mel-card__body {
-    padding: space-tokens.mel-space(5) space-tokens.mel-space(6);
+    padding: var(--mel-immersive-pad-secondary) var(--mel-immersive-pad-primary);
 
     @include breakpoints.mel-break(lg) {
-      padding: space-tokens.mel-space(6) space-tokens.mel-space(7);
+      padding: var(--mel-immersive-pad-primary) calc(var(--mel-immersive-pad-primary) + #{space-tokens.mel-space(1)});
     }
   }
 
   .mel-card--highlights .mel-card__header,
   .mel-card--highlights .mel-card__body {
-    padding: space-tokens.mel-space(4) space-tokens.mel-space(5);
+    padding: var(--mel-immersive-pad-tertiary) var(--mel-immersive-pad-secondary);
   }
 
   .mel-card--expect .mel-card__header,
   .mel-card--expect .mel-card__body {
-    padding: space-tokens.mel-space(5) space-tokens.mel-space(6);
+    padding: var(--mel-immersive-pad-secondary) var(--mel-immersive-pad-primary);
   }
 
   .mel-card--sticky .mel-card__header,
   .mel-card--sticky .mel-card__body {
-    padding: space-tokens.mel-space(5) space-tokens.mel-space(5);
+    padding: var(--mel-immersive-pad-secondary);
 
     @include breakpoints.mel-break(lg) {
-      padding: space-tokens.mel-space(6);
+      padding: var(--mel-immersive-pad-primary) var(--mel-immersive-pad-secondary);
     }
+  }
+
+  .mel-card__header {
+    margin-bottom: 0;
+  }
+
+  .mel-card__title {
+    margin-bottom: var(--mel-immersive-block-gap);
   }
 
   .mel-event-layout__main,
@@ -789,10 +826,13 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   .mel-card--sticky .mel-chip--filled,
   .mel-card--sticky .mel-chip {
-    background: var(--mel-event-accent-soft);
-    border: 1px solid var(--mel-event-chip-border, var(--mel-event-accent));
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 85%, transparent);
+    border: none;
     color: var(--mel-event-accent-strong);
     box-shadow: none;
+    font-size: var(--mel-immersive-label-size);
+    font-weight: 600;
+    letter-spacing: 0.01em;
   }
 
   .mel-card--sticky .mel-booking-panel__item-icon,
@@ -802,15 +842,15 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-card--sticky .mel-booking-panel__item--highlight {
-    background: color-mix(in srgb, var(--mel-event-accent-soft) 70%, var(--mel-event-surface-spotlight) 30%);
-    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border));
-    border-radius: radii.$mel-radius-md;
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 55%, var(--mel-event-surface-spotlight) 45%);
+    border: none;
+    border-radius: var(--mel-immersive-radius-inner);
   }
 
   .mel-card--sticky .mel-booking-panel__save,
   .mel-card--sticky .mel-booking-panel__save--fav {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid var(--mel-event-border);
+    background: rgba(255, 255, 255, 0.04);
+    border: none;
     box-shadow: none;
     color: var(--mel-immersive-text-body);
   }
@@ -819,14 +859,17 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-layout__main .mel-event__signal,
   .mel-event-layout__sidebar .mel-event__signal {
     color: var(--mel-immersive-text-body);
-    background: var(--mel-event-accent-soft);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 80%, transparent);
+    border: none;
+    box-shadow: none;
+    font-size: var(--mel-immersive-label-size);
   }
 
   .mel-event__signal--strong,
   .mel-card--sticky .mel-event__signal--strong {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
-    box-shadow: 0 8px 24px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
   }
 
   .mel-event-info__title,
@@ -835,25 +878,50 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     color: var(--mel-immersive-text);
     font-size: var(--mel-immersive-heading-size);
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.22;
     letter-spacing: -0.02em;
+  }
+
+  .mel-card--highlights .mel-card__title,
+  .mel-event-section--share .mel-event-section__title {
+    font-size: var(--mel-immersive-heading-secondary);
+    font-weight: 600;
   }
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
-    height: 3px;
+    height: 2px;
+    margin-top: space-tokens.mel-space(2);
     background: linear-gradient(
       90deg,
-      var(--mel-event-accent, colors.$mel-color-primary) 0%,
-      var(--mel-event-divider) 80%
+      color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 70%, transparent) 0%,
+      var(--mel-event-divider) 72%
     );
-    opacity: 1;
+    opacity: 0.9;
   }
 
   .mel-event-info__body,
   .mel-event-section__body {
     font-size: var(--mel-immersive-body-size);
-    line-height: 1.65;
+    line-height: 1.68;
+  }
+
+  .mel-event-section__lede {
+    font-size: var(--mel-immersive-lede-size);
+    line-height: 1.6;
+    margin-bottom: var(--mel-immersive-block-gap);
+  }
+
+  .mel-event-info__label {
+    font-size: var(--mel-immersive-label-size);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .mel-card--sticky .mel-card__title {
+    font-size: var(--mel-immersive-heading-secondary);
+    margin-bottom: space-tokens.mel-space(3);
   }
 
   // Typography — beat _event-full.scss dim hardcoded greys on dark surfaces.
@@ -872,6 +940,11 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-info__body li,
   .mel-event-section__body li {
     color: var(--mel-immersive-text-body);
+  }
+
+  .mel-event-info__body p + p,
+  .mel-event-section__body p + p {
+    margin-top: 1em;
   }
 
   .mel-text--muted,
@@ -924,17 +997,21 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-highlights__icon {
-    background: var(--mel-event-accent-soft);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 75%, transparent);
     color: var(--mel-event-accent-strong);
-    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border));
+    border: none;
   }
 
+  .mel-card--highlights .mel-event-highlights__item {
+    gap: space-tokens.mel-space(3);
+  }
+
+  // Extras — featured primary block, integrated rows (not nested commerce widgets).
   .mel-event-section--extras.mel-card--surface {
-    background: color-mix(in srgb, var(--mel-event-accent-soft) 38%, var(--mel-event-surface-spotlight) 62%);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 32%, var(--mel-event-surface-spotlight) 68%);
     border: none;
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.07),
-      0 24px 52px rgba(0, 0, 0, 0.38);
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-featured);
 
     > .mel-card__header,
     > .mel-card__body {
@@ -945,47 +1022,95 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-section--extras .mel-card__title,
   .mel-event-section--extras .mel-event-section__title {
     color: var(--mel-immersive-text);
+    font-size: var(--mel-immersive-heading-size);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser.mel-card--surface {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
   }
 
   .mel-event-section--extras .mel-addon-teaser__list {
-    gap: space-tokens.mel-space(3);
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 
   .mel-event-section--extras .mel-addon-teaser__item {
-    padding: space-tokens.mel-space(4);
-    background: rgba(22, 30, 42, 0.75);
+    display: flex;
+    align-items: center;
+    gap: var(--mel-immersive-block-gap);
+    padding: var(--mel-immersive-pad-secondary) 0;
+    background: transparent;
     border: none;
-    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3);
+    border-bottom: 1px solid var(--mel-event-divider);
+    border-radius: 0;
+    box-shadow: none;
+
+    &:last-child {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+
+    &:first-child {
+      padding-top: space-tokens.mel-space(2);
+    }
   }
 
   .mel-event-section--extras .mel-addon-teaser__thumb {
-    width: 64px;
-    height: 64px;
-    border-radius: radii.$mel-radius-lg;
+    width: 72px;
+    height: 72px;
+    border-radius: var(--mel-immersive-radius-inner);
+    object-fit: cover;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__name {
+    font-size: var(--mel-immersive-body-size);
+    font-weight: 600;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__price {
+    font-size: var(--mel-immersive-meta-size);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__actions {
+    margin-top: var(--mel-immersive-block-gap);
+    padding-top: var(--mel-immersive-block-gap);
+    border-top: 1px solid var(--mel-event-divider);
   }
 
   .mel-event-section--extras .mel-addon-teaser__cta,
   .mel-event-section--extras .mel-addon-teaser__scroll,
   .mel-event-section--extras .mel-addon-teaser__cta.mel-btn--secondary,
   .mel-event-section--extras .mel-addon-teaser__scroll.mel-btn--secondary {
-    border-color: var(--mel-event-accent);
+    border: none;
     color: var(--mel-immersive-text);
-    background: color-mix(in srgb, var(--mel-event-accent-soft) 45%, transparent);
+    background: var(--mel-event-accent, colors.$mel-color-primary);
     min-height: 44px;
     font-weight: 600;
+    border-radius: var(--mel-immersive-radius-inner);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background: var(--mel-event-accent-soft);
-        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+        filter: brightness(1.06);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.32);
       }
     }
   }
 
   .mel-event-map-embed {
     border: none;
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
-    border-radius: radii.$mel-radius-lg;
+    box-shadow: var(--mel-immersive-shadow-quiet);
+    border-radius: var(--mel-immersive-radius-inner);
   }
 
   .mel-event-share--panel .mel-event-share__chip-icon {
@@ -999,39 +1124,35 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     color: var(--mel-immersive-text-secondary);
   }
 
-  .mel-event-support-zone {
-    border-top: 1px solid var(--mel-event-border-strong);
-    color: var(--mel-immersive-text-body);
-  }
-
-  // Primary CTA glow — sidebar + mobile bar only (not every panel).
+  // Conversion CTA — sidebar + mobile only; calm panel, bright button.
   .mel-card--sticky .mel-btn--primary,
   .mel-card--sticky .mel-btn--coral-cta,
   .mel-card--sticky .button--primary,
   .mel-mobile-cta .mel-btn--primary,
   .mel-mobile-cta .mel-btn--coral-cta {
     background-color: var(--mel-event-accent, colors.$mel-color-primary);
-    border-color: color-mix(in srgb, var(--mel-event-accent) 88%, #fff 12%);
+    border-color: transparent;
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
     min-height: 48px;
     font-weight: 700;
+    letter-spacing: 0.01em;
     box-shadow:
-      0 14px 36px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.38)),
-      0 0 0 1px color-mix(in srgb, var(--mel-event-accent) 55%, #fff 45%);
+      0 12px 28px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.32)),
+      0 2px 8px rgba(0, 0, 0, 0.2);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        filter: brightness(1.08) saturate(1.06);
+        filter: brightness(1.06) saturate(1.04);
         box-shadow:
-          0 18px 42px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.45)),
-          0 0 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.28));
+          0 16px 34px var(--mel-event-accent-glow-cta, rgba(0, 0, 0, 0.36)),
+          0 4px 12px rgba(0, 0, 0, 0.22);
       }
     }
   }
 
   .mel-card--sticky .mel-btn--coral-cta,
   .mel-mobile-cta .mel-btn--coral-cta {
-    border-radius: 16px;
+    border-radius: var(--mel-immersive-radius-inner);
   }
 
   .mel-btn--primary,
@@ -1047,32 +1168,59 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   .mel-btn--secondary,
   .button--secondary {
-    background: var(--mel-event-surface-spotlight);
-    border-color: var(--mel-event-border-strong);
+    background: color-mix(in srgb, var(--mel-event-surface-spotlight) 90%, transparent);
+    border: none;
     color: var(--mel-event-heading);
     min-height: 44px;
+    box-shadow: var(--mel-immersive-inset-highlight);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        border-color: var(--mel-event-accent);
+        background: color-mix(in srgb, var(--mel-event-accent-soft) 40%, var(--mel-event-surface-spotlight) 60%);
         color: var(--mel-event-accent-strong);
       }
     }
   }
 
-  .mel-mobile-cta {
-    background: var(--mel-event-surface-raised);
-    border-top: 1px solid var(--mel-event-border-strong);
-    box-shadow: 0 -10px 36px rgba(0, 0, 0, 0.42);
+  .mel-organiser-card,
+  .mel-return-block {
+    border-radius: var(--mel-immersive-radius);
+    box-shadow: var(--mel-immersive-shadow-quiet);
+    border: none;
+  }
+
+  .mel-event-support-zone {
+    border-top: 1px solid var(--mel-event-divider);
+    padding-top: var(--mel-immersive-pad-primary);
+    margin-top: var(--mel-immersive-block-gap);
     color: var(--mel-immersive-text-body);
+  }
+
+  @include breakpoints.mel-break(lg) {
+    .mel-event-layout__sidebar > .mel-card--sticky {
+      position: sticky;
+      top: space-tokens.mel-space(4);
+    }
+  }
+
+  .mel-mobile-cta {
+    background: color-mix(in srgb, var(--mel-event-surface-raised) 92%, transparent);
+    border-top: none;
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.36);
+    color: var(--mel-immersive-text-body);
+    backdrop-filter: blur(10px);
   }
 
   @include breakpoints.mel-break(md, max) {
     --mel-immersive-section-gap: #{space-tokens.mel-space(5)};
+    --mel-immersive-block-gap: #{space-tokens.mel-space(3)};
     --mel-immersive-heading-size: 1.3125rem;
+    --mel-immersive-pad-primary: #{space-tokens.mel-space(5)};
+    --mel-immersive-pad-secondary: #{space-tokens.mel-space(4)};
+    --mel-immersive-pad-tertiary: #{space-tokens.mel-space(4)};
 
-    padding-top: space-tokens.mel-space(4);
-    padding-bottom: space-tokens.mel-space(6);
+    padding-top: space-tokens.mel-space(5);
+    padding-bottom: space-tokens.mel-space(7);
 
     .mel-event-hero--featured-style {
       min-height: 20rem;
@@ -1129,6 +1277,18 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     .mel-btn--secondary,
     .button--secondary {
       min-height: 44px;
+    }
+
+    .mel-event-section--extras .mel-addon-teaser__thumb {
+      width: 64px;
+      height: 64px;
+    }
+
+    .mel-card--highlights .mel-card__header,
+    .mel-card--highlights .mel-card__body,
+    .mel-card--expect .mel-card__header,
+    .mel-card--expect .mel-card__body {
+      padding: var(--mel-immersive-pad-tertiary) var(--mel-immersive-pad-secondary);
     }
   }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -484,8 +484,10 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   --mel-event-border: rgba(255, 255, 255, 0.16);
   --mel-event-border-strong: rgba(255, 255, 255, 0.24);
   --mel-event-heading: #ffffff;
-  --mel-event-text: #eef2f8;
-  --mel-event-text-muted: #b7c2d2;
+  --mel-event-text: #ebe6e1;
+  --mel-event-text-secondary: #d4dce6;
+  --mel-event-text-muted: #c2ccd9;
+  --mel-event-divider: rgba(237, 230, 222, 0.28);
   --mel-event-shadow-elevated:
     0 22px 54px rgba(0, 0, 0, 0.48),
     0 0 0 1px rgba(255, 255, 255, 0.07),
@@ -590,7 +592,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-meta__secondary {
-    color: var(--mel-event-text);
+    color: var(--mel-event-text-secondary);
   }
 
   .mel-event-meta__icon {
@@ -653,9 +655,12 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-card--sticky .mel-booking-panel__chip,
-  .mel-event__meta,
-  .mel-event-info__label {
+  .mel-event__meta {
     color: var(--mel-event-text-muted);
+  }
+
+  .mel-event-info__label {
+    color: var(--mel-event-text-secondary);
   }
 
   .mel-card--sticky .mel-chip--filled,
@@ -708,16 +713,76 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
-    background: var(--mel-event-accent, colors.$mel-color-primary);
+    background: linear-gradient(
+      90deg,
+      var(--mel-event-accent, colors.$mel-color-primary) 0%,
+      var(--mel-event-divider) 72%
+    );
     opacity: 1;
   }
 
-  .mel-text--muted,
-  .mel-event-section__lede,
-  .mel-muted,
-  .mel-event-info__body p,
-  .mel-event-section__body p {
+  // Typography readability — beat _event-full.scss dim hardcoded greys on dark surfaces.
+  .mel-event-info__body,
+  .mel-event-info__body .field__item,
+  .mel-event-info__body .text-formatted,
+  .mel-event-section__body,
+  .mel-event-section__body .text-formatted {
     color: var(--mel-event-text);
+  }
+
+  .mel-text--muted,
+  .mel-muted,
+  .mel-event-section__lede,
+  .mel-event-info__body p,
+  .mel-event-section__body p,
+  .mel-event-info__body li,
+  .mel-event-section__body li {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-section__lede,
+  .mel-event-section--extras .mel-addon-teaser__intro,
+  .mel-event-section--extras .mel-addon-teaser__hint,
+  .mel-event-section--extras .mel-addon-teaser__more {
+    color: var(--mel-event-text-secondary);
+  }
+
+  .mel-card--sticky .mel-booking-panel__chip,
+  .mel-card--sticky .mel-booking-panel__product,
+  .mel-card--sticky .mel-booking-panel__trust-line,
+  .mel-card--sticky .mel-booking-panel__trust-micro,
+  .mel-card--sticky .mel-booking-panel__trust-micro p,
+  .mel-card--sticky .mel-trust-rotator,
+  .mel-card--sticky .mel-trust-rotator .mel-trust-item,
+  .mel-card--sticky .mel-trust-rotator .mel-trust-item__text,
+  .mel-card--sticky .mel-booking-panel__save-hint,
+  .mel-card--sticky .mel-booking-panel__save-text p {
+    color: var(--mel-event-text-muted);
+  }
+
+  .mel-card--sticky .mel-booking-panel__trust-micro-primary,
+  .mel-card--sticky .mel-booking-panel__save-label,
+  .mel-card--sticky .mel-booking-panel__save-text strong {
+    color: var(--mel-event-text-secondary);
+  }
+
+  .mel-card--sticky .mel-booking-panel__rule,
+  .mel-card--sticky .mel-booking-panel__trust-micro,
+  .mel-card--sticky .mel-decision-prompts {
+    border-top-color: var(--mel-event-divider);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__name {
+    color: var(--mel-event-text-secondary);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__price {
+    color: var(--mel-event-text);
+    font-weight: 600;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__actions {
+    border-top-color: var(--mel-event-divider);
   }
 
   .mel-event-highlights__icon {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -117,11 +117,11 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     box-shadow: 0 4px 14px rgba(41, 50, 65, 0.18);
   }
 
-  // Intelligence / popularity chip in hero content (Twig uses mel_event_signal, not hero__chip).
-  .mel-event-hero--featured-style .mel-event-hero__content .mel-event__signal {
+  // Popularity / intelligence pill in hero chip (Mockup 1 top-left).
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__signal--hero-chip,
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__signal {
     display: inline-flex;
     align-items: center;
-    align-self: flex-start;
     margin: 0;
     padding: 6px 14px;
     border-radius: 999px;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -470,52 +470,136 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
   }
 }
 
-// Immersive — cinematic full-page treatment (obvious vs Classic).
+// Immersive shell — extend page gutters to match cinematic backdrop.
+body:has(.mel-event-page--immersive.mel-event--v2),
+main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
+  background-color: #060a12;
+}
+
+// Immersive — cinematic full-page treatment (readable, high-contrast, palette-forward).
 .mel-event-page--immersive.mel-event--v2 {
-  --mel-event-surface: #{color.mix(colors.$mel-color-navy, #0d1117, 88%)};
-  --mel-event-surface-raised: #{color.mix(colors.$mel-color-navy, #1a2330, 72%)};
-  --mel-event-text: #{colors.$mel-color-text-inverse};
-  --mel-event-text-muted: #{color.mix(#fff, colors.$mel-color-navy, 62%)};
+  --mel-event-surface: #1a2230;
+  --mel-event-surface-raised: #232d3d;
+  --mel-event-surface-spotlight: #2b3749;
+  --mel-event-border: rgba(255, 255, 255, 0.16);
+  --mel-event-border-strong: rgba(255, 255, 255, 0.24);
+  --mel-event-heading: #ffffff;
+  --mel-event-text: #eef2f8;
+  --mel-event-text-muted: #b7c2d2;
+  --mel-event-shadow-elevated:
+    0 22px 54px rgba(0, 0, 0, 0.48),
+    0 0 0 1px rgba(255, 255, 255, 0.07),
+    0 0 40px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
+  --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 78%, #fff 22%);
 
   background:
-    radial-gradient(120% 80% at 50% -10%, rgba(255, 255, 255, 0.08) 0%, transparent 55%),
-    linear-gradient(
-      180deg,
-      color.mix(colors.$mel-color-navy, #000, 92%) 0%,
-      color.mix(colors.$mel-color-navy, #1a2330, 72%) 100%
-    );
+    radial-gradient(ellipse 95% 62% at 50% -8%, color-mix(in srgb, var(--mel-event-accent) 22%, transparent) 0%, transparent 58%),
+    radial-gradient(ellipse 55% 40% at 100% 12%, color-mix(in srgb, var(--mel-event-accent) 12%, transparent) 0%, transparent 52%),
+    radial-gradient(ellipse 45% 35% at 0% 88%, rgba(255, 255, 255, 0.04) 0%, transparent 55%),
+    linear-gradient(180deg, #060a12 0%, #0d121b 42%, #141b27 100%);
   color: var(--mel-event-text);
+  min-height: 100vh;
+
+  .mel-container {
+    color: var(--mel-event-text);
+  }
+
+  // Immersive-only palette lift (Classic colour tokens above stay unchanged).
+  &.mel-event-page--colour-coral {
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #1a2230, 28%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.48)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 28%)};
+  }
+
+  &.mel-event-page--colour-purple {
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-accent, #1a2230, 32%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.5)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 30%)};
+  }
+
+  &.mel-event-page--colour-mint {
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-success, #1a2230, 30%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.42)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 32%)};
+  }
+
+  &.mel-event-page--colour-gold {
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #1a2230, 30%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.46)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 30%)};
+  }
+
+  &.mel-event-page--colour-blue {
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-info, #1a2230, 30%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.44)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 30%)};
+  }
 
   .mel-event-hero--featured-style {
     border-radius: radii.$mel-radius-xl;
     overflow: hidden;
-    box-shadow: 0 24px 56px rgba(0, 0, 0, 0.45);
+    box-shadow:
+      0 28px 64px rgba(0, 0, 0, 0.55),
+      0 0 48px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.25));
   }
 
   .mel-event-hero--featured-style .mel-event-hero__overlay {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.05) 0%,
-      rgba(13, 17, 23, 0.55) 42%,
-      rgba(13, 17, 23, 0.94) 100%
+      rgba(0, 0, 0, 0.08) 0%,
+      rgba(10, 14, 22, 0.52) 45%,
+      rgba(8, 11, 18, 0.9) 100%
     );
   }
 
   .mel-event-hero__content,
   .mel-event-hero-card__title,
   #mel-event-title {
-    color: var(--mel-event-text);
-    text-shadow: 0 2px 24px rgba(0, 0, 0, 0.55);
+    color: var(--mel-event-heading);
+    text-shadow: 0 2px 28px rgba(0, 0, 0, 0.65);
     letter-spacing: -0.02em;
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__datetime,
+  .mel-event-hero--featured-style .mel-event-hero__venue {
+    color: #f3f6fb;
+    opacity: 1;
+  }
+
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__category,
+  .mel-event-hero--featured-style .mel-event__category,
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__signal--hero-chip,
+  .mel-event-hero--featured-style .mel-event-hero__chip .mel-event__signal {
+    background: var(--mel-event-accent, colors.$mel-color-primary);
+    color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
+    box-shadow: 0 6px 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
   }
 
   .mel-event-meta-bar {
     margin-top: space-tokens.mel-space(3);
     background: var(--mel-event-surface-raised);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+    border: 1px solid var(--mel-event-border-strong);
+    box-shadow: var(--mel-event-shadow-elevated);
     color: var(--mel-event-text);
-    backdrop-filter: blur(6px);
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-event-meta__primary {
+    color: var(--mel-event-heading);
+    font-weight: 600;
+  }
+
+  .mel-event-meta__secondary {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-meta__icon {
+    color: var(--mel-event-accent-strong);
+    opacity: 1;
+  }
+
+  .mel-event-meta-bar a {
+    color: var(--mel-event-accent-strong);
   }
 
   .mel-event__card,
@@ -523,10 +607,33 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
   .mel-event-layout__main .mel-card,
   .mel-card--surface {
     background: var(--mel-event-surface-raised);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+    border: 1px solid var(--mel-event-border-strong);
+    box-shadow: var(--mel-event-shadow-elevated);
     color: var(--mel-event-text);
-    backdrop-filter: blur(6px);
+    backdrop-filter: blur(10px);
+  }
+
+  .mel-card--highlights,
+  .mel-card--expect {
+    background: var(--mel-event-surface-spotlight);
+    border-color: var(--mel-event-border-strong);
+  }
+
+  .mel-card--sticky {
+    box-shadow:
+      var(--mel-event-shadow-elevated),
+      0 0 32px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
+  }
+
+  .mel-card--surface .mel-card__header,
+  .mel-card--surface .mel-card__body,
+  .mel-card--sticky .mel-card__header,
+  .mel-card--sticky .mel-card__body {
+    padding: space-tokens.mel-space(4);
+
+    @include breakpoints.mel-break(lg) {
+      padding: space-tokens.mel-space(5);
+    }
   }
 
   .mel-event-layout__main,
@@ -536,14 +643,13 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     color: var(--mel-event-text);
   }
 
-  .mel-event-meta-bar a,
-  .mel-event-layout__main a:not(.mel-btn) {
-    color: color.mix(#fff, colors.$mel-color-accent, 70%);
+  .mel-event-layout__main a:not(.mel-btn):not(.mel-social) {
+    color: var(--mel-event-accent-strong);
   }
 
-  .mel-card--sticky .mel-booking-panel__price,
-  .mel-event__signal {
-    color: var(--mel-event-text);
+  .mel-card--sticky .mel-booking-panel__price {
+    color: var(--mel-event-heading);
+    font-weight: 700;
   }
 
   .mel-card--sticky .mel-booking-panel__chip,
@@ -552,51 +658,189 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     color: var(--mel-event-text-muted);
   }
 
-  .mel-event__signal--strong {
+  .mel-card--sticky .mel-chip--filled,
+  .mel-card--sticky .mel-chip {
+    background: var(--mel-event-accent-soft);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-accent));
+    color: var(--mel-event-accent-strong);
+    box-shadow: 0 4px 14px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.25));
+  }
+
+  .mel-card--sticky .mel-booking-panel__item-icon,
+  .mel-card--sticky .mel-booking-panel__item--highlight .mel-icon,
+  .mel-card--sticky .mel-trust-item__text {
+    color: var(--mel-event-accent-strong);
+  }
+
+  .mel-card--sticky .mel-booking-panel__item--highlight {
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 70%, var(--mel-event-surface-spotlight) 30%);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border));
+    border-radius: radii.$mel-radius-md;
+  }
+
+  .mel-card--sticky .mel-booking-panel__save,
+  .mel-card--sticky .mel-booking-panel__save--fav {
+    background: var(--mel-event-surface-spotlight);
+    border-color: var(--mel-event-border-strong);
+    color: var(--mel-event-text);
+  }
+
+  .mel-event__signal,
+  .mel-event-layout__main .mel-event__signal,
+  .mel-event-layout__sidebar .mel-event__signal {
+    color: var(--mel-event-text);
+    background: var(--mel-event-accent-soft);
+  }
+
+  .mel-event__signal--strong,
+  .mel-card--sticky .mel-event__signal--strong {
     background: var(--mel-event-accent, colors.$mel-color-primary);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 8px 24px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
   }
 
   .mel-event-info__title,
   .mel-event-section__title,
   .mel-card__title {
-    color: var(--mel-event-text);
+    color: var(--mel-event-heading);
+    font-weight: 700;
   }
 
   .mel-event-info__title::after,
   .mel-event-section__title::after {
     background: var(--mel-event-accent, colors.$mel-color-primary);
+    opacity: 1;
   }
 
-  .mel-event-section--extras {
-    background: color.mix(colors.$mel-color-navy, colors.$mel-color-primary, 92%);
-    border-color: rgba(255, 255, 255, 0.12);
+  .mel-text--muted,
+  .mel-event-section__lede,
+  .mel-muted,
+  .mel-event-info__body p,
+  .mel-event-section__body p {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-highlights__icon {
+    background: var(--mel-event-accent-soft);
+    color: var(--mel-event-accent-strong);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border));
+  }
+
+  .mel-event-section--extras.mel-card--surface {
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 42%, var(--mel-event-surface-spotlight) 58%);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border-strong));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 18px 42px rgba(0, 0, 0, 0.35);
+
+    > .mel-card__header,
+    > .mel-card__body {
+      background: transparent;
+    }
+  }
+
+  .mel-event-section--extras .mel-card__title,
+  .mel-event-section--extras .mel-event-section__title {
+    color: var(--mel-event-accent-strong);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__item {
+    background: var(--mel-event-surface-raised);
+    border: 1px solid var(--mel-event-border-strong);
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.28);
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__cta,
+  .mel-event-section--extras .mel-addon-teaser__scroll,
+  .mel-event-section--extras .mel-addon-teaser__cta.mel-btn--secondary,
+  .mel-event-section--extras .mel-addon-teaser__scroll.mel-btn--secondary {
+    border-color: var(--mel-event-accent);
+    color: var(--mel-event-accent-strong);
+    background: color-mix(in srgb, var(--mel-event-accent-soft) 35%, transparent);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: var(--mel-event-accent-soft);
+        box-shadow: 0 8px 20px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.3));
+      }
+    }
+  }
+
+  .mel-event-map-embed {
+    border: 1px solid var(--mel-event-border-strong);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  }
+
+  .mel-event-share--panel .mel-event-share__chip-icon {
+    background: var(--mel-event-accent-soft);
+    border: 1px solid var(--mel-event-chip-border, var(--mel-event-border-strong));
+    color: var(--mel-event-accent-strong);
+    box-shadow: 0 6px 18px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.28));
+  }
+
+  .mel-event-share--panel .mel-event-share__chip-label {
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-support-zone {
+    border-top: 1px solid var(--mel-event-border-strong);
+    color: var(--mel-event-text);
+  }
+
+  .mel-event-support-zone__link,
+  .mel-organiser-card,
+  .mel-return-block {
+    color: var(--mel-event-text);
   }
 
   .mel-btn--primary,
   .button--primary,
-  .mel-event--v2 .mel-btn--primary {
+  .mel-event--v2 .mel-btn--primary,
+  .mel-event--v2 .mel-btn--coral-cta {
     background-color: var(--mel-event-accent, colors.$mel-color-primary);
-    border-color: var(--mel-event-accent, colors.$mel-color-primary);
+    border-color: color-mix(in srgb, var(--mel-event-accent) 88%, #fff 12%);
     color: var(--mel-event-accent-contrast, colors.$mel-color-on-primary);
-    min-height: 44px;
+    min-height: 48px;
     font-weight: 700;
-    box-shadow: 0 10px 28px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
+    box-shadow:
+      0 12px 32px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.4)),
+      0 0 0 1px color-mix(in srgb, var(--mel-event-accent) 65%, #fff 35%);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        filter: brightness(1.06) saturate(1.08);
+        box-shadow:
+          0 16px 38px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.48)),
+          0 0 24px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.35));
+      }
+    }
+  }
+
+  .mel-card--sticky .mel-btn--coral-cta,
+  .mel-mobile-cta .mel-btn--coral-cta {
+    border-radius: 16px;
+    min-height: 48px;
   }
 
   .mel-btn--secondary,
   .button--secondary {
-    background: transparent;
-    border-color: rgba(255, 255, 255, 0.38);
-    color: var(--mel-event-text);
+    background: var(--mel-event-surface-spotlight);
+    border-color: var(--mel-event-border-strong);
+    color: var(--mel-event-heading);
     min-height: 44px;
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        border-color: var(--mel-event-accent);
+        color: var(--mel-event-accent-strong);
+      }
+    }
   }
 
   .mel-mobile-cta {
     background: var(--mel-event-surface-raised);
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.35);
+    border-top: 1px solid var(--mel-event-border-strong);
+    box-shadow: 0 -10px 36px rgba(0, 0, 0, 0.42);
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -608,6 +852,15 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     .mel-event__card,
     .mel-card--sticky {
       backdrop-filter: none;
+    }
+
+    .mel-btn--primary,
+    .button--primary,
+    .mel-event--v2 .mel-btn--primary,
+    .mel-event--v2 .mel-btn--coral-cta {
+      &:hover {
+        filter: none;
+      }
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -473,32 +473,45 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 // Immersive shell — extend page gutters to match cinematic backdrop.
 body:has(.mel-event-page--immersive.mel-event--v2),
 main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
-  background-color: #060a12;
+  background-color: #0a0f18;
 }
 
-// Immersive — cinematic full-page treatment (readable, high-contrast, palette-forward).
+// Immersive — cinematic Pro experience (readability, depth, editorial spacing).
 .mel-event-page--immersive.mel-event--v2 {
-  --mel-event-surface: #1a2230;
-  --mel-event-surface-raised: #232d3d;
-  --mel-event-surface-spotlight: #2b3749;
-  --mel-event-border: rgba(255, 255, 255, 0.16);
-  --mel-event-border-strong: rgba(255, 255, 255, 0.24);
-  --mel-event-heading: #ffffff;
-  --mel-event-text: #ebe6e1;
-  --mel-event-text-secondary: #d4dce6;
-  --mel-event-text-muted: #c2ccd9;
-  --mel-event-divider: rgba(237, 230, 222, 0.28);
+  // Typography scale (immersive-only).
+  --mel-immersive-text: #fff;
+  --mel-immersive-text-body: rgba(255, 255, 255, 0.84);
+  --mel-immersive-text-secondary: rgba(255, 255, 255, 0.74);
+  --mel-immersive-text-muted: rgba(255, 255, 255, 0.62);
+  --mel-immersive-text-meta: rgba(255, 255, 255, 0.72);
+  --mel-event-heading: var(--mel-immersive-text);
+  --mel-event-text: var(--mel-immersive-text-body);
+  --mel-event-text-secondary: var(--mel-immersive-text-secondary);
+  --mel-event-text-muted: var(--mel-immersive-text-muted);
+  --mel-event-divider: rgba(255, 255, 255, 0.22);
+  // Depth — lifted panels, softer OLED backdrop.
+  --mel-event-surface: rgba(26, 34, 48, 0.92);
+  --mel-event-surface-raised: rgba(35, 45, 61, 0.94);
+  --mel-event-surface-spotlight: rgba(43, 55, 73, 0.96);
+  --mel-event-border: rgba(255, 255, 255, 0.14);
+  --mel-event-border-strong: rgba(255, 255, 255, 0.22);
   --mel-event-shadow-elevated:
-    0 22px 54px rgba(0, 0, 0, 0.48),
-    0 0 0 1px rgba(255, 255, 255, 0.07),
-    0 0 40px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
+    0 20px 48px rgba(0, 0, 0, 0.42),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --mel-event-shadow-sidebar:
+    0 20px 48px rgba(0, 0, 0, 0.42),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 22px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.14));
   --mel-event-accent-strong: color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 78%, #fff 22%);
+  --mel-event-surface-tint: transparent;
+  --mel-immersive-section-gap: #{space-tokens.mel-space(6)};
 
   background:
-    radial-gradient(ellipse 95% 62% at 50% -8%, color-mix(in srgb, var(--mel-event-accent) 22%, transparent) 0%, transparent 58%),
-    radial-gradient(ellipse 55% 40% at 100% 12%, color-mix(in srgb, var(--mel-event-accent) 12%, transparent) 0%, transparent 52%),
-    radial-gradient(ellipse 45% 35% at 0% 88%, rgba(255, 255, 255, 0.04) 0%, transparent 55%),
-    linear-gradient(180deg, #060a12 0%, #0d121b 42%, #141b27 100%);
+    radial-gradient(ellipse 100% 70% at 50% -12%, color-mix(in srgb, var(--mel-event-accent) 18%, transparent) 0%, transparent 62%),
+    radial-gradient(ellipse 50% 42% at 100% 8%, color-mix(in srgb, var(--mel-event-accent) 10%, transparent) 0%, transparent 55%),
+    radial-gradient(ellipse 40% 38% at 0% 92%, rgba(255, 255, 255, 0.03) 0%, transparent 58%),
+    linear-gradient(180deg, #0a0f18 0%, #101825 45%, #161f2e 100%);
   color: var(--mel-event-text);
   min-height: 100vh;
 
@@ -506,43 +519,49 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     color: var(--mel-event-text);
   }
 
-  // Immersive-only palette lift (Classic colour tokens above stay unchanged).
+  // Immersive-only palette tuning (Classic colour tokens above stay unchanged).
   &.mel-event-page--colour-coral {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #1a2230, 28%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.48)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 28%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-primary, #232d3d, 32%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-primary, $alpha: 0.38)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-primary, #fff, 32%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-primary, #161f2e, 12%)};
   }
 
   &.mel-event-page--colour-purple {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-accent, #1a2230, 32%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.5)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 30%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-accent, #232d3d, 34%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-accent, $alpha: 0.4)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-accent, #fff, 34%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-accent, #161f2e, 14%)};
   }
 
   &.mel-event-page--colour-mint {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-success, #1a2230, 30%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.42)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 32%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-success, #232d3d, 32%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-success, $alpha: 0.36)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-success, #fff, 34%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-success, #161f2e, 12%)};
   }
 
   &.mel-event-page--colour-gold {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #1a2230, 30%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.46)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 30%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-orange, #232d3d, 32%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-orange, $alpha: 0.38)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-orange, #fff, 32%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-orange, #161f2e, 12%)};
   }
 
   &.mel-event-page--colour-blue {
-    --mel-event-accent-soft: #{color.mix(colors.$mel-color-info, #1a2230, 30%)};
-    --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.44)};
-    --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 30%)};
+    --mel-event-accent-soft: #{color.mix(colors.$mel-color-info, #232d3d, 32%)};
+    --mel-event-accent-glow: #{color.change(colors.$mel-color-info, $alpha: 0.36)};
+    --mel-event-chip-border: #{color.mix(colors.$mel-color-info, #fff, 34%)};
+    --mel-event-surface-tint: #{color.mix(colors.$mel-color-info, #161f2e, 12%)};
   }
 
   .mel-event-hero--featured-style {
+    margin-bottom: space-tokens.mel-space(2);
     border-radius: radii.$mel-radius-xl;
     overflow: hidden;
     box-shadow:
-      0 28px 64px rgba(0, 0, 0, 0.55),
-      0 0 48px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.25));
+      0 28px 64px rgba(0, 0, 0, 0.5),
+      0 0 36px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
   }
 
   .mel-event-hero--featured-style .mel-event-hero__overlay {
@@ -578,21 +597,22 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-meta-bar {
-    margin-top: space-tokens.mel-space(3);
+    margin-top: space-tokens.mel-space(4);
+    margin-bottom: space-tokens.mel-space(2);
     background: var(--mel-event-surface-raised);
     border: 1px solid var(--mel-event-border-strong);
     box-shadow: var(--mel-event-shadow-elevated);
-    color: var(--mel-event-text);
-    backdrop-filter: blur(10px);
+    color: var(--mel-immersive-text-body);
+    backdrop-filter: blur(12px);
   }
 
   .mel-event-meta__primary {
-    color: var(--mel-event-heading);
+    color: var(--mel-immersive-text);
     font-weight: 600;
   }
 
   .mel-event-meta__secondary {
-    color: var(--mel-event-text-secondary);
+    color: var(--mel-immersive-text-meta);
   }
 
   .mel-event-meta__icon {
@@ -601,18 +621,44 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-meta-bar a {
-    color: var(--mel-event-accent-strong);
+    color: var(--mel-immersive-text);
+    text-decoration-color: var(--mel-event-accent-strong);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        color: var(--mel-event-accent-strong);
+      }
+    }
+  }
+
+  .mel-event-layout {
+    margin-top: var(--mel-immersive-section-gap);
+    gap: space-tokens.mel-space(5);
+  }
+
+  .mel-event-layout__main,
+  .mel-event-layout__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mel-immersive-section-gap);
   }
 
   .mel-event__card,
-  .mel-card--sticky,
   .mel-event-layout__main .mel-card,
   .mel-card--surface {
-    background: var(--mel-event-surface-raised);
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 35%, var(--mel-event-surface-raised) 65%);
     border: 1px solid var(--mel-event-border-strong);
     box-shadow: var(--mel-event-shadow-elevated);
-    color: var(--mel-event-text);
-    backdrop-filter: blur(10px);
+    color: var(--mel-immersive-text-body);
+    backdrop-filter: blur(12px);
+  }
+
+  .mel-card--sticky {
+    background: color-mix(in srgb, var(--mel-event-surface-tint, transparent) 28%, var(--mel-event-surface-raised) 72%);
+    border: 1px solid var(--mel-event-border-strong);
+    box-shadow: var(--mel-event-shadow-sidebar);
+    color: var(--mel-immersive-text-body);
+    backdrop-filter: blur(12px);
   }
 
   .mel-card--highlights,
@@ -621,46 +667,50 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     border-color: var(--mel-event-border-strong);
   }
 
-  .mel-card--sticky {
-    box-shadow:
-      var(--mel-event-shadow-elevated),
-      0 0 32px var(--mel-event-accent-glow, rgba(0, 0, 0, 0.2));
-  }
-
   .mel-card--surface .mel-card__header,
   .mel-card--surface .mel-card__body,
   .mel-card--sticky .mel-card__header,
   .mel-card--sticky .mel-card__body {
-    padding: space-tokens.mel-space(4);
+    padding: space-tokens.mel-space(5);
 
     @include breakpoints.mel-break(lg) {
-      padding: space-tokens.mel-space(5);
+      padding: space-tokens.mel-space(6);
     }
   }
 
   .mel-event-layout__main,
   .mel-event-layout__sidebar,
   .mel-event-info__body,
-  .mel-event-section__body {
-    color: var(--mel-event-text);
+  .mel-event-section__body,
+  .mel-card--surface,
+  .mel-card--sticky,
+  .mel-event-meta-bar,
+  .mel-event-section--extras.mel-card--surface,
+  .mel-event-share--panel,
+  .mel-organiser-card,
+  .mel-return-block,
+  .mel-event-support-zone {
+    color: var(--mel-immersive-text-body);
   }
 
-  .mel-event-layout__main a:not(.mel-btn):not(.mel-social) {
-    color: var(--mel-event-accent-strong);
+  .mel-event-layout__main a:not(.mel-btn):not(.mel-social),
+  .mel-event-support-zone__link {
+    color: var(--mel-immersive-text);
+    text-decoration-color: var(--mel-event-accent-strong);
   }
 
   .mel-card--sticky .mel-booking-panel__price {
-    color: var(--mel-event-heading);
+    color: var(--mel-immersive-text);
     font-weight: 700;
   }
 
   .mel-card--sticky .mel-booking-panel__chip,
   .mel-event__meta {
-    color: var(--mel-event-text-muted);
+    color: var(--mel-immersive-text-meta);
   }
 
   .mel-event-info__label {
-    color: var(--mel-event-text-secondary);
+    color: var(--mel-immersive-text-secondary);
   }
 
   .mel-card--sticky .mel-chip--filled,
@@ -687,13 +737,13 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-card--sticky .mel-booking-panel__save--fav {
     background: var(--mel-event-surface-spotlight);
     border-color: var(--mel-event-border-strong);
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text-body);
   }
 
   .mel-event__signal,
   .mel-event-layout__main .mel-event__signal,
   .mel-event-layout__sidebar .mel-event__signal {
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text-body);
     background: var(--mel-event-accent-soft);
   }
 
@@ -707,7 +757,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-event-info__title,
   .mel-event-section__title,
   .mel-card__title {
-    color: var(--mel-event-heading);
+    color: var(--mel-immersive-text);
     font-weight: 700;
   }
 
@@ -721,33 +771,36 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     opacity: 1;
   }
 
-  // Typography readability — beat _event-full.scss dim hardcoded greys on dark surfaces.
+  // Typography — beat _event-full.scss dim hardcoded greys on dark surfaces.
   .mel-event-info__body,
   .mel-event-info__body .field__item,
   .mel-event-info__body .text-formatted,
   .mel-event-section__body,
-  .mel-event-section__body .text-formatted {
-    color: var(--mel-event-text);
+  .mel-event-section__body .text-formatted,
+  .mel-card--highlights,
+  .mel-card--expect {
+    color: var(--mel-immersive-text-body);
   }
 
-  .mel-text--muted,
-  .mel-muted,
-  .mel-event-section__lede,
   .mel-event-info__body p,
   .mel-event-section__body p,
   .mel-event-info__body li,
   .mel-event-section__body li {
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text-body);
+  }
+
+  .mel-text--muted,
+  .mel-muted {
+    color: var(--mel-immersive-text-muted);
   }
 
   .mel-event-section__lede,
   .mel-event-section--extras .mel-addon-teaser__intro,
   .mel-event-section--extras .mel-addon-teaser__hint,
   .mel-event-section--extras .mel-addon-teaser__more {
-    color: var(--mel-event-text-secondary);
+    color: var(--mel-immersive-text-secondary);
   }
 
-  .mel-card--sticky .mel-booking-panel__chip,
   .mel-card--sticky .mel-booking-panel__product,
   .mel-card--sticky .mel-booking-panel__trust-line,
   .mel-card--sticky .mel-booking-panel__trust-micro,
@@ -757,13 +810,13 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   .mel-card--sticky .mel-trust-rotator .mel-trust-item__text,
   .mel-card--sticky .mel-booking-panel__save-hint,
   .mel-card--sticky .mel-booking-panel__save-text p {
-    color: var(--mel-event-text-muted);
+    color: var(--mel-immersive-text-muted);
   }
 
   .mel-card--sticky .mel-booking-panel__trust-micro-primary,
   .mel-card--sticky .mel-booking-panel__save-label,
   .mel-card--sticky .mel-booking-panel__save-text strong {
-    color: var(--mel-event-text-secondary);
+    color: var(--mel-immersive-text-secondary);
   }
 
   .mel-card--sticky .mel-booking-panel__rule,
@@ -773,11 +826,11 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-section--extras .mel-addon-teaser__name {
-    color: var(--mel-event-text-secondary);
+    color: var(--mel-immersive-text-secondary);
   }
 
   .mel-event-section--extras .mel-addon-teaser__price {
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text);
     font-weight: 600;
   }
 
@@ -844,18 +897,12 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-share--panel .mel-event-share__chip-label {
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text-secondary);
   }
 
   .mel-event-support-zone {
     border-top: 1px solid var(--mel-event-border-strong);
-    color: var(--mel-event-text);
-  }
-
-  .mel-event-support-zone__link,
-  .mel-organiser-card,
-  .mel-return-block {
-    color: var(--mel-event-text);
+    color: var(--mel-immersive-text-body);
   }
 
   .mel-btn--primary,
@@ -906,6 +953,47 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     background: var(--mel-event-surface-raised);
     border-top: 1px solid var(--mel-event-border-strong);
     box-shadow: 0 -10px 36px rgba(0, 0, 0, 0.42);
+    color: var(--mel-immersive-text-body);
+  }
+
+  @include breakpoints.mel-break(md, max) {
+    --mel-immersive-section-gap: #{space-tokens.mel-space(5)};
+
+    .mel-event-meta-bar {
+      margin-top: space-tokens.mel-space(3);
+    }
+
+    .mel-event-meta-bar__items {
+      flex-direction: column;
+      align-items: stretch;
+      gap: space-tokens.mel-space(3);
+    }
+
+    .mel-event-meta-bar__cluster {
+      width: 100%;
+    }
+
+    .mel-event-meta__primary,
+    .mel-event-meta__secondary {
+      font-size: 15px;
+      line-height: 1.45;
+    }
+
+    .mel-card--surface .mel-card__header,
+    .mel-card--surface .mel-card__body,
+    .mel-card--sticky .mel-card__header,
+    .mel-card--sticky .mel-card__body {
+      padding: space-tokens.mel-space(4);
+    }
+
+    .mel-btn--primary,
+    .button--primary,
+    .mel-event--v2 .mel-btn--primary,
+    .mel-event--v2 .mel-btn--coral-cta,
+    .mel-btn--secondary,
+    .button--secondary {
+      min-height: 44px;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -483,18 +483,19 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
 
 // Immersive — cinematic Pro experience (single authored visual system).
 .mel-event-page--immersive.mel-event--v2 {
-  // Typography scale.
+  // Typography scale — authoritative immersive contrast (explicit rgba, no opacity fade).
   --mel-immersive-text: #fff;
-  --mel-immersive-text-body: rgba(255, 255, 255, 0.86);
-  --mel-immersive-text-secondary: rgba(255, 255, 255, 0.76);
-  --mel-immersive-text-muted: rgba(255, 255, 255, 0.64);
-  --mel-immersive-text-meta: rgba(255, 255, 255, 0.74);
-  --mel-immersive-text-label: rgba(255, 255, 255, 0.7);
+  --mel-immersive-text-secondary: rgba(255, 255, 255, 0.82);
+  --mel-immersive-text-muted: rgba(255, 255, 255, 0.72);
+  --mel-immersive-text-helper: rgba(255, 255, 255, 0.64);
+  --mel-immersive-text-body: var(--mel-immersive-text-secondary);
+  --mel-immersive-text-meta: var(--mel-immersive-text-helper);
+  --mel-immersive-text-label: var(--mel-immersive-text-muted);
   --mel-event-heading: var(--mel-immersive-text);
-  --mel-event-text: var(--mel-immersive-text-body);
+  --mel-event-text: var(--mel-immersive-text-secondary);
   --mel-event-text-secondary: var(--mel-immersive-text-secondary);
   --mel-event-text-muted: var(--mel-immersive-text-muted);
-  --mel-event-divider: rgba(255, 255, 255, 0.14);
+  --mel-event-divider: rgba(255, 255, 255, 0.1);
   --mel-immersive-heading-size: clamp(1.375rem, 2.1vw, 1.6rem);
   --mel-immersive-heading-secondary: clamp(1.125rem, 1.6vw, 1.25rem);
   --mel-immersive-body-size: 1.0625rem;
@@ -821,7 +822,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   }
 
   .mel-event-info__label {
-    color: var(--mel-immersive-text-secondary);
+    color: var(--mel-immersive-text-muted);
   }
 
   .mel-card--sticky .mel-chip--filled,
@@ -924,22 +925,40 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     margin-bottom: space-tokens.mel-space(3);
   }
 
-  // Typography — beat _event-full.scss dim hardcoded greys on dark surfaces.
+  // ---------------------------------------------------------------------------
+  // Immersive typography authority — beats _event-full.scss grey/dark inheritance.
+  // ---------------------------------------------------------------------------
+
+  .mel-event-meta-bar,
+  .mel-event-meta,
+  .mel-event-layout__main,
+  .mel-event-layout__sidebar,
+  .mel-card--surface,
+  .mel-card--highlights,
+  .mel-card--expect,
+  .mel-card--sticky,
+  .mel-event-section--extras,
+  .mel-event-share--panel,
+  .mel-organiser-card,
+  .mel-return-block,
+  .mel-event-support-zone,
+  .mel-mobile-cta {
+    opacity: 1;
+  }
+
   .mel-event-info__body,
   .mel-event-info__body .field__item,
   .mel-event-info__body .text-formatted,
   .mel-event-section__body,
   .mel-event-section__body .text-formatted,
-  .mel-card--highlights,
-  .mel-card--expect {
-    color: var(--mel-immersive-text-body);
-  }
-
   .mel-event-info__body p,
   .mel-event-section__body p,
   .mel-event-info__body li,
-  .mel-event-section__body li {
-    color: var(--mel-immersive-text-body);
+  .mel-event-section__body li,
+  .mel-event-info__body dd,
+  .mel-event-info__body dt {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
   }
 
   .mel-event-info__body p + p,
@@ -947,34 +966,136 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     margin-top: 1em;
   }
 
+  .mel-card--expect .mel-card__body,
+  .mel-card--expect .mel-card__body p,
+  .mel-card--expect .mel-card__body li,
+  .mel-card--expect .mel-card__body .field__item,
+  .mel-card--expect .mel-card__body .text-formatted {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
+  .mel-event-highlights,
+  .mel-event-highlights__item,
+  .mel-event-highlights__text {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
   .mel-text--muted,
   .mel-muted {
     color: var(--mel-immersive-text-muted);
+    opacity: 1;
   }
 
-  .mel-event-section__lede,
+  .mel-event-section__lede {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
+  .mel-event-meta__secondary,
+  .mel-event-location__address,
+  .mel-event-meta--venue .mel-event-location__address,
+  .mel-event-meta--venue a {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
+  .mel-info-row__label {
+    color: var(--mel-immersive-text);
+    opacity: 1;
+  }
+
+  .mel-info-row__value,
+  .mel-info-row__value .field__item,
+  .mel-info-row__value .text-formatted,
+  .mel-info-row__value p,
+  .mel-info-row__value a:not(.mel-btn) {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
+  .mel-info-row__category-label {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
+  .mel-organiser-card__title {
+    color: var(--mel-immersive-text-helper);
+    opacity: 1;
+  }
+
+  .mel-organiser-card__name,
+  .mel-organiser-card__tagline {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
+  .mel-organiser-card__tagline--muted {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
+  .mel-event-layout__main .mel-return-header h3 {
+    color: var(--mel-immersive-text);
+    opacity: 1;
+  }
+
+  .mel-event-layout__main .mel-return-header p {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
   .mel-event-section--extras .mel-addon-teaser__intro,
   .mel-event-section--extras .mel-addon-teaser__hint,
   .mel-event-section--extras .mel-addon-teaser__more {
-    color: var(--mel-immersive-text-secondary);
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__name {
+    color: var(--mel-immersive-text);
+    opacity: 1;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__price {
+    color: var(--mel-immersive-text);
+    font-weight: 600;
+    opacity: 1;
+  }
+
+  .mel-event-section--extras .mel-addon-teaser__actions {
+    border-top-color: var(--mel-event-divider);
+  }
+
+  .mel-card--sticky .mel-booking-panel__chip {
+    color: var(--mel-immersive-text-helper);
+    opacity: 1;
   }
 
   .mel-card--sticky .mel-booking-panel__product,
+  .mel-card--sticky .mel-booking-panel__subline,
+  .mel-card--sticky .mel-booking-panel__item p,
   .mel-card--sticky .mel-booking-panel__trust-line,
   .mel-card--sticky .mel-booking-panel__trust-micro,
   .mel-card--sticky .mel-booking-panel__trust-micro p,
   .mel-card--sticky .mel-trust-rotator,
   .mel-card--sticky .mel-trust-rotator .mel-trust-item,
   .mel-card--sticky .mel-trust-rotator .mel-trust-item__text,
+  .mel-card--sticky .mel-trust-item__text,
   .mel-card--sticky .mel-booking-panel__save-hint,
-  .mel-card--sticky .mel-booking-panel__save-text p {
-    color: var(--mel-immersive-text-muted);
+  .mel-card--sticky .mel-booking-panel__save-text p,
+  .mel-decision-prompts .mel-decision-item__text {
+    color: var(--mel-immersive-text-helper);
+    opacity: 1;
   }
 
   .mel-card--sticky .mel-booking-panel__trust-micro-primary,
   .mel-card--sticky .mel-booking-panel__save-label,
-  .mel-card--sticky .mel-booking-panel__save-text strong {
+  .mel-card--sticky .mel-booking-panel__save-text strong,
+  .mel-card--sticky .mel-booking-panel__item strong {
     color: var(--mel-immersive-text-secondary);
+    opacity: 1;
   }
 
   .mel-card--sticky .mel-booking-panel__rule,
@@ -983,17 +1104,36 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     border-top-color: var(--mel-event-divider);
   }
 
-  .mel-event-section--extras .mel-addon-teaser__name {
-    color: var(--mel-immersive-text-secondary);
+  .mel-event-share--panel .mel-event-share__chip-label {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
   }
 
-  .mel-event-section--extras .mel-addon-teaser__price {
+  .mel-event-support-zone,
+  .mel-event-support-zone p {
+    color: var(--mel-immersive-text-muted);
+    opacity: 1;
+  }
+
+  .mel-mobile-cta__eyebrow {
     color: var(--mel-immersive-text);
-    font-weight: 600;
+    opacity: 1;
   }
 
-  .mel-event-section--extras .mel-addon-teaser__actions {
-    border-top-color: var(--mel-event-divider);
+  .mel-mobile-cta__urgency,
+  .mel-mobile-cta__helper,
+  .mel-mobile-cta__soldout-head {
+    color: var(--mel-immersive-text-secondary);
+    opacity: 1;
+  }
+
+  .mel-mobile-cta__waitlist-sub,
+  .mel-mobile-cta__waitlist-sub--muted,
+  .mel-mobile-cta__trust,
+  .mel-mobile-cta__trust-t,
+  .mel-mobile-cta__trust-d {
+    color: var(--mel-immersive-text-helper);
+    opacity: 1;
   }
 
   .mel-event-highlights__icon {

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -149,7 +149,6 @@
 @use 'components/live-operations';
 @use 'components/event-page';
 @use 'components/event-full' as event_full_component;
-@use 'components/event-page-themes';
 @use 'components/mel-calendar';
 @use 'components/event-node';
 @use 'components/event' as event-component;
@@ -226,6 +225,9 @@
 @use 'pages/contact';
 @use 'pages/discovery';
 @use 'pages/vendor';
+
+// Event page Classic/Immersive themes — load after pages/event so Mockup 1 rules win cascade.
+@use 'components/event-page-themes';
 
 // ---------------------------------------------------------------------------
 // 7. Utilities

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -95,12 +95,13 @@
             {{ content.field_category }}
           </div>
         </div>
+      {% elseif mel_signal %}
+        <div class="mel-event-hero__chip" aria-hidden="true">
+          <div class="mel-event__signal mel-event__signal--hero-chip">{{ mel_signal }}</div>
+        </div>
       {% endif %}
       <div class="mel-event-hero__content">
         <h1 class="mel-event-hero__title" id="mel-event-title">{{ label }}</h1>
-        {% if mel_signal %}
-          <div class="mel-event__signal">{{ mel_signal }}</div>
-        {% endif %}
         {% if hero_datetime %}
           <p class="mel-event-hero__datetime">{{ hero_datetime }}</p>
         {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-builder.scss
@@ -1161,6 +1161,20 @@ $color-primary: $primary;
   }
 }
 
+.mel-event-studio .mel-option-card .mel-option-card__badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  margin: 0 0 4px;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  line-height: 1.2;
+}
+
 .mel-event-studio .mel-option-card:focus-within {
   outline: 2px solid $ml-color-accent;
   outline-offset: 2px;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches both Event Studio form-building (#after_build injection + cached form object service wiring) and public theme rendering/classes, so regressions could affect event branding UX and booking/event page styling across view modes.
> 
> **Overview**
> Adds a new `BrandingHeroFocalAugmenter` service that injects a `focal_point` field + indicator into the existing `image_widget_crop` hero widget, plus updated `mel-branding-hero-tools.js`/CSS to show active focal shortcuts, an *ARIA* status message, and a 16:9 “public framing” preview.
> 
> Extends Event Studio’s page-style radios to support card badges (Twig + preprocess + radios processor), refreshes the option-card styling, and updates the page-style chooser copy/layout.
> 
> Propagates resolved `event_page_classes` (Classic/Immersive + colour) into the public booking template and event preprocessing, and significantly updates Classic/Immersive SCSS tokens and component styling (including moving `event-page-themes` later in the main stylesheet for cascade).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771107c087b4c502f1d8fbd13a8294eef5add2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->