### PR TITLE
feat(event-studio): add ticket setup preview panel

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
@@ -1,0 +1,179 @@
+/**
+ * @file
+ * Event Studio tickets section — customer booking preview panel.
+ */
+
+.mel-event-ticket-preview {
+  --mel-ticket-preview-bg: #fff9f5;
+  --mel-ticket-preview-surface: #ffffff;
+  --mel-ticket-preview-text: #1f2933;
+  --mel-ticket-preview-muted: #6b7280;
+  --mel-ticket-preview-border: #e9e3de;
+  --mel-ticket-preview-accent: #f26d5b;
+  margin-block: 1.5rem 0;
+}
+
+.mel-event-ticket-preview__header {
+  margin-block-end: 1rem;
+}
+
+.mel-event-ticket-preview__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--mel-ticket-preview-text);
+}
+
+.mel-event-ticket-preview__lede,
+.mel-event-ticket-preview__helpers,
+.mel-event-ticket-preview__save-note {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--mel-ticket-preview-muted);
+}
+
+.mel-event-ticket-preview__helpers {
+  margin-block-start: 0.5rem;
+  padding-inline-start: 1.15rem;
+}
+
+.mel-event-ticket-preview__helpers li + li {
+  margin-block-start: 0.25rem;
+}
+
+.mel-event-ticket-preview__save-note {
+  margin-block-start: 0.5rem;
+  font-style: italic;
+}
+
+.mel-event-ticket-preview__canvas {
+  padding: 1.25rem;
+  border-radius: 24px;
+  border: 1px solid var(--mel-ticket-preview-border);
+  background: var(--mel-ticket-preview-bg);
+  color: var(--mel-ticket-preview-text);
+}
+
+.mel-event-ticket-preview__mode-row {
+  margin-block-end: 0.75rem;
+}
+
+.mel-event-ticket-preview__mode-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: var(--mel-ticket-preview-surface);
+  border: 1px solid var(--mel-ticket-preview-border);
+  color: var(--mel-ticket-preview-text);
+}
+
+.mel-event-ticket-preview__heading {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mel-event-ticket-preview__capacity,
+.mel-event-ticket-preview__availability,
+.mel-event-ticket-preview__cta-reason,
+.mel-event-ticket-preview__ticket-empty,
+.mel-event-ticket-preview__empty-copy {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--mel-ticket-preview-muted);
+}
+
+.mel-event-ticket-preview__ticket-rows {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mel-event-ticket-preview__ticket-row {
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  background: var(--mel-ticket-preview-surface);
+  border: 1px solid var(--mel-ticket-preview-border);
+}
+
+.mel-event-ticket-preview__ticket-main {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.mel-event-ticket-preview__ticket-name {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.mel-event-ticket-preview__ticket-price {
+  font-weight: 700;
+  font-size: 0.9375rem;
+  white-space: nowrap;
+}
+
+.mel-event-ticket-preview__ticket-availability {
+  margin: 0.35rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--mel-ticket-preview-muted);
+}
+
+.mel-event-ticket-preview__cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 44px;
+  margin-block: 0.25rem 0.75rem;
+  padding: 0.65rem 1rem;
+  border: 0;
+  border-radius: 999px;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--mel-ticket-preview-accent);
+  cursor: default;
+}
+
+.mel-event-ticket-preview__cta.is-disabled {
+  opacity: 0.72;
+}
+
+.mel-event-ticket-preview__trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.8125rem;
+  color: var(--mel-ticket-preview-muted);
+}
+
+.mel-event-ticket-preview__empty {
+  padding: 1rem 0.25rem;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .mel-event-ticket-preview__canvas {
+    padding: 1rem;
+  }
+
+  .mel-event-ticket-preview__ticket-main {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-ticket-preview.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-ticket-preview.js
@@ -1,0 +1,76 @@
+/**
+ * @file
+ * Event Studio tickets — update preview mode badge from booking model radios.
+ */
+(function (Drupal, drupalSettings, once) {
+  'use strict';
+
+  var MODE_MAP = {
+    rsvp: 'rsvp',
+    paid: 'paid',
+    external: 'external',
+  };
+
+  /**
+   * @param {object} settings
+   * @return {object}
+   */
+  function previewSettings(settings) {
+    return settings && settings.melEventTicketPreview
+      ? settings.melEventTicketPreview
+      : {};
+  }
+
+  /**
+   * @param {HTMLElement} preview
+   * @param {string} mode
+   * @param {object} cfg
+   */
+  function applyModeBadge(preview, mode, cfg) {
+    var badge = preview.querySelector('[data-mel-ticket-preview-mode-badge]');
+    var empty = preview.querySelector('[data-mel-ticket-preview-empty]');
+    var labels = cfg.modeLabels || {};
+    var state = MODE_MAP[mode] || 'not_configured';
+    preview.dataset.previewState = state;
+    if (badge) {
+      badge.textContent = labels[state] || labels.not_configured || '';
+    }
+    if (empty) {
+      empty.hidden = state !== 'not_configured';
+    }
+  }
+
+  Drupal.behaviors.melEventTicketPreview = {
+    attach: function attach(context, settings) {
+      var cfg = previewSettings(settings);
+      once('mel-event-ticket-preview', '[data-mel-ticket-preview]', context).forEach(
+        function initPreview(preview) {
+          var stack = preview.closest('.mel-event-studio-section__form-stack');
+          if (!stack) {
+            return;
+          }
+
+          var syncFromRadios = function syncFromRadios() {
+            var checked = stack.querySelector(
+              'input[name="mel[field_event_type]"]:checked'
+            );
+            applyModeBadge(preview, checked ? checked.value : '', cfg);
+          };
+
+          stack.addEventListener('change', function onChange(event) {
+            var target = event.target;
+            if (
+              target
+              && target.matches
+              && target.matches('input[name="mel[field_event_type]"]')
+            ) {
+              syncFromRadios();
+            }
+          });
+
+          syncFromRadios();
+        }
+      );
+    },
+  };
+})(Drupal, drupalSettings, once);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -82,6 +82,18 @@ mel_branding_preview:
     - core/drupalSettings
     - core/once
 
+mel_ticket_preview:
+  version: 1.0
+  css:
+    theme:
+      css/mel-event-ticket-preview.css: {}
+  js:
+    js/mel-event-ticket-preview.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once
+
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
   version: 1.1

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -165,6 +165,21 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-branding-preview',
     ],
+    'mel_event_ticket_preview' => [
+      'variables' => [
+        'preview_state' => 'not_configured',
+        'mode_badge' => '',
+        'heading' => '',
+        'cta' => [],
+        'availability' => [],
+        'ticket_rows' => [],
+        'rsvp_summary' => NULL,
+        'trust_rows' => [],
+        'show_empty_state' => TRUE,
+        'wrapper_classes' => [],
+      ],
+      'template' => 'mel-event-ticket-preview',
+    ],
     'mel_customer_operational_experience' => [
       'variables' => [
         'experience' => [],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -95,6 +95,7 @@ services:
       - '@myeventlane_event_studio.mel_support_resolver'
       - '@?myeventlane_capacity.service'
       - '@?myeventlane_metrics.service'
+      - '@myeventlane_event_studio.event_ticket_preview_builder'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper
@@ -298,6 +299,16 @@ services:
       - '@file_url_generator'
       - '@current_user'
       - '@string_translation'
+
+  myeventlane_event_studio.event_ticket_preview_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventTicketPreviewBuilder
+    arguments:
+      - '@myeventlane_event.booking_flow_resolver'
+      - '@myeventlane_event.ticket_tier_lifecycle'
+      - '@myeventlane_event.event_mode_manager'
+      - '@commerce_price.currency_formatter'
+      - '@string_translation'
+      - '@?myeventlane_commerce.ticket_capacity'
 
   myeventlane_event_studio.event_style_access:
     class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -37,6 +37,7 @@ final class EventStudioSectionRenderer {
     private readonly MelSupportResolverInterface $supportResolver,
     private readonly ?EventCapacityServiceInterface $capacityService = NULL,
     private readonly ?EventMetricsServiceInterface $metricsService = NULL,
+    private readonly ?EventTicketPreviewBuilder $eventTicketPreviewBuilder = NULL,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -185,8 +186,17 @@ final class EventStudioSectionRenderer {
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-studio-section__form-stack']],
       'mode' => $this->formBuilder->getForm(EventStudioTicketsForm::class, $event),
-      'operational' => $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event),
     ];
+
+    if ($this->eventTicketPreviewBuilder instanceof EventTicketPreviewBuilder) {
+      $preview = $this->eventTicketPreviewBuilder->build($event);
+      if ($preview !== []) {
+        $build['ticket_preview'] = $preview;
+        $build['ticket_preview']['#weight'] = 5;
+      }
+    }
+
+    $build['operational'] = $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event);
 
     $event_type = $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()
       ? (string) $event->get('field_event_type')->value

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_price\Price;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\TicketCapacityService;
+use Drupal\myeventlane_event\Service\BookingFlowResolver;
+use Drupal\myeventlane_event\Service\EventModeManager;
+use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds a customer-safe booking preview for Event Studio ticket setup.
+ */
+final class EventTicketPreviewBuilder {
+
+  use StringTranslationTrait;
+
+  public const PREVIEW_NOT_CONFIGURED = 'not_configured';
+
+  public const PREVIEW_RSVP = 'rsvp';
+
+  public const PREVIEW_PAID = 'paid';
+
+  public const PREVIEW_EXTERNAL = 'external';
+
+  public function __construct(
+    private readonly BookingFlowResolver $bookingFlowResolver,
+    private readonly TicketTierLifecycleService $ticketTierLifecycle,
+    private readonly EventModeManager $eventModeManager,
+    private readonly CurrencyFormatter $currencyFormatter,
+    TranslationInterface $string_translation,
+    private readonly ?TicketCapacityService $ticketCapacity = NULL,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Render array for the tickets section preview panel.
+   *
+   * @return array<string, mixed>
+   */
+  public function build(NodeInterface $event): array {
+    if ($event->bundle() !== 'event' || $event->isNew() || $event->id() === NULL) {
+      return [];
+    }
+
+    $configuredMode = $this->resolveConfiguredMode($event);
+    $previewState = $this->resolvePreviewState($event, $configuredMode);
+    $cta = $this->resolveCtaPreview($event, $previewState);
+    $availability = $this->resolveAvailabilityPreview($event, $previewState);
+
+    $build = [
+      '#theme' => 'mel_event_ticket_preview',
+      '#preview_state' => $previewState,
+      '#mode_badge' => $this->modeBadgeLabel($previewState),
+      '#heading' => $this->previewHeading($previewState),
+      '#cta' => $cta,
+      '#availability' => $availability,
+      '#ticket_rows' => $this->buildTicketRows($event, $previewState),
+      '#rsvp_summary' => $this->buildRsvpSummary($event, $previewState),
+      '#trust_rows' => $this->buildTrustRows($previewState),
+      '#show_empty_state' => $previewState === self::PREVIEW_NOT_CONFIGURED,
+      '#wrapper_classes' => ['mel-event-ticket-preview'],
+      '#attached' => [
+        'library' => ['myeventlane_event_studio/mel_ticket_preview'],
+        'drupalSettings' => [
+          'melEventTicketPreview' => [
+            'modeLabels' => [
+              self::PREVIEW_NOT_CONFIGURED => (string) $this->t('Not configured'),
+              self::PREVIEW_RSVP => (string) $this->t('RSVP'),
+              self::PREVIEW_PAID => (string) $this->t('Paid tickets'),
+              self::PREVIEW_EXTERNAL => (string) $this->t('External'),
+            ],
+            'saveReminder' => (string) $this->t('Save to refresh ticket rows.'),
+          ],
+        ],
+      ],
+      '#cache' => [
+        'tags' => $this->buildCacheTags($event),
+        'contexts' => ['user.permissions'],
+      ],
+    ];
+
+    return $build;
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function buildCacheTags(NodeInterface $event): array {
+    $tags = $event->getCacheTags();
+    if ($event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
+      $product = $event->get('field_product_target')->entity;
+      if ($product !== NULL) {
+        $tags = array_merge($tags, $product->getCacheTags());
+      }
+    }
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
+      $tags = array_merge($tags, $ticket->getCacheTags());
+    }
+    return array_values(array_unique($tags));
+  }
+
+  private function resolveConfiguredMode(NodeInterface $event): string {
+    if (!$event->hasField('field_event_type') || $event->get('field_event_type')->isEmpty()) {
+      return '';
+    }
+    return (string) $event->get('field_event_type')->value;
+  }
+
+  private function resolvePreviewState(NodeInterface $event, string $configuredMode): string {
+    return match ($configuredMode) {
+      'rsvp' => self::PREVIEW_RSVP,
+      'paid' => self::PREVIEW_PAID,
+      'external' => self::PREVIEW_EXTERNAL,
+      default => self::PREVIEW_NOT_CONFIGURED,
+    };
+  }
+
+  private function modeBadgeLabel(string $previewState): string {
+    return match ($previewState) {
+      self::PREVIEW_RSVP => (string) $this->t('RSVP'),
+      self::PREVIEW_PAID => (string) $this->t('Paid tickets'),
+      self::PREVIEW_EXTERNAL => (string) $this->t('External'),
+      default => (string) $this->t('Not configured'),
+    };
+  }
+
+  private function previewHeading(string $previewState): string {
+    return match ($previewState) {
+      self::PREVIEW_RSVP => (string) $this->t('Free RSVP'),
+      self::PREVIEW_PAID => (string) $this->t('Tickets'),
+      self::PREVIEW_EXTERNAL => (string) $this->t('External booking'),
+      default => '',
+    };
+  }
+
+  /**
+   * @return array{label: string, disabled: bool, reason: string|null}
+   */
+  private function resolveCtaPreview(NodeInterface $event, string $previewState): array {
+    if ($previewState === self::PREVIEW_NOT_CONFIGURED) {
+      return [
+        'label' => '',
+        'disabled' => TRUE,
+        'reason' => NULL,
+      ];
+    }
+
+    if ($event->isPublished()) {
+      $primary = $this->bookingFlowResolver->getPrimaryCta($event);
+      return [
+        'label' => (string) ($primary['label'] ?? ''),
+        'disabled' => !empty($primary['disabled']),
+        'reason' => isset($primary['reason']) && $primary['reason'] !== '' ? (string) $primary['reason'] : NULL,
+      ];
+    }
+
+    return match ($previewState) {
+      self::PREVIEW_RSVP => [
+        'label' => (string) $this->t('RSVP free'),
+        'disabled' => FALSE,
+        'reason' => NULL,
+      ],
+      self::PREVIEW_PAID => [
+        'label' => (string) $this->t('Get your tickets'),
+        'disabled' => FALSE,
+        'reason' => NULL,
+      ],
+      self::PREVIEW_EXTERNAL => [
+        'label' => (string) $this->t('View details'),
+        'disabled' => FALSE,
+        'reason' => NULL,
+      ],
+      default => [
+        'label' => '',
+        'disabled' => TRUE,
+        'reason' => NULL,
+      ],
+    };
+  }
+
+  /**
+   * @return array{state: string, message: string|null}
+   */
+  private function resolveAvailabilityPreview(NodeInterface $event, string $previewState): array {
+    if ($previewState === self::PREVIEW_NOT_CONFIGURED) {
+      return ['state' => 'none', 'message' => NULL];
+    }
+
+    if (!$event->isPublished()) {
+      return ['state' => 'draft', 'message' => NULL];
+    }
+
+    $availability = $this->bookingFlowResolver->getAvailabilityState($event);
+    $message = match ($availability) {
+      BookingFlowResolver::AVAILABILITY_SOLD_OUT => (string) $this->t('This event is sold out.'),
+      BookingFlowResolver::AVAILABILITY_ENDED => (string) $this->t('This event has ended.'),
+      BookingFlowResolver::AVAILABILITY_NOT_STARTED => (string) $this->t('Booking is not open yet.'),
+      BookingFlowResolver::AVAILABILITY_UNAVAILABLE => (string) $this->t('Booking is not available for this event.'),
+      default => NULL,
+    };
+
+    return [
+      'state' => $availability,
+      'message' => $message,
+    ];
+  }
+
+  /**
+   * @return list<array{name: string, price: string, availability: string}>
+   */
+  private function buildTicketRows(NodeInterface $event, string $previewState): array {
+    if ($previewState !== self::PREVIEW_PAID) {
+      return [];
+    }
+
+    $rows = [];
+    $eventId = (int) $event->id();
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
+      if ($ticket->getTicketKind() !== 'paid' || !$ticket->isPublished()) {
+        continue;
+      }
+      $rows[] = [
+        'name' => $ticket->getTitle(),
+        'price' => $this->formatTicketPrice($ticket),
+        'availability' => $this->formatTierAvailability($event, $eventId, $ticket),
+      ];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * @return array{capacity_line: string|null}|null
+   */
+  private function buildRsvpSummary(NodeInterface $event, string $previewState): ?array {
+    if ($previewState !== self::PREVIEW_RSVP) {
+      return NULL;
+    }
+
+    $rsvp = $this->eventModeManager->getRsvpAvailability($event);
+    $line = NULL;
+    if (isset($rsvp['spots_remaining']) && $rsvp['spots_remaining'] !== NULL) {
+      $remaining = (int) $rsvp['spots_remaining'];
+      if ($remaining === 0) {
+        $line = (string) $this->t('No spots remaining.');
+      }
+      else {
+        $line = (string) $this->t('@count spot(s) remaining.', ['@count' => $remaining]);
+      }
+    }
+    elseif (!empty($rsvp['reason']) && is_string($rsvp['reason'])) {
+      $line = $rsvp['reason'];
+    }
+
+    return [
+      'capacity_line' => $line,
+    ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function buildTrustRows(string $previewState): array {
+    $confirmation = (string) $this->t('Confirmation email');
+    return match ($previewState) {
+      self::PREVIEW_PAID => [
+        (string) $this->t('Secure checkout'),
+        $confirmation,
+      ],
+      self::PREVIEW_RSVP => [
+        (string) $this->t('No payment required'),
+        $confirmation,
+      ],
+      default => [$confirmation],
+    };
+  }
+
+  private function formatTicketPrice(TicketTypeInterface $ticket): string {
+    $price = $ticket->toPriceValue();
+    if (!$price instanceof Price) {
+      return (string) $this->t('Free');
+    }
+    if ($price->isZero()) {
+      return (string) $this->t('Free');
+    }
+    return $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode());
+  }
+
+  private function formatTierAvailability(
+    NodeInterface $event,
+    int $eventId,
+    TicketTypeInterface $ticket,
+  ): string {
+    if ($ticket->get('capacity')->isEmpty()) {
+      return (string) $this->t('Available');
+    }
+
+    $cap = (int) $ticket->get('capacity')->value;
+    if ($cap < 1) {
+      return (string) $this->t('Available');
+    }
+
+    if (!$this->ticketCapacity instanceof TicketCapacityService) {
+      return (string) $this->t('Available');
+    }
+
+    $variationId = $ticket->get('commerce_variation')->isEmpty()
+      ? 0
+      : (int) $ticket->get('commerce_variation')->target_id;
+    if ($variationId < 1) {
+      return (string) $this->t('Available');
+    }
+
+    $pool = $this->ticketCapacity->getRemaining($eventId, (int) $ticket->id(), $variationId, $ticket);
+    if ($pool < 1) {
+      return (string) $this->t('Limited availability');
+    }
+    if ($pool === 1) {
+      return (string) $this->t('Only 1 left');
+    }
+    if ($pool <= 10) {
+      return (string) $this->t('Only @count left', ['@count' => (string) $pool]);
+    }
+
+    return (string) $this->t('Available');
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
@@ -1,0 +1,116 @@
+{#
+/**
+ * @file
+ * Customer booking preview for Event Studio ticket setup.
+ *
+ * Variables:
+ * - preview_state: not_configured|rsvp|paid|external
+ * - mode_badge: short mode label
+ * - heading: section heading inside canvas
+ * - cta: { label, disabled, reason }
+ * - availability: { state, message }
+ * - ticket_rows: list of { name, price, availability }
+ * - rsvp_summary: { capacity_line }|null
+ * - trust_rows: list of trust strings
+ * - show_empty_state: bool
+ * - wrapper_classes: BEM classes
+ */
+#}
+{% set preview_classes = wrapper_classes|default(['mel-event-ticket-preview']) %}
+<section
+  class="{{ preview_classes|join(' ') }}"
+  aria-labelledby="mel-es-ticket-preview-title"
+  data-mel-ticket-preview
+  data-preview-state="{{ preview_state|default('not_configured') }}"
+>
+  <header class="mel-event-ticket-preview__header">
+    <h3 class="mel-event-ticket-preview__title" id="mel-es-ticket-preview-title">
+      {{ 'Customer booking preview'|t }}
+    </h3>
+    <p class="mel-event-ticket-preview__lede">
+      {{ 'This is a preview of what customers will see when they book.'|t }}
+    </p>
+    <ul class="mel-event-ticket-preview__helpers">
+      <li>{{ 'Ticket rows and RSVP limits update here after saving.'|t }}</li>
+      <li>{{ 'The public booking button uses the same booking resolver as the event page.'|t }}</li>
+      <li>{{ 'Customers will not see this setup panel.'|t }}</li>
+    </ul>
+    <p class="mel-event-ticket-preview__save-note" data-mel-ticket-preview-save-note>
+      {{ 'Save to refresh ticket rows.'|t }}
+    </p>
+  </header>
+
+  <div class="mel-event-ticket-preview__canvas">
+    <div class="mel-event-ticket-preview__mode-row">
+      <span class="mel-event-ticket-preview__mode-badge" data-mel-ticket-preview-mode-badge>
+        {{ mode_badge|default('') }}
+      </span>
+    </div>
+
+    {% if show_empty_state %}
+      <div class="mel-event-ticket-preview__empty" data-mel-ticket-preview-empty>
+        <p class="mel-event-ticket-preview__empty-copy">
+          {{ 'Choose RSVP or Paid tickets to preview the customer booking experience.'|t }}
+        </p>
+      </div>
+    {% else %}
+      {% if heading %}
+        <h4 class="mel-event-ticket-preview__heading">{{ heading }}</h4>
+      {% endif %}
+
+      {% if preview_state == 'rsvp' and rsvp_summary %}
+        {% if rsvp_summary.capacity_line %}
+          <p class="mel-event-ticket-preview__capacity">{{ rsvp_summary.capacity_line }}</p>
+        {% endif %}
+      {% endif %}
+
+      {% if preview_state == 'paid' %}
+        {% if ticket_rows is not empty %}
+          <ul class="mel-event-ticket-preview__ticket-rows" aria-label="{{ 'Ticket options'|t }}">
+            {% for row in ticket_rows %}
+              <li class="mel-event-ticket-preview__ticket-row">
+                <div class="mel-event-ticket-preview__ticket-main">
+                  <span class="mel-event-ticket-preview__ticket-name">{{ row.name }}</span>
+                  <span class="mel-event-ticket-preview__ticket-price">{{ row.price }}</span>
+                </div>
+                {% if row.availability %}
+                  <p class="mel-event-ticket-preview__ticket-availability">{{ row.availability }}</p>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="mel-event-ticket-preview__ticket-empty mel-text--muted">
+            {{ 'Paid ticket rows appear here after you save tickets below.'|t }}
+          </p>
+        {% endif %}
+      {% endif %}
+
+      {% if availability.message %}
+        <p class="mel-event-ticket-preview__availability" role="status">{{ availability.message }}</p>
+      {% endif %}
+
+      {% if cta.label %}
+        <button
+          type="button"
+          class="mel-event-ticket-preview__cta{% if cta.disabled %} is-disabled{% endif %}"
+          disabled
+          aria-disabled="true"
+        >
+          {{ cta.label }}
+        </button>
+        {% if cta.reason %}
+          <p class="mel-event-ticket-preview__cta-reason mel-text--muted">{{ cta.reason }}</p>
+        {% endif %}
+      {% endif %}
+
+      {% if trust_rows is not empty %}
+        <ul class="mel-event-ticket-preview__trust">
+          {% for row in trust_rows %}
+            <li>{{ row }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
Adds a customer-facing Ticket Setup Preview inside Event Studio.

Includes:
- Preview between booking mode and operational ticket rows
- RSVP, paid, unavailable, and not-configured states
- Reuses BookingFlowResolver for CTA/status
- Reuses TicketTierLifecycleService for ticket rows
- Reuses EventModeManager for RSVP capacity
- Reuses TicketCapacityService for remaining ticket display
- Scoped Twig, CSS, and lightweight JS
- No checkout, Stripe, cart, order, RSVP lifecycle, or Commerce sync changes

Known limits:
- Preview uses saved ticket data
- Unsaved mode changes only update the badge until save
- Legacy wizard tickets step does not yet include this preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new render logic and a new service into the tickets section, which could affect Event Studio page rendering and caching/DI wiring. No checkout or purchase flows are mutated, but the preview pulls data from ticket and availability services that may vary by event state.
> 
> **Overview**
> Adds a new **Ticket Setup Preview** panel in the Event Studio tickets stack (rendered between mode selection and operational ticket settings) to show a customer-safe snapshot of booking state.
> 
> Introduces `EventTicketPreviewBuilder` and a new `mel_event_ticket_preview` Twig theme/template, plus a dedicated library (`mel_ticket_preview`) with scoped CSS and lightweight JS that syncs the preview mode badge to the unsaved `field_event_type` radio selection. The builder reuses existing resolvers to display CTA label/disabled reason, availability messaging, RSVP remaining spots, and saved paid ticket rows (with optional remaining-capacity messaging), and wires cache tags/contexts for the preview output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6489d0915078a6508926e8149627b18df0a3e30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->