### PR TITLE
Feature/event page sidebar gallery layout

### DIFF
--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -12,19 +12,21 @@
   {{ attach_library('myeventlane_theme/mel_event_gallery') }}
   {% set style_mod = event_page_style == 'immersive' ? 'immersive' : 'classic' %}
   <section
-    class="mel-event-gallery mel-event-gallery--{{ style_mod }} mel-event-gallery--carousel mel-event-gallery--count-{{ gallery.count }}"
+    class="mel-event-gallery mel-event-gallery--{{ style_mod }} mel-event-gallery--carousel mel-event-gallery--count-{{ gallery.count }} mel-event-full__card"
     aria-labelledby="mel-event-gallery-title"
     data-mel-lightbox-root
     data-mel-lightbox-root-id="mel-event-gallery-main"
   >
-    <header class="mel-event-gallery__header">
-      <h2 class="mel-event-gallery__title" id="mel-event-gallery-title">{{ 'Moments from this event'|t }}</h2>
-      <p class="mel-event-gallery__lede">{{ 'A closer look — tap any photo to expand.'|t }}</p>
-    </header>
+    <div class="mel-event-full__gallery-card mel-card mel-card--surface">
+      <header class="mel-event-gallery__header mel-card__header">
+        <h2 class="mel-event-gallery__title mel-card__title" id="mel-event-gallery-title">{{ 'Moments from this event'|t }}</h2>
+        <p class="mel-event-gallery__lede">{{ 'A closer look — tap any photo to expand.'|t }}</p>
+      </header>
 
     <div
-      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }}{% if gallery.count < 2 %} mel-sidebar-carousel--single{% endif %}"
+      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }}{% if gallery.count < 2 %} mel-sidebar-carousel--single{% endif %}{% if gallery.count >= 2 %} mel-event-gallery--rail{% endif %}"
       data-mel-sidebar-carousel
+      {% if gallery.count >= 2 %}data-mel-gallery-rail{% endif %}
       data-mel-sidebar-slide-count="{{ gallery.count }}"
       role="region"
       aria-roledescription="{{ 'Carousel'|t }}"
@@ -114,6 +116,7 @@
           </div>
         {% endif %}
       </div>
+    </div>
     </div>
 
     <dialog class="mel-media-lightbox" data-mel-lightbox-dialog aria-label="{{ 'Expanded photo'|t }}">

--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -31,7 +31,13 @@
       aria-label="{{ 'Event photo gallery'|t }}"
     >
       <div class="mel-card mel-card--surface mel-event-gallery__carousel-shell">
-        <div class="mel-sidebar-carousel__viewport mel-event-gallery__viewport" data-mel-sidebar-viewport tabindex="0">
+        <div
+          class="mel-sidebar-carousel__viewport mel-event-gallery__viewport"
+          data-mel-sidebar-viewport
+          tabindex="0"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           <div class="mel-sidebar-carousel__track mel-event-gallery__track" data-mel-sidebar-track>
             {% for item in gallery.items %}
               <div

--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -24,9 +24,9 @@
       </header>
 
     <div
-      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }}{% if gallery.count < 2 %} mel-sidebar-carousel--single{% endif %}{% if gallery.count >= 2 %} mel-event-gallery--rail{% endif %}"
+      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }} mel-event-gallery--rail{% if gallery.count < 2 %} mel-event-gallery--rail-single{% endif %}"
       data-mel-sidebar-carousel
-      {% if gallery.count >= 2 %}data-mel-gallery-rail{% endif %}
+      data-mel-gallery-rail
       data-mel-sidebar-slide-count="{{ gallery.count }}"
       role="region"
       aria-roledescription="{{ 'Carousel'|t }}"
@@ -50,7 +50,6 @@
                 role="group"
                 aria-roledescription="{{ 'Slide'|t }}"
                 aria-label="{{ 'Photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}"
-                {% if not loop.first %}hidden{% endif %}
               >
                 <button
                   type="button"

--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Event gallery — editorial composition from EventMediaPresenter.
+ * Event gallery — main-column carousel with native dialog lightbox.
  *
  * Variables:
  * - gallery: { role, count, composition, items[] }
@@ -11,9 +11,8 @@
 {% if gallery.count > 0 %}
   {{ attach_library('myeventlane_theme/mel_event_gallery') }}
   {% set style_mod = event_page_style == 'immersive' ? 'immersive' : 'classic' %}
-  {% set composition = gallery.composition|default('editorial') %}
   <section
-    class="mel-event-gallery mel-event-gallery--{{ style_mod }} mel-event-gallery--composition-{{ composition }} mel-event-gallery--count-{{ gallery.count }}"
+    class="mel-event-gallery mel-event-gallery--{{ style_mod }} mel-event-gallery--carousel mel-event-gallery--count-{{ gallery.count }}"
     aria-labelledby="mel-event-gallery-title"
     data-mel-lightbox-root
     data-mel-lightbox-root-id="mel-event-gallery-main"
@@ -22,37 +21,95 @@
       <h2 class="mel-event-gallery__title" id="mel-event-gallery-title">{{ 'Moments from this event'|t }}</h2>
       <p class="mel-event-gallery__lede">{{ 'A closer look — tap any photo to expand.'|t }}</p>
     </header>
-    <ul
-      class="mel-event-gallery__grid mel-event-gallery__grid--{{ composition }}"
-      role="list"
+
+    <div
+      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }}{% if gallery.count < 2 %} mel-sidebar-carousel--single{% endif %}"
+      data-mel-sidebar-carousel
+      data-mel-sidebar-slide-count="{{ gallery.count }}"
+      role="region"
+      aria-roledescription="{{ 'Carousel'|t }}"
+      aria-label="{{ 'Event photo gallery'|t }}"
     >
-      {% for item in gallery.items %}
-        <li
-          class="mel-event-gallery__item {{ item.layout_class }} mel-event-gallery__item--role-{{ item.role }} mel-event-gallery__item--emphasis-{{ item.emphasis }}"
-          role="listitem"
-        >
-          <button
-            type="button"
-            class="mel-event-gallery__trigger"
-            data-mel-lightbox-open
-            data-mel-lightbox-index="{{ item.index }}"
-            aria-label="{{ 'View photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}{% if item.alt %}: {{ item.alt }}{% endif %}"
-          >
-            <img
-              class="mel-event-gallery__img"
-              src="{{ item.urls.card }}"
-              srcset="{{ item.srcset }}"
-              sizes="{{ item.sizes }}"
-              alt="{{ item.alt }}"
-              width="{{ item.width > 0 ? item.width : 960 }}"
-              height="{{ item.height > 0 ? item.height : 640 }}"
-              loading="lazy"
-              decoding="async"
-            />
-          </button>
-        </li>
-      {% endfor %}
-    </ul>
+      <div class="mel-card mel-card--surface mel-event-gallery__carousel-shell">
+        <div class="mel-sidebar-carousel__viewport mel-event-gallery__viewport" data-mel-sidebar-viewport tabindex="0">
+          <div class="mel-sidebar-carousel__track mel-event-gallery__track" data-mel-sidebar-track>
+            {% for item in gallery.items %}
+              <div
+                class="mel-sidebar-carousel__slide mel-event-gallery__slide{% if loop.first %} is-active{% endif %}"
+                data-mel-sidebar-slide
+                data-slide-id="photo-{{ item.index }}"
+                id="mel-gallery-slide-{{ item.index }}"
+                role="group"
+                aria-roledescription="{{ 'Slide'|t }}"
+                aria-label="{{ 'Photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}"
+                {% if not loop.first %}hidden{% endif %}
+              >
+                <button
+                  type="button"
+                  class="mel-event-gallery__trigger"
+                  data-mel-lightbox-open
+                  data-mel-lightbox-index="{{ item.index }}"
+                  aria-label="{{ 'View photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}{% if item.alt %}: {{ item.alt }}{% endif %}"
+                >
+                  <img
+                    class="mel-event-gallery__img"
+                    src="{{ item.urls.card }}"
+                    srcset="{{ item.srcset }}"
+                    sizes="{{ item.sizes }}"
+                    alt="{{ item.alt }}"
+                    width="{{ item.width > 0 ? item.width : 960 }}"
+                    height="{{ item.height > 0 ? item.height : 640 }}"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </button>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+
+        {% if gallery.count > 1 %}
+          <div class="mel-sidebar-carousel__footer mel-event-gallery__footer">
+            <div class="mel-sidebar-carousel__nav" role="group" aria-label="{{ 'Gallery navigation'|t }}">
+              <button
+                type="button"
+                class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--prev"
+                data-mel-sidebar-prev
+                aria-label="{{ 'Previous photo'|t }}"
+                disabled
+              >
+                <span aria-hidden="true">←</span>
+              </button>
+              <div class="mel-sidebar-carousel__dots mel-event-gallery__dots" role="tablist" aria-label="{{ 'Choose photo'|t }}">
+                {% for item in gallery.items %}
+                  <button
+                    type="button"
+                    class="mel-sidebar-carousel__dot{% if loop.first %} is-active{% endif %}"
+                    data-mel-sidebar-dot
+                    data-slide-index="{{ loop.index0 }}"
+                    role="tab"
+                    aria-selected="{{ loop.first ? 'true' : 'false' }}"
+                    aria-controls="mel-gallery-slide-{{ item.index }}"
+                    id="mel-gallery-tab-{{ item.index }}"
+                  >
+                    <span class="visually-hidden">{{ 'Photo @n'|t({'@n': loop.index}) }}</span>
+                  </button>
+                {% endfor %}
+              </div>
+              <button
+                type="button"
+                class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--next"
+                data-mel-sidebar-next
+                aria-label="{{ 'Next photo'|t }}"
+              >
+                <span aria-hidden="true">→</span>
+              </button>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+
     <dialog class="mel-media-lightbox" data-mel-lightbox-dialog aria-label="{{ 'Expanded photo'|t }}">
       <div class="mel-media-lightbox__inner">
         <button type="button" class="mel-media-lightbox__close" data-mel-lightbox-close aria-label="{{ 'Close'|t }}">

--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -5,14 +5,13 @@
  *
  * Variables:
  * - gallery: { role, count, composition, items[] }
- * - event_page_style: classic|immersive
+ * - event_page_style: (deprecated) styling uses mel-event-page--* on <article>.
  */
 #}
 {% if gallery.count > 0 %}
   {{ attach_library('myeventlane_theme/mel_event_gallery') }}
-  {% set style_mod = event_page_style == 'immersive' ? 'immersive' : 'classic' %}
   <section
-    class="mel-event-gallery mel-event-gallery--{{ style_mod }} mel-event-gallery--carousel mel-event-gallery--count-{{ gallery.count }} mel-event-full__card"
+    class="mel-event-gallery mel-event-gallery--carousel mel-event-gallery--count-{{ gallery.count }} mel-event-full__card"
     aria-labelledby="mel-event-gallery-title"
     data-mel-lightbox-root
     data-mel-lightbox-root-id="mel-event-gallery-main"
@@ -25,7 +24,7 @@
 
     {# Thumbnail rail — uses mel-event-sidebar-carousel.js (data-mel-sidebar-carousel). #}
     <div
-      class="mel-event-gallery__rail mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }} mel-event-gallery--rail{% if gallery.count < 2 %} mel-event-gallery--rail-single{% endif %}"
+      class="mel-event-gallery__rail mel-sidebar-carousel mel-event-gallery--rail{% if gallery.count < 2 %} mel-event-gallery--rail-single{% endif %}"
       data-mel-sidebar-carousel
       data-mel-gallery-rail
       data-mel-sidebar-slide-count="{{ gallery.count }}"

--- a/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-gallery.html.twig
@@ -23,8 +23,9 @@
         <p class="mel-event-gallery__lede">{{ 'A closer look — tap any photo to expand.'|t }}</p>
       </header>
 
+    {# Thumbnail rail — uses mel-event-sidebar-carousel.js (data-mel-sidebar-carousel). #}
     <div
-      class="mel-event-gallery__carousel mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }} mel-event-gallery--rail{% if gallery.count < 2 %} mel-event-gallery--rail-single{% endif %}"
+      class="mel-event-gallery__rail mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }} mel-event-gallery--rail{% if gallery.count < 2 %} mel-event-gallery--rail-single{% endif %}"
       data-mel-sidebar-carousel
       data-mel-gallery-rail
       data-mel-sidebar-slide-count="{{ gallery.count }}"
@@ -32,89 +33,87 @@
       aria-roledescription="{{ 'Carousel'|t }}"
       aria-label="{{ 'Event photo gallery'|t }}"
     >
-      <div class="mel-card mel-card--surface mel-event-gallery__carousel-shell">
-        <div
-          class="mel-sidebar-carousel__viewport mel-event-gallery__viewport"
-          data-mel-sidebar-viewport
-          tabindex="0"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          <div class="mel-sidebar-carousel__track mel-event-gallery__track" data-mel-sidebar-track>
-            {% for item in gallery.items %}
-              <div
-                class="mel-sidebar-carousel__slide mel-event-gallery__slide{% if loop.first %} is-active{% endif %}"
-                data-mel-sidebar-slide
-                data-slide-id="photo-{{ item.index }}"
-                id="mel-gallery-slide-{{ item.index }}"
-                role="group"
-                aria-roledescription="{{ 'Slide'|t }}"
-                aria-label="{{ 'Photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}"
-              >
-                <button
-                  type="button"
-                  class="mel-event-gallery__trigger"
-                  data-mel-lightbox-open
-                  data-mel-lightbox-index="{{ item.index }}"
-                  aria-label="{{ 'View photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}{% if item.alt %}: {{ item.alt }}{% endif %}"
-                >
-                  <img
-                    class="mel-event-gallery__img"
-                    src="{{ item.urls.card }}"
-                    srcset="{{ item.srcset }}"
-                    sizes="{{ item.sizes }}"
-                    alt="{{ item.alt }}"
-                    width="{{ item.width > 0 ? item.width : 960 }}"
-                    height="{{ item.height > 0 ? item.height : 640 }}"
-                    loading="lazy"
-                    decoding="async"
-                  />
-                </button>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-
-        {% if gallery.count > 1 %}
-          <div class="mel-sidebar-carousel__footer mel-event-gallery__footer">
-            <div class="mel-sidebar-carousel__nav" role="group" aria-label="{{ 'Gallery navigation'|t }}">
+      <div
+        class="mel-sidebar-carousel__viewport mel-event-gallery__viewport"
+        data-mel-sidebar-viewport
+        tabindex="0"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <div class="mel-sidebar-carousel__track mel-event-gallery__track" data-mel-sidebar-track>
+          {% for item in gallery.items %}
+            <div
+              class="mel-sidebar-carousel__slide mel-event-gallery__slide{% if loop.first %} is-active{% endif %}"
+              data-mel-sidebar-slide
+              data-slide-id="photo-{{ item.index }}"
+              id="mel-gallery-slide-{{ item.index }}"
+              role="group"
+              aria-roledescription="{{ 'Slide'|t }}"
+              aria-label="{{ 'Photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}"
+            >
               <button
                 type="button"
-                class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--prev"
-                data-mel-sidebar-prev
-                aria-label="{{ 'Previous photo'|t }}"
-                disabled
+                class="mel-event-gallery__trigger"
+                data-mel-lightbox-open
+                data-mel-lightbox-index="{{ item.index }}"
+                aria-label="{{ 'View photo @n of @total'|t({'@n': item.index + 1, '@total': gallery.count}) }}{% if item.alt %}: {{ item.alt }}{% endif %}"
               >
-                <span aria-hidden="true">←</span>
-              </button>
-              <div class="mel-sidebar-carousel__dots mel-event-gallery__dots" role="tablist" aria-label="{{ 'Choose photo'|t }}">
-                {% for item in gallery.items %}
-                  <button
-                    type="button"
-                    class="mel-sidebar-carousel__dot{% if loop.first %} is-active{% endif %}"
-                    data-mel-sidebar-dot
-                    data-slide-index="{{ loop.index0 }}"
-                    role="tab"
-                    aria-selected="{{ loop.first ? 'true' : 'false' }}"
-                    aria-controls="mel-gallery-slide-{{ item.index }}"
-                    id="mel-gallery-tab-{{ item.index }}"
-                  >
-                    <span class="visually-hidden">{{ 'Photo @n'|t({'@n': loop.index}) }}</span>
-                  </button>
-                {% endfor %}
-              </div>
-              <button
-                type="button"
-                class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--next"
-                data-mel-sidebar-next
-                aria-label="{{ 'Next photo'|t }}"
-              >
-                <span aria-hidden="true">→</span>
+                <img
+                  class="mel-event-gallery__img"
+                  src="{{ item.urls.card }}"
+                  srcset="{{ item.srcset }}"
+                  sizes="{{ item.sizes }}"
+                  alt="{{ item.alt }}"
+                  width="{{ item.width > 0 ? item.width : 960 }}"
+                  height="{{ item.height > 0 ? item.height : 640 }}"
+                  loading="lazy"
+                  decoding="async"
+                />
               </button>
             </div>
-          </div>
-        {% endif %}
+          {% endfor %}
+        </div>
       </div>
+
+      {% if gallery.count > 1 %}
+        <div class="mel-sidebar-carousel__footer mel-event-gallery__footer">
+          <div class="mel-sidebar-carousel__nav" role="group" aria-label="{{ 'Gallery navigation'|t }}">
+            <button
+              type="button"
+              class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--prev"
+              data-mel-sidebar-prev
+              aria-label="{{ 'Previous photo'|t }}"
+              disabled
+            >
+              <span aria-hidden="true">←</span>
+            </button>
+            <div class="mel-sidebar-carousel__dots mel-event-gallery__dots" role="tablist" aria-label="{{ 'Choose photo'|t }}">
+              {% for item in gallery.items %}
+                <button
+                  type="button"
+                  class="mel-sidebar-carousel__dot{% if loop.first %} is-active{% endif %}"
+                  data-mel-sidebar-dot
+                  data-slide-index="{{ loop.index0 }}"
+                  role="tab"
+                  aria-selected="{{ loop.first ? 'true' : 'false' }}"
+                  aria-controls="mel-gallery-slide-{{ item.index }}"
+                  id="mel-gallery-tab-{{ item.index }}"
+                >
+                  <span class="visually-hidden">{{ 'Photo @n'|t({'@n': loop.index}) }}</span>
+                </button>
+              {% endfor %}
+            </div>
+            <button
+              type="button"
+              class="mel-sidebar-carousel__arrow mel-sidebar-carousel__arrow--next"
+              data-mel-sidebar-next
+              aria-label="{{ 'Next photo'|t }}"
+            >
+              <span aria-hidden="true">→</span>
+            </button>
+          </div>
+        </div>
+      {% endif %}
     </div>
     </div>
 

--- a/web/modules/custom/myeventlane_event/templates/mel-event-sidebar-carousel.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-event-sidebar-carousel.html.twig
@@ -5,14 +5,13 @@
  *
  * Variables:
  * - carousel: { slides, count, lightbox_root_id }
- * - event_page_style: classic|immersive
+ * - event_page_style: (deprecated) styling uses mel-event-page--* on <article>.
  */
 #}
-{% set style_mod = event_page_style == 'immersive' ? 'immersive' : 'classic' %}
 {% set slide_count = carousel.count|default(0) %}
 {% if slide_count > 0 %}
   <div
-    class="mel-sidebar-carousel mel-sidebar-carousel--{{ style_mod }}{% if slide_count < 2 %} mel-sidebar-carousel--single{% endif %}"
+    class="mel-sidebar-carousel{% if slide_count < 2 %} mel-sidebar-carousel--single{% endif %}"
     data-mel-sidebar-carousel
     data-mel-sidebar-slide-count="{{ slide_count }}"
     role="region"

--- a/web/themes/custom/myeventlane_theme/js/mel-event-sidebar-carousel.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-event-sidebar-carousel.js
@@ -17,6 +17,9 @@
     const next = carousel.querySelector("[data-mel-sidebar-next]");
     const dots = Array.from(carousel.querySelectorAll("[data-mel-sidebar-dot]"));
     const viewport = carousel.querySelector("[data-mel-sidebar-viewport]");
+    const isRail =
+      carousel.hasAttribute("data-mel-gallery-rail") ||
+      carousel.classList.contains("mel-event-gallery--rail");
     let active = slides.findIndex((slide) => slide.classList.contains("is-active"));
     if (active < 0) {
       active = 0;
@@ -29,17 +32,30 @@
      */
     function goTo(index) {
       const target = Math.max(0, Math.min(index, slides.length - 1));
-      if (target === active) {
-        return;
-      }
-      slides[active].classList.remove("is-active");
-      slides[active].hidden = true;
-      slides[active].setAttribute("aria-hidden", "true");
 
-      active = target;
-      slides[active].classList.add("is-active");
-      slides[active].hidden = false;
-      slides[active].removeAttribute("aria-hidden");
+      if (target !== active) {
+        if (isRail) {
+          slides[active].classList.remove("is-active");
+          slides[active].setAttribute("aria-hidden", "true");
+          active = target;
+          slides[active].classList.add("is-active");
+          slides[active].removeAttribute("aria-hidden");
+          slides[active].scrollIntoView({
+            behavior: reducedMotion ? "auto" : "smooth",
+            block: "nearest",
+            inline: "center",
+          });
+        } else {
+          slides[active].classList.remove("is-active");
+          slides[active].hidden = true;
+          slides[active].setAttribute("aria-hidden", "true");
+
+          active = target;
+          slides[active].classList.add("is-active");
+          slides[active].hidden = false;
+          slides[active].removeAttribute("aria-hidden");
+        }
+      }
 
       dots.forEach((dot, i) => {
         const selected = i === active;
@@ -143,6 +159,14 @@
 
     if (!reducedMotion && slides.length > 1) {
       carousel.setAttribute("data-mel-sidebar-enhanced", "true");
+    }
+
+    if (isRail) {
+      slides.forEach((slide, i) => {
+        slide.hidden = false;
+        slide.classList.toggle("is-active", i === active);
+        slide.setAttribute("aria-hidden", i === active ? "false" : "true");
+      });
     }
 
     goTo(active);

--- a/web/themes/custom/myeventlane_theme/js/mel-event-sidebar-carousel.js
+++ b/web/themes/custom/myeventlane_theme/js/mel-event-sidebar-carousel.js
@@ -70,17 +70,34 @@
       });
     });
 
+    /**
+     * @param {KeyboardEvent} event
+     */
+    function handleCarouselKey(event) {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goTo(active - 1);
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        goTo(active + 1);
+        return;
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        goTo(0);
+        return;
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        goTo(slides.length - 1);
+      }
+    }
+
+    carousel.addEventListener("keydown", handleCarouselKey);
     if (viewport) {
-      viewport.addEventListener("keydown", (event) => {
-        if (event.key === "ArrowLeft") {
-          event.preventDefault();
-          goTo(active - 1);
-        }
-        if (event.key === "ArrowRight") {
-          event.preventDefault();
-          goTo(active + 1);
-        }
-      });
+      viewport.addEventListener("keydown", handleCarouselKey);
 
       let touchStartX = 0;
       let touchDeltaX = 0;

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -153,7 +153,7 @@ myeventlane_event_full:
     js/event-full-trust-rotator.js: { attributes: { defer: true } }
 
 mel_event_gallery:
-  version: 1.2
+  version: 1.3
   js:
     js/mel-media-lightbox.js: {}
     js/mel-event-sidebar-carousel.js: { attributes: { defer: true } }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -153,7 +153,7 @@ myeventlane_event_full:
     js/event-full-trust-rotator.js: { attributes: { defer: true } }
 
 mel_event_gallery:
-  version: 1.3
+  version: 1.4
   js:
     js/mel-media-lightbox.js: {}
     js/mel-event-sidebar-carousel.js: { attributes: { defer: true } }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -153,9 +153,10 @@ myeventlane_event_full:
     js/event-full-trust-rotator.js: { attributes: { defer: true } }
 
 mel_event_gallery:
-  version: 1.1
+  version: 1.2
   js:
     js/mel-media-lightbox.js: {}
+    js/mel-event-sidebar-carousel.js: { attributes: { defer: true } }
   dependencies:
     - core/drupal
     - core/once

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3900,14 +3900,25 @@ function _myeventlane_theme_build_mel_event_branding(string $style, string $colo
     $secondary = '#F26D5B';
   }
 
-  $css_vars = [
-    '--mel-event-page-bg' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-page-bg'], $defaults['--mel-event-page-bg']),
-    '--mel-event-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-surface'], $defaults['--mel-event-surface']),
-    '--mel-event-soft-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-soft-surface'], $defaults['--mel-event-soft-surface']),
-    '--mel-event-border' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-border'], $defaults['--mel-event-border']),
-    '--mel-event-accent' => $accent,
-    '--mel-event-secondary-accent' => _myeventlane_theme_sanitize_event_branding_hex($secondary, $defaults['--mel-event-secondary-accent']),
-  ];
+  // Immersive surfaces and typography come from _event-page-themes.scss (no rgba in inline).
+  // Inline vars must not force Classic light tokens over Immersive on public full pages.
+  $style_key = strtolower(trim($style));
+  if ($style_key === 'immersive') {
+    $css_vars = [
+      '--mel-event-accent' => $accent,
+      '--mel-event-secondary-accent' => _myeventlane_theme_sanitize_event_branding_hex($secondary, $defaults['--mel-event-secondary-accent']),
+    ];
+  }
+  else {
+    $css_vars = [
+      '--mel-event-page-bg' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-page-bg'], $defaults['--mel-event-page-bg']),
+      '--mel-event-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-surface'], $defaults['--mel-event-surface']),
+      '--mel-event-soft-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-soft-surface'], $defaults['--mel-event-soft-surface']),
+      '--mel-event-border' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-border'], $defaults['--mel-event-border']),
+      '--mel-event-accent' => $accent,
+      '--mel-event-secondary-accent' => _myeventlane_theme_sanitize_event_branding_hex($secondary, $defaults['--mel-event-secondary-accent']),
+    ];
+  }
 
   $parts = [];
   foreach ($css_vars as $name => $hex) {
@@ -4309,6 +4320,10 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
  * pages use node__event__full and do not invoke preprocess_node__event.
  */
 function myeventlane_theme_preprocess_node__event__full(array &$variables): void {
+  $node = $variables['node'] ?? NULL;
+  if ($node instanceof NodeInterface) {
+    _myeventlane_theme_apply_event_page_style_theme_variables($variables, $node);
+  }
   _myeventlane_theme_attach_event_sidebar_carousel($variables);
 }
 

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -3835,6 +3835,95 @@ function _myeventlane_theme_resolve_event_page_style_for_node(NodeInterface $nod
 }
 
 /**
+ * Sanitises a hex colour for safe inline CSS custom properties.
+ */
+function _myeventlane_theme_sanitize_event_branding_hex(?string $value, string $fallback): string {
+  $value = strtoupper(trim((string) $value));
+  if (preg_match('/^#([0-9A-F]{3}|[0-9A-F]{6})$/', $value) !== 1) {
+    return $fallback;
+  }
+  if (strlen($value) === 4) {
+    $value = '#' . $value[1] . $value[1] . $value[2] . $value[2] . $value[3] . $value[3];
+  }
+  return $value;
+}
+
+/**
+ * Approved accent hex values keyed by Event Studio theme colour machine name.
+ *
+ * @return array<string, string>
+ */
+function _myeventlane_theme_event_branding_accent_hex_map(): array {
+  return [
+    'coral' => '#F26D5B',
+    'purple' => '#7C83FD',
+    'mint' => '#3D9B7A',
+    'gold' => '#F5A04C',
+    'blue' => '#5B8DEF',
+  ];
+}
+
+/**
+ * Builds safe branding CSS variables for public event full pages.
+ *
+ * Uses Event Studio field_mel_theme_colour (resolved) only — no raw user CSS.
+ *
+ * @return array{
+ *   style: string,
+ *   colour: string,
+ *   css_vars: array<string, string>,
+ *   css_inline: string,
+ * }
+ */
+function _myeventlane_theme_build_mel_event_branding(string $style, string $colour): array {
+  $defaults = [
+    '--mel-event-page-bg' => '#FFF9F5',
+    '--mel-event-surface' => '#FFFFFF',
+    '--mel-event-soft-surface' => '#FDF1EC',
+    '--mel-event-border' => '#E9E3DE',
+    '--mel-event-accent' => '#F26D5B',
+    '--mel-event-secondary-accent' => '#7C83FD',
+  ];
+
+  $accent_map = _myeventlane_theme_event_branding_accent_hex_map();
+  $accent = $accent_map[$colour] ?? $defaults['--mel-event-accent'];
+  $accent = _myeventlane_theme_sanitize_event_branding_hex($accent, $defaults['--mel-event-accent']);
+
+  $secondary = $colour === 'purple' ? '#7C83FD' : ($colour === 'coral' ? '#7C83FD' : $accent);
+  if ($colour === 'mint') {
+    $secondary = '#7C83FD';
+  }
+  elseif ($colour === 'gold') {
+    $secondary = '#7C83FD';
+  }
+  elseif ($colour === 'blue') {
+    $secondary = '#F26D5B';
+  }
+
+  $css_vars = [
+    '--mel-event-page-bg' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-page-bg'], $defaults['--mel-event-page-bg']),
+    '--mel-event-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-surface'], $defaults['--mel-event-surface']),
+    '--mel-event-soft-surface' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-soft-surface'], $defaults['--mel-event-soft-surface']),
+    '--mel-event-border' => _myeventlane_theme_sanitize_event_branding_hex($defaults['--mel-event-border'], $defaults['--mel-event-border']),
+    '--mel-event-accent' => $accent,
+    '--mel-event-secondary-accent' => _myeventlane_theme_sanitize_event_branding_hex($secondary, $defaults['--mel-event-secondary-accent']),
+  ];
+
+  $parts = [];
+  foreach ($css_vars as $name => $hex) {
+    $parts[] = $name . ': ' . $hex;
+  }
+  $css_inline = implode('; ', $parts);
+
+  return [
+    'style' => $style,
+    'colour' => $colour,
+    'css_vars' => $css_vars,
+    'css_inline' => $css_inline,
+  ];
+}
+
+/**
  * Applies Classic/Immersive page style classes to event node template variables.
  */
 function _myeventlane_theme_apply_event_page_style_theme_variables(array &$variables, NodeInterface $node): void {
@@ -3846,12 +3935,19 @@ function _myeventlane_theme_apply_event_page_style_theme_variables(array &$varia
   $variables['event_page_style'] = $resolved['style'];
   $variables['event_theme_colour'] = $resolved['colour'];
   $variables['event_page_classes'] = $resolved['classes'];
+  $variables['mel_event_branding'] = _myeventlane_theme_build_mel_event_branding(
+    $resolved['style'],
+    $resolved['colour'],
+  );
 
   if (!isset($variables['attributes']) || !$variables['attributes'] instanceof Attribute) {
     $existing = $variables['attributes'] ?? [];
     $variables['attributes'] = new Attribute(is_array($existing) ? $existing : []);
   }
   $variables['attributes']->addClass($resolved['classes']);
+  if (!empty($variables['mel_event_branding']['css_inline'])) {
+    $variables['attributes']->setAttribute('style', $variables['mel_event_branding']['css_inline']);
+  }
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1251,26 +1251,148 @@
   margin-top: 6px;
 }
 
-// Mobile: booking sidebar before long-form content — hero + meta stay above; then CTA card, then About/details/organiser.
-// Uses display:contents on __main so main sections and aside can be flex-ordered.
+// Option 1 mobile stack: hero → booking → gallery → long-form content (view details stays in sidebar stack).
 @media (width <= 768px) {
-  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) {
+  .mel-event--v2 .mel-event-layout--option1:has(> .mel-event-layout__sidebar) {
     display: flex;
     flex-direction: column;
     gap: space-tokens.mel-space(5);
   }
 
-  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__main {
+  .mel-event--v2 .mel-event-layout--option1:has(> .mel-event-layout__sidebar) > .mel-event-layout__main {
     display: contents;
   }
 
-  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__sidebar {
+  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > .mel-event-hero {
     order: 1;
   }
 
-  .mel-event--v2 .mel-event-layout:has(> .mel-event-layout__sidebar) > .mel-event-layout__main > * {
+  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__sidebar {
     order: 2;
   }
+
+  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > .mel-event-gallery {
+    order: 3;
+  }
+
+  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > *:not(.mel-event-hero, .mel-event-gallery) {
+    order: 4;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar rail — light MEL event-node surfaces (booking + view details)
+// ---------------------------------------------------------------------------
+
+.mel-event-sidebar-rail {
+  --mel-sidebar-page-bg: #fff9f5;
+  --mel-sidebar-card-surface: #fff;
+  --mel-sidebar-card-soft: #fdf1ec;
+  --mel-sidebar-text: #24303a;
+  --mel-sidebar-muted: #7c8791;
+  --mel-sidebar-border: #e9e3de;
+  --mel-sidebar-coral: #f26d5b;
+  --mel-sidebar-lavender: #7c83fd;
+
+  display: flex;
+  flex-direction: column;
+  gap: space-tokens.mel-space(3);
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-event-sidebar-rail .mel-card--surface {
+  background: var(--mel-sidebar-card-surface);
+  border: 1px solid var(--mel-sidebar-border);
+  box-shadow: 0 12px 32px rgba(36, 48, 58, 0.06);
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-sidebar-rail .mel-card__title {
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-sidebar-rail .mel-booking-panel__price {
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-sidebar-rail .mel-booking-panel__item strong,
+.mel-event-sidebar-rail .mel-booking-panel__save-label {
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-sidebar-rail .mel-booking-panel__item p,
+.mel-event-sidebar-rail .mel-booking-panel__save-hint,
+.mel-event-sidebar-rail .mel-booking-panel__trust-micro,
+.mel-event-sidebar-rail .mel-trust-rotator {
+  color: var(--mel-sidebar-muted);
+}
+
+.mel-event-sidebar-rail .mel-booking-panel__save--fav {
+  background: var(--mel-sidebar-card-soft);
+  border-color: color-mix(in srgb, var(--mel-sidebar-coral) 22%, transparent);
+}
+
+.mel-event-sidebar-details {
+  display: grid;
+  gap: space-tokens.mel-space(3);
+}
+
+.mel-event-sidebar-details__row {
+  display: grid;
+  gap: space-tokens.mel-space(1);
+}
+
+.mel-event-sidebar-details__label {
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-semibold;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mel-sidebar-muted);
+}
+
+.mel-event-sidebar-details__value {
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-sidebar-details__primary {
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-event-sidebar-details__secondary {
+  margin-top: 2px;
+  color: var(--mel-sidebar-muted);
+}
+
+.mel-event-sidebar-details__action {
+  margin: space-tokens.mel-space(1) 0 0;
+  padding-top: space-tokens.mel-space(2);
+  border-top: 1px solid var(--mel-sidebar-border);
+}
+
+.mel-event-sidebar-details__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: var(--mel-sidebar-lavender);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--mel-sidebar-lavender) 55%, transparent);
+    outline-offset: 2px;
+    border-radius: radii.$mel-radius-sm;
+  }
+}
+
+.mel-event-sidebar__details {
+  background: var(--mel-sidebar-card-soft);
 }
 
 .mel-btn--full {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1251,32 +1251,42 @@
   margin-top: 6px;
 }
 
-// Option 1 mobile stack: hero → booking → gallery → long-form content (view details stays in sidebar stack).
-@media (width <= 768px) {
-  .mel-event--v2 .mel-event-layout--option1:has(> .mel-event-layout__sidebar) {
+// Mockup mobile stack: hero → booking → view details → gallery → content.
+@media (width <= 767px) {
+  .mel-event-full__layout {
     display: flex;
     flex-direction: column;
-    gap: space-tokens.mel-space(5);
+    gap: 24px;
   }
 
-  .mel-event--v2 .mel-event-layout--option1:has(> .mel-event-layout__sidebar) > .mel-event-layout__main {
+  .mel-event-full__main,
+  .mel-event-full__sidebar {
     display: contents;
   }
 
-  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > .mel-event-hero {
+  .mel-event-full__hero {
     order: 1;
   }
 
-  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__sidebar {
+  .mel-event-full__booking {
     order: 2;
   }
 
-  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > .mel-event-gallery {
+  .mel-event-full__view-details {
     order: 3;
   }
 
-  .mel-event--v2 .mel-event-layout--option1 > .mel-event-layout__main > *:not(.mel-event-hero, .mel-event-gallery) {
+  .mel-event-full__gallery {
     order: 4;
+  }
+
+  .mel-event-full__content-grid,
+  .mel-event-full__content-below {
+    order: 5;
+  }
+
+  .mel-event-full__support {
+    order: 6;
   }
 }
 
@@ -2414,4 +2424,278 @@ button.mel-filter-chip--reset {
   &:hover {
     border-color: rgba(242, 109, 91, 0.55);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Event full — mockup layout shell (light MEL v2)
+// ---------------------------------------------------------------------------
+
+body:has(.mel-event-full),
+main.mel-main:has(.mel-event-full),
+body:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full),
+main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full) {
+  background-color: #fff9f5;
+  background-image: none;
+}
+
+.mel-event-page--immersive.mel-event--v2:has(.mel-event-full) {
+  background: transparent;
+  min-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  color: #24303a;
+}
+
+.mel-event-full {
+  --mel-full-page-bg: #fff9f5;
+  --mel-full-surface: #fff;
+  --mel-full-surface-soft: #fdf1ec;
+  --mel-full-text: #24303a;
+  --mel-full-text-secondary: #5b6670;
+  --mel-full-text-muted: #7c8791;
+  --mel-full-border: #e9e3de;
+  --mel-full-coral: #f26d5b;
+  --mel-full-lavender: #7c83fd;
+  --mel-full-radius-lg: 24px;
+  --mel-full-radius-md: 16px;
+  --mel-full-shadow-1: 0 2px 8px rgba(36, 48, 58, 0.06);
+  --mel-full-shadow-2: 0 6px 18px rgba(36, 48, 58, 0.08);
+
+  color: var(--mel-full-text);
+}
+
+.mel-event-full__layout {
+  display: grid;
+  gap: 32px;
+  align-items: start;
+  max-width: min(100%, 82.5rem);
+  margin-inline: auto;
+
+  @media (width >= 1024px) {
+    grid-template-columns: minmax(0, 1fr) 390px;
+  }
+}
+
+.mel-event-full__main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.mel-event-full__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.mel-event-full__card {
+  background: var(--mel-full-surface);
+  border: 1px solid var(--mel-full-border);
+  border-radius: var(--mel-full-radius-lg);
+  box-shadow: var(--mel-full-shadow-1);
+  color: var(--mel-full-text);
+}
+
+.mel-event-full__card .mel-card__title,
+.mel-event-full__card .mel-event-gallery__title {
+  color: var(--mel-full-text);
+}
+
+.mel-event-full__card .mel-card__body,
+.mel-event-full__card .mel-event-gallery__lede {
+  color: var(--mel-full-text-secondary);
+}
+
+// Force light surfaces inside immersive article for layout shell.
+.mel-event-page--immersive.mel-event--v2 .mel-event-full {
+  .mel-event-full__card,
+  .mel-event-sidebar-rail .mel-card--surface,
+  .mel-event-layout__main .mel-card--surface,
+  .mel-event-layout__main .mel-card--highlights,
+  .mel-event-layout__main .mel-card--expect,
+  .mel-event-full__content-below .mel-card--surface,
+  .mel-event-full__content-below .mel-organiser-card,
+  .mel-event-full__booking.mel-card--sticky {
+    background: var(--mel-full-surface);
+    border: 1px solid var(--mel-full-border);
+    border-radius: var(--mel-full-radius-lg);
+    box-shadow: var(--mel-full-shadow-1);
+    backdrop-filter: none;
+    color: var(--mel-full-text);
+  }
+
+  .mel-card__title,
+  .mel-booking-panel__price,
+  .mel-booking-panel__item strong,
+  .mel-booking-panel__save-label,
+  .mel-event-sidebar-details__value,
+  .mel-info-row__label,
+  .mel-info-row__value {
+    color: var(--mel-full-text);
+  }
+
+  .mel-booking-panel__item p,
+  .mel-booking-panel__save-hint,
+  .mel-booking-panel__trust-micro,
+  .mel-trust-rotator,
+  .mel-event-sidebar-details__label,
+  .mel-event-sidebar-details__secondary,
+  .mel-text--muted,
+  .mel-event-section__lede {
+    color: var(--mel-full-text-secondary);
+  }
+
+  .mel-event-gallery__title {
+    color: var(--mel-full-text);
+  }
+
+  .mel-event-gallery__lede {
+    color: var(--mel-full-text-secondary);
+  }
+
+  .mel-event-layout__main,
+  .mel-event-layout__sidebar,
+  .mel-event-full__content-below {
+    color: var(--mel-full-text);
+  }
+
+  .mel-event-layout__main a:not(.mel-btn, .mel-social),
+  .mel-event-support-zone__link {
+    color: var(--mel-full-lavender);
+  }
+}
+
+.mel-event-full__content-grid {
+  display: grid;
+  gap: 24px;
+
+  @media (width >= 1024px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-event-full__expect {
+  @media (width >= 1024px) {
+    grid-column: 1 / -1;
+  }
+}
+
+.mel-event-full__content-below {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.mel-event-full__content-below > .mel-card,
+.mel-event-full__content-below > .mel-event-section,
+.mel-event-full__content-below > .mel-organiser-card,
+.mel-event-full__content-below > .mel-return-block {
+  margin-top: 0;
+}
+
+.mel-event-full__content-below > .mel-card--surface,
+.mel-event-full__content-below > .mel-event-section.mel-card--surface,
+.mel-event-full__content-below > .mel-organiser-card.mel-card--surface {
+  background: var(--mel-full-surface);
+  border: 1px solid var(--mel-full-border);
+  border-radius: var(--mel-full-radius-lg);
+  box-shadow: var(--mel-full-shadow-1);
+  color: var(--mel-full-text);
+}
+
+// Booking panel — compact sticky card.
+.mel-event-full__booking {
+  align-self: start;
+  height: fit-content;
+  padding: 0;
+  border-radius: var(--mel-full-radius-lg);
+
+  @media (width >= 1024px) {
+    position: sticky;
+    top: 7rem;
+  }
+}
+
+.mel-event-full__booking-body {
+  padding: 28px;
+}
+
+.mel-event-full__booking-heading,
+.mel-booking-panel__heading {
+  margin: 0 0 12px;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-bold;
+  line-height: 1.25;
+  color: var(--mel-full-text);
+}
+
+.mel-event-full__booking .mel-booking-panel {
+  gap: 12px;
+}
+
+.mel-event-full__booking .mel-booking-panel__rule {
+  margin: 8px 0;
+}
+
+.mel-event-full__booking .mel-decision-prompts {
+  gap: 8px;
+}
+
+.mel-event-full__view-details {
+  padding: 28px;
+
+  .mel-card__header {
+    margin-bottom: 16px;
+    padding: 0;
+  }
+
+  .mel-card__body {
+    padding: 0;
+  }
+}
+
+.mel-event-full__support {
+  margin-top: 0;
+  padding: 0 4px;
+  font-size: typography.mel-font-size(sm);
+
+  .mel-event-support-zone__link {
+    color: var(--mel-full-text-secondary);
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--mel-full-lavender) 55%, transparent);
+      outline-offset: 2px;
+      border-radius: radii.$mel-radius-sm;
+    }
+  }
+}
+
+@media (width <= 767px) {
+  .mel-event--v2 .mel-container:has(.mel-event-full) {
+    padding-inline: 16px;
+  }
+
+  .mel-event-full__booking {
+    position: static;
+  }
+}
+
+// Gallery wrapper spacing.
+.mel-event-full__gallery {
+  margin: 0;
+  min-width: 0;
+}
+
+.mel-event-full__gallery-card {
+  padding: 28px 28px 20px;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+.mel-event-full__gallery .mel-event-gallery {
+  margin-block: 0;
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1260,7 +1260,7 @@
   .mel-event-full__layout {
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: var(--mel-full-stack-gap, 20px);
   }
 
   .mel-event-full__main,
@@ -1567,14 +1567,14 @@
   background: var(--mel-sidebar-card-soft);
 }
 
-// Immersive event pages — keep sidebar + main gallery rail on light MEL surfaces.
+// Immersive event pages — sidebar tokens follow immersive article theme.
 .mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail {
-  --mel-sidebar-page-bg: var(--mel-event-page-bg, #fff9f5);
-  --mel-sidebar-card-surface: var(--mel-event-surface, #fff);
-  --mel-sidebar-card-soft: var(--mel-event-soft-surface, #fdf1ec);
-  --mel-sidebar-text: #24303a;
-  --mel-sidebar-muted: #5b6670;
-  --mel-sidebar-border: var(--mel-event-border, #e9e3de);
+  --mel-sidebar-page-bg: transparent;
+  --mel-sidebar-card-surface: var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78));
+  --mel-sidebar-card-soft: var(--mel-event-surface-quiet, rgba(22, 28, 40, 0.55));
+  --mel-sidebar-text: var(--mel-event-heading, #fff);
+  --mel-sidebar-muted: var(--mel-event-text-muted, rgba(255, 255, 255, 0.72));
+  --mel-sidebar-border: var(--mel-event-border, rgba(255, 255, 255, 0.06));
   --mel-sidebar-coral: var(--mel-event-accent, #f26d5b);
   --mel-sidebar-lavender: var(--mel-event-secondary-accent, #7c83fd);
 }
@@ -1583,7 +1583,7 @@
   background: var(--mel-sidebar-card-surface);
   border-color: var(--mel-sidebar-border);
   color: var(--mel-sidebar-text);
-  box-shadow: 0 12px 32px rgba(36, 48, 58, 0.08);
+  box-shadow: var(--mel-event-shadow-sidebar, 0 18px 44px rgba(0, 0, 0, 0.32));
 }
 
 .mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-card__title,
@@ -1739,21 +1739,13 @@
 .mel-event-full .mel-card--expect {
   min-height: 0;
   height: auto;
+  background: var(--mel-full-surface, #fff);
+  border: 1px solid var(--mel-full-border, #e9e3de);
 }
 
 .mel-event--v2 .mel-card--highlights {
   background: colors.$mel-color-surface-alt;
   border: 1px solid rgba(0, 0, 0, 0.06);
-}
-
-.mel-event-full .mel-card--highlights {
-  background: var(--mel-full-surface, #fff);
-  border: 1px solid var(--mel-full-border, #e9e3de);
-}
-
-.mel-event-full .mel-card--expect {
-  background: var(--mel-full-surface, #fff);
-  border: 1px solid var(--mel-full-border, #e9e3de);
 }
 
 .mel-event-highlights {
@@ -2608,10 +2600,10 @@ button.mel-filter-chip--reset {
 // Event full — mockup layout shell (light MEL v2)
 // ---------------------------------------------------------------------------
 
-body:has(.mel-event-full),
-main.mel-main:has(.mel-event-full),
-body:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full),
-main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full) {
+body:has(.mel-event-page--classic.mel-event--v2 .mel-event-full),
+main.mel-main:has(.mel-event-page--classic.mel-event--v2 .mel-event-full),
+body:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event--v2)),
+main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event--v2)) {
   background-color: #fff9f5;
   background-image: none;
 }
@@ -2621,7 +2613,6 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   min-height: 0;
   padding-top: 0;
   padding-bottom: 0;
-  color: #24303a;
 }
 
 .mel-event-full {
@@ -2640,8 +2631,20 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   --mel-full-radius-md: 16px;
   --mel-full-shadow-1: 0 2px 8px rgba(36, 48, 58, 0.06);
   --mel-full-shadow-2: 0 6px 18px rgba(36, 48, 58, 0.08);
+  --mel-full-card-pad: 20px;
+  --mel-full-card-header-gap: 12px;
+  --mel-full-stack-gap: 20px;
+  --mel-full-grid-gap: 20px;
 
   color: var(--mel-full-text);
+
+  .mel-info-row {
+    padding: space-tokens.mel-space(2) 0;
+  }
+
+  .mel-organiser-card {
+    padding: var(--mel-full-card-pad);
+  }
 }
 
 .mel-event--v2 .mel-container:has(.mel-event-full) {
@@ -2651,7 +2654,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 
 .mel-event-full__layout {
   display: grid;
-  gap: 32px;
+  gap: var(--mel-full-stack-gap, 20px);
   align-items: start;
   max-width: 100%;
   margin-inline: auto;
@@ -2664,15 +2667,19 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 .mel-event-full__main {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
 }
 
 .mel-event-full__sidebar {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
+}
+
+.mel-event-full .mel-event-sidebar-rail {
+  gap: space-tokens.mel-space(2);
 }
 
 .mel-event-full__card {
@@ -2693,8 +2700,22 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   color: var(--mel-full-text-secondary);
 }
 
-// Force light surfaces inside immersive article for layout shell.
+// Immersive branding — map layout shell tokens to article immersive theme.
 .mel-event-page--immersive.mel-event--v2 .mel-event-full {
+  --mel-full-page-bg: transparent;
+  --mel-full-surface: var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78));
+  --mel-full-surface-soft: var(--mel-event-surface-quiet, rgba(22, 28, 40, 0.55));
+  --mel-full-text: var(--mel-event-heading, #fff);
+  --mel-full-text-secondary: var(--mel-event-text-secondary, rgba(255, 255, 255, 0.82));
+  --mel-full-text-muted: var(--mel-event-text-muted, rgba(255, 255, 255, 0.72));
+  --mel-full-border: var(--mel-event-border, rgba(255, 255, 255, 0.06));
+  --mel-full-coral: var(--mel-event-accent, #f26d5b);
+  --mel-full-lavender: var(--mel-event-secondary-accent, #7c83fd);
+  --mel-full-shadow-1: var(--mel-immersive-shadow-quiet, 0 14px 36px rgba(0, 0, 0, 0.22));
+  --mel-full-shadow-2: var(--mel-immersive-shadow-panel, 0 22px 52px rgba(0, 0, 0, 0.3));
+
+  color: var(--mel-full-text);
+
   .mel-event-full__card,
   .mel-event-sidebar-rail .mel-card--surface,
   .mel-event-layout__main .mel-card--surface,
@@ -2737,7 +2758,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   }
 
   .mel-event-gallery__lede {
-    color: var(--mel-full-text-secondary);
+    color: var(--mel-full-text-muted);
   }
 
   .mel-event-layout__main,
@@ -2750,11 +2771,15 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   .mel-event-support-zone__link {
     color: var(--mel-full-lavender);
   }
+
+  .mel-info-row {
+    border-top-color: var(--mel-full-border);
+  }
 }
 
 .mel-event-full__content-grid {
   display: grid;
-  gap: 24px;
+  gap: var(--mel-full-grid-gap, 20px);
   min-width: 0;
   grid-template-columns: minmax(0, 1fr);
 }
@@ -2767,10 +2792,10 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__content-grid > .mel-event-full__card {
-  padding: 32px;
+  padding: var(--mel-full-card-pad, 20px);
 
   .mel-card__header {
-    margin-bottom: 16px;
+    margin-bottom: var(--mel-full-card-header-gap, 12px);
     padding: 0;
   }
 
@@ -2803,14 +2828,28 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 .mel-event-full__content-below {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
+
+  > .mel-card--surface .mel-card__header,
+  > .mel-card--surface .mel-card__body,
+  > .mel-event-section.mel-card--surface .mel-card__header,
+  > .mel-event-section.mel-card--surface .mel-card__body,
+  > .mel-organiser-card.mel-card--surface .mel-card__header,
+  > .mel-organiser-card.mel-card--surface .mel-card__body {
+    padding: var(--mel-full-card-pad, 20px);
+  }
+
+  > .mel-event-section .mel-card__header {
+    padding-bottom: space-tokens.mel-space(2);
+  }
 }
 
 .mel-event-full__content-below > .mel-card,
 .mel-event-full__content-below > .mel-event-section,
 .mel-event-full__content-below > .mel-organiser-card,
-.mel-event-full__content-below > .mel-return-block {
+.mel-event-full__content-below > .mel-return-block,
+.mel-event-full__content-below > .mel-mt-5 {
   margin-top: 0;
 }
 
@@ -2890,7 +2929,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__booking-body {
-  padding: 28px;
+  padding: var(--mel-full-card-pad, 20px);
 }
 
 .mel-event-full__booking-heading,
@@ -2903,7 +2942,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__booking .mel-booking-panel {
-  gap: 18px;
+  gap: 14px;
 }
 
 .mel-event-full__booking .mel-booking-panel__rule {
@@ -2920,7 +2959,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .mel-booking-panel__trust-row {
@@ -2943,7 +2982,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__view-details {
-  padding: 28px;
+  padding: var(--mel-full-card-pad, 20px);
 
   .mel-event-sidebar-details__header {
     margin-bottom: 0;
@@ -2958,7 +2997,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 .mel-event-sidebar-details__rule {
   border: 0;
   border-top: 1px solid var(--mel-full-border, #e9e3de);
-  margin: 16px 0;
+  margin: 12px 0;
   width: 100%;
 }
 
@@ -3000,12 +3039,12 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 
 // Gallery wrapper spacing.
 .mel-event-full__gallery {
-  margin: 24px 0 0;
+  margin: var(--mel-full-stack-gap, 20px) 0 0;
   min-width: 0;
 }
 
 .mel-event-full__gallery-card {
-  padding: 32px;
+  padding: var(--mel-full-card-pad, 20px);
   border: 1px solid var(--mel-full-border, #e9e3de);
   border-radius: var(--mel-full-radius-lg, 24px);
   box-shadow: var(--mel-full-shadow-1);
@@ -3072,12 +3111,41 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   }
 
   .mel-sidebar-carousel__footer {
-    margin-top: 16px;
+    margin-top: 12px;
     padding: 0;
     border-top: 0;
   }
 }
 
 .mel-event-full__gallery .mel-event-gallery__header {
-  margin-bottom: 20px;
+  margin-bottom: var(--mel-full-card-header-gap, 12px);
+}
+
+// Immersive gallery card inside unified layout shell.
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__gallery-card,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full .mel-event-gallery.mel-event-full__card {
+  background:
+    radial-gradient(
+      ellipse 90% 70% at 50% 0%,
+      color-mix(in srgb, var(--mel-event-accent, #{colors.$mel-color-primary}) 16%, transparent) 0%,
+      transparent 62%
+    ),
+    color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+  border-color: var(--mel-full-border);
+  box-shadow: var(--mel-full-shadow-2, 0 22px 52px rgba(0, 0, 0, 0.3));
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__gallery .mel-event-gallery--carousel {
+  .mel-event-gallery__title {
+    color: var(--mel-full-text);
+  }
+
+  .mel-event-gallery__lede {
+    color: var(--mel-full-text-muted);
+  }
+
+  .mel-event-gallery__trigger {
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+    border: 0;
+  }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -17,6 +17,10 @@
 // MEL v2 Event Page (Reference Implementation)
 // ==========================================================================
 
+.mel-event--v2:has(.mel-event-full) {
+  padding: space-tokens.mel-space(3) 0 space-tokens.mel-space(5);
+}
+
 .mel-event--v2 {
   padding: space-tokens.mel-space(4) 0 space-tokens.mel-space(6);
 
@@ -1407,19 +1411,25 @@
 
 .mel-event-sidebar-details__action-btn {
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  padding: 0;
+  gap: 4px;
+  min-width: 4.5rem;
+  min-height: 4.5rem;
+  padding: 8px 10px;
   border: 1px solid var(--mel-sidebar-border);
-  border-radius: radii.$mel-radius-full;
+  border-radius: 14px;
   background: var(--mel-sidebar-card-surface);
   color: var(--mel-sidebar-coral);
   text-decoration: none;
   cursor: pointer;
   list-style: none;
   box-shadow: 0 4px 12px rgba(36, 48, 58, 0.06);
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-semibold;
+  line-height: 1.2;
+  text-align: center;
 
   &::-webkit-details-marker {
     display: none;
@@ -1429,6 +1439,10 @@
     outline: 2px solid color-mix(in srgb, var(--mel-sidebar-lavender) 55%, transparent);
     outline-offset: 2px;
   }
+}
+
+.mel-event-sidebar-details__action-label {
+  display: block;
 }
 
 .mel-event-sidebar-details__action-icon {
@@ -1494,6 +1508,7 @@
 .mel-event-sidebar-details__link {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   min-height: 44px;
   font-size: typography.mel-font-size(sm);
   font-weight: typography.$mel-font-semibold;
@@ -1506,6 +1521,11 @@
     outline-offset: 2px;
     border-radius: radii.$mel-radius-sm;
   }
+}
+
+.mel-event-sidebar-details__link-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
 }
 
 .mel-booking-panel__trust-line {
@@ -1715,9 +1735,25 @@
 // ---------------------------------------------------------------------------
 // Highlights: quick-scan, calm, distinct from body copy.
 
+.mel-event-full .mel-card--highlights,
+.mel-event-full .mel-card--expect {
+  min-height: 0;
+  height: auto;
+}
+
 .mel-event--v2 .mel-card--highlights {
   background: colors.$mel-color-surface-alt;
   border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.mel-event-full .mel-card--highlights {
+  background: var(--mel-full-surface, #fff);
+  border: 1px solid var(--mel-full-border, #e9e3de);
+}
+
+.mel-event-full .mel-card--expect {
+  background: var(--mel-full-surface, #fff);
+  border: 1px solid var(--mel-full-border, #e9e3de);
 }
 
 .mel-event-highlights {
@@ -2608,11 +2644,16 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   color: var(--mel-full-text);
 }
 
+.mel-event--v2 .mel-container:has(.mel-event-full) {
+  max-width: min(100%, 82.5rem);
+  padding-inline: clamp(16px, 3vw, 24px);
+}
+
 .mel-event-full__layout {
   display: grid;
   gap: 32px;
   align-items: start;
-  max-width: min(100%, 86.25rem);
+  max-width: 100%;
   margin-inline: auto;
 
   @media (width >= 1100px) {
@@ -2715,9 +2756,13 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   display: grid;
   gap: 24px;
   min-width: 0;
+  grid-template-columns: minmax(0, 1fr);
+}
 
+.mel-event-full__content-grid--duo {
   @media (width >= 1100px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
   }
 }
 
@@ -2734,13 +2779,22 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   }
 }
 
+.mel-event-full__about--wide,
 .mel-event-full__about:only-child {
   @media (width >= 1100px) {
     grid-column: 1 / -1;
   }
 }
 
+.mel-event-full__highlights {
+  align-self: start;
+  height: fit-content;
+}
+
 .mel-event-full__expect {
+  height: fit-content;
+  min-height: 0;
+
   @media (width >= 1100px) {
     grid-column: 1 / -1;
   }
@@ -2774,13 +2828,65 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 .mel-event-full__booking {
   align-self: start;
   height: fit-content;
+  min-height: 0;
+  max-width: 100%;
   padding: 0;
   border-radius: var(--mel-full-radius-lg);
+  overflow: visible;
 
-  @media (width >= 1024px) {
+  @media (width >= 1100px) {
     position: sticky;
-    top: 7rem;
+    top: 5.5rem;
   }
+}
+
+.mel-event-full__booking-body,
+.mel-event-full__booking .mel-booking-panel {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.mel-event-full__booking .mel-booking-panel__cta,
+.mel-event-full__booking .mel-event-sticky-cta,
+.mel-event-full__booking .mel-event-sticky-cta--sidebar {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.mel-event-full__booking .mel-booking-panel__cta .mel-btn {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.mel-booking-panel__status-label {
+  margin: 0;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-bold;
+  line-height: 1.25;
+  color: var(--mel-full-text);
+}
+
+.mel-booking-panel__urgency-line {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: var(--mel-full-coral, #f26d5b);
+}
+
+.mel-booking-panel__save {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  min-height: 0;
+}
+
+.mel-booking-panel__save-flag {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .mel-event-full__booking-body {
@@ -2910,10 +3016,66 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   margin-block: 0;
 }
 
-.mel-event-full__gallery .mel-event-gallery__carousel-shell {
-  border: 0;
-  box-shadow: none;
-  background: transparent;
+.mel-event-full__gallery .mel-event-gallery__rail {
+  min-width: 0;
+}
+
+.mel-event-full__gallery .mel-event-gallery--carousel {
+  margin-block: 0;
+}
+
+// Beat _event-sidebar-carousel.scss stacked grid (single visible slide at full width).
+.mel-event-full__gallery .mel-event-gallery--rail {
+  .mel-sidebar-carousel__viewport {
+    overflow: visible;
+  }
+
+  .mel-sidebar-carousel__track {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 14px;
+    grid-template-columns: unset;
+    grid-template-rows: unset;
+  }
+
+  .mel-sidebar-carousel__slide {
+    position: relative;
+    grid-area: auto;
+    flex: 0 0 clamp(11.25rem, 18%, 13.125rem);
+    width: clamp(11.25rem, 18%, 13.125rem);
+    max-width: 13.125rem;
+    min-width: 11.25rem;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .mel-event-gallery__trigger {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    line-height: 0;
+  }
+
+  .mel-event-gallery__img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: clamp(9.0625rem, 11vw, 10.3125rem);
+    min-height: 9.0625rem;
+    max-height: 10.3125rem;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+  }
+
+  .mel-sidebar-carousel__footer {
+    margin-top: 16px;
+    padding: 0;
+    border-top: 0;
+  }
 }
 
 .mel-event-full__gallery .mel-event-gallery__header {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1289,7 +1289,7 @@
   --mel-sidebar-card-surface: #fff;
   --mel-sidebar-card-soft: #fdf1ec;
   --mel-sidebar-text: #24303a;
-  --mel-sidebar-muted: #7c8791;
+  --mel-sidebar-muted: #5b6670;
   --mel-sidebar-border: #e9e3de;
   --mel-sidebar-coral: #f26d5b;
   --mel-sidebar-lavender: #7c83fd;
@@ -1393,6 +1393,46 @@
 
 .mel-event-sidebar__details {
   background: var(--mel-sidebar-card-soft);
+}
+
+// Immersive event pages — keep sidebar + main gallery rail on light MEL surfaces.
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail {
+  --mel-sidebar-page-bg: #fff9f5;
+  --mel-sidebar-card-surface: #fff;
+  --mel-sidebar-card-soft: #fdf1ec;
+  --mel-sidebar-text: #24303a;
+  --mel-sidebar-muted: #5b6670;
+  --mel-sidebar-border: #e9e3de;
+  --mel-sidebar-coral: #f26d5b;
+  --mel-sidebar-lavender: #7c83fd;
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-card--surface {
+  background: var(--mel-sidebar-card-surface);
+  border-color: var(--mel-sidebar-border);
+  color: var(--mel-sidebar-text);
+  box-shadow: 0 12px 32px rgba(36, 48, 58, 0.08);
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-card__title,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__price,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__item strong,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__save-label,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-event-sidebar-details__value {
+  color: var(--mel-sidebar-text);
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__item p,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__save-hint,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-booking-panel__trust-micro,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-trust-rotator,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-event-sidebar-details__label,
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-event-sidebar-details__secondary {
+  color: var(--mel-sidebar-muted);
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-event-sidebar-details__link {
+  color: var(--mel-sidebar-lavender);
 }
 
 .mel-btn--full {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1295,14 +1295,14 @@
 // ---------------------------------------------------------------------------
 
 .mel-event-sidebar-rail {
-  --mel-sidebar-page-bg: #fff9f5;
-  --mel-sidebar-card-surface: #fff;
-  --mel-sidebar-card-soft: #fdf1ec;
+  --mel-sidebar-page-bg: var(--mel-event-page-bg, #fff9f5);
+  --mel-sidebar-card-surface: var(--mel-event-surface, #fff);
+  --mel-sidebar-card-soft: var(--mel-event-soft-surface, #fdf1ec);
   --mel-sidebar-text: #24303a;
   --mel-sidebar-muted: #5b6670;
-  --mel-sidebar-border: #e9e3de;
-  --mel-sidebar-coral: #f26d5b;
-  --mel-sidebar-lavender: #7c83fd;
+  --mel-sidebar-border: var(--mel-event-border, #e9e3de);
+  --mel-sidebar-coral: var(--mel-event-accent, #f26d5b);
+  --mel-sidebar-lavender: var(--mel-event-secondary-accent, #7c83fd);
 
   display: flex;
   flex-direction: column;
@@ -1384,6 +1384,102 @@
   border-top: 1px solid var(--mel-sidebar-border);
 }
 
+.mel-event-sidebar-details__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: space-tokens.mel-space(2);
+  margin-top: space-tokens.mel-space(1);
+  padding-top: space-tokens.mel-space(2);
+  border-top: 1px solid var(--mel-sidebar-border);
+}
+
+.mel-event-sidebar-details__action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border: 1px solid var(--mel-sidebar-border);
+  border-radius: radii.$mel-radius-full;
+  background: var(--mel-sidebar-card-surface);
+  color: var(--mel-sidebar-coral);
+  text-decoration: none;
+  cursor: pointer;
+  list-style: none;
+  box-shadow: 0 4px 12px rgba(36, 48, 58, 0.06);
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--mel-sidebar-lavender) 55%, transparent);
+    outline-offset: 2px;
+  }
+}
+
+.mel-event-sidebar-details__action-icon {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.mel-event-sidebar-details__calendar {
+  position: relative;
+}
+
+.mel-event-sidebar-details__calendar-links {
+  position: absolute;
+  z-index: 5;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 11rem;
+  margin: 0;
+  padding: space-tokens.mel-space(2);
+  list-style: none;
+  background: var(--mel-sidebar-card-surface);
+  border: 1px solid var(--mel-sidebar-border);
+  border-radius: radii.$mel-radius-md;
+  box-shadow: 0 12px 28px rgba(36, 48, 58, 0.1);
+}
+
+.mel-event-sidebar-details__calendar-link {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 space-tokens.mel-space(2);
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: var(--mel-sidebar-text);
+  text-decoration: none;
+  border-radius: radii.$mel-radius-sm;
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--mel-sidebar-lavender) 55%, transparent);
+    outline-offset: 2px;
+  }
+}
+
+.mel-event-sidebar-details__action-save {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+
+  .flag-event-save a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid var(--mel-sidebar-border);
+    border-radius: radii.$mel-radius-full;
+    background: var(--mel-sidebar-card-surface);
+    color: var(--mel-sidebar-coral);
+  }
+}
+
 .mel-event-sidebar-details__link {
   display: inline-flex;
   align-items: center;
@@ -1401,20 +1497,59 @@
   }
 }
 
+.mel-booking-panel__trust-line {
+  display: flex;
+  align-items: center;
+  gap: space-tokens.mel-space(2);
+  margin: 0;
+}
+
+.mel-booking-panel__trust-svg,
+.mel-trust-item__icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mel-sidebar-coral, var(--mel-event-accent, #f26d5b));
+}
+
+.mel-trust-item {
+  display: flex;
+  align-items: flex-start;
+  gap: space-tokens.mel-space(2);
+}
+
+.mel-decision-item .mel-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--mel-sidebar-coral, var(--mel-event-accent, #f26d5b));
+}
+
+.mel-event-full__booking .mel-booking-panel__trust {
+  gap: space-tokens.mel-space(2);
+}
+
+.mel-event-full__booking .mel-booking-panel__trust-micro {
+  gap: space-tokens.mel-space(1);
+}
+
 .mel-event-sidebar__details {
   background: var(--mel-sidebar-card-soft);
 }
 
 // Immersive event pages — keep sidebar + main gallery rail on light MEL surfaces.
 .mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail {
-  --mel-sidebar-page-bg: #fff9f5;
-  --mel-sidebar-card-surface: #fff;
-  --mel-sidebar-card-soft: #fdf1ec;
+  --mel-sidebar-page-bg: var(--mel-event-page-bg, #fff9f5);
+  --mel-sidebar-card-surface: var(--mel-event-surface, #fff);
+  --mel-sidebar-card-soft: var(--mel-event-soft-surface, #fdf1ec);
   --mel-sidebar-text: #24303a;
   --mel-sidebar-muted: #5b6670;
-  --mel-sidebar-border: #e9e3de;
-  --mel-sidebar-coral: #f26d5b;
-  --mel-sidebar-lavender: #7c83fd;
+  --mel-sidebar-border: var(--mel-event-border, #e9e3de);
+  --mel-sidebar-coral: var(--mel-event-accent, #f26d5b);
+  --mel-sidebar-lavender: var(--mel-event-secondary-accent, #7c83fd);
 }
 
 .mel-event-page--immersive.mel-event--v2 .mel-event-sidebar-rail .mel-card--surface {
@@ -2620,7 +2755,11 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__booking-body {
-  padding: 28px;
+  padding: space-tokens.mel-space(4);
+
+  @include breakpoints.mel-break(lg) {
+    padding: space-tokens.mel-space(5);
+  }
 }
 
 .mel-event-full__booking-heading,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -1280,13 +1280,24 @@
     order: 4;
   }
 
-  .mel-event-full__content-grid,
-  .mel-event-full__content-below {
+  .mel-event-full__about {
     order: 5;
   }
 
-  .mel-event-full__support {
+  .mel-event-full__highlights {
     order: 6;
+  }
+
+  .mel-event-full__expect {
+    order: 7;
+  }
+
+  .mel-event-full__content-below {
+    order: 8;
+  }
+
+  .mel-event-full__support {
+    order: 9;
   }
 }
 
@@ -1526,10 +1537,6 @@
   width: 28px;
   height: 28px;
   color: var(--mel-sidebar-coral, var(--mel-event-accent, #f26d5b));
-}
-
-.mel-event-full__booking .mel-booking-panel__trust {
-  gap: space-tokens.mel-space(2);
 }
 
 .mel-event-full__booking .mel-booking-panel__trust-micro {
@@ -2582,6 +2589,8 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full {
+  overflow-x: clip;
+
   --mel-full-page-bg: #fff9f5;
   --mel-full-surface: #fff;
   --mel-full-surface-soft: #fdf1ec;
@@ -2603,10 +2612,10 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
   display: grid;
   gap: 32px;
   align-items: start;
-  max-width: min(100%, 82.5rem);
+  max-width: min(100%, 86.25rem);
   margin-inline: auto;
 
-  @media (width >= 1024px) {
+  @media (width >= 1100px) {
     grid-template-columns: minmax(0, 1fr) 390px;
   }
 }
@@ -2705,14 +2714,34 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 .mel-event-full__content-grid {
   display: grid;
   gap: 24px;
+  min-width: 0;
 
-  @media (width >= 1024px) {
+  @media (width >= 1100px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
+.mel-event-full__content-grid > .mel-event-full__card {
+  padding: 32px;
+
+  .mel-card__header {
+    margin-bottom: 16px;
+    padding: 0;
+  }
+
+  .mel-card__body {
+    padding: 0;
+  }
+}
+
+.mel-event-full__about:only-child {
+  @media (width >= 1100px) {
+    grid-column: 1 / -1;
+  }
+}
+
 .mel-event-full__expect {
-  @media (width >= 1024px) {
+  @media (width >= 1100px) {
     grid-column: 1 / -1;
   }
 }
@@ -2755,11 +2784,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__booking-body {
-  padding: space-tokens.mel-space(4);
-
-  @include breakpoints.mel-break(lg) {
-    padding: space-tokens.mel-space(5);
-  }
+  padding: 28px;
 }
 
 .mel-event-full__booking-heading,
@@ -2772,28 +2797,73 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 }
 
 .mel-event-full__booking .mel-booking-panel {
-  gap: 12px;
+  gap: 18px;
 }
 
 .mel-event-full__booking .mel-booking-panel__rule {
-  margin: 8px 0;
+  margin: 4px 0;
 }
 
-.mel-event-full__booking .mel-decision-prompts {
-  gap: 8px;
+.mel-event-full__booking .mel-booking-panel__trust {
+  gap: 12px;
+}
+
+.mel-booking-panel__trust-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mel-booking-panel__trust-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.4;
+  color: var(--mel-full-text-secondary, #5b6670);
+}
+
+.mel-booking-panel__trust-row-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.mel-booking-panel__trust-row--urgent .mel-booking-panel__trust-row-text {
+  color: var(--mel-full-coral, #f26d5b);
+  font-weight: typography.$mel-font-semibold;
 }
 
 .mel-event-full__view-details {
   padding: 28px;
 
-  .mel-card__header {
-    margin-bottom: 16px;
+  .mel-event-sidebar-details__header {
+    margin-bottom: 0;
     padding: 0;
   }
 
   .mel-card__body {
     padding: 0;
   }
+}
+
+.mel-event-sidebar-details__rule {
+  border: 0;
+  border-top: 1px solid var(--mel-full-border, #e9e3de);
+  margin: 16px 0;
+  width: 100%;
+}
+
+.mel-event-full__view-details > .mel-event-sidebar-details__rule:first-of-type {
+  margin-top: 0;
+}
+
+.mel-event-full__view-details .mel-event-sidebar-details__actions {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
 }
 
 .mel-event-full__support {
@@ -2824,17 +2894,28 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):has(.mel-event-full)
 
 // Gallery wrapper spacing.
 .mel-event-full__gallery {
-  margin: 0;
+  margin: 24px 0 0;
   min-width: 0;
 }
 
 .mel-event-full__gallery-card {
-  padding: 28px 28px 20px;
+  padding: 32px;
+  border: 1px solid var(--mel-full-border, #e9e3de);
+  border-radius: var(--mel-full-radius-lg, 24px);
+  box-shadow: var(--mel-full-shadow-1);
+  background: var(--mel-full-surface, #fff);
+}
+
+.mel-event-full__gallery .mel-event-gallery {
+  margin-block: 0;
+}
+
+.mel-event-full__gallery .mel-event-gallery__carousel-shell {
   border: 0;
   box-shadow: none;
   background: transparent;
 }
 
-.mel-event-full__gallery .mel-event-gallery {
-  margin-block: 0;
+.mel-event-full__gallery .mel-event-gallery__header {
+  margin-bottom: 20px;
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -21,6 +21,78 @@
 
 .mel-event-gallery--carousel {
   margin-block: spacing.mel-space(4) spacing.mel-space(5);
+
+  &.mel-event-gallery--classic,
+  &.mel-event-gallery--immersive {
+    margin-inline: 0;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+
+    &::before {
+      display: none;
+    }
+  }
+
+  .mel-event-gallery__title {
+    color: #24303a;
+  }
+
+  .mel-event-gallery__lede {
+    color: #5b6670;
+  }
+
+  .mel-event-gallery__carousel-shell {
+    overflow: hidden;
+    padding: 0;
+    background: #fff;
+    border: 1px solid #e9e3de;
+    border-radius: radii.$mel-radius-lg;
+    box-shadow: 0 12px 32px rgba(36, 48, 58, 0.06);
+    color: #24303a;
+  }
+
+  .mel-event-gallery__header {
+    margin-bottom: spacing.mel-space(3);
+  }
+
+  .mel-event-gallery__viewport {
+    max-height: 11.25rem;
+    margin-inline: auto;
+    max-width: min(100%, 28rem);
+  }
+
+  .mel-sidebar-carousel__footer {
+    border-top-color: #e9e3de;
+  }
+
+  .mel-sidebar-carousel__arrow {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    border-color: #e9e3de;
+    background: #fdf1ec;
+    color: #24303a;
+
+    &:focus-visible {
+      outline: 2px solid #7c83fd;
+      outline-offset: 2px;
+    }
+  }
+
+  .mel-sidebar-carousel__dot {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    background: color-mix(in srgb, #24303a 20%, transparent);
+
+    &.is-active {
+      background: #f26d5b;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #7c83fd;
+      outline-offset: 2px;
+    }
+  }
 }
 
 .mel-event-gallery__carousel-shell {
@@ -30,6 +102,12 @@
 
 .mel-event-gallery__viewport {
   outline: none;
+
+  &:focus-visible {
+    outline: 2px solid #7c83fd;
+    outline-offset: 2px;
+    border-radius: radii.$mel-radius-md;
+  }
 }
 
 .mel-event-gallery__slide {
@@ -40,24 +118,21 @@
   display: block;
   width: 100%;
   min-height: 2.75rem;
-  border-radius: radii.$mel-radius-lg;
+  border-radius: radii.$mel-radius-md;
+
+  &:focus-visible {
+    outline: 2px solid #7c83fd;
+    outline-offset: 2px;
+  }
 }
 
 .mel-event-gallery--carousel .mel-event-gallery__img {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 9;
+  max-height: 11.25rem;
+  aspect-ratio: 4 / 3;
   object-fit: cover;
-}
-
-.mel-event-gallery--carousel .mel-sidebar-carousel__arrow {
-  min-width: 2.75rem;
-  min-height: 2.75rem;
-}
-
-.mel-event-gallery--carousel .mel-sidebar-carousel__dot {
-  min-width: 2.75rem;
-  min-height: 2.75rem;
+  border-radius: radii.$mel-radius-md;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -21,17 +21,13 @@
 
 .mel-event-gallery--carousel {
   margin-block: spacing.mel-space(4) spacing.mel-space(5);
+  margin-inline: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
 
-  &.mel-event-gallery--classic,
-  &.mel-event-gallery--immersive {
-    margin-inline: 0;
-    padding: 0;
-    background: transparent;
-    box-shadow: none;
-
-    &::before {
-      display: none;
-    }
+  &::before {
+    display: none;
   }
 
   .mel-event-gallery__title {
@@ -414,7 +410,7 @@
 // Classic — warm editorial magazine
 // ---------------------------------------------------------------------------
 
-.mel-event-page--classic .mel-event-gallery--classic {
+.mel-event-page--classic.mel-event--v2 .mel-event-gallery:not(.mel-event-full__card) {
   padding: spacing.mel-space(5) spacing.mel-space(5) spacing.mel-space(6);
   border-radius: radii.$mel-radius-xl;
   border: 1px solid color-mix(in srgb, var(--mel-event-border, rgba(36, 48, 58, 0.08)) 80%, transparent);
@@ -454,7 +450,7 @@
 // Immersive — cinematic, designed (not themed)
 // ---------------------------------------------------------------------------
 
-.mel-event-page--immersive .mel-event-gallery--immersive {
+.mel-event-page--immersive.mel-event--v2 .mel-event-gallery:not(.mel-event-full__card) {
   margin-inline: calc(-1 * #{spacing.mel-space(4)});
   padding: spacing.mel-space(6) spacing.mel-space(4) spacing.mel-space(7);
   border-radius: radii.$mel-radius-xl;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -65,38 +65,63 @@
   &.mel-event-gallery--rail {
     .mel-event-gallery__viewport {
       max-height: none;
+      overflow: visible;
     }
 
     .mel-sidebar-carousel__track {
       display: flex;
-      flex-direction: row;
-      gap: 12px;
+      flex-flow: row nowrap;
+      gap: 14px;
       overflow-x: auto;
+      overflow-y: hidden;
       scroll-snap-type: x proximity;
-      padding-bottom: 4px;
+      padding-bottom: 6px;
       -webkit-overflow-scrolling: touch;
+      grid-template-columns: none;
+      grid-template-rows: none;
     }
 
     .mel-sidebar-carousel__slide {
+      position: static;
+      grid-area: auto;
       flex: 0 0 auto;
-      width: clamp(7.5rem, 18%, 10.625rem);
+      width: clamp(11.25rem, 22vw, 13.125rem);
+      min-width: 11.25rem;
       opacity: 1;
       visibility: visible;
       pointer-events: auto;
-      scroll-snap-align: center;
+      scroll-snap-align: start;
+      transition: none;
+    }
+
+    .mel-event-gallery__trigger {
+      border-radius: 14px;
+      overflow: hidden;
     }
 
     .mel-event-gallery__img {
+      display: block;
+      width: 100%;
+      height: clamp(9.0625rem, 12vw, 10.3125rem);
+      max-height: 10.3125rem;
       aspect-ratio: 4 / 3;
       object-fit: cover;
-      max-height: 10.625rem;
-      width: 100%;
-      height: auto;
+      border-radius: 14px;
     }
 
     .mel-sidebar-carousel__slide.is-active .mel-event-gallery__trigger {
       outline: 2px solid var(--mel-event-accent, #f26d5b);
       outline-offset: 2px;
+    }
+
+    &.mel-event-gallery--rail-single {
+      .mel-sidebar-carousel__track {
+        justify-content: flex-start;
+      }
+
+      .mel-sidebar-carousel__slide {
+        width: clamp(11.25rem, 55%, 13.125rem);
+      }
     }
   }
 
@@ -118,11 +143,16 @@
   }
 
   .mel-sidebar-carousel__dot {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
-    background: color-mix(in srgb, #24303a 20%, transparent);
+    width: 0.5rem;
+    height: 0.5rem;
+    min-width: 0.5rem;
+    min-height: 0.5rem;
+    padding: 0;
+    border-radius: 999px;
+    background: color-mix(in srgb, #24303a 22%, transparent);
 
     &.is-active {
+      transform: scale(1.15);
       background: var(--mel-event-accent, #f26d5b);
     }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -3,6 +3,7 @@
 @use '../tokens/shadows';
 @use '../tokens/typography';
 @use '../tokens/colors';
+@use '../tokens/breakpoints';
 
 // ---------------------------------------------------------------------------
 // Event gallery — editorial composition (presenter-driven roles)
@@ -12,6 +13,63 @@
   position: relative;
   // Vertical rhythm owned by _event-cinematic-convergence.scss per page style.
   margin-block: spacing.mel-space(5);
+}
+
+// ---------------------------------------------------------------------------
+// Main-column carousel (reuses mel-event-sidebar-carousel.js)
+// ---------------------------------------------------------------------------
+
+.mel-event-gallery--carousel {
+  margin-block: spacing.mel-space(4) spacing.mel-space(5);
+}
+
+.mel-event-gallery__carousel-shell {
+  overflow: hidden;
+  padding: 0;
+}
+
+.mel-event-gallery__viewport {
+  outline: none;
+}
+
+.mel-event-gallery__slide {
+  padding: 0;
+}
+
+.mel-event-gallery--carousel .mel-event-gallery__trigger {
+  display: block;
+  width: 100%;
+  min-height: 2.75rem;
+  border-radius: radii.$mel-radius-lg;
+}
+
+.mel-event-gallery--carousel .mel-event-gallery__img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.mel-event-gallery--carousel .mel-sidebar-carousel__arrow {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
+.mel-event-gallery--carousel .mel-sidebar-carousel__dot {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-gallery--carousel .mel-event-gallery__trigger:hover {
+    transform: none;
+  }
+}
+
+@include breakpoints.mel-break(md, max) {
+  .mel-event-gallery--carousel .mel-event-gallery__viewport {
+    touch-action: pan-y;
+  }
 }
 
 .mel-event-gallery__header {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -57,12 +57,21 @@
   }
 
   .mel-event-gallery__viewport {
-    max-height: 10.625rem;
-    margin-inline: auto;
+    max-height: none;
+    margin-inline: 0;
     max-width: 100%;
+    overflow: visible;
   }
 
   &.mel-event-gallery--rail {
+    .mel-event-gallery__rail,
+    .mel-event-gallery__carousel {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      min-width: 0;
+    }
+
     .mel-event-gallery__viewport {
       max-height: none;
       overflow: visible;
@@ -71,11 +80,13 @@
     .mel-sidebar-carousel__track {
       display: flex;
       flex-flow: row nowrap;
+      align-items: stretch;
+      justify-content: flex-start;
       gap: 14px;
       overflow-x: auto;
       overflow-y: hidden;
       scroll-snap-type: x proximity;
-      padding-bottom: 6px;
+      padding: 0;
       -webkit-overflow-scrolling: touch;
       grid-template-columns: none;
       grid-template-rows: none;
@@ -85,7 +96,8 @@
       position: static;
       grid-area: auto;
       flex: 0 0 auto;
-      width: clamp(11.25rem, 22vw, 13.125rem);
+      width: clamp(11.25rem, 18%, 13.125rem);
+      max-width: 13.125rem;
       min-width: 11.25rem;
       opacity: 1;
       visibility: visible;
@@ -95,14 +107,21 @@
     }
 
     .mel-event-gallery__trigger {
+      display: block;
+      width: 100%;
+      height: 100%;
+      padding: 0;
+      border: 0;
       border-radius: 14px;
       overflow: hidden;
+      line-height: 0;
     }
 
     .mel-event-gallery__img {
       display: block;
       width: 100%;
-      height: clamp(9.0625rem, 12vw, 10.3125rem);
+      height: clamp(9.0625rem, 11vw, 10.3125rem);
+      min-height: 9.0625rem;
       max-height: 10.3125rem;
       aspect-ratio: 4 / 3;
       object-fit: cover;
@@ -120,13 +139,21 @@
       }
 
       .mel-sidebar-carousel__slide {
-        width: clamp(11.25rem, 55%, 13.125rem);
+        width: clamp(11.25rem, 42%, 13.125rem);
+        max-width: 13.125rem;
       }
     }
   }
 
   .mel-sidebar-carousel__footer {
-    border-top-color: #e9e3de;
+    margin-top: 16px;
+    padding: 0;
+    border-top: 0;
+  }
+
+  .mel-sidebar-carousel__nav {
+    justify-content: center;
+    gap: 12px;
   }
 
   .mel-sidebar-carousel__arrow {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -45,8 +45,8 @@
   .mel-event-gallery__carousel-shell {
     overflow: hidden;
     padding: 0;
-    background: #fff;
-    border: 1px solid #e9e3de;
+    background: var(--mel-event-surface, #fff);
+    border: 1px solid var(--mel-event-border, #e9e3de);
     border-radius: radii.$mel-radius-lg;
     box-shadow: 0 12px 32px rgba(36, 48, 58, 0.06);
     color: #24303a;
@@ -87,12 +87,15 @@
     }
 
     .mel-event-gallery__img {
+      aspect-ratio: 4 / 3;
+      object-fit: cover;
       max-height: 10.625rem;
       width: 100%;
+      height: auto;
     }
 
     .mel-sidebar-carousel__slide.is-active .mel-event-gallery__trigger {
-      outline: 2px solid #f26d5b;
+      outline: 2px solid var(--mel-event-accent, #f26d5b);
       outline-offset: 2px;
     }
   }
@@ -104,8 +107,8 @@
   .mel-sidebar-carousel__arrow {
     min-width: 2.75rem;
     min-height: 2.75rem;
-    border-color: #e9e3de;
-    background: #fdf1ec;
+    border-color: var(--mel-event-border, #e9e3de);
+    background: var(--mel-event-soft-surface, #fdf1ec);
     color: #24303a;
 
     &:focus-visible {
@@ -120,7 +123,7 @@
     background: color-mix(in srgb, #24303a 20%, transparent);
 
     &.is-active {
-      background: #f26d5b;
+      background: var(--mel-event-accent, #f26d5b);
     }
 
     &:focus-visible {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-gallery.scss
@@ -57,9 +57,44 @@
   }
 
   .mel-event-gallery__viewport {
-    max-height: 11.25rem;
+    max-height: 10.625rem;
     margin-inline: auto;
-    max-width: min(100%, 28rem);
+    max-width: 100%;
+  }
+
+  &.mel-event-gallery--rail {
+    .mel-event-gallery__viewport {
+      max-height: none;
+    }
+
+    .mel-sidebar-carousel__track {
+      display: flex;
+      flex-direction: row;
+      gap: 12px;
+      overflow-x: auto;
+      scroll-snap-type: x proximity;
+      padding-bottom: 4px;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .mel-sidebar-carousel__slide {
+      flex: 0 0 auto;
+      width: clamp(7.5rem, 18%, 10.625rem);
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+      scroll-snap-align: center;
+    }
+
+    .mel-event-gallery__img {
+      max-height: 10.625rem;
+      width: 100%;
+    }
+
+    .mel-sidebar-carousel__slide.is-active .mel-event-gallery__trigger {
+      outline: 2px solid #f26d5b;
+      outline-offset: 2px;
+    }
   }
 
   .mel-sidebar-carousel__footer {
@@ -144,6 +179,10 @@
 @include breakpoints.mel-break(md, max) {
   .mel-event-gallery--carousel .mel-event-gallery__viewport {
     touch-action: pan-y;
+  }
+
+  .mel-event-gallery--carousel.mel-event-gallery--rail .mel-event-gallery__img {
+    max-height: 9.375rem;
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
@@ -93,10 +93,102 @@
   left: spacing.mel-space(5);
   z-index: 3;
   display: flex;
-  max-width: 34rem;
+  max-width: min(42rem, calc(100% - #{spacing.mel-space(10)}));
   flex-direction: column;
   align-items: flex-start;
   gap: spacing.mel-space(2);
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__info.mel-event-hero__glass {
+  gap: spacing.mel-space(2);
+  padding: spacing.mel-space(3) spacing.mel-space(4);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: color-mix(in srgb, rgba(16, 20, 28, 0.62) 100%, transparent);
+  backdrop-filter: blur(12px) saturate(140%);
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta {
+  list-style: none;
+  margin: spacing.mel-space(2) 0 0;
+  padding: 0;
+  display: grid;
+  gap: spacing.mel-space(2);
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-item {
+  display: flex;
+  gap: spacing.mel-space(2);
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  background: rgba(242, 109, 91, 0.28);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    background: #f26d5b;
+    opacity: 0.95;
+  }
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon--time {
+  background: rgba(124, 131, 253, 0.28);
+
+  &::after {
+    background: #7c83fd;
+    border-radius: 999px;
+    width: 10px;
+    height: 10px;
+  }
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon--location {
+  background: rgba(242, 109, 91, 0.22);
+
+  &::after {
+    width: 10px;
+    height: 12px;
+    border-radius: 2px 2px 4px 4px;
+    background: #f26d5b;
+  }
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-primary,
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-secondary {
+  display: block;
+  color: rgba(255, 255, 255, 0.94);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+  line-height: 1.35;
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-primary {
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-secondary {
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-regular;
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__title,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
@@ -68,10 +68,9 @@
   z-index: 2;
   background: linear-gradient(
     to top,
-    rgba(0, 0, 0, 0.8) 0%,
-    rgba(0, 0, 0, 0.5) 35%,
-    rgba(0, 0, 0, 0.2) 65%,
-    rgba(0, 0, 0, 0.05) 100%
+    rgba(36, 48, 58, 0.88) 0%,
+    rgba(36, 48, 58, 0.45) 38%,
+    transparent 72%
   );
   pointer-events: none;
 }
@@ -88,12 +87,12 @@
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__content,
 .mel-booking-v2 .mel-event-hero--featured-style .mel-event-hero__content {
   position: absolute;
-  right: spacing.mel-space(5);
+  right: auto;
   bottom: spacing.mel-space(5);
   left: spacing.mel-space(5);
   z-index: 3;
   display: flex;
-  max-width: min(42rem, calc(100% - #{spacing.mel-space(10)}));
+  max-width: min(48rem, calc(100% - #{spacing.mel-space(10)}));
   flex-direction: column;
   align-items: flex-start;
   gap: spacing.mel-space(2);
@@ -179,16 +178,20 @@
 }
 
 .mel-event-full__hero.mel-event-hero--featured-style {
-  min-height: clamp(22.5rem, 42vw, 32.5rem);
+  width: 100%;
+  min-height: clamp(26.25rem, 42vw, 33.75rem);
   border-radius: 24px;
+  border: 0;
+  box-shadow: 0 12px 32px rgba(36, 48, 58, 0.1);
 
   @media (width <= 767px) {
     min-height: 20rem;
   }
 }
 
-.mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style {
-  min-height: clamp(22.5rem, 42vw, 32.5rem);
+.mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style {
+  min-height: clamp(26.25rem, 42vw, 33.75rem);
 
   @media (width <= 767px) {
     min-height: 20rem;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
@@ -99,70 +99,57 @@
   gap: spacing.mel-space(2);
 }
 
-.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__info.mel-event-hero__glass {
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: spacing.mel-space(2);
-  padding: spacing.mel-space(3) spacing.mel-space(4);
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: color-mix(in srgb, rgba(16, 20, 28, 0.62) 100%, transparent);
-  backdrop-filter: blur(12px) saturate(140%);
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta {
   list-style: none;
   margin: spacing.mel-space(2) 0 0;
   padding: 0;
-  display: grid;
-  gap: spacing.mel-space(2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: spacing.mel-space(2) spacing.mel-space(4);
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-item {
   display: flex;
   gap: spacing.mel-space(2);
-  align-items: flex-start;
+  align-items: center;
   min-width: 0;
+  max-width: 100%;
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon {
   flex: 0 0 auto;
-  width: 28px;
-  height: 28px;
-  border-radius: 10px;
-  background: rgba(242, 109, 91, 0.28);
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    margin: auto;
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
-    background: #f26d5b;
-    opacity: 0.95;
-  }
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--mel-event-accent, #f26d5b);
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon--time {
-  background: rgba(124, 131, 253, 0.28);
-
-  &::after {
-    background: #7c83fd;
-    border-radius: 999px;
-    width: 10px;
-    height: 10px;
-  }
+  color: var(--mel-event-secondary-accent, #7c83fd);
 }
 
-.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-icon--location {
-  background: rgba(242, 109, 91, 0.22);
-
-  &::after {
-    width: 10px;
-    height: 12px;
-    border-radius: 2px 2px 4px 4px;
-    background: #f26d5b;
-  }
+.mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-svg {
+  display: block;
+  width: 28px;
+  height: 28px;
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__meta-text {
@@ -192,8 +179,16 @@
 }
 
 .mel-event-full__hero.mel-event-hero--featured-style {
-  min-height: clamp(20rem, 42vw, 32.5rem);
+  min-height: clamp(22.5rem, 42vw, 32.5rem);
   border-radius: 24px;
+
+  @media (width <= 767px) {
+    min-height: 20rem;
+  }
+}
+
+.mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style {
+  min-height: clamp(22.5rem, 42vw, 32.5rem);
 
   @media (width <= 767px) {
     min-height: 20rem;
@@ -211,7 +206,19 @@
 }
 
 .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
-  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-size: clamp(1.75rem, 3.2vw, 2.5rem);
+}
+
+@media (width >= 768px) {
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
+    font-size: 2.5rem;
+  }
+}
+
+@media (width <= 767px) {
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
+    font-size: 1.75rem;
+  }
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__datetime,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
@@ -11,7 +11,7 @@
   position: relative;
   display: block;
   min-width: 0;
-  min-height: 26.25rem;
+  min-height: 20rem;
   overflow: hidden;
   border-radius: radii.$mel-radius-lg;
   border: 1px solid rgba(255, 255, 255, 0.32);
@@ -191,6 +191,15 @@
   color: rgba(255, 255, 255, 0.86);
 }
 
+.mel-event-full__hero.mel-event-hero--featured-style {
+  min-height: clamp(20rem, 42vw, 32.5rem);
+  border-radius: 24px;
+
+  @media (width <= 767px) {
+    min-height: 20rem;
+  }
+}
+
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__title,
 .mel-booking-v2 .mel-event-hero--featured-style .mel-event-hero__title {
   margin: 0;
@@ -199,6 +208,10 @@
   font-weight: typography.$mel-font-bold;
   line-height: typography.$mel-leading-tight;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
 }
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__datetime,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-hero.scss
@@ -179,7 +179,7 @@
 
 .mel-event-full__hero.mel-event-hero--featured-style {
   width: 100%;
-  min-height: clamp(26.25rem, 42vw, 33.75rem);
+  min-height: clamp(26.875rem, 42vw, 31.25rem);
   border-radius: 24px;
   border: 0;
   box-shadow: 0 12px 32px rgba(36, 48, 58, 0.1);
@@ -187,11 +187,54 @@
   @media (width <= 767px) {
     min-height: 20rem;
   }
+
+  .mel-event-hero__content {
+    right: auto;
+    bottom: spacing.mel-space(4);
+    left: spacing.mel-space(4);
+    max-width: min(44rem, calc(100% - #{spacing.mel-space(8)}));
+  }
+
+  .mel-event-hero__title {
+    font-size: clamp(1.5rem, 2.4vw, 2rem);
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  .mel-event-hero__meta {
+    margin-top: spacing.mel-space(2);
+    flex-wrap: nowrap;
+    gap: spacing.mel-space(2) spacing.mel-space(3);
+    align-items: center;
+  }
+
+  .mel-event-hero__meta-item {
+    align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .mel-event-hero__meta-primary {
+    font-size: typography.mel-font-size(sm);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media (width <= 767px) {
+    .mel-event-hero__meta {
+      flex-wrap: wrap;
+    }
+
+    .mel-event-hero__meta-primary {
+      white-space: normal;
+    }
+  }
 }
 
 .mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style,
 .mel-event-page--immersive.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style {
-  min-height: clamp(26.25rem, 42vw, 33.75rem);
+  min-height: clamp(26.875rem, 42vw, 31.25rem);
 
   @media (width <= 767px) {
     min-height: 20rem;
@@ -208,21 +251,6 @@
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
-.mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
-  font-size: clamp(1.75rem, 3.2vw, 2.5rem);
-}
-
-@media (width >= 768px) {
-  .mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
-    font-size: 2.5rem;
-  }
-}
-
-@media (width <= 767px) {
-  .mel-event-page--classic.mel-event--v2 .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__title {
-    font-size: 1.75rem;
-  }
-}
 
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__datetime,
 .mel-event--v2 .mel-event-hero--featured-style .mel-event-hero__venue,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -56,18 +56,18 @@
 // Page shell warmth when Classic event is present (article bg alone leaves white gutters).
 body:has(.mel-event-page--classic.mel-event--v2),
 main.mel-main:has(.mel-event-page--classic.mel-event--v2) {
-  background-color: #fff8f4;
+  background-color: #fff9f5;
 }
 
 body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
-  background-color: #fff8f4;
+  background-color: #fff9f5;
   color: #1f2933;
 }
 
 // Classic — warm MEL default (Mockup 1): light page, white cards, preset accent CTAs.
 // Accent colours come from mel-event-page--colour-* on <article> (coral default).
 .mel-event-page--classic.mel-event--v2 {
-  --mel-event-page-bg: #fff8f4;
+  --mel-event-page-bg: #fff9f5;
   --mel-event-surface: #ffffff;
   --mel-event-surface-soft: #fff1ec;
   --mel-event-border: rgba(242, 109, 91, 0.18);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -473,8 +473,15 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 }
 
 // Immersive shell — atmospheric canvas (article carries local accents).
-body:has(.mel-event-page--immersive.mel-event--v2),
-main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
+// When mel-event-full layout is present, keep the page shell light (mockup v2).
+body:has(.mel-event-page--immersive.mel-event--v2 .mel-event-full),
+main.mel-main:has(.mel-event-page--immersive.mel-event--v2 .mel-event-full) {
+  background-color: #fff9f5;
+  background-image: none;
+}
+
+body:has(.mel-event-page--immersive.mel-event--v2):not(:has(.mel-event-full)),
+main.mel-main:has(.mel-event-page--immersive.mel-event--v2):not(:has(.mel-event-full)) {
   background-color: #080c14;
   background-image:
     radial-gradient(ellipse 120% 55% at 50% -8%, rgba(255, 255, 255, 0.04) 0%, transparent 58%),

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -69,8 +69,10 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 .mel-event-page--classic.mel-event--v2 {
   --mel-event-page-bg: #fff9f5;
   --mel-event-surface: #ffffff;
-  --mel-event-surface-soft: #fff1ec;
-  --mel-event-border: rgba(242, 109, 91, 0.18);
+  --mel-event-soft-surface: #fdf1ec;
+  --mel-event-surface-soft: #fdf1ec;
+  --mel-event-border: #e9e3de;
+  --mel-event-secondary-accent: #7c83fd;
   --mel-event-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
   --mel-event-text: #1f2933;
   --mel-event-muted: #6b7280;
@@ -102,12 +104,12 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     overflow: hidden;
   }
 
-  .mel-event-hero--featured-style .mel-event-hero__overlay {
+  .mel-event-full__hero.mel-event-hero--featured-style .mel-event-hero__overlay {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.08) 0%,
-      rgba(31, 41, 51, 0.45) 55%,
-      rgba(31, 41, 51, 0.82) 100%
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.12) 45%,
+      rgba(36, 48, 58, 0.72) 100%
     );
   }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -475,15 +475,8 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
 }
 
 // Immersive shell — atmospheric canvas (article carries local accents).
-// When mel-event-full layout is present, keep the page shell light (mockup v2).
-body:has(.mel-event-page--immersive.mel-event--v2 .mel-event-full),
-main.mel-main:has(.mel-event-page--immersive.mel-event--v2 .mel-event-full) {
-  background-color: #fff9f5;
-  background-image: none;
-}
-
-body:has(.mel-event-page--immersive.mel-event--v2):not(:has(.mel-event-full)),
-main.mel-main:has(.mel-event-page--immersive.mel-event--v2):not(:has(.mel-event-full)) {
+body:has(.mel-event-page--immersive.mel-event--v2),
+main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
   background-color: #080c14;
   background-image:
     radial-gradient(ellipse 120% 55% at 50% -8%, rgba(255, 255, 255, 0.04) 0%, transparent 58%),
@@ -492,7 +485,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2):not(:has(.mel-event-
     linear-gradient(180deg, #080c14 0%, #0c121c 50%, #101826 100%);
 }
 
-// Immersive — cinematic Pro experience (single authored visual system).
+// Immersive — cinematic Pro experience (Event Studio branding tab).
 .mel-event-page--immersive.mel-event--v2 {
   // Typography scale — authoritative immersive contrast (explicit rgba, no opacity fade).
   --mel-immersive-text: #fff;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -237,6 +237,8 @@ body:has(.mel-event-page--classic.mel-event--v2) .mel-footer {
     background: var(--mel-event-surface);
     border: 1px solid var(--mel-event-border);
     box-shadow: var(--mel-event-shadow);
+    min-height: 0;
+    height: auto;
   }
 
   .mel-event-highlights__icon {

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
@@ -38,5 +38,8 @@
     <path d="M20 8.5a2 2 0 0 0-2-2h-1.2a1.5 1.5 0 0 1 0-3H18a4 4 0 0 1 4 4v1.5a2.5 2.5 0 0 0 0 5V16a4 4 0 0 1-4 4h-1.2a1.5 1.5 0 0 1 0-3H18a2 2 0 0 0 2-2v-1a2.5 2.5 0 0 0 0-5V8.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
   {% elseif icon == 'flame' %}
     <path d="M12 22c4-3.5 6-7 6-11a6 6 0 0 0-11-3.5C5.5 9.5 6 13 8 16c-.5-2.5 0-4.5 2-6.5-1 3-1 5.5 2 8.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+  {% elseif icon == 'external' %}
+    <path d="M14 4.5h5.5V10M9.75 14.25 19.5 4.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M19 14.5v5H5V5.5h5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
   {% endif %}
 </svg>

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
@@ -1,0 +1,42 @@
+{#
+  Inline SVG icons for public event page UI (outline style, currentColor).
+  Usage: {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar', class: 'mel-event-icon', size: 24 } only %}
+#}
+{% set _size = size|default(24) %}
+{% set _class = (class|default('mel-event-icon'))|e('html_attr') %}
+<svg class="{{ _class }}" width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  {% if icon == 'calendar' %}
+    <rect x="3.5" y="5.5" width="17" height="15" rx="2.25" stroke="currentColor" stroke-width="1.75"/>
+    <path d="M8 4v3M16 4v3M3.5 10h17" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+  {% elseif icon == 'clock' %}
+    <circle cx="12" cy="12" r="8.25" stroke="currentColor" stroke-width="1.75"/>
+    <path d="M12 8v4.25l2.75 2.75" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  {% elseif icon == 'map-pin' %}
+    <path d="M12 21s6-5.2 6-10.5a6 6 0 1 0-12 0C6 15.8 12 21 12 21Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <circle cx="12" cy="10.5" r="2.25" stroke="currentColor" stroke-width="1.75"/>
+  {% elseif icon == 'shield-check' %}
+    <path d="M12 3.5 5.5 6v5.2c0 4.1 2.8 7.9 6.5 9.3 3.7-1.4 6.5-5.2 6.5-9.3V6L12 3.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <path d="m9.25 12 1.75 1.75L15 10.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  {% elseif icon == 'mail' %}
+    <path d="M4 6.75C4 5.784 4.784 5 5.75 5h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 18.25 19H5.75A1.75 1.75 0 0 1 4 17.25V6.75Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <path d="m4.6 7.2 6.65 4.55a1.25 1.25 0 0 0 1.4 0L19.4 7.2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  {% elseif icon == 'heart' %}
+    <path d="M12 20.25s-6.75-4.35-6.75-9.1C5.25 7.65 7.65 5.25 10.5 5.25c1.65 0 3.15.9 3.75 2.2.6-1.3 2.1-2.2 3.75-2.2 2.85 0 5.25 2.4 5.25 5.9 0 4.75-6.75 9.1-6.75 9.1Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+  {% elseif icon == 'share' %}
+    <path d="M14 4.5h5.5V10M9.75 14.25 19.5 4.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M19 14.5v5H5V5.5h5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  {% elseif icon == 'calendar-plus' %}
+    <rect x="3.5" y="5.5" width="17" height="15" rx="2.25" stroke="currentColor" stroke-width="1.75"/>
+    <path d="M8 4v3M16 4v3M12 11v5M9.5 13.5H14.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+  {% elseif icon == 'bolt' %}
+    <path d="M13 2 5 14h6l-1 8 8-12h-6l1-8Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+  {% elseif icon == 'user' %}
+    <circle cx="12" cy="8.25" r="3.25" stroke="currentColor" stroke-width="1.75"/>
+    <path d="M5.5 19.5c1.4-3.5 4-5.25 6.5-5.25s5.1 1.75 6.5 5.25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+  {% elseif icon == 'ticket' %}
+    <path d="M4 8.5a2 2 0 0 1 2-2h1.2a1.5 1.5 0 0 0 0-3H6a4 4 0 0 0-4 4v1.5a2.5 2.5 0 0 1 0 5V16a4 4 0 0 0 4 4h1.2a1.5 1.5 0 0 0 0-3H6a2 2 0 0 1-2-2v-1a2.5 2.5 0 0 1 0-5V8.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <path d="M20 8.5a2 2 0 0 0-2-2h-1.2a1.5 1.5 0 0 1 0-3H18a4 4 0 0 1 4 4v1.5a2.5 2.5 0 0 0 0 5V16a4 4 0 0 1-4 4h-1.2a1.5 1.5 0 0 1 0-3H18a2 2 0 0 0 2-2v-1a2.5 2.5 0 0 0 0-5V8.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+  {% elseif icon == 'flame' %}
+    <path d="M12 22c4-3.5 6-7 6-11a6 6 0 0 0-11-3.5C5.5 9.5 6 13 8 16c-.5-2.5 0-4.5 2-6.5-1 3-1 5.5 2 8.5Z" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+  {% endif %}
+</svg>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -69,6 +69,14 @@
 
 <article{{ attributes.addClass('mel-event', 'mel-event--v2') }}>
   <div class="mel-container">
+    {% if mel_event_state is defined and mel_event_state == 'cancelled' %}
+      <div class="mel-alert mel-alert--warning" role="status">
+        <strong>{{ 'This event has been cancelled.'|t }}</strong>
+      </div>
+    {% endif %}
+
+    <div class="mel-event-layout mel-event-layout--option1">
+      <div class="mel-event-layout__main">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
     <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">
       <div class="mel-event-hero__media">
@@ -116,97 +124,16 @@
       </div>
     </section>
 
-    {# Meta row: when / where (primary CTA + trust live in the sticky sidebar card) #}
-    <section class="mel-event-meta-bar" aria-label="{{ 'Event summary'|t }}">
-      <div class="mel-event-meta-bar__items">
-        {% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
-          <div class="mel-event-meta-bar__cluster">
-            <div class="mel-event-meta">
-              <span class="mel-event-meta__icon" aria-hidden="true"></span>
-              <div class="mel-event-meta__text">
-                {% set start_day = node.field_event_start.value|date('l, F j') %}
-                {% set start_year = node.field_event_start.value|date('Y') %}
-                {% set end_day = (node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value) ? node.field_event_end.value|date('l, F j') : '' %}
-                {% set end_year = (node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value) ? node.field_event_end.value|date('Y') : '' %}
-
-                <div class="mel-event-meta__primary">
-                  {{ start_day }}
-                  {% if end_day and end_day != start_day %}
-                    – {{ end_day }}
-                  {% endif %}
-                </div>
-                <div class="mel-event-meta__secondary">
-                  {{ start_year }}
-                  {% if end_year and end_year != start_year %}
-                    – {{ end_year }}
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-
-            <div class="mel-event-meta mel-event-meta--time">
-              <span class="mel-event-meta__icon mel-event-meta__icon--time" aria-hidden="true"></span>
-              <div class="mel-event-meta__text">
-                <div class="mel-event-meta__primary">
-                  {{ node.field_event_start.value|date('g:i A') }}
-                  {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
-                    – {{ node.field_event_end.value|date('g:i A') }}
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-          </div>
+        {% if mel_event_gallery is defined and mel_event_gallery.count > 0 %}
+          {{
+            {
+              '#theme': 'mel_event_gallery',
+              '#gallery': mel_event_gallery,
+              '#event_page_style': event_page_style|default('classic'),
+            }
+          }}
         {% endif %}
 
-        {% set display_address = mel_address|default('')|trim %}
-        {% set has_field_location = node.hasField('field_location') and not node.field_location.isEmpty %}
-        {% set has_venue_name = node.hasField('field_venue_name') and not node.field_venue_name.isEmpty %}
-        {% set venue_entity_label = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
-        {% set venue_line = has_venue_name ? node.field_venue_name.value|trim : venue_entity_label|trim %}
-        {% set location_has_markup = content.field_location is defined and content.field_location|render|striptags|trim %}
-        {% set has_address = display_address is not empty or has_field_location %}
-        {% if venue_line is not empty or has_address %}
-          <div class="mel-event-meta mel-event-meta--venue">
-            <span class="mel-event-meta__icon mel-event-meta__icon--location" aria-hidden="true"></span>
-            <div class="mel-event-meta__text mel-event-location">
-              {% if venue_line is not empty %}
-                <div class="mel-event-location__venue">{{ venue_line }}</div>
-              {% endif %}
-              {% if has_address %}
-                <div class="mel-event-location__address">
-                  {% if location_has_markup %}
-                    {{ content.field_location }}
-                  {% elseif display_address is not empty %}
-                    {{ display_address }}
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
-          </div>
-        {% endif %}
-      </div>
-
-    </section>
-
-    {% if mel_event_gallery is defined and mel_event_gallery.count > 0 %}
-      {{
-        {
-          '#theme': 'mel_event_gallery',
-          '#gallery': mel_event_gallery,
-          '#event_page_style': event_page_style|default('classic'),
-        }
-      }}
-    {% endif %}
-
-    {# Cancelled banner #}
-    {% if mel_event_state is defined and mel_event_state == 'cancelled' %}
-      <div class="mel-alert mel-alert--warning" role="status">
-        <strong>{{ 'This event has been cancelled.'|t }}</strong>
-      </div>
-    {% endif %}
-
-    <div class="mel-event-layout">
-      <div class="mel-event-layout__main">
         {% set body_render = (content.body is defined) ? (content.body|render) : '' %}
         {% set body_plain = body_render|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
         {% if body_plain %}
@@ -309,7 +236,7 @@
         {% endif %}
 
         {# Event Information: Location first (with map under address), then Category, Age Suitability. #}
-        <div class="mel-card mel-card--surface mel-mt-5">
+        <div class="mel-card mel-card--surface mel-mt-5" id="mel-event-information">
           <div class="mel-card__header">
             <h2 class="mel-card__title">{{ 'Event Information'|t }}</h2>
           </div>
@@ -630,210 +557,9 @@
            These are configuration inputs, not attendee-facing content. #}
       </div>
 
-      <aside class="mel-event-layout__sidebar" aria-label="{{ 'Tickets and event information'|t }}">
-        {% if mel_sidebar_carousel %}
-          {{ mel_sidebar_carousel }}
-        {% else %}
-        <div class="mel-card mel-card--surface mel-card--sticky mel-event__card">
-          <div class="mel-card__body">
-            <div class="mel-booking-panel" role="region" aria-label="{{ 'Book this event'|t }}">
-              {% if mel_mode_chip %}
-                <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
-                  <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
-                </div>
-              {% endif %}
-              {% if mel_show_sidebar_scarcity_badge %}
-                <div class="mel-event__badge">
-                  {{ 'Limited availability'|t }}
-                </div>
-              {% endif %}
-              {% if mel_signal %}
-                <div class="mel-event__signal mel-event__signal--strong">{{ mel_signal }}</div>
-              {% endif %}
-              {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
-                <div class="mel-booking-panel__price mel-price" aria-label="{{ 'Price'|t }}">
-                  {{ mel_sidebar_pricing }}
-                  {% if cta_type is defined and cta_type == 'paid' and mel_show_price_includes_gst_note|default(false) %}
-                    <span class="mel-price__tax-note">{{ 'Includes GST'|t }}</span>
-                  {% endif %}
-                </div>
-              {% endif %}
-              {% if cta_type is defined and cta_type == 'paid'
-                and mel_event_selling_fast|default(false)
-                and (event_ui is not defined or not (event_ui.is_sold_out|default(false) == true)) %}
-                <div class="mel-event__urgency">
-                  {{ 'Tickets selling fast'|t }}
-                </div>
-              {% endif %}
-              {% if content.field_product_target is defined %}
-                <div class="mel-booking-panel__product">
-                  {{ content.field_product_target }}
-                </div>
-              {% endif %}
-
-              {% if mel_event_state is not defined or mel_event_state != 'cancelled' %}
-                {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
-                  <div class="mel-booking-panel__cta mel-event__cta">
-                    <div class="mel-event-sticky-cta mel-event-sticky-cta--sidebar" role="group" aria-label="{{ 'Register or buy tickets'|t }}">
-                      {% include '@myeventlane_theme/node/partial--event-full-booking-cta.html.twig' with { 'mel_cta_slot': 'sidebar' } %}
-                    </div>
-                  </div>
-                  <hr class="mel-booking-panel__rule" role="separator" />
-                {% endif %}
-
-
-
-                {% if mel_show_booking_trust_copy %}
-                <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
-                  <div class="mel-booking-panel__trust-micro">
-                    {% if mel_trust_checkout and cta_type is defined and cta_type == 'paid' %}
-                      <p class="mel-booking-panel__trust-micro-primary">{{ 'Secure checkout'|t }}</p>
-                      <p>{{ 'Payment processed securely via Stripe'|t }}</p>
-                    {% elseif cta_type is defined and cta_type == 'rsvp' %}
-                      <p class="mel-booking-panel__trust-micro-primary">{{ 'Free RSVP'|t }}</p>
-                      <p>{{ 'No payment required — confirmation by email'|t }}</p>
-                    {% endif %}
-                    <p>{{ 'No hidden fees on MyEventLane'|t }}</p>
-                  </div>
-                  {% set _mel_trust_capacity_highlight = event_ui is defined
-                    and (mel_cta_urgency|default('')|striptags|length == 0)
-                    and (not mel_event_selling_fast|default(false))
-                    and (not (event_ui.is_sold_out|default(false) is same as(true)))
-                    and (
-                      (event_ui.is_limited|default(false))
-                      or (event_ui.capacity_hint|default('')|striptags|length > 0)
-                    ) %}
-                  <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
-                    <div class="mel-trust-item is-active" data-trust-item>
-                      {% if event_viewer_count is not empty %}
-                        <span class="mel-trust-item__text">{{ event_viewer_count }}</span>
-                      {% else %}
-                        <span class="mel-trust-item__text">🔥 {{ 'Popular on MyEventLane'|t }}</span>
-                      {% endif %}
-                    </div>
-                    <div class="mel-trust-item" data-trust-item>
-                      <span class="mel-trust-item__text">✉️ {{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
-                    </div>
-                  </div>
-                  {% set _show_mel_decision_prompts = (not logged_in)
-                    or (event_ui is defined and (event_ui.is_free|default(false) == true))
-                    or (event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not _mel_trust_capacity_highlight)) %}
-                  {% if _show_mel_decision_prompts %}
-                    {% set _decision_count = 0 %}
-                    <div class="mel-decision-prompts">
-                      {% if _decision_count < 2 and (not logged_in) %}
-                        {% set _decision_count = _decision_count + 1 %}
-                        <div class="mel-decision-item">
-                          <span class="mel-icon">👤</span>
-                          <div>
-                            <strong>{{ 'First time here?'|t }}</strong>
-                            <p>{{ 'Book in seconds — no account needed'|t }}</p>
-                          </div>
-                        </div>
-                      {% endif %}
-                      {% if _decision_count < 2 and event_ui is defined and (event_ui.is_free|default(false) == true) %}
-                        {% set _decision_count = _decision_count + 1 %}
-                        <div class="mel-decision-item">
-                          <span class="mel-icon">🎟</span>
-                          <div>
-                            <strong>{{ 'Free event'|t }}</strong>
-                            <p>{{ 'No payment required'|t }}</p>
-                          </div>
-                        </div>
-                      {% endif %}
-                      {% if _decision_count < 2
-                        and event_ui is defined
-                        and (event_ui.capacity_hint|default('')|striptags|length > 0)
-                        and (not _mel_trust_capacity_highlight) %}
-                        {% set _decision_count = _decision_count + 1 %}
-                        <div class="mel-decision-item mel-decision-item--urgent">
-                          <span class="mel-icon">⚡</span>
-                          <div>
-                            <strong>{{ event_ui.capacity_hint }}</strong>
-                            <p>{{ "Don't miss out"|t }}</p>
-                          </div>
-                        </div>
-                      {% endif %}
-                    </div>
-                  {% endif %}
-                  {% if _mel_trust_capacity_highlight %}
-                    <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
-                      <span class="mel-icon" aria-hidden="true">⚡</span>
-                      <div>
-                        <p class="mel-booking-panel__capacity" role="status">
-                          <strong>{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</strong>
-                        </p>
-                        <p>{{ 'Secure your spot today'|t }}</p>
-                      </div>
-                    </div>
-                  {% endif %}
-                  {% if _support_urgent %}
-                    <div class="mel-booking-panel__item">
-                      <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
-                      <div>
-                        <strong>{{ mel_cta_urgency }}</strong>
-                        <p>{{ 'Secure your spot today'|t }}</p>
-                      </div>
-                    </div>
-                  {% endif %}
-                  {% if event_save_count_total|default(0) > 0 and event_save_count is not empty %}
-                    <div class="mel-booking-panel__item mel-booking-panel__item--social">
-                      <span class="mel-icon" aria-hidden="true">💖</span>
-                      <div>
-                        <strong>{{ event_save_count }}</strong>
-                      </div>
-                    </div>
-                  {% endif %}
-                  {% if event_interest is defined and event_interest.label is defined %}
-                    <div class="mel-booking-panel__item mel-booking-panel__item--interest mel-booking-panel__item--{{ event_interest.type }}">
-                      <strong>{{ event_interest.label }}</strong>
-                    </div>
-                  {% endif %}
-                </div>
-                {% endif %}
-                {% if google_calendar_url|default('')|length > 0 %}
-                  <div class="mel-booking-panel__item">
-                    <span class="mel-booking-panel__item-icon" aria-hidden="true">📅</span>
-                    <div>
-                      <div class="mel-calendar">
-                        <div class="mel-calendar__tabs" role="tablist" aria-label="{{ 'Add to calendar'|t }}">
-                          <button type="button" class="mel-calendar__tab is-active" data-tab="apple" role="tab" aria-selected="true">{{ 'Apple'|t }}</button>
-                          <button type="button" class="mel-calendar__tab" data-tab="outlook" role="tab" aria-selected="false">{{ 'Outlook'|t }}</button>
-                          <button type="button" class="mel-calendar__tab" data-tab="google" role="tab" aria-selected="false">{{ 'Google'|t }}</button>
-                        </div>
-                        <div class="mel-calendar__content">
-                          <div class="mel-calendar__pane is-active" data-pane="apple">
-                            <a href="{{ apple_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Apple Calendar'|t }}</a>
-                          </div>
-                          <div class="mel-calendar__pane" data-pane="outlook">
-                            <a href="{{ outlook_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Outlook'|t }}</a>
-                          </div>
-                          <div class="mel-calendar__pane" data-pane="google">
-                            <a href="{{ google_calendar_url }}" class="mel-button mel-button--ghost" target="_blank" rel="noopener noreferrer">{{ 'Add to Google Calendar'|t }}</a>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                {% endif %}
-                {% if event_flag_event_save %}
-                  <div class="mel-booking-panel__save mel-booking-panel__save--fav" role="group" aria-label="{{ 'Save for later'|t }}">
-                    <div class="mel-booking-panel__save-inner">
-                      <div id="mel-event-full-save" class="mel-event-save mel-booking-panel__save-flag">
-                        {{ event_flag_event_save }}
-                      </div>
-                      <div class="mel-booking-panel__save-copy">
-                        <span class="mel-booking-panel__save-label">{{ 'Save for later'|t }}</span>
-                        <span class="mel-booking-panel__save-hint mel-text--muted">{{ 'Tap the heart to remember this event'|t }}</span>
-                      </div>
-                    </div>
-                  </div>
-                {% endif %}
-              {% endif %}
-            </div>
-          </div>
-        </div>
-        {% endif %}
+      <aside class="mel-event-layout__sidebar mel-event-sidebar-rail" aria-label="{{ 'Tickets and event information'|t }}">
+        {% include '@myeventlane_theme/node/partial--event-full-booking-panel.html.twig' %}
+        {% include '@myeventlane_theme/node/partial--event-full-view-details.html.twig' %}
 
         {# Registration metadata intentionally hidden on Event Full (capacity, sales windows, etc.)
            to keep the sidebar calm and attendee-focused. #}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -205,10 +205,12 @@
           {% endfor %}
         {% endif %}
 
-        {% if body_plain or highlights|length or expect_text %}
-          <div class="mel-event-full__content-grid">
-            {% if body_plain %}
-              <div class="mel-event-full__about mel-card mel-card--surface mel-event-full__card">
+        {% set _has_about = body_plain is not empty %}
+        {% set _has_highlights = highlights|length > 0 %}
+        {% if _has_about or _has_highlights or expect_text %}
+          <div class="mel-event-full__content-grid{% if _has_about and _has_highlights %} mel-event-full__content-grid--duo{% endif %}">
+            {% if _has_about %}
+              <div class="mel-event-full__about mel-card mel-card--surface mel-event-full__card{% if not _has_highlights %} mel-event-full__about--wide{% endif %}">
                 <div class="mel-card__header">
                   <h2 class="mel-card__title">{{ 'About the Event'|t }}</h2>
                 </div>
@@ -218,7 +220,7 @@
               </div>
             {% endif %}
 
-            {% if highlights|length %}
+            {% if _has_highlights %}
               <div class="mel-event-full__highlights mel-card mel-card--surface mel-card--highlights mel-event-full__card" aria-label="{{ 'Highlights'|t }}">
                 <div class="mel-card__header">
                   <h2 class="mel-card__title">{{ 'Highlights'|t }}</h2>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -4,6 +4,8 @@
  * Event node template for full view mode.
  *
  * Design source of truth: MEL v2 event page reference.
+ * Classic and Immersive (Event Studio branding) share this template; page style is
+ * mel-event-page--classic|immersive + mel-event-page--colour-* on <article> only.
  * Requirements:
  * - No inline script/style tags.
  * - All assets via libraries (Vite → dist).
@@ -176,7 +178,6 @@
               {
                 '#theme': 'mel_event_gallery',
                 '#gallery': mel_event_gallery,
-                '#event_page_style': event_page_style|default('classic'),
               }
             }}
           </div>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -110,18 +110,19 @@
         </div>
       {% endif %}
       <div class="mel-event-hero__content">
-        <div class="mel-event-hero__glass mel-event-hero__info">
+        <div class="mel-event-hero__info">
           <h1 class="mel-event-hero__title" id="mel-event-title">{{ label }}</h1>
           {% set _hero_has_schedule = node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
           {% set _hero_venue_entity = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
           {% set _hero_venue_line = (node.hasField('field_venue_name') and not node.field_venue_name.isEmpty) ? node.field_venue_name.value|trim : _hero_venue_entity|trim %}
-          {% set _hero_address = mel_address|default('')|trim %}
-          {% set _hero_has_location = _hero_venue_line is not empty or _hero_address is not empty or (node.hasField('field_location') and not node.field_location.isEmpty) %}
+          {% set _hero_has_location = _hero_venue_line is not empty %}
           {% if _hero_has_schedule or _hero_has_location %}
             <ul class="mel-event-hero__meta" role="list">
               {% if _hero_has_schedule %}
                 <li class="mel-event-hero__meta-item">
-                  <span class="mel-event-hero__meta-icon" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar', class: 'mel-event-hero__meta-svg', size: 28 } only %}
+                  </span>
                   <span class="mel-event-hero__meta-text">
                     <span class="mel-event-hero__meta-primary">
                       {{ node.field_event_start.value|date('l, F j, Y') }}
@@ -135,7 +136,9 @@
                   </span>
                 </li>
                 <li class="mel-event-hero__meta-item mel-event-hero__meta-item--time">
-                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--time" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--time" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'clock', class: 'mel-event-hero__meta-svg mel-event-hero__meta-svg--time', size: 28 } only %}
+                  </span>
                   <span class="mel-event-hero__meta-text">
                     <span class="mel-event-hero__meta-primary">
                       {{ node.field_event_start.value|date('g:i A') }}
@@ -148,14 +151,11 @@
               {% endif %}
               {% if _hero_has_location %}
                 <li class="mel-event-hero__meta-item mel-event-hero__meta-item--location">
-                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--location" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--location" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'map-pin', class: 'mel-event-hero__meta-svg mel-event-hero__meta-svg--location', size: 28 } only %}
+                  </span>
                   <span class="mel-event-hero__meta-text">
-                    {% if _hero_venue_line is not empty %}
-                      <span class="mel-event-hero__meta-primary">{{ _hero_venue_line }}</span>
-                    {% endif %}
-                    {% if _hero_address is not empty %}
-                      <span class="mel-event-hero__meta-secondary">{{ _hero_address }}</span>
-                    {% endif %}
+                    <span class="mel-event-hero__meta-primary">{{ _hero_venue_line }}</span>
                   </span>
                 </li>
               {% endif %}
@@ -176,7 +176,7 @@
               {
                 '#theme': 'mel_event_gallery',
                 '#gallery': mel_event_gallery,
-                '#event_page_style': 'classic',
+                '#event_page_style': event_page_style|default('classic'),
               }
             }}
           </div>
@@ -382,7 +382,7 @@
         </div>
 
         {% if canonical_url %}
-          <section class="mel-event-section mel-event-section--share mel-card mel-card--surface mel-mt-5" role="region" aria-labelledby="mel-event-full-share-label">
+          <section class="mel-event-section mel-event-section--share mel-card mel-card--surface mel-mt-5" id="mel-event-full-share" role="region" aria-labelledby="mel-event-full-share-label">
             <div class="mel-card__header mel-event-section__header">
               <h2 class="mel-card__title mel-event-section__title" id="mel-event-full-share-label">{{ 'Share this event'|t }}</h2>
               <p class="mel-event-section__lede mel-text--muted">{{ 'Send the link to friends who might want to come along.'|t }}</p>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -75,10 +75,11 @@
       </div>
     {% endif %}
 
-    <div class="mel-event-layout mel-event-layout--option1">
-      <div class="mel-event-layout__main">
+    <div class="mel-event-full">
+      <div class="mel-event-full__layout mel-event-layout mel-event-layout--option1">
+        <div class="mel-event-full__main mel-event-layout__main">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
-    <section class="mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">
+    <section class="mel-event-full__hero mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">
       <div class="mel-event-hero__media">
         {% if content.field_event_image %}
           {{ content.field_event_image }}
@@ -170,27 +171,21 @@
     </section>
 
         {% if mel_event_gallery is defined and mel_event_gallery.count > 0 %}
-          {{
-            {
-              '#theme': 'mel_event_gallery',
-              '#gallery': mel_event_gallery,
-              '#event_page_style': event_page_style|default('classic'),
-            }
-          }}
+          <div class="mel-event-full__gallery">
+            {{
+              {
+                '#theme': 'mel_event_gallery',
+                '#gallery': mel_event_gallery,
+                '#event_page_style': 'classic',
+              }
+            }}
+          </div>
         {% endif %}
 
         {% set body_render = (content.body is defined) ? (content.body|render) : '' %}
         {% set body_plain = body_render|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
-        {% if body_plain %}
-          <div class="mel-card mel-card--surface">
-            <div class="mel-card__header">
-              <h2 class="mel-card__title">{{ 'About the Event'|t }}</h2>
-            </div>
-            <div class="mel-card__body">
-              {{ content.body }}
-            </div>
-          </div>
-        {% endif %}
+        {% set expect_html = (content.field_event_intro is defined and content.field_event_intro) ? (content.field_event_intro|render) : '' %}
+        {% set expect_text = expect_html|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
 
         {# Highlights: render only when there are non-empty items (quick-scan list). #}
         {% set highlights = [] %}
@@ -210,60 +205,72 @@
           {% endfor %}
         {% endif %}
 
-        {% if highlights|length %}
-          <div class="mel-card mel-card--surface mel-card--highlights mel-mt-5" aria-label="{{ 'Highlights'|t }}">
-            <div class="mel-card__header">
-              <h2 class="mel-card__title">{{ 'Highlights'|t }}</h2>
-            </div>
-            <div class="mel-card__body">
-              <ul class="mel-event-highlights" role="list">
-                {% for item in highlights %}
-                  {% set icon_key = item.icon|default('') %}
-                  {% set icon_char = '' %}
-                  {# Keys match paragraph.field_highlight_icon allowed_values (config/sync). #}
-                  {% if icon_key == 'star' %}
-                    {% set icon_char = '★' %}
-                  {% elseif icon_key == 'music' %}
-                    {% set icon_char = '♪' %}
-                  {% elseif icon_key == 'food' %}
-                    {% set icon_char = '☕' %}
-                  {% elseif icon_key == 'clock' %}
-                    {% set icon_char = '🕐' %}
-                  {% elseif icon_key == 'info' %}
-                    {% set icon_char = 'ℹ' %}
-                  {% elseif icon_key == 'access' %}
-                    {% set icon_char = '♿' %}
-                  {% endif %}
+        {% if body_plain or highlights|length or expect_text %}
+          <div class="mel-event-full__content-grid">
+            {% if body_plain %}
+              <div class="mel-event-full__about mel-card mel-card--surface mel-event-full__card">
+                <div class="mel-card__header">
+                  <h2 class="mel-card__title">{{ 'About the Event'|t }}</h2>
+                </div>
+                <div class="mel-card__body">
+                  {{ content.body }}
+                </div>
+              </div>
+            {% endif %}
 
-                  <li class="mel-event-highlights__item">
-                    <span class="mel-event-highlights__icon" aria-hidden="true">
-                      {% if icon_char %}
-                        {{ icon_char }}
+            {% if highlights|length %}
+              <div class="mel-event-full__highlights mel-card mel-card--surface mel-card--highlights mel-event-full__card" aria-label="{{ 'Highlights'|t }}">
+                <div class="mel-card__header">
+                  <h2 class="mel-card__title">{{ 'Highlights'|t }}</h2>
+                </div>
+                <div class="mel-card__body">
+                  <ul class="mel-event-highlights" role="list">
+                    {% for item in highlights %}
+                      {% set icon_key = item.icon|default('') %}
+                      {% set icon_char = '' %}
+                      {# Keys match paragraph.field_highlight_icon allowed_values (config/sync). #}
+                      {% if icon_key == 'star' %}
+                        {% set icon_char = '★' %}
+                      {% elseif icon_key == 'music' %}
+                        {% set icon_char = '♪' %}
+                      {% elseif icon_key == 'food' %}
+                        {% set icon_char = '☕' %}
+                      {% elseif icon_key == 'clock' %}
+                        {% set icon_char = '🕐' %}
+                      {% elseif icon_key == 'info' %}
+                        {% set icon_char = 'ℹ' %}
+                      {% elseif icon_key == 'access' %}
+                        {% set icon_char = '♿' %}
                       {% endif %}
-                    </span>
-                    <span class="mel-event-highlights__text">{{ item.text|e }}</span>
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
+
+                      <li class="mel-event-highlights__item">
+                        <span class="mel-event-highlights__icon" aria-hidden="true">
+                          {% if icon_char %}
+                            {{ icon_char }}
+                          {% endif %}
+                        </span>
+                        <span class="mel-event-highlights__text">{{ item.text|e }}</span>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endif %}
+
+            {% if expect_text %}
+              <div class="mel-event-full__expect mel-card mel-card--surface mel-card--expect mel-event-full__card">
+                <div class="mel-card__header">
+                  <h2 class="mel-card__title">{{ 'What to expect'|t }}</h2>
+                </div>
+                <div class="mel-card__body">
+                  {{ expect_html }}
+                </div>
+              </div>
+            {% endif %}
           </div>
         {% endif %}
 
-        {# What to expect: render only if non-trivial (not empty/whitespace markup). #}
-        {% set expect_html = (content.field_event_intro is defined and content.field_event_intro) ? (content.field_event_intro|render) : '' %}
-        {% set expect_text = expect_html|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
-
-        {% if expect_text %}
-          <div class="mel-card mel-card--surface mel-card--expect mel-mt-5">
-            <div class="mel-card__header">
-              <h2 class="mel-card__title">{{ 'What to expect'|t }}</h2>
-            </div>
-            <div class="mel-card__body">
-              {{ expect_html }}
-            </div>
-          </div>
-        {% endif %}
-
+        <div class="mel-event-full__content-below">
         {% if operational_addon_teaser or (content.mel_operational_addon_teaser is defined and content.mel_operational_addon_teaser) %}
           <section class="mel-event-section mel-event-section--extras mel-card mel-card--surface mel-mt-5" aria-labelledby="mel-event-extras-section-title">
             <div class="mel-card__header mel-event-section__header">
@@ -534,15 +541,6 @@
           </div>
         {% endif %}
 
-        <nav class="mel-event-support-zone mel-mt-5" aria-label="{{ 'Help and policies'|t }}">
-          <ul class="mel-event-support-zone__list">
-            <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a></li>
-            <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_support.page') }}">{{ 'Support'|t }}</a></li>
-            <li><a class="mel-event-support-zone__link" href="/privacy">{{ 'Privacy'|t }}</a></li>
-            <li><a class="mel-event-support-zone__link" href="/terms">{{ 'Terms'|t }}</a></li>
-          </ul>
-        </nav>
-
         {% set cancellation_html = (content.field_cancellation_policy is defined and content.field_cancellation_policy) ? (content.field_cancellation_policy|render) : '' %}
         {% set cancellation_text = cancellation_html|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
 
@@ -600,15 +598,23 @@
 
         {# Note: We intentionally do NOT render field_ticket_types or field_attendee_questions on Event Full.
            These are configuration inputs, not attendee-facing content. #}
+        </div>
+        </div>
+
+        <aside class="mel-event-full__sidebar mel-event-layout__sidebar mel-event-sidebar-rail" aria-label="{{ 'Tickets and event information'|t }}">
+          {% include '@myeventlane_theme/node/partial--event-full-booking-panel.html.twig' %}
+          {% include '@myeventlane_theme/node/partial--event-full-view-details.html.twig' %}
+
+          <nav class="mel-event-full__support mel-event-support-zone" aria-label="{{ 'Help and policies'|t }}">
+            <ul class="mel-event-support-zone__list">
+              <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a></li>
+              <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_support.page') }}">{{ 'Support'|t }}</a></li>
+              <li><a class="mel-event-support-zone__link" href="/privacy">{{ 'Privacy'|t }}</a></li>
+              <li><a class="mel-event-support-zone__link" href="/terms">{{ 'Terms'|t }}</a></li>
+            </ul>
+          </nav>
+        </aside>
       </div>
-
-      <aside class="mel-event-layout__sidebar mel-event-sidebar-rail" aria-label="{{ 'Tickets and event information'|t }}">
-        {% include '@myeventlane_theme/node/partial--event-full-booking-panel.html.twig' %}
-        {% include '@myeventlane_theme/node/partial--event-full-view-details.html.twig' %}
-
-        {# Registration metadata intentionally hidden on Event Full (capacity, sales windows, etc.)
-           to keep the sidebar calm and attendee-focused. #}
-      </aside>
     </div>
   </div>
 

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -109,18 +109,63 @@
         </div>
       {% endif %}
       <div class="mel-event-hero__content">
-        <h1 class="mel-event-hero__title" id="mel-event-title">{{ label }}</h1>
-        {% if hero_datetime %}
-          <p class="mel-event-hero__datetime">{{ hero_datetime }}</p>
-        {% endif %}
-        {% if hero_venue %}
-          <p class="mel-event-hero__venue">{{ hero_venue }}</p>
-        {% endif %}
-        {% if (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) or hero_status %}
-          {% set _hero_status_mod = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? 'sold-out' : (hero_status_modifier|default('default')) %}
-          {% set _hero_status_text = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? (event_ui.status_label|default('')|striptags|length > 0 ? event_ui.status_label : ('Sold out'|t)) : hero_status %}
-          <p class="mel-event-hero__status mel-event-card__status mel-event-card__status--{{ _hero_status_mod }}">{{ _hero_status_text }}</p>
-        {% endif %}
+        <div class="mel-event-hero__glass mel-event-hero__info">
+          <h1 class="mel-event-hero__title" id="mel-event-title">{{ label }}</h1>
+          {% set _hero_has_schedule = node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
+          {% set _hero_venue_entity = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
+          {% set _hero_venue_line = (node.hasField('field_venue_name') and not node.field_venue_name.isEmpty) ? node.field_venue_name.value|trim : _hero_venue_entity|trim %}
+          {% set _hero_address = mel_address|default('')|trim %}
+          {% set _hero_has_location = _hero_venue_line is not empty or _hero_address is not empty or (node.hasField('field_location') and not node.field_location.isEmpty) %}
+          {% if _hero_has_schedule or _hero_has_location %}
+            <ul class="mel-event-hero__meta" role="list">
+              {% if _hero_has_schedule %}
+                <li class="mel-event-hero__meta-item">
+                  <span class="mel-event-hero__meta-icon" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-text">
+                    <span class="mel-event-hero__meta-primary">
+                      {{ node.field_event_start.value|date('l, F j, Y') }}
+                      {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
+                        {% set _hero_end_day = node.field_event_end.value|date('l, F j, Y') %}
+                        {% if _hero_end_day != node.field_event_start.value|date('l, F j, Y') %}
+                          – {{ _hero_end_day }}
+                        {% endif %}
+                      {% endif %}
+                    </span>
+                  </span>
+                </li>
+                <li class="mel-event-hero__meta-item mel-event-hero__meta-item--time">
+                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--time" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-text">
+                    <span class="mel-event-hero__meta-primary">
+                      {{ node.field_event_start.value|date('g:i A') }}
+                      {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
+                        – {{ node.field_event_end.value|date('g:i A') }}
+                      {% endif %}
+                    </span>
+                  </span>
+                </li>
+              {% endif %}
+              {% if _hero_has_location %}
+                <li class="mel-event-hero__meta-item mel-event-hero__meta-item--location">
+                  <span class="mel-event-hero__meta-icon mel-event-hero__meta-icon--location" aria-hidden="true"></span>
+                  <span class="mel-event-hero__meta-text">
+                    {% if _hero_venue_line is not empty %}
+                      <span class="mel-event-hero__meta-primary">{{ _hero_venue_line }}</span>
+                    {% endif %}
+                    {% if _hero_address is not empty %}
+                      <span class="mel-event-hero__meta-secondary">{{ _hero_address }}</span>
+                    {% endif %}
+                  </span>
+                </li>
+              {% endif %}
+            </ul>
+          {% endif %}
+          {% if (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) or hero_status %}
+            {% set _hero_status_mod = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? 'sold-out' : (hero_status_modifier|default('default')) %}
+            {% set _hero_status_text = (event_ui is defined and (event_ui.is_sold_out|default(false) == true)) ? (event_ui.status_label|default('')|striptags|length > 0 ? event_ui.status_label : ('Sold out'|t)) : hero_status %}
+            <p class="mel-event-hero__status mel-event-card__status mel-event-card__status--{{ _hero_status_mod }}">{{ _hero_status_text }}</p>
+          {% endif %}
+        </div>
       </div>
     </section>
 

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -29,15 +29,16 @@
             <span class="mel-price__tax-note">{{ 'Includes GST'|t }}</span>
           {% endif %}
         </div>
+      {% elseif cta_type is defined and cta_type == 'rsvp' %}
+        <p class="mel-booking-panel__status-label">{{ 'Free RSVP'|t }}</p>
       {% endif %}
       {% if cta_type is defined and cta_type == 'paid'
         and mel_event_selling_fast|default(false)
         and (event_ui is not defined or not (event_ui.is_sold_out|default(false) == true)) %}
-        <div class="mel-event__urgency">
-          {{ 'Tickets selling fast'|t }}
-        </div>
+        <p class="mel-booking-panel__urgency-line">{{ 'Tickets selling fast'|t }}</p>
       {% endif %}
-      {% if content.field_product_target is defined %}
+      {% set _product_markup = (content.field_product_target is defined) ? (content.field_product_target|render|striptags|trim) : '' %}
+      {% if _product_markup is not empty %}
         <div class="mel-booking-panel__product">
           {{ content.field_product_target }}
         </div>
@@ -76,7 +77,14 @@
                 </span>
                 <span class="mel-booking-panel__trust-row-text">{{ 'Instant confirmation'|t }}</span>
               </li>
-              {% if _support_urgent %}
+              {% if mel_event_selling_fast|default(false) and (event_ui is not defined or not (event_ui.is_sold_out|default(false) is same as(true))) %}
+                <li class="mel-booking-panel__trust-row mel-booking-panel__trust-row--urgent">
+                  <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
+                  <span class="mel-booking-panel__trust-row-text">{{ 'Tickets selling fast'|t }}</span>
+                </li>
+              {% elseif _support_urgent %}
                 <li class="mel-booking-panel__trust-row mel-booking-panel__trust-row--urgent">
                   <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
                     {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
@@ -99,6 +107,17 @@
                 </li>
               {% endif %}
             </ul>
+          </div>
+        {% endif %}
+
+        {% if event_flag_event_save %}
+          <div class="mel-booking-panel__save" aria-label="{{ 'Save for later'|t }}">
+            <span class="mel-booking-panel__save-icon" aria-hidden="true">
+              {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'heart', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+            </span>
+            <div class="mel-booking-panel__save-flag">
+              {{ event_flag_event_save }}
+            </div>
           </div>
         {% endif %}
       {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -66,7 +66,12 @@
                 <p class="mel-booking-panel__trust-micro-primary">{{ 'Free RSVP'|t }}</p>
                 <p>{{ 'No payment required — confirmation by email'|t }}</p>
               {% endif %}
-              <p>{{ 'No hidden fees on MyEventLane'|t }}</p>
+              <p class="mel-booking-panel__trust-line">
+                <span class="mel-booking-panel__trust-line-icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'shield-check', class: 'mel-booking-panel__trust-svg', size: 18 } only %}
+                </span>
+                {{ 'No hidden fees on MyEventLane'|t }}
+              </p>
             </div>
             {% set _mel_trust_capacity_highlight = event_ui is defined
               and (mel_cta_urgency|default('')|striptags|length == 0)
@@ -79,13 +84,22 @@
             <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
               <div class="mel-trust-item is-active" data-trust-item>
                 {% if event_viewer_count is not empty %}
+                  <span class="mel-trust-item__icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'flame', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
                   <span class="mel-trust-item__text">{{ event_viewer_count }}</span>
                 {% else %}
-                  <span class="mel-trust-item__text">🔥 {{ 'Popular on MyEventLane'|t }}</span>
+                  <span class="mel-trust-item__icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'flame', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
+                  <span class="mel-trust-item__text">{{ 'Popular on MyEventLane'|t }}</span>
                 {% endif %}
               </div>
               <div class="mel-trust-item" data-trust-item>
-                <span class="mel-trust-item__text">✉️ {{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
+                <span class="mel-trust-item__icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'mail', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                </span>
+                <span class="mel-trust-item__text">{{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
               </div>
             </div>
             {% set _show_mel_decision_prompts = (not logged_in)
@@ -97,7 +111,9 @@
                 {% if _decision_count < 2 and (not logged_in) %}
                   {% set _decision_count = _decision_count + 1 %}
                   <div class="mel-decision-item">
-                    <span class="mel-icon">👤</span>
+                    <span class="mel-icon" aria-hidden="true">
+                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'user', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                    </span>
                     <div>
                       <strong>{{ 'First time here?'|t }}</strong>
                       <p>{{ 'Book in seconds — no account needed'|t }}</p>
@@ -107,7 +123,9 @@
                 {% if _decision_count < 2 and event_ui is defined and (event_ui.is_free|default(false) == true) %}
                   {% set _decision_count = _decision_count + 1 %}
                   <div class="mel-decision-item">
-                    <span class="mel-icon">🎟</span>
+                    <span class="mel-icon" aria-hidden="true">
+                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'ticket', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                    </span>
                     <div>
                       <strong>{{ 'Free event'|t }}</strong>
                       <p>{{ 'No payment required'|t }}</p>
@@ -120,7 +138,9 @@
                   and (not _mel_trust_capacity_highlight) %}
                   {% set _decision_count = _decision_count + 1 %}
                   <div class="mel-decision-item mel-decision-item--urgent">
-                    <span class="mel-icon">⚡</span>
+                    <span class="mel-icon" aria-hidden="true">
+                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                    </span>
                     <div>
                       <strong>{{ event_ui.capacity_hint }}</strong>
                       <p>{{ "Don't miss out"|t }}</p>
@@ -131,7 +151,9 @@
             {% endif %}
             {% if _mel_trust_capacity_highlight %}
               <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
-                <span class="mel-icon" aria-hidden="true">⚡</span>
+                <span class="mel-icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                </span>
                 <div>
                   <p class="mel-booking-panel__capacity" role="status">
                     <strong>{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</strong>
@@ -142,7 +164,9 @@
             {% endif %}
             {% if _support_urgent %}
               <div class="mel-booking-panel__item">
-                <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
+                <span class="mel-booking-panel__item-icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                </span>
                 <div>
                   <strong>{{ mel_cta_urgency }}</strong>
                   <p>{{ 'Secure your spot today'|t }}</p>
@@ -151,7 +175,9 @@
             {% endif %}
             {% if event_save_count_total|default(0) > 0 and event_save_count is not empty %}
               <div class="mel-booking-panel__item mel-booking-panel__item--social">
-                <span class="mel-icon" aria-hidden="true">💖</span>
+                <span class="mel-icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'heart', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                </span>
                 <div>
                   <strong>{{ event_save_count }}</strong>
                 </div>
@@ -162,44 +188,6 @@
                 <strong>{{ event_interest.label }}</strong>
               </div>
             {% endif %}
-          </div>
-        {% endif %}
-        {% if google_calendar_url|default('')|length > 0 %}
-          <div class="mel-booking-panel__item">
-            <span class="mel-booking-panel__item-icon" aria-hidden="true">📅</span>
-            <div>
-              <div class="mel-calendar">
-                <div class="mel-calendar__tabs" role="tablist" aria-label="{{ 'Add to calendar'|t }}">
-                  <button type="button" class="mel-calendar__tab is-active" data-tab="apple" role="tab" aria-selected="true">{{ 'Apple'|t }}</button>
-                  <button type="button" class="mel-calendar__tab" data-tab="outlook" role="tab" aria-selected="false">{{ 'Outlook'|t }}</button>
-                  <button type="button" class="mel-calendar__tab" data-tab="google" role="tab" aria-selected="false">{{ 'Google'|t }}</button>
-                </div>
-                <div class="mel-calendar__content">
-                  <div class="mel-calendar__pane is-active" data-pane="apple">
-                    <a href="{{ apple_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Apple Calendar'|t }}</a>
-                  </div>
-                  <div class="mel-calendar__pane" data-pane="outlook">
-                    <a href="{{ outlook_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Outlook'|t }}</a>
-                  </div>
-                  <div class="mel-calendar__pane" data-pane="google">
-                    <a href="{{ google_calendar_url }}" class="mel-button mel-button--ghost" target="_blank" rel="noopener noreferrer">{{ 'Add to Google Calendar'|t }}</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endif %}
-        {% if event_flag_event_save %}
-          <div class="mel-booking-panel__save mel-booking-panel__save--fav" role="group" aria-label="{{ 'Save for later'|t }}">
-            <div class="mel-booking-panel__save-inner">
-              <div id="mel-event-full-save" class="mel-event-save mel-booking-panel__save-flag">
-                {{ event_flag_event_save }}
-              </div>
-              <div class="mel-booking-panel__save-copy">
-                <span class="mel-booking-panel__save-label">{{ 'Save for later'|t }}</span>
-                <span class="mel-booking-panel__save-hint mel-text--muted">{{ 'Tap the heart to remember this event'|t }}</span>
-              </div>
-            </div>
           </div>
         {% endif %}
       {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -2,9 +2,16 @@
   Sticky booking card — single conversion surface (sidebar + mobile stack).
   Trust copy and primary CTA live here only; do not duplicate in main column.
 #}
-<div class="mel-card mel-card--surface mel-card--sticky mel-event__card mel-event-sidebar__booking">
-  <div class="mel-card__body">
+<div class="mel-event-full__booking mel-card mel-card--surface mel-card--sticky mel-event__card mel-event-sidebar__booking">
+  <div class="mel-card__body mel-event-full__booking-body">
     <div class="mel-booking-panel" role="region" aria-label="{{ 'Book this event'|t }}">
+      {% set _booking_panel_heading = mel_booking_action_label|default('')|striptags|trim %}
+      {% if _booking_panel_heading is empty and mel_mode_chip %}
+        {% set _booking_panel_heading = mel_mode_chip %}
+      {% endif %}
+      {% if _booking_panel_heading is not empty %}
+        <h2 class="mel-booking-panel__heading mel-event-full__booking-heading">{{ _booking_panel_heading }}</h2>
+      {% endif %}
       {% if mel_mode_chip %}
         <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
           <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -1,0 +1,201 @@
+{#
+  Sticky booking card — single conversion surface (sidebar + mobile stack).
+  Trust copy and primary CTA live here only; do not duplicate in main column.
+#}
+<div class="mel-card mel-card--surface mel-card--sticky mel-event__card mel-event-sidebar__booking">
+  <div class="mel-card__body">
+    <div class="mel-booking-panel" role="region" aria-label="{{ 'Book this event'|t }}">
+      {% if mel_mode_chip %}
+        <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
+          <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
+        </div>
+      {% endif %}
+      {% if mel_show_sidebar_scarcity_badge %}
+        <div class="mel-event__badge">
+          {{ 'Limited availability'|t }}
+        </div>
+      {% endif %}
+      {% if mel_signal %}
+        <div class="mel-event__signal mel-event__signal--strong">{{ mel_signal }}</div>
+      {% endif %}
+      {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
+        <div class="mel-booking-panel__price mel-price" aria-label="{{ 'Price'|t }}">
+          {{ mel_sidebar_pricing }}
+          {% if cta_type is defined and cta_type == 'paid' and mel_show_price_includes_gst_note|default(false) %}
+            <span class="mel-price__tax-note">{{ 'Includes GST'|t }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+      {% if cta_type is defined and cta_type == 'paid'
+        and mel_event_selling_fast|default(false)
+        and (event_ui is not defined or not (event_ui.is_sold_out|default(false) == true)) %}
+        <div class="mel-event__urgency">
+          {{ 'Tickets selling fast'|t }}
+        </div>
+      {% endif %}
+      {% if content.field_product_target is defined %}
+        <div class="mel-booking-panel__product">
+          {{ content.field_product_target }}
+        </div>
+      {% endif %}
+
+      {% if mel_event_state is not defined or mel_event_state != 'cancelled' %}
+        {% if mel_show_booking_cta and (mel_cta_text|striptags|length > 0) %}
+          <div class="mel-booking-panel__cta mel-event__cta">
+            <div class="mel-event-sticky-cta mel-event-sticky-cta--sidebar" role="group" aria-label="{{ 'Register or buy tickets'|t }}">
+              {% include '@myeventlane_theme/node/partial--event-full-booking-cta.html.twig' with { 'mel_cta_slot': 'sidebar' } %}
+            </div>
+          </div>
+          <hr class="mel-booking-panel__rule" role="separator" />
+        {% endif %}
+
+        {% if mel_show_booking_trust_copy %}
+          <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
+            <div class="mel-booking-panel__trust-micro">
+              {% if mel_trust_checkout and cta_type is defined and cta_type == 'paid' %}
+                <p class="mel-booking-panel__trust-micro-primary">{{ 'Secure checkout'|t }}</p>
+                <p>{{ 'Payment processed securely via Stripe'|t }}</p>
+              {% elseif cta_type is defined and cta_type == 'rsvp' %}
+                <p class="mel-booking-panel__trust-micro-primary">{{ 'Free RSVP'|t }}</p>
+                <p>{{ 'No payment required — confirmation by email'|t }}</p>
+              {% endif %}
+              <p>{{ 'No hidden fees on MyEventLane'|t }}</p>
+            </div>
+            {% set _mel_trust_capacity_highlight = event_ui is defined
+              and (mel_cta_urgency|default('')|striptags|length == 0)
+              and (not mel_event_selling_fast|default(false))
+              and (not (event_ui.is_sold_out|default(false) is same as(true)))
+              and (
+                (event_ui.is_limited|default(false))
+                or (event_ui.capacity_hint|default('')|striptags|length > 0)
+              ) %}
+            <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
+              <div class="mel-trust-item is-active" data-trust-item>
+                {% if event_viewer_count is not empty %}
+                  <span class="mel-trust-item__text">{{ event_viewer_count }}</span>
+                {% else %}
+                  <span class="mel-trust-item__text">🔥 {{ 'Popular on MyEventLane'|t }}</span>
+                {% endif %}
+              </div>
+              <div class="mel-trust-item" data-trust-item>
+                <span class="mel-trust-item__text">✉️ {{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
+              </div>
+            </div>
+            {% set _show_mel_decision_prompts = (not logged_in)
+              or (event_ui is defined and (event_ui.is_free|default(false) == true))
+              or (event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not _mel_trust_capacity_highlight)) %}
+            {% if _show_mel_decision_prompts %}
+              {% set _decision_count = 0 %}
+              <div class="mel-decision-prompts">
+                {% if _decision_count < 2 and (not logged_in) %}
+                  {% set _decision_count = _decision_count + 1 %}
+                  <div class="mel-decision-item">
+                    <span class="mel-icon">👤</span>
+                    <div>
+                      <strong>{{ 'First time here?'|t }}</strong>
+                      <p>{{ 'Book in seconds — no account needed'|t }}</p>
+                    </div>
+                  </div>
+                {% endif %}
+                {% if _decision_count < 2 and event_ui is defined and (event_ui.is_free|default(false) == true) %}
+                  {% set _decision_count = _decision_count + 1 %}
+                  <div class="mel-decision-item">
+                    <span class="mel-icon">🎟</span>
+                    <div>
+                      <strong>{{ 'Free event'|t }}</strong>
+                      <p>{{ 'No payment required'|t }}</p>
+                    </div>
+                  </div>
+                {% endif %}
+                {% if _decision_count < 2
+                  and event_ui is defined
+                  and (event_ui.capacity_hint|default('')|striptags|length > 0)
+                  and (not _mel_trust_capacity_highlight) %}
+                  {% set _decision_count = _decision_count + 1 %}
+                  <div class="mel-decision-item mel-decision-item--urgent">
+                    <span class="mel-icon">⚡</span>
+                    <div>
+                      <strong>{{ event_ui.capacity_hint }}</strong>
+                      <p>{{ "Don't miss out"|t }}</p>
+                    </div>
+                  </div>
+                {% endif %}
+              </div>
+            {% endif %}
+            {% if _mel_trust_capacity_highlight %}
+              <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
+                <span class="mel-icon" aria-hidden="true">⚡</span>
+                <div>
+                  <p class="mel-booking-panel__capacity" role="status">
+                    <strong>{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</strong>
+                  </p>
+                  <p>{{ 'Secure your spot today'|t }}</p>
+                </div>
+              </div>
+            {% endif %}
+            {% if _support_urgent %}
+              <div class="mel-booking-panel__item">
+                <span class="mel-booking-panel__item-icon" aria-hidden="true">⚡</span>
+                <div>
+                  <strong>{{ mel_cta_urgency }}</strong>
+                  <p>{{ 'Secure your spot today'|t }}</p>
+                </div>
+              </div>
+            {% endif %}
+            {% if event_save_count_total|default(0) > 0 and event_save_count is not empty %}
+              <div class="mel-booking-panel__item mel-booking-panel__item--social">
+                <span class="mel-icon" aria-hidden="true">💖</span>
+                <div>
+                  <strong>{{ event_save_count }}</strong>
+                </div>
+              </div>
+            {% endif %}
+            {% if event_interest is defined and event_interest.label is defined %}
+              <div class="mel-booking-panel__item mel-booking-panel__item--interest mel-booking-panel__item--{{ event_interest.type }}">
+                <strong>{{ event_interest.label }}</strong>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
+        {% if google_calendar_url|default('')|length > 0 %}
+          <div class="mel-booking-panel__item">
+            <span class="mel-booking-panel__item-icon" aria-hidden="true">📅</span>
+            <div>
+              <div class="mel-calendar">
+                <div class="mel-calendar__tabs" role="tablist" aria-label="{{ 'Add to calendar'|t }}">
+                  <button type="button" class="mel-calendar__tab is-active" data-tab="apple" role="tab" aria-selected="true">{{ 'Apple'|t }}</button>
+                  <button type="button" class="mel-calendar__tab" data-tab="outlook" role="tab" aria-selected="false">{{ 'Outlook'|t }}</button>
+                  <button type="button" class="mel-calendar__tab" data-tab="google" role="tab" aria-selected="false">{{ 'Google'|t }}</button>
+                </div>
+                <div class="mel-calendar__content">
+                  <div class="mel-calendar__pane is-active" data-pane="apple">
+                    <a href="{{ apple_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Apple Calendar'|t }}</a>
+                  </div>
+                  <div class="mel-calendar__pane" data-pane="outlook">
+                    <a href="{{ outlook_ics_url }}" class="mel-button mel-button--ghost">{{ 'Download for Outlook'|t }}</a>
+                  </div>
+                  <div class="mel-calendar__pane" data-pane="google">
+                    <a href="{{ google_calendar_url }}" class="mel-button mel-button--ghost" target="_blank" rel="noopener noreferrer">{{ 'Add to Google Calendar'|t }}</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+        {% if event_flag_event_save %}
+          <div class="mel-booking-panel__save mel-booking-panel__save--fav" role="group" aria-label="{{ 'Save for later'|t }}">
+            <div class="mel-booking-panel__save-inner">
+              <div id="mel-event-full-save" class="mel-event-save mel-booking-panel__save-flag">
+                {{ event_flag_event_save }}
+              </div>
+              <div class="mel-booking-panel__save-copy">
+                <span class="mel-booking-panel__save-label">{{ 'Save for later'|t }}</span>
+                <span class="mel-booking-panel__save-hint mel-text--muted">{{ 'Tap the heart to remember this event'|t }}</span>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -12,7 +12,7 @@
       {% if _booking_panel_heading is not empty %}
         <h2 class="mel-booking-panel__heading mel-event-full__booking-heading">{{ _booking_panel_heading }}</h2>
       {% endif %}
-      {% if mel_mode_chip %}
+      {% if mel_mode_chip and (_booking_panel_heading|default('')|striptags|trim|lower != mel_mode_chip|striptags|trim|lower) %}
         <div class="mel-booking-panel__chip" aria-label="{{ 'Registration type'|t }}">
           <span class="mel-chip mel-chip--sm mel-chip--filled">{{ mel_mode_chip }}</span>
         </div>
@@ -21,9 +21,6 @@
         <div class="mel-event__badge">
           {{ 'Limited availability'|t }}
         </div>
-      {% endif %}
-      {% if mel_signal %}
-        <div class="mel-event__signal mel-event__signal--strong">{{ mel_signal }}</div>
       {% endif %}
       {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
         <div class="mel-booking-panel__price mel-price" aria-label="{{ 'Price'|t }}">
@@ -57,137 +54,51 @@
         {% endif %}
 
         {% if mel_show_booking_trust_copy %}
+          {% set _mel_trust_capacity_highlight = event_ui is defined
+            and (mel_cta_urgency|default('')|striptags|length == 0)
+            and (not mel_event_selling_fast|default(false))
+            and (not (event_ui.is_sold_out|default(false) is same as(true)))
+            and (
+              (event_ui.is_limited|default(false))
+              or (event_ui.capacity_hint|default('')|striptags|length > 0)
+            ) %}
           <div class="mel-booking-panel__trust" role="group" aria-label="{{ 'Booking details'|t }}">
-            <div class="mel-booking-panel__trust-micro">
-              {% if mel_trust_checkout and cta_type is defined and cta_type == 'paid' %}
-                <p class="mel-booking-panel__trust-micro-primary">{{ 'Secure checkout'|t }}</p>
-                <p>{{ 'Payment processed securely via Stripe'|t }}</p>
-              {% elseif cta_type is defined and cta_type == 'rsvp' %}
-                <p class="mel-booking-panel__trust-micro-primary">{{ 'Free RSVP'|t }}</p>
-                <p>{{ 'No payment required — confirmation by email'|t }}</p>
-              {% endif %}
-              <p class="mel-booking-panel__trust-line">
-                <span class="mel-booking-panel__trust-line-icon" aria-hidden="true">
-                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'shield-check', class: 'mel-booking-panel__trust-svg', size: 18 } only %}
+            <ul class="mel-booking-panel__trust-rows" role="list">
+              <li class="mel-booking-panel__trust-row">
+                <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
+                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'shield-check', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
                 </span>
-                {{ 'No hidden fees on MyEventLane'|t }}
-              </p>
-            </div>
-            {% set _mel_trust_capacity_highlight = event_ui is defined
-              and (mel_cta_urgency|default('')|striptags|length == 0)
-              and (not mel_event_selling_fast|default(false))
-              and (not (event_ui.is_sold_out|default(false) is same as(true)))
-              and (
-                (event_ui.is_limited|default(false))
-                or (event_ui.capacity_hint|default('')|striptags|length > 0)
-              ) %}
-            <div class="mel-trust-rotator" data-rotate aria-live="polite" aria-atomic="true">
-              <div class="mel-trust-item is-active" data-trust-item>
-                {% if event_viewer_count is not empty %}
-                  <span class="mel-trust-item__icon" aria-hidden="true">
-                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'flame', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                  </span>
-                  <span class="mel-trust-item__text">{{ event_viewer_count }}</span>
-                {% else %}
-                  <span class="mel-trust-item__icon" aria-hidden="true">
-                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'flame', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                  </span>
-                  <span class="mel-trust-item__text">{{ 'Popular on MyEventLane'|t }}</span>
-                {% endif %}
-              </div>
-              <div class="mel-trust-item" data-trust-item>
-                <span class="mel-trust-item__icon" aria-hidden="true">
+                <span class="mel-booking-panel__trust-row-text">{{ 'No hidden fees on MyEventLane'|t }}</span>
+              </li>
+              <li class="mel-booking-panel__trust-row">
+                <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
                   {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'mail', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
                 </span>
-                <span class="mel-trust-item__text">{{ 'Instant confirmation'|t }} — {% if mel_trust_checkout %}{{ 'You’ll receive confirmation by email'|t }}{% else %}{{ 'You’ll get a confirmation email'|t }}{% endif %}</span>
-              </div>
-            </div>
-            {% set _show_mel_decision_prompts = (not logged_in)
-              or (event_ui is defined and (event_ui.is_free|default(false) == true))
-              or (event_ui is defined and (event_ui.capacity_hint|default('')|striptags|length > 0) and (not _mel_trust_capacity_highlight)) %}
-            {% if _show_mel_decision_prompts %}
-              {% set _decision_count = 0 %}
-              <div class="mel-decision-prompts">
-                {% if _decision_count < 2 and (not logged_in) %}
-                  {% set _decision_count = _decision_count + 1 %}
-                  <div class="mel-decision-item">
-                    <span class="mel-icon" aria-hidden="true">
-                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'user', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                    </span>
-                    <div>
-                      <strong>{{ 'First time here?'|t }}</strong>
-                      <p>{{ 'Book in seconds — no account needed'|t }}</p>
-                    </div>
-                  </div>
-                {% endif %}
-                {% if _decision_count < 2 and event_ui is defined and (event_ui.is_free|default(false) == true) %}
-                  {% set _decision_count = _decision_count + 1 %}
-                  <div class="mel-decision-item">
-                    <span class="mel-icon" aria-hidden="true">
-                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'ticket', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                    </span>
-                    <div>
-                      <strong>{{ 'Free event'|t }}</strong>
-                      <p>{{ 'No payment required'|t }}</p>
-                    </div>
-                  </div>
-                {% endif %}
-                {% if _decision_count < 2
-                  and event_ui is defined
-                  and (event_ui.capacity_hint|default('')|striptags|length > 0)
-                  and (not _mel_trust_capacity_highlight) %}
-                  {% set _decision_count = _decision_count + 1 %}
-                  <div class="mel-decision-item mel-decision-item--urgent">
-                    <span class="mel-icon" aria-hidden="true">
-                      {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                    </span>
-                    <div>
-                      <strong>{{ event_ui.capacity_hint }}</strong>
-                      <p>{{ "Don't miss out"|t }}</p>
-                    </div>
-                  </div>
-                {% endif %}
-              </div>
-            {% endif %}
-            {% if _mel_trust_capacity_highlight %}
-              <div class="mel-booking-panel__item mel-booking-panel__item--highlight">
-                <span class="mel-icon" aria-hidden="true">
-                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                </span>
-                <div>
-                  <p class="mel-booking-panel__capacity" role="status">
-                    <strong>{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</strong>
-                  </p>
-                  <p>{{ 'Secure your spot today'|t }}</p>
-                </div>
-              </div>
-            {% endif %}
-            {% if _support_urgent %}
-              <div class="mel-booking-panel__item">
-                <span class="mel-booking-panel__item-icon" aria-hidden="true">
-                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                </span>
-                <div>
-                  <strong>{{ mel_cta_urgency }}</strong>
-                  <p>{{ 'Secure your spot today'|t }}</p>
-                </div>
-              </div>
-            {% endif %}
-            {% if event_save_count_total|default(0) > 0 and event_save_count is not empty %}
-              <div class="mel-booking-panel__item mel-booking-panel__item--social">
-                <span class="mel-icon" aria-hidden="true">
-                  {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'heart', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
-                </span>
-                <div>
-                  <strong>{{ event_save_count }}</strong>
-                </div>
-              </div>
-            {% endif %}
-            {% if event_interest is defined and event_interest.label is defined %}
-              <div class="mel-booking-panel__item mel-booking-panel__item--interest mel-booking-panel__item--{{ event_interest.type }}">
-                <strong>{{ event_interest.label }}</strong>
-              </div>
-            {% endif %}
+                <span class="mel-booking-panel__trust-row-text">{{ 'Instant confirmation'|t }}</span>
+              </li>
+              {% if _support_urgent %}
+                <li class="mel-booking-panel__trust-row mel-booking-panel__trust-row--urgent">
+                  <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
+                  <span class="mel-booking-panel__trust-row-text">{{ mel_cta_urgency }}</span>
+                </li>
+              {% elseif _mel_trust_capacity_highlight %}
+                <li class="mel-booking-panel__trust-row mel-booking-panel__trust-row--urgent">
+                  <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
+                  <span class="mel-booking-panel__trust-row-text">{{ event_ui.capacity_hint|default('Limited spots remaining'|t) }}</span>
+                </li>
+              {% elseif event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
+                <li class="mel-booking-panel__trust-row mel-booking-panel__trust-row--urgent">
+                  <span class="mel-booking-panel__trust-row-icon" aria-hidden="true">
+                    {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'bolt', class: 'mel-booking-panel__trust-svg', size: 20 } only %}
+                  </span>
+                  <span class="mel-booking-panel__trust-row-text">{{ 'Sold out'|t }}</span>
+                </li>
+              {% endif %}
+            </ul>
           </div>
         {% endif %}
       {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
@@ -1,7 +1,7 @@
 {#
   View details — compact when/where summary; links to full Event Information in main.
 #}
-<div class="mel-card mel-card--surface mel-event-sidebar__details">
+<div class="mel-event-full__view-details mel-card mel-card--surface mel-event-sidebar__details mel-event-full__card">
   <div class="mel-card__header">
     <h2 class="mel-card__title">{{ 'View details'|t }}</h2>
   </div>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
@@ -62,6 +62,49 @@
       </div>
     {% endif %}
 
+    {% set _has_calendar = (apple_ics_url|default('')|length > 0) or (google_calendar_url|default('')|length > 0) or (outlook_ics_url|default('')|length > 0) %}
+    {% set _has_share = canonical_url is defined and canonical_url %}
+    {% if _has_share or _has_calendar or event_flag_event_save %}
+      <div class="mel-event-sidebar-details__actions" role="group" aria-label="{{ 'Event actions'|t }}">
+        {% if _has_share %}
+          <a class="mel-event-sidebar-details__action-btn" href="#mel-event-full-share" aria-label="{{ 'Share this event'|t }}">
+            {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'share', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
+            <span class="visually-hidden">{{ 'Share'|t }}</span>
+          </a>
+        {% endif %}
+        {% if _has_calendar %}
+          <details class="mel-event-sidebar-details__calendar">
+            <summary class="mel-event-sidebar-details__action-btn mel-event-sidebar-details__action-btn--calendar">
+              {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar-plus', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
+              <span class="visually-hidden">{{ 'Add to calendar'|t }}</span>
+            </summary>
+            <ul class="mel-event-sidebar-details__calendar-links">
+              {% if apple_ics_url|default('')|length > 0 %}
+                <li>
+                  <a href="{{ apple_ics_url }}" class="mel-event-sidebar-details__calendar-link">{{ 'Apple Calendar'|t }}</a>
+                </li>
+              {% endif %}
+              {% if outlook_ics_url|default('')|length > 0 %}
+                <li>
+                  <a href="{{ outlook_ics_url }}" class="mel-event-sidebar-details__calendar-link">{{ 'Outlook'|t }}</a>
+                </li>
+              {% endif %}
+              {% if google_calendar_url|default('')|length > 0 %}
+                <li>
+                  <a href="{{ google_calendar_url }}" class="mel-event-sidebar-details__calendar-link" target="_blank" rel="noopener noreferrer">{{ 'Google Calendar'|t }}</a>
+                </li>
+              {% endif %}
+            </ul>
+          </details>
+        {% endif %}
+        {% if event_flag_event_save %}
+          <div class="mel-event-sidebar-details__action-save" aria-label="{{ 'Save for later'|t }}">
+            {{ event_flag_event_save }}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
     <p class="mel-event-sidebar-details__action">
       <a class="mel-event-sidebar-details__link" href="#mel-event-information">{{ 'See full event information'|t }}</a>
     </p>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
@@ -2,9 +2,10 @@
   View details — compact when/where summary; links to full Event Information in main.
 #}
 <div class="mel-event-full__view-details mel-card mel-card--surface mel-event-sidebar__details mel-event-full__card">
-  <div class="mel-card__header">
+  <div class="mel-card__header mel-event-sidebar-details__header">
     <h2 class="mel-card__title">{{ 'View details'|t }}</h2>
   </div>
+  <hr class="mel-event-sidebar-details__rule" role="separator" />
   <div class="mel-card__body mel-event-sidebar-details">
     {% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
       <div class="mel-event-sidebar-details__row">
@@ -62,10 +63,13 @@
       </div>
     {% endif %}
 
+    <hr class="mel-event-sidebar-details__rule" role="separator" />
+
     {% set _has_calendar = (apple_ics_url|default('')|length > 0) or (google_calendar_url|default('')|length > 0) or (outlook_ics_url|default('')|length > 0) %}
     {% set _has_share = canonical_url is defined and canonical_url %}
     {% if _has_share or _has_calendar or event_flag_event_save %}
       <div class="mel-event-sidebar-details__actions" role="group" aria-label="{{ 'Event actions'|t }}">
+        <span class="visually-hidden">{{ 'Share, calendar, and save'|t }}</span>
         {% if _has_share %}
           <a class="mel-event-sidebar-details__action-btn" href="#mel-event-full-share" aria-label="{{ 'Share this event'|t }}">
             {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'share', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
@@ -1,0 +1,69 @@
+{#
+  View details — compact when/where summary; links to full Event Information in main.
+#}
+<div class="mel-card mel-card--surface mel-event-sidebar__details">
+  <div class="mel-card__header">
+    <h2 class="mel-card__title">{{ 'View details'|t }}</h2>
+  </div>
+  <div class="mel-card__body mel-event-sidebar-details">
+    {% if node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
+      <div class="mel-event-sidebar-details__row">
+        <span class="mel-event-sidebar-details__label">{{ 'When'|t }}</span>
+        <div class="mel-event-sidebar-details__value">
+          <div class="mel-event-sidebar-details__primary">
+            {{ node.field_event_start.value|date('l, F j, Y') }}
+            {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
+              {% set end_day = node.field_event_end.value|date('l, F j, Y') %}
+              {% if end_day != node.field_event_start.value|date('l, F j, Y') %}
+                <span class="mel-event-sidebar-details__range"> – {{ end_day }}</span>
+              {% endif %}
+            {% endif %}
+          </div>
+          <div class="mel-event-sidebar-details__secondary">
+            {{ node.field_event_start.value|date('g:i A') }}
+            {% if node.hasField('field_event_end') and not node.field_event_end.isEmpty and node.field_event_end.value %}
+              – {{ node.field_event_end.value|date('g:i A') }}
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% set display_address = mel_address|default('')|trim %}
+    {% set has_field_location = node.hasField('field_location') and not node.field_location.isEmpty %}
+    {% set has_venue_name = node.hasField('field_venue_name') and not node.field_venue_name.isEmpty %}
+    {% set venue_entity_label = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
+    {% set venue_line = has_venue_name ? node.field_venue_name.value|trim : venue_entity_label|trim %}
+    {% set location_has_markup = content.field_location is defined and content.field_location|render|striptags|trim %}
+    {% if venue_line is not empty or display_address is not empty or has_field_location %}
+      <div class="mel-event-sidebar-details__row">
+        <span class="mel-event-sidebar-details__label">{{ 'Where'|t }}</span>
+        <div class="mel-event-sidebar-details__value mel-event-location">
+          {% if venue_line is not empty %}
+            <div class="mel-event-location__venue">{{ venue_line }}</div>
+          {% endif %}
+          {% if display_address is not empty or has_field_location %}
+            <div class="mel-event-location__address">
+              {% if location_has_markup %}
+                {{ content.field_location }}
+              {% elseif display_address is not empty %}
+                {{ display_address }}
+              {% endif %}
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+
+    {% if mel_category_label is defined and mel_category_label %}
+      <div class="mel-event-sidebar-details__row">
+        <span class="mel-event-sidebar-details__label">{{ 'Category'|t }}</span>
+        <div class="mel-event-sidebar-details__value">{{ mel_category_label }}</div>
+      </div>
+    {% endif %}
+
+    <p class="mel-event-sidebar-details__action">
+      <a class="mel-event-sidebar-details__link" href="#mel-event-information">{{ 'See full event information'|t }}</a>
+    </p>
+  </div>
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-view-details.html.twig
@@ -1,5 +1,7 @@
 {#
   View details — compact when/where summary; links to full Event Information in main.
+  Calendar links (Apple, Google, Outlook) render only when apple_ics_url, google_calendar_url,
+  or outlook_ics_url are set in myeventlane_theme preprocess (not invented in Twig).
 #}
 <div class="mel-event-full__view-details mel-card mel-card--surface mel-event-sidebar__details mel-event-full__card">
   <div class="mel-card__header mel-event-sidebar-details__header">
@@ -65,41 +67,32 @@
 
     <hr class="mel-event-sidebar-details__rule" role="separator" />
 
-    {% set _has_calendar = (apple_ics_url|default('')|length > 0) or (google_calendar_url|default('')|length > 0) or (outlook_ics_url|default('')|length > 0) %}
     {% set _has_share = canonical_url is defined and canonical_url %}
-    {% if _has_share or _has_calendar or event_flag_event_save %}
+    {% if _has_share or apple_ics_url|default('')|length > 0 or google_calendar_url|default('')|length > 0 or outlook_ics_url|default('')|length > 0 or event_flag_event_save %}
       <div class="mel-event-sidebar-details__actions" role="group" aria-label="{{ 'Event actions'|t }}">
-        <span class="visually-hidden">{{ 'Share, calendar, and save'|t }}</span>
         {% if _has_share %}
           <a class="mel-event-sidebar-details__action-btn" href="#mel-event-full-share" aria-label="{{ 'Share this event'|t }}">
             {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'share', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
-            <span class="visually-hidden">{{ 'Share'|t }}</span>
+            <span class="mel-event-sidebar-details__action-label">{{ 'Share'|t }}</span>
           </a>
         {% endif %}
-        {% if _has_calendar %}
-          <details class="mel-event-sidebar-details__calendar">
-            <summary class="mel-event-sidebar-details__action-btn mel-event-sidebar-details__action-btn--calendar">
-              {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar-plus', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
-              <span class="visually-hidden">{{ 'Add to calendar'|t }}</span>
-            </summary>
-            <ul class="mel-event-sidebar-details__calendar-links">
-              {% if apple_ics_url|default('')|length > 0 %}
-                <li>
-                  <a href="{{ apple_ics_url }}" class="mel-event-sidebar-details__calendar-link">{{ 'Apple Calendar'|t }}</a>
-                </li>
-              {% endif %}
-              {% if outlook_ics_url|default('')|length > 0 %}
-                <li>
-                  <a href="{{ outlook_ics_url }}" class="mel-event-sidebar-details__calendar-link">{{ 'Outlook'|t }}</a>
-                </li>
-              {% endif %}
-              {% if google_calendar_url|default('')|length > 0 %}
-                <li>
-                  <a href="{{ google_calendar_url }}" class="mel-event-sidebar-details__calendar-link" target="_blank" rel="noopener noreferrer">{{ 'Google Calendar'|t }}</a>
-                </li>
-              {% endif %}
-            </ul>
-          </details>
+        {% if apple_ics_url|default('')|length > 0 %}
+          <a class="mel-event-sidebar-details__action-btn mel-event-sidebar-details__action-btn--calendar" href="{{ apple_ics_url }}" aria-label="{{ 'Add to Apple Calendar'|t }}">
+            {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
+            <span class="mel-event-sidebar-details__action-label">{{ 'Apple'|t }}</span>
+          </a>
+        {% endif %}
+        {% if google_calendar_url|default('')|length > 0 %}
+          <a class="mel-event-sidebar-details__action-btn mel-event-sidebar-details__action-btn--calendar" href="{{ google_calendar_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ 'Add to Google Calendar'|t }}">
+            {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
+            <span class="mel-event-sidebar-details__action-label">{{ 'Google'|t }}</span>
+          </a>
+        {% endif %}
+        {% if outlook_ics_url|default('')|length > 0 %}
+          <a class="mel-event-sidebar-details__action-btn mel-event-sidebar-details__action-btn--calendar" href="{{ outlook_ics_url }}" aria-label="{{ 'Add to Outlook Calendar'|t }}">
+            {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'calendar', class: 'mel-event-sidebar-details__action-icon', size: 22 } only %}
+            <span class="mel-event-sidebar-details__action-label">{{ 'Outlook'|t }}</span>
+          </a>
         {% endif %}
         {% if event_flag_event_save %}
           <div class="mel-event-sidebar-details__action-save" aria-label="{{ 'Save for later'|t }}">
@@ -110,7 +103,12 @@
     {% endif %}
 
     <p class="mel-event-sidebar-details__action">
-      <a class="mel-event-sidebar-details__link" href="#mel-event-information">{{ 'See full event information'|t }}</a>
+      <a class="mel-event-sidebar-details__link" href="#mel-event-information">
+        {{ 'See full event information'|t }}
+        <span class="mel-event-sidebar-details__link-icon" aria-hidden="true">
+          {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with { icon: 'external', class: 'mel-event-sidebar-details__action-icon', size: 18 } only %}
+        </span>
+      </a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This PR finalises the full event page layout reset.

It aligns Classic and Immersive event pages to the same Twig structure, with style controlled by Event Studio branding classes on the article element.

Key outcomes:
- Unified Classic and Immersive event page structure
- Booking panel, View details, gallery rail, and content cards now share the same layout
- Immersive style is controlled by article classes and CSS variables, not alternate child Twig markup
- Reduced excessive internal card spacing
- Preserved Commerce, RSVP, Stripe, checkout, and BookingFlowResolver logic
- No new gallery/lightbox system added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to significant restructuring of the event full-page Twig/CSS and updated carousel behavior, which could introduce layout/accessibility regressions across classic/immersive styles.
> 
> **Overview**
> Unifies the `node--event--full.html.twig` structure for Classic and Immersive pages into a single layout shell (`.mel-event-full`), moving the cancelled banner to the top, reorganising main content into a grid, and replacing the previous sidebar markup with new partials for `Booking` and `View details` (including in-page anchors for share/info sections).
> 
> Reworks `mel-event-gallery.html.twig` from an editorial grid to a main-column thumbnail *rail carousel* that reuses the sidebar carousel JS and keeps the existing dialog-based lightbox; `mel_event_gallery` now also loads `mel-event-sidebar-carousel.js`.
> 
> Adds safe, whitelisted event branding CSS custom properties (sanitised hex + inline style vars) during preprocess for full event nodes, and updates `mel-event-sidebar-carousel.js` to support rail mode (scroll-into-view, no `hidden` toggling) plus improved keyboard navigation (Home/End, handler attached to carousel). Extensive SCSS updates align hero, gallery, sidebar rail, and full-page cards with the new unified layout and token-based theming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3e9c3fe4c407d277d5e6934ff5da5998275e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->