### PR TITLE
docs(help): log editorial updates for priority articles

### DIFF
--- a/docs/content-audit/publish-prep/editorial-update-log.md
+++ b/docs/content-audit/publish-prep/editorial-update-log.md
@@ -1,0 +1,135 @@
+# Editorial update log — priority help articles
+
+**Date:** 2026-05-22  
+**Branch:** `feature/help-article-editorial-updates`  
+**Publish-prep on main:** Confirmed (`docs/content-audit/publish-prep/` from commit `644f171b`)
+
+## Working tree note
+
+Unrelated uncommitted files were present at start (`myeventlane_event_studio/*`). They were **not** staged or committed. Editorial work used Drush entity saves only.
+
+---
+
+## Node 1498 — Contacting support
+
+| | Before | After |
+|---|--------|-------|
+| Title | Contacting support | Contacting support (unchanged) |
+| Summary | How to get help | How to get help with a booking, payment, or ticket — and when to contact the event organiser instead. |
+| Body | ~100 chars (single paragraph) | ~987 chars (steps, organiser vs platform, `/my-tickets`, `/my/support`, `/help`) |
+| Audience | public | public |
+| `field_help_status` | published | published |
+| `field_help_ai_allowed` | true | true |
+| Article type | Guide | Guide |
+
+**Source:** `support-contact-merge.md`
+
+---
+
+## Node 1510 — Payouts and fees
+
+| | Before | After |
+|---|--------|-------|
+| Title | Payouts and fees | Payouts and fees (unchanged) |
+| Summary | Payments and fees | How organisers connect Stripe, sell paid tickets, and where to check payouts and fees. |
+| Body | ~61 chars | ~1069 chars (Connect Stripe, payouts/fees, troubleshooting) |
+| Audience | vendor | vendor |
+| `field_help_status` | published | published |
+| `field_help_ai_allowed` | true | true |
+| Article type | FAQ | FAQ |
+
+**Edits:** Removed internal “Needs verification” label from published body; replaced with “Check there for current fee details.” No payout timing promises.
+
+**Source:** `stripe-payouts-merge.md`
+
+---
+
+## Checkout errors — new article
+
+| Decision | Detail |
+|----------|--------|
+| Duplicate search | No matching `help_article` for checkout / payment failed / card declined |
+| Action | **Created** new node |
+| **nid** | **1668** |
+| Title | Having trouble checking out |
+| Audience | public |
+| Article type | Troubleshooting (tid 74) |
+| `field_help_status` | published |
+| `field_help_ai_allowed` | true |
+| Moderation | Set to `published` (initial save left `draft` / unpublished — corrected in same pass) |
+
+**Source:** `checkout-errors-verification.md` + cautious wording (no specific Stripe decline strings).
+
+---
+
+## Skipped / blocked (not published)
+
+| Article | Status |
+|---------|--------|
+| Waitlist | **Blocked** — staging QA required (`waitlist-verification.md`) |
+| Ticket confirmation | **Blocked** — staging QA required (`ticket-confirmation-verification.md`) |
+
+---
+
+## Commands run
+
+```bash
+ddev drush php:eval   # entity updates (1498, 1510, create 1668, moderation fix)
+ddev drush cr
+ddev drush search-api:index mel_content
+ddev drush search-api:status mel_content
+composer validate
+npm run mel:lint
+npm run mel:build
+```
+
+---
+
+## Validation results
+
+| Check | Result |
+|-------|--------|
+| `composer validate` | Pass |
+| `mel:lint` | Pass |
+| `mel:build` | Pass (pre-commit hook on prior commits) |
+
+## Search API status
+
+| Index | Status |
+|-------|--------|
+| `mel_content` | **100%** (60/60) — 3 items indexed this pass (updates + new node) |
+
+---
+
+## Access verification
+
+| Node | Anonymous | Vendor (uid 2) |
+|------|-----------|----------------|
+| 1498 | allow | allow |
+| 1510 | deny | allow |
+| 1668 | allow (after moderation publish) | allow |
+
+## Help Assistant verification
+
+| Query | Anonymous | Vendor |
+|-------|-----------|--------|
+| Support / contacting help | Includes **1498** | — |
+| Checkout trouble / payment failed | Includes **1668** | — |
+| Payouts / Stripe fees | Excludes **1510** | Includes **1510** |
+
+---
+
+## Remaining risks
+
+| Risk | Notes |
+|------|-------|
+| Path aliases | 1498, 1510, 1668 still `/node/{nid}` unless aliases added separately |
+| Fee dashboard labels | 1510 does not quote exact fees (by design) |
+| Waitlist / ticket confirmation | Still blocked for publish |
+| New node 1668 | Requires content moderation `published` when creating help articles via API |
+
+---
+
+## Git commit
+
+Only this log file is committed; **Drupal node content is database-only** (not exported to config in this pass).

--- a/docs/content-audit/publish-prep/help-article-publish-register.md
+++ b/docs/content-audit/publish-prep/help-article-publish-register.md
@@ -2,15 +2,15 @@
 
 **Date:** 2026-05-22  
 **Branch:** `feature/help-article-publish-prep`  
-**Drupal nodes:** not updated in this pass
+**Drupal nodes:** updated 2026-05-22 on `feature/help-article-editorial-updates` — see `editorial-update-log.md`
 
 | Article | Source | Existing node | Audience | Action | Publish readiness | Blockers | Next step |
 |---------|--------|---------------|----------|--------|-------------------|----------|-----------|
-| Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Merge** draft into 1498; expand body & summary | **Ready for editorial update** | Friendly path alias unconfirmed | Update nid 1498 in CMS; `drush search-api:index mel_content` |
-| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Merge** draft into 1510; keep title | **Ready for editorial update** (staging labels) | Exact fee/payout copy on dashboard | Update nid 1510; verify `/stripe/connect` labels on staging |
-| Waitlist | Draft only | None (no matching published title) | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging: join UI, offer email, RSVP vs paid clarity | Browser QA on sold-out paid event; then write node |
-| Ticket confirmation | Draft only | None (“How to access your tickets” seed not on staging) | public | **New article** after QA | **Blocked until product behaviour is verified** | Wallet UI, email attachments, assignment flow | Complete test purchase on staging; then write node |
-| Checkout errors | Draft only | None | public | **New article** (generic copy OK) | **Ready for editorial update** | Optional: capture real decline message on staging | Editorial review → new node; link from checkout help |
+| Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Done** — merged body/summary | **Published** | Path alias | — |
+| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Done** — merged body/summary | **Published** | Dashboard fee labels on staging | — |
+| Waitlist | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Browser QA; then create node |
+| Ticket confirmation | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Test purchase; then create node |
+| Checkout errors | Draft + **nid 1668** | 1668 “Having trouble checking out” | public | **Done** — created | **Published** | Moderation state must be `published` on create | Optional checkout contextual link |
 
 ## Working tree note (start of pass)
 


### PR DESCRIPTION
- record Drupal updates to nids 1498 and 1510
- record new checkout help article nid 1668
- document access, Assistant, and Search API verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add/update internal publish-prep records; no runtime code, config, or schema changes. Main risk is process-related (Drupal node edits are database-only and must be repeated/verified in the CMS).
> 
> **Overview**
> Adds a new `editorial-update-log.md` documenting the May 2026 editorial pass: expanded content for help nodes **1498** (support contact) and **1510** (payouts/fees), and creation/publish verification of new checkout troubleshooting node **1668**, including access/Search API/Assistant checks and remaining follow-ups.
> 
> Updates `help-article-publish-register.md` to reflect that these items are now **done/published**, and points readers to the new log for details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf55cb1a2c3132c39e8e6dee0c1ebfcb657c4691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->