### PR TITLE
Fix/bugbot pr review issues

### DIFF
--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -144,12 +144,22 @@ services:
       - '@myeventlane_commerce.ticket_booking_session'
       - '@myeventlane_commerce.ticket_tier_waitlist'
       - '@current_user'
+      - '@string_translation'
       - '@myeventlane_commerce.ticket_access_code'
       - '@myeventlane_commerce.ticket_group_eligibility'
       - '@myeventlane_commerce.ticket_capacity'
       - '@cache.data'
       - '@current_route_match'
       - '@request_stack'
+
+  myeventlane_commerce.customer_ticket_tier_display:
+    class: Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder
+    arguments:
+      - '@myeventlane_commerce.ticket_availability'
+      - '@myeventlane_event.ticket_tier_lifecycle'
+      - '@commerce_price.currency_formatter'
+      - '@myeventlane_commerce.ticket_tier_waitlist'
+      - '@string_translation'
 
   myeventlane_commerce.ticket_waitlist_order_subscriber:
     class: Drupal\myeventlane_commerce\EventSubscriber\TicketWaitlistOrderSubscriber

--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
 use Drupal\myeventlane_capacity\Service\CapacityOrderInspector;
 use Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface;
+use Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder;
 use Drupal\myeventlane_commerce\Service\TicketAccessCodeService;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\myeventlane_commerce\Service\TicketBookingSessionService;
@@ -63,6 +64,7 @@ final class TicketSelectionForm extends FormBase {
     protected CapacityOrderInspector $orderInspector,
     protected TicketTypeManager $ticketTypeManager,
     protected ?EventCapacityServiceInterface $capacityService = NULL,
+    protected ?CustomerTicketTierDisplayBuilder $customerTicketTierDisplay = NULL,
   ) {}
 
   /**
@@ -84,6 +86,9 @@ final class TicketSelectionForm extends FormBase {
       $container->get('myeventlane_event.ticket_type_manager'),
       $container->has('myeventlane_capacity.service')
         ? $container->get('myeventlane_capacity.service')
+        : NULL,
+      $container->has('myeventlane_commerce.customer_ticket_tier_display')
+        ? $container->get('myeventlane_commerce.customer_ticket_tier_display')
         : NULL,
     );
   }
@@ -858,6 +863,9 @@ final class TicketSelectionForm extends FormBase {
     ?TicketTypeInterface $tier,
     int $variationId,
   ): string {
+    if ($this->customerTicketTierDisplay instanceof CustomerTicketTierDisplayBuilder) {
+      return $this->customerTicketTierDisplay->buyerFacingAvailabilityMessage($event, $tier, $variationId);
+    }
     if (!$tier instanceof TicketTypeInterface) {
       return (string) $this->t('Available');
     }

--- a/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\mel_ticket\Entity\TicketType;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Read-only customer-visible ticket rows for display parity (book page, Studio).
+ */
+final class CustomerTicketTierDisplayBuilder {
+
+  use StringTranslationTrait;
+
+  /**
+   * @param \Drupal\myeventlane_commerce\Service\TicketAvailabilityService $ticketAvailability
+   *   Purchasability and buyer availability helpers.
+   * @param \Drupal\myeventlane_event\Service\TicketTierLifecycleService $ticketTierLifecycle
+   *   Ordered mel_ticket_type rows for an event.
+   * @param \Drupal\commerce_price\CurrencyFormatter $currencyFormatter
+   *   Formats variation prices for display.
+   * @param \Drupal\myeventlane_commerce\Service\TicketTierWaitlistService $tierWaitlist
+   *   Waitlist hold counts for availability copy.
+   */
+  public function __construct(
+    private readonly TicketCustomerDisplayGatewayInterface $ticketAvailability,
+    private readonly EventPaidTicketLoaderInterface $ticketTierLifecycle,
+    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly TicketTierWaitlistHoldCounterInterface $tierWaitlist,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds customer-visible rows and vendor-only exclusion diagnostics.
+   *
+   * @return array{
+   *   visible_rows: list<array{
+   *     name: string,
+   *     price: string,
+   *     availability: string,
+   *     description: string|null,
+   *     variation_id: int,
+   *     ticket_id: int|null,
+   *   }>,
+   *   excluded_rows: list<array{name: string, diagnostic: string}>,
+   *   cache_tags: list<string>,
+   * }
+   */
+  public function buildForEvent(NodeInterface $event): array {
+    $empty = [
+      'visible_rows' => [],
+      'excluded_rows' => [],
+      'cache_tags' => $this->baseCacheTags($event),
+    ];
+
+    if ($event->bundle() !== 'event' || $event->isNew() || $event->id() === NULL) {
+      return $empty;
+    }
+
+    if (!$event->hasField('field_product_target') || $event->get('field_product_target')->isEmpty()) {
+      return $empty;
+    }
+
+    $product = $event->get('field_product_target')->entity;
+    if (!$product instanceof ProductInterface) {
+      return $empty;
+    }
+
+    $cache_tags = $this->baseCacheTags($event, $product);
+    if (!$product->isPublished()) {
+      return [
+        'visible_rows' => [],
+        'excluded_rows' => [[
+          'name' => (string) $this->t('Ticket product'),
+          'diagnostic' => (string) $this->t('Hidden from checkout: the linked ticket product is not published.'),
+        ]],
+        'cache_tags' => $cache_tags,
+      ];
+    }
+
+    $context = $this->ticketAvailability->buildDefaultCustomerAccessContext($event);
+    $purchasable = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context);
+    $purchasable_variation_ids = [];
+    foreach ($purchasable as $variation) {
+      $purchasable_variation_ids[(int) $variation->id()] = $variation;
+    }
+
+    $label_map = $this->buildVariationLabelMap($event);
+    $visible_rows = [];
+    foreach ($purchasable as $variation) {
+      $variation_id = (int) $variation->id();
+      $tier = $this->ticketAvailability->resolveTierForVariation($event, $variation);
+      $visible_rows[] = [
+        'name' => $this->resolveCustomerLabel($variation, $label_map),
+        'price' => $this->formatVariationPrice($variation),
+        'availability' => $this->buyerFacingAvailabilityMessage($event, $tier, $variation_id),
+        'description' => $this->resolveShortDescription($tier),
+        'variation_id' => $variation_id,
+        'ticket_id' => $tier instanceof TicketTypeInterface ? (int) $tier->id() : NULL,
+      ];
+      if ($tier instanceof TicketTypeInterface) {
+        $cache_tags = array_merge($cache_tags, $tier->getCacheTags());
+      }
+      $cache_tags[] = 'commerce_product_variation:' . (string) $variation_id;
+    }
+
+    $excluded_rows = [];
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
+      if ($ticket->getTicketKind() !== 'paid' || $ticket->isArchived()) {
+        continue;
+      }
+      $variation = $ticket->get('commerce_variation')->entity;
+      $variation_id = $variation instanceof ProductVariationInterface ? (int) $variation->id() : 0;
+      if ($variation_id > 0 && isset($purchasable_variation_ids[$variation_id])) {
+        continue;
+      }
+      $excluded_rows[] = [
+        'name' => $ticket->getTitle(),
+        'diagnostic' => $this->ticketAvailability->explainVendorPreviewExclusion(
+          $event,
+          $product,
+          $ticket,
+          $variation instanceof ProductVariationInterface ? $variation : NULL,
+          $context,
+        ),
+      ];
+      $cache_tags = array_merge($cache_tags, $ticket->getCacheTags());
+    }
+
+    return [
+      'visible_rows' => $visible_rows,
+      'excluded_rows' => $excluded_rows,
+      'cache_tags' => array_values(array_unique($cache_tags)),
+    ];
+  }
+
+  /**
+   * Buyer-facing availability line aligned with TicketSelectionForm.
+   */
+  public function buyerFacingAvailabilityMessage(
+    NodeInterface $event,
+    ?TicketTypeInterface $tier,
+    int $variationId,
+  ): string {
+    if (!$tier instanceof TicketTypeInterface) {
+      return (string) $this->t('Available');
+    }
+    if ($tier->get('capacity')->isEmpty()) {
+      return (string) $this->t('Available');
+    }
+    $cap = (int) $tier->get('capacity')->value;
+    if ($cap < 1) {
+      return (string) $this->t('Available');
+    }
+    $eid = (int) $event->id();
+    $sold = $this->ticketAvailability->countCompletedSoldForVariation($eid, $variationId);
+    $held = $this->tierWaitlist->sumActiveOfferReserved($eid, (int) $tier->id());
+    $pool = max(0, $cap - $sold - $held);
+    if ($pool < 1) {
+      return (string) $this->t('Limited availability');
+    }
+    if ($pool === 1) {
+      return (string) $this->t('Only 1 left');
+    }
+    if ($pool <= 10) {
+      return (string) $this->t('Only @count left', ['@count' => (string) $pool]);
+    }
+    return (string) $this->t('Available');
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  private function buildVariationLabelMap(NodeInterface $event): array {
+    $map = [];
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return $map;
+    }
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $ticket) {
+      if (!$ticket instanceof TicketTypeInterface || $ticket->isArchived()) {
+        continue;
+      }
+      if ($ticket instanceof TicketType && !$ticket->get('commerce_variation')->isEmpty()) {
+        $variation = $ticket->get('commerce_variation')->entity;
+        if ($variation instanceof ProductVariationInterface) {
+          $map[$variation->uuid()] = $ticket->label();
+        }
+      }
+    }
+    return $map;
+  }
+
+  /**
+   * @param array<string, string> $label_map
+   */
+  private function resolveCustomerLabel(
+    ProductVariationInterface $variation,
+    array $label_map,
+  ): string {
+    $label = $label_map[$variation->uuid()] ?? $variation->label();
+    if (strpos($label, ' – ') !== FALSE) {
+      $parts = explode(' – ', $label, 2);
+      $label = $parts[1] ?? $label;
+    }
+    return $label;
+  }
+
+  private function resolveShortDescription(?TicketTypeInterface $tier): ?string {
+    if (!$tier instanceof TicketTypeInterface) {
+      return NULL;
+    }
+    if (!$tier->hasField('short_description') || $tier->get('short_description')->isEmpty()) {
+      return NULL;
+    }
+    $text = trim((string) $tier->get('short_description')->value);
+    return $text !== '' ? $text : NULL;
+  }
+
+  private function formatVariationPrice(ProductVariationInterface $variation): string {
+    $price = $variation->getPrice();
+    if (!$price instanceof Price) {
+      return (string) $this->t('Free');
+    }
+    if ($price->isZero()) {
+      return (string) $this->t('Free');
+    }
+    return $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode());
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function baseCacheTags(NodeInterface $event, ?ProductInterface $product = NULL): array {
+    $tags = $event->getCacheTags();
+    if ($product instanceof ProductInterface) {
+      $tags = array_merge($tags, $product->getCacheTags());
+      foreach ($product->getVariations() as $variation) {
+        $tags[] = 'commerce_product_variation:' . (string) $variation->id();
+      }
+    }
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
+      $tags = array_merge($tags, $ticket->getCacheTags());
+    }
+    return array_values(array_unique($tags));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
@@ -12,6 +12,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\mel_ticket\Entity\TicketWaitlistEntry;
 use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
@@ -23,7 +25,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * Enforces mel_ticket_type rules, event capacity, and Commerce alignment at purchase.
  */
-final class TicketAvailabilityService implements TicketTierForVariationResolverInterface {
+final class TicketAvailabilityService implements TicketCustomerDisplayGatewayInterface {
+
+  use StringTranslationTrait;
 
   private const PURCHASABLE_CACHE_MAX_AGE = 90;
 
@@ -37,13 +41,16 @@ final class TicketAvailabilityService implements TicketTierForVariationResolverI
     private readonly TicketBookingSessionService $bookingSession,
     private readonly TicketTierWaitlistService $tierWaitlist,
     private readonly AccountProxyInterface $currentUser,
+    TranslationInterface $string_translation,
     private readonly ?TicketAccessCodeService $accessCodeService = NULL,
     private readonly ?TicketGroupEligibilityService $groupEligibility = NULL,
     private readonly ?TicketCapacityService $capacity = NULL,
     private readonly ?CacheBackendInterface $cache = NULL,
     private readonly ?RouteMatchInterface $routeMatch = NULL,
     private readonly ?RequestStack $requestStack = NULL,
-  ) {}
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
 
   public function buildPublicAccessContext(NodeInterface $event): TicketAccessContext {
     $eid = (int) $event->id();
@@ -54,6 +61,20 @@ final class TicketAvailabilityService implements TicketTierForVariationResolverI
       grantedTierIds: $this->resolveGrantedTierIds($event),
       waitlistClaimEntryId: $this->bookingSession->getWaitlistClaimEntryId($eid),
       groupEligible: $this->resolveGroupEligible($account, $event),
+      routeSource: 'public_booking',
+    );
+  }
+
+  /**
+   * Anonymous default-customer context for vendor Studio preview (no grants).
+   */
+  public function buildDefaultCustomerAccessContext(NodeInterface $event): TicketAccessContext {
+    return new TicketAccessContext(
+      eventId: (int) $event->id(),
+      account: NULL,
+      grantedTierIds: [],
+      waitlistClaimEntryId: NULL,
+      groupEligible: FALSE,
       routeSource: 'public_booking',
     );
   }
@@ -128,21 +149,25 @@ final class TicketAvailabilityService implements TicketTierForVariationResolverI
   public function filterPurchasableVariations(
     NodeInterface $event,
     ProductInterface $product,
+    ?TicketAccessContext $accessContext = NULL,
   ): array {
     $eid = (int) $event->id();
     $pid = (int) $product->id();
-    $uid = (int) $this->currentUser->id();
+    $context = $accessContext ?? $this->buildPublicAccessContext($event);
     $route = $this->cacheRouteName();
     $sessionId = $this->cacheSessionId();
-    $grants = $this->resolveGrantedTierIds($event);
+    $grants = $context->grantedTierIds;
     sort($grants, SORT_NUMERIC);
-    $waitlistClaimId = $this->bookingSession->getWaitlistClaimEntryId($eid) ?? 0;
+    $waitlistClaimId = $context->waitlistClaimEntryId ?? 0;
+    $account_uid = $context->account !== NULL ? (int) $context->account->id() : 0;
     $cid = 'mel_ticket:purchasable_variations:' . hash('sha256', implode(':', [
       (string) $eid,
       (string) $pid,
-      (string) $uid,
+      (string) $account_uid,
       $sessionId,
       $route,
+      $context->routeSource,
+      $context->groupEligible ? '1' : '0',
       implode(',', $grants),
       (string) $waitlistClaimId,
     ]));
@@ -164,7 +189,6 @@ final class TicketAvailabilityService implements TicketTierForVariationResolverI
       }
     }
 
-    $context = $this->buildPublicAccessContext($event);
     $capacityMaps = $this->buildCapacityMapsForProduct($event, $product);
 
     $out = [];
@@ -533,6 +557,80 @@ final class TicketAvailabilityService implements TicketTierForVariationResolverI
    */
   public function countCompletedSoldForVariation(int $eventId, int $variationId): int {
     return $this->variationSold->countCompletedSoldForVariation($eventId, $variationId);
+  }
+
+  /**
+   * Vendor-only reason a saved tier is not on the public book matrix.
+   */
+  public function explainVendorPreviewExclusion(
+    NodeInterface $event,
+    ProductInterface $product,
+    TicketTypeInterface $tier,
+    ?ProductVariationInterface $variation,
+    TicketAccessContext $context,
+  ): string {
+    if (!$tier->isPublished()) {
+      return (string) $this->t('Hidden from checkout: this ticket is not published.');
+    }
+
+    if ($variation === NULL || !$variation->isPublished()) {
+      return (string) $this->t('Hidden from checkout: linked product variation is missing or unpublished.');
+    }
+
+    $visibility = $this->tierAccess->visibilityReason($tier, $context->account, $context);
+    $visibility_copy = match ($visibility) {
+      TicketTierAccessService::REASON_HIDDEN => (string) $this->t('Hidden from checkout: ticket is not visible to this customer.'),
+      TicketTierAccessService::REASON_ACCESS_CODE_REQUIRED => (string) $this->t('Hidden from checkout: ticket requires an access code for this customer.'),
+      TicketTierAccessService::REASON_GROUP_ONLY => (string) $this->t('Hidden from checkout: ticket is not visible to this customer.'),
+      default => NULL,
+    };
+    if ($visibility_copy !== NULL) {
+      return $visibility_copy;
+    }
+
+    $status = TicketStatusEvaluator::evaluate($tier, $this->variationSold, $this->time, $event);
+    $status_copy = match ($status) {
+      TicketStatusEvaluator::STATUS_UPCOMING => (string) $this->t('Hidden from checkout: sale has not started.'),
+      TicketStatusEvaluator::STATUS_ENDED => (string) $this->t('Hidden from checkout: sale has ended.'),
+      TicketStatusEvaluator::STATUS_INACTIVE => (string) $this->t('Hidden from checkout: this ticket is not on sale.'),
+      TicketStatusEvaluator::STATUS_ARCHIVED => (string) $this->t('Hidden from checkout: this ticket is archived.'),
+      TicketStatusEvaluator::STATUS_SOLD_OUT => (string) $this->t('Hidden from checkout: sold out.'),
+      default => NULL,
+    };
+    if ($status_copy !== NULL) {
+      return $status_copy;
+    }
+
+    try {
+      $this->assertPaidVariationLineConstraints($event, $product, $variation, 1, $context);
+      return (string) $this->t('Hidden from checkout: ticket is not available on the book page.');
+    }
+    catch (CapacityExceededException $exception) {
+      return $this->mapPurchasabilityExceptionToVendorDiagnostic($exception->getMessage());
+    }
+  }
+
+  private function mapPurchasabilityExceptionToVendorDiagnostic(string $message): string {
+    $message = trim($message);
+    if ($message === '') {
+      return (string) $this->t('Hidden from checkout: ticket is not available on the book page.');
+    }
+    if (str_contains($message, 'not started')) {
+      return (string) $this->t('Hidden from checkout: sale has not started.');
+    }
+    if (str_contains($message, 'ended')) {
+      return (string) $this->t('Hidden from checkout: sale has ended.');
+    }
+    if (str_contains($message, 'sold out') || str_contains($message, 'remaining')) {
+      return (string) $this->t('Hidden from checkout: sold out.');
+    }
+    if (str_contains($message, 'not on sale') || str_contains($message, 'not available')) {
+      return (string) $this->t('Hidden from checkout: ticket is not visible to this customer.');
+    }
+    if (str_contains($message, 'price')) {
+      return (string) $this->t('Hidden from checkout: linked product variation price does not match this ticket.');
+    }
+    return (string) $this->t('Hidden from checkout: @reason', ['@reason' => $message]);
   }
 
   private function capacitySoldCount(int $eventId, int $variationId): int {

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketCustomerDisplayGatewayInterface.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketCustomerDisplayGatewayInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Read-only ticket purchasability surface for customer-facing display builders.
+ */
+interface TicketCustomerDisplayGatewayInterface extends TicketTierForVariationResolverInterface {
+
+  /**
+   * Anonymous default-customer context (no access-code grants).
+   */
+  public function buildDefaultCustomerAccessContext(NodeInterface $event): TicketAccessContext;
+
+  /**
+   * Variations that may appear on the public ticket selection form.
+   *
+   * @return \Drupal\commerce_product\Entity\ProductVariationInterface[]
+   */
+  public function filterPurchasableVariations(
+    NodeInterface $event,
+    ProductInterface $product,
+    ?TicketAccessContext $accessContext = NULL,
+  ): array;
+
+  /**
+   * Completed-order quantity for this variation and event.
+   */
+  public function countCompletedSoldForVariation(int $eventId, int $variationId): int;
+
+  /**
+   * Vendor-only reason a saved tier is not on the public book matrix.
+   */
+  public function explainVendorPreviewExclusion(
+    NodeInterface $event,
+    ProductInterface $product,
+    TicketTypeInterface $tier,
+    ?ProductVariationInterface $variation,
+    TicketAccessContext $context,
+  ): string;
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketTierWaitlistHoldCounterInterface.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketTierWaitlistHoldCounterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+/**
+ * Active waitlist offer holds against tier capacity pools.
+ */
+interface TicketTierWaitlistHoldCounterInterface {
+
+  /**
+   * Sum of reserved quantities from active waitlist offers for a tier.
+   */
+  public function sumActiveOfferReserved(int $eventId, int $tierId): int;
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketTierWaitlistService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketTierWaitlistService.php
@@ -21,7 +21,7 @@ use Drupal\user\UserInterface;
 /**
  * Tier waitlist queue, offers, and capacity holds for paid tickets.
  */
-final class TicketTierWaitlistService {
+final class TicketTierWaitlistService implements TicketTierWaitlistHoldCounterInterface {
 
   private const OFFER_TTL = 172800;
 

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/CustomerTicketTierDisplayBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/CustomerTicketTierDisplayBuilderTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Language\LanguageDefault;
+use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder;
+use Drupal\myeventlane_commerce\Service\TicketAccessContext;
+use Drupal\myeventlane_commerce\Service\TicketCustomerDisplayGatewayInterface;
+use Drupal\myeventlane_commerce\Service\TicketTierWaitlistHoldCounterInterface;
+use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
+
+  /**
+   * @covers ::buildForEvent
+   */
+  public function testPurchasableTierAppearsInVisibleRows(): void {
+    $event = $this->eventNode(42, TRUE);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('isPublished')->willReturn(TRUE);
+    $product->method('id')->willReturn('7');
+    $product->method('getCacheTags')->willReturn(['commerce_product:7']);
+    $product->method('getVariations')->willReturn([]);
+
+    $variation = $this->variation(11, '10.00', 'General admission');
+    $tier = $this->tier(5, 'General admission', TRUE, 'public', 50, TRUE, 11);
+
+    $availability = $this->availabilityMock();
+    $availability->method('buildDefaultCustomerAccessContext')->willReturn($this->customerContext(42));
+    $availability->method('filterPurchasableVariations')->willReturn([$variation]);
+    $availability->method('resolveTierForVariation')->willReturn($tier);
+    $availability->method('countCompletedSoldForVariation')->willReturn(0);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([$tier]);
+
+    $builder = $this->builder($availability, $lifecycle);
+    $result = $builder->buildForEvent($event);
+
+    $this->assertCount(1, $result['visible_rows']);
+    $this->assertSame('General admission', $result['visible_rows'][0]['name']);
+    $this->assertSame('$10.00', $result['visible_rows'][0]['price']);
+    $this->assertSame('Available', $result['visible_rows'][0]['availability']);
+    $this->assertSame([], $result['excluded_rows']);
+  }
+
+  /**
+   * @covers ::buildForEvent
+   */
+  public function testHiddenTierIsExcludedNotVisible(): void {
+    $event = $this->eventNode(42, TRUE);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('isPublished')->willReturn(TRUE);
+    $product->method('id')->willReturn('7');
+    $product->method('getCacheTags')->willReturn(['commerce_product:7']);
+    $product->method('getVariations')->willReturn([]);
+
+    $hidden_tier = $this->tier(8, 'Hidden VIP', TRUE, 'hidden', NULL);
+    $variation = $this->variation(12, '20.00', 'Hidden VIP');
+
+    $availability = $this->availabilityMock();
+    $availability->method('buildDefaultCustomerAccessContext')->willReturn($this->customerContext(42));
+    $availability->method('filterPurchasableVariations')->willReturn([]);
+    $availability->method('explainVendorPreviewExclusion')->willReturn(
+      'Hidden from checkout: ticket is not visible to this customer.'
+    );
+    $availability->method('resolveTierForVariation')->willReturn($hidden_tier);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([$hidden_tier]);
+
+    $builder = $this->builder($availability, $lifecycle);
+    $result = $builder->buildForEvent($event);
+
+    $this->assertSame([], $result['visible_rows']);
+    $this->assertCount(1, $result['excluded_rows']);
+    $this->assertStringContainsString('Hidden from checkout', $result['excluded_rows'][0]['diagnostic']);
+  }
+
+  /**
+   * @covers ::buildForEvent
+   */
+  public function testMissingVariationIsExcluded(): void {
+    $event = $this->eventNode(42, TRUE);
+    $tier = $this->tier(9, 'Broken tier', TRUE, 'public', NULL, FALSE);
+
+    $availability = $this->availabilityMock();
+    $availability->method('buildDefaultCustomerAccessContext')->willReturn($this->customerContext(42));
+    $availability->method('filterPurchasableVariations')->willReturn([]);
+    $availability->method('explainVendorPreviewExclusion')->willReturn(
+      'Hidden from checkout: linked product variation is missing or unpublished.'
+    );
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([$tier]);
+
+    $builder = $this->builder($availability, $lifecycle);
+    $result = $builder->buildForEvent($event);
+
+    $this->assertSame([], $result['visible_rows']);
+    $this->assertStringContainsString('variation', strtolower($result['excluded_rows'][0]['diagnostic']));
+  }
+
+  private function builder(
+    TicketCustomerDisplayGatewayInterface&MockObject $availability,
+    ?EventPaidTicketLoaderInterface $lifecycle = NULL,
+    ?TicketTierWaitlistHoldCounterInterface $waitlist = NULL,
+  ): CustomerTicketTierDisplayBuilder {
+    $lifecycle ??= $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([]);
+
+    $formatter = $this->createMock(CurrencyFormatter::class);
+    $formatter->method('format')->willReturnCallback(
+      static fn (string $number, string $currency) => '$' . $number
+    );
+
+    $waitlist ??= $this->createMock(TicketTierWaitlistHoldCounterInterface::class);
+    $waitlist->method('sumActiveOfferReserved')->willReturn(0);
+
+    return new CustomerTicketTierDisplayBuilder(
+      $availability,
+      $lifecycle,
+      $formatter,
+      $waitlist,
+      new TranslationManager(new LanguageDefault([])),
+    );
+  }
+
+  /**
+   * @return TicketCustomerDisplayGatewayInterface&MockObject
+   */
+  private function availabilityMock(): TicketCustomerDisplayGatewayInterface&MockObject {
+    return $this->createMock(TicketCustomerDisplayGatewayInterface::class);
+  }
+
+  private function customerContext(int $event_id): TicketAccessContext {
+    return new TicketAccessContext(
+      eventId: $event_id,
+      account: NULL,
+      grantedTierIds: [],
+      waitlistClaimEntryId: NULL,
+      groupEligible: FALSE,
+      routeSource: 'public_booking',
+    );
+  }
+
+  private function eventNode(int $nid, bool $with_product): NodeInterface&MockObject {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('isNew')->willReturn(FALSE);
+    $event->method('id')->willReturn((string) $nid);
+    $event->method('getCacheTags')->willReturn(['node:' . $nid]);
+
+    $product = NULL;
+    if ($with_product) {
+      $product = $this->createMock(ProductInterface::class);
+      $product->method('isPublished')->willReturn(TRUE);
+      $product->method('id')->willReturn('7');
+      $product->method('getCacheTags')->willReturn(['commerce_product:7']);
+      $product->method('getVariations')->willReturn([]);
+    }
+
+    $product_field = new EntityReferenceFieldStub($product);
+    $ticket_types_field = new EntityReferenceFieldStub(NULL, TRUE);
+    $empty_field = new EntityReferenceFieldStub(NULL, TRUE);
+
+    $event->method('hasField')->willReturnCallback(
+      static fn (string $name) => in_array($name, ['field_product_target', 'field_ticket_types'], TRUE)
+    );
+    $event->method('get')->willReturnCallback(
+      static function (string $name) use ($product_field, $ticket_types_field, $empty_field) {
+        return match ($name) {
+          'field_product_target' => $product_field,
+          'field_ticket_types' => $ticket_types_field,
+          default => $empty_field,
+        };
+      }
+    );
+
+    return $event;
+  }
+
+  private function variation(int $id, string $amount, string $label): ProductVariationInterface&MockObject {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('id')->willReturn((string) $id);
+    $variation->method('uuid')->willReturn('uuid-' . $id);
+    $variation->method('label')->willReturn($label);
+    $variation->method('getPrice')->willReturn(new Price($amount, 'AUD'));
+    return $variation;
+  }
+
+  /**
+   * @return TicketTypeInterface&MockObject
+   */
+  private function tier(
+    int $id,
+    string $title,
+    bool $published,
+    string $visibility,
+    ?int $capacity,
+    bool $with_variation = TRUE,
+    ?int $variation_id = NULL,
+  ): TicketTypeInterface&MockObject {
+    $tier = $this->createStub(TicketTypeInterface::class);
+    $tier->method('id')->willReturn((string) $id);
+    $tier->method('getTitle')->willReturn($title);
+    $tier->method('label')->willReturn($title);
+    $tier->method('getTicketKind')->willReturn('paid');
+    $tier->method('isArchived')->willReturn(FALSE);
+    $tier->method('getCacheTags')->willReturn(['mel_ticket_type:' . $id]);
+    $tier->method('hasField')->willReturnCallback(
+      static fn (string $name) => in_array($name, ['visibility_mode', 'capacity', 'short_description', 'commerce_variation'], TRUE)
+    );
+
+    $variation = $with_variation
+      ? $this->variation($variation_id ?? ($id + 100), '10.00', $title)
+      : NULL;
+    $empty_field = new ScalarFieldStub(NULL, TRUE);
+    $tier->method('get')->willReturnCallback(
+      static function (string $name) use ($visibility, $capacity, $variation, $empty_field) {
+        return match ($name) {
+          'visibility_mode' => new ScalarFieldStub($visibility),
+          'capacity' => new ScalarFieldStub($capacity === NULL ? NULL : (string) $capacity, $capacity === NULL),
+          'commerce_variation' => new EntityReferenceFieldStub($variation),
+          'short_description' => new ScalarFieldStub(NULL, TRUE),
+          default => $empty_field,
+        };
+      }
+    );
+
+    return $tier;
+  }
+
+}
+
+/**
+ * Minimal field list stub for entity reference fields in unit tests.
+ */
+final class EntityReferenceFieldStub {
+
+  public mixed $entity;
+
+  public mixed $target_id;
+
+  public function __construct(
+    mixed $entity,
+    private readonly bool $empty = FALSE,
+  ) {
+    $this->entity = $entity;
+    $this->target_id = is_object($entity) && method_exists($entity, 'id') ? $entity->id() : NULL;
+  }
+
+  public function isEmpty(): bool {
+    return $this->empty;
+  }
+
+}
+
+/**
+ * Minimal field list stub for scalar ticket fields in unit tests.
+ */
+final class ScalarFieldStub {
+
+  public mixed $value;
+
+  public function __construct(
+    mixed $value,
+    private readonly bool $empty = FALSE,
+  ) {
+    $this->value = $value;
+  }
+
+  public function isEmpty(): bool {
+    return $this->empty;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/myeventlane_core.install
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.install
@@ -835,3 +835,24 @@ function myeventlane_core_update_9118(): void {
   $module_schema = myeventlane_core_schema();
   $schema->createTable('myeventlane_public_analytics_event', $module_schema['myeventlane_public_analytics_event']);
 }
+
+/**
+ * Points main menu Support at the public Help Centre hub (not /my/support).
+ *
+ * /my/support remains on the account menu; a restricted main-menu link was
+ * hidden for anonymous users while Twig also rendered a hardcoded Support item.
+ */
+function myeventlane_core_update_9119(): void {
+  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+  $links = $storage->loadByProperties([
+    'menu_name' => 'main',
+    'title' => 'Support',
+  ]);
+  foreach ($links as $link) {
+    $uri = $link->get('link')->uri ?? '';
+    if ($uri === 'internal:/my/support' || str_ends_with((string) $uri, '/my/support')) {
+      $link->set('link', ['uri' => 'internal:/help']);
+      $link->save();
+    }
+  }
+}

--- a/web/modules/custom/myeventlane_event/src/Service/EventPaidTicketLoaderInterface.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventPaidTicketLoaderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Loads ordered ticket type entities attached to an event.
+ */
+interface EventPaidTicketLoaderInterface {
+
+  /**
+   * @return list<\Drupal\mel_ticket\Entity\TicketTypeInterface>
+   */
+  public function loadOrderedTicketsForEvent(NodeInterface $event): array;
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
  * Forms and controllers must not call mel_ticket_type storage->create() directly;
  * use this service so Commerce projection stays consistent.
  */
-final class TicketTierLifecycleService {
+final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface {
 
   public const CURRENCY_MISMATCH_MESSAGE = 'All tickets for an event must use the same currency.';
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
@@ -123,9 +123,48 @@
   white-space: nowrap;
 }
 
+.mel-event-ticket-preview__ticket-description,
 .mel-event-ticket-preview__ticket-availability {
   margin: 0.35rem 0 0;
   font-size: 0.8125rem;
+  color: var(--mel-ticket-preview-muted);
+}
+
+.mel-event-ticket-preview__excluded {
+  margin-block: 1rem 0;
+  padding: 0.85rem 0.9rem;
+  border-radius: 14px;
+  background: var(--mel-ticket-preview-surface);
+  border: 1px dashed var(--mel-ticket-preview-border);
+}
+
+.mel-event-ticket-preview__excluded-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--mel-ticket-preview-text);
+}
+
+.mel-event-ticket-preview__excluded-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mel-event-ticket-preview__excluded-row {
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.8125rem;
+}
+
+.mel-event-ticket-preview__excluded-name {
+  font-weight: 600;
+  color: var(--mel-ticket-preview-text);
+}
+
+.mel-event-ticket-preview__excluded-diagnostic {
   color: var(--mel-ticket-preview-muted);
 }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -173,6 +173,8 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'cta' => [],
         'availability' => [],
         'ticket_rows' => [],
+        'excluded_rows' => [],
+        'show_customer_ticket_empty' => FALSE,
         'rsvp_summary' => NULL,
         'trust_rows' => [],
         'show_empty_state' => TRUE,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -304,11 +304,9 @@ services:
     class: Drupal\myeventlane_event_studio\Service\EventTicketPreviewBuilder
     arguments:
       - '@myeventlane_event.booking_flow_resolver'
-      - '@myeventlane_event.ticket_tier_lifecycle'
       - '@myeventlane_event.event_mode_manager'
-      - '@commerce_price.currency_formatter'
+      - '@myeventlane_commerce.customer_ticket_tier_display'
       - '@string_translation'
-      - '@?myeventlane_commerce.ticket_capacity'
 
   myeventlane_event_studio.event_style_access:
     class: Drupal\myeventlane_event_studio\Service\EventStyleAccessManager

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -188,16 +188,16 @@ final class EventStudioSectionRenderer {
       'mode' => $this->formBuilder->getForm(EventStudioTicketsForm::class, $event),
     ];
 
+    $build['operational'] = $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event);
+    $build['operational']['#weight'] = 5;
+
     if ($this->eventTicketPreviewBuilder instanceof EventTicketPreviewBuilder) {
       $preview = $this->eventTicketPreviewBuilder->build($event);
       if ($preview !== []) {
         $build['ticket_preview'] = $preview;
-        $build['ticket_preview']['#weight'] = 5;
+        $build['ticket_preview']['#weight'] = 10;
       }
     }
-
-    $build['operational'] = $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event);
-    $build['operational']['#weight'] = 10;
 
     $event_type = $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()
       ? (string) $event->get('field_event_type')->value

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
-use Drupal\commerce_price\CurrencyFormatter;
-use Drupal\commerce_price\Price;
-use Drupal\mel_ticket\Entity\TicketTypeInterface;
-use Drupal\myeventlane_commerce\Service\TicketCapacityService;
+use Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_event\Service\EventModeManager;
-use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
@@ -34,11 +30,9 @@ final class EventTicketPreviewBuilder {
 
   public function __construct(
     private readonly BookingFlowResolver $bookingFlowResolver,
-    private readonly TicketTierLifecycleService $ticketTierLifecycle,
     private readonly EventModeManager $eventModeManager,
-    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly CustomerTicketTierDisplayBuilder $customerTicketTierDisplay,
     TranslationInterface $string_translation,
-    private readonly ?TicketCapacityService $ticketCapacity = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -57,6 +51,7 @@ final class EventTicketPreviewBuilder {
     $previewState = $this->resolvePreviewState($event, $configuredMode);
     $cta = $this->resolveCtaPreview($event, $previewState);
     $availability = $this->resolveAvailabilityPreview($event, $previewState);
+    $tierDisplay = $this->buildPaidTierDisplay($event, $previewState);
 
     $build = [
       '#theme' => 'mel_event_ticket_preview',
@@ -65,7 +60,9 @@ final class EventTicketPreviewBuilder {
       '#heading' => $this->previewHeading($previewState),
       '#cta' => $cta,
       '#availability' => $availability,
-      '#ticket_rows' => $this->buildTicketRows($event, $previewState),
+      '#ticket_rows' => $tierDisplay['visible_rows'],
+      '#excluded_rows' => $tierDisplay['excluded_rows'],
+      '#show_customer_ticket_empty' => $tierDisplay['show_customer_ticket_empty'],
       '#rsvp_summary' => $this->buildRsvpSummary($event, $previewState),
       '#trust_rows' => $this->buildTrustRows($previewState),
       '#show_empty_state' => $previewState === self::PREVIEW_NOT_CONFIGURED,
@@ -81,12 +78,12 @@ final class EventTicketPreviewBuilder {
               self::PREVIEW_EXTERNAL => (string) $this->t('External'),
               self::PREVIEW_BOTH => (string) $this->t('RSVP + Paid'),
             ],
-            'saveReminder' => (string) $this->t('Save to refresh ticket rows.'),
+            'saveReminder' => (string) $this->t('Save tickets above to refresh this preview.'),
           ],
         ],
       ],
       '#cache' => [
-        'tags' => $this->buildCacheTags($event),
+        'tags' => $tierDisplay['cache_tags'],
         'contexts' => ['user.permissions'],
       ],
     ];
@@ -95,20 +92,42 @@ final class EventTicketPreviewBuilder {
   }
 
   /**
-   * @return list<string>
+   * @return array{
+   *   visible_rows: list<array<string, mixed>>,
+   *   excluded_rows: list<array{name: string, diagnostic: string}>,
+   *   show_customer_ticket_empty: bool,
+   *   cache_tags: list<string>,
+   * }
    */
-  private function buildCacheTags(NodeInterface $event): array {
-    $tags = $event->getCacheTags();
-    if ($event->hasField('field_product_target') && !$event->get('field_product_target')->isEmpty()) {
-      $product = $event->get('field_product_target')->entity;
-      if ($product !== NULL) {
-        $tags = array_merge($tags, $product->getCacheTags());
-      }
+  private function buildPaidTierDisplay(NodeInterface $event, string $previewState): array {
+    $base = [
+      'visible_rows' => [],
+      'excluded_rows' => [],
+      'show_customer_ticket_empty' => FALSE,
+      'cache_tags' => $event->getCacheTags(),
+    ];
+
+    if (!in_array($previewState, [self::PREVIEW_PAID, self::PREVIEW_BOTH], TRUE)) {
+      return $base;
     }
-    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
-      $tags = array_merge($tags, $ticket->getCacheTags());
+
+    $display = $this->customerTicketTierDisplay->buildForEvent($event);
+    $visible_rows = [];
+    foreach ($display['visible_rows'] as $row) {
+      $visible_rows[] = [
+        'name' => $row['name'],
+        'price' => $row['price'],
+        'availability' => $row['availability'],
+        'description' => $row['description'],
+      ];
     }
-    return array_values(array_unique($tags));
+
+    return [
+      'visible_rows' => $visible_rows,
+      'excluded_rows' => $display['excluded_rows'],
+      'show_customer_ticket_empty' => $visible_rows === [] && $display['excluded_rows'] === [],
+      'cache_tags' => $display['cache_tags'],
+    ];
   }
 
   private function resolveConfiguredMode(NodeInterface $event): string {
@@ -226,30 +245,6 @@ final class EventTicketPreviewBuilder {
   }
 
   /**
-   * @return list<array{name: string, price: string, availability: string}>
-   */
-  private function buildTicketRows(NodeInterface $event, string $previewState): array {
-    if (!in_array($previewState, [self::PREVIEW_PAID, self::PREVIEW_BOTH], TRUE)) {
-      return [];
-    }
-
-    $rows = [];
-    $eventId = (int) $event->id();
-    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $ticket) {
-      if ($ticket->getTicketKind() !== 'paid' || !$ticket->isPublished()) {
-        continue;
-      }
-      $rows[] = [
-        'name' => $ticket->getTitle(),
-        'price' => $this->formatTicketPrice($ticket),
-        'availability' => $this->formatTierAvailability($event, $eventId, $ticket),
-      ];
-    }
-
-    return $rows;
-  }
-
-  /**
    * @return array{capacity_line: string|null}|null
    */
   private function buildRsvpSummary(NodeInterface $event, string $previewState): ?array {
@@ -298,56 +293,6 @@ final class EventTicketPreviewBuilder {
       ],
       default => [$confirmation],
     };
-  }
-
-  private function formatTicketPrice(TicketTypeInterface $ticket): string {
-    $price = $ticket->toPriceValue();
-    if (!$price instanceof Price) {
-      return (string) $this->t('Free');
-    }
-    if ($price->isZero()) {
-      return (string) $this->t('Free');
-    }
-    return $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode());
-  }
-
-  private function formatTierAvailability(
-    NodeInterface $event,
-    int $eventId,
-    TicketTypeInterface $ticket,
-  ): string {
-    if ($ticket->get('capacity')->isEmpty()) {
-      return (string) $this->t('Available');
-    }
-
-    $cap = (int) $ticket->get('capacity')->value;
-    if ($cap < 1) {
-      return (string) $this->t('Available');
-    }
-
-    if (!$this->ticketCapacity instanceof TicketCapacityService) {
-      return (string) $this->t('Available');
-    }
-
-    $variationId = $ticket->get('commerce_variation')->isEmpty()
-      ? 0
-      : (int) $ticket->get('commerce_variation')->target_id;
-    if ($variationId < 1) {
-      return (string) $this->t('Available');
-    }
-
-    $pool = $this->ticketCapacity->getRemaining($eventId, (int) $ticket->id(), $variationId, $ticket);
-    if ($pool < 1) {
-      return (string) $this->t('Sold out');
-    }
-    if ($pool === 1) {
-      return (string) $this->t('Only 1 left');
-    }
-    if ($pool <= 10) {
-      return (string) $this->t('Only @count left', ['@count' => (string) $pool]);
-    }
-
-    return (string) $this->t('Available');
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
@@ -9,7 +9,9 @@
  * - heading: section heading inside canvas
  * - cta: { label, disabled, reason }
  * - availability: { state, message }
- * - ticket_rows: list of { name, price, availability }
+ * - ticket_rows: list of { name, price, availability, description? }
+ * - excluded_rows: list of { name, diagnostic }
+ * - show_customer_ticket_empty: bool
  * - rsvp_summary: { capacity_line }|null
  * - trust_rows: list of trust strings
  * - show_empty_state: bool
@@ -31,12 +33,12 @@
       {{ 'This is a preview of what customers will see when they book.'|t }}
     </p>
     <ul class="mel-event-ticket-preview__helpers">
-      <li>{{ 'Ticket rows and RSVP limits update here after saving.'|t }}</li>
+      <li>{{ 'Rows match checkout-visible tickets on the public book page (default customer, no access code).'|t }}</li>
       <li>{{ 'The public booking button uses the same booking resolver as the event page.'|t }}</li>
       <li>{{ 'Customers will not see this setup panel.'|t }}</li>
     </ul>
     <p class="mel-event-ticket-preview__save-note" data-mel-ticket-preview-save-note>
-      {{ 'Save to refresh ticket rows.'|t }}
+      {{ 'Save tickets above to refresh this preview.'|t }}
     </p>
   </header>
 
@@ -66,23 +68,40 @@
 
       {% if preview_state in ['paid', 'both'] %}
         {% if ticket_rows is not empty %}
-          <ul class="mel-event-ticket-preview__ticket-rows" aria-label="{{ 'Ticket options'|t }}">
+          <ul class="mel-event-ticket-preview__ticket-rows" aria-label="{{ 'Ticket options customers can book'|t }}">
             {% for row in ticket_rows %}
               <li class="mel-event-ticket-preview__ticket-row">
                 <div class="mel-event-ticket-preview__ticket-main">
                   <span class="mel-event-ticket-preview__ticket-name">{{ row.name }}</span>
                   <span class="mel-event-ticket-preview__ticket-price">{{ row.price }}</span>
                 </div>
+                {% if row.description %}
+                  <p class="mel-event-ticket-preview__ticket-description mel-text--muted">{{ row.description }}</p>
+                {% endif %}
                 {% if row.availability %}
                   <p class="mel-event-ticket-preview__ticket-availability">{{ row.availability }}</p>
                 {% endif %}
               </li>
             {% endfor %}
           </ul>
-        {% else %}
+        {% elseif show_customer_ticket_empty %}
           <p class="mel-event-ticket-preview__ticket-empty mel-text--muted">
-            {{ 'Paid ticket rows appear here after you save tickets below.'|t }}
+            {{ 'No checkout-visible tickets yet. Save paid tickets above, then check again.'|t }}
           </p>
+        {% endif %}
+
+        {% if excluded_rows is not empty %}
+          <div class="mel-event-ticket-preview__excluded" role="note" aria-label="{{ 'Tickets hidden from checkout'|t }}">
+            <p class="mel-event-ticket-preview__excluded-title">{{ 'Not shown on the public book page'|t }}</p>
+            <ul class="mel-event-ticket-preview__excluded-rows">
+              {% for row in excluded_rows %}
+                <li class="mel-event-ticket-preview__excluded-row">
+                  <span class="mel-event-ticket-preview__excluded-name">{{ row.name }}</span>
+                  <span class="mel-event-ticket-preview__excluded-diagnostic">{{ row.diagnostic }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
         {% endif %}
       {% endif %}
 

--- a/web/themes/custom/myeventlane_theme/templates/menu--main.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/menu--main.html.twig
@@ -70,20 +70,6 @@
         {% endif %}
       </li>
     {% endfor %}
-    {% if menu_level == 0 %}
-      <li class="mel-nav__item mel-nav-dropdown">
-        <button class="mel-nav__link mel-nav-dropdown-toggle" aria-expanded="false" aria-haspopup="true">
-          {{ 'Support'|t }}
-          <svg class="mel-dropdown-arrow" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </button>
-        <ul class="mel-nav-dropdown-menu">
-          <li><a href="/support" class="mel-nav-dropdown-link">{{ 'Contact Support'|t }}</a></li>
-          <li><a href="/help" class="mel-nav-dropdown-link">{{ 'Help Centre'|t }}</a></li>
-        </ul>
-      </li>
-    {% endif %}
     </ul>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ticket availability filtering/caching inputs and introduces new vendor-only exclusion diagnostics, which could affect which ticket variations are shown in checkout/preview. Also adds a database update that modifies main menu links, so deployment/updb ordering matters.
> 
> **Overview**
> Adds a new `CustomerTicketTierDisplayBuilder` service to produce **customer-visible paid ticket rows** (name/price/availability/short description) and **vendor-only diagnostics** for tiers excluded from checkout, reusing purchasability logic and adding cache tags.
> 
> Refactors `TicketAvailabilityService` to expose a read-only display gateway (`TicketCustomerDisplayGatewayInterface`), support a default anonymous access context for Studio previews, and allow `filterPurchasableVariations()` to accept an explicit `TicketAccessContext` (with cache keys updated to include context details). `TicketSelectionForm` can now delegate availability copy to the new builder when present.
> 
> Updates Event Studio’s ticket preview to use the new builder, display descriptions, and show a “Not shown on the public book page” list with exclusion reasons; includes new CSS and Twig variables. Separately removes a hardcoded Support dropdown from the main menu template and adds `myeventlane_core_update_9119()` to repoint the `main` menu’s `Support` link from `/my/support` to `/help`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddeb62345742c07a938d810ea2407a639818424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->