### PR TITLE
Fix/staging drush memory

### DIFF
--- a/docs/staging-drush-memory-fix.md
+++ b/docs/staging-drush-memory-fix.md
@@ -1,0 +1,67 @@
+# Staging deploy: Drush CLI memory limit
+
+## Problem
+
+Staging deploys run Drush during `scripts/deploy/remote-deploy.sh` (maintenance mode, cache rebuilds, optional `updb`/`cim`, domain `cset`, finalize). On constrained hosts, `drush cr` and related steps can exhaust PHP CLI memory and exit with errors such as “Drush command terminated abnormally” after a successful bootstrap.
+
+## Audit (2026-05)
+
+| Layer | Finding |
+|-------|---------|
+| **CI** | `.github/workflows/deploy-staging.yml` SSHs to the host and runs `bash scripts/deploy/remote-deploy.sh` with `APP_ENV=staging`, `SITE_URI`, `ARTIFACT_PATH`. No PHP memory settings in the workflow. |
+| **Deploy script** | All Drush usage is in `scripts/deploy/remote-deploy.sh`. Rollback/cleanup uses the same script (`mel_deploy_cleanup` trap). |
+| **Composer** | No deploy-time Drush wrappers in root `composer.json` scripts. |
+| **Drush 13** | `vendor/bin/drush` is a shell launcher → `drush.php`. **`DRUSH_PHP_OPTIONS` is not read by Drush 13** (no references in `vendor/drush`). A prior `export DRUSH_PHP_OPTIONS=...` in the deploy script did not apply PHP flags. |
+| **Web PHP** | Unchanged. This fix only affects CLI invocations from the deploy script. |
+
+Drush 13 supports deploy-time CLI flags via **`--php-options`**, which maps to `runtime.php.options` and is applied to Drush subprocesses (e.g. `updatedb`).
+
+## Fix
+
+1. **`mel_drush()`** — single wrapper used for every deploy Drush call:
+
+   ```bash
+   vendor/bin/drush --php-options="-d memory_limit=${MEL_DRUSH_PHP_MEMORY_LIMIT} ${MEL_DRUSH_PHP_EXTRA}" "$@"
+   ```
+
+2. **Defaults**
+   - `MEL_DRUSH_PHP_MEMORY_LIMIT` → `-1` (unlimited CLI memory for deploy)
+   - Falls back to `PHP_MEMORY_LIMIT` if set
+   - `MEL_DRUSH_PHP_EXTRA` → `-d opcache.enable_cli=0` (avoids stale class issues during container rebuild)
+
+3. **Rollback / cleanup** — unchanged behaviour: failed deploy still rolls back `current/` and runs `mel_drush` maintenance off + `cr` via the same wrapper.
+
+## Overrides (staging host or CI)
+
+```bash
+# Cap memory instead of unlimited (example)
+MEL_DRUSH_PHP_MEMORY_LIMIT=1G bash scripts/deploy/remote-deploy.sh
+
+# Or use the generic alias
+PHP_MEMORY_LIMIT=512M bash scripts/deploy/remote-deploy.sh
+```
+
+Do **not** change PHP-FPM / Apache `memory_limit` for this issue.
+
+## Local dry-run (no deploy)
+
+From a release directory with `vendor/bin/drush` and valid `settings.php`:
+
+```bash
+export SITE_URI=https://staging.myeventlane.com.au
+MEL_DRUSH_PHP_MEMORY_LIMIT=-1
+source /path/to/scripts/deploy/remote-deploy.sh  # defines mel_drush only if sourced carefully — prefer:
+
+mel_drush() {
+  vendor/bin/drush --php-options="-d memory_limit=-1 -d opcache.enable_cli=0" "$@"
+}
+mel_drush status --uri="$SITE_URI"
+mel_drush php:eval 'echo ini_get("memory_limit");'
+```
+
+Expect `memory_limit` to reflect the override (often `-1`).
+
+## Residual risk
+
+- Unlimited CLI memory can allow a runaway Drush process to use more RAM on a small VPS; override with `MEL_DRUSH_PHP_MEMORY_LIMIT=1G` if needed.
+- Does not fix non-memory Drush failures (DB down, bad config import, etc.).

--- a/docs/staging-drush-memory-fix.md
+++ b/docs/staging-drush-memory-fix.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Staging deploys run Drush during `scripts/deploy/remote-deploy.sh` (maintenance mode, cache rebuilds, optional `updb`/`cim`, domain `cset`, finalize). On constrained hosts, `drush cr` and related steps can exhaust PHP CLI memory and exit with errors such as “Drush command terminated abnormally” after a successful bootstrap.
+Staging deploys run Drush during `scripts/deploy/remote-deploy.sh` (maintenance mode, cache rebuilds, optional `updb`/`cim`, domain `cset`, finalize). On constrained hosts, `drush cr` and related steps can exhaust PHP CLI memory (often 128M on the server) and exit with errors such as “Drush command terminated abnormally” after a successful bootstrap.
 
 ## Audit (2026-05)
 
@@ -11,57 +11,57 @@ Staging deploys run Drush during `scripts/deploy/remote-deploy.sh` (maintenance 
 | **CI** | `.github/workflows/deploy-staging.yml` SSHs to the host and runs `bash scripts/deploy/remote-deploy.sh` with `APP_ENV=staging`, `SITE_URI`, `ARTIFACT_PATH`. No PHP memory settings in the workflow. |
 | **Deploy script** | All Drush usage is in `scripts/deploy/remote-deploy.sh`. Rollback/cleanup uses the same script (`mel_deploy_cleanup` trap). |
 | **Composer** | No deploy-time Drush wrappers in root `composer.json` scripts. |
-| **Drush 13** | `vendor/bin/drush` is a shell launcher → `drush.php`. **`DRUSH_PHP_OPTIONS` is not read by Drush 13** (no references in `vendor/drush`). A prior `export DRUSH_PHP_OPTIONS=...` in the deploy script did not apply PHP flags. |
+| **Drush 13** | `vendor/bin/drush` is a shell launcher → `drush.php`. **`DRUSH_PHP_OPTIONS` is not honored** by that launcher. Prior `export DRUSH_PHP_OPTIONS=...` in the deploy script had no effect. |
 | **Web PHP** | Unchanged. This fix only affects CLI invocations from the deploy script. |
-
-Drush 13 supports deploy-time CLI flags via **`--php-options`**, which maps to `runtime.php.options` and is applied to Drush subprocesses (e.g. `updatedb`).
 
 ## Fix
 
-1. **`mel_drush()`** — single wrapper used for every deploy Drush call:
+1. **`mel_drush()`** — every deploy Drush call goes through PHP with explicit `-d` flags on `vendor/bin/drush.php`:
 
    ```bash
-   vendor/bin/drush --php-options="-d memory_limit=${MEL_DRUSH_PHP_MEMORY_LIMIT} ${MEL_DRUSH_PHP_EXTRA}" "$@"
+   php \
+     -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" \
+     -d opcache.enable_cli=0 \
+     vendor/bin/drush.php "$@"
    ```
 
-2. **Defaults**
-   - `MEL_DRUSH_PHP_MEMORY_LIMIT` → `-1` (unlimited CLI memory for deploy)
-   - Falls back to `PHP_MEMORY_LIMIT` if set
-   - `MEL_DRUSH_PHP_EXTRA` → `-d opcache.enable_cli=0` (avoids stale class issues during container rebuild)
+2. **Default** — `MEL_DRUSH_PHP_MEMORY=1024M` (raised from ineffective 512M via `DRUSH_PHP_OPTIONS`).
 
-3. **Rollback / cleanup** — unchanged behaviour: failed deploy still rolls back `current/` and runs `mel_drush` maintenance off + `cr` via the same wrapper.
+3. **Pre-switch `drush cr` removed** — cache rebuild on the unreleased tree before symlink switch was a major memory peak; finalize still runs `mel_drush cr` after switch.
+
+4. **Maintenance on previous release** — when `current/` exists, maintenance mode is enabled from the live release directory (lighter bootstrap) before switching symlink.
+
+5. **`mel_drush_run`** — streams stdout/stderr (no capture) so PHP fatals appear in CI/SSH logs.
+
+6. **Rollback / cleanup** — unchanged: failed deploy rolls back `current/` and runs `mel_drush` maintenance off + `cr` via the same wrapper.
+
+7. **`mel_drush_log_cli_limits`** — logs host CLI `memory_limit` / `max_execution_time` before Drush steps.
 
 ## Overrides (staging host or CI)
 
 ```bash
-# Cap memory instead of unlimited (example)
-MEL_DRUSH_PHP_MEMORY_LIMIT=1G bash scripts/deploy/remote-deploy.sh
-
-# Or use the generic alias
-PHP_MEMORY_LIMIT=512M bash scripts/deploy/remote-deploy.sh
+MEL_DRUSH_PHP_MEMORY=-1 bash scripts/deploy/remote-deploy.sh
+# or
+MEL_DRUSH_PHP_MEMORY=2G bash scripts/deploy/remote-deploy.sh
 ```
 
 Do **not** change PHP-FPM / Apache `memory_limit` for this issue.
 
 ## Local dry-run (no deploy)
 
-From a release directory with `vendor/bin/drush` and valid `settings.php`:
+From project root with database available:
 
 ```bash
-export SITE_URI=https://staging.myeventlane.com.au
-MEL_DRUSH_PHP_MEMORY_LIMIT=-1
-source /path/to/scripts/deploy/remote-deploy.sh  # defines mel_drush only if sourced carefully — prefer:
-
-mel_drush() {
-  vendor/bin/drush --php-options="-d memory_limit=-1 -d opcache.enable_cli=0" "$@"
-}
-mel_drush status --uri="$SITE_URI"
-mel_drush php:eval 'echo ini_get("memory_limit");'
+MEL_DRUSH_PHP_MEMORY=1024M
+php -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" -d opcache.enable_cli=0 \
+  vendor/bin/drush.php status --uri=https://myeventlane.ddev.site
+php -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" vendor/bin/drush.php php:eval 'echo ini_get("memory_limit");' --uri=...
 ```
 
-Expect `memory_limit` to reflect the override (often `-1`).
+(DDEV may still cap `memory_limit` in the container; staging bare-metal CLI uses the `-d` values.)
 
 ## Residual risk
 
-- Unlimited CLI memory can allow a runaway Drush process to use more RAM on a small VPS; override with `MEL_DRUSH_PHP_MEMORY_LIMIT=1G` if needed.
-- Does not fix non-memory Drush failures (DB down, bad config import, etc.).
+- `1024M` may still be insufficient for very large config imports; set `MEL_DRUSH_PHP_MEMORY=-1` if needed.
+- Removing pre-switch `drush cr` means caches are only rebuilt post-switch (intended trade-off for memory).
+- Does not fix non-memory Drush failures (DB down, bad `cim`, etc.).

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -28,21 +28,31 @@ MEL_CURRENT_SWITCHED=0
 MEL_MM_ENABLED_ATTEMPTED=0
 MEL_PREVIOUS_CURRENT=""
 
-# Avoid CLI opcache/stale-class issues and OOM during container rebuild on constrained hosts.
-export DRUSH_PHP_OPTIONS="${DRUSH_PHP_OPTIONS:--d memory_limit=512M -d opcache.enable_cli=0}"
+# Drush 12's vendor/bin/drush launcher does NOT honor DRUSH_PHP_OPTIONS — invoke drush.php via php.
+MEL_DRUSH_PHP_MEMORY="${MEL_DRUSH_PHP_MEMORY:-1024M}"
 
+mel_drush() {
+  php \
+    -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" \
+    -d opcache.enable_cli=0 \
+    vendor/bin/drush.php "$@"
+}
+
+mel_drush_log_cli_limits() {
+  echo "Drush CLI PHP limits (before deploy Drush steps):"
+  php -r 'printf("  memory_limit=%s\n  max_execution_time=%s\n", ini_get("memory_limit"), ini_get("max_execution_time"));'
+  echo "  mel_drush uses memory_limit=${MEL_DRUSH_PHP_MEMORY}"
+}
+
+# Run a command with streamed stdout/stderr so PHP fatals appear in CI logs (not swallowed).
 mel_drush_run() {
   local label="$1"
   shift
   echo "${label}..."
-  local out rc
   set +e
-  out="$("$@" 2>&1)"
-  rc=$?
+  "$@"
+  local rc=$?
   set -e
-  if [ -n "$out" ]; then
-    printf '%s\n' "$out"
-  fi
   if [ "$rc" -ne 0 ]; then
     echo "ERROR: ${label} failed (exit ${rc})." >&2
     return "$rc"
@@ -54,7 +64,7 @@ mel_drush_maintenance_mode() {
   # state:set (alias sset) requires a bootstrapped site; use integer for 0/1.
   local mode="$1"
   mel_drush_run "Set system.maintenance_mode=${mode}" \
-    vendor/bin/drush state:set system.maintenance_mode "$mode" \
+    mel_drush state:set system.maintenance_mode "$mode" \
       --input-format=integer \
       --uri="$SITE_URI"
 }
@@ -71,7 +81,7 @@ On the staging host, check:
   3. Host vs socket: if host is 127.0.0.1 but MySQL only listens on a Unix socket,
      set 'host' => 'localhost' in $databases['default']['default'] (or enable TCP bind).
   4. Manual test from the release directory:
-       cd ~/staging/current && vendor/bin/drush sql:query "SELECT 1" --uri="$SITE_URI"
+       cd ~/staging/current && php -d memory_limit=1024M vendor/bin/drush.php sql:query "SELECT 1" --uri="$SITE_URI"
 EOF
 }
 
@@ -80,7 +90,7 @@ mel_verify_drush_bootstrap() {
   echo "${label}: verifying Drupal bootstrap (Drush)..."
   local out
   set +e
-  out="$(vendor/bin/drush status --uri="$SITE_URI" 2>&1)"
+  out="$(mel_drush status --uri="$SITE_URI" 2>&1)"
   local rc=$?
   set -e
   if [ "$rc" -ne 0 ] || ! echo "$out" | grep -qE 'Drupal bootstrap\s*:\s*Successful'; then
@@ -105,11 +115,11 @@ mel_deploy_cleanup() {
   fi
   local drush_cwd=""
   drush_cwd="$(readlink -f "$CURRENT_PATH" 2>/dev/null || true)"
-  if [ -n "$drush_cwd" ] && [ -x "$drush_cwd/vendor/bin/drush" ]; then
+  if [ -n "$drush_cwd" ] && [ -f "$drush_cwd/vendor/bin/drush.php" ]; then
     if [ "${MEL_MM_ENABLED_ATTEMPTED:-0}" = "1" ]; then
       ( cd "$drush_cwd" && mel_drush_maintenance_mode 0 2>/dev/null || true )
     fi
-    ( cd "$drush_cwd" && vendor/bin/drush cr --uri="$SITE_URI" 2>/dev/null || true )
+    ( cd "$drush_cwd" && mel_drush cr --uri="$SITE_URI" 2>/dev/null || true )
   fi
 }
 trap mel_deploy_cleanup EXIT
@@ -251,10 +261,12 @@ fi
 cd "$RELEASE_PATH"
 
 # ---- DRUSH CHECK ----
-if [ ! -x "vendor/bin/drush" ]; then
-  echo "Drush not found in artifact"
+if [ ! -f "vendor/bin/drush.php" ]; then
+  echo "Drush not found in artifact (expected vendor/bin/drush.php)"
   exit 1
 fi
+
+mel_drush_log_cli_limits
 
 # Fail fast before switching current/: new code + shared settings must bootstrap and reach MySQL.
 mel_verify_drush_bootstrap "Preflight (new release, before symlink switch)"
@@ -265,9 +277,15 @@ if [ -e "$CURRENT_PATH" ]; then
 fi
 
 # ---- MAINTENANCE MODE ----
+# Prefer the live release for maintenance toggles (lighter, already warmed).
 MEL_MM_ENABLED_ATTEMPTED=1
-mel_drush_maintenance_mode 1
-mel_drush_run "Cache rebuild (pre-switch)" vendor/bin/drush cr --uri="$SITE_URI"
+if [ -n "${MEL_PREVIOUS_CURRENT:-}" ] && [ -f "${MEL_PREVIOUS_CURRENT}/vendor/bin/drush.php" ]; then
+  ( cd "$MEL_PREVIOUS_CURRENT" && mel_drush_maintenance_mode 1 )
+else
+  mel_drush_maintenance_mode 1
+fi
+# No pre-switch cache rebuild: drush cr on the unreleased tree peaks memory during container
+# rebuild; staging CLI defaults are often 128M. Post-switch finalize runs drush cr with mel_drush.
 
 # ---- SWITCH RELEASE (ATOMIC) ----
 ln -sfn "$RELEASE_PATH" "$CURRENT_PATH"
@@ -307,15 +325,15 @@ fi
 
 # ---- OPTIONAL UPDATES ----
 if [ "$RUN_UPDB" = "1" ]; then
-  vendor/bin/drush updb -y --uri="$SITE_URI"
+  mel_drush updb -y --uri="$SITE_URI"
 fi
 
 if [ "$RUN_CIM" = "1" ]; then
-  vendor/bin/drush cim -y --uri="$SITE_URI"
+  mel_drush cim -y --uri="$SITE_URI"
 
   # Deploy safety: active storage must match sync after import (see Drush docs: grep "No differences").
   echo "Verifying config:status after import..."
-  CST_OUT="$(vendor/bin/drush cst --uri="$SITE_URI" 2>&1)" || true
+  CST_OUT="$(mel_drush cst --uri="$SITE_URI" 2>&1)" || true
   if echo "$CST_OUT" | grep -qi 'configuration differences'; then
     echo "ERROR: config:status reports configuration differences — deployment aborted." >&2
     echo "$CST_OUT" >&2
@@ -356,52 +374,28 @@ MEL_DEPLOY_MODE="$(mel_resolve_deploy_mode)"
 
 if [ "$MEL_DEPLOY_MODE" = "production" ]; then
   echo "Applying production domain settings (APP_ENV/SITE_URI → production)..."
-  vendor/bin/drush cset myeventlane_core.domain_settings public_domain 'https://myeventlane.com.au' -y --uri="$SITE_URI"
-  vendor/bin/drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.myeventlane.com.au' -y --uri="$SITE_URI"
-  vendor/bin/drush cset myeventlane_core.domain_settings admin_domain 'https://admin.myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings public_domain 'https://myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings admin_domain 'https://admin.myeventlane.com.au' -y --uri="$SITE_URI"
 elif [ "$MEL_DEPLOY_MODE" = "staging" ]; then
   echo "Applying staging domain settings (APP_ENV/SITE_URI → staging)..."
-  vendor/bin/drush cset myeventlane_core.domain_settings public_domain 'https://staging.myeventlane.com.au' -y --uri="$SITE_URI"
-  vendor/bin/drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.staging.myeventlane.com.au' -y --uri="$SITE_URI"
-  vendor/bin/drush cset myeventlane_core.domain_settings admin_domain 'https://admin.staging.myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings public_domain 'https://staging.myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings vendor_domain 'https://vendor.staging.myeventlane.com.au' -y --uri="$SITE_URI"
+  mel_drush cset myeventlane_core.domain_settings admin_domain 'https://admin.staging.myeventlane.com.au' -y --uri="$SITE_URI"
 else
   echo "NOTICE: Skipping automatic domain cset (set APP_ENV=production|staging, or SITE_URI with staging vs myeventlane.com.au)." >&2
 fi
 
 # ---- FINALISE ----
 # These drush invocations are strict (no "|| true"): failures must surface in CI/SSH logs.
-echo "Finalize: drush cr (post-domain cset)..."
-set +e
-_mel_drush_cr_out="$(vendor/bin/drush cr --uri="$SITE_URI" 2>&1)"
-_mel_drush_cr_rc=$?
-set -e
-printf '%s\n' "$_mel_drush_cr_out"
-if [ "$_mel_drush_cr_rc" -ne 0 ]; then
-  echo "ERROR: drush cr failed during finalize (exit $_mel_drush_cr_rc)." >&2
-  exit "$_mel_drush_cr_rc"
-fi
+mel_drush_run "Finalize: drush cr (post-domain cset)" \
+  mel_drush cr --uri="$SITE_URI"
 
-echo "Finalize: drush state:set system.maintenance_mode 0..."
-set +e
-_mel_drush_mm_out="$(mel_drush_maintenance_mode 0 2>&1)"
-_mel_drush_mm_rc=$?
-set -e
-printf '%s\n' "$_mel_drush_mm_out"
-if [ "$_mel_drush_mm_rc" -ne 0 ]; then
-  echo "ERROR: drush state:set system.maintenance_mode 0 failed during finalize (exit $_mel_drush_mm_rc)." >&2
-  exit "$_mel_drush_mm_rc"
-fi
+mel_drush_run "Finalize: drush state:set system.maintenance_mode 0" \
+  mel_drush_maintenance_mode 0
 
-echo "Finalize: drush cr (after maintenance off)..."
-set +e
-_mel_drush_cr2_out="$(vendor/bin/drush cr --uri="$SITE_URI" 2>&1)"
-_mel_drush_cr2_rc=$?
-set -e
-printf '%s\n' "$_mel_drush_cr2_out"
-if [ "$_mel_drush_cr2_rc" -ne 0 ]; then
-  echo "ERROR: second drush cr failed during finalize (exit $_mel_drush_cr2_rc)." >&2
-  exit "$_mel_drush_cr2_rc"
-fi
+mel_drush_run "Finalize: drush cr (after maintenance off)" \
+  mel_drush cr --uri="$SITE_URI"
 
 DEPLOY_SUCCEEDED=1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the staging deploy flow and all Drush invocations (maintenance mode, cache rebuilds, rollback), so failures could leave staging in maintenance mode or with incomplete cache rebuilds if the wrapper or paths behave differently on-host.
> 
> **Overview**
> Staging deploy Drush calls are now routed through a new `mel_drush()` wrapper that runs `vendor/bin/drush.php` via `php -d memory_limit=... -d opcache.enable_cli=0`, with a configurable `MEL_DRUSH_PHP_MEMORY` defaulting to `1024M`, and the script now logs CLI PHP limits before running Drush.
> 
> The deploy script stops using `DRUSH_PHP_OPTIONS`, updates all Drush usages (including rollback/cleanup) to the wrapper, streams Drush output directly to SSH/CI logs, removes the **pre-switch** cache rebuild, and prefers enabling maintenance mode from the previous live release when available. A new doc (`docs/staging-drush-memory-fix.md`) documents the issue, rationale, and override knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42fe80aece25a08eec79d9dde745b7c7782a5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->