### PR TITLE
Feature/event studio ticket preview

### DIFF
--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1624,6 +1624,16 @@ function myeventlane_theme_preprocess_html(array &$variables): void {
       $variables['attributes']['class'][] = 'mel-commerce-order-detail';
     }
   }
+
+  $route_node = $route_match->getParameter('node');
+  if ($route_node instanceof NodeInterface && $route_node->bundle() === 'event') {
+    $variables['attributes']['class'][] = 'mel-body--event-full';
+    $resolved_style = _myeventlane_theme_resolve_event_page_style_for_node($route_node);
+    $style = $resolved_style['style'] ?? 'classic';
+    $variables['attributes']['class'][] = $style === 'immersive'
+      ? 'mel-body--event-full-immersive'
+      : 'mel-body--event-full-classic';
+  }
 }
 
 /**
@@ -2030,13 +2040,28 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
   $variables['mel_hero_mobile_url'] = $hero_mobile_url;
   $variables['mel_category_slug'] = $category_slug;
 
+  // Event full: page shell classes + skip empty status region (placeholder adds white gap).
+  $route_node = \Drupal::routeMatch()->getParameter('node');
+  if ($route_node instanceof NodeInterface && $route_node->bundle() === 'event') {
+    $resolved_style = _myeventlane_theme_resolve_event_page_style_for_node($route_node);
+    $variables['mel_event_full_page'] = TRUE;
+    $variables['mel_event_page_style'] = $resolved_style['style'] ?? 'classic';
+    $variables['mel_show_highlighted'] = FALSE;
+    foreach (\Drupal::messenger()->all() as $type_messages) {
+      if (!empty($type_messages)) {
+        $variables['mel_show_highlighted'] = TRUE;
+        break;
+      }
+    }
+  }
+
   // Status messages: when Highlighted has no blocks (config not imported, etc.),
   // page.highlighted is empty and users see no success/errors (e.g. /contact).
   // Build the same system block programmatically as a fallback only in that case.
   $page_render = $variables['page'] ?? [];
   $highlighted = $page_render['highlighted'] ?? [];
   $highlighted_has_blocks = is_array($highlighted) && count(Element::children($highlighted)) > 0;
-  if (!$highlighted_has_blocks) {
+  if (!$highlighted_has_blocks && empty($variables['mel_event_full_page'])) {
     try {
       $block_manager = \Drupal::service('plugin.manager.block');
       $messages_block = $block_manager->createInstance('system_messages_block', []);
@@ -4526,6 +4551,7 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
   $variables['mel_signal_is_community'] = FALSE;
   $variables['mel_signal_trust_label'] = NULL;
   $variables['mel_signal_urgency_label'] = NULL;
+  $variables['mel_refund_policy_text'] = NULL;
   $variables['event_page_style'] = 'classic';
   $variables['event_theme_colour'] = 'coral';
   $variables['event_page_classes'] = ['mel-event-page--classic', 'mel-event-page--colour-coral'];
@@ -4635,6 +4661,19 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
         $variables['event_summary_excerpt'] = Unicode::truncate($plain, 220, TRUE, TRUE);
       }
     }
+  }
+
+  if ($event->hasField('field_refund_policy') && !$event->get('field_refund_policy')->isEmpty()) {
+    $refund_key = (string) $event->get('field_refund_policy')->value;
+    $refund_map = [
+      'none_specified' => new TranslatableMarkup('No specified policy on refunds'),
+      '1_day' => new TranslatableMarkup('Refunds are available up to 1 day prior to the event'),
+      '7_days' => new TranslatableMarkup('Refunds are available up to 7 days prior to the event'),
+      '14_days' => new TranslatableMarkup('Refunds are available up to 14 days prior to the event'),
+      '30_days' => new TranslatableMarkup('Refunds are available up to 30 days prior to the event'),
+      'no_refunds' => new TranslatableMarkup('No refunds'),
+    ];
+    $variables['mel_refund_policy_text'] = $refund_map[$refund_key] ?? NULL;
   }
 
   if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -1,0 +1,335 @@
+// ==========================================================================
+// Book page layout — mel-book-page (convergence with public event full page)
+// ==========================================================================
+// Complements _event-book.scss (ticket matrix, CTA, immersive/classic themes).
+
+@use '../tokens/colors';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/spacing';
+@use '../tokens/typography';
+@use '../tokens/breakpoints';
+
+$mel-book-max: 72.5rem; // ~1160px
+
+.mel-page:has(.mel-book-page.mel-event-page--classic) {
+  background-color: #fff9f5;
+}
+
+.mel-book-page {
+  padding: spacing.mel-space(4) 0 spacing.mel-space(7);
+  color: #24303a;
+}
+
+.mel-book-page__shell {
+  max-width: $mel-book-max;
+  margin-inline: auto;
+  width: 100%;
+}
+
+// ---------------------------------------------------------------------------
+// Compact event context header
+// ---------------------------------------------------------------------------
+
+.mel-book-header {
+  margin: 0 0 spacing.mel-space(4);
+  padding: spacing.mel-space(4);
+  background: #fff;
+  border: 1px solid rgba(36, 48, 58, 0.08);
+  border-radius: radii.$mel-radius-lg;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-book-header__nav {
+  margin-bottom: spacing.mel-space(3);
+}
+
+.mel-book-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: spacing.mel-space(1);
+  min-height: 44px;
+  padding: spacing.mel-space(1) 0;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-secondary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid colors.$mel-color-secondary;
+    outline-offset: 2px;
+    border-radius: radii.$mel-radius-sm;
+  }
+}
+
+.mel-book-back-link__icon {
+  font-size: typography.mel-font-size(lg);
+  line-height: 1;
+}
+
+.mel-book-header__inner {
+  display: flex;
+  gap: spacing.mel-space(4);
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.mel-book-header__thumb {
+  flex: 0 0 auto;
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: radii.$mel-radius-md;
+  overflow: hidden;
+  background: colors.$mel-color-bg;
+  border: 1px solid rgba(36, 48, 58, 0.08);
+
+  img,
+  picture,
+  .field,
+  .field__item {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.mel-book-header__thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mel-book-header__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.mel-book-header__category {
+  margin: 0 0 spacing.mel-space(2);
+}
+
+.mel-book-title {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: clamp(1.375rem, 2.5vw, 1.75rem);
+  font-weight: typography.$mel-font-extrabold;
+  line-height: 1.2;
+  color: #24303a;
+  letter-spacing: typography.$mel-tracking-tight;
+}
+
+.mel-book-meta {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(1);
+  margin: 0;
+}
+
+.mel-book-meta__item {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+  color: colors.$mel-color-text-muted;
+}
+
+// ---------------------------------------------------------------------------
+// Two-column book layout
+// ---------------------------------------------------------------------------
+
+.mel-book-page .mel-event-info-strip {
+  margin-bottom: spacing.mel-space(5);
+}
+
+.mel-book-layout {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(5);
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.mel-book-main,
+.mel-book-sidebar {
+  min-width: 0;
+}
+
+.mel-book-panel {
+  background: #fff;
+  border: 1px solid rgba(36, 48, 58, 0.08);
+  border-radius: radii.$mel-radius-lg;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-book-page .mel-ticket-panel {
+  padding: spacing.mel-space(4);
+}
+
+.mel-book-page .mel-ticket-panel__title {
+  margin: 0 0 spacing.mel-space(3);
+  padding: 0;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-extrabold;
+  color: #24303a;
+}
+
+.mel-book-sidebar__inner {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+}
+
+// Hide duplicate copy already shown in header / trust panel.
+.mel-book-page .mel-booking__intro h2 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mel-book-page .mel-booking__reassurance {
+  display: none;
+}
+
+// Trust panel (sidebar)
+.mel-book-trust {
+  padding: spacing.mel-space(4);
+}
+
+.mel-book-trust__title {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(md);
+  font-weight: typography.$mel-font-bold;
+  color: #24303a;
+}
+
+.mel-book-trust__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(3);
+}
+
+.mel-book-trust__item {
+  display: flex;
+  gap: spacing.mel-space(2);
+  align-items: flex-start;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-trust__item--urgent {
+  color: colors.$mel-color-primary;
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-book-trust__icon {
+  flex: 0 0 auto;
+  width: 1.25rem;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.mel-book-trust__support {
+  margin: spacing.mel-space(4) 0 0;
+  padding-top: spacing.mel-space(3);
+  border-top: 1px solid rgba(36, 48, 58, 0.08);
+  font-size: typography.mel-font-size(sm);
+}
+
+.mel-book-summary__excerpt {
+  margin: spacing.mel-space(3) 0 0;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+}
+
+// Touch targets
+.mel-book-page .mel-ticket-quantity,
+.mel-book-page .mel-event-book__form-body .mel-btn,
+.mel-book-page .mel-event-book__form-body .button,
+.mel-book-page .mel-event-book__form-body input[type='submit'] {
+  min-height: 44px;
+}
+
+@media (min-width: 960px) {
+  .mel-book-layout:not(.mel-book-layout--single) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+    gap: 24px;
+    align-items: start;
+  }
+
+  .mel-book-sidebar {
+    position: sticky;
+    top: 96px;
+    align-self: start;
+  }
+}
+
+@media (max-width: 959px) {
+  .mel-book-layout {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mel-book-main {
+    order: 1;
+  }
+
+  .mel-book-sidebar {
+    order: 2;
+    margin-top: 0;
+  }
+
+  .mel-book-header__inner {
+    flex-direction: column;
+  }
+
+  .mel-book-header__thumb {
+    width: 100%;
+    max-width: 12rem;
+    height: auto;
+    aspect-ratio: 16 / 10;
+  }
+}
+
+// Classic / immersive hooks reuse _event-book.scss; align shell width.
+.mel-book-page.mel-event-page--classic .mel-book-page__shell,
+.mel-book-page.mel-event-page--immersive .mel-book-page__shell {
+  max-width: $mel-book-max;
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-header,
+.mel-book-page.mel-event-page--immersive .mel-book-panel {
+  background: var(--mel-event-surface, rgba(34, 44, 60, 0.78));
+  border-color: var(--mel-event-border, rgba(255, 255, 255, 0.06));
+  color: var(--mel-immersive-text-secondary, rgba(255, 255, 255, 0.82));
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-title,
+.mel-book-page.mel-event-page--immersive .mel-book-trust__title,
+.mel-book-page.mel-event-page--immersive .mel-ticket-panel__title {
+  color: var(--mel-immersive-text, #fff);
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-meta__item,
+.mel-book-page.mel-event-page--immersive .mel-book-trust__item {
+  color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-back-link {
+  color: var(--mel-event-secondary-accent, #7c83fd);
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -250,14 +250,163 @@ $mel-book-max: 72.5rem; // ~1160px
   font-size: typography.mel-font-size(sm);
 }
 
-.mel-book-summary__excerpt {
+.mel-book-trust__note {
   margin: spacing.mel-space(3) 0 0;
   font-size: typography.mel-font-size(sm);
   line-height: 1.5;
+  color: colors.$mel-color-text-muted;
 }
 
-// Touch targets
-.mel-book-page .mel-ticket-quantity,
+// ---------------------------------------------------------------------------
+// Ticket rows + quantity controls
+// ---------------------------------------------------------------------------
+
+.mel-book-page .mel-ticket-list {
+  gap: spacing.mel-space(3);
+}
+
+.mel-book-page .mel-ticket-row {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'main'
+    'meta';
+  gap: spacing.mel-space(2) spacing.mel-space(3);
+}
+
+.mel-book-page .mel-ticket-row__meta {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: spacing.mel-space(3);
+  padding-top: spacing.mel-space(2);
+  border-top: 1px solid rgba(36, 48, 58, 0.1);
+  text-align: right;
+}
+
+.mel-book-page .mel-event-book__form-body .mel-ticket-row__meta .form-item {
+  flex: 0 0 auto;
+  width: 8.75rem;
+  max-width: 10rem;
+  min-width: 7.5rem;
+  margin: 0;
+}
+
+.mel-book-page .mel-event-book__form-body .mel-ticket-row__meta .form-item label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Override .mel-event-book__form-body input[type='number'] { width: 100% } from _event-book.scss.
+.mel-book-page .mel-event-book__form-body .mel-ticket-row__meta input[type='number'].mel-ticket-quantity,
+.mel-book-page .mel-event-book__form-body .mel-ticket-row .mel-ticket-quantity {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 10rem;
+  min-width: 7.5rem;
+  min-height: 44px;
+  margin: 0;
+  padding: 0 spacing.mel-space(3);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  border-radius: radii.$mel-radius-md;
+  border: 2px solid rgba(36, 48, 58, 0.12);
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(36, 48, 58, 0.06);
+}
+
+.mel-book-page .mel-ticket-row__meta input[type='number'].mel-ticket-quantity:focus-visible,
+.mel-book-page .mel-ticket-row .mel-ticket-quantity:focus-visible {
+  border-color: colors.$mel-color-secondary;
+  box-shadow: 0 0 0 3px rgba(124, 131, 253, 0.25);
+  outline: none;
+}
+
+// ---------------------------------------------------------------------------
+// Checkout action — in-panel on desktop; sticky footer on mobile only
+// ---------------------------------------------------------------------------
+
+.mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
+  .mel-mobile-booking-bar {
+    display: flex;
+  }
+
+  .form-actions {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 960px) {
+  .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
+    position: static;
+    bottom: auto;
+    z-index: auto;
+    margin: spacing.mel-space(4) 0 0;
+    padding: spacing.mel-space(4) 0 0;
+    background: transparent;
+    border-top: 1px solid rgba(36, 48, 58, 0.1);
+    box-shadow: none;
+
+    .mel-mobile-booking-bar {
+      display: none;
+    }
+
+    .mel-booking__cta-note {
+      margin-bottom: spacing.mel-space(3);
+    }
+
+    .form-actions {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .mel-btn--primary,
+    .mel-add-to-cart-button,
+    .form-actions .button--primary {
+      width: auto;
+      min-width: min(100%, 14rem);
+      max-width: 100%;
+      min-height: 48px;
+      padding-inline: spacing.mel-space(5);
+      border-radius: radii.$mel-radius-full;
+      transform: none;
+      box-shadow: 0 8px 22px rgba(242, 109, 91, 0.28);
+    }
+  }
+}
+
+@media (max-width: 959px) {
+  .mel-book-page .mel-ticket-panel {
+    padding-bottom: 0;
+  }
+
+  .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
+    position: sticky;
+    bottom: 0;
+    z-index: 6;
+    margin: spacing.mel-space(4) calc(-1 * #{spacing.mel-space(4)}) 0;
+    padding: spacing.mel-space(3) spacing.mel-space(4);
+    padding-bottom: calc(#{spacing.mel-space(3)} + env(safe-area-inset-bottom, 0));
+    background: #fff;
+    border-top: 1px solid rgba(36, 48, 58, 0.1);
+    box-shadow: 0 -8px 24px rgba(36, 48, 58, 0.08);
+
+    .mel-btn--primary,
+    .mel-add-to-cart-button {
+      width: 100%;
+      min-height: 48px;
+    }
+  }
+}
+
+// Touch targets (non-quantity actions)
 .mel-book-page .mel-event-book__form-body .mel-btn,
 .mel-book-page .mel-event-book__form-body .button,
 .mel-book-page .mel-event-book__form-body input[type='submit'] {
@@ -332,4 +481,33 @@ $mel-book-max: 72.5rem; // ~1160px
 
 .mel-book-page.mel-event-page--immersive .mel-book-back-link {
   color: var(--mel-event-secondary-accent, #7c83fd);
+}
+
+.mel-book-page.mel-event-page--immersive .mel-ticket-row__meta {
+  border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+}
+
+.mel-book-page.mel-event-page--immersive .mel-ticket-row__meta input[type='number'].mel-ticket-quantity,
+.mel-book-page.mel-event-page--immersive .mel-ticket-row .mel-ticket-quantity {
+  background: color-mix(in srgb, var(--mel-event-surface-spotlight, rgba(40, 52, 70, 0.85)) 88%, transparent);
+  border-color: var(--mel-event-border-strong, rgba(255, 255, 255, 0.1));
+  color: var(--mel-immersive-text, #fff);
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-trust__note {
+  color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+@media (min-width: 960px) {
+  .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
+    border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+  }
+}
+
+@media (max-width: 959px) {
+  .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
+    background: color-mix(in srgb, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 94%, transparent);
+    border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.36);
+  }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-book.scss
@@ -1104,23 +1104,23 @@
   }
 }
 
-// Mobile: order summary + extras teaser before ticket form (matches event full sidebar).
+// Legacy mel-event-layout book grid (module template). mel-book-page uses _booking-page.scss order.
 @media (width <= 768px) {
-  .mel-booking-v2 .mel-event-layout:not(.mel-event-layout--booking-single) {
+  .mel-booking-v2:not(.mel-book-page) .mel-event-layout:not(.mel-event-layout--booking-single) {
     display: flex;
     flex-direction: column;
     gap: spacing.mel-space(5);
   }
 
-  .mel-booking-v2 .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__main {
+  .mel-booking-v2:not(.mel-book-page) .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__main {
     display: contents;
   }
 
-  .mel-booking-v2 .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__side {
+  .mel-booking-v2:not(.mel-book-page) .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__side {
     order: 1;
   }
 
-  .mel-booking-v2 .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__main > * {
+  .mel-booking-v2:not(.mel-book-page) .mel-event-layout:not(.mel-event-layout--booking-single) > .mel-event-layout__main > * {
     order: 2;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -18,11 +18,15 @@
 // ==========================================================================
 
 .mel-event--v2:has(.mel-event-full) {
-  padding: space-tokens.mel-space(3) 0 space-tokens.mel-space(5);
+  padding-top: 0;
+  padding-bottom: space-tokens.mel-space(5);
+}
+
+.mel-event--v2:not(:has(.mel-event-full)) {
+  padding: space-tokens.mel-space(4) 0 space-tokens.mel-space(6);
 }
 
 .mel-event--v2 {
-  padding: space-tokens.mel-space(4) 0 space-tokens.mel-space(6);
 
   // Event Intelligence Layer — single calm chip (copy from preprocess).
   .mel-event__signal {
@@ -1159,7 +1163,7 @@
   line-height: 1.2;
 }
 
-.mel-event-layout {
+.mel-event-layout:not(.mel-event-full__layout) {
   margin-top: space-tokens.mel-space(5);
   display: grid;
   gap: space-tokens.mel-space(5);
@@ -1255,7 +1259,7 @@
   margin-top: 6px;
 }
 
-// Mockup mobile stack: hero → booking → view details → gallery → content.
+// Mockup mobile stack: hero → booking → view details → gallery → content (grid areas, not flex order).
 @media (width <= 767px) {
   .mel-event-full__layout {
     display: flex;
@@ -1263,45 +1267,40 @@
     gap: var(--mel-full-stack-gap, 20px);
   }
 
-  .mel-event-full__main,
-  .mel-event-full__sidebar {
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__primary,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__primary {
+    display: grid;
+    gap: var(--mel-full-stack-gap, 20px);
+    grid-template-areas:
+      'hero'
+      'sidebar'
+      'content'
+      'support';
+  }
+
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__main-col,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__main-col {
     display: contents;
   }
 
-  .mel-event-full__hero {
-    order: 1;
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__main--hero,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__main--hero {
+    grid-area: hero;
   }
 
-  .mel-event-full__booking {
-    order: 2;
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__main--content,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__main--content {
+    grid-area: content;
   }
 
-  .mel-event-full__view-details {
-    order: 3;
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__sidebar,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__sidebar {
+    grid-area: sidebar;
   }
 
-  .mel-event-full__gallery {
-    order: 4;
-  }
-
-  .mel-event-full__about {
-    order: 5;
-  }
-
-  .mel-event-full__highlights {
-    order: 6;
-  }
-
-  .mel-event-full__expect {
-    order: 7;
-  }
-
-  .mel-event-full__content-below {
-    order: 8;
-  }
-
-  .mel-event-full__support {
-    order: 9;
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__support,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__support {
+    grid-area: support;
   }
 }
 
@@ -2650,25 +2649,123 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
 .mel-event--v2 .mel-container:has(.mel-event-full) {
   max-width: min(100%, 82.5rem);
   padding-inline: clamp(16px, 3vw, 24px);
+  padding-top: 0;
 }
 
-.mel-event-full__layout {
-  display: grid;
+// Event full — flush under site header; main is full-bleed (not capped at 1200px).
+.mel-page:has(.mel-event-full) > main.mel-main {
+  max-width: none;
+  width: 100%;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+main.mel-main:has(.mel-event-full) {
+  padding-top: 0;
+}
+
+// Immersive canvas on page shell so no white band shows above hero.
+.mel-page:has(.mel-event-page--immersive.mel-event--v2 .mel-event-full) {
+  background-color: #080c14;
+  background-image:
+    radial-gradient(ellipse 120% 55% at 50% -8%, rgba(255, 255, 255, 0.04) 0%, transparent 58%),
+    radial-gradient(ellipse 70% 50% at 100% 50%, rgba(255, 255, 255, 0.02) 0%, transparent 52%),
+    radial-gradient(ellipse 55% 45% at 0% 100%, rgba(0, 0, 0, 0.35) 0%, transparent 50%),
+    linear-gradient(180deg, #080c14 0%, #0c121c 50%, #101826 100%);
+}
+
+.mel-page:has(.mel-event-page--classic.mel-event--v2 .mel-event-full) {
+  background-color: #fff9f5;
+}
+
+// Event full layout: DOM order hero → sidebar → content (mobile); named grid at 1100px+.
+.mel-event-page--classic.mel-event--v2 .mel-event-full__layout.mel-event-layout,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__layout.mel-event-layout {
+  margin-top: 0;
+}
+
+main.mel-main:has(.mel-event-full) .mel-region-highlighted:not(:has(.messages)) {
+  display: none;
+  margin: 0;
+  padding: 0;
+  min-height: 0;
+  border: 0;
+}
+
+.mel-event-full__layout.mel-event-layout {
+  display: flex;
+  flex-direction: column;
   gap: var(--mel-full-stack-gap, 20px);
-  align-items: start;
+  align-items: stretch;
   max-width: 100%;
   margin-inline: auto;
+}
+
+// Desktop: main column stacks hero + content; sidebar rail is a separate grid column.
+.mel-event-page--classic.mel-event--v2 .mel-event-full__primary,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__primary {
+  display: grid;
+  gap: var(--mel-full-stack-gap, 20px);
+  min-width: 0;
 
   @media (width >= 1100px) {
     grid-template-columns: minmax(0, 1fr) 390px;
+    grid-template-areas:
+      'stack sidebar'
+      'support sidebar';
+    gap: var(--mel-full-stack-gap, 20px) 32px;
+    align-items: start;
   }
 }
 
-.mel-event-full__main {
+.mel-event-page--classic.mel-event--v2 .mel-event-full__main-col,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__main-col {
   display: flex;
   flex-direction: column;
   gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
+
+  @media (width >= 1100px) {
+    grid-area: stack;
+  }
+}
+
+.mel-event-full__main,
+.mel-event-full__main--hero,
+.mel-event-full__main--content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-full-stack-gap, 20px);
+  min-width: 0;
+}
+
+@media (width >= 1100px) {
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__sidebar,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__sidebar {
+    grid-area: sidebar;
+    grid-row: 1 / -1;
+    align-self: start;
+    width: 390px;
+    max-width: 390px;
+  }
+
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__sidebar-inner,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__sidebar-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mel-full-stack-gap, 20px);
+    position: sticky;
+    top: var(--mel-sticky-offset, 5.5rem);
+    max-height: calc(100vh - var(--mel-sticky-offset, 5.5rem) - #{space-tokens.mel-space(4)});
+    overflow-y: auto;
+  }
+
+  .mel-event-page--classic.mel-event--v2 .mel-event-full__support.mel-event-support-zone,
+  .mel-event-page--immersive.mel-event--v2 .mel-event-full__support.mel-event-support-zone {
+    grid-area: support;
+    align-self: start;
+    margin-top: 0;
+  }
 }
 
 .mel-event-full__sidebar {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -2757,7 +2757,6 @@ main.mel-main:has(.mel-event-full) .mel-region-highlighted:not(:has(.messages)) 
     position: sticky;
     top: var(--mel-sticky-offset, 5.5rem);
     max-height: calc(100vh - var(--mel-sticky-offset, 5.5rem) - #{space-tokens.mel-space(4)});
-    overflow-y: auto;
   }
 
   .mel-event-page--classic.mel-event--v2 .mel-event-full__support.mel-event-support-zone,

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -177,6 +177,7 @@
 @use 'components/confirmation';
 @use 'components/ticket-types';
 @use 'components/event-book';
+@use 'components/booking-page';
 @use 'components/diagnostics';
 @use 'components/vendor-profile';
 @use 'components/card-carousel/card-carousel';

--- a/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
@@ -1,10 +1,235 @@
 {#
 /**
  * @file
- * Theme override for the event booking page.
+ * Event booking page — MEL book surface aligned with public event full page.
  *
- * Extends the module default so markup stays in one place; replace this file
- * with a full template if the theme needs a divergent layout.
+ * Ticket matrix, access code, and Add to cart remain in Drupal forms unchanged.
  */
 #}
-{% extends "@myeventlane_commerce/myeventlane-event-book.html.twig" %}
+{% set extras_in_sidebar = addons_available and (extras_sidebar_selection|default(false) or extras_book_placement|default('main_before_access') == 'sidebar') %}
+{% set extras_in_main = addons_available and (extras_inline_before_access_code|default(false) or not extras_in_sidebar) %}
+{% set mel_book_paid = event_mode == 'paid' %}
+<article class="mel-book-page mel-booking-v2 mel-event-book mel-event--v2{% if event_page_classes is defined and event_page_classes %} {{ event_page_classes|join(' ') }}{% else %} mel-event-page--classic mel-event-page--colour-coral{% endif %}" data-event-mode="{{ event_mode }}">
+  <div class="mel-book-page__shell mel-container">
+    <header class="mel-book-header mel-card" aria-labelledby="mel-booking-event-title">
+      {% if event_back_url %}
+        <nav class="mel-book-header__nav" aria-label="{{ 'Event navigation'|t }}">
+          <a class="mel-book-back-link" href="{{ event_back_url }}">
+            <span class="mel-book-back-link__icon" aria-hidden="true">←</span>
+            {{ event_back_label|default('Back to event'|t) }}
+          </a>
+        </nav>
+      {% endif %}
+      <div class="mel-book-header__inner">
+        {% if hero_image or hero_url %}
+          <div class="mel-book-header__thumb" aria-hidden="true">
+            {% if hero_image %}
+              {{ hero_image }}
+            {% else %}
+              <img class="mel-book-header__thumb-img" src="{{ hero_url }}" alt="" width="120" height="80" loading="lazy" decoding="async" />
+            {% endif %}
+          </div>
+        {% endif %}
+        <div class="mel-book-header__copy">
+          {% if mel_category_label %}
+            <p class="mel-book-header__category">
+              <span class="mel-pill mel-pill--category mel-pill--cat-{{ mel_category_slug|default('default') }}">
+                <span class="mel-pill__label">{{ mel_category_label }}</span>
+              </span>
+            </p>
+          {% endif %}
+          <h1 class="mel-book-title" id="mel-booking-event-title">{{ label }}</h1>
+          <div class="mel-book-meta">
+            {% if hero_datetime %}
+              <p class="mel-book-meta__item mel-book-meta__datetime">{{ hero_datetime }}</p>
+            {% endif %}
+            {% if hero_venue %}
+              <p class="mel-book-meta__item mel-book-meta__venue">{{ hero_venue }}</p>
+            {% endif %}
+            {% if hero_status %}
+              <p class="mel-book-meta__item mel-book-meta__status mel-event-card__status mel-event-card__status--{{ hero_status_modifier|default('default') }}">{{ hero_status }}</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="mel-event-info-strip mel-card" role="note">
+      {% if event_mode == 'paid' %}
+        <span class="mel-event-info-strip__item">{{ 'Secure checkout'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'No hidden fees'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'Confirmation email sent'|t }}</span>
+      {% elseif event_mode == 'rsvp' %}
+        <span class="mel-event-info-strip__item">{{ 'No payment required'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'Your RSVP will be confirmed by email'|t }}</span>
+      {% elseif event_mode == 'external' %}
+        <span class="mel-event-info-strip__item">{{ 'External ticketing'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'You will leave this site to buy tickets'|t }}</span>
+      {% else %}
+        <span class="mel-event-info-strip__item">{{ 'Hosted on MyEventLane'|t }}</span>
+      {% endif %}
+    </div>
+
+    {% if not addons_available and mel_customer_operational_experience %}
+      <div class="mel-booking-operational-experience">
+        {{ mel_customer_operational_experience }}
+      </div>
+    {% endif %}
+
+    {% if not addons_available and mel_operational_checkout %}
+      <div class="mel-booking-operational-checkout">
+        {{ mel_operational_checkout }}
+      </div>
+    {% endif %}
+
+    {% if not addons_available and mel_operational_purchase_composition %}
+      <div class="mel-booking-operational-composition">
+        {{ mel_operational_purchase_composition }}
+      </div>
+    {% endif %}
+
+    <div class="mel-book-layout mel-booking-container{% if not mel_book_paid %} mel-book-layout--single mel-event-layout--booking-single{% endif %}">
+      <main class="mel-book-main mel-event-layout__main">
+        <div class="mel-ticket-panel mel-book-panel mel-card mel-event-book__form" aria-labelledby="mel-ticket-panel-title">
+          <h2 class="mel-ticket-panel__title" id="mel-ticket-panel-title">
+            {% if event_mode == 'paid' %}
+              {{ 'Choose your tickets'|t }}
+            {% elseif event_mode == 'rsvp' %}
+              {{ 'Your details'|t }}
+            {% elseif event_mode == 'external' %}
+              {{ 'Continue'|t }}
+            {% else %}
+              {{ 'Booking'|t }}
+            {% endif %}
+          </h2>
+
+          <div class="mel-ticket-panel__body mel-event-book__form-body mel-booking-flow" data-mel-booking-flow>
+            {% if ticket_form is not empty %}
+              {{ ticket_form }}
+            {% elseif matrix_form is not empty %}
+              {{ matrix_form }}
+            {% elseif rsvp_form is not empty %}
+              {{ rsvp_form }}
+            {% else %}
+              <div class="mel-alert mel-alert--info" role="status">
+                {% if event_mode == 'none' %}
+                  {{ 'Registration opens soon.'|t }}
+                {% else %}
+                  {{ "We couldn't load the booking form. Please refresh the page."|t }}
+                {% endif %}
+              </div>
+            {% endif %}
+
+            {% if extras_in_main and operational_addon_form %}
+              <section id="mel-operational-addons--inline" class="mel-booking-extras mel-booking-extras--inline mel-operational-addons-section mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title--inline" tabindex="-1">
+                <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title--inline">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
+                <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
+                {{ operational_addon_form }}
+              </section>
+            {% endif %}
+
+            {% if ticket_booking_access is not empty %}
+              <div class="mel-ticket-booking-access-wrap">
+                {{ ticket_booking_access }}
+              </div>
+            {% endif %}
+
+            {% if ticket_form_actions is not empty %}
+              <div class="mel-booking__cta mel-booking-flow__checkout mel-book-mobile-action" role="region" aria-label="{{ 'Reserve tickets'|t }}">
+                <div class="mel-mobile-booking-bar" data-mel-mobile-booking-bar>
+                  <span class="mel-mobile-booking-bar__count" data-mel-booking-count></span>
+                  <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
+                </div>
+                <p class="mel-booking__cta-note">
+                  {{ "Tickets will be added to your cart — checkout when you're ready."|t }}
+                </p>
+                {{ ticket_form_actions }}
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </main>
+
+      {% if mel_book_paid %}
+        <aside class="mel-book-sidebar mel-event-layout__side" aria-label="{{ 'Order summary and booking details'|t }}">
+          <div class="mel-book-sidebar__inner">
+            <div class="mel-book-summary mel-book-panel mel-card" data-mel-booking-summary>
+              <header class="mel-booking-summary__header">
+                <h3 class="mel-booking-summary__title">{{ 'Your selection'|t }}</h3>
+                <p class="mel-booking-summary__kicker mel-text--muted">{{ 'Clear pricing before you pay.'|t }}</p>
+              </header>
+              <div class="mel-booking-summary__body">
+                <div class="mel-booking-summary__empty" data-mel-summary-empty>
+                  <p class="mel-booking-summary__empty-line">{{ 'Choose your tickets to see your total.'|t }}</p>
+                  <p class="mel-booking-summary__empty-line mel-booking-summary__empty-line--soft">{{ 'You can review everything before checkout.'|t }}</p>
+                </div>
+                <div class="mel-booking-summary__items" data-mel-summary-items aria-live="polite" aria-atomic="true"></div>
+                <div class="mel-booking-summary__subtotal" data-mel-summary-subtotal hidden>
+                  <span class="mel-booking-summary__subtotal-label">{{ 'Subtotal'|t }}</span>
+                  <span class="mel-booking-summary__subtotal-value" data-mel-summary-subtotal-value></span>
+                </div>
+              </div>
+              <footer class="mel-booking-summary__footer">
+                <p class="mel-booking-summary__cta-note">{{ 'Tickets go to your cart first — continue to checkout when you are ready.'|t }}</p>
+              </footer>
+            </div>
+
+            <div class="mel-book-trust mel-book-panel mel-card" role="region" aria-label="{{ 'Booking reassurance'|t }}">
+              <h3 class="mel-book-trust__title">{{ 'Before you pay'|t }}</h3>
+              <ul class="mel-book-trust__list" role="list">
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">🔒</span>
+                  <span class="mel-book-trust__text">{{ 'Secure checkout — payment processed safely'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
+                  <span class="mel-book-trust__text">{{ 'No hidden fees on MyEventLane'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✉</span>
+                  <span class="mel-book-trust__text">{{ 'Instant confirmation by email'|t }}</span>
+                </li>
+                {% if mel_signal_trust_label %}
+                  <li class="mel-book-trust__item">
+                    <span class="mel-book-trust__icon" aria-hidden="true">◎</span>
+                    <span class="mel-book-trust__text">{{ mel_signal_trust_label }}</span>
+                  </li>
+                {% endif %}
+                {% if mel_signal_urgency_label %}
+                  <li class="mel-book-trust__item mel-book-trust__item--urgent">
+                    <span class="mel-book-trust__icon" aria-hidden="true">⚡</span>
+                    <span class="mel-book-trust__text">{{ mel_signal_urgency_label }}</span>
+                  </li>
+                {% endif %}
+                {% if mel_refund_policy_text is defined and mel_refund_policy_text %}
+                  <li class="mel-book-trust__item">
+                    <span class="mel-book-trust__icon" aria-hidden="true">↩</span>
+                    <span class="mel-book-trust__text">{{ mel_refund_policy_text }}</span>
+                  </li>
+                {% endif %}
+              </ul>
+              {% if event_summary_excerpt %}
+                <p class="mel-book-summary__excerpt mel-text--muted">{{ event_summary_excerpt }}</p>
+              {% endif %}
+              <p class="mel-book-trust__support">
+                <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
+              </p>
+            </div>
+
+            {% if operational_addon_teaser %}
+              {{ operational_addon_teaser }}
+            {% endif %}
+
+            {% if extras_in_sidebar and operational_addon_form %}
+              <section id="mel-operational-addons--sidebar" class="mel-booking-extras mel-booking-extras--sidebar mel-operational-addons-section mel-operational-addons-section--sidebar mel-booking-flow__addons" aria-labelledby="mel-operational-addons-title--sidebar" tabindex="-1">
+                <h3 class="mel-operational-addons-section__title" id="mel-operational-addons-title--sidebar">{{ operational_addons_section_title|default('Grab the extras'|t) }}</h3>
+                <p class="mel-operational-addons-section__lede">{{ operational_addons_section_lede|default('Merch, perks, and add-ons for this booking — collect at the event after checkout.'|t) }}</p>
+                {{ operational_addon_form }}
+              </section>
+            {% endif %}
+          </div>
+        </aside>
+      {% endif %}
+    </div>
+  </div>
+</article>

--- a/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
@@ -135,7 +135,7 @@
             {% endif %}
 
             {% if ticket_form_actions is not empty %}
-              <div class="mel-booking__cta mel-booking-flow__checkout mel-book-mobile-action" role="region" aria-label="{{ 'Reserve tickets'|t }}">
+              <div class="mel-booking__cta mel-booking__cta--panel mel-booking-flow__checkout mel-book-mobile-action" role="region" aria-label="{{ 'Reserve tickets'|t }}">
                 <div class="mel-mobile-booking-bar" data-mel-mobile-booking-bar>
                   <span class="mel-mobile-booking-bar__count" data-mel-booking-count></span>
                   <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
@@ -208,9 +208,9 @@
                   </li>
                 {% endif %}
               </ul>
-              {% if event_summary_excerpt %}
-                <p class="mel-book-summary__excerpt mel-text--muted">{{ event_summary_excerpt }}</p>
-              {% endif %}
+              <p class="mel-book-trust__note mel-text--muted">
+                {{ 'You can review your order before checkout. Your tickets are only confirmed once checkout is complete.'|t }}
+              </p>
               <p class="mel-book-trust__support">
                 <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
               </p>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -79,7 +79,10 @@
 
     <div class="mel-event-full">
       <div class="mel-event-full__layout mel-event-layout mel-event-layout--option1">
-        <div class="mel-event-full__main mel-event-layout__main">
+        {# Primary column: mobile flex order hero → sidebar → content → support; desktop inner grid. #}
+        <div class="mel-event-full__primary mel-event-layout__main">
+        <div class="mel-event-full__main-col">
+        <div class="mel-event-full__main mel-event-full__main--hero">
     {# Hero: node--event--full — same stack as homepage featured_hero (mel-event-card variant). #}
     <section class="mel-event-full__hero mel-event-hero mel-event-hero--featured-style" aria-labelledby="mel-event-title">
       <div class="mel-event-hero__media">
@@ -171,7 +174,9 @@
         </div>
       </div>
     </section>
+        </div>
 
+        <div class="mel-event-full__main mel-event-full__main--content">
         {% if mel_event_gallery is defined and mel_event_gallery.count > 0 %}
           <div class="mel-event-full__gallery">
             {{
@@ -603,20 +608,24 @@
            These are configuration inputs, not attendee-facing content. #}
         </div>
         </div>
+        </div>
 
         <aside class="mel-event-full__sidebar mel-event-layout__sidebar mel-event-sidebar-rail" aria-label="{{ 'Tickets and event information'|t }}">
-          {% include '@myeventlane_theme/node/partial--event-full-booking-panel.html.twig' %}
-          {% include '@myeventlane_theme/node/partial--event-full-view-details.html.twig' %}
-
-          <nav class="mel-event-full__support mel-event-support-zone" aria-label="{{ 'Help and policies'|t }}">
-            <ul class="mel-event-support-zone__list">
-              <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a></li>
-              <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_support.page') }}">{{ 'Support'|t }}</a></li>
-              <li><a class="mel-event-support-zone__link" href="/privacy">{{ 'Privacy'|t }}</a></li>
-              <li><a class="mel-event-support-zone__link" href="/terms">{{ 'Terms'|t }}</a></li>
-            </ul>
-          </nav>
+          <div class="mel-event-full__sidebar-inner">
+            {% include '@myeventlane_theme/node/partial--event-full-booking-panel.html.twig' %}
+            {% include '@myeventlane_theme/node/partial--event-full-view-details.html.twig' %}
+          </div>
         </aside>
+
+        <nav class="mel-event-full__support mel-event-support-zone" aria-label="{{ 'Help and policies'|t }}">
+          <ul class="mel-event-support-zone__list">
+            <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a></li>
+            <li><a class="mel-event-support-zone__link" href="{{ path('myeventlane_support.page') }}">{{ 'Support'|t }}</a></li>
+            <li><a class="mel-event-support-zone__link" href="/privacy">{{ 'Privacy'|t }}</a></li>
+            <li><a class="mel-event-support-zone__link" href="/terms">{{ 'Terms'|t }}</a></li>
+          </ul>
+        </nav>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Pushed branch feature/event-studio-ticket-preview

Included commits:

58177588 fix event sidebar layout

0e95b092 remove sidebar overflow

92a574d1 align booking page with event layout

d64b0058 polish ticket controls and booking action

Unrelated local files remain unstaged and were not pushed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it significantly restructures Twig markup and CSS for key event/booking pages, which can introduce layout regressions across breakpoints and page styles (classic/immersive). Changes are theme-layer only and don’t alter commerce/checkout logic.
> 
> **Overview**
> Unifies the *public event full* and *event booking* experiences by introducing a new booking-page template and `booking-page` SCSS that creates a two-column layout with a compact event header, sidebar “trust/summary” panel, and refined ticket quantity/CTA behavior across mobile vs desktop.
> 
> Updates event full page structure and styling to be flush under the site header, use page-shell backgrounds for classic/immersive modes, switch mobile stacking to grid areas, and make the sidebar rail sticky via a new inner wrapper. Adds route-based body/page variables/classes for event nodes, suppresses empty highlighted/status regions on event full pages, and exposes `mel_refund_policy_text` from `field_refund_policy` for display in the booking trust panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64b00589b02a883056565f9147dbde1372e94fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->