### PR TITLE
docs(help): log waitlist and ticket confirmation publication

### DIFF
--- a/docs/content-audit/publish-prep/help-article-publish-register.md
+++ b/docs/content-audit/publish-prep/help-article-publish-register.md
@@ -1,33 +1,35 @@
 # Help article publish decision register
 
 **Date:** 2026-05-22  
-**Branch:** `feature/help-article-publish-prep`  
-**Drupal nodes:** updated 2026-05-22 on `feature/help-article-editorial-updates` — see `editorial-update-log.md`
+**Branch:** `feature/help-publish-waitlist-ticket-confirmation`  
+**Publication log:** `waitlist-ticket-confirmation-publish-log.md`
 
 | Article | Source | Existing node | Audience | Action | Publish readiness | Blockers | Next step |
 |---------|--------|---------------|----------|--------|-------------------|----------|-----------|
 | Support contact | Draft + nid **1498** | 1498 “Contacting support” | public | **Done** | **Published** | — | Alias `/help/attendees/contacting-support` |
-| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Done** | **Published** | — | Alias `/help/vendors/payouts-and-fees`; fee wording verified (code) |
-| Waitlist | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Browser QA; then create node |
-| Ticket confirmation | Draft only | None | public | **New article** after QA | **Blocked until product behaviour is verified** | Staging QA | Test purchase; then create node |
-| Checkout errors | Draft + **nid 1668** | 1668 “Having trouble checking out” | public | **Done** | **Published** | — | Alias `/help/attendees/having-trouble-checking-out`; checkout contextual link updated |
+| Stripe payouts | Draft + nid **1510** | 1510 “Payouts and fees” | vendor | **Done** | **Published** | — | Alias `/help/vendors/payouts-and-fees` |
+| Waitlist | Draft + QA | **1669** “Joining a waitlist” | public | **Done** | **Published** | Offer/claim E2E still conditional in copy | Alias `/help/attendees/joining-a-waitlist` |
+| Ticket confirmation | Draft + QA | **1497** “After you book a ticket” | public | **Done** (merged nid 1497) | **Published** | QR/PDF conditional when tickets not issued | Alias `/help/attendees/after-you-book-a-ticket` |
+| Checkout errors | Draft + **nid 1668** | 1668 “Having trouble checking out” | public | **Done** | **Published** | — | Alias `/help/attendees/having-trouble-checking-out` |
 
-## Working tree note (start of pass)
+## Working tree note
 
-- Branch: `feature/help-article-publish-prep`
-- Clean of help code changes; unrelated items may still exist locally (`package.json`, other untracked `docs/content-audit/*` planning files).
+- Drupal node content is **database-only** in this pass (not in `config/sync`).
+- See `waitlist-ticket-confirmation-publish-log.md` for nid, aliases, and verification.
 
 ## Governance reminders
 
 - Do not set `field_help_ai_allowed` false without reason.
 - Do not publish vendor audience copy to public hubs.
 - Do not mention AI in article body.
-- Merge 1498/1510 rather than duplicate.
+- `field_audience: public` required for anonymous Help Assistant retrieval.
 
 ## Related prep documents
 
-- `support-contact-merge.md`
-- `stripe-payouts-merge.md`
+- `waitlist-ticket-confirmation-publish-log.md`
 - `waitlist-verification.md`
 - `ticket-confirmation-verification.md`
+- `support-contact-merge.md`
+- `stripe-payouts-merge.md`
 - `checkout-errors-verification.md`
+- `editorial-update-log.md`

--- a/docs/content-audit/publish-prep/waitlist-ticket-confirmation-publish-log.md
+++ b/docs/content-audit/publish-prep/waitlist-ticket-confirmation-publish-log.md
@@ -1,0 +1,117 @@
+# Waitlist and ticket confirmation — publication log
+
+**Date:** 2026-05-22  
+**Branch:** `feature/help-publish-waitlist-ticket-confirmation`  
+**Drupal:** database-only (nodes + path aliases); not exported to `config/sync` in this pass.
+
+---
+
+## Duplicate search
+
+| Query terms | Result |
+|-------------|--------|
+| waitlist, sold out | **No** existing `help_article` |
+| confirmation, ticket confirmation, my tickets, wallet, calendar, booking confirmation | **No** exact duplicate |
+| Related | nid **1497** “What happens after booking” — thin overlap; **updated in place** (not a second node) |
+| Related | nid **1501** “Adding events to your calendar” — calendar only; kept separate |
+| Related | nid **1492** “How to buy tickets” — cross-linked |
+
+---
+
+## Published articles
+
+### Waitlist — **new**
+
+| Field | Value |
+|-------|-------|
+| **nid** | **1669** |
+| **Title** | Joining a waitlist |
+| **Alias** | `/help/attendees/joining-a-waitlist` |
+| **Audience** | `field_audience`: public |
+| **Article type** | Guide (tid 70) |
+| **Topic** | Buying Tickets (tid 79) |
+| **`field_help_status`** | published |
+| **`field_help_ai_allowed`** | true |
+| **Summary** | When a paid ticket type is sold out and the organiser has enabled a waitlist, you can register your interest on the event booking page. Joining does not book or buy a ticket. |
+
+### Ticket confirmation — **updated (merge)**
+
+| Field | Value |
+|-------|-------|
+| **nid** | **1497** (was “What happens after booking”) |
+| **Title** | After you book a ticket |
+| **Alias** | `/help/attendees/after-you-book-a-ticket` |
+| **Audience** | `field_audience`: public |
+| **Article type** | Guide (tid 70) |
+| **Topic** | Tickets (tid 45) |
+| **`field_help_status`** | published |
+| **`field_help_ai_allowed`** | true |
+| **Summary** | Where to find your booking confirmation, My Tickets, calendar links, and optional wallet passes after you buy a ticket. |
+
+**Merge rationale:** Avoid duplicating “after booking” content. Expanded nid 1497 instead of creating a second node.
+
+---
+
+## Wording deliberately kept conditional
+
+| Topic | Constraint in published body |
+|-------|------------------------------|
+| Waitlist offers | “If the organiser has enabled automatic offers… MyEventLane **may** give you a way to complete purchase”; “Offers are not automatic on every event”; no promise of email |
+| Waitlist ticket | “does **not** book or buy a ticket”; “does **not** guarantee” |
+| RSVP waitlist | Separate from paid ticket waitlist on book page |
+| Confirmation email | “may receive”; “can take a few minutes”; check junk |
+| Wallet | “may appear”; “optional”; “not available on every order”; signed-in buyer only |
+| QR/PDF | “Some events”; “may arrive in a later email”; assign-tickets step |
+| Calendar | “Where supported”; depends on event/device |
+| My Tickets / wallet URLs | Sign-in required; anonymous cannot use buyer wallet links |
+
+---
+
+## Commands run
+
+```bash
+ddev drush php:script   # one-off publish script (DB-only; not committed)
+ddev drush search-api:index mel_content
+ddev drush search-api:status mel_content
+ddev drush cr
+ddev drush php:eval   # HelpRetriever anonymous checks
+
+composer validate
+npm run mel:lint
+npm run mel:build
+```
+
+---
+
+## Validation results
+
+| Check | Result |
+|-------|--------|
+| `mel_content` index | **100%** (61/61) — 3 items indexed (1669 new, 1497 updated, possible related) |
+| Anonymous HTTP `/help/attendees/joining-a-waitlist` | **200** |
+| Anonymous HTTP `/help/attendees/after-you-book-a-ticket` | **200** |
+| `composer validate` | Pass |
+| `npm run mel:lint` | Pass |
+| `npm run mel:build` | Pass |
+
+---
+
+## Access verification
+
+| Node | Anonymous HTTP | `field_audience` | Help Assistant (anonymous) |
+|------|----------------|------------------|----------------------------|
+| 1669 | 200 | public | Retrieved for “join waitlist sold out tickets” |
+| 1497 | 200 | public | Retrieved for “ticket confirmation email my tickets”, “apple wallet after booking” |
+| 1510 (control) | — | vendor | **Not** returned for “stripe payouts vendor fees” |
+
+---
+
+## Remaining risks
+
+| Risk | Notes |
+|------|-------|
+| Waitlist offer / claim E2E | Article uses conditional offer language; not re-tested in this pass |
+| nid 1497 merge | Old title “What happens after booking” replaced; bookmarks to old title text only |
+| Path aliases | Manual aliases; not pathauto |
+| Drupal content not in git | Replicate via same editorial copy or export workflow if needed on other envs |
+| `how_to_access_tickets` seed | Still not a published node; ticket article covers My Tickets without duplicating access guide |


### PR DESCRIPTION
## Summary

Logs the publication of the final two previously blocked Help Centre articles:

- Joining a waitlist
- After you book a ticket

Drupal content changes were made in the database. This PR records the publication evidence, validation, aliases, and remaining risks.

## Published content

- nid 1669: Joining a waitlist
  - Alias: /help/attendees/joining-a-waitlist
  - Audience: public
  - Status: published
  - AI allowed: true

- nid 1497: After you book a ticket
  - Updated in place from “What happens after booking”
  - Alias: /help/attendees/after-you-book-a-ticket
  - Audience: public
  - Status: published
  - AI allowed: true

## Wording controls

- Waitlist copy avoids promising a ticket, email, auto-invite, or claim link.
- Ticket confirmation copy keeps wallet, calendar, QR, and PDF wording conditional.
- Buyer-scoped wallet access is described as signed-in only.
- RSVP waitlist is kept separate from paid ticket waitlist.

## Validation

- ddev drush cr passed.
- composer validate passed.
- npm run mel:lint passed.
- npm run mel:build passed.
- mel_content Search API index is 100%: 61/61.
- Anonymous users can access public articles.
- Help Assistant returns waitlist and ticket confirmation articles for public queries.
- Anonymous Help Assistant does not return vendor-only payout article 1510.

## Remaining risks

- Waitlist offer/claim flow remains conditional until full E2E testing.
- Drupal content changes are DB-only and need replication/export for other environments.
- Old nid 1497 title may need redirect handling if there were existing bookmarks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes, but it references DB-only Drupal node/alias updates that must be replicated via the proper content workflow in other environments.
> 
> **Overview**
> Records publication of two Help Centre articles by updating the publish decision register and adding a new `waitlist-ticket-confirmation-publish-log.md` with nids, aliases, audience/status fields, and the rationale for merging into existing nid `1497`.
> 
> Captures verification evidence (duplicate search, commands run, indexing and anonymous access checks) and explicitly notes conditional wording constraints plus remaining risks (manual aliases, DB-only content, and the nid `1497` title change implications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f86a41e60032091367ad91891959d154837207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->