### PR TITLE
Fix/bugbot pr review issues round2

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/CustomerTicketTierDisplayBuilder.php
@@ -96,7 +96,7 @@ final class CustomerTicketTierDisplayBuilder {
     }
 
     $context = $this->ticketAvailability->buildDefaultCustomerAccessContext($event);
-    $purchasable = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context);
+    $purchasable = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context, FALSE);
     $purchasable = $this->sortPurchasableLikeBookForm($event, $purchasable);
     $best_value_variation_id = $this->resolveBestValueVariationId($event);
     $purchasable_variation_ids = [];

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketAvailabilityService.php
@@ -150,6 +150,7 @@ final class TicketAvailabilityService implements TicketCustomerDisplayGatewayInt
     NodeInterface $event,
     ProductInterface $product,
     ?TicketAccessContext $accessContext = NULL,
+    bool $useCache = TRUE,
   ): array {
     $eid = (int) $event->id();
     $pid = (int) $product->id();
@@ -172,7 +173,7 @@ final class TicketAvailabilityService implements TicketCustomerDisplayGatewayInt
       (string) $waitlistClaimId,
     ]));
 
-    if ($this->cache !== NULL && ($cached = $this->cache->get($cid))) {
+    if ($useCache && $this->cache !== NULL && ($cached = $this->cache->get($cid))) {
       $ids = $cached->data;
       if (is_array($ids)) {
         $by_id = [];
@@ -218,7 +219,7 @@ final class TicketAvailabilityService implements TicketCustomerDisplayGatewayInt
       }
     }
 
-    if ($this->cache !== NULL) {
+    if ($useCache && $this->cache !== NULL) {
       $this->cache->set(
         $cid,
         array_map(static fn (ProductVariationInterface $v) => (int) $v->id(), $out),
@@ -615,20 +616,34 @@ final class TicketAvailabilityService implements TicketCustomerDisplayGatewayInt
     if ($message === '') {
       return (string) $this->t('Hidden from checkout: ticket is not available on the book page.');
     }
-    if (str_contains($message, 'not started')) {
+    if (str_contains($message, 'Ticketing is not configured')) {
+      return (string) $this->t('Hidden from checkout: ticketing is not configured for this event.');
+    }
+    if (str_contains($message, 'not available for this event')) {
+      return (string) $this->t('Hidden from checkout: linked product variation is not mapped to this event.');
+    }
+    if (str_contains($message, 'temporarily unavailable')
+      || str_contains($message, 'not available for purchase')
+      || str_contains($message, 'price')) {
+      return (string) $this->t('Hidden from checkout: linked product variation price does not match this ticket.');
+    }
+    if (str_contains($message, 'not started') || str_contains($message, 'Sales have not started')) {
       return (string) $this->t('Hidden from checkout: sale has not started.');
     }
-    if (str_contains($message, 'ended')) {
+    if (str_contains($message, 'ended') || str_contains($message, 'Sales have ended')) {
       return (string) $this->t('Hidden from checkout: sale has ended.');
     }
     if (str_contains($message, 'sold out') || str_contains($message, 'remaining')) {
       return (string) $this->t('Hidden from checkout: sold out.');
     }
-    if (str_contains($message, 'not on sale') || str_contains($message, 'not available')) {
-      return (string) $this->t('Hidden from checkout: ticket is not visible to this customer.');
+    if (str_contains($message, 'no longer available')) {
+      return (string) $this->t('Hidden from checkout: this ticket is archived.');
     }
-    if (str_contains($message, 'price')) {
-      return (string) $this->t('Hidden from checkout: linked product variation price does not match this ticket.');
+    if (str_contains($message, 'not on sale')) {
+      return (string) $this->t('Hidden from checkout: this ticket is not on sale.');
+    }
+    if ($message === 'This ticket is not available.') {
+      return (string) $this->t('Hidden from checkout: ticket is not visible to this customer.');
     }
     return (string) $this->t('Hidden from checkout: @reason', ['@reason' => $message]);
   }

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketCustomerDisplayGatewayInterface.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketCustomerDisplayGatewayInterface.php
@@ -28,6 +28,7 @@ interface TicketCustomerDisplayGatewayInterface extends TicketTierForVariationRe
     NodeInterface $event,
     ProductInterface $product,
     ?TicketAccessContext $accessContext = NULL,
+    bool $useCache = TRUE,
   ): array;
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -582,7 +582,6 @@ final class EventCheckoutQuestionsForm extends FormBase {
         '#title_display' => 'invisible',
         '#default_value' => (string) ($row['label'] ?? ''),
         '#maxlength' => 255,
-        '#required' => $isNew,
         '#attributes' => ['class' => ['mel-event-studio-questions__label']],
         '#description' => $isNew ? $this->t('Write this exactly as attendees should see it.') : NULL,
       ],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventTicketPreviewBuilder.php
@@ -49,9 +49,9 @@ final class EventTicketPreviewBuilder {
 
     $configuredMode = $this->resolveConfiguredMode($event);
     $previewState = $this->resolvePreviewState($event, $configuredMode);
-    $cta = $this->resolveCtaPreview($event, $previewState);
-    $availability = $this->resolveAvailabilityPreview($event, $previewState);
     $tierDisplay = $this->buildPaidTierDisplay($event, $previewState);
+    $cta = $this->resolveCtaPreview($event, $previewState, $tierDisplay);
+    $availability = $this->resolveAvailabilityPreview($event, $previewState, $tierDisplay);
 
     $build = [
       '#theme' => 'mel_event_ticket_preview',
@@ -169,9 +169,16 @@ final class EventTicketPreviewBuilder {
   }
 
   /**
+   * @param array{
+   *   visible_rows: list<array<string, mixed>>,
+   *   excluded_rows: list<array{name: string, diagnostic: string}>,
+   *   show_customer_ticket_empty: bool,
+   *   cache_tags: list<string>,
+   * } $tierDisplay
+   *
    * @return array{label: string, disabled: bool, reason: string|null}
    */
-  private function resolveCtaPreview(NodeInterface $event, string $previewState): array {
+  private function resolveCtaPreview(NodeInterface $event, string $previewState, array $tierDisplay): array {
     if ($previewState === self::PREVIEW_NOT_CONFIGURED) {
       return [
         'label' => '',
@@ -181,6 +188,11 @@ final class EventTicketPreviewBuilder {
     }
 
     if ($event->isPublished()) {
+      $availability = $this->resolveAvailabilityPreview($event, $previewState, $tierDisplay);
+      if ($this->usesCustomerTierAvailability($previewState, $availability['state'])) {
+        return $this->ctaFromCustomerTierAvailability($previewState, $availability['state']);
+      }
+
       $primary = $this->bookingFlowResolver->getPrimaryCta($event);
       return [
         'label' => (string) ($primary['label'] ?? ''),
@@ -219,9 +231,16 @@ final class EventTicketPreviewBuilder {
   }
 
   /**
+   * @param array{
+   *   visible_rows: list<array<string, mixed>>,
+   *   excluded_rows: list<array{name: string, diagnostic: string}>,
+   *   show_customer_ticket_empty: bool,
+   *   cache_tags: list<string>,
+   * } $tierDisplay
+   *
    * @return array{state: string, message: string|null}
    */
-  private function resolveAvailabilityPreview(NodeInterface $event, string $previewState): array {
+  private function resolveAvailabilityPreview(NodeInterface $event, string $previewState, array $tierDisplay): array {
     if ($previewState === self::PREVIEW_NOT_CONFIGURED) {
       return ['state' => 'none', 'message' => NULL];
     }
@@ -231,6 +250,16 @@ final class EventTicketPreviewBuilder {
     }
 
     $availability = $this->bookingFlowResolver->getAvailabilityState($event);
+    if (in_array($previewState, [self::PREVIEW_PAID, self::PREVIEW_BOTH], TRUE)
+      && in_array($availability, [
+        BookingFlowResolver::AVAILABILITY_AVAILABLE,
+        BookingFlowResolver::AVAILABILITY_SOLD_OUT,
+      ], TRUE)) {
+      $availability = $tierDisplay['visible_rows'] === []
+        ? BookingFlowResolver::AVAILABILITY_SOLD_OUT
+        : BookingFlowResolver::AVAILABILITY_AVAILABLE;
+    }
+
     $message = match ($availability) {
       BookingFlowResolver::AVAILABILITY_SOLD_OUT => (string) $this->t('This event is sold out.'),
       BookingFlowResolver::AVAILABILITY_ENDED => (string) $this->t('This event has ended.'),
@@ -271,6 +300,43 @@ final class EventTicketPreviewBuilder {
     return [
       'capacity_line' => $line,
     ];
+  }
+
+  /**
+   * Paid preview CTA/availability use anonymous default-customer tier rows, not vendor session grants.
+   */
+  private function usesCustomerTierAvailability(string $previewState, string $availability): bool {
+    return in_array($previewState, [self::PREVIEW_PAID, self::PREVIEW_BOTH], TRUE)
+      && in_array($availability, [
+        BookingFlowResolver::AVAILABILITY_AVAILABLE,
+        BookingFlowResolver::AVAILABILITY_SOLD_OUT,
+      ], TRUE);
+  }
+
+  /**
+   * @return array{label: string, disabled: bool, reason: string|null}
+   */
+  private function ctaFromCustomerTierAvailability(string $previewState, string $availability): array {
+    if ($availability === BookingFlowResolver::AVAILABILITY_SOLD_OUT) {
+      return [
+        'label' => (string) $this->t('Sold out'),
+        'disabled' => TRUE,
+        'reason' => (string) $this->t('This event is sold out.'),
+      ];
+    }
+
+    return match ($previewState) {
+      self::PREVIEW_PAID, self::PREVIEW_BOTH => [
+        'label' => (string) $this->t('Get your tickets'),
+        'disabled' => FALSE,
+        'reason' => NULL,
+      ],
+      default => [
+        'label' => '',
+        'disabled' => TRUE,
+        'reason' => NULL,
+      ],
+    };
   }
 
   /**


### PR DESCRIPTION
fix(event-studio): allow saving checkout questions without a new label (high severity)
Removed #required from the always-visible “add question” row in EventCheckoutQuestionsForm.php. Drupal was blocking every save when that field was empty, even when only editing existing questions. submittedNewRow() still ignores empty labels.

fix(commerce): align Studio ticket preview with anonymous checkout

Vendor diagnostics — mapPurchasabilityExceptionToVendorDiagnostic() now matches specific exception text (mapping, price, sale window, sold out) instead of any message containing "not available".
Stale cache — CustomerTicketTierDisplayBuilder calls filterPurchasableVariations(..., useCache: FALSE) so excluded tiers and diagnostics stay in sync.
Preview CTA / availability — Published paid preview uses default-customer visible_rows for sold-out vs available, not the vendor’s session grants via BookingFlowResolver.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes ticket purchasability caching and how Studio determines sold-out/CTA states, which can affect what tickets appear available in previews/checkout-related UI.
> 
> **Overview**
> Improves Event Studio and checkout parity by making the paid ticket preview’s **CTA and availability** derive from the same customer-visible tier rows (treating zero visible rows as sold out) instead of vendor/session-specific availability.
> 
> Adds a `useCache` toggle to `filterPurchasableVariations()` and disables caching in `CustomerTicketTierDisplayBuilder` to prevent stale purchasable/excluded tier diagnostics; vendor exclusion diagnostics are also refined to map specific purchasability errors (ticketing not configured, unmapped variation, price mismatch, sale window ended/not started, archived/not on sale) instead of broadly matching “not available”.
> 
> Fixes Event Studio checkout questions saving by removing the `#required` constraint from the always-visible “add question” label field so editing existing questions no longer fails when the new-question row is blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5373a2ec0a5087e6fb10d7726da91af3ede30e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->