### PR TITLE
docs(help): prepare priority articles for publishing

### DIFF
--- a/docs/content-audit/publish-prep/checkout-errors-verification.md
+++ b/docs/content-audit/publish-prep/checkout-errors-verification.md
@@ -1,0 +1,53 @@
+# Checkout errors — product verification
+
+**Date:** 2026-05-22  
+**Draft:** `help-article-drafts/checkout-errors.md`
+
+## Evidence found
+
+| Item | Evidence |
+|------|----------|
+| Checkout surface | Commerce checkout `MelEventCheckoutFlow`; Stripe Payment Element via `stripe_connect` gateway |
+| User-facing validation | `MelReadinessHelper::customerCheckoutErrorSummaryLine()` → “Please complete the required details to continue.” |
+| Payment trust copy | “You will not be charged until you confirm your booking.” |
+| Recovery route | `/my-tickets` for signed-in users; Help Centre / support for help |
+| Contextual help | `checkout_booking` contextual card; support panel on checkout (`myeventlane_help_centre_preprocess_commerce_checkout_form`) |
+| Stripe failures | Handled via Commerce Stripe / PaymentIntent (no custom public “card declined” string found in MEL checkout_flow module) |
+
+**Code paths:**
+
+- `web/modules/custom/myeventlane_core/src/MelReadinessHelper.php` — checkout hero/error summary
+- `web/modules/custom/myeventlane_checkout_flow/` — checkout panes, grouped summary
+- `web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php`
+- `web/modules/custom/myeventlane_help_centre/` — checkout help links (not changed in this task)
+
+## User-facing behaviour (safe to describe)
+
+- Checkout can stop if required fields are missing (generic summary message).
+- Card or bank declines are typically shown via the payment step (Stripe/Commerce messaging — **exact text not catalogued** in this pass).
+- Users should not assume failure means charged — check confirmation email before paying again.
+- Recovery: retry checkout, try another card, check My tickets, contact support.
+
+## Unsupported or unverified claims
+
+| Claim | Verdict |
+|-------|---------|
+| Specific error codes or Stripe decline messages | **Do not list** without staging capture |
+| Automatic retry by MEL | Not confirmed — do not promise |
+| Refund on failed payment | **Do not claim** — bank holds vary |
+
+## Proposed safe article wording (summary)
+
+Keep draft structure; remove any implication of specific Stripe error strings. Use:
+
+- “If checkout stops or your bank declines the payment…”
+- “Read the message on the payment step”
+- “Check email and My tickets before paying again”
+
+## Publish readiness
+
+**Ready for editorial update** (as new article) with light edits.
+
+**Reason:** Article is intentionally generic and matches how checkout presents errors today. No false product promises. Recommend **staging spot-check** of one declined test card to optionally add one example message — not required for first publish.
+
+**Next step:** Create new `help_article` node (no duplicate found) with `field_audience: public`, `field_help_status: approved` or `published` after editorial sign-off.

--- a/docs/content-audit/publish-prep/help-article-publish-register.md
+++ b/docs/content-audit/publish-prep/help-article-publish-register.md
@@ -1,0 +1,33 @@
+# Help article publish decision register
+
+**Date:** 2026-05-22  
+**Branch:** `feature/help-article-publish-prep`  
+**Drupal nodes:** not updated in this pass
+
+| Article | Source | Existing node | Audience | Action | Publish readiness | Blockers | Next step |
+|---------|--------|---------------|----------|--------|-------------------|----------|-----------|
+| Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Merge** draft into 1498; expand body & summary | **Ready for editorial update** | Friendly path alias unconfirmed | Update nid 1498 in CMS; `drush search-api:index mel_content` |
+| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Merge** draft into 1510; keep title | **Ready for editorial update** (staging labels) | Exact fee/payout copy on dashboard | Update nid 1510; verify `/stripe/connect` labels on staging |
+| Waitlist | Draft only | None (no matching published title) | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging: join UI, offer email, RSVP vs paid clarity | Browser QA on sold-out paid event; then write node |
+| Ticket confirmation | Draft only | None (“How to access your tickets” seed not on staging) | public | **New article** after QA | **Blocked until product behaviour is verified** | Wallet UI, email attachments, assignment flow | Complete test purchase on staging; then write node |
+| Checkout errors | Draft only | None | public | **New article** (generic copy OK) | **Ready for editorial update** | Optional: capture real decline message on staging | Editorial review → new node; link from checkout help |
+
+## Working tree note (start of pass)
+
+- Branch: `feature/help-article-publish-prep`
+- Clean of help code changes; unrelated items may still exist locally (`package.json`, other untracked `docs/content-audit/*` planning files).
+
+## Governance reminders
+
+- Do not set `field_help_ai_allowed` false without reason.
+- Do not publish vendor audience copy to public hubs.
+- Do not mention AI in article body.
+- Merge 1498/1510 rather than duplicate.
+
+## Related prep documents
+
+- `support-contact-merge.md`
+- `stripe-payouts-merge.md`
+- `waitlist-verification.md`
+- `ticket-confirmation-verification.md`
+- `checkout-errors-verification.md`

--- a/docs/content-audit/publish-prep/stripe-payouts-merge.md
+++ b/docs/content-audit/publish-prep/stripe-payouts-merge.md
@@ -1,0 +1,93 @@
+# Stripe payouts — merge prep (nid 1510)
+
+**Date:** 2026-05-22  
+**Canonical node:** 1510 — “Payouts and fees”  
+**Draft source:** `help-article-drafts/stripe-payouts.md`
+
+## Existing node summary
+
+| Field | Value |
+|-------|--------|
+| nid | 1510 |
+| Title | Payouts and fees |
+| Audience | `vendor` |
+| Published (node status) | Yes |
+| `field_help_status` | `published` |
+| `field_help_ai_allowed` | true |
+| Article type | FAQ |
+| Summary | Payments and fees |
+| Body (current) | One sentence: payments processed securely and paid out to your account. |
+| Related articles | None |
+| Path alias | `/node/1510` |
+| Safe for vendor | Yes (vendor audience; node access enforced) |
+| Needs updating | **Yes** — lacks Stripe Connect onboarding and fee context |
+
+## Draft summary
+
+Draft explains Stripe connected accounts, onboarding before paid sales, dashboard/payout checks, and avoids fixed payout schedules. Uses “organiser” in user-facing text. Flags exact timing and dashboard labels as **Needs verification**.
+
+## Conflicts
+
+| Topic | Node | Draft | Resolution |
+|-------|------|-------|------------|
+| Title | Payouts and fees | Connecting Stripe and receiving payouts | **Keep** “Payouts and fees” (already live); expand body to cover connection + payouts |
+| Audience | vendor | vendor | Keep `vendor` (internal); user-facing copy says “organiser” |
+| Article type | FAQ | guide | Keep FAQ unless editorial prefers Guide |
+| Fee detail | None | Implied | Do not invent fee percentages; refer to dashboard/Stripe |
+
+## Missing facts (do not invent)
+
+- Exact payout delay (days) in Stripe dashboard.
+- Exact UI labels for Stripe section in vendor dashboard (**Needs verification** on staging).
+- Whether `charges_enabled` gate blocks publish (referenced in audits — confirm label shown to organisers).
+
+## Evidence (code)
+
+- Vendor Stripe Connect route: `myeventlane_vendor.stripe_connect` → `/stripe/connect`
+- Callback: `/stripe/connect/callback`
+- Payments via `stripe_connect` Commerce payment gateway
+
+## Proposed final title
+
+**Payouts and fees**
+
+## Proposed final summary
+
+How organisers connect Stripe, sell paid tickets, and where to check payouts and fees.
+
+## Proposed final body
+
+```html
+<p>Paid ticket sales on MyEventLane are processed through Stripe. You need a connected Stripe account before you can sell paid tickets and receive payouts.</p>
+
+<h2>Connect Stripe</h2>
+<ol>
+  <li>Sign in to your organiser dashboard.</li>
+  <li>Open the Stripe or payments area and start Connect — the path is usually <a href="/stripe/connect">Connect Stripe</a>.</li>
+  <li>Complete Stripe’s verification steps (business and bank details as required).</li>
+  <li>Return to your event and confirm paid ticket types can be published.</li>
+</ol>
+
+<h2>Payouts and fees</h2>
+<p>When tickets sell, funds are handled according to Stripe’s rules and your account status. Payout timing and fees are shown in Stripe and in your organiser dashboard — they can vary by account and verification state.</p>
+<p>Platform and processing fees, if applicable, are described in your dashboard or fee schedule. <strong>Needs verification:</strong> exact fee wording on staging.</p>
+
+<h2>If something looks wrong</h2>
+<p>If onboarding stalls or a payout does not match what you expect, note any message from Stripe and contact MyEventLane support with your event name. Do not share secret keys or full bank details in support messages.</p>
+```
+
+## Recommended field values
+
+| Field | Recommended value |
+|-------|-------------------|
+| `field_audience` | `vendor` |
+| `field_help_status` | `published` |
+| `field_help_ai_allowed` | `true` |
+| `field_help_article_type` | FAQ (keep) or Guide (editorial choice) |
+| Path alias | **Needs verification** — e.g. `/help/payouts-and-fees` |
+
+## Publish readiness
+
+**Ready for editorial update** (with staging label check).
+
+**Reason:** Core behaviour (Stripe Connect route, connected payments) is confirmed. Do not publish exact payout calendars until verified on staging. Merge into nid 1510; do not create a second article.

--- a/docs/content-audit/publish-prep/support-contact-merge.md
+++ b/docs/content-audit/publish-prep/support-contact-merge.md
@@ -1,0 +1,89 @@
+# Support contact — merge prep (nid 1498)
+
+**Date:** 2026-05-22  
+**Canonical node:** 1498 — “Contacting support”  
+**Draft source:** `help-article-drafts/support-contact.md`
+
+## Existing node summary
+
+| Field | Value |
+|-------|--------|
+| nid | 1498 |
+| Title | Contacting support |
+| Audience | `public` |
+| Published (node status) | Yes |
+| `field_help_status` | `published` |
+| `field_help_ai_allowed` | true |
+| Article type | Guide |
+| Summary | How to get help |
+| Body (current) | Single short paragraph: check event page first; organiser for event issues; MEL support for platform help. |
+| Related articles | None |
+| Path alias | `/node/1498` (no friendly alias) |
+| Safe for public | Yes |
+| Needs updating | **Yes** — body is too thin for hub/Assistant quality |
+
+## Draft summary
+
+The draft adds booking-specific framing (tickets, payment, refund, access), numbered steps, organiser vs platform split, and “if it still does not work”. It correctly flags signed-in support path and anonymous flow as **Needs verification**.
+
+## Conflicts
+
+| Topic | Node | Draft | Resolution |
+|-------|------|-------|------------|
+| Title | Contacting support | Contacting support about a booking | Keep shorter canonical title; use booking context in summary and intro |
+| Support URL | Not stated | `/my/support` | **Confirmed** for signed-in users with `view own escalation` |
+| Anonymous support | Not stated | Help Centre Contact support | **Confirmed:** anonymous users without escalation permission land on Help Centre (`HelpCentreController` / `_myeventlane_help_centre_contact_support_url`) |
+| SLA / response time | None | None | Do not add |
+| Email address | None | None | Do not invent |
+
+## Missing facts (do not invent)
+
+- Public email for support (none confirmed in code audit).
+- Whether anonymous users can open escalations without signing in.
+- Exact menu label for “My tickets” (route exists: `/my-tickets`).
+
+## Proposed final title
+
+**Contacting support**
+
+(Optional subtitle in summary only: “about a booking or ticket”.)
+
+## Proposed final summary
+
+How to get help with a booking, payment, or ticket — and when to contact the event organiser instead.
+
+## Proposed final body
+
+```html
+<p>Start with the event page if your question is about the venue, schedule, or what to bring. The organiser is best placed to answer those questions when contact details are listed there.</p>
+
+<p>For booking, payment, refunds, or problems accessing your tickets on MyEventLane, use the steps below.</p>
+
+<h2>What to do next</h2>
+<ol>
+  <li>Find your confirmation email or sign in and open <strong>My tickets</strong> at <a href="/my-tickets">/my-tickets</a>.</li>
+  <li>Note the event name, date, and your order or ticket reference if you have one.</li>
+  <li>If you are signed in, open <a href="/my/support">Support</a> to view or add a support request.</li>
+  <li>Describe what happened and what you need (for example a missing email, wrong ticket, or refund question).</li>
+  <li>If you are not signed in, go to the <a href="/help">Help Centre</a> and use <strong>Contact support</strong> from there.</li>
+</ol>
+
+<h2>If it still does not work</h2>
+<p>If you cannot use the support area, check your junk folder for confirmation mail. For event-day questions, use the organiser contact on the event page. Do not submit multiple payments unless you are sure no confirmation arrived.</p>
+```
+
+## Recommended field values
+
+| Field | Recommended value |
+|-------|-------------------|
+| `field_audience` | `public` |
+| `field_help_status` | `published` (keep) |
+| `field_help_ai_allowed` | `true` (keep) |
+| `field_help_article_type` | Guide (keep) |
+| Path alias | **Needs verification** — suggest `/help/contacting-support` when aliases are standardised |
+
+## Publish readiness
+
+**Ready for editorial update.**
+
+**Reason:** Routes `/my/support` and `/my-tickets` are confirmed in code. No duplicate node should be created. Update nid 1498 body and summary in Drupal when publishing is authorised; reindex `mel_content` after save.

--- a/docs/content-audit/publish-prep/ticket-confirmation-verification.md
+++ b/docs/content-audit/publish-prep/ticket-confirmation-verification.md
@@ -1,0 +1,75 @@
+# Ticket confirmation, calendar, wallet — product verification
+
+**Date:** 2026-05-22  
+**Draft:** `help-article-drafts/ticket-confirmation.md`
+
+## Evidence found
+
+### After ticket purchase
+
+| Item | Evidence |
+|------|----------|
+| Order confirmation email | Yes — template `order_confirmation` (`myeventlane_messaging.template.order_confirmation.yml`) |
+| Email content | Order number, event details, ticket summary, PDF/QR assignment note, **calendar .ics attachment** referenced in template |
+| My tickets | Yes — route `myeventlane_checkout_flow.my_tickets` → `/my-tickets`; order detail `/my-tickets/order/{commerce_order}` |
+| Checkout complete step | Commerce checkout flow `complete` step; sidebar copy: “Confirmation email sent as soon as you complete booking” (`MelReadinessHelper::customerCheckoutSidebarConfidenceLines`) |
+| Calendar hint | “Add to your calendar from My Tickets after booking” (same helper) |
+| Event .ics (RSVP) | `myeventlane_rsvp.ics_download` — `/event/{node}/ics` (RSVP/events; order email also attaches calendar files per template) |
+
+### Wallet
+
+| Item | Evidence |
+|------|----------|
+| Module | `myeventlane_wallet` — Apple + Google Wallet |
+| Routes | `/wallet/apple/{order_item_id}`, `/wallet/google/{order_item_id}` |
+| Config | `show_wallet_buttons` on confirmation; `show_wallet_in_email` for confirmation emails |
+| Access | `WalletDownloadAccessChecker` — authorised buyer access |
+
+### QR / PDF
+
+| Item | Evidence |
+|------|----------|
+| Order email | Mentions PDF and QR when tickets need assignment |
+| Ticket issuance | `myeventlane_tickets` pipeline (referenced in messaging tests) |
+
+### Existing help overlap
+
+- Seed `how_to_access_tickets` exists in YAML; **not found** as published node on staging (only “How to buy tickets” nid 1492 in ticket-related list).
+- New article complements seeds; avoid duplicating full “access tickets” guide if that node is later published.
+
+## User-facing behaviour (safe to describe)
+
+- After checkout, buyers should receive a **confirmation email** with order details.
+- Email may include **calendar attachments** (.ics) per template copy.
+- Buyers can open **My tickets** to view the order and download tickets.
+- **Wallet** passes may be available on confirmation and in email when enabled in wallet settings (**Needs verification** on staging UI).
+
+## Unsupported or unverified claims
+
+| Claim | Verdict |
+|-------|---------|
+| Exact menu label “My tickets” | Route confirmed; menu label **Needs verification** |
+| Apple Wallet / Google Wallet always shown | Config-gated — say “if available on your order page or email” |
+| Calendar add from confirmation page only | Email + My tickets both mentioned in product copy |
+| Instant email | Reasonable; timing **Needs verification** (queue/cron) |
+| Wallet for all events | **Needs verification** (eligibility, issued ticket required) |
+
+## Proposed safe article wording (summary)
+
+**Title:** Ticket confirmation emails and receipts  
+
+**Intro:** After you buy tickets, you should get a confirmation email. You can also open My tickets to view your order.
+
+**Steps:** Check inbox and junk → open My tickets → use ticket link or QR → keep email as proof.
+
+**Calendar:** Order emails may include a calendar file (.ics); you can also add from My tickets where offered.
+
+**Wallet:** If your order page or email shows wallet options, you can add passes to your phone — **Needs verification** on staging.
+
+## Publish readiness
+
+**Blocked until product behaviour is verified** (staging QA).
+
+**Reason:** Strong code/template evidence, but wallet buttons, assignment flow, and live email attachments were not browser-tested this pass. Publish after one completed test purchase on staging.
+
+**Next step:** New help article (no canonical node) after QA; cross-link “How to buy tickets” (nid 1492).

--- a/docs/content-audit/publish-prep/waitlist-verification.md
+++ b/docs/content-audit/publish-prep/waitlist-verification.md
@@ -1,0 +1,62 @@
+# Waitlist — product verification
+
+**Date:** 2026-05-22  
+**Draft:** `help-article-drafts/waitlist.md`
+
+## Evidence found
+
+### Paid ticket waitlist (primary public path)
+
+| Item | Evidence |
+|------|----------|
+| Exists | Yes — `TicketTierWaitlistService`, entity `mel_ticket_waitlist_entry` |
+| Public-facing UI | Yes — `TicketSelectionForm` on event book flow: email, quantity, **Join waitlist** per sold-out paid tier |
+| Scope | **Paid ticket tiers only** — `joinWaitlist()` throws if not paid tier or tier not sold out |
+| Join | `joinWaitlist()` creates `STATUS_WAITING` entry; shows position message |
+| Auto-invite / offer | **Tier-level** `auto_promote_waitlist` on `mel_ticket_type`; `processAutoPromotions()` creates `STATUS_OFFERED` with token + expiry |
+| Offer email | Queue `mel_ticket_waitlist_offer_mail` → `TicketTierWaitlistOfferMailWorker` |
+| RSVP waitlist | Separate — `myeventlane_rsvp` waitlist for free RSVP capacity (`RsvpPromotionManager`, settings `auto_promote`) |
+
+**Code paths:**
+
+- `web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php` — waitlist form + `joinWaitlistSubmit`
+- `web/modules/custom/myeventlane_commerce/src/Service/TicketTierWaitlistService.php` — join, offer, `processAutoPromotions`, cron hook at ~550
+- `web/modules/custom/mel_ticket/src/Entity/TicketWaitlistEntry.php`
+- `web/modules/custom/myeventlane_rsvp/` — RSVP waitlist (different product surface)
+
+## User-facing behaviour (safe to describe)
+
+- On a **sold-out paid ticket** type where the organiser enabled waitlist, buyers can submit email + quantity on the event booking page.
+- Joining does **not** guarantee a ticket.
+- When auto-promotion is enabled on that tier and capacity opens, the system may create a **time-limited offer** and queue an email (implementation present; copy not verified on staging).
+
+## Unsupported or unverified claims (draft review)
+
+| Claim | Verdict |
+|-------|---------|
+| “Event may offer a waitlist” | OK if sold-out + tier waitlist enabled |
+| “You may receive an offer to complete purchase” | OK with qualifier: **when the organiser enabled auto-promotion and a spot opens** |
+| “Offers may expire” | OK — `OFFER_TTL` in service |
+| “Message from organiser or MyEventLane” | Prefer **email from MyEventLane** for ticket offers; organiser message not confirmed |
+| RSVP / free event waitlist in same article | **Avoid** unless clearly split into two sections — different module |
+| Guaranteed ticket | **Remove** — never promise |
+
+## Proposed safe article wording (summary)
+
+**Title:** Joining a waitlist when tickets are sold out  
+
+**Intro:** If a paid ticket type is sold out, you may be able to join a waitlist on the event page. This records your interest; it does not guarantee a ticket.
+
+**Steps:** Open event → sold-out tier → enter email → Join waitlist → watch email.
+
+**If spot opens:** If enabled for that ticket type, you may receive an email with a link to complete purchase within a limited time.
+
+**RSVP:** Optional one-line cross-link: free RSVP events may use a separate waitlist — **Needs verification** for public CTA copy on RSVP form.
+
+## Publish readiness
+
+**Blocked until product behaviour is verified** (staging QA).
+
+**Reason:** Code supports paid-tier waitlist and offer emails, but this pass did not confirm on staging: visible “Join waitlist” on a real sold-out event, offer email content, claim link URL, or RSVP vs paid wording. Recommend browser test on one sold-out paid event before publishing.
+
+**Next step:** Staging QA checklist → then editorial update as **new** help article (no duplicate node found) or section in “How to buy tickets”.


### PR DESCRIPTION
- add merge prep for support contact (nid 1498) and payouts (nid 1510)
- verify waitlist, ticket confirmation, and checkout error behaviour
- publish decision register with readiness and blockers

## Summary

Prepares the next priority MyEventLane Help Centre articles for editorial update and staging QA.

This is a docs-only branch. It does not change code, routes, permissions, Views, Help Assistant behaviour, or Drupal node content.

## What changed

Created publish-prep documentation under:

docs/content-audit/publish-prep/

Includes:

- support-contact-merge.md
- stripe-payouts-merge.md
- waitlist-verification.md
- ticket-confirmation-verification.md
- checkout-errors-verification.md
- help-article-publish-register.md

## Key findings

- nid 1498 “Contacting support” should remain canonical and be expanded from the support contact draft.
- nid 1510 “Payouts and fees” should remain canonical and be expanded from the Stripe payouts draft.
- Checkout errors is ready for editorial update as a new article.
- Waitlist article is blocked until staging QA confirms paid waitlist behaviour and email/claim flow.
- Ticket confirmation article is blocked until staging QA confirms confirmation email, My Tickets, calendar, and wallet behaviour.

## Validation

- composer validate passed.
- ddev drush cr succeeded.
- npm run mel:lint passed.
- npm run mel:build passed.
- PHP lint skipped because no PHP files changed.

## Notes

No Drupal content was updated. Editorial publishing should happen in a separate, controlled pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions with no changes to application code, routes, permissions, or Drupal content; risk is limited to editorial guidance accuracy if the verification notes are wrong.
> 
> **Overview**
> Adds a new `docs/content-audit/publish-prep/` set of documents to prepare priority Help Centre articles for publishing.
> 
> This introduces a decision register plus merge-prep writeups for updating existing canonical nodes (`1498` support contact, `1510` payouts) and verification notes for new/blocked articles (waitlist, ticket confirmation, checkout errors), including what claims are safe vs requiring staging QA before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644f171b14ef954c9d88cb279e325d421888fbd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->