### PR TITLE
fix(checkout): hide empty grouped order summary

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
@@ -16,6 +16,7 @@ declare(strict_types=1);
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\MelSurfaceId;
 use Drupal\myeventlane_surface\MelWorkflowContext;
@@ -29,6 +30,7 @@ function myeventlane_checkout_flow_form_commerce_checkout_flow_mel_event_checkou
     /** @var \Drupal\myeventlane_checkout_flow\Service\CheckoutUxAttacher $attacher */
     $attacher = \Drupal::service('myeventlane_checkout_flow.checkout_ux_attacher');
     $attacher->attachCompleteStepSidebar($form);
+    myeventlane_checkout_flow_hide_empty_complete_sidebar_panes($form);
     return;
   }
   if ($step_id !== 'checkout') {
@@ -54,6 +56,30 @@ function myeventlane_checkout_flow_form_commerce_checkout_flow_mel_event_checkou
   $attacher->attach($form);
 
   myeventlane_checkout_flow_attach_fast_checkout($form, $form_state);
+}
+
+/**
+ * Hides empty checkout sidebar panes on the completion step.
+ *
+ * Commerce sets #access from visible children for main panes only; sidebar panes
+ * (including grouped_order_summary) can render an empty fieldset shell otherwise.
+ */
+function myeventlane_checkout_flow_hide_empty_complete_sidebar_panes(array &$form): void {
+  if (!isset($form['sidebar']) || !is_array($form['sidebar'])) {
+    return;
+  }
+
+  $disabled_summary_panes = ['grouped_order_summary', 'mel_fee_transparency'];
+  foreach (Element::children($form['sidebar']) as $pane_id) {
+    if (!isset($form['sidebar'][$pane_id]) || !is_array($form['sidebar'][$pane_id])) {
+      continue;
+    }
+    if (in_array($pane_id, $disabled_summary_panes, TRUE)) {
+      $form['sidebar'][$pane_id]['#access'] = FALSE;
+      continue;
+    }
+    $form['sidebar'][$pane_id]['#access'] = (bool) Element::getVisibleChildren($form['sidebar'][$pane_id]);
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
@@ -44,7 +44,8 @@ final class MelCheckoutSummaryPresenter {
     ];
 
     $has_pricing_block = $this->hasPricingBlock($built);
-    if ($built['grouped_items'] === [] && !$has_pricing_block) {
+    $has_grouped_line_items = $this->hasGroupedLineItems($built);
+    if (!$has_grouped_line_items && !$has_pricing_block) {
       return [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-checkout-order-summary', 'mel-checkout-order-summary--empty-state']],
@@ -74,9 +75,38 @@ final class MelCheckoutSummaryPresenter {
       'labels' => $labels,
       'trust' => $trust,
       'has_pricing_block' => $has_pricing_block,
+      'has_grouped_line_items' => $has_grouped_line_items,
       'surface' => $surface,
       'show_jump_to_payment' => $surface === 'checkout',
     ];
+  }
+
+  /**
+   * Whether any event group has ticket/add-on lines to show (not pricing-only).
+   *
+   * @param array<string, mixed> $built
+   *   Output shape from CheckoutGroupedSummaryBuilder::build().
+   */
+  private function hasGroupedLineItems(array $built): bool {
+    foreach ($built['grouped_items'] as $event) {
+      if (!is_array($event)) {
+        continue;
+      }
+      foreach ($event['items'] ?? [] as $item) {
+        if (!is_array($item)) {
+          continue;
+        }
+        if ((int) ($item['quantity'] ?? 0) <= 0) {
+          continue;
+        }
+        $ticket_type = trim((string) ($item['ticket_type'] ?? ''));
+        $total_price = trim((string) ($item['total_price'] ?? ''));
+        if ($ticket_type !== '' || $total_price !== '' || !empty($item['operational_addon_display'])) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
@@ -83,6 +83,48 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
 
     $this->assertSame('complete', $render['surface']);
     $this->assertFalse($render['show_jump_to_payment']);
+    $this->assertFalse($render['has_grouped_line_items']);
+    $this->assertTrue($render['has_pricing_block']);
+  }
+
+  /**
+   * @covers ::buildGroupedSummaryRenderArray
+   */
+  public function testGroupedLineItemsFlagWhenTicketRowsExist(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCacheTags')->willReturn(['commerce_order:3']);
+    $order->method('getCacheContexts')->willReturn(['user']);
+
+    $built = [
+      'grouped_items' => [[
+        'title' => 'Show',
+        'items' => [[
+          'quantity' => 2,
+          'ticket_type' => 'General',
+          'total_price' => '$20.00',
+        ]],
+      ]],
+      'order_total' => '$20.00',
+      'subtotal_formatted' => '$20.00',
+      'optional_donation_formatted' => '',
+      'tax_rows' => [],
+      'fee_rows' => [],
+      'platform_fee_absorbed' => FALSE,
+      'show_includes_gst_note' => FALSE,
+      'cache_tags' => [],
+    ];
+
+    $grouped = $this->createMock(CheckoutGroupedSummaryBuilderInterface::class);
+    $grouped->method('build')->willReturn($built);
+
+    $readiness = new MelReadinessHelper($this->getStringTranslationStub());
+    $templates = new GovernedOperationalTemplates($readiness);
+
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates);
+    $render = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'complete']);
+
+    $this->assertTrue($render['has_grouped_line_items']);
+    $this->assertSame('mel_checkout_order_summary_grouped', $render['#theme']);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/GroupedSummaryPane.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/src/Plugin/Commerce/CheckoutPane/GroupedSummaryPane.php
@@ -39,9 +39,12 @@ final class GroupedSummaryPane extends CheckoutPaneBase {
         $pane_form['summary'] = $rendered;
       }
       else {
-        // Return empty array to hide the pane when view is empty.
-        return [];
+        // Sidebar panes do not get Commerce's main-pane empty #access handling.
+        $pane_form['#access'] = FALSE;
       }
+    }
+    else {
+      $pane_form['#access'] = FALSE;
     }
     return $pane_form;
   }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -165,6 +165,7 @@ function myeventlane_theme_theme(array $existing, string $type, string $theme, s
         'labels' => [],
         'trust' => [],
         'has_pricing_block' => TRUE,
+        'has_grouped_line_items' => FALSE,
         'surface' => 'checkout',
         'show_jump_to_payment' => TRUE,
       ],
@@ -646,7 +647,9 @@ function myeventlane_theme_preprocess_commerce_checkout_order_summary(array &$va
   }
   /** @var \Drupal\myeventlane_checkout_flow\Service\MelCheckoutSummaryPresenter $presenter */
   $presenter = \Drupal::service('myeventlane_checkout_flow.checkout_summary_presenter');
-  $variables['mel_checkout_order_summary_build'] = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'checkout']);
+  $step = \Drupal::routeMatch()->getParameter('step');
+  $surface = $step === 'complete' ? 'complete' : 'checkout';
+  $variables['mel_checkout_order_summary_build'] = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => $surface]);
   $variables['order_entity'] = $order;
   _myeventlane_theme_attach_mel_operational_checkout($variables);
 }

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-order-summary.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-order-summary.html.twig
@@ -6,6 +6,7 @@
  * @see myeventlane_theme_preprocess_commerce_checkout_order_summary()
  */
 #}
+{% if mel_checkout_order_summary_build is not empty %}
 <div{{ attributes.addClass('checkout-order-summary', 'mel-checkout-order-summary', 'mel-checkout-order-summary--presented') }}>
   {{ mel_checkout_order_summary_build }}
   {% if mel_operational_checkout %}
@@ -14,3 +15,4 @@
     </div>
   {% endif %}
 </div>
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
@@ -7,10 +7,13 @@
 {% set labels = labels|default({}) %}
 {% set trust = trust|default({}) %}
 {% set surface = surface|default('checkout') %}
-{% if grouped_items is not empty or subtotal_formatted or optional_donation_formatted|default('') or tax_rows is not empty or fee_rows is not empty or platform_fee_absorbed %}
+{% set has_grouped_line_items = has_grouped_line_items|default(false) %}
+{% set show_grouped_summary = has_grouped_line_items or has_pricing_block|default(false) %}
+{% if show_grouped_summary %}
 <div class="mel-checkout-order-summary mel-summary-grouped mel-summary-grouped--{{ surface|e('html_attr') }}" role="region" aria-label="{{ labels.summary_region }}">
   <h2 class="visually-hidden">{{ labels.core_heading_visually_hidden }}</h2>
 
+  {% if has_grouped_line_items %}
   {% for event in grouped_items %}
     <article class="mel-summary-event mel-summary-event--card">
       {% if event.thumbnail_url|default('') %}
@@ -47,7 +50,9 @@
       </div>
     </article>
   {% endfor %}
+  {% endif %}
 
+  {% if has_pricing_block|default(false) %}
   <div class="mel-summary-breakdown" role="group" aria-label="{{ labels.pricing_breakdown_region }}">
     {% if subtotal_formatted %}
       <div class="mel-summary-row mel-summary-row--subtotal">
@@ -89,6 +94,7 @@
     <span class="mel-summary-total__label">{{ labels.total_label }}</span>
     <strong class="mel-summary-total__value">{{ order_total }}</strong>
   </div>
+  {% endif %}
 
   {% if show_includes_gst_note %}
     <p class="mel-tax-note">{{ labels.gst_note }}</p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to checkout summary/sidebar rendering and `#access` handling, with no payment, pricing calculation, or data writes affected.
> 
> **Overview**
> Prevents empty “shell” sidebar panes from rendering on the checkout *complete* step by explicitly setting `#access` based on visible children and forcibly hiding specific panes (e.g. `grouped_order_summary`, `mel_fee_transparency`).
> 
> Tightens grouped order summary presentation by introducing a `has_grouped_line_items` flag (distinct from pricing-only rows), updating Twig to only render event line items and/or the pricing breakdown when relevant, and adding unit coverage for the new behavior. Additionally, the grouped summary checkout pane now hides itself via `#access = FALSE` when its backing View is unavailable or empty, and the theme preprocess passes the correct `surface` (`checkout` vs `complete`) to the presenter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561f1baa06a89330db251b367f17f715be990429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->