### PR TITLE
feature/event-studio-branding-preview

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-branding-preview.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-branding-preview.css
@@ -1,0 +1,296 @@
+/**
+ * @file
+ * Event Studio branding tab — scoped public page feel preview.
+ */
+
+.mel-event-branding-preview {
+  --mel-branding-preview-accent: #f26d5b;
+  --mel-branding-preview-bg: #fff9f5;
+  --mel-branding-preview-surface: #ffffff;
+  --mel-branding-preview-text: #1f2933;
+  --mel-branding-preview-muted: #6b7280;
+  --mel-branding-preview-border: #e9e3de;
+  margin: 0 0 20px;
+  padding: 0;
+}
+
+.mel-event-branding-preview__header {
+  margin-bottom: 16px;
+}
+
+.mel-event-branding-preview__title {
+  margin: 0 0 8px;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--mel-color-text, #1f2933);
+}
+
+.mel-event-branding-preview__lede {
+  margin: 0 0 6px;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  color: var(--mel-color-text-secondary, #4b5563);
+}
+
+.mel-event-branding-preview__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+}
+
+.mel-event-branding-preview__canvas {
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid var(--mel-branding-preview-border);
+  background: var(--mel-branding-preview-bg);
+  color: var(--mel-branding-preview-text);
+  box-shadow: 0 18px 45px rgba(41, 50, 65, 0.08);
+}
+
+.mel-event-branding-preview__hero {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  min-height: 140px;
+  background: linear-gradient(135deg, #fdf1ec 0%, #f5e6dc 48%, #e9e3de 100%);
+  overflow: hidden;
+}
+
+.mel-event-branding-preview__hero--empty {
+  background: linear-gradient(135deg, #fdf1ec 0%, #f8ebe3 55%, #efe4db 100%);
+}
+
+.mel-event-branding-preview__hero-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.mel-event-branding-preview__hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 20, 28, 0.08) 0%, rgba(15, 20, 28, 0.55) 100%);
+  pointer-events: none;
+}
+
+.mel-event-branding-preview__hero-copy {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 16px 18px;
+  z-index: 1;
+}
+
+.mel-event-branding-preview__event-title {
+  margin: 0 0 6px;
+  font-size: clamp(1rem, 2.4vw, 1.25rem);
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+}
+
+.mel-event-branding-preview__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.mel-event-branding-preview__body {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px 18px;
+}
+
+.mel-event-branding-preview__style-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.mel-event-branding-preview__style-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--mel-branding-preview-surface);
+  border: 1px solid var(--mel-branding-preview-border);
+  color: var(--mel-branding-preview-text);
+}
+
+.mel-event-branding-preview__accent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.75rem;
+  color: var(--mel-branding-preview-muted);
+}
+
+.mel-event-branding-preview__accent-chip-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--mel-branding-preview-accent);
+  box-shadow: 0 0 0 2px var(--mel-branding-preview-surface), 0 0 0 3px var(--mel-branding-preview-border);
+}
+
+.mel-event-branding-preview__booking {
+  padding: 14px;
+  border-radius: 16px;
+  background: var(--mel-branding-preview-surface);
+  border: 1px solid var(--mel-branding-preview-border);
+}
+
+.mel-event-branding-preview__booking-price {
+  margin: 0 0 10px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--mel-branding-preview-text);
+}
+
+.mel-event-branding-preview__booking-cta {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 12px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--mel-branding-preview-accent);
+  cursor: not-allowed;
+}
+
+.mel-event-branding-preview__trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.6875rem;
+  color: var(--mel-branding-preview-muted);
+}
+
+.mel-event-branding-preview__gallery-rail {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mel-event-branding-preview__gallery-rail li {
+  flex: 0 0 auto;
+}
+
+.mel-event-branding-preview__gallery-rail img {
+  display: block;
+  width: 72px;
+  height: 54px;
+  border-radius: 10px;
+  object-fit: cover;
+  border: 1px solid var(--mel-branding-preview-border);
+}
+
+.mel-event-branding-preview__gallery-placeholder {
+  display: block;
+  width: 72px;
+  height: 54px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+  border: 1px dashed var(--mel-branding-preview-border);
+}
+
+.mel-event-branding-preview__gallery-empty {
+  margin: 8px 0 0;
+  font-size: 0.75rem;
+}
+
+/* Colour presets — accent chip + CTA (scoped; mirrors approved public palettes). */
+.mel-event-branding-preview.mel-event-page--colour-coral {
+  --mel-branding-preview-accent: #f26d5b;
+}
+
+.mel-event-branding-preview.mel-event-page--colour-purple {
+  --mel-branding-preview-accent: #7c83fd;
+}
+
+.mel-event-branding-preview.mel-event-page--colour-mint {
+  --mel-branding-preview-accent: #3d9b7a;
+}
+
+.mel-event-branding-preview.mel-event-page--colour-gold {
+  --mel-branding-preview-accent: #f5a04c;
+}
+
+.mel-event-branding-preview.mel-event-page--colour-blue {
+  --mel-branding-preview-accent: #5b8def;
+}
+
+/* Classic — light public page feel. */
+.mel-event-branding-preview.mel-event-branding-preview--classic,
+.mel-event-branding-preview.mel-event-page--classic {
+  --mel-branding-preview-bg: #fff9f5;
+  --mel-branding-preview-surface: #ffffff;
+  --mel-branding-preview-text: #1f2933;
+  --mel-branding-preview-muted: #6b7280;
+  --mel-branding-preview-border: #e9e3de;
+}
+
+/* Immersive — dark cinematic feel. */
+.mel-event-branding-preview.mel-event-branding-preview--immersive,
+.mel-event-branding-preview.mel-event-page--immersive {
+  --mel-branding-preview-bg: #080c14;
+  --mel-branding-preview-surface: rgba(28, 36, 50, 0.88);
+  --mel-branding-preview-text: #fff;
+  --mel-branding-preview-muted: rgba(255, 255, 255, 0.72);
+  --mel-branding-preview-border: rgba(255, 255, 255, 0.12);
+}
+
+.mel-event-branding-preview.mel-event-branding-preview--immersive .mel-event-branding-preview__canvas,
+.mel-event-branding-preview.mel-event-page--immersive .mel-event-branding-preview__canvas {
+  background: linear-gradient(180deg, #080c14 0%, #0c121c 50%, #101826 100%);
+  box-shadow: 0 22px 52px rgba(0, 0, 0, 0.3);
+}
+
+.mel-event-branding-preview.mel-event-branding-preview--immersive .mel-event-branding-preview__style-pill,
+.mel-event-branding-preview.mel-event-page--immersive .mel-event-branding-preview__style-pill {
+  background: rgba(28, 36, 50, 0.72);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.mel-event-branding-preview.mel-event-branding-preview--immersive .mel-event-branding-preview__hero--empty,
+.mel-event-branding-preview.mel-event-page--immersive .mel-event-branding-preview__hero--empty {
+  background: linear-gradient(135deg, #141c28 0%, #1a2433 55%, #101826 100%);
+}
+
+.mel-event-branding-preview.mel-event-branding-preview--immersive .mel-event-branding-preview__gallery-placeholder,
+.mel-event-branding-preview.mel-event-page--immersive .mel-event-branding-preview__gallery-placeholder {
+  background: linear-gradient(135deg, #1a2433 0%, #243044 100%);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+@media (max-width: 640px) {
+  .mel-event-branding-preview__canvas {
+    border-radius: 20px;
+  }
+
+  .mel-event-branding-preview__body {
+    padding: 14px;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-branding-preview.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-branding-preview.js
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * Event Studio branding tab — sync preview style/colour with form radios.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  var STYLE_CLASS_PREFIX = 'mel-event-branding-preview--';
+  var PAGE_STYLE_PREFIX = 'mel-event-page--';
+  var COLOUR_CLASS = 'mel-event-page--colour-';
+
+  /**
+   * @param {HTMLElement} preview
+   * @param {string} style
+   * @param {string} colour
+   */
+  function applyPreviewModifiers(preview, style, colour) {
+    var allowedStyles = ['classic', 'immersive'];
+    var allowedColours = ['coral', 'purple', 'mint', 'gold', 'blue'];
+    if (allowedStyles.indexOf(style) === -1) {
+      style = 'classic';
+    }
+    if (allowedColours.indexOf(colour) === -1) {
+      colour = 'coral';
+    }
+
+    preview.dataset.previewStyle = style;
+    preview.dataset.previewColour = colour;
+
+    preview.classList.forEach(function (cls) {
+      if (
+        cls.indexOf(STYLE_CLASS_PREFIX) === 0
+        || cls.indexOf(PAGE_STYLE_PREFIX) === 0
+      ) {
+        preview.classList.remove(cls);
+      }
+    });
+
+    preview.classList.add('mel-event-branding-preview--' + style);
+    preview.classList.add('mel-event-page--' + style);
+    preview.classList.add(COLOUR_CLASS + colour);
+  }
+
+  /**
+   * @param {HTMLElement} preview
+   * @param {HTMLFormElement|null} form
+   */
+  function bindPreview(preview, form) {
+    if (!form) {
+      return;
+    }
+
+    var styleName = 'mel[field_mel_page_style]';
+    var colourName = 'mel[field_mel_theme_colour]';
+
+    function readRadio(name) {
+      var checked = form.querySelector('input[name="' + name + '"]:checked');
+      return checked ? String(checked.value || '') : '';
+    }
+
+    function syncFromForm() {
+      applyPreviewModifiers(preview, readRadio(styleName), readRadio(colourName));
+    }
+
+    form.addEventListener('change', function (event) {
+      var target = event.target;
+      if (!target || (target.name !== styleName && target.name !== colourName)) {
+        return;
+      }
+      syncFromForm();
+    });
+
+    syncFromForm();
+  }
+
+  Drupal.behaviors.melEventBrandingPreview = {
+    attach: function attach(context) {
+      once('mel-event-branding-preview', '[data-mel-branding-preview]', context).forEach(
+        function (preview) {
+          var form = preview.closest('form');
+          bindPreview(preview, form instanceof HTMLFormElement ? form : null);
+        },
+      );
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -70,6 +70,17 @@ mel_branding_hero_tools:
     - core/once
     - focal_point/drupal.focal_point
 
+mel_branding_preview:
+  version: 1.0
+  css:
+    theme:
+      css/mel-event-branding-preview.css: {}
+  js:
+    js/mel-event-branding-preview.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
   version: 1.1

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -145,6 +145,23 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-extra-preview',
     ],
+    'mel_event_branding_preview' => [
+      'variables' => [
+        'title' => '',
+        'hero' => NULL,
+        'gallery' => [],
+        'style' => 'classic',
+        'colour' => 'coral',
+        'style_label' => '',
+        'colour_label' => '',
+        'accent_hex' => '#F26D5B',
+        'wrapper_classes' => [],
+        'sample_meta' => [],
+        'sample_cta' => '',
+        'trust_rows' => [],
+      ],
+      'template' => 'mel-event-branding-preview',
+    ],
     'mel_customer_operational_experience' => [
       'variables' => [
         'experience' => [],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -290,6 +290,14 @@ services:
       - '@file_url_generator'
       - '@string_translation'
 
+  myeventlane_event_studio.event_branding_preview_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventBrandingPreviewBuilder
+    arguments:
+      - '@myeventlane_event_studio.event_page_style_resolver'
+      - '@myeventlane_event.media_presenter'
+      - '@file_url_generator'
+      - '@string_translation'
+
   myeventlane_event_studio.event_style_access:
     class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager
     arguments:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\myeventlane_event_studio\Service\BrandingHeroFocalAugmenter;
+use Drupal\myeventlane_event_studio\Service\EventBrandingPreviewBuilder;
 use Drupal\myeventlane_event_studio\Service\EventPageStyleResolver;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStyleAccessManager;
@@ -25,6 +26,8 @@ final class EventBrandingForm extends EventStudioBaseForm {
   private EventPageStyleResolver $eventPageStyleResolver;
 
   private BrandingHeroFocalAugmenter $brandingHeroFocalAugmenter;
+
+  private EventBrandingPreviewBuilder $eventBrandingPreviewBuilder;
 
   /**
    * {@inheritdoc}
@@ -50,7 +53,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
    * after parent::create() are not re-initialized unless restored here.
    */
   private function ensureInjectedServices(?ContainerInterface $container = NULL): void {
-    if (isset($this->eventStyleAccess, $this->eventPageStyleResolver, $this->brandingHeroFocalAugmenter)) {
+    if (isset($this->eventStyleAccess, $this->eventPageStyleResolver, $this->brandingHeroFocalAugmenter, $this->eventBrandingPreviewBuilder)) {
       return;
     }
     $container ??= \Drupal::getContainer();
@@ -62,6 +65,9 @@ final class EventBrandingForm extends EventStudioBaseForm {
     }
     if (!isset($this->brandingHeroFocalAugmenter)) {
       $this->brandingHeroFocalAugmenter = $container->get('myeventlane_event_studio.branding_hero_focal_augmenter');
+    }
+    if (!isset($this->eventBrandingPreviewBuilder)) {
+      $this->eventBrandingPreviewBuilder = $container->get('myeventlane_event_studio.event_branding_preview_builder');
     }
   }
 
@@ -454,6 +460,9 @@ final class EventBrandingForm extends EventStudioBaseForm {
       ),
       '#weight' => 15,
     ];
+
+    $form['mel']['branding_preview'] = $this->eventBrandingPreviewBuilder->build($node);
+    $form['mel']['branding_preview']['#weight'] = 16;
 
     $style_options = [
       EventPageStyleResolver::STYLE_CLASSIC => $this->t('Classic MyEventLane'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventBrandingPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventBrandingPreviewBuilder.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\file\FileInterface;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\image\ImageStyleInterface;
+use Drupal\myeventlane_event\Service\EventMediaPresenter;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds a customer-safe public event page preview for Event Studio branding.
+ */
+final class EventBrandingPreviewBuilder {
+
+  use StringTranslationTrait;
+
+  private const HERO_STYLE = 'mel_event_hero_featured';
+
+  private const GALLERY_PREVIEW_MAX = 5;
+
+  /**
+   * Approved accent hex values (mirrors public theme branding map).
+   *
+   * @var array<string, string>
+   */
+  private const ACCENT_HEX = [
+    EventPageStyleResolver::COLOUR_CORAL => '#F26D5B',
+    EventPageStyleResolver::COLOUR_PURPLE => '#7C83FD',
+    EventPageStyleResolver::COLOUR_MINT => '#3D9B7A',
+    EventPageStyleResolver::COLOUR_GOLD => '#F5A04C',
+    EventPageStyleResolver::COLOUR_BLUE => '#5B8DEF',
+  ];
+
+  public function __construct(
+    private readonly EventPageStyleResolver $eventPageStyleResolver,
+    private readonly EventMediaPresenter $eventMediaPresenter,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Render array for the branding tab preview panel.
+   *
+   * @return array<string, mixed>
+   */
+  public function build(NodeInterface $event): array {
+    if ($event->bundle() !== 'event') {
+      return [];
+    }
+
+    $resolved = $this->eventPageStyleResolver->resolveForPublicRender($event);
+    $style = $resolved['style'];
+    $colour = $resolved['colour'];
+    $colour_labels = $this->eventPageStyleResolver->colourOptions();
+    $style_labels = $this->eventPageStyleResolver->styleOptions();
+
+    $hero = $this->buildHeroPayload($event);
+    $gallery = $this->buildGalleryThumbnails($event);
+
+    $wrapper_classes = array_merge(
+      ['mel-event-branding-preview'],
+      $resolved['classes'],
+      [
+        'mel-event-branding-preview--' . $style,
+      ],
+    );
+
+    return [
+      '#theme' => 'mel_event_branding_preview',
+      '#title' => $event->label(),
+      '#hero' => $hero,
+      '#gallery' => $gallery,
+      '#style' => $style,
+      '#colour' => $colour,
+      '#style_label' => $style_labels[$style] ?? $style,
+      '#colour_label' => $colour_labels[$colour] ?? $colour,
+      '#accent_hex' => self::ACCENT_HEX[$colour] ?? self::ACCENT_HEX[EventPageStyleResolver::COLOUR_CORAL],
+      '#wrapper_classes' => $wrapper_classes,
+      '#sample_meta' => [
+        'date' => (string) $this->t('Sat 14 Jun 2026'),
+        'time' => (string) $this->t('7:00 pm – 10:00 pm'),
+        'location' => (string) $this->t('Sample venue, Sydney'),
+      ],
+      '#sample_cta' => (string) $this->t('Get tickets'),
+      '#trust_rows' => [
+        (string) $this->t('Secure checkout'),
+        (string) $this->t('Instant confirmation'),
+        (string) $this->t('Mobile tickets'),
+      ],
+      '#attached' => [
+        'library' => ['myeventlane_event_studio/mel_branding_preview'],
+      ],
+      '#cache' => [
+        'tags' => $event->getCacheTags(),
+        'contexts' => ['user.permissions'],
+      ],
+    ];
+  }
+
+  /**
+   * @return array{url: string, alt: string}|null
+   */
+  private function buildHeroPayload(NodeInterface $event): ?array {
+    if (!$event->hasField('field_event_image') || $event->get('field_event_image')->isEmpty()) {
+      return NULL;
+    }
+
+    $file = $event->get('field_event_image')->entity;
+    if (!$file instanceof FileInterface) {
+      return NULL;
+    }
+
+    $uri = $file->getFileUri();
+    if ($uri === '') {
+      return NULL;
+    }
+
+    $style = $this->loadImageStyle(self::HERO_STYLE);
+    try {
+      $url = $style instanceof ImageStyleInterface
+        ? $style->buildUrl($uri)
+        : $this->fileUrlGenerator->generateString($uri);
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+
+    $image_item = $event->get('field_event_image')->first();
+    $alt = trim((string) ($image_item?->alt ?? ''));
+    if ($alt === '') {
+      $alt = (string) $event->label();
+    }
+
+    return [
+      'url' => $url,
+      'alt' => $alt,
+    ];
+  }
+
+  /**
+   * @return list<array{url: string, alt: string}>
+   */
+  private function buildGalleryThumbnails(NodeInterface $event): array {
+    $gallery = $this->eventMediaPresenter->buildGalleryViewModel($event);
+    $items = is_array($gallery['items'] ?? NULL) ? $gallery['items'] : [];
+    $out = [];
+    foreach ($items as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $urls = is_array($item['urls'] ?? NULL) ? $item['urls'] : [];
+      $url = trim((string) ($urls['card'] ?? ''));
+      if ($url === '') {
+        continue;
+      }
+      $out[] = [
+        'url' => $url,
+        'alt' => trim((string) ($item['alt'] ?? '')),
+      ];
+      if (count($out) >= self::GALLERY_PREVIEW_MAX) {
+        break;
+      }
+    }
+    return $out;
+  }
+
+  private function loadImageStyle(string $id): ?ImageStyleInterface {
+    $style = ImageStyle::load($id);
+    return $style instanceof ImageStyleInterface ? $style : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-branding-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-branding-preview.html.twig
@@ -1,0 +1,114 @@
+{#
+/**
+ * @file
+ * Public event page feel preview for Event Studio branding tab.
+ *
+ * Variables:
+ * - title: Event title (public).
+ * - hero: { url, alt }|null
+ * - gallery: list of { url, alt }
+ * - style: classic|immersive
+ * - colour: coral|purple|mint|gold|blue
+ * - style_label, colour_label: human labels
+ * - accent_hex: safe hex for accent chip
+ * - wrapper_classes: BEM + mel-event-page--* modifiers
+ * - sample_meta: { date, time, location }
+ * - sample_cta: sample button label
+ * - trust_rows: list of sample trust strings
+ */
+#}
+{% set preview_classes = wrapper_classes|default(['mel-event-branding-preview']) %}
+<section
+  class="{{ preview_classes|join(' ') }}"
+  aria-labelledby="mel-es-branding-preview-title"
+  data-mel-branding-preview
+  data-preview-style="{{ style|default('classic') }}"
+  data-preview-colour="{{ colour|default('coral') }}"
+>
+  <header class="mel-event-branding-preview__header">
+    <h3 class="mel-event-branding-preview__title" id="mel-es-branding-preview-title">
+      {{ 'This is how your public event page will feel'|t }}
+    </h3>
+    <p class="mel-event-branding-preview__lede">
+      {{ 'Your selected page style, colour, hero image, and gallery shape the public event page.'|t }}
+    </p>
+    <p class="mel-event-branding-preview__hint mel-text--muted">
+      {{ 'Style and colour update as you choose options. Save to refresh hero and gallery images.'|t }}
+    </p>
+  </header>
+
+  <div class="mel-event-branding-preview__canvas">
+    <div class="mel-event-branding-preview__hero{% if not hero %} mel-event-branding-preview__hero--empty{% endif %}">
+      {% if hero and hero.url|default('') %}
+        <img
+          class="mel-event-branding-preview__hero-img"
+          src="{{ hero.url }}"
+          alt="{{ hero.alt|default(title) }}"
+          loading="lazy"
+          decoding="async"
+        />
+      {% endif %}
+      <div class="mel-event-branding-preview__hero-overlay" aria-hidden="true"></div>
+      <div class="mel-event-branding-preview__hero-copy">
+        <h4 class="mel-event-branding-preview__event-title">{{ title|default('') }}</h4>
+        <ul class="mel-event-branding-preview__meta" aria-label="{{ 'Sample event details'|t }}">
+          <li>{{ sample_meta.date|default('') }}</li>
+          <li aria-hidden="true">·</li>
+          <li>{{ sample_meta.time|default('') }}</li>
+          <li aria-hidden="true">·</li>
+          <li>{{ sample_meta.location|default('') }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="mel-event-branding-preview__body">
+      <div class="mel-event-branding-preview__style-row">
+        <span class="mel-event-branding-preview__style-pill">{{ style_label|default(style) }}</span>
+        <span
+          class="mel-event-branding-preview__accent-chip"
+          style="--mel-branding-preview-accent: {{ accent_hex|default('#F26D5B') }}"
+          title="{{ colour_label|default(colour) }}"
+        >
+          <span class="mel-event-branding-preview__accent-chip-swatch" aria-hidden="true"></span>
+          <span class="mel-event-branding-preview__accent-chip-label">{{ colour_label|default(colour) }}</span>
+        </span>
+      </div>
+
+      <aside class="mel-event-branding-preview__booking" aria-label="{{ 'Sample booking card'|t }}">
+        <p class="mel-event-branding-preview__booking-price">{{ 'From $45'|t }}</p>
+        <button type="button" class="mel-event-branding-preview__booking-cta" disabled>
+          {{ sample_cta|default('Get tickets'|t) }}
+        </button>
+        <ul class="mel-event-branding-preview__trust">
+          {% for row in trust_rows|default([]) %}
+            <li>{{ row }}</li>
+          {% endfor %}
+        </ul>
+      </aside>
+
+      <div class="mel-event-branding-preview__gallery" aria-label="{{ 'Gallery preview'|t }}">
+        {% if gallery is not empty %}
+          <ul class="mel-event-branding-preview__gallery-rail">
+            {% for thumb in gallery %}
+              <li>
+                <img
+                  src="{{ thumb.url }}"
+                  alt="{{ thumb.alt|default('') }}"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <ul class="mel-event-branding-preview__gallery-rail mel-event-branding-preview__gallery-rail--placeholder" aria-hidden="true">
+            {% for i in 1..4 %}
+              <li><span class="mel-event-branding-preview__gallery-placeholder"></span></li>
+            {% endfor %}
+          </ul>
+          <p class="mel-event-branding-preview__gallery-empty mel-text--muted">{{ 'Gallery photos appear here when you add them above.'|t }}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Adds an Event Studio Branding Preview panel so vendors can see how their public event page will feel before saving.

Includes:
- Preview builder service using the existing EventPageStyleResolver
- Preview Twig template
- Scoped preview CSS
- Lightweight JS for style/colour radio changes
- Theme hook and library registration

Safety:
- No Commerce, Stripe, checkout, ticketing, RSVP, cart, order, or BookingFlowResolver changes
- No private customer/vendor/admin data exposed
- Clean branch from origin/main
- Single commit: 8243a758

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI addition: introduces a new preview render service, Twig template, and small JS/CSS library without changing persistence, commerce, or checkout flows.
> 
> **Overview**
> Adds a new **branding preview panel** to the Event Studio branding step so organisers can see a public-page-style preview (hero, gallery thumbnails, sample booking card) alongside the style/colour options.
> 
> Implements the preview via a new `EventBrandingPreviewBuilder` service + `mel-event-branding-preview.html.twig`, registers a `mel_branding_preview` library with scoped CSS, and adds lightweight JS to live-update preview classes when the style/colour radio selections change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8243a758c0d836e1fae52d4727d28023b8cfaef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->