### PR TITLE
fix(bugbot): map demo seed validation errors to correct form fields

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -647,6 +647,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       return $row;
     }
     if ($submittedTitle === '') {
+      $row['title'] = '';
       return $row;
     }
     $row['title'] = $submittedTitle;

--- a/web/modules/custom/myeventlane_seed/src/Form/DemoContentSettingsForm.php
+++ b/web/modules/custom/myeventlane_seed/src/Form/DemoContentSettingsForm.php
@@ -410,7 +410,8 @@ final class DemoContentSettingsForm extends ConfigFormBase {
       $this->demoEventSeeder->validateSettings($values);
     }
     catch (\InvalidArgumentException $e) {
-      $form_state->setErrorByName('general][event_count', $e->getMessage());
+      $element = $this->validationErrorElementForSettingsException($e);
+      $form_state->setErrorByName($element, $e->getMessage());
     }
 
     $parents = $form_state->getTriggeringElement()['#parents'] ?? [];
@@ -556,6 +557,52 @@ final class DemoContentSettingsForm extends ConfigFormBase {
       'require_confirm_text' => $bool($s('require_confirm_text')),
       'confirm_text_value' => trim((string) $s('confirm_text_value')),
     ];
+  }
+
+  /**
+   * Maps seeder validation messages to the matching form element name.
+   */
+  private function validationErrorElementForSettingsException(\InvalidArgumentException $exception): string {
+    $message = $exception->getMessage();
+
+    if (str_starts_with($message, 'event_count must')) {
+      return 'general][event_count';
+    }
+    if (str_starts_with($message, 'future_date_start_days must')) {
+      return 'general][future_date_start_days';
+    }
+    if (str_starts_with($message, 'future_date_spacing_days must')) {
+      return 'general][future_date_spacing_days';
+    }
+    if (str_starts_with($message, 'owner_username')) {
+      return 'general][owner_username';
+    }
+    if (str_contains($message, 'generate_rsvp_events or generate_paid_events')) {
+      return 'mix][generate_rsvp_events';
+    }
+    if (str_contains($message, 'rsvp_event_count + paid_event_count')) {
+      return 'mix][rsvp_event_count';
+    }
+    if (str_starts_with($message, 'rsvp_event_count must')) {
+      return 'mix][rsvp_event_count';
+    }
+    if (str_starts_with($message, 'paid_event_count must')) {
+      return 'mix][paid_event_count';
+    }
+    if (str_starts_with($message, 'populate_ticket_types requires')) {
+      return 'population][populate_ticket_types';
+    }
+    if (str_starts_with($message, 'populate_rsvp_settings requires')) {
+      return 'population][populate_rsvp_settings';
+    }
+    if (preg_match('/Required setting "(populate_[^"]+)"/', $message, $matches) === 1) {
+      return 'population][' . $matches[1];
+    }
+    if (str_starts_with($message, 'min_ticket_price cannot')) {
+      return 'tickets][min_ticket_price';
+    }
+
+    return '';
   }
 
   /**


### PR DESCRIPTION
Route DemoEventSeeder validateSettings() failures to the matching general, mix, population, or tickets element instead of always highlighting event_count. Normalize whitespace-only ticket titles to an empty string before lifecycle validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to form validation/error highlighting and input normalization, with no changes to data models or persistence logic.
> 
> **Overview**
> Fixes demo seed settings validation UX by routing `DemoEventSeeder::validateSettings()` exceptions to the specific offending form element (general/mix/population/tickets) instead of always flagging `event_count`.
> 
> Adjusts Event Studio ticket row normalization so whitespace-only existing ticket titles are treated as an explicit empty string before lifecycle validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de59d68b327f776d5e44e6c5c72b5fc62f2c7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->