### PR TITLE
fix(event-branding): set #description_display on hero focal field

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/BrandingHeroFocalAugmenter.php
@@ -93,6 +93,9 @@ final class BrandingHeroFocalAugmenter {
     if (isset($delta['focal_point']) && is_array($delta['focal_point'])) {
       // Cached or prior builds may still reference the core focal widget validator.
       $delta['focal_point']['#element_validate'] = [[$this, 'validateFocalPointElement']];
+      if (!empty($delta['focal_point']['#description']) && !isset($delta['focal_point']['#description_display'])) {
+        $delta['focal_point']['#description_display'] = 'after';
+      }
       return;
     }
 
@@ -105,6 +108,7 @@ final class BrandingHeroFocalAugmenter {
       '#type' => 'textfield',
       '#title' => $this->t('Focal point'),
       '#description' => $this->t('Focus area for the public event and book page hero (16:9). Saved when you save branding.'),
+      '#description_display' => 'after',
       '#default_value' => $focal_value,
       '#element_validate' => [[$this, 'validateFocalPointElement']],
       '#attributes' => [


### PR DESCRIPTION
## Summary

- Fixes PHP warnings (`Undefined array key "#description_display"`) on Event Studio branding loads.
- The hero focal point textfield in `BrandingHeroFocalAugmenter` defined `#description` without `#description_display`, which Drupal core expects in `FormPreprocess::preprocessFormElement()`.

## Test plan

- [ ] Open Event Studio → Branding for an event with a hero image
- [ ] Run `drush ws` and confirm no new `#description_display` PHP warnings
- [ ] Save branding with focal point changes; confirm focal still persists correctly


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/Form API tweak that only adjusts form element metadata to avoid Drupal preprocess warnings; no data model or persistence logic changes.
> 
> **Overview**
> Prevents Drupal form preprocessing warnings on Event Studio branding by ensuring the injected `focal_point` element always sets `#description_display` when a `#description` is present.
> 
> This applies both when the augmenter creates the focal point textfield and when it encounters a pre-existing cached `focal_point` element, keeping the validator override intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec59abf500d9b81927c032e530898b405ea4a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->