### PR TITLE
Fix/bugbot form validation and event

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -600,7 +600,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $qty = (int) ($line['quantity'] ?? 0);
       if ($qty < 1) {
         if ($line_index !== NULL) {
-          $form_state->setErrorByName('lines][' . $index . '][quantity]', $this->t('Choose a quantity of at least 1.'));
+          $form_state->setErrorByName('lines][' . $index . '][quantity', $this->t('Choose a quantity of at least 1.'));
         }
         continue;
       }
@@ -617,7 +617,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $vid = $this->resolveVariationIdForLine($line, $entry);
       if ($vid < 1) {
         if (!empty($entry['requires_size_selection'])) {
-          $form_state->setErrorByName('lines][' . $index . '][selected_size]', $this->t('Please choose a size before adding to cart.'));
+          $form_state->setErrorByName('lines][' . $index . '][selected_size', $this->t('Please choose a size before adding to cart.'));
         }
         else {
           $form_state->setErrorByName('lines', $this->t('Something went wrong with your selection. Please refresh and try again.'));

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -138,7 +138,7 @@ final class EventStudioEventExtrasForm extends FormBase {
 
     $form['event_id'] = [
       '#type' => 'hidden',
-      '#default_value' => (string) $event->id(),
+      '#value' => (string) $event->id(),
     ];
 
     $form['intro'] = [
@@ -572,6 +572,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       $form_state->setErrorByName('', $this->t('The event could not be loaded.'));
       return;
     }
+    $this->assertCanManageEvent($event);
     $trigger = $form_state->getTriggeringElement();
     if (!is_array($trigger)) {
       return;
@@ -632,6 +633,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     if (!$event instanceof NodeInterface) {
       return;
     }
+    $this->assertCanManageEvent($event);
     $trigger = $form_state->getTriggeringElement();
     $pid = (int) ($trigger['#product_id'] ?? 0);
     if ($pid < 1) {
@@ -659,6 +661,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       $this->messenger()->addError($this->t('The event could not be loaded.'));
       return;
     }
+    $this->assertCanManageEvent($event);
     try {
       $input = $this->collectInput($form_state);
       $product = $this->productCreationManager->saveEventExtraForVendor($this->currentUser(), $event, $input);
@@ -793,23 +796,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   private function loadSubmittedEvent(FormStateInterface $form_state): ?NodeInterface {
     $event_id = (int) ($form_state->getValue('event_id') ?? 0);
     if ($event_id < 1) {
-      $input = $form_state->getUserInput();
-      if (isset($input['event_id'])) {
-        $event_id = (int) $input['event_id'];
-      }
-    }
-    if ($event_id < 1) {
-      $args = $form_state->getBuildInfo()['args'] ?? [];
-      $route_event = $args[0] ?? NULL;
-      if ($route_event instanceof NodeInterface && $route_event->bundle() === 'event') {
-        return $route_event;
-      }
-      try {
-        return $this->getRouteEvent();
-      }
-      catch (\Throwable) {
-        return NULL;
-      }
+      return NULL;
     }
     $event = $this->entityTypeManager->getStorage('node')->load($event_id);
     return $event instanceof NodeInterface && $event->bundle() === 'event' ? $event : NULL;


### PR DESCRIPTION
Commits pushed
fix(commerce): correct addon cart validation error element names
fix(event-studio): harden event extras form event_id handling
Branch: fix/bugbot-form-validation-and-event-id
PR link: https://github.com/anna-pye/myeventlane-platform/pull/new/fix/bugbot-form-validation-and-event-id

Pre-commit hooks ran npm run mel:lint and npm run mel:build successfully on both commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Drupal form validation and submission paths for commerce add-ons and vendor extras; mistakes here could block adding items to cart or saving extras, but changes are small and localized.
> 
> **Overview**
> Fixes validation error targeting in `EventOperationalAddonCartForm` so quantity/size errors attach to the correct per-line inputs (adjusts `setErrorByName` element keys).
> 
> Hardens `EventStudioEventExtrasForm` by making `event_id` a fixed hidden `#value`, requiring `assertCanManageEvent()` in validate/toggle/save flows, and simplifying `loadSubmittedEvent()` to only accept an explicit submitted `event_id` (no route/args fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74b9299f32f1e0fb4ec50c0ea78b9b9d51c85c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->