### PR TITLE
 Follow-up help centre work

### DIFF
--- a/docs/content-audit/help-article-drafts/checkout-errors.md
+++ b/docs/content-audit/help-article-drafts/checkout-errors.md
@@ -1,0 +1,38 @@
+---
+title: What to do when checkout fails
+audience: public
+article_type: guide
+product_area: checkout
+help_status: draft
+ai_allowed: true
+recommended_route: /help/attendees
+source_evidence: commerce_checkout.form contextual help; myeventlane_help_centre support panels
+needs_verification: Exact checkout error messages and retry behaviour on staging
+---
+
+# What to do when checkout fails
+
+If your card is declined or checkout stops before you finish, this page explains what to try and when to ask for help.
+
+## What this means
+
+Checkout can fail for several common reasons: card details entered incorrectly, your bank declining the payment, a slow connection, or the ticket no longer being available. It does not always mean you have been charged.
+
+## What to do next
+
+1. Check the total, ticket type, and quantity on the order summary.
+2. Confirm your card number, expiry date, and security code.
+3. Try the same card again on a stable internet connection.
+4. If you have another card, try that instead.
+5. If the event looks sold out, check whether a waitlist is offered on the event page.
+6. If you received a confirmation email, your order may already be complete — check your inbox and junk folder before paying again.
+
+## If it still does not work
+
+Open **My tickets** if you have an account, or contact support with the event name, date, and any error message shown on screen. Do not submit multiple payments unless you are sure no confirmation arrived.
+
+## Related help
+
+- How to buy tickets
+- Ticket confirmation emails and receipts
+- Contacting support about a booking

--- a/docs/content-audit/help-article-drafts/stripe-payouts.md
+++ b/docs/content-audit/help-article-drafts/stripe-payouts.md
@@ -1,0 +1,39 @@
+---
+title: Connecting Stripe and receiving payouts
+audience: vendor
+article_type: guide
+product_area: payments
+help_status: draft
+ai_allowed: true
+recommended_route: /help/vendors
+source_evidence: /stripe/connect; vendor onboarding routes; docs/audits/mel-stripe-connect-audit.md
+needs_verification: Exact payout timing, dashboard labels, and charges_enabled gating on staging
+existing_article_note: Published article "Payouts and fees" (nid 1510) may overlap — merge or cross-link before publish
+---
+
+# Connecting Stripe and receiving payouts
+
+This page explains how organisers connect a Stripe account to sell paid tickets and where to check payout status.
+
+## What this means
+
+Paid ticket sales are processed through Stripe. MyEventLane uses a connected account so payouts go to you according to Stripe’s rules and your account status. You must complete Stripe onboarding before paid tickets can go on sale.
+
+## What to do next
+
+1. Sign in to your organiser dashboard.
+2. Open the Stripe or payouts section (wording may vary).
+3. Follow the prompts to connect or finish verifying your Stripe account.
+4. Return to your event and confirm paid ticket types are available to publish.
+5. After tickets sell, check Stripe or your dashboard for payout and fee details.
+
+## If it still does not work
+
+If onboarding stalls or payouts look wrong, note any message from Stripe and contact MyEventLane support with your event name. Payout timing depends on Stripe and your account — **Needs verification** for exact schedules shown in the product.
+
+## Related help
+
+- Payouts and fees
+- Choosing RSVP or paid tickets
+- Setting up ticket types and pricing
+- When you can start selling paid tickets

--- a/docs/content-audit/help-article-drafts/support-contact.md
+++ b/docs/content-audit/help-article-drafts/support-contact.md
@@ -1,0 +1,39 @@
+---
+title: Contacting support about a booking
+audience: public
+article_type: guide
+product_area: support
+help_status: draft
+ai_allowed: true
+recommended_route: /help/attendees
+source_evidence: /my/support routes; myeventlane_escalations_portal; Help Centre contact support URLs
+needs_verification: Exact signed-in support URL and whether anonymous users use /help only
+existing_article_note: Published article "Contacting support" (nid 1498) exists — review for merge before publish
+---
+
+# Contacting support about a booking
+
+Use this page when you need help with a ticket, payment, refund, or access problem.
+
+## What this means
+
+For questions about the event itself (timing, venue, accessibility at the door), contact the organiser first if their details are on the event page. For booking, payment, or platform issues, use MyEventLane support.
+
+## What to do next
+
+1. Find your confirmation email or open **My tickets** if you have an account.
+2. Note the event name, date, and order or ticket reference if you have one.
+3. Sign in and open the support or help area — **Needs verification** for the exact path (`/my/support` for signed-in customers).
+4. Describe what happened and what you need (refund, missing email, wrong ticket, and so on).
+5. If you are not signed in, start from the Help Centre and use **Contact support** — **Needs verification** for anonymous flow.
+
+## If it still does not work
+
+If you cannot reach support through the site, reply to any confirmation email if a reply address is shown, or use the contact option listed on the event page for organiser-specific issues.
+
+## Related help
+
+- Contacting support
+- How to request a refund
+- Ticket confirmation emails and receipts
+- What to do when checkout fails

--- a/docs/content-audit/help-article-drafts/ticket-confirmation.md
+++ b/docs/content-audit/help-article-drafts/ticket-confirmation.md
@@ -1,0 +1,38 @@
+---
+title: Ticket confirmation emails and receipts
+audience: public
+article_type: guide
+product_area: post-purchase
+help_status: draft
+ai_allowed: true
+recommended_route: /help/attendees
+source_evidence: checkout complete step; /my-tickets route; docs/phase-6-confirmation-and-receipts.md (internal)
+needs_verification: Wallet links, calendar attachments, and exact email templates on staging
+---
+
+# Ticket confirmation emails and receipts
+
+After you buy tickets or complete an RSVP, you should receive confirmation by email. This page explains what to look for and where to find your tickets again.
+
+## What this means
+
+A confirmation email is your record of the booking. It usually includes the event name, date, and how to access tickets. A receipt may be included for paid orders.
+
+## What to do next
+
+1. Check your inbox for a message from MyEventLane or the organiser.
+2. Check your junk or spam folder.
+3. Sign in and open **My tickets** if you have an account — **Needs verification** for exact menu label.
+4. Open the ticket link or QR code shown in the email or account page.
+5. Save the email until after the event if you need proof of purchase.
+
+## If it still does not work
+
+If nothing arrives within a few minutes, do not assume the order failed — contact support with the event name, date, and the email address you used at checkout. Add to calendar or wallet options — **Needs verification** unless shown on your confirmation screen.
+
+## Related help
+
+- How to buy tickets
+- How to access your tickets
+- What to do when checkout fails
+- Contacting support about a booking

--- a/docs/content-audit/help-article-drafts/waitlist.md
+++ b/docs/content-audit/help-article-drafts/waitlist.md
@@ -1,0 +1,37 @@
+---
+title: Joining a waitlist when an event is sold out
+audience: public
+article_type: guide
+product_area: booking
+help_status: draft
+ai_allowed: true
+recommended_route: /help/attendees
+source_evidence: Ticket waitlist entities; event field_waitlist_capacity; docs/qa/journeys.md
+needs_verification: Whether buyers receive automatic offers, email copy, and claim links on staging
+---
+
+# Joining a waitlist when an event is sold out
+
+If tickets are sold out, the event may offer a waitlist. This page explains how to join and what to expect.
+
+## What this means
+
+A waitlist records your interest when no tickets are available. It does **not** guarantee a ticket. If space opens later, you may receive an offer to complete purchase — **Needs verification** for how and when offers are sent on your site.
+
+## What to do next
+
+1. Open the event page.
+2. If you see a waitlist option, follow the prompts to join.
+3. Use an email address you check regularly.
+4. Watch for a message from the organiser or MyEventLane if a spot becomes available.
+5. Complete checkout promptly if you receive an offer — offers may expire.
+
+## If it still does not work
+
+If you cannot join the waitlist or never hear back, contact the event organiser through the event page if details are listed, or contact support with the event name and date.
+
+## Related help
+
+- How to buy tickets
+- What to do when checkout fails
+- Ticket confirmation emails and receipts

--- a/docs/content-audit/help-docs-gap-analysis.md
+++ b/docs/content-audit/help-docs-gap-analysis.md
@@ -1,0 +1,97 @@
+# Help documentation gap analysis
+
+**Audit date:** 2026-05-22
+
+## Existing baseline (do not duplicate)
+
+YAML seeds in `myeventlane_help_centre.help_content.yml` (10 articles):
+
+| Seed key | Title | Audience (canonical) |
+|----------|-------|----------------------|
+| `how_to_buy_tickets` | How to buy tickets | public |
+| `how_to_rsvp` | How to RSVP to a free event | public |
+| `how_to_access_tickets` | How to access your tickets | public |
+| `how_to_request_refund` | How to request a refund | public |
+| `how_to_create_event` | How to create an event | public |
+| `choosing_rsvp_or_paid` | Choosing RSVP or paid tickets | public |
+| `managing_dashboard` | Managing your event dashboard | public |
+| `vendor_dashboard_overview` | Vendor dashboard overview | vendor |
+| `refund_policy` | Refund policy | public |
+| `community_guidelines` | Community guidelines | public |
+
+**Needs verification:** Which seeds exist as published nodes on staging/production and whether aliases match.
+
+---
+
+## Missing help articles
+
+### Attendee / public
+
+| Proposed title | Audience | Product area | User problem | Source evidence | Priority | Status |
+|----------------|----------|--------------|--------------|-----------------|----------|--------|
+| Finding events on MyEventLane | public | Discovery | Where to browse, filters, categories | `views.view.upcoming_events.yml` paths `/events`, `/events/free` | P1 | ready to write |
+| What to do when checkout fails or payment is declined | public | Checkout | Card errors, abandoned cart | `support_panels.buy_tickets` surfaces `commerce_checkout.form`; `myeventlane_commerce` | P1 | **Markdown draft** — `help-article-drafts/checkout-errors.md` (not published) |
+| Creating a MyEventLane account | public | Account | Register and verify email | `/user/register`, `mel-surface-architecture.md` | P1 | ready to write |
+| Resetting your password | public | Account | Locked out | Core user routes | P2 | ready to write |
+| Joining a waitlist when an event is sold out | public | Booking | Sold-out CTA behaviour | `docs/qa/journeys.md` waitlist CTA table | P1 | **Markdown draft** — `help-article-drafts/waitlist.md` (not published; auto-invite **Needs verification**) |
+| Cancelling your RSVP | public | RSVP | Release a free spot | `/rsvp/{rsvp_id}/cancel` in `myeventlane_rsvp.routing.yml` | P2 | ready to write |
+| Adding an event to your calendar | public | RSVP/Events | ICS download | `/event/{node}/ics` | P3 | ready to write |
+| Using Apple Wallet or Google Wallet for your ticket | public | Tickets | Mobile pass | `myeventlane_wallet.routing.yml` | P2 | needs verification (eligibility rules) |
+| Transferring or assigning a ticket to someone else | public | Tickets | Assignee flow | `/ticket/assign/{token}` | P2 | needs verification |
+| Understanding ticket confirmation emails and receipts | public | Post-purchase | What arrives after checkout | `docs/phase-6-confirmation-and-receipts.md` (internal reference) | P1 | **Markdown draft** — `help-article-drafts/ticket-confirmation.md` (not published; wallet/calendar **Needs verification**) |
+| Contacting support about a booking | public | Support | When and how to open a case | `/my/support`, `/my/support/escalations/add` | P1 | **Markdown draft** — `help-article-drafts/support-contact.md` (not published; overlaps nid **1498** — merge before publish) |
+| Accessibility information on event pages | public | Events | What hosts can publish; attendee needs | `docs/qa/journeys.md` accessibility section | P2 | needs verification (field names on event) |
+| What happens when an event is cancelled | public | Refunds/Events | Refunds, notifications | Event state `Cancelled` in journeys.md; refunds module | P1 | needs verification |
+
+### Organiser / vendor (public or vendor audience)
+
+| Proposed title | Audience | Product area | User problem | Source evidence | Priority | Status |
+|----------------|----------|--------------|--------------|-----------------|----------|--------|
+| Setting up ticket types and pricing | vendor | Tickets | Configure paid tickets | `/vendor/events/{event}/studio/tickets`, tickets module routes | P1 | ready to write |
+| Connecting Stripe to receive payouts | vendor | Payments | Connect onboarding | `/stripe/connect`, `/vendor/onboard/stripe`; `docs/audits/mel-stripe-connect-audit.md` | P1 | **Markdown draft** — `help-article-drafts/stripe-payouts.md` (not published; overlaps nid **1510** — merge before publish) |
+| When you can start selling paid tickets | vendor | Payments | charges_enabled gating | Stripe safety rules / vendor module — **do not invent thresholds** | P1 | needs verification |
+| Managing attendees and orders for your event | vendor | Operations | Lists, export, door | `/vendor/events/{node}/attendees`, attendees module | P1 | ready to write |
+| Checking in guests with QR scan | vendor | Check-in | Door operations | RSVP/tickets check-in routes | P2 | code evidence only — browser verification needed |
+| Handling refund requests from attendees | vendor | Refunds | Approve/reject | `/vendor/events/{node}/refund-requests` | P1 | ready to write |
+| Publishing, unpublishing, and event visibility | vendor | Event Studio | Draft vs live | Event states in journeys.md; studio publish routes | P1 | ready to write |
+| Setting capacity and waitlists | vendor | Capacity | Limits | Wizard step 4 in journeys.md; capacity module | P2 | needs verification |
+| Promoting your event with Boost | vendor | Marketing | Paid promotion | `myeventlane_boost` routes | P3 | needs verification |
+| Checkout questions and collecting attendee details | vendor | Checkout | Custom questions | `/vendor/event/{event}/checkout-questions` | P2 | ready to write |
+| Ticket access codes and hidden ticket types | vendor | Tickets | Access codes routes | tickets module access-code routes | P3 | code evidence only |
+| Embedding a ticket widget on your website | vendor | Tickets | Purchase surfaces | tickets widgets routes | P3 | code evidence only |
+
+### Policies and trust (extend seeds)
+
+| Proposed title | Audience | Product area | User problem | Source evidence | Priority | Status |
+|----------------|----------|--------------|--------------|-----------------|----------|--------|
+| Privacy and how we use your data | public | Legal | Privacy expectations | `/privacy` redirect; `myeventlane_privacy`, `myeventlane_legal` modules | P2 | needs verification (canonical policy node) |
+| Public trust and safety reporting | public | Trust | Report issues | `myeventlane_public_trust` route (see support-route audit) | P3 | needs verification |
+
+### Not recommended as public help_article
+
+| Topic | Reason |
+|-------|--------|
+| Staff escalation playbooks | Use `staff_playbook` only |
+| Internal support procedures | `support_procedure` bundle — staff playbooks gap file |
+| Communication snippet authoring | Route requires `administer escalations` |
+
+---
+
+## Coverage summary
+
+| Area | Seeded | Gap count (proposed) |
+|------|--------|----------------------|
+| Attendee booking/RSVP | 3 | 10+ |
+| Organiser/vendor ops | 4 | 12+ |
+| Policies | 2 | 2 |
+| Checkout/payments | 0 dedicated | 3 |
+| Support contact | 0 dedicated | 1 |
+
+## Editorial workflow reminders
+
+Before marking **ready to write**:
+
+1. Set `field_audience` (canonical list, not taxonomy alone).
+2. Set `field_help_ai_allowed` if article should appear in Help Assistant.
+3. Set `field_help_status` to `published` or `approved`.
+4. Reindex `mel_content` after publish batch.

--- a/docs/content-audit/help-hub-policy-extension-audit.md
+++ b/docs/content-audit/help-hub-policy-extension-audit.md
@@ -1,0 +1,95 @@
+# Help hub browse policy extension audit
+
+**Date:** 2026-05-22  
+**Prior fix:** commit `0126d0f6` — `/help/search` metadata leak  
+**This pass:** extend `HelpArticleBrowsePolicy` to other public browse listings; organiser IA interim; priority article drafts.
+
+## Views audited
+
+| View | Display | Route / placement | Lists help_article | Renders teaser metadata | YAML `field_audience` | YAML `field_help_status` | Pre-pass leak risk |
+|------|---------|-------------------|--------------------|-------------------------|----------------------|--------------------------|-------------------|
+| `mel_help_search` | `block_search` | `/help/search` | Yes | Yes | Exposed (empty default) | None | **Fixed in 0126d0f6** |
+| `mel_help_attendee_help` | `block_attendees` | `/help/attendees` | Yes | Yes | `public` fixed | None | Draft status possible |
+| `mel_help_organiser_help` | `block_organisers` | `/help/organisers` | Yes | Yes | `public` fixed | None | Draft; duplicate of attendees |
+| `mel_help_vendor_help` | `block_vendors` | `/help/vendors` | Yes | Yes | `vendor` fixed | None | Draft status possible |
+| `mel_help_policies_help` | `block_policies` | `/help/policies` | Yes | Yes | `public` + policy type | None | Draft status possible |
+| `mel_help_featured_articles` | `block_featured` | `/help` homepage | Yes | Yes | **None** | None | **Vendor featured could leak** |
+| `mel_help_faq` | `block_faq` | `/help` homepage | Yes (FAQ type) | Yes | **None** | None | Vendor FAQ type possible |
+| `mel_help_related_articles` | `block_related` | `node--help-article` full | Yes | Yes | **None** | None | Cross-audience related teasers |
+| `mel_help_category_listing` | `block_1` | Not on main hub routes | Yes + faq | Yes | None | None | Not extended (unused on audited routes) |
+| `mel_help_centre_homepage` | — | Not referenced in controller | — | — | — | — | No change |
+| `mel_help_*_admin` / analytics | admin | Staff only | Yes | Varies | N/A | N/A | Excluded (not public browse) |
+| `mel_help_internal_procedures` | admin | Staff | support_procedure | — | — | — | Excluded |
+
+## Views changed (policy applied)
+
+All rows in **Views changed** use `HelpArticleBrowsePolicy` via `hook_views_pre_view()` and `hook_views_query_alter()`:
+
+- `mel_help_search`
+- `mel_help_attendee_help`
+- `mel_help_organiser_help`
+- `mel_help_vendor_help`
+- `mel_help_policies_help`
+- `mel_help_featured_articles`
+- `mel_help_faq`
+- `mel_help_related_articles`
+
+**Not changed:** admin/analytics views; `mel_help_category_listing` (no public hub route in this audit).
+
+## Why each change was needed
+
+| View | Reason |
+|------|--------|
+| `mel_help_search` | Already fixed; kept in browse list |
+| `mel_help_featured_articles` | No audience filter — could list vendor-featured articles on `/help` |
+| `mel_help_faq` | No audience filter — FAQ article type only |
+| `mel_help_related_articles` | No audience filter — related teasers on public articles |
+| Hub views with YAML audience | YAML caps hub intent; policy adds **status** filter and intersects account policy (e.g. staff never on public hubs) |
+
+**Hub audience caps (intersected with account policy):**
+
+| View | Cap |
+|------|-----|
+| Attendee, organiser, policies | `public` only |
+| Vendor hub | `vendor` only |
+| Search, featured, faq, related | Account policy only |
+
+**Help Assistant:** unchanged (`HelpRetriever`).
+
+## Organiser IA (Scope B)
+
+| Item | Decision |
+|------|----------|
+| Long-term | `/help/organisers` = public organiser onboarding; `/help/vendors` = authenticated console help (UI label “Organiser help”) |
+| Interim implemented | Logged-in vendor-console users hitting `/help/organisers` → **302** to `/help/vendors` |
+| User-facing label | Vendor hub H1/title → **Organiser help** (route `vendors_index` unchanged) |
+| Deferred | Renaming routes, permissions, roles, or merging duplicate public lists |
+
+## Routes verified
+
+| Route | Anonymous | Vendor (uid 2) | Notes |
+|-------|-----------|------------------|-------|
+| `/help` | 200 | 200 | Featured/faq policy applied |
+| `/help/search?q=ticketing` | 200, no nid 1521 | 200, includes 1521 | curl + Drush |
+| `/help/attendees` | 200 | 200 | Public only |
+| `/help/organisers` | 200 public list | 302 → `/help/vendors` | Redirect for vendor trust |
+| `/help/vendors` | 200 empty or no vendor teasers | 200 vendor articles | Vendor cap |
+| `/help/policies` | 200 | 200 | Public + policy type |
+| `/node/1521` | 403 | Allowed | Unchanged |
+
+**Staff:** `staff_playbook` not in `mel_content`; no staff audience in anon/vendor browse queries.
+
+## Remaining risks
+
+| Risk | Severity |
+|------|----------|
+| `mel_help_category_listing` if placed publicly without policy | Low |
+| Organiser vs attendee hubs still show same 15 public articles | Medium (IA deferred) |
+| Draft articles on `/help/vendors` if `field_help_status` not set on vendor nodes | Low — status filter now applied |
+| Duplicate published articles vs new Markdown drafts (1498, 1510) | Editorial |
+
+## Code files (Scope A + B)
+
+- `HelpArticleBrowsePolicy.php` — browse view list, hub caps, `effectiveAudiencesForBrowseView()`
+- `myeventlane_help_centre.module` — shared apply helper; query alter for all browse views
+- `HelpCentreController.php` — organiser redirect; vendor hub title

--- a/docs/content-audit/top-20-priority-help-articles.md
+++ b/docs/content-audit/top-20-priority-help-articles.md
@@ -1,0 +1,51 @@
+# Top 20 priority help articles
+
+**Audit date:** 2026-05-22  
+Ranked for first production writing pass. Items marked **(seeded)** already exist in `myeventlane_help_centre.help_content.yml` — expand/review, don’t blindly duplicate.
+
+| Rank | Title | Audience | Product area | Seeded? | Source evidence | Action |
+|------|-------|----------|--------------|---------|-----------------|--------|
+| 1 | How to buy tickets | public | Booking | Yes | `how_to_buy_tickets` seed; `/event/{node}/book` | Review + verify checkout steps on staging |
+| 2 | How to RSVP to a free event | public | RSVP | Yes | `how_to_rsvp`; `/event/{event}/rsvp` | Review + add cancel/calendar links |
+| 3 | How to access your tickets | public | Tickets | Yes | `how_to_access_tickets`; `/my-tickets` | Review + wallet/assign if applicable |
+| 4 | How to request a refund | public | Refunds | Yes | `how_to_request_refund`; refund routes | Review + link My Tickets path |
+| 5 | Refund policy | public | Policies | Yes | `refund_policy`; `/help/policies` | Legal review |
+| 6 | Finding events on MyEventLane | public | Discovery | No | `upcoming_events` `/events` | **Write** |
+| 7 | Creating a MyEventLane account | public | Account | No | `/user/register` | **Write** |
+| 8 | Ticket confirmation emails and receipts | public | Post-purchase | No | checkout flow + phase-6 docs | **Drafted** — `help-article-drafts/ticket-confirmation.md` |
+| 9 | Contacting support about a booking | public | Support | Partial (nid 1498) | `/my/support` | **Drafted** — `help-article-drafts/support-contact.md` (merge with 1498) |
+| 10 | What to do when checkout fails | public | Checkout | No | checkout contextual panel | **Drafted** — `help-article-drafts/checkout-errors.md` |
+| 11 | How to create an event | public | Organiser | Yes | `how_to_create_event`; Event Studio | Review for Studio vs wizard |
+| 12 | Choosing RSVP or paid tickets | vendor/public | Tickets | Yes | `choosing_rsvp_or_paid` | Review audience tags |
+| 13 | Setting up ticket types and pricing | vendor | Tickets | No | Studio tickets; vendor ticket routes | **Write** |
+| 14 | Connecting Stripe to receive payouts | vendor | Payments | Partial (nid 1510) | `/stripe/connect`, Stripe audit doc | **Drafted** — `help-article-drafts/stripe-payouts.md` (merge with 1510) |
+| 15 | Managing your event dashboard | public | Organiser | Yes | `managing_dashboard`; `/dashboard` | Review |
+| 16 | Managing attendees and orders | vendor | Operations | No | `/vendor/events/{node}/attendees` | **Write** |
+| 17 | Handling refund requests from attendees | vendor | Refunds | No | vendor refund-requests routes | **Write** |
+| 18 | Publishing and event visibility | vendor | Event Studio | No | publish routes; journeys.md states | **Write** |
+| 19 | Vendor dashboard overview | vendor | Getting started | Yes | `vendor_dashboard_overview` | Review |
+| 20 | Accessibility on your event listing | public | Events | No | journeys.md accessibility section | **Write** — needs verification |
+
+## Honourable mentions (21–25)
+
+| Title | Audience | Why next |
+|-------|----------|----------|
+| Community guidelines | public | Seeded — policy review |
+| Joining a waitlist when sold out | public | **Drafted** — `help-article-drafts/waitlist.md` |
+| Cancelling your RSVP | public | Route exists |
+| Checking in guests at the door | vendor | Event-day ops |
+| When you can start selling paid tickets | vendor | Stripe gating — must match live rules |
+
+## Publishing checklist (all 20)
+
+1. `field_audience` correct (canonical list).
+2. `field_help_status`: `published` or `approved`.
+3. `field_help_ai_allowed`: ON for Assistant-eligible public/vendor articles.
+4. Path alias under `/help/...` consistent with hub IA.
+5. `drush search-api:index mel_content` (or project equivalent) after batch publish.
+
+## What not to put in this list
+
+- `staff_playbook` topics (separate backlog).
+- Internal `support_procedure` articles without staff access review.
+- Features marked **Needs verification** until staging QA confirms UI labels and gates.

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.module
@@ -720,24 +720,24 @@ function myeventlane_help_centre_preprocess_commerce_checkout_form(array &$varia
 }
 
 /**
- * Implements hook_views_pre_view().
- *
- * Enforces audience on mel_help_search before the SQL query runs so titles/summaries
- * for vendor/staff articles are not listed for anonymous users.
+ * Applies browse listing audience constraints on a Views handler when present.
  */
-function myeventlane_help_centre_views_pre_view(ViewExecutable $view, string $display_id, ?array &$args): void {
-  if ($view->id() !== 'mel_help_search') {
+function _myeventlane_help_centre_apply_browse_listing_policy(ViewExecutable $view): void {
+  /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
+  $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
+  if (!$policy->isBrowseListingView($view->id())) {
     return;
   }
 
-  /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
-  $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
-  $account = \Drupal::currentUser()->getAccount();
   $exposed = $view->getExposedInput();
   $requested = isset($exposed['audience']) && is_string($exposed['audience']) && $exposed['audience'] !== ''
     ? trim($exposed['audience'])
     : NULL;
-  $effective = $policy->effectiveAudienceFilter($account, $requested);
+  $effective = $policy->effectiveAudiencesForBrowseView(
+    $view->id(),
+    \Drupal::currentUser()->getAccount(),
+    $requested,
+  );
 
   $handler = $view->display_handler->getHandler('filter', 'field_audience_value');
   if ($handler !== NULL) {
@@ -747,20 +747,34 @@ function myeventlane_help_centre_views_pre_view(ViewExecutable $view, string $di
 }
 
 /**
+ * Implements hook_views_pre_view().
+ *
+ * Enforces audience on help browse listings before SQL runs.
+ */
+function myeventlane_help_centre_views_pre_view(ViewExecutable $view, string $display_id, ?array &$args): void {
+  _myeventlane_help_centre_apply_browse_listing_policy($view);
+}
+
+/**
  * Implements hook_views_query_alter().
  */
 function myeventlane_help_centre_views_query_alter(ViewExecutable $view, QueryPluginBase $query): void {
-  if ($view->id() === 'mel_help_search' && $query instanceof Sql) {
-    /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
-    $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
+  /** @var \Drupal\myeventlane_help_centre\Service\HelpArticleBrowsePolicy $policy */
+  $policy = \Drupal::service('myeventlane_help_centre.help_browse_policy');
+  if ($policy->isBrowseListingView($view->id()) && $query instanceof Sql) {
     $account = \Drupal::currentUser()->getAccount();
     $exposed = $view->getExposedInput();
     $requested = isset($exposed['audience']) && is_string($exposed['audience']) && $exposed['audience'] !== ''
       ? trim($exposed['audience'])
       : NULL;
-    $audiences = $policy->effectiveAudienceFilter($account, $requested);
+    $audiences = $policy->effectiveAudiencesForBrowseView($view->id(), $account, $requested);
     $query->ensureTable('node__field_audience');
-    $query->addWhere(0, 'node__field_audience.field_audience_value', $audiences, 'IN');
+    if ($audiences === []) {
+      $query->addWhereExpression(0, '1 = 0');
+    }
+    else {
+      $query->addWhere(0, 'node__field_audience.field_audience_value', $audiences, 'IN');
+    }
     $statuses = $policy->allowedHelpStatusesForBrowse($account);
     $query->ensureTable('node__field_help_status');
     $query->addWhere(0, 'node__field_help_status.field_help_status_value', $statuses, 'IN');

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\VendorConsoleTrust;
 use Drupal\myeventlane_help_centre\Service\HelpAnalyticsService;
 use Drupal\myeventlane_help_centre\Service\MelSupportSettingsBuilder;
 use Drupal\taxonomy\TermInterface;
@@ -144,7 +145,10 @@ final class HelpCentreController extends ControllerBase {
   /**
    * Renders the organiser Help Centre listing.
    */
-  public function organisersIndex(): array {
+  public function organisersIndex(): array|RedirectResponse {
+    if (VendorConsoleTrust::accountIsTrustedForVendorConsole($this->currentUser())) {
+      return $this->redirect('myeventlane_help_centre.vendors_index', [], [], 302);
+    }
     return $this->buildViewPage((string) $this->t('Organiser help'), 'mel_help_organiser_help', 'block_organisers');
   }
 
@@ -152,7 +156,7 @@ final class HelpCentreController extends ControllerBase {
    * Renders the vendor Help Centre listing.
    */
   public function vendorsIndex(): array {
-    return $this->buildViewPage((string) $this->t('Vendor help'), 'mel_help_vendor_help', 'block_vendors', TRUE);
+    return $this->buildViewPage((string) $this->t('Organiser help'), 'mel_help_vendor_help', 'block_vendors', TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpArticleBrowsePolicy.php
@@ -15,6 +15,63 @@ use Drupal\Core\Session\AccountInterface;
 final class HelpArticleBrowsePolicy {
 
   /**
+   * Views that list help_article metadata (title, summary, teaser) on public hubs.
+   */
+  public const BROWSE_LISTING_VIEWS = [
+    'mel_help_search',
+    'mel_help_attendee_help',
+    'mel_help_organiser_help',
+    'mel_help_vendor_help',
+    'mel_help_policies_help',
+    'mel_help_featured_articles',
+    'mel_help_faq',
+    'mel_help_related_articles',
+  ];
+
+  /**
+   * Whether a view display should apply browse listing policy.
+   */
+  public function isBrowseListingView(string $viewId): bool {
+    return in_array($viewId, self::BROWSE_LISTING_VIEWS, TRUE);
+  }
+
+  /**
+   * Hub-specific audience cap (intersected with account policy).
+   *
+   * @return list<string>|null
+   *   Fixed scope, or NULL when only account policy applies.
+   */
+  public function hubAudienceScope(string $viewId): ?array {
+    return match ($viewId) {
+      'mel_help_attendee_help',
+      'mel_help_organiser_help',
+      'mel_help_policies_help' => ['public'],
+      'mel_help_vendor_help' => ['vendor'],
+      default => NULL,
+    };
+  }
+
+  /**
+   * Effective audience filter values for a browse listing view and account.
+   *
+   * @return list<string>
+   */
+  public function effectiveAudiencesForBrowseView(
+    string $viewId,
+    AccountInterface $account,
+    ?string $requestedAudience = NULL,
+  ): array {
+    $policyAudiences = $viewId === 'mel_help_search'
+      ? $this->effectiveAudienceFilter($account, $requestedAudience)
+      : $this->allowedAudienceValues($account);
+    $scope = $this->hubAudienceScope($viewId);
+    if ($scope === NULL) {
+      return $policyAudiences;
+    }
+    return array_values(array_intersect($policyAudiences, $scope));
+  }
+
+  /**
    * Canonical field_audience values allowed in browse/search for this account.
    *
    * @return list<string>


### PR DESCRIPTION
## Follow-up help centre work

This adds two focused follow-up commits after the initial help search metadata leak fix.

### Help hub browse policy

- Extended `HelpArticleBrowsePolicy` to other help article listing views.
- Applied audience and help-status filtering to help hub browse views.
- Prevents draft, vendor, or staff metadata appearing on public help hubs.
- Preserves Help Assistant behaviour.
- Preserves vendor access to vendor help articles.
- Keeps staff playbooks isolated.

### Organiser IA

- Keeps internal `vendor` naming for roles, routes, permissions, stores, and Commerce ownership.
- Uses “organiser” as the user-facing language.
- Redirects logged-in vendor-console users from `/help/organisers` to `/help/vendors`.
- Renames the vendor hub page title to “Organiser help”.
- Leaves larger route/name cleanup deferred.

### Documentation drafts

Created Markdown drafts only, not live Drupal content:

- Checkout errors
- Stripe payouts
- Waitlist
- Ticket confirmation
- Support contact

Drafts include verification notes and are not ready to publish until overlaps with existing articles are merged and staging QA is complete.

### Validation

- PHP lint passed.
- `ddev drush cr` succeeded.
- `mel_content` Search API index is 100%.
- Anonymous users cannot access `/node/1521`.
- Anonymous search no longer exposes vendor article 1521.
- Vendor search still includes vendor-safe article 1521.
- Staff playbooks remain excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filtering logic for multiple public Help Centre Views and adds a new redirect, which could inadvertently hide or expose articles if audience/status rules are wrong. Mostly isolated to help-content discovery paths and includes safety guards (e.g., empty-audience returns no results).
> 
> **Overview**
> Extends Help Centre *browse* protection beyond `/help/search` by applying `HelpArticleBrowsePolicy` to additional listing Views (featured, FAQ, related, and hub listings) and enforcing both `field_audience` and `field_help_status` constraints in `hook_views_pre_view()`/`hook_views_query_alter()` to prevent vendor/staff or draft metadata from appearing on public pages.
> 
> Adjusts interim organiser/vendor information architecture by redirecting trusted vendor-console users from `/help/organisers` to `/help/vendors` (302) and renaming the vendor hub page heading to **“Organiser help”**.
> 
> Adds several new **draft-only** Markdown help article drafts plus audit/planning docs (gap analysis, policy extension audit, priority list) with verification notes and no publishing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0230db57dd5432e9dea83f5f87c3aaebd1ba6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->