### PR TITLE
fix(event-book): placement-aware extras anchors and theme preprocess

### DIFF
--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -228,6 +228,7 @@ services:
     class: Drupal\myeventlane_commerce\Service\EventOperationalAddonTeaserBuilder
     arguments:
       - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@myeventlane_commerce.event_extras_book_placement_resolver'
       - '@commerce_price.currency_formatter'
       - '@string_translation'
 

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonTeaserBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonTeaserBuilder.php
@@ -21,10 +21,15 @@ final class EventOperationalAddonTeaserBuilder {
 
   public const CONTRACT_FLAG = 'mel_operational_addon_teaser';
 
+  public const FRAGMENT_INLINE = 'mel-operational-addons--inline';
+
+  public const FRAGMENT_SIDEBAR = 'mel-operational-addons--sidebar';
+
   private const MAX_ITEMS = 3;
 
   public function __construct(
     private readonly EventOperationalAddonBuilder $addonBuilder,
+    private readonly EventExtrasBookPlacementResolver $extrasBookPlacementResolver,
     private readonly CurrencyFormatter $currencyFormatter,
     TranslationInterface $string_translation,
   ) {
@@ -77,8 +82,11 @@ final class EventOperationalAddonTeaserBuilder {
 
     $total = count($addons);
     $more = max(0, $total - count($items));
+    $addons_fragment = $this->extrasBookPlacementResolver->isSidebar($event)
+      ? self::FRAGMENT_SIDEBAR
+      : self::FRAGMENT_INLINE;
     $book_url = Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event_id], [
-      'fragment' => 'mel-operational-addons',
+      'fragment' => $addons_fragment,
     ])->toString();
     $on_book_page = $surface === 'book';
 
@@ -98,7 +106,7 @@ final class EventOperationalAddonTeaserBuilder {
       'show_book_cta' => !$on_book_page,
       'show_scroll_cta' => $on_book_page,
       'book_url' => $on_book_page ? '' : $book_url,
-      'book_anchor' => '#mel-operational-addons',
+      'book_anchor' => '#' . $addons_fragment,
       'choose_label' => (string) $this->t('Choose extras ↓'),
       'book_cta_label' => (string) $this->t('View & add when booking'),
       'more_label' => $more > 0

--- a/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
+++ b/web/modules/custom/myeventlane_commerce/templates/myeventlane-event-book.html.twig
@@ -122,8 +122,8 @@
               {% endif %}
 
               {% if extras_in_main and operational_addon_form %}
-                <section id="mel-operational-addons" class="mel-booking-extras mel-booking-extras--inline mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
-                  <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
+                <section id="mel-operational-addons--inline" class="mel-booking-extras mel-booking-extras--inline mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title--inline" tabindex="-1">
+                  <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title--inline">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
                   <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
                   {{ operational_addon_form }}
                 </section>
@@ -187,8 +187,8 @@
             {% endif %}
 
             {% if extras_in_sidebar and operational_addon_form %}
-              <section id="mel-operational-addons" class="mel-booking-extras mel-booking-extras--sidebar mel-operational-addons-section mel-operational-addons-section--sidebar mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title" tabindex="-1">
-                <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
+              <section id="mel-operational-addons--sidebar" class="mel-booking-extras mel-booking-extras--sidebar mel-operational-addons-section mel-operational-addons-section--sidebar mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title--sidebar" tabindex="-1">
+                <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title--sidebar">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
                 <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
                 {{ operational_addon_form }}
               </section>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3840,7 +3840,7 @@ function _myeventlane_theme_apply_event_page_style_theme_variables(array &$varia
     $existing = $variables['attributes'] ?? [];
     $variables['attributes'] = new Attribute(is_array($existing) ? $existing : []);
   }
-  $variables['attributes']->addClass($classes);
+  $variables['attributes']->addClass($resolved['classes']);
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -993,6 +993,13 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     opacity: 1;
   }
 
+  .mel-event-location__venue,
+  .mel-event-meta--venue .mel-event-location__venue {
+    color: var(--mel-immersive-text);
+    font-weight: 700;
+    opacity: 1;
+  }
+
   .mel-event-meta__secondary,
   .mel-event-location__address,
   .mel-event-meta--venue .mel-event-location__address,


### PR DESCRIPTION
Split operational addon section IDs for inline vs sidebar so teaser links scroll to the visible block. Fix undefined $classes when applying event page style classes. Improve immersive venue name contrast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to booking-page anchor IDs/URL fragments, a small theme preprocess bugfix for applying classes, and a minor CSS contrast tweak; main risk is broken in-page scrolling if any external links rely on the old `#mel-operational-addons` anchor.
> 
> **Overview**
> Booking-page *extras* anchors are now placement-aware: the operational add-ons sections use distinct IDs (`mel-operational-addons--inline` vs `--sidebar`), and `EventOperationalAddonTeaserBuilder` now selects the matching URL fragment/anchor via `EventExtrasBookPlacementResolver`.
> 
> Fixes a theme preprocess bug by applying `$resolved['classes']` instead of an undefined `$classes` when adding event page style classes, and updates immersive theme SCSS to render venue names with higher-contrast, bold text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a092fb8fd58a0351e9819199abfb5f1b1526ab2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->