### PR TITLE
Feature/event page sidebar gallery layout

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -3011,20 +3011,54 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   border-top: 0;
 }
 
-.mel-event-full__support {
+// Sidebar help links — compact strip (overrides global .mel-event-support-zone card + 44px targets).
+.mel-event-full__support.mel-event-support-zone {
   margin-top: 0;
-  padding: 0 4px;
-  font-size: typography.mel-font-size(sm);
+  padding: 12px 16px;
+  border-radius: var(--mel-full-radius-md, 16px);
+  background: var(--mel-full-surface-soft, #fdf1ec);
+  border: 1px solid var(--mel-full-border, #e9e3de);
+  box-shadow: none;
+  color: var(--mel-full-text-secondary, #5b6670);
+
+  .mel-event-support-zone__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 14px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 
   .mel-event-support-zone__link {
-    color: var(--mel-full-text-secondary);
+    display: inline;
+    min-height: 0;
+    padding: 0;
+    font-size: 0.8125rem;
+    font-weight: typography.$mel-font-medium;
+    line-height: 1.35;
+    color: var(--mel-full-text-secondary, #5b6670);
+    text-decoration: none;
+    text-underline-offset: 0.14em;
+
+    &:hover {
+      color: var(--mel-full-lavender, #7c83fd);
+      text-decoration: underline;
+    }
 
     &:focus-visible {
-      outline: 2px solid color-mix(in srgb, var(--mel-full-lavender) 55%, transparent);
+      outline: 2px solid color-mix(in srgb, var(--mel-full-lavender, #7c83fd) 55%, transparent);
       outline-offset: 2px;
       border-radius: radii.$mel-radius-sm;
     }
   }
+}
+
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__support.mel-event-support-zone {
+  padding-top: 12px;
+  margin-top: 0;
+  border-top: 0;
 }
 
 @media (width <= 767px) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-sidebar-carousel.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-sidebar-carousel.scss
@@ -312,7 +312,7 @@
 }
 
 // Classic
-.mel-event-page--classic .mel-sidebar-carousel--classic {
+.mel-event-page--classic.mel-event--v2 .mel-sidebar-carousel {
   .mel-sidebar-carousel__slide-header,
   .mel-sidebar-carousel__slide-body {
     color: var(--mel-event-text, colors.$mel-color-text);
@@ -335,7 +335,7 @@
 }
 
 // Immersive
-.mel-event-page--immersive .mel-sidebar-carousel--immersive {
+.mel-event-page--immersive.mel-event--v2 .mel-sidebar-carousel {
   .mel-sidebar-carousel__footer {
     border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only changes that tweak event page sidebar presentation and selector scoping; risk is limited to potential visual regressions on v2 classic/immersive pages due to selector changes.
> 
> **Overview**
> Tightens the event full-page sidebar “help/support” area into a compact, inline link strip by overriding `.mel-event-support-zone` styling (new padding/background/border, removes 44px min-height targets, and updates hover/focus treatment).
> 
> Updates sidebar carousel theming rules to target `.mel-sidebar-carousel` on `mel-event--v2` classic/immersive pages (instead of the `--classic/--immersive` modifier classes), adjusting where those color/border styles apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cef2a792bd7e7a4ad122e303786969a7522724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->