### PR TITLE
Fix/bugbot pr review issues

### DIFF
--- a/docs/content-audit/help-retrieval-and-access-audit.md
+++ b/docs/content-audit/help-retrieval-and-access-audit.md
@@ -1,0 +1,151 @@
+# Help retrieval and access audit
+
+**Audit date:** 2026-05-22
+
+## Help Assistant retrieval pipeline
+
+```mermaid
+flowchart TD
+  Q[User question] --> HA[HelpAssistantService::answerQuestion]
+  HA --> HR[HelpRetriever::retrieve]
+  HR --> SAPI[Search API index mel_content]
+  SAPI --> FILT[PHP filters per result node]
+  FILT --> AI[Optional AiManager synthesis]
+  AI --> OUT[Answer + article links]
+```
+
+### Step 1: Search API query (`HelpRetriever::executeQuery`)
+
+**File:** `web/modules/custom/myeventlane_help_assistant/src/Service/HelpRetriever.php`
+
+| Constraint | Value |
+|------------|-------|
+| Index | `mel_content` |
+| Bundle | `type = help_article` only |
+| Published | `status = 1` |
+| Fulltext fields | `title`, `field_help_summary`, `body`, `field_help_keywords` |
+| Audience (index query) | OR group on `field_audience`: anonymous → `public` only; authenticated → `public` OR `vendor` |
+| Fetch cap | `max(24, limit * 6)` then trim to 3–5 results |
+| Sort | `search_api_relevance` DESC |
+
+**Explicitly excluded at query level:** `staff_playbook`, `support_procedure`, `event`, `page`, `blog_post` (not `help_article` type).
+
+### Step 2: Per-node safety (`isNodeRetrievableForAssistant`)
+
+Applied to each Search API hit after load:
+
+| Check | Rule |
+|-------|------|
+| Published | `isPublished()` |
+| Node access | `$node->access('view', $currentUser)` |
+| AI allow-list | `field_help_ai_allowed` must be TRUE |
+| Documentation status | If `field_help_status` set: must be `published` or `approved` |
+| Audience | `nodeAudienceAllowedForAssistant`: no `staff`; only `public`/`vendor`; must overlap allowed set for current user |
+
+Staff-tagged `help_article` nodes are **never** returned, even for staff users (by design in retriever).
+
+### Step 3: UnifiedHelpRetriever (defence in depth)
+
+**File:** `web/modules/custom/myeventlane_help_shared/src/Service/UnifiedHelpRetriever.php`
+
+- Switches active user via `AccountSwitcher` before calling `HelpRetriever`
+- Re-validates each row with same policy; logs `notice` on mismatch (`ai_not_allowed`, `staff_audience`, `status_invalid`, etc.)
+- Used when retrieval must be evaluated **as** a specific user (e.g. escalations context) — **Found but usage unclear** for all call sites; grep shows service registered in `myeventlane_help_shared.services.yml`
+
+### Step 4: HelpAssistantService
+
+**File:** `web/modules/custom/myeventlane_help_assistant/src/Service/HelpAssistantService.php`
+
+- If assistant disabled → fallback message + support URL
+- If zero results or low retrieval confidence → fallback with article links optional
+- If platform AI disabled → articles only, no synthesis
+- Otherwise grounded synthesis using retrieved excerpts only (guardrails in service — full prompt rules **Needs verification** in `myeventlane_ai` config)
+
+## Allowed content (Help Assistant)
+
+| Content | Allowed when |
+|---------|----------------|
+| `help_article` | Published, viewable, `field_help_ai_allowed = 1`, status `published` or `approved`, `field_audience` includes `public` (anon) or `public`/`vendor` (auth), not staff-only |
+| Grounded CTAs | From `field_help_cta_label` / `field_help_cta_link` on same nodes |
+
+## Disallowed content (Help Assistant)
+
+| Content | Reason |
+|---------|--------|
+| `staff_playbook` | Not in index; separate `hook_node_access` |
+| `support_procedure` | Not in index; internal bundle |
+| `help_article` with `field_audience: staff` | Hard exclude in retriever |
+| Draft / review / archived help | `field_help_status` filter |
+| `help_article` with AI not allowed | `field_help_ai_allowed` |
+| Unpublished or access-denied nodes | status + `node_access` |
+| Events, blog posts, pages | Wrong bundle in query |
+
+## Staff content protection
+
+| Mechanism | Location |
+|-----------|----------|
+| `staff_playbook` node access | `myeventlane_staff_playbooks_node_access` — forbidden without staff permissions |
+| Staff audience on `help_article` | `hook_node_access` requires `administer escalations` for view |
+| Help Assistant audience filter | Never returns `staff` audience values |
+| Playbooks on escalation | Only rendered if `view staff playbooks`; vendor/customer never see panel |
+| Staff snippet guide | Route `administer escalations` only |
+
+**staff_playbook is not in `mel_content` index** — confirmed `config/sync/search_api.index.mel_content.yml` bundle list.
+
+## Search API involvement
+
+- **Indexing:** Help articles indexed with `content_access` processor → node grants in index
+- **Query:** Help Assistant adds bundle + status + audience conditions; grants applied at query via processor
+- **Gap:** `field_help_ai_allowed` and `field_help_status` are **not** indexed filters — all Assistant policy enforcement is post-query in PHP (correct for safety, possible performance cost at scale)
+
+## Node access involvement
+
+- Standard Drupal node grants + `content_access` Search API processor
+- Additional `hook_node_access` for `help_article`/`faq` audience rules
+- Vendor-only articles: anonymous users forbidden at node level when audience is vendor-only (no public)
+
+## Public / vendor Help Centre listings (Views)
+
+Views use SQL (`node_field_data`), not Search API:
+
+| View | Audience filter | AI/status filter |
+|------|-----------------|------------------|
+| `mel_help_attendee_help` | `public` | None |
+| `mel_help_organiser_help` | `public` | None |
+| `mel_help_vendor_help` | `vendor` | None |
+| `mel_help_search` | **Enforced** via `HelpArticleBrowsePolicy` + `hook_views_query_alter` (audience `IN` + status `IN`; optional exposed `?audience=` intersected with account allowances) | `published` / `approved` for normal users |
+| `mel_help_featured_articles` | None (featured flag only) | None |
+
+**2026-05-22 update:** Help Search (`/help/search`, view `mel_help_search`) no longer relies on node access after rendering result metadata. Audience and `field_help_status` are applied at SQL query time in `myeventlane_help_centre_views_query_alter()`. Help Assistant path unchanged (`HelpRetriever`).
+
+**Mismatch:** A non-AI-allowed article could still appear in browse/search UI if published and viewable, but **not** in Help Assistant. Draft/review articles are now excluded from search for normal users. Editorial workflow should align status + AI flag before publish.
+
+## Retriever vs Views vs node access — mismatch matrix
+
+| Scenario | Browse /help | Help Assistant |
+|----------|--------------|----------------|
+| Published, AI allowed, approved, public | Yes | Yes |
+| Published, AI **not** allowed | Yes | No |
+| Status `review` | No (if unpublished) or Yes if published — **Needs verification** per workflow | No |
+| Staff audience help_article | No (except staff with permission) | No |
+| Vendor-only, anonymous user | No (query policy + node access) | No |
+| Vendor-only, logged-in attendee without vendor console | No (search policy: public only) | Yes if AI allowed |
+| Vendor-only, vendor console user | Yes (search + node access) | Yes if AI allowed |
+| `staff_playbook` | No | No |
+
+## Items needing verification
+
+1. Live count of `help_article` nodes with `field_help_ai_allowed = 0` still published.
+2. Whether any `help_article` uses `staff` audience for internal docs shown only to escalations admins — Assistant excludes them; confirm staff browse path is intentional.
+3. `support_procedure` nodes: reachable via any public URL or only admin?
+4. Whether `/help/ask` and POST `/help/assistant` share identical retrieval path (both should use `HelpAssistantService` — **Needs verification** in `HelpCentreAiController`).
+5. Reindex schedule after bulk content imports (`myeventlane_docs_importer`).
+6. Anonymous users have `access myeventlane help assistant` — confirm product intent for public AI usage.
+
+## Code references
+
+- `HelpRetriever.php` — lines 62–180 (query + filters)
+- `UnifiedHelpRetriever.php` — `validateNode`, `nodeAudienceAllowed`
+- `myeventlane_help_centre.module` — `myeventlane_help_centre_node_access` (~line 437)
+- `myeventlane_staff_playbooks.module` — `hook_node_access`
+- `search_api.index.mel_content.yml` — bundle whitelist

--- a/docs/content-audit/staging-help-content-inventory.md
+++ b/docs/content-audit/staging-help-content-inventory.md
@@ -1,0 +1,632 @@
+# Staging Help Content Inventory
+
+## Scope
+
+- **Environment:** Local DDEV site (same codebase as repo; database reflects current local/staging import — **Needs verification** if production differs).
+- **Date:** 2026-05-22
+- **Mode:** Read-only. No content, code, config, Search API reindex, or commits were changed.
+- **Reference docs:** `docs/content-audit/current-help-setup.md`, `help-retrieval-and-access-audit.md`, and related audit files.
+
+---
+
+## Commands Run
+
+| Command | Result |
+|---------|--------|
+| `git status --short` | Untracked `docs/content-audit/`; unrelated `package.json` change |
+| `ddev drush cr` | Success |
+| `ddev drush search-api:list` | `mel_content` enabled |
+| `ddev drush search-api:status mel_content` | 100% — 58/58 indexed |
+| `ddev drush entity:info node` | **Not available** on this Drush build |
+| `ddev drush sqlq "SELECT type, status, COUNT(*) …"` | See node counts below |
+| `ddev drush sqlq` (support_procedure count) | 0 nodes |
+| `ddev drush php:eval` | `help_article` field inventory (×3), `staff_playbook` access check, Search API bundle sample |
+| `ddev drush route \| grep -Ei …` | Help/assistant/staff routes listed in prior audit |
+| `ddev drush route \| grep -i internal/governance` | Staff/governance routes only |
+
+No temporary files were created.
+
+---
+
+## Help Article Counts
+
+| Metric | Count |
+|--------|------:|
+| Total `help_article` nodes | 31 |
+| Published (`status = 1`) | 31 |
+| Unpublished | 0 |
+| `field_audience` = public (nodes; single-value rows) | 15 |
+| `field_audience` = vendor (nodes; single-value rows) | 16 |
+| `field_audience` = staff | 0 |
+| Missing `field_audience` | 0 |
+| `field_help_status` = published | 30 |
+| `field_help_status` = draft | 1 |
+| `field_help_status` = review / approved / archived | 0 |
+| Missing `field_help_status` | 0 |
+| `field_help_ai_allowed` = true | 31 |
+| `field_help_ai_allowed` = false | 0 |
+| `field_help_ai_allowed` empty | 0 |
+| Using deprecated `field_help_audience` (any value) | 0 |
+| `field_help_seed_key` populated | 0 |
+| `field_featured_help` = true | 0 |
+
+**By help article type (taxonomy):** Guide 27, FAQ 3, Policy 1.
+
+**Indexed in `mel_content`:** 31 `help_article` nodes (matches node count).
+
+**Compared to YAML seeds:** Install config defines 10 seeded articles (`myeventlane_help_centre.help_content.yml`). Live site has **31** published articles and **no** `field_help_seed_key` values — content has outgrown seeds; seed keys not recorded on nodes (**Needs verification** whether seeder was run without seed_key persistence).
+
+---
+
+## Help Article Risk List
+
+Assistant rules applied from `HelpRetriever.php`: published, `field_help_ai_allowed`, status `published|approved`, no `staff` audience, node access, audience `public` (anonymous) or `public|vendor` (authenticated).
+
+| Title | Audience | Help Status | Published | AI Allowed | Risk | Action |
+|-------|----------|-------------|-----------|------------|------|--------|
+| Accessibility at events | public | published | yes | yes | None | None |
+| Adding events to your calendar | public | published | yes | yes | None | None |
+| Booking multiple tickets | public | published | yes | yes | None | None |
+| Checking event details before booking | public | published | yes | yes | None | None |
+| Choosing event categories | vendor | published | yes | yes | Expected vendor-only browse | None — appears on `/help/vendors` |
+| Communicating with attendees | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Contacting support | public | published | yes | yes | None | None |
+| Creating an account | public | published | yes | yes | None | None |
+| Editing your event | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Event visibility and promotion | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Getting started as an organiser | vendor | published | yes | yes | **IA mismatch:** not on `/help/organisers` (view filters `public` only) | Add `public` tag, duplicate summary for organisers, or change organiser view filter — product decision |
+| Handling refunds as an organiser | vendor | published | yes | yes | IA mismatch (organiser hub) | Same as above |
+| How to buy tickets | public | published | yes | yes | None | None |
+| How to create an event | vendor | published | yes | yes | IA mismatch (organiser hub) | Same as above |
+| How to find events | public | published | yes | yes | None | None |
+| How to save events | public | published | yes | yes | None | None |
+| Managing attendees | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Payouts and fees | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Refunds explained | public | published | yes | yes | None | None |
+| Resetting your password | public | published | yes | yes | None | None |
+| Setting event capacity | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Setting Up Ticketing for Your Event | vendor | **draft** | yes | yes | **Assistant blocked** (status draft); published node inconsistent with editorial status | Set `field_help_status` to `published` or unpublish node |
+| Setting up tickets | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Tracking event performance | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Understanding ticket types | public | published | yes | yes | None | None |
+| Updating ticket availability | vendor | published | yes | yes | Expected vendor-only browse | None |
+| Using filters to find events | public | published | yes | yes | None | None |
+| Using images for your event | vendor | published | yes | yes | Expected vendor-only browse | None |
+| What happens after booking | public | published | yes | yes | None | None |
+| What to bring to an event | public | published | yes | yes | None | None |
+| Writing a strong event description | vendor | published | yes | yes | Expected vendor-only browse | None |
+
+### Targeted lists (from inventory queries)
+
+**`field_audience` = staff:** None.
+
+**`field_help_ai_allowed` = true but status not published/approved:**
+
+- Setting Up Ticketing for Your Event (nid 1521) — `draft`
+
+**Public/vendor articles with AI false or empty:** None (all 31 have AI allowed).
+
+**Published but not safe for Help Assistant (authenticated user):**
+
+- Setting Up Ticketing for Your Event (nid 1521) — `field_help_status = draft`
+
+**Published but not safe for Help Assistant (anonymous user):** All 15 `public` articles are safe. Sixteen `vendor`-only articles are correctly excluded (not a defect).
+
+---
+
+## Staff Playbook Check
+
+| Metric | Value |
+|--------|------:|
+| Total `staff_playbook` nodes | 10 |
+| Published | 10 |
+| Unpublished | 0 |
+| Anonymous `view` access | **0** (all forbidden) |
+
+**Titles (nid):** Refund decision flow (1475), Vendor dispute handling (1476), Event moderation checklist (1477), Escalation handling guide (1478), Handling support requests (1479), Reviewing refund edge cases (1480), Content quality review (1481), Handling repeated complaints (1482), Vendor onboarding support (1483), Ticket issue resolution (1484).
+
+**Browse routes (staff only):**
+
+| Route | Permission |
+|-------|------------|
+| `/admin/myeventlane/governance` | `administer escalations` |
+| `/admin/myeventlane/playbooks/{node}/ai/summary` | Staff playbooks AI |
+| Escalation canonical sidebar | `view staff playbooks` |
+
+**No** Views list `staff_playbook` (grep `config/sync/views.view.*`).
+
+**Search API `mel_content`:** `staff_playbook` **not** in indexed bundles; **0** staff playbooks in index query sample.
+
+**Risk:** Low on this environment — access hook blocks anonymous; playbooks not in Search API or public Views.
+
+---
+
+## Support Procedure Check
+
+| Item | Finding |
+|------|---------|
+| Bundle exists | Yes — `config/sync/node.type.support_procedure.yml` |
+| Live nodes | **0** |
+| View | `mel_help_internal_procedures` — bundle filter `support_procedure` only |
+| View access plugin | `perm: access content` |
+| View displays | `default`, `block_internal` only — **no page route** |
+| Block placement | **0** blocks placed for `views_block:mel_help_internal_procedures-block_internal` |
+
+**Reachability today:** With zero nodes and no block placement, anonymous/authenticated/vendor users are unlikely to see content. **Risk if nodes are added without access hardening:** View does not filter `field_audience` or staff permissions — would rely solely on `hook_node_access` for `support_procedure` (**Needs verification** — no `support_procedure` hook found in `myeventlane_help_centre.module`; only `help_article` and `faq`).
+
+**Recommended verification:** Confirm whether `support_procedure` has `hook_node_access` elsewhere or inherits unrestricted published node access.
+
+---
+
+## Search API Check
+
+| Item | Finding |
+|------|---------|
+| Index | `mel_content` — enabled, 100% (58/58) |
+| Indexed bundles (config) | `blog_post`, `event`, `help_article`, `help_landing_page`, `page` |
+| `staff_playbook` excluded | Yes (config + live query) |
+| `support_procedure` excluded | Yes |
+| `help_article` in index | Yes — 31 items |
+| Live bundle breakdown (sample query) | event 17, help_article 31, help_landing_page 5, page 2 |
+
+**Retriever filters (not in index):** `HelpRetriever` adds `type = help_article`, `status = 1`, `field_audience` OR group, then PHP checks `field_help_ai_allowed`, `field_help_status`, node access (`web/modules/custom/myeventlane_help_assistant/src/Service/HelpRetriever.php`).
+
+**Risk:** Low for staff playbook leakage via Search API. Index includes **events** and **pages** — Assistant query restricts to `help_article` only.
+
+---
+
+## Help View Visibility Check
+
+### Views listing `help_article`
+
+| View ID | Audience filter | `field_help_status` | `field_help_ai_allowed` | Notes |
+|---------|-----------------|---------------------|-------------------------|-------|
+| `mel_help_attendee_help` | `public` | No | No | Used on `/help/attendees` |
+| `mel_help_organiser_help` | `public` | No | No | Used on `/help/organisers` — **same 15 nodes as attendee** |
+| `mel_help_vendor_help` | `vendor` | No | No | Used on `/help/vendors` — 16 nodes |
+| `mel_help_search` | Exposed optional | No | No | `/help/search` |
+| `mel_help_featured_articles` | None | No | No | **`field_featured_help` — 0 nodes flagged** → hub featured area likely empty |
+| `mel_help_faq` | None (type = FAQ term) | No | No | 3 FAQ-type articles |
+| `mel_help_policies_help` | `public` + Policy type | No | No | 1 Policy-type public article |
+| `mel_help_category_listing` | No | No | No | Category pages |
+| `mel_help_related_articles` | No | No | No | Related block |
+| `mel_help_centre_homepage` | help_article | No | No | Hub blocks |
+| `mel_help_articles_by_audience` | No | No | No | Includes deprecated `faq` bundle in filter |
+| `mel_docs_register` | Admin register | No | No | Staff editorial |
+| `mel_help_feedback_admin` / analytics views | Admin | — | — | Staff |
+
+### Views listing `staff_playbook`
+
+None in `config/sync`.
+
+### Views listing `support_procedure`
+
+| View ID | Access | Placement |
+|---------|--------|-----------|
+| `mel_help_internal_procedures` | `access content` | Block display exists; **not placed** |
+
+### Browse vs Help Assistant mismatches
+
+| Mismatch | Severity | Detail |
+|----------|----------|--------|
+| Views omit `field_help_ai_allowed` / `field_help_status` | Low | Browse can show articles Assistant would drop — only **one** live article (1521) affected today |
+| `/help/organisers` vs vendor-tagged organiser content | Medium (UX) | 16 organiser-topic articles use `vendor` audience; organiser index only lists `public` articles |
+| `/help/attendees` vs `/help/organisers` | Low | Identical listing (15 public articles) — consider merging or differentiating |
+| Featured block empty | Low | No articles have `field_featured_help` |
+| Hub FAQ block | OK | 3 FAQ-type articles exist |
+
+**Node access:** Vendor-only articles deny anonymous view (confirmed on nid 1507) — aligns with `myeventlane_help_centre_node_access`.
+
+---
+
+## Recommended Fix Queue
+
+Do not implement in this task — ordered by priority:
+
+### 1. Access-control risks
+
+1. **Verify `support_procedure` node access** before creating any nodes — view uses `access content` and has no audience filter; bundle currently empty.
+2. **Keep `staff_playbook` out of `mel_content`** — confirmed; re-check after any index config change.
+
+### 2. Assistant safety risks
+
+1. **Fix nid 1521** — “Setting Up Ticketing for Your Event”: published node with `field_help_status = draft` and AI allowed — excluded from Assistant; confusing for editors.
+2. **Confirm anonymous Help Assistant** only surfaces `public` articles (15 nodes) — matches retriever design.
+
+### 3. Stale / inconsistent help articles
+
+1. Decide editorial rule when `field_help_status` ≠ published node status.
+2. Optionally set `field_featured_help` on top articles for hub (currently zero).
+
+### 4. Missing AI flags
+
+- None on this site (all 31 allowed). Maintain on new articles.
+
+### 5. IA / missing plain-English help
+
+1. Resolve **organiser hub vs vendor audience** — 16 vendor articles invisible on `/help/organisers`.
+2. Continue gap articles from `help-docs-gap-analysis.md` (checkout failures, Stripe, waitlist, wallet) — many attendee topics now exist (15 public articles cover core flows).
+3. Map live titles to `top-20-priority-help-articles.md` — several priorities already published (buy tickets, find events, account, refunds, support).
+
+### 6. Blog / FAQ backlog
+
+1. Only 3 FAQ-type articles — expand FAQ set per `faq-backlog.md` if hub FAQ block should be richer.
+2. Blog remains separate (`/blog`, `blog_post` in index).
+
+---
+
+## Final Summary
+
+### What is safe
+
+- **No staff-audience `help_article` nodes** and **no `field_help_audience` usage** on help articles.
+- **All 31 help articles** have `field_audience`, `field_help_status`, and `field_help_ai_allowed` populated.
+- **`staff_playbook`** (10 nodes): anonymous cannot view; not in Search API; no public View.
+- **Help Assistant alignment** for **15 public articles**: safe for anonymous and authenticated retrieval.
+- **16 vendor articles**: correctly hidden from anonymous Assistant; available to authenticated users with vendor role + node access (verified uid 2).
+- **Search API** matches documented bundle list; 31/31 help articles indexed.
+
+### What needs verification
+
+- Whether this DDEV database matches **staging/production** counts.
+- **`support_procedure` access** if content type is used in future.
+- **Browser check** of `/help`, `/help/organisers`, `/help/vendors`, Assistant on anonymous vs logged-in sessions.
+- Whether **organiser hub duplicating attendee listing** is intentional product IA.
+
+### Fix before writing more content
+
+1. **nid 1521** status alignment (draft vs published).
+2. **Organiser vs vendor audience** strategy for `/help/organisers`.
+3. **`support_procedure` access model** if staff procedures will be added.
+
+### Safe to write immediately
+
+- New **public** attendee articles (checkout edge cases, waitlist, wallet) — flags and audience model are healthy.
+- New **vendor** articles — set `field_audience: vendor`, `field_help_ai_allowed: 1`, `field_help_status: published`.
+- **FAQ entries** — only 3 exist; room to grow without duplicating existing Guide titles.
+- **Staff playbooks** — separate workflow; 10 playbooks already cover core escalation themes.
+
+---
+
+## Alignment with documentation audit
+
+| Documented setup | Live match? |
+|------------------|-------------|
+| `/help` hub | Yes |
+| `field_audience` canonical | Yes — no deprecated field data |
+| Assistant filters | Yes — one draft-status outlier |
+| `staff_playbook` excluded from Assistant index | Yes |
+| 10 YAML seeds | **Partial** — 31 live articles; seed keys empty |
+| Top-20 priority gaps | **Partially closed** — many attendee guides now exist |
+
+---
+
+## Follow-up Verification: Node 1521 and Browser Pass
+
+**Date/time:** 2026-05-22 (local DDEV, `https://myeventlane.ddev.site`)
+
+**Scope:** Editorial fix on node 1521 only; read-only verification otherwise. No code, routes, views, permissions, or Search API reindex performed.
+
+### Commands run
+
+| Command | Purpose |
+|---------|---------|
+| `ddev drush sqlq` (node 1521 fields + body) | Content inspection |
+| `ddev drush php:eval` | Set `field_help_status` → `published`; post-fix verification; Help Assistant retrieval; staff leak check |
+| `ddev drush cr` | Cache rebuild (×2) |
+| `ddev drush search-api:status mel_content` | Index drift check |
+| `ddev drush sqlq` (nid 1521 + field values) | After-state confirmation |
+| `git status --short` | Change scope |
+| Browser (Cursor IDE) | `/help`, `/help/search`, `/help/organisers`, `/help/vendors`, `/node/1521` |
+
+`curl` was unavailable in the agent shell; browser + Drush used instead.
+
+### Node 1521 inspection summary
+
+| Field / check | Value |
+|---------------|-------|
+| Title | Setting Up Ticketing for Your Event |
+| Published | Yes (`status = 1`) |
+| `field_audience` | `vendor` |
+| `field_help_status` (before) | `draft` |
+| `field_help_ai_allowed` | `true` |
+| Article type | Guide |
+| Summary | Present — step-by-step ticketing setup for organisers |
+| Body | ~922 chars; numbered steps (log in, Events, Ticketing tab, ticket types, publish) |
+| Placeholder text | None found |
+| Internal-only content | None found |
+| Safe for vendor help | Yes — generic vendor console guidance, no staff procedures |
+
+**Duplicate note:** Overlaps topic with “Setting up tickets” (nid 1508). Both can coexist; 1521 is a longer guide.
+
+### Node 1521 decision
+
+**Action taken:** Set `field_help_status` to **`published`** (node left published).
+
+**Why not unpublish:** Body and summary are complete, accurate enough for vendor self-service, and aligned with other published vendor guides. The issue was editorial status out of sync with the published node, not unsafe or incomplete content.
+
+**Why not rewrite:** No wording changes required for the status decision.
+
+### Before / after state
+
+| | Before | After |
+|---|--------|-------|
+| Node published | yes | yes |
+| `field_help_status` | `draft` | `published` |
+| `field_help_ai_allowed` | true | true |
+| `field_audience` | vendor | vendor |
+| Help Assistant (authenticated vendor, uid 2) | Blocked (status) | **Retrieves nid 1521** for query “setting up ticketing event” |
+| Help Assistant (anonymous, Drush) | Blocked | Blocked (expected — vendor audience + node access) |
+| `mel_content` index | 58/58 (100%) | **57/58 (98.3%)** — drift after save |
+
+### Browser / access checks
+
+| Check | Result |
+|-------|--------|
+| `/help` | Loads — Help Centre hub, Help Assistant region, FAQ buttons |
+| `/help/search` | Loads — lists articles including “Setting Up Ticketing for Your Event” |
+| `/help/attendees` | Not re-opened this pass; prior audit: public-only listing |
+| `/help/organisers` | Loads — **15 public articles only**; **no** “Setting Up Ticketing for Your Event” |
+| `/help/vendors` | Loads — **includes** “Setting Up Ticketing for Your Event” |
+| `/node/1521` | Full article visible in browser session (**session had Account menu / cart — logged-in user**, not anonymous) |
+| Anonymous access (Drush `node->access('view', anonymous)`) | **Denied** for nid 1521 |
+| Help Assistant staff leakage (Drush) | No `staff_playbook` anonymous access; no staff bundles in retrieval sample |
+| `/help/assistant` | Embedded on `/help` hub; dedicated route not isolated in this pass |
+
+**Browse/search note:** `/help/search` (anonymous or default view) can show **titles** of vendor-audience articles without an audience filter applied by default. Node access should still block full view for anonymous users on canonical URLs (**Needs verification** in a logged-out browser session).
+
+### Search API status
+
+```
+mel_content: 98.3% complete — 57 indexed / 58 total
+```
+
+- Drift appeared immediately after saving node 1521 (field change).
+- **Reindex not run** (per task instructions).
+- Help Assistant retrieval for authenticated vendor **worked without reindex** in this test (post-save).
+- **Recommendation:** Run `ddev drush search-api:index mel_content` before production Assistant QA if answers seem stale; optional on local DDEV.
+
+### Remaining risks
+
+| Risk | Severity | Notes |
+|------|----------|-------|
+| Organiser hub IA | Medium (UX) | `/help/organisers` lists `public` only; vendor-topic articles only on `/help/vendors` |
+| Search view audience filter | Low | Exposed filter includes legacy label “Organiser” — canonical values are `public` / `vendor` / `staff` |
+| `mel_content` index drift | Low | 1 item pending index |
+| `support_procedure` | Low (0 nodes) | Unchanged |
+| Vendor article titles on `/help/search` | Low | Possible title leakage in listings — confirm logged-out behaviour |
+
+### Recommendation: organiser hub IA (do not fix in this task)
+
+**Current behaviour:**
+
+- `/help/organisers` → View `mel_help_organiser_help` filters `field_audience: public` (same 15 articles as attendee hub).
+- `/help/vendors` → View `mel_help_vendor_help` filters `field_audience: vendor` (16 articles, including organiser-topic guides).
+- Sixteen vendor-audience articles (e.g. “How to create an event”, “Setting Up Ticketing for Your Event”) **do not appear** on `/help/organisers`.
+
+**Recommendation (product/content, later):**
+
+1. Decide whether “organiser” in the UI means **public** (attendee-adjacent) or **vendor console** (authenticated host).
+2. If organiser means host: either add a second audience value on key articles (`public` + `vendor`), change `mel_help_organiser_help` to include `vendor`, or replace organiser hub copy with a clear CTA to `/help/vendors` for logged-in hosts.
+3. Avoid duplicating all 16 articles on both hubs without a content strategy.
+
+### Fix queue update (post–nid 1521)
+
+1. ~~Align nid 1521 `field_help_status`~~ — **Done** (`published`).
+2. Organiser hub IA — still open.
+3. Optional `mel_content` reindex when convenient.
+4. ~~Logged-out browser pass for `/help/search` + `/node/1521`~~ — **Done** (see Final Public Verification below).
+
+---
+
+## Final Public Verification: Help Search, Vendor Article Access, and Index Alignment
+
+**Date/time:** 2026-05-22 (local DDEV, `https://myeventlane.ddev.site`)
+
+**Scope:** Read-only verification + allowed `mel_content` reindex. No code, views, routes, permissions, or node edits.
+
+### Commands run
+
+| Command | Result |
+|---------|---------|
+| `ddev drush search-api:status mel_content` (before) | 96.6% — 57/59 |
+| `ddev drush search-api:index mel_content` | Indexed **2** pending items |
+| `ddev drush search-api:status mel_content` (after) | **100% — 59/59** |
+| `ddev drush cr` | Success |
+| `ddev drush php:eval` | Anonymous/vendor node access; Help Assistant retrieval; staff playbook isolation |
+| `git status --short` | No help-content edits; unrelated module changes in tree |
+| `ddev drush sqlq` (node counts) | Unchanged help/staff counts |
+| `/usr/bin/curl -sk` (no cookies) | Anonymous HTTP checks on help routes + `/node/1521` |
+| `curl -sk -X POST /help/assistant` (JSON, no cookies) | Anonymous Assistant query |
+| Browser (logged-in admin/vendor session) | `/help/vendors`, `/node/1521` — confirms vendor access when authenticated |
+
+### Reindex result
+
+| Stage | Indexed | Total | % |
+|-------|---------|-------|---|
+| Before | 57 | 59 | 96.6% |
+| After `search-api:index mel_content` | 59 | 59 | **100%** |
+
+Search API warning during index: rendered_item field missing some view mode config (pre-existing; not changed in this task).
+
+### Anonymous route checks (curl, no session cookie)
+
+| URL | HTTP | Title / outcome | Article 1521 |
+|-----|------|-----------------|--------------|
+| `/help` | 200 | MyEventLane Help Centre | Not in hub HTML |
+| `/help/search` | 200 | Search Help | **Title listed** (2 mentions); **summary teaser text** in listing (`field_help_summary` excerpt); **no body** (`Ticketing</strong> tab` not in HTML) |
+| `/help/attendees` | 200 | Help for Attendees | Not listed |
+| `/help/organisers` | 200 | Help for Organisers | Not listed (`How to create an event` = 0) |
+| `/help/vendors` | 200 | Page title still “Help for Organisers” (copy bug) | **Title listed** in listing HTML |
+| `/node/1521` | **403** | **Access denied** | Full body **not** shown |
+| Click-through `/node/1521` from search | **403** | Access denied | Protected |
+
+**Drush (anonymous):** `node->access('view')` = **false** for nid 1521.
+
+**Help Assistant (anonymous JSON POST):** `{"question":"setting up ticketing for your event"}` → `status: fallback`, **no nid 1521**, empty `articles` array.
+
+**Conclusion:** Anonymous users **cannot** read article 1521 body. Search **does** expose title + short summary in the default listing (teaser view) without an audience filter — **not** full article body. Clicking the link is **blocked**.
+
+### Logged-in vendor checks
+
+| Check | Result |
+|-------|--------|
+| Drush uid 2 (`vendor` role) `access('view')` on nid 1521 | **true** |
+| Drush Help Assistant as uid 2 (“setting up ticketing”) | **Returns nid 1521** |
+| Browser `/help/vendors` | Lists “Setting Up Ticketing for Your Event” |
+| Browser `/node/1521` | Full article body visible (admin toolbar session) |
+| Help Assistant on hub | Not re-tested end-to-end in browser; Drush + prior pass OK |
+
+### Staff playbook isolation
+
+| Check | Result |
+|-------|--------|
+| Anonymous can view any `staff_playbook` (Drush sample) | **0** leaks |
+| Vendor uid 2 can view staff playbook sample | **0** leaks |
+| `staff_playbook` in `mel_content` Search API query | **0** items |
+| Staff routes | `/admin/myeventlane/governance` requires `administer escalations` (unchanged) |
+
+### Organiser IA recommendation (not fixed)
+
+**Current behaviour (confirmed):**
+
+| Hub | View filter | What users see |
+|-----|-------------|----------------|
+| `/help/attendees` | `field_audience: public` | 15 public articles |
+| `/help/organisers` | `field_audience: public` | **Same 15 public articles** (not host guides) |
+| `/help/vendors` | `field_audience: vendor` | 16 vendor articles (host/organiser operations) |
+
+**Labelling issue:** `/help/vendors` page `<title>` is still “Help for Organisers” while H1 is “Vendor help” — may confuse users.
+
+**Recommended product decision:**
+
+| Option | Assessment |
+|--------|------------|
+| **A** — Merge under one “Organisers” label | Simplest IA, but blurs attendee vs host operations unless content is re-tagged carefully. |
+| **B** — Public organisers vs vendor console (preferred long-term) | Keep `/help/organisers` for **public** host onboarding copy; keep `/help/vendors` for **authenticated** console help; fix duplicate attendee/organiser lists and page titles. |
+| **C** — Redirect organisers → vendors when logged in | Good **interim** fix: vendors land on the right articles without duplicating content. |
+
+**Recommendation:** Adopt **Option B** for structure and labelling; implement **Option C** as a quick win (redirect `/help/organisers` → `/help/vendors` for users with vendor access) until organiser hub content is split intentionally.
+
+### Remaining risks
+
+| Risk | Severity | Status after this pass |
+|------|----------|------------------------|
+| Search lists vendor titles/summaries to anonymous | Low | Confirmed — mitigated by 403 on canonical node |
+| Organiser/vendor hub duplication and title mismatch | Medium | Open — product IA |
+| `support_procedure` with `access content` view | Low | 0 nodes; block not placed |
+| Featured help block empty | Low | Unchanged |
+
+### Final status
+
+| Criterion | Status |
+|-----------|--------|
+| `mel_content` at 100% | **Pass** |
+| Node 1521 `field_help_status` = published | **Pass** (unchanged this pass) |
+| Anonymous denied `/node/1521` | **Pass** |
+| Anonymous Assistant excludes 1521 | **Pass** |
+| Vendor Assistant includes 1521 | **Pass** |
+| Staff playbooks isolated | **Pass** |
+| Help Centre public routes load | **Pass** |
+
+**Overall:** Help Centre access controls and post-fix node 1521 behaviour are **aligned with documented MEL policy**. Remaining work is **content IA** (organiser vs vendor hubs) and optional hardening of `/help/search` default filters for anonymous users (audience filter default = public only).
+
+## Search Metadata Leak Fix Verification
+
+**Date:** 2026-05-22
+
+### Issue summary
+
+Anonymous users received HTTP 403 on `/node/1521` (vendor-only help article) and Help Assistant correctly excluded nid 1521, but `/help/search` listed the article **title and summary teaser** because `mel_help_search` used SQL Views with an **exposed** `field_audience` filter defaulting to empty (no restriction). Node access ran only on canonical view, not before listing metadata rendered.
+
+### Implementation chosen
+
+1. **`HelpArticleBrowsePolicy`** service (`myeventlane_help_centre.help_browse_policy`) — centralises browse/search audience and status rules (not used by Help Assistant).
+2. **`hook_views_pre_view()`** — sets `field_audience_value` filter to effective audiences (intersects optional `?audience=` with account allowances).
+3. **`hook_views_query_alter()`** — adds SQL `IN` constraints on `field_audience` and `field_help_status` so filters survive exposed-form processing (defence in depth).
+
+**Audience rules (search/browse):**
+
+| Account | Allowed `field_audience` |
+|---------|--------------------------|
+| Anonymous / authenticated without vendor console | `public` only |
+| Vendor console / `view vendor help centre` | `public`, `vendor` |
+| `administer escalations` | `public`, `vendor`, `staff` |
+
+**Status rules (search/browse):** normal users → `published`, `approved` only; bypass / `administer help articles` → includes `draft`, `review`.
+
+**`field_help_ai_allowed`:** not required for browse/search (unchanged; Assistant still enforces via `HelpRetriever`).
+
+**Config YAML:** `views.view.mel_help_search.yml` unchanged (UUIDs/display IDs preserved).
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php` | **New** policy service |
+| `web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml` | Register `help_browse_policy` |
+| `web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module` | `views_pre_view` + `views_query_alter` for `mel_help_search` |
+
+### Commands run
+
+```bash
+php -l web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+php -l web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php
+ddev drush cr
+ddev drush search-api:index mel_content   # already 100%
+ddev drush search-api:status mel_content
+ddev drush config:status
+```
+
+### Before / after — anonymous search
+
+| Check | Before fix | After fix |
+|-------|------------|-----------|
+| `/help/search?q=ticketing` lists nid 1521 title/summary | **Yes** (teaser) | **No** |
+| `/help/search?q=Setting+Up+Ticketing` lists nid 1521 | **Yes** | **No** |
+| `/node/1521` | 403 | 403 (unchanged) |
+| Public articles in search (e.g. tickets) | Yes | Yes |
+| Help Assistant | Excludes 1521 | Excludes 1521 (unchanged) |
+
+**Anonymous curl (no cookies):** `/help/search?q=ticketing` → HTTP 200, **0** `/node/1521` links; `/node/1521` → HTTP 403.
+
+### Before / after — vendor search
+
+| Check | Before fix | After fix |
+|-------|------------|-----------|
+| `/node/1521` access (uid 2) | Allowed | Allowed |
+| `/help/search?q=ticketing` includes nid 1521 | Yes | **Yes** (Drush view execute) |
+| Help Assistant “setting up ticketing” | Includes 1521 | Includes 1521 (unchanged) |
+
+### Search API status
+
+| Index | Status |
+|-------|--------|
+| `mel_content` | **100%** (59/59 indexed) |
+
+Browse/search listing uses **Views SQL**, not Search API; reindex not required for this fix.
+
+### Staff isolation (re-checked)
+
+| Check | Result |
+|-------|--------|
+| `staff_playbook` in `mel_content` bundles | **Not indexed** (`help_article`, `event`, `page` only) |
+| Published `staff_playbook` nodes | 10 (admin paths only) |
+| `support_procedure` nodes | **0** |
+| Staff-audience `help_article` in anonymous/vendor search | Excluded by policy |
+
+### Remaining risks
+
+| Risk | Severity |
+|------|----------|
+| Other `mel_help_*` listing views still lack `field_help_status` filter | Low — hub views filter by audience; draft vendor articles could appear on `/help/vendors` |
+| Organiser/vendor hub duplication and title mismatch | Medium — **deferred** (organiser IA not changed) |
+| `countSearchResults()` analytics uses same view — counts now respect policy | Informational |
+
+### Tests
+
+No targeted PHPUnit test for `HelpArticleBrowsePolicy` or `mel_help_search` access filtering. Existing `HelpRetrieverKernelTest` covers Assistant only.
+
+### Organiser IA
+
+**Deferred** — no changes to `/help/organisers`, `/help/vendors`, or redirects.

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -152,6 +152,9 @@ services:
       - '@current_route_match'
       - '@request_stack'
 
+  myeventlane_commerce.event_default_ticket_resolver:
+    alias: myeventlane_event.ticket_type_manager
+
   myeventlane_commerce.customer_ticket_tier_display:
     class: Drupal\myeventlane_commerce\Service\CustomerTicketTierDisplayBuilder
     arguments:
@@ -159,6 +162,7 @@ services:
       - '@myeventlane_event.ticket_tier_lifecycle'
       - '@commerce_price.currency_formatter'
       - '@myeventlane_commerce.ticket_tier_waitlist'
+      - '@myeventlane_commerce.event_default_ticket_resolver'
       - '@string_translation'
 
   myeventlane_commerce.ticket_waitlist_order_subscriber:

--- a/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
@@ -11,6 +11,7 @@ use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\mel_ticket\Entity\TicketType;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\myeventlane_commerce\Service\EventDefaultTicketResolverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
@@ -31,12 +32,15 @@ final class CustomerTicketTierDisplayBuilder {
    *   Formats variation prices for display.
    * @param \Drupal\myeventlane_commerce\Service\TicketTierWaitlistService $tierWaitlist
    *   Waitlist hold counts for availability copy.
+   * @param \Drupal\myeventlane_commerce\Service\EventDefaultTicketResolverInterface $defaultTicketResolver
+   *   Resolves default ticket ordering aligned with TicketSelectionForm.
    */
   public function __construct(
     private readonly TicketCustomerDisplayGatewayInterface $ticketAvailability,
     private readonly EventPaidTicketLoaderInterface $ticketTierLifecycle,
     private readonly CurrencyFormatter $currencyFormatter,
     private readonly TicketTierWaitlistHoldCounterInterface $tierWaitlist,
+    private readonly EventDefaultTicketResolverInterface $defaultTicketResolver,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -50,7 +54,8 @@ final class CustomerTicketTierDisplayBuilder {
    *     name: string,
    *     price: string,
    *     availability: string,
-   *     description: string|null,
+   *     short_description: string|null,
+   *     is_best_value: bool,
    *     variation_id: int,
    *     ticket_id: int|null,
    *   }>,
@@ -92,6 +97,8 @@ final class CustomerTicketTierDisplayBuilder {
 
     $context = $this->ticketAvailability->buildDefaultCustomerAccessContext($event);
     $purchasable = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context);
+    $purchasable = $this->sortPurchasableLikeBookForm($event, $purchasable);
+    $best_value_variation_id = $this->resolveBestValueVariationId($event);
     $purchasable_variation_ids = [];
     foreach ($purchasable as $variation) {
       $purchasable_variation_ids[(int) $variation->id()] = $variation;
@@ -106,7 +113,8 @@ final class CustomerTicketTierDisplayBuilder {
         'name' => $this->resolveCustomerLabel($variation, $label_map),
         'price' => $this->formatVariationPrice($variation),
         'availability' => $this->buyerFacingAvailabilityMessage($event, $tier, $variation_id),
-        'description' => $this->resolveShortDescription($tier),
+        'short_description' => $this->resolveShortDescription($tier),
+        'is_best_value' => $best_value_variation_id !== NULL && $variation_id === $best_value_variation_id,
         'variation_id' => $variation_id,
         'ticket_id' => $tier instanceof TicketTypeInterface ? (int) $tier->id() : NULL,
       ];
@@ -215,6 +223,74 @@ final class CustomerTicketTierDisplayBuilder {
       $label = $parts[1] ?? $label;
     }
     return $label;
+  }
+
+  /**
+   * Aligns purchasable variation order with TicketSelectionForm.
+   *
+   * @param \Drupal\commerce_product\Entity\ProductVariationInterface[] $variations
+   *
+   * @return \Drupal\commerce_product\Entity\ProductVariationInterface[]
+   */
+  private function sortPurchasableLikeBookForm(NodeInterface $event, array $variations): array {
+    $default_tier = $this->defaultTicketResolver->getDefaultTicket($event);
+    $default_variation_id = $this->resolveDefaultVariationId($default_tier);
+    if ($default_variation_id === NULL) {
+      return $variations;
+    }
+    return $this->sortVariationsDefaultFirst($variations, $default_variation_id);
+  }
+
+  private function resolveDefaultVariationId(?TicketTypeInterface $tier): ?int {
+    if (!$tier instanceof TicketTypeInterface
+      || !$tier->hasField('commerce_variation')
+      || $tier->get('commerce_variation')->isEmpty()) {
+      return NULL;
+    }
+    $variation_id = (int) $tier->get('commerce_variation')->target_id;
+    return $variation_id > 0 ? $variation_id : NULL;
+  }
+
+  /**
+   * First mel_ticket_type flagged field_is_best_value, matching TicketSelectionForm.
+   */
+  private function resolveBestValueVariationId(NodeInterface $event): ?int {
+    if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
+      return NULL;
+    }
+
+    foreach ($event->get('field_ticket_types')->referencedEntities() as $ticket) {
+      if (!$ticket instanceof TicketTypeInterface || $ticket->isArchived()) {
+        continue;
+      }
+      if (!$ticket->hasField('field_is_best_value') || !$ticket->isBestValueTicket()) {
+        continue;
+      }
+      if (!$ticket->hasField('commerce_variation') || $ticket->get('commerce_variation')->isEmpty()) {
+        continue;
+      }
+      $variation_id = (int) $ticket->get('commerce_variation')->target_id;
+      return $variation_id > 0 ? $variation_id : NULL;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @param \Drupal\commerce_product\Entity\ProductVariationInterface[] $variations
+   *
+   * @return \Drupal\commerce_product\Entity\ProductVariationInterface[]
+   */
+  private function sortVariationsDefaultFirst(array $variations, int $defaultVariationId): array {
+    usort($variations, static function (ProductVariationInterface $a, ProductVariationInterface $b) use ($defaultVariationId): int {
+      $a_default = (int) $a->id() === $defaultVariationId;
+      $b_default = (int) $b->id() === $defaultVariationId;
+      if ($a_default === $b_default) {
+        return 0;
+      }
+      return $a_default ? -1 : 1;
+    });
+    return $variations;
   }
 
   private function resolveShortDescription(?TicketTypeInterface $tier): ?string {

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventDefaultTicketResolverInterface.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventDefaultTicketResolverInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Resolves the organiser default ticket for customer-facing ticket ordering.
+ */
+interface EventDefaultTicketResolverInterface {
+
+  /**
+   * Resolves the default ticket for an event (same semantics as the book form).
+   */
+  public function getDefaultTicket(NodeInterface $event): ?TicketTypeInterface;
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/CustomerTicketTierDisplayBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/CustomerTicketTierDisplayBuilderTest.php
@@ -16,6 +16,7 @@ use Drupal\myeventlane_commerce\Service\TicketAccessContext;
 use Drupal\myeventlane_commerce\Service\TicketCustomerDisplayGatewayInterface;
 use Drupal\myeventlane_commerce\Service\TicketTierWaitlistHoldCounterInterface;
 use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\myeventlane_commerce\Service\EventDefaultTicketResolverInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,7 +58,88 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     $this->assertSame('General admission', $result['visible_rows'][0]['name']);
     $this->assertSame('$10.00', $result['visible_rows'][0]['price']);
     $this->assertSame('Available', $result['visible_rows'][0]['availability']);
+    $this->assertFalse($result['visible_rows'][0]['is_best_value']);
+    $this->assertNull($result['visible_rows'][0]['short_description']);
     $this->assertSame([], $result['excluded_rows']);
+  }
+
+  /**
+   * @covers ::buildForEvent
+   */
+  public function testBestValueFlagAndShortDescription(): void {
+    $variation = $this->variation(11, '10.00', 'Concession');
+    $tier = $this->tier(
+      5,
+      'Concession',
+      TRUE,
+      'public',
+      50,
+      TRUE,
+      11,
+      TRUE,
+      'Under 18 pricing',
+    );
+    $event = $this->eventNode(42, TRUE, [$tier]);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('isPublished')->willReturn(TRUE);
+    $product->method('id')->willReturn('7');
+    $product->method('getCacheTags')->willReturn(['commerce_product:7']);
+    $product->method('getVariations')->willReturn([]);
+
+    $availability = $this->availabilityMock();
+    $availability->method('buildDefaultCustomerAccessContext')->willReturn($this->customerContext(42));
+    $availability->method('filterPurchasableVariations')->willReturn([$variation]);
+    $availability->method('resolveTierForVariation')->willReturn($tier);
+    $availability->method('countCompletedSoldForVariation')->willReturn(0);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([$tier]);
+
+    $default_resolver = new EventDefaultTicketResolverStub($tier);
+
+    $builder = $this->builder($availability, $lifecycle, NULL, $default_resolver);
+    $result = $builder->buildForEvent($event);
+
+    $this->assertTrue($result['visible_rows'][0]['is_best_value']);
+    $this->assertSame('Under 18 pricing', $result['visible_rows'][0]['short_description']);
+  }
+
+  /**
+   * @covers ::buildForEvent
+   */
+  public function testRowOrderMatchesBookDefaultFirst(): void {
+    $general = $this->variation(11, '50.00', 'General admission');
+    $concession = $this->variation(12, '30.00', 'Concession');
+    $general_tier = $this->tier(5, 'General admission', TRUE, 'public', NULL, TRUE, 11);
+    $concession_tier = $this->tier(6, 'Concession', TRUE, 'public', NULL, TRUE, 12);
+    $event = $this->eventNode(42, TRUE, [$general_tier, $concession_tier]);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('isPublished')->willReturn(TRUE);
+    $product->method('id')->willReturn('7');
+    $product->method('getCacheTags')->willReturn(['commerce_product:7']);
+    $product->method('getVariations')->willReturn([]);
+
+    $availability = $this->availabilityMock();
+    $availability->method('buildDefaultCustomerAccessContext')->willReturn($this->customerContext(42));
+    $availability->method('filterPurchasableVariations')->willReturn([$general, $concession]);
+    $availability->method('resolveTierForVariation')->willReturnCallback(
+      static function (NodeInterface $event, ProductVariationInterface $variation) use ($general_tier, $concession_tier): TicketTypeInterface {
+        return (int) $variation->id() === 12 ? $concession_tier : $general_tier;
+      }
+    );
+    $availability->method('countCompletedSoldForVariation')->willReturn(0);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([$general_tier, $concession_tier]);
+
+    $default_resolver = new EventDefaultTicketResolverStub($concession_tier);
+
+    $builder = $this->builder($availability, $lifecycle, NULL, $default_resolver);
+    $result = $builder->buildForEvent($event);
+
+    $this->assertCount(2, $result['visible_rows']);
+    $this->assertSame('Concession', $result['visible_rows'][0]['name']);
+    $this->assertSame('General admission', $result['visible_rows'][1]['name']);
   }
 
   /**
@@ -121,6 +203,7 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     TicketCustomerDisplayGatewayInterface&MockObject $availability,
     ?EventPaidTicketLoaderInterface $lifecycle = NULL,
     ?TicketTierWaitlistHoldCounterInterface $waitlist = NULL,
+    ?EventDefaultTicketResolverInterface $default_resolver = NULL,
   ): CustomerTicketTierDisplayBuilder {
     $lifecycle ??= $this->createMock(EventPaidTicketLoaderInterface::class);
     $lifecycle->method('loadOrderedTicketsForEvent')->willReturn([]);
@@ -133,11 +216,14 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     $waitlist ??= $this->createMock(TicketTierWaitlistHoldCounterInterface::class);
     $waitlist->method('sumActiveOfferReserved')->willReturn(0);
 
+    $default_resolver ??= new EventDefaultTicketResolverStub(NULL);
+
     return new CustomerTicketTierDisplayBuilder(
       $availability,
       $lifecycle,
       $formatter,
       $waitlist,
+      $default_resolver,
       new TranslationManager(new LanguageDefault([])),
     );
   }
@@ -160,7 +246,10 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     );
   }
 
-  private function eventNode(int $nid, bool $with_product): NodeInterface&MockObject {
+  /**
+   * @param list<\Drupal\mel_ticket\Entity\TicketTypeInterface> $ticket_types
+   */
+  private function eventNode(int $nid, bool $with_product, array $ticket_types = []): NodeInterface&MockObject {
     $event = $this->createMock(NodeInterface::class);
     $event->method('bundle')->willReturn('event');
     $event->method('isNew')->willReturn(FALSE);
@@ -177,7 +266,7 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     }
 
     $product_field = new EntityReferenceFieldStub($product);
-    $ticket_types_field = new EntityReferenceFieldStub(NULL, TRUE);
+    $ticket_types_field = new TicketTypesFieldStub($ticket_types);
     $empty_field = new EntityReferenceFieldStub(NULL, TRUE);
 
     $event->method('hasField')->willReturnCallback(
@@ -216,6 +305,8 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     ?int $capacity,
     bool $with_variation = TRUE,
     ?int $variation_id = NULL,
+    bool $is_best_value = FALSE,
+    ?string $short_description = NULL,
   ): TicketTypeInterface&MockObject {
     $tier = $this->createStub(TicketTypeInterface::class);
     $tier->method('id')->willReturn((string) $id);
@@ -225,20 +316,28 @@ final class CustomerTicketTierDisplayBuilderTest extends UnitTestCase {
     $tier->method('isArchived')->willReturn(FALSE);
     $tier->method('getCacheTags')->willReturn(['mel_ticket_type:' . $id]);
     $tier->method('hasField')->willReturnCallback(
-      static fn (string $name) => in_array($name, ['visibility_mode', 'capacity', 'short_description', 'commerce_variation'], TRUE)
+      static fn (string $name) => in_array($name, [
+        'visibility_mode',
+        'capacity',
+        'short_description',
+        'commerce_variation',
+        'field_is_best_value',
+      ], TRUE)
     );
+    $tier->method('isBestValueTicket')->willReturn($is_best_value);
 
     $variation = $with_variation
       ? $this->variation($variation_id ?? ($id + 100), '10.00', $title)
       : NULL;
     $empty_field = new ScalarFieldStub(NULL, TRUE);
     $tier->method('get')->willReturnCallback(
-      static function (string $name) use ($visibility, $capacity, $variation, $empty_field) {
+      static function (string $name) use ($visibility, $capacity, $variation, $empty_field, $short_description, $is_best_value) {
         return match ($name) {
           'visibility_mode' => new ScalarFieldStub($visibility),
           'capacity' => new ScalarFieldStub($capacity === NULL ? NULL : (string) $capacity, $capacity === NULL),
           'commerce_variation' => new EntityReferenceFieldStub($variation),
-          'short_description' => new ScalarFieldStub(NULL, TRUE),
+          'short_description' => new ScalarFieldStub($short_description, $short_description === NULL),
+          'field_is_best_value' => new ScalarFieldStub($is_best_value ? 1 : 0, !$is_best_value),
           default => $empty_field,
         };
       }
@@ -268,6 +367,46 @@ final class EntityReferenceFieldStub {
 
   public function isEmpty(): bool {
     return $this->empty;
+  }
+
+}
+
+/**
+ * Test double for default ticket resolution.
+ */
+final class EventDefaultTicketResolverStub implements EventDefaultTicketResolverInterface {
+
+  public function __construct(
+    private readonly ?TicketTypeInterface $default,
+  ) {}
+
+  public function getDefaultTicket(NodeInterface $event): ?TicketTypeInterface {
+    return $this->default;
+  }
+
+}
+
+/**
+ * Minimal field stub for event field_ticket_types in unit tests.
+ */
+final class TicketTypesFieldStub {
+
+  /**
+   * @param list<\Drupal\mel_ticket\Entity\TicketTypeInterface> $tickets
+   */
+  public function __construct(
+    private readonly array $tickets,
+  ) {}
+
+  public function isEmpty(): bool {
+    return $this->tickets === [];
+  }
+
+  /**
+   * @return list<\Drupal\mel_ticket\Entity\TicketTypeInterface>
+   */
+  public function referencedEntities(): array {
+    return $this->tickets;
   }
 
 }

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTypeManager.php
@@ -16,13 +16,14 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\EventDefaultTicketResolverInterface;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\node\NodeInterface;
 
 /**
  * Manages ticket type entities and syncs paid types to Commerce variations.
  */
-final class TicketTypeManager {
+final class TicketTypeManager implements EventDefaultTicketResolverInterface {
 
   use StringTranslationTrait;
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-ticket-preview.css
@@ -105,16 +105,44 @@
   border: 1px solid var(--mel-ticket-preview-border);
 }
 
+.mel-event-ticket-preview__ticket-row--best-value {
+  border-color: rgba(242, 109, 91, 0.42);
+  box-shadow: 0 6px 18px rgba(242, 109, 91, 0.1);
+}
+
 .mel-event-ticket-preview__ticket-main {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+}
+
+.mel-event-ticket-preview__ticket-title {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  min-width: 0;
 }
 
 .mel-event-ticket-preview__ticket-name {
   font-weight: 600;
   font-size: 0.9375rem;
+}
+
+.mel-event-ticket-preview__best-value-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(242, 109, 91, 0.12);
+  color: var(--mel-ticket-preview-accent);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .mel-event-ticket-preview__ticket-price {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
@@ -118,7 +118,8 @@ final class EventTicketPreviewBuilder {
         'name' => $row['name'],
         'price' => $row['price'],
         'availability' => $row['availability'],
-        'description' => $row['description'],
+        'short_description' => $row['short_description'] ?? NULL,
+        'is_best_value' => !empty($row['is_best_value']),
       ];
     }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-ticket-preview.html.twig
@@ -9,7 +9,7 @@
  * - heading: section heading inside canvas
  * - cta: { label, disabled, reason }
  * - availability: { state, message }
- * - ticket_rows: list of { name, price, availability, description? }
+ * - ticket_rows: list of { name, price, availability, short_description?, is_best_value? }
  * - excluded_rows: list of { name, diagnostic }
  * - show_customer_ticket_empty: bool
  * - rsvp_summary: { capacity_line }|null
@@ -70,13 +70,18 @@
         {% if ticket_rows is not empty %}
           <ul class="mel-event-ticket-preview__ticket-rows" aria-label="{{ 'Ticket options customers can book'|t }}">
             {% for row in ticket_rows %}
-              <li class="mel-event-ticket-preview__ticket-row">
+              <li class="mel-event-ticket-preview__ticket-row{% if row.is_best_value %} mel-event-ticket-preview__ticket-row--best-value{% endif %}">
                 <div class="mel-event-ticket-preview__ticket-main">
-                  <span class="mel-event-ticket-preview__ticket-name">{{ row.name }}</span>
+                  <div class="mel-event-ticket-preview__ticket-title">
+                    <span class="mel-event-ticket-preview__ticket-name">{{ row.name }}</span>
+                    {% if row.is_best_value %}
+                      <span class="mel-event-ticket-preview__best-value-badge">{{ 'Best value'|t }}</span>
+                    {% endif %}
+                  </div>
                   <span class="mel-event-ticket-preview__ticket-price">{{ row.price }}</span>
                 </div>
-                {% if row.description %}
-                  <p class="mel-event-ticket-preview__ticket-description mel-text--muted">{{ row.description }}</p>
+                {% if row.short_description %}
+                  <p class="mel-event-ticket-preview__ticket-description mel-text--muted">{{ row.short_description|e }}</p>
                 {% endif %}
                 {% if row.availability %}
                   <p class="mel-event-ticket-preview__ticket-availability">{{ row.availability }}</p>

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -17,6 +17,7 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Drupal\myeventlane_help_centre\Service\ContextualHelpResolver;
 use Drupal\node\NodeInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -719,9 +720,52 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
 }
 
 /**
+ * Implements hook_views_pre_view().
+ *
+ * Enforces audience on mel_help_search before the SQL query runs so titles/summaries
+ * for vendor/staff articles are not listed for anonymous users.
+ */
+function myeventlane_help_centre_views_pre_view(ViewExecutable $view, string $display_id, ?array &$args): void {
+  if ($view->id() !== 'mel_help_search') {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
+  $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
+  $account = \Drupal::currentUser()->getAccount();
+  $exposed = $view->getExposedInput();
+  $requested = isset($exposed['audience']) && is_string($exposed['audience']) && $exposed['audience'] !== ''
+    ? trim($exposed['audience'])
+    : NULL;
+  $effective = $policy->effectiveAudienceFilter($account, $requested);
+
+  $handler = $view->display_handler->getHandler('filter', 'field_audience_value');
+  if ($handler !== NULL) {
+    $handler->value = array_combine($effective, $effective) ?: [];
+    $handler->operator = 'or';
+  }
+}
+
+/**
  * Implements hook_views_query_alter().
  */
 function myeventlane_help_centre_views_query_alter(ViewExecutable $view, QueryPluginBase $query): void {
+  if ($view->id() === 'mel_help_search' && $query instanceof Sql) {
+    /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
+    $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
+    $account = \Drupal::currentUser()->getAccount();
+    $exposed = $view->getExposedInput();
+    $requested = isset($exposed['audience']) && is_string($exposed['audience']) && $exposed['audience'] !== ''
+      ? trim($exposed['audience'])
+      : NULL;
+    $audiences = $policy->effectiveAudienceFilter($account, $requested);
+    $query->ensureTable('node__field_audience');
+    $query->addWhere(0, 'node__field_audience.field_audience_value', $audiences, 'IN');
+    $statuses = $policy->allowedHelpStatusesForBrowse($account);
+    $query->ensureTable('node__field_help_status');
+    $query->addWhere(0, 'node__field_help_status.field_help_status_value', $statuses, 'IN');
+  }
+
   if ($view->id() !== 'mel_help_related_articles' || $view->current_display !== 'block_related') {
     return;
   }

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.services.yml
@@ -9,6 +9,9 @@ services:
     arguments:
       - '@config.factory'
 
+  myeventlane_help_centre.help_browse_policy:
+    class: Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy
+
   myeventlane_help_centre.support_panel_builder:
     class: Drupal\myeventlane_help_centre\Service\SupportPanelBuilder
     arguments:

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_help_centre\Service;
+
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Audience and status rules for Help Centre browse/search listings (not Assistant).
+ *
+ * Aligns with HelpRetriever audience splits where applicable, but applies stricter
+ * vendor gating for authenticated users without vendor console permissions.
+ */
+final class HelpArticleBrowsePolicy {
+
+  /**
+   * Canonical field_audience values allowed in browse/search for this account.
+   *
+   * @return list<string>
+   */
+  public function allowedAudienceValues(AccountInterface $account): array {
+    if ($account->hasPermission('administer escalations')) {
+      return ['public', 'vendor', 'staff'];
+    }
+    if ($account->hasPermission('access vendor console')
+      || $account->hasPermission('view vendor help centre')) {
+      return ['public', 'vendor'];
+    }
+    return ['public'];
+  }
+
+  /**
+   * Help status values that may appear in public browse/search listings.
+   *
+   * @return list<string>
+   */
+  public function allowedHelpStatusesForBrowse(AccountInterface $account): array {
+    if ($account->hasPermission('bypass node access')
+      || $account->hasPermission('administer help articles')) {
+      return ['published', 'approved', 'review', 'draft'];
+    }
+    return ['published', 'approved'];
+  }
+
+  /**
+   * Resolves effective audience filter values for a Help search request.
+   *
+   * Intersects optional exposed ?audience= with account allowances so URL params
+   * cannot widen access (e.g. anonymous ?audience=vendor).
+   *
+   * @return list<string>
+   */
+  public function effectiveAudienceFilter(AccountInterface $account, ?string $requestedAudience): array {
+    $allowed = $this->allowedAudienceValues($account);
+    if ($requestedAudience !== NULL && $requestedAudience !== '') {
+      if (in_array($requestedAudience, ['public', 'vendor', 'staff'], TRUE)
+        && in_array($requestedAudience, $allowed, TRUE)) {
+        return [$requestedAudience];
+      }
+      return $allowed;
+    }
+    return $allowed;
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Help Centre search query constraints (audience/status) and customer-facing ticket row ordering/badging, which could hide/show content or change purchase UX if the policy logic is wrong.
> 
> **Overview**
> **Help Centre search privacy hardening:** Adds `HelpArticleBrowsePolicy` and applies it to `mel_help_search` via `hook_views_pre_view()` and `hook_views_query_alter()` to enforce audience (and `field_help_status`) constraints at SQL query time, preventing anonymous users from seeing vendor/staff article titles/teasers via exposed filters.
> 
> **Ticket preview UX alignment:** Updates `CustomerTicketTierDisplayBuilder` to sort purchasable variations with the same default-ticket semantics as the booking form (via new `EventDefaultTicketResolverInterface` implemented by `TicketTypeManager`), and to surface `short_description` plus an `is_best_value` flag; Event Studio’s preview template/CSS now highlights best-value tickets.
> 
> **Docs:** Adds detailed audit/inventory markdown documenting help retrieval/access behavior and findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0126d0f6a8105480cfdffa87c136cb89d5e92ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->