### PR TITLE
fix(events): attach sidebar carousel on event full pages

### DIFF
--- a/docs/event-sidebar-carousel-preprocess-fix.md
+++ b/docs/event-sidebar-carousel-preprocess-fix.md
@@ -1,0 +1,59 @@
+# Event sidebar carousel preprocess fix
+
+**Date:** 2026-05-21  
+**Branch:** `fix/event-full-sidebar-carousel-preprocess`
+
+## Problem
+
+`mel_sidebar_carousel` was built in `myeventlane_theme_preprocess_node__event()` but event canonical pages render with theme hook suggestion `node__event__full` (`node--event--full.html.twig`).
+
+Drupal’s theme registry attaches bundle-specific preprocess only to the matching hook depth:
+
+| Theme hook | `myeventlane_theme_preprocess_node__event` registered? |
+|------------|--------------------------------------------------------|
+| `node__event` | Yes |
+| `node__event__full` | **No** (only `myeventlane_theme_preprocess_node`) |
+
+Verified via `drush php:eval` on `theme.registry` → `node__event__full['preprocess functions']`.
+
+Result: `mel_sidebar_carousel` was never set on full pages; `node--event--full.html.twig` fell through to the static sidebar `{% else %}` branch.
+
+## Where carousel is built
+
+- **PHP:** `_myeventlane_theme_attach_event_sidebar_carousel()` in `myeventlane_theme.theme`
+- **Service:** `myeventlane_event.sidebar_carousel_builder` → `EventSidebarCarouselBuilder::buildFromEventPageVariables()`
+- **Render:** `#theme` => `mel_event_sidebar_carousel` (`mel-event-sidebar-carousel.html.twig`)
+
+## Where carousel is rendered
+
+- `web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig` (sidebar `{% if mel_sidebar_carousel %}`)
+
+## Fallback when carousel missing
+
+Static `mel-card mel-card--sticky` booking panel in the same template (`{% else %}`), including trust rotator, calendar tabs, and save-for-later — Phase 1 monolithic sidebar.
+
+## Trust / CTA duplication
+
+Template already branches:
+
+```twig
+{% if mel_sidebar_carousel %}
+  {{ mel_sidebar_carousel }}
+{% else %}
+  … static booking + trust …
+{% endif %}
+```
+
+When carousel is present, static trust/CTA block is skipped. Mobile sticky CTA (`partial--event-full-booking-cta`, slot `mobile`) remains separate by design (Phase 1). **No Twig change required.**
+
+## Fix
+
+1. Extract carousel attach logic to `_myeventlane_theme_attach_event_sidebar_carousel()`.
+2. Call from `myeventlane_theme_preprocess_node__event()` (non-full event templates / `node__event` hook).
+3. Add `myeventlane_theme_preprocess_node__event__full()` for full pages.
+
+Cache metadata from the builder and module preprocess (`#cache` on child render arrays, media tags) is unchanged; the helper does not strip or overwrite `#cache`.
+
+## Residual notes (out of scope)
+
+Other variables only set in `preprocess_node__event()` (e.g. `mel_organiser`, `hero_datetime`, calendar URLs) are still absent on `node__event__full` until a broader preprocess alignment is done. Carousel still renders (booking slide minimum); organiser/trust slides in the manifest may be fewer without those vars.

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -4203,20 +4203,51 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
     $variables['operational_addon_teaser'] = NULL;
   }
 
-  $view_mode = (string) ($variables['view_mode'] ?? '');
-  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_event.sidebar_carousel_builder')) {
-    /** @var \Drupal\myeventlane_event\Service\EventSidebarCarouselBuilder $carousel_builder */
-    $carousel_builder = \Drupal::service('myeventlane_event.sidebar_carousel_builder');
-    $carousel = $carousel_builder->buildFromEventPageVariables($variables);
-    $variables['mel_sidebar_carousel'] = [
-      '#theme' => 'mel_event_sidebar_carousel',
-      '#carousel' => $carousel,
-      '#event_page_style' => $variables['event_page_style'] ?? 'classic',
-      '#attached' => [
-        'library' => ['myeventlane_theme/mel_event_sidebar_carousel'],
-      ],
-    ];
+  _myeventlane_theme_attach_event_sidebar_carousel($variables);
+}
+
+/**
+ * Preprocess event nodes in full view mode (node--event--full.html.twig).
+ *
+ * Drupal registers bundle preprocess only for matching theme-hook depth; full
+ * pages use node__event__full and do not invoke preprocess_node__event.
+ */
+function myeventlane_theme_preprocess_node__event__full(array &$variables): void {
+  _myeventlane_theme_attach_event_sidebar_carousel($variables);
+}
+
+/**
+ * Attaches the event full-page sidebar carousel render array when available.
+ */
+function _myeventlane_theme_attach_event_sidebar_carousel(array &$variables): void {
+  if ((string) ($variables['view_mode'] ?? '') !== 'full') {
+    return;
   }
+
+  $node = $variables['node'] ?? NULL;
+  if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+    return;
+  }
+
+  if (isset($variables['mel_sidebar_carousel'])) {
+    return;
+  }
+
+  if (!\Drupal::hasService('myeventlane_event.sidebar_carousel_builder')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_event\Service\EventSidebarCarouselBuilder $carousel_builder */
+  $carousel_builder = \Drupal::service('myeventlane_event.sidebar_carousel_builder');
+  $carousel = $carousel_builder->buildFromEventPageVariables($variables);
+  $variables['mel_sidebar_carousel'] = [
+    '#theme' => 'mel_event_sidebar_carousel',
+    '#carousel' => $carousel,
+    '#event_page_style' => $variables['event_page_style'] ?? 'classic',
+    '#attached' => [
+      'library' => ['myeventlane_theme/mel_event_sidebar_carousel'],
+    ],
+  ];
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk theme-layer change that only affects render/preprocess variables for event pages; main concern is potential sidebar rendering differences on `node--event--full` view mode.
> 
> **Overview**
> Fixes event canonical pages missing `mel_sidebar_carousel` by adding a `myeventlane_theme_preprocess_node__event__full()` preprocess and reusing shared attach logic.
> 
> Extracts the carousel render-array construction into `_myeventlane_theme_attach_event_sidebar_carousel()` and calls it from both `preprocess_node__event` and the new full-view preprocess, ensuring the dynamic carousel renders instead of the static sidebar fallback. Adds a short doc explaining the Drupal theme-hook depth issue and the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6991ef0cc0a7cf5efcfef758084166ebd1d1fd91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->