### PR TITLE
Feature/help article final polish

### DIFF
--- a/config/sync/myeventlane_help_centre.contextual_help.yml
+++ b/config/sync/myeventlane_help_centre.contextual_help.yml
@@ -25,8 +25,8 @@ links:
     text: 'Tips for completing your event setup'
     path: /help/organisers/how-to-create-an-event
   checkout:
-    text: 'Help with checkout and tickets'
-    path: /help/attendees/how-to-request-a-refund
+    text: 'Having trouble checking out?'
+    path: /help/attendees/having-trouble-checking-out
   refunds:
     text: 'How refunds work on MyEventLane'
     path: /help/attendees/how-to-request-a-refund

--- a/docs/content-audit/publish-prep/editorial-update-log.md
+++ b/docs/content-audit/publish-prep/editorial-update-log.md
@@ -133,3 +133,47 @@ npm run mel:build
 ## Git commit
 
 Only this log file is committed; **Drupal node content is database-only** (not exported to config in this pass).
+
+---
+
+## Final polish pass (2026-05-22)
+
+**Branch:** `feature/help-article-final-polish`
+
+### Path aliases applied (local DDEV)
+
+| nid | Alias | Anonymous HTTP |
+|-----|-------|----------------|
+| 1498 | `/help/attendees/contacting-support` | 200 |
+| 1510 | `/help/vendors/payouts-and-fees` | 403 (vendor-only; expected) |
+| 1668 | `/help/attendees/having-trouble-checking-out` | 200 |
+
+Pattern matches seeded articles in `myeventlane_help_centre.help_content.yml` (`/help/attendees/…`, `/help/vendors/…`). No pathauto pattern exists for `help_article`; aliases created manually.
+
+### Stripe fee label verification (nid 1510)
+
+**Method:** Code audit (vendor dashboard, checkout, analytics) — vendor UI not browser-walked this pass.
+
+| UI surface | Label found |
+|------------|-------------|
+| Checkout fee pane | “Platform fee” (`FeeTransparencyPane`) |
+| Vendor analytics KPI | “platform_fees” / net earnings |
+| Stripe Connect dashboard copy | “payouts”, “Connect Stripe to receive card payments and payouts” |
+
+**Decision:** No change to nid 1510 body. Existing copy (“Platform and processing fees”, “organiser dashboard or Stripe”) aligns with product terminology without quoting percentages or payout schedules.
+
+### Checkout contextual link
+
+| Item | Before | After |
+|------|--------|-------|
+| Config key `checkout` | “Help with checkout and tickets” → `/help/attendees/how-to-request-a-refund` | “Having trouble checking out?” → `/help/attendees/having-trouble-checking-out` |
+| Refund link | Unchanged (`refunds_checkout` key) | — |
+
+**Files:** `config/sync/myeventlane_help_centre.contextual_help.yml` + active config updated via Drush.
+
+**Rationale:** Smallest safe fix — config only, no module changes. Surfaces when checkout has no inline support card (`mel_help_checkout_guide` in `myeventlane_help_centre_preprocess_commerce_checkout_form`).
+
+### Articles unchanged
+
+- Waitlist, ticket confirmation — still blocked.
+- No body copy edits on 1498, 1510, 1668.

--- a/docs/content-audit/publish-prep/help-article-publish-register.md
+++ b/docs/content-audit/publish-prep/help-article-publish-register.md
@@ -6,11 +6,11 @@
 
 | Article | Source | Existing node | Audience | Action | Publish readiness | Blockers | Next step |
 |---------|--------|---------------|----------|--------|-------------------|----------|-----------|
-| Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Done** — merged body/summary | **Published** | Path alias | — |
-| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Done** — merged body/summary | **Published** | Dashboard fee labels on staging | — |
+| Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Done** | **Published** | — | Alias `/help/attendees/contacting-support` |
+| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Done** | **Published** | — | Alias `/help/vendors/payouts-and-fees`; fee wording verified (code) |
 | Waitlist | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Browser QA; then create node |
 | Ticket confirmation | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Test purchase; then create node |
-| Checkout errors | Draft + **nid 1668** | 1668 “Having trouble checking out” | public | **Done** — created | **Published** | Moderation state must be `published` on create | Optional checkout contextual link |
+| Checkout errors | Draft + **nid 1668** | 1668 “Having trouble checking out” | public | **Done** | **Published** | — | Alias `/help/attendees/having-trouble-checking-out`; checkout contextual link updated |
 
 ## Working tree note (start of pass)
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -358,6 +358,209 @@
   }
 }
 
+/* Table-style checkout questions workspace (Slice 1) */
+.mel-event-studio-questions--table .mel-event-studio-questions__table {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__row {
+  display: grid;
+  grid-template-columns:
+    minmax(140px, 1.6fr)
+    minmax(108px, 0.9fr)
+    minmax(72px, 0.45fr)
+    minmax(120px, 0.95fr)
+    minmax(120px, 1fr)
+    minmax(100px, 0.75fr)
+    minmax(64px, 0.4fr);
+  gap: 10px 12px;
+  align-items: start;
+  padding: 12px 14px;
+  border-bottom: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__row--head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 10px 14px;
+  border-bottom: 1px solid #cbd5e1;
+  background: #f8fafc;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__row--head .mel-event-studio-questions__head-label {
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__row.is-archived {
+  background: #f8fafc;
+  opacity: 0.92;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__row.mel-event-studio-questions__locked {
+  border-left: 3px solid #f59e0b;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell {
+  min-width: 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell--label .form-item {
+  margin: 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell .form-item {
+  margin: 0 0 6px;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell .form-item:last-child {
+  margin-bottom: 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell input,
+.mel-event-studio-questions--table .mel-event-studio-questions__cell select,
+.mel-event-studio-questions--table .mel-event-studio-questions__cell textarea {
+  width: 100%;
+  min-height: 44px;
+  max-width: 100%;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell--required .form-type-checkbox {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  margin: 0;
+  padding: 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell--required .form-type-checkbox input {
+  min-height: 1.25rem;
+  width: auto;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell--tickets .form-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 160px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__cell--tickets .form-type-checkbox {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__locked-note {
+  margin: 6px 0 0;
+  color: #9a3412;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__details {
+  grid-column: 1 / -1;
+  margin: 4px 0 0;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__details > summary {
+  cursor: pointer;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  font-weight: 650;
+  color: #334155;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__per-order-note {
+  margin: 8px 0 0;
+  color: #64748b;
+  font-size: 0.8125rem;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__empty {
+  padding: 16px 14px;
+  border-bottom: 1px solid #e2e8f0;
+  color: #64748b;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__add {
+  margin-top: 16px;
+}
+
+.mel-event-studio-questions--table .mel-event-studio-questions__add .mel-event-studio-questions__row--add {
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  margin-top: 10px;
+}
+
+.mel-event-studio-questions__builder-cta {
+  margin: 0 0 16px;
+  padding: 14px 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mel-event-studio-questions__builder-cta-copy {
+  margin: 0 0 10px;
+  color: #475569;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.mel-event-studio-questions__builder-cta-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+}
+
+@media (max-width: 900px) {
+  .mel-event-studio-questions--table .mel-event-studio-questions__row--head {
+    display: none;
+  }
+
+  .mel-event-studio-questions--table .mel-event-studio-questions__row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 14px;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    margin-bottom: 12px;
+  }
+
+  .mel-event-studio-questions--table .mel-event-studio-questions__cell::before {
+    content: attr(data-cell-label);
+    display: block;
+    margin-bottom: 4px;
+    color: #64748b;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .mel-event-studio-questions--table .mel-event-studio-questions__cell--actions::before {
+    content: none;
+  }
+}
+
 /* -------------------------------------------------------------------------- */
 /* Sidebar nav (#mel-wizard-nav)                                               */
 /* -------------------------------------------------------------------------- */

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.20
+  version: 1.21
   css:
     theme:
       css/mel-event-studio.css: {}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -72,8 +72,10 @@ final class EventCheckoutQuestionsForm extends FormBase {
 
     $form['#tree'] = TRUE;
     $form['#attributes']['class'][] = 'mel-event-studio-questions';
+    $form['#attributes']['class'][] = 'mel-event-studio-questions--table';
     $form['#attributes']['data-mel-event-studio-form'] = '1';
     $form['#attributes']['data-mel-event-studio-section'] = 'questions';
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio';
 
     $form['event_id'] = [
       '#type' => 'hidden',
@@ -108,9 +110,14 @@ final class EventCheckoutQuestionsForm extends FormBase {
       'per_order_notice' => [
         '#markup' => '<p class="mel-event-studio-questions__notice">' . $this->t('Recommended: keep questions short. Attendees can edit their answers before submitting checkout.') . '</p>',
       ],
+      'per_order_planned' => [
+        '#markup' => '<p class="mel-event-studio-questions__per-order-note">' . $this->t('Per order questions are planned but not active yet.') . '</p>',
+      ],
     ];
 
     $ticket_options = $this->studioQuestionTemplateManager->ticketOptions($event);
+    $question_rows = $this->studioQuestionTemplateManager->loadRows($event);
+
     $form['questions_card'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-es-card', 'mel-event-studio-questions__manager']],
@@ -119,20 +126,24 @@ final class EventCheckoutQuestionsForm extends FormBase {
       '#type' => 'container',
       '#tree' => TRUE,
       '#attributes' => [
-        'class' => ['mel-event-studio-questions__table', 'mel-event-studio-questions__cards'],
-        'role' => 'list',
+        'class' => ['mel-event-studio-questions__table'],
+        'role' => 'table',
       ],
     ];
+    $form['questions_card']['questions']['header'] = $this->buildTableHeaderRow();
 
-    $question_rows = $this->studioQuestionTemplateManager->loadRows($event);
     foreach ($question_rows as $row) {
       $row_id = (int) $row['id'];
       $form['questions_card']['questions'][$row_id] = $this->buildQuestionRow($event, $row, $ticket_options);
     }
+
     if ($question_rows === []) {
       $form['questions_card']['questions']['empty'] = [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-questions__empty']],
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__empty'],
+          'role' => 'row',
+        ],
         'copy' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
@@ -152,18 +163,8 @@ final class EventCheckoutQuestionsForm extends FormBase {
         '#value' => $this->t('Ask for the information you actually need to welcome people well. You can archive questions later without losing past answers.'),
         '#attributes' => ['class' => ['mel-event-studio-questions__add-helper']],
       ],
-    ] + $this->buildQuestionEditor([
-      'id' => 0,
-      'weight' => count($this->studioQuestionTemplateManager->loadRows($event)),
-      'label' => '',
-      'type' => 'textfield',
-      'required' => FALSE,
-      'status' => EventStudioQuestionTemplateManager::STATUS_ACTIVE,
-      'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET,
-      'ticket_type_ids' => [],
-      'options' => '',
-      'machine_name' => '',
-    ], $ticket_options, TRUE);
+      'row' => $this->buildNewQuestionRow($ticket_options, count($question_rows)),
+    ];
 
     $form['actions'] = [
       '#type' => 'actions',
@@ -171,6 +172,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
         '#type' => 'submit',
         '#value' => $this->t('Save questions'),
         '#button_type' => 'primary',
+        '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
       ],
     ];
 
@@ -225,172 +227,37 @@ final class EventCheckoutQuestionsForm extends FormBase {
   }
 
   /**
-   * @param array<string, mixed> $row
-   * @param array<int, string> $ticketOptions
+   * Column headings for the questions table.
+   *
+   * @return array<string, mixed>
    */
-  private function buildQuestionRow(NodeInterface $event, array $row, array $ticketOptions): array {
-    $editor = $this->buildQuestionEditor($row, $ticketOptions, FALSE);
-    $row_id = (int) $row['id'];
-    $editor['label']['#parents'] = ['questions_card', 'questions', $row_id, 'label', 'label'];
-    $editor['type']['#parents'] = ['questions_card', 'questions', $row_id, 'type', 'type'];
-    $editor['options']['#parents'] = ['questions_card', 'questions', $row_id, 'type', 'options'];
-    $editor['applicability']['#parents'] = ['questions_card', 'questions', $row_id, 'applicability', 'applicability'];
-    $editor['ticket_type_ids']['#parents'] = ['questions_card', 'questions', $row_id, 'applicability', 'ticket_type_ids'];
-    $editor['required']['#parents'] = ['questions_card', 'questions', $row_id, 'required', 'required'];
-    $editor['status']['#parents'] = ['questions_card', 'questions', $row_id, 'status', 'status'];
-    $editor['machine_name']['#parents'] = ['questions_card', 'questions', $row_id, 'actions', 'machine_name'];
-    $preview = $this->buildPreviewText($row);
-    $status = (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE);
-    $required = !empty($row['required']);
-    $type_label = (string) ($row['type_label'] ?? $this->studioQuestionTemplateManager->typeOptions()[(string) ($row['type'] ?? '')] ?? $row['type'] ?? $this->t('Question'));
-    $applicability_label = $this->applicabilityLabel((string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET));
-    $has_answers = $this->questionHasHistoricalAnswers($event, $row);
+  private function buildTableHeaderRow(): array {
+    $head_cell = function (string $label, string $modifier): array {
+      return [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--' . $modifier],
+          'role' => 'columnheader',
+        ],
+        'text' => [
+          '#markup' => '<span class="mel-event-studio-questions__head-label">' . $label . '</span>',
+        ],
+      ];
+    };
 
     return [
       '#type' => 'container',
       '#attributes' => [
-        'class' => [
-          'mel-event-studio-questions__card',
-          $status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED ? 'is-archived' : 'is-active',
-        ],
-        'role' => 'listitem',
+        'class' => ['mel-event-studio-questions__row', 'mel-event-studio-questions__row--head'],
+        'role' => 'row',
       ],
-      'header' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-questions__header']],
-        'id' => [
-          '#type' => 'hidden',
-          '#value' => (string) (int) $row['id'],
-          '#parents' => ['questions_card', 'questions', $row_id, 'label', 'id'],
-        ],
-        'weight' => [
-          '#type' => 'hidden',
-          '#value' => (string) (int) $row['weight'],
-          '#parents' => ['questions_card', 'questions', $row_id, 'label', 'weight'],
-        ],
-        'identity' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__identity']],
-          'label' => $editor['label'],
-          'preview' => [
-            '#markup' => '<p class="mel-event-studio-questions__preview">' . $preview . '</p>',
-          ],
-        ],
-        'badges' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__badges']],
-          'type' => [
-            '#type' => 'html_tag',
-            '#tag' => 'span',
-            '#value' => $type_label,
-            '#attributes' => ['class' => ['mel-event-studio-card-badge', 'mel-event-studio-card-badge--type']],
-          ],
-          'required' => [
-            '#type' => 'html_tag',
-            '#tag' => 'span',
-            '#value' => $required ? $this->t('Required') : $this->t('Optional'),
-            '#attributes' => ['class' => ['mel-event-studio-card-badge', $required ? 'mel-event-studio-card-badge--required' : 'mel-event-studio-card-badge--muted']],
-          ],
-          'status' => [
-            '#type' => 'html_tag',
-            '#tag' => 'span',
-            '#value' => $status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED ? $this->t('Archived') : $this->t('Active'),
-            '#attributes' => ['class' => ['mel-event-studio-card-badge', $status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED ? 'mel-event-studio-card-badge--muted' : 'mel-event-studio-card-badge--active']],
-          ],
-        ],
-      ],
-      'body' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-questions__body']],
-        'answer_preview' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__preview-panel']],
-          'heading' => [
-            '#type' => 'html_tag',
-            '#tag' => 'h4',
-            '#value' => $this->t('How attendees will see this'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__group-title']],
-          ],
-          'content' => $this->buildAnswerPreview($row, $type_label),
-          'reassurance' => [
-            '#type' => 'html_tag',
-            '#tag' => 'p',
-            '#value' => $required
-              ? $this->t('Attendees will answer this before checkout can continue.')
-              : $this->t('Attendees can skip this if it does not apply.'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__preview-reassurance']],
-          ],
-        ],
-        'summary' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__summary-row']],
-          'applies' => [
-            '#type' => 'html_tag',
-            '#tag' => 'p',
-            '#value' => $this->t('Shown for: @scope', ['@scope' => $applicability_label]),
-            '#attributes' => ['class' => ['mel-event-studio-questions__summary-pill']],
-          ],
-          'status' => [
-            '#type' => 'html_tag',
-            '#tag' => 'p',
-            '#value' => $status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED
-              ? $this->t('Archived for new checkouts')
-              : $this->t('Active in checkout'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__summary-pill']],
-          ],
-        ],
-      ],
-      'advanced' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-questions__advanced-content']],
-        '#prefix' => '<details class="mel-event-studio-questions__advanced"><summary>' . $this->t('Optional question settings') . '</summary>',
-        '#suffix' => '</details>',
-        'governance_note' => [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $has_answers
-            ? $this->t('This question already has attendee answers. To protect past responses, archive it and add a new question when you need a different answer shape.')
-            : $this->t('Most events can leave these settings as-is. Use them when a question should appear only for certain tickets.'),
-          '#attributes' => ['class' => array_filter(['mel-event-studio-questions__governance-note', $has_answers ? 'has-warning' : NULL])],
-        ],
-        'type_group' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__field-group', 'mel-event-studio-questions__type']],
-          'heading' => [
-            '#type' => 'html_tag',
-            '#tag' => 'h4',
-            '#value' => $this->t('Answer setup'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__group-title']],
-          ],
-          'type' => $editor['type'],
-          'options' => $editor['options'],
-          'required' => $editor['required'],
-        ],
-        'audience_group' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__field-group', 'mel-event-studio-questions__applicability']],
-          'heading' => [
-            '#type' => 'html_tag',
-            '#tag' => 'h4',
-            '#value' => $this->t('Where it appears'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__group-title']],
-          ],
-          'applicability' => $editor['applicability'],
-          'ticket_type_ids' => $editor['ticket_type_ids'],
-        ],
-        'governance_group' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-studio-questions__field-group', 'mel-event-studio-questions__governance']],
-          'heading' => [
-            '#type' => 'html_tag',
-            '#tag' => 'h4',
-            '#value' => $this->t('Governance'),
-            '#attributes' => ['class' => ['mel-event-studio-questions__group-title']],
-          ],
-          'status' => $editor['status'],
-          'machine_name' => $editor['machine_name'],
-        ],
-      ],
+      'label' => $head_cell((string) $this->t('Question'), 'label'),
+      'type' => $head_cell((string) $this->t('Type'), 'type'),
+      'required' => $head_cell((string) $this->t('Required'), 'required'),
+      'applicability' => $head_cell((string) $this->t('Applies to'), 'applicability'),
+      'tickets' => $head_cell((string) $this->t('Ticket types'), 'tickets'),
+      'status' => $head_cell((string) $this->t('Status'), 'status'),
+      'actions' => $head_cell((string) $this->t('More'), 'actions'),
     ];
   }
 
@@ -400,50 +267,363 @@ final class EventCheckoutQuestionsForm extends FormBase {
    *
    * @return array<string, mixed>
    */
-  private function buildQuestionEditor(array $row, array $ticketOptions, bool $isNew): array {
-    $applicabilitySelector = $isNew
-      ? ':input[name="questions_card[new_question][applicability]"]'
-      : ':input[name="questions_card[questions][' . (int) $row['id'] . '][applicability][applicability]"]';
+  private function buildQuestionRow(NodeInterface $event, array $row, array $ticketOptions): array {
+    $row_id = (int) $row['id'];
+    $status = (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE);
+    $applicability = (string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET);
+    $has_answers = $this->questionHasHistoricalAnswers($event, $row);
+    $type_selector = ':input[name="questions_card[questions][' . $row_id . '][type][type]"]';
+    $applicability_selector = ':input[name="questions_card[questions][' . $row_id . '][applicability][applicability]"]';
+
+    $editor = $this->buildQuestionEditor(
+      $row,
+      $ticketOptions,
+      FALSE,
+      $has_answers,
+      $type_selector,
+      $applicability_selector,
+      $applicability
+    );
+
+    $editor['label']['#parents'] = ['questions_card', 'questions', $row_id, 'label', 'label'];
+    $editor['type']['#parents'] = ['questions_card', 'questions', $row_id, 'type', 'type'];
+    $editor['options']['#parents'] = ['questions_card', 'questions', $row_id, 'type', 'options'];
+    $editor['applicability']['#parents'] = ['questions_card', 'questions', $row_id, 'applicability', 'applicability'];
+    $editor['ticket_type_ids']['#parents'] = ['questions_card', 'questions', $row_id, 'applicability', 'ticket_type_ids'];
+    $editor['required']['#parents'] = ['questions_card', 'questions', $row_id, 'required', 'required'];
+    $editor['status']['#parents'] = ['questions_card', 'questions', $row_id, 'status', 'status'];
+    $editor['machine_name']['#parents'] = ['questions_card', 'questions', $row_id, 'actions', 'machine_name'];
+
+    $type_label = (string) ($row['type_label'] ?? $this->studioQuestionTemplateManager->typeOptions()[(string) ($row['type'] ?? '')] ?? $row['type'] ?? $this->t('Question'));
+
+    $row_classes = [
+      'mel-event-studio-questions__row',
+      $status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED ? 'is-archived' : 'is-active',
+    ];
+    if ($has_answers) {
+      $row_classes[] = 'mel-event-studio-questions__locked';
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => $row_classes,
+        'role' => 'row',
+      ],
+      'label_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--label'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Question'),
+        ],
+        'id' => [
+          '#type' => 'hidden',
+          '#value' => (string) $row_id,
+          '#parents' => ['questions_card', 'questions', $row_id, 'label', 'id'],
+        ],
+        'weight' => [
+          '#type' => 'hidden',
+          '#value' => (string) (int) $row['weight'],
+          '#parents' => ['questions_card', 'questions', $row_id, 'label', 'weight'],
+        ],
+        'label' => $editor['label'],
+        'locked_note' => $has_answers ? [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Has attendee answers — archive to retire; unsafe edits are blocked on save.'),
+          '#attributes' => ['class' => ['mel-event-studio-questions__locked-note']],
+        ] : [],
+      ],
+      'type_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--type'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Type'),
+        ],
+        'type' => $editor['type'],
+      ],
+      'required_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--required'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Required'),
+        ],
+        'required' => $editor['required'],
+      ],
+      'applicability_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--applicability'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Applies to'),
+        ],
+        'applicability' => $editor['applicability'],
+      ],
+      'tickets_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--tickets'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Ticket types'),
+        ],
+        'ticket_type_ids' => $editor['ticket_type_ids'],
+      ],
+      'status_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--status'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Status'),
+        ],
+        'status' => $editor['status'],
+      ],
+      'actions_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--actions'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('More'),
+        ],
+        'details_toggle' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $this->t('Expand row below'),
+          '#attributes' => ['class' => ['visually-hidden']],
+        ],
+      ],
+      'details' => [
+        '#type' => 'details',
+        '#title' => $this->t('Options and preview'),
+        '#open' => FALSE,
+        '#attributes' => ['class' => ['mel-event-studio-questions__details']],
+        'options' => $editor['options'],
+        'machine_name' => $editor['machine_name'],
+        'preview_heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h4',
+          '#value' => $this->t('How attendees will see this'),
+          '#attributes' => ['class' => ['mel-event-studio-questions__group-title']],
+        ],
+        'preview' => $this->buildAnswerPreview($row, $type_label),
+        'preview_reassurance' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => !empty($row['required'])
+            ? $this->t('Attendees will answer this before checkout can continue.')
+            : $this->t('Attendees can skip this if it does not apply.'),
+          '#attributes' => ['class' => ['mel-event-studio-questions__preview-reassurance']],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<int, string> $ticketOptions
+   *
+   * @return array<string, mixed>
+   */
+  private function buildNewQuestionRow(array $ticketOptions, int $weight): array {
+    $type_selector = ':input[name="questions_card[new_question][row][type][type]"]';
+    $applicability_selector = ':input[name="questions_card[new_question][row][applicability][applicability]"]';
+    $row = [
+      'id' => 0,
+      'weight' => $weight,
+      'label' => '',
+      'type' => 'textfield',
+      'required' => FALSE,
+      'status' => EventStudioQuestionTemplateManager::STATUS_ACTIVE,
+      'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET,
+      'ticket_type_ids' => [],
+      'options' => '',
+      'machine_name' => '',
+    ];
+    $editor = $this->buildQuestionEditor(
+      $row,
+      $ticketOptions,
+      TRUE,
+      FALSE,
+      $type_selector,
+      $applicability_selector,
+      EventStudioQuestionTemplateManager::APPLIES_PER_TICKET
+    );
+
+    $editor['label']['#parents'] = ['questions_card', 'new_question', 'row', 'label', 'label'];
+    $editor['type']['#parents'] = ['questions_card', 'new_question', 'row', 'type', 'type'];
+    $editor['options']['#parents'] = ['questions_card', 'new_question', 'row', 'type', 'options'];
+    $editor['applicability']['#parents'] = ['questions_card', 'new_question', 'row', 'applicability', 'applicability'];
+    $editor['ticket_type_ids']['#parents'] = ['questions_card', 'new_question', 'row', 'applicability', 'ticket_type_ids'];
+    $editor['required']['#parents'] = ['questions_card', 'new_question', 'row', 'required', 'required'];
+    $editor['status']['#parents'] = ['questions_card', 'new_question', 'row', 'status', 'status'];
+    $editor['machine_name']['#parents'] = ['questions_card', 'new_question', 'row', 'actions', 'machine_name'];
+    $editor['weight']['#parents'] = ['questions_card', 'new_question', 'row', 'label', 'weight'];
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-event-studio-questions__row', 'mel-event-studio-questions__row--add'],
+        'role' => 'row',
+      ],
+      'label_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--label'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Question'),
+        ],
+        'label' => $editor['label'],
+        'weight' => $editor['weight'],
+      ],
+      'type_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--type'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Type'),
+        ],
+        'type' => $editor['type'],
+      ],
+      'required_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--required'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Required'),
+        ],
+        'required' => $editor['required'],
+      ],
+      'applicability_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--applicability'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Applies to'),
+        ],
+        'applicability' => $editor['applicability'],
+      ],
+      'tickets_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--tickets'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Ticket types'),
+        ],
+        'ticket_type_ids' => $editor['ticket_type_ids'],
+      ],
+      'status_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--status'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('Status'),
+        ],
+        'status' => $editor['status'],
+      ],
+      'actions_cell' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__cell', 'mel-event-studio-questions__cell--actions'],
+          'role' => 'cell',
+          'data-cell-label' => (string) $this->t('More'),
+        ],
+      ],
+      'details' => [
+        '#type' => 'details',
+        '#title' => $this->t('Options and machine name'),
+        '#open' => FALSE,
+        '#attributes' => ['class' => ['mel-event-studio-questions__details']],
+        'options' => $editor['options'],
+        'machine_name' => $editor['machine_name'],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<int, string> $ticketOptions
+   * @param bool $isNew
+   * @param bool $locked
+   * @param string $typeSelector
+   * @param string $applicabilitySelector
+   * @param string $currentApplicability
+   *
+   * @return array<string, mixed>
+   */
+  private function buildQuestionEditor(
+    array $row,
+    array $ticketOptions,
+    bool $isNew,
+    bool $locked,
+    string $typeSelector,
+    string $applicabilitySelector,
+    string $currentApplicability,
+  ): array {
+    $lock_message = $locked
+      ? (string) $this->t('Locked because attendee answers exist. Archive this question and add a new one to change answer shape.')
+      : NULL;
+
+    $type = (string) ($row['type'] ?? 'textfield');
+    $options_visible_states = [
+      'visible' => [
+        $typeSelector => [
+          ['value' => 'select'],
+          ['value' => 'checkboxes'],
+          ['value' => 'radios'],
+        ],
+      ],
+    ];
+
     return [
       'label' => [
         '#type' => 'textfield',
         '#title' => $this->t('Question'),
-        '#title_display' => 'before',
+        '#title_display' => 'invisible',
         '#default_value' => (string) ($row['label'] ?? ''),
         '#maxlength' => 255,
+        '#required' => $isNew,
         '#attributes' => ['class' => ['mel-event-studio-questions__label']],
-        '#description' => $this->t('Write this exactly as attendees should see it.'),
+        '#description' => $isNew ? $this->t('Write this exactly as attendees should see it.') : NULL,
       ],
       'type' => [
         '#type' => 'select',
         '#title' => $this->t('Type'),
-        '#title_display' => 'before',
+        '#title_display' => 'invisible',
         '#options' => $this->studioQuestionTemplateManager->typeOptions(),
-        '#default_value' => (string) ($row['type'] ?? 'textfield'),
+        '#default_value' => $type,
+        '#disabled' => $locked,
+        '#description' => $lock_message,
       ],
       'options' => [
         '#type' => 'textarea',
         '#title' => $this->t('Options'),
+        '#title_display' => 'before',
         '#default_value' => (string) ($row['options'] ?? ''),
         '#rows' => 3,
-        '#description' => $this->t('One option per line. Keep choices clear and easy to answer.'),
+        '#disabled' => $locked,
+        '#description' => $this->t('One option per line.'),
+        '#states' => $options_visible_states,
       ],
       'applicability' => [
         '#type' => 'select',
         '#title' => $this->t('Applies to'),
-        '#title_display' => 'before',
-        '#options' => $this->studioQuestionTemplateManager->applicabilityOptions(),
-        '#default_value' => (string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
-        '#description' => $isNew ? $this->t('Most events can use Per ticket. Choose Per ticket type only when a question applies to specific offers.') : NULL,
+        '#title_display' => 'invisible',
+        '#options' => $this->workspaceApplicabilityOptions($currentApplicability),
+        '#default_value' => $currentApplicability,
+        '#disabled' => $locked || $currentApplicability === EventStudioQuestionTemplateManager::APPLIES_PER_ORDER,
+        '#description' => $isNew ? $this->t('Most events can use Per ticket.') : $lock_message,
       ],
       'ticket_type_ids' => [
         '#type' => 'checkboxes',
         '#title' => $this->t('Ticket types'),
+        '#title_display' => 'invisible',
         '#options' => $ticketOptions,
         '#default_value' => $row['ticket_type_ids'] ?? [],
+        '#disabled' => $locked,
         '#description' => $ticketOptions === []
           ? $this->t('Create ticket types before using per-ticket-type questions.')
-          : $this->t('Required when Applies to is Per ticket type.'),
+          : NULL,
         '#states' => [
           'visible' => [
             $applicabilitySelector => ['value' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE],
@@ -453,20 +633,25 @@ final class EventCheckoutQuestionsForm extends FormBase {
       'required' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Required'),
+        '#title_display' => 'invisible',
         '#default_value' => !empty($row['required']),
+        '#disabled' => $locked,
       ],
       'status' => [
         '#type' => 'select',
         '#title' => $this->t('Status'),
-        '#title_display' => 'before',
+        '#title_display' => 'invisible',
         '#options' => $this->studioQuestionTemplateManager->statusOptions(),
         '#default_value' => (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
+        '#description' => $locked ? $this->t('Archive to hide from new checkouts while keeping past answers.') : NULL,
       ],
       'machine_name' => [
         '#type' => 'textfield',
         '#title' => $this->t('Machine name'),
+        '#title_display' => 'before',
         '#default_value' => (string) ($row['machine_name'] ?? ''),
         '#maxlength' => 64,
+        '#disabled' => $locked,
         '#description' => $this->t('Optional stable key. Leave blank to generate from the label.'),
       ],
       'weight' => [
@@ -477,16 +662,17 @@ final class EventCheckoutQuestionsForm extends FormBase {
   }
 
   /**
-   * @param array<string, mixed> $row
+   * Applicability choices for workspace UI (per_order not selectable).
+   *
+   * @return array<string, string>
    */
-  private function buildPreviewText(array $row): string {
-    $status = (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE);
-    $required = !empty($row['required']) ? (string) $this->t('Required') : (string) $this->t('Optional');
-    $type_label = (string) ($row['type_label'] ?? $this->studioQuestionTemplateManager->typeOptions()[(string) ($row['type'] ?? '')] ?? $row['type'] ?? $this->t('Question'));
-    if ($status === EventStudioQuestionTemplateManager::STATUS_ARCHIVED) {
-      return (string) $this->t('Archived: hidden from new checkout sessions.');
+  private function workspaceApplicabilityOptions(string $currentApplicability = EventStudioQuestionTemplateManager::APPLIES_PER_TICKET): array {
+    $options = $this->studioQuestionTemplateManager->applicabilityOptions();
+    unset($options[EventStudioQuestionTemplateManager::APPLIES_PER_ORDER]);
+    if ($currentApplicability === EventStudioQuestionTemplateManager::APPLIES_PER_ORDER) {
+      $options[EventStudioQuestionTemplateManager::APPLIES_PER_ORDER] = (string) $this->t('Per order (not active in checkout yet)');
     }
-    return $required . ' • ' . $type_label;
+    return $options;
   }
 
   /**
@@ -510,11 +696,6 @@ final class EventCheckoutQuestionsForm extends FormBase {
       '#value' => $this->t('@type answer field shown at checkout.', ['@type' => $typeLabel]),
       '#attributes' => ['class' => ['mel-event-studio-questions__answer-placeholder']],
     ];
-  }
-
-  private function applicabilityLabel(string $applicability): string {
-    $options = $this->studioQuestionTemplateManager->applicabilityOptions();
-    return $options[$applicability] ?? $options[EventStudioQuestionTemplateManager::APPLIES_PER_TICKET];
   }
 
   /**
@@ -553,21 +734,25 @@ final class EventCheckoutQuestionsForm extends FormBase {
    * @return array<string, mixed>|null
    */
   private function submittedNewRow(FormStateInterface $form_state): ?array {
-    $row = $form_state->getValue(['questions_card', 'new_question']) ?? NULL;
-    if (!is_array($row) || trim((string) ($row['label'] ?? '')) === '') {
+    $row = $form_state->getValue(['questions_card', 'new_question', 'row']) ?? NULL;
+    if (!is_array($row)) {
+      return NULL;
+    }
+    $label = trim((string) ($row['label']['label'] ?? ''));
+    if ($label === '') {
       return NULL;
     }
     return [
       'id' => 0,
-      'weight' => (int) ($row['weight'] ?? 999),
-      'label' => (string) ($row['label'] ?? ''),
-      'type' => (string) ($row['type'] ?? 'textfield'),
-      'options' => (string) ($row['options'] ?? ''),
-      'applicability' => (string) ($row['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
-      'ticket_type_ids' => $row['ticket_type_ids'] ?? [],
-      'required' => !empty($row['required']),
-      'status' => (string) ($row['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
-      'machine_name' => (string) ($row['machine_name'] ?? ''),
+      'weight' => (int) ($row['label']['weight'] ?? 999),
+      'label' => $label,
+      'type' => (string) ($row['type']['type'] ?? 'textfield'),
+      'options' => (string) ($row['type']['options'] ?? ''),
+      'applicability' => (string) ($row['applicability']['applicability'] ?? EventStudioQuestionTemplateManager::APPLIES_PER_TICKET),
+      'ticket_type_ids' => $row['applicability']['ticket_type_ids'] ?? [],
+      'required' => !empty($row['required']['required']),
+      'status' => (string) ($row['status']['status'] ?? EventStudioQuestionTemplateManager::STATUS_ACTIVE),
+      'machine_name' => (string) ($row['actions']['machine_name'] ?? ''),
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -1001,6 +1001,22 @@ final class EventStudioForm extends FormBase {
           'mel-attendee-questions-editor',
         ],
       ],
+      'checkout_workspace_cta' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-studio-questions__builder-cta']],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Use Checkout questions for attendee details shown during ticket checkout.'),
+          '#attributes' => ['class' => ['mel-event-studio-questions__builder-cta-copy']],
+        ],
+        'link' => [
+          '#type' => 'link',
+          '#title' => $this->t('Manage checkout questions'),
+          '#url' => Url::fromRoute('myeventlane_event_studio.workspace_questions', ['node' => $event->id()]),
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-studio-questions__builder-cta-link']],
+        ],
+      ],
       'library_wrap' => [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-attendee-questions-library']],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures the `EventCheckoutQuestionsForm` render array and submission parsing, which could affect saving/validation of checkout questions, plus a large CSS addition that may impact Studio layout.
> 
> **Overview**
> Updates the help-centre contextual `checkout` link to point to the new “Having trouble checking out?” article instead of incorrectly routing to refunds, and records the final polish/audit outcomes in the publish-prep docs.
> 
> In Event Studio, refactors the checkout questions workspace UI from card-style rows into a table-like grid with a sticky header, responsive stacked layout on small screens, and a new CTA in the main `EventStudioForm` that links vendors to the dedicated questions workspace.
> 
> Tightens question editing rules/UX by adding explicit “locked” handling when historical answers exist (disables unsafe field edits and adds guidance), hides/disables `per_order` applicability in the workspace (while still displaying it as not-yet-active), and updates new-question form nesting/submit extraction accordingly; bumps the `mel_event_studio` library version and adds the supporting CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fbd46cf07878ca24853f8c657064148c95eccf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->