### PR TITLE
ux(event-studio): support ticket-specific question targeting

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -234,6 +234,22 @@
   max-width: 100%;
 }
 
+.mel-event-studio .mel-event-studio-questions__targeting-helper {
+  margin: 0.5rem 0 0;
+  color: var(--mel-color-text-muted, #5c6570);
+  font-size: 0.9375rem;
+}
+
+.mel-event-studio .mel-event-studio-questions__legacy-notice {
+  margin: 1rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--mel-radius-md, 8px);
+  background: var(--mel-color-surface-alt, #f4f6f8);
+  border: 1px solid var(--mel-color-border, #d8dee6);
+  color: var(--mel-color-text, #1a1f26);
+  font-size: 0.9375rem;
+}
+
 .mel-event-studio .mel-event-studio-questions__notice {
   margin: 12px 0 0;
   padding: 10px 12px;

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -113,7 +113,30 @@ final class EventCheckoutQuestionsForm extends FormBase {
       'per_order_planned' => [
         '#markup' => '<p class="mel-event-studio-questions__per-order-note">' . $this->t('Per order questions are planned but not active yet.') . '</p>',
       ],
+      'targeting_helper' => [
+        '#markup' => '<p class="mel-event-studio-questions__targeting-helper">' . $this->t('Use ticket type targeting when a question only applies to selected ticket types.') . '</p>',
+      ],
     ];
+
+    $legacy_summary = $this->studioQuestionTemplateManager->findLegacyTierQuestionSummary($event);
+    if ($legacy_summary['total_count'] > 0) {
+      $ticket_names = implode(', ', $legacy_summary['ticket_type_names']);
+      $form['intro']['legacy_tier_notice'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $this->t(
+          'This event has @count ticket-type question templates saved on individual ticket types (@tickets). They still work at checkout, but new targeting should be managed here using “Specific ticket types”.',
+          [
+            '@count' => (int) $legacy_summary['total_count'],
+            '@tickets' => $ticket_names,
+          ]
+        ),
+        '#attributes' => [
+          'class' => ['mel-event-studio-questions__legacy-notice'],
+          'role' => 'note',
+        ],
+      ];
+    }
 
     $ticket_options = $this->studioQuestionTemplateManager->ticketOptions($event);
     $question_rows = $this->studioQuestionTemplateManager->loadRows($event);
@@ -611,7 +634,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
         '#options' => $this->workspaceApplicabilityOptions($currentApplicability),
         '#default_value' => $currentApplicability,
         '#disabled' => $locked || $currentApplicability === EventStudioQuestionTemplateManager::APPLIES_PER_ORDER,
-        '#description' => $isNew ? $this->t('Most events can use Per ticket.') : $lock_message,
+        '#description' => $lock_message,
       ],
       'ticket_type_ids' => [
         '#type' => 'checkboxes',
@@ -621,8 +644,8 @@ final class EventCheckoutQuestionsForm extends FormBase {
         '#default_value' => $row['ticket_type_ids'] ?? [],
         '#disabled' => $locked,
         '#description' => $ticketOptions === []
-          ? $this->t('Create ticket types before using per-ticket-type questions.')
-          : NULL,
+          ? $this->t('Create ticket types before using specific ticket type targeting.')
+          : ($isNew ? $this->t('Use ticket type targeting when a question only applies to selected ticket types.') : $lock_message),
         '#states' => [
           'visible' => [
             $applicabilitySelector => ['value' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE],
@@ -666,7 +689,7 @@ final class EventCheckoutQuestionsForm extends FormBase {
    * @return array<string, string>
    */
   private function workspaceApplicabilityOptions(string $currentApplicability = EventStudioQuestionTemplateManager::APPLIES_PER_TICKET): array {
-    $options = $this->studioQuestionTemplateManager->applicabilityOptions();
+    $options = $this->studioQuestionTemplateManager->workspaceApplicabilityLabels();
     unset($options[EventStudioQuestionTemplateManager::APPLIES_PER_ORDER]);
     if ($currentApplicability === EventStudioQuestionTemplateManager::APPLIES_PER_ORDER) {
       $options[EventStudioQuestionTemplateManager::APPLIES_PER_ORDER] = (string) $this->t('Per order (not active in checkout yet)');

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
@@ -54,6 +54,66 @@ final class EventStudioQuestionTemplateManager {
   }
 
   /**
+   * Vendor-facing applicability labels for the Event Studio questions table.
+   *
+   * @return array<string, string>
+   */
+  public function workspaceApplicabilityLabels(): array {
+    return [
+      self::APPLIES_PER_TICKET => (string) $this->t('All ticket holders'),
+      self::APPLIES_PER_TICKET_TYPE => (string) $this->t('Specific ticket types'),
+      self::APPLIES_PER_ORDER => (string) $this->t('Per order'),
+    ];
+  }
+
+  /**
+   * Summarises legacy tier-level attendee question templates on ticket types.
+   *
+   * @return array{
+   *   total_count: int,
+   *   ticket_type_names: list<string>,
+   *   questions_per_ticket_type: array<string, int>
+   * }
+   */
+  public function findLegacyTierQuestionSummary(NodeInterface $event): array {
+    $total_count = 0;
+    $ticket_type_names = [];
+    $questions_per_ticket_type = [];
+
+    foreach ($this->loadEventTickets($event) as $ticket) {
+      if (!$ticket->hasField('field_use_ticket_attendee_questions')
+        || empty($ticket->get('field_use_ticket_attendee_questions')->value)) {
+        continue;
+      }
+      if (!$ticket->hasField('field_attendee_questions')
+        || $ticket->get('field_attendee_questions')->isEmpty()) {
+        continue;
+      }
+
+      $count = 0;
+      foreach ($ticket->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+        if ($paragraph instanceof ParagraphInterface && $paragraph->bundle() === 'attendee_extra_field') {
+          $count++;
+        }
+      }
+      if ($count < 1) {
+        continue;
+      }
+
+      $total_count += $count;
+      $name = $ticket->label();
+      $ticket_type_names[] = $name;
+      $questions_per_ticket_type[$name] = $count;
+    }
+
+    return [
+      'total_count' => $total_count,
+      'ticket_type_names' => $ticket_type_names,
+      'questions_per_ticket_type' => $questions_per_ticket_type,
+    ];
+  }
+
+  /**
    * @return array<string, string>
    */
   public function statusOptions(): array {
@@ -368,7 +428,25 @@ final class EventStudioQuestionTemplateManager {
       }
     }
 
+    $old_ticket_ids = $this->paragraphTicketTypeIds($paragraph);
+    $new_ticket_ids = $this->normalizeTicketTypeIds($newRow['ticket_type_ids'] ?? []);
+    if (!$this->ticketTypeIdSetsEqual($old_ticket_ids, $new_ticket_ids)) {
+      return (string) $this->t('@question already has attendee answers, so its ticket type targeting cannot be changed. Archive it and add a new question instead.', ['@question' => $context]);
+    }
+
     return NULL;
+  }
+
+  /**
+   * @param list<int> $left
+   * @param list<int> $right
+   */
+  public function ticketTypeIdSetsEqual(array $left, array $right): bool {
+    $normalized_left = $this->normalizeTicketTypeIds($left);
+    $normalized_right = $this->normalizeTicketTypeIds($right);
+    sort($normalized_left);
+    sort($normalized_right);
+    return $normalized_left === $normalized_right;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\myeventlane_event_studio\Unit;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_event_studio\Service\EventStudioQuestionAnswerExistenceRepository;
 use Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager;
 use Drupal\myeventlane_event_studio\Service\QuestionFieldTypeRegistry;
@@ -16,10 +17,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 if (!interface_exists(NodeInterface::class)) {
-  eval('namespace Drupal\node; interface NodeInterface {}');
+  eval('namespace Drupal\node; interface NodeInterface { public function hasField($field_name); public function get($field_name); }');
 }
 if (!interface_exists(ParagraphInterface::class)) {
-  eval('namespace Drupal\paragraphs; interface ParagraphInterface { public function hasField($field_name); public function get($field_name); public function id(); }');
+  eval('namespace Drupal\paragraphs; interface ParagraphInterface { public function hasField($field_name); public function get($field_name); public function id(); public function bundle(); }');
+}
+if (!interface_exists(TicketTypeInterface::class)) {
+  eval('namespace Drupal\mel_ticket\Entity; interface TicketTypeInterface { public function label(); public function hasField($field_name); public function get($field_name); public function isArchived(); }');
 }
 require_once dirname(__DIR__, 3) . '/src/Service/QuestionFieldTypeRegistry.php';
 require_once dirname(__DIR__, 3) . '/src/Service/EventStudioQuestionAnswerExistenceRepository.php';
@@ -139,6 +143,118 @@ final class EventStudioQuestionTemplateManagerTest extends TestCase {
     $this->assertNull($error);
   }
 
+  /**
+   * @covers ::workspaceApplicabilityLabels
+   */
+  public function testWorkspaceApplicabilityLabelsUseVendorFacingCopy(): void {
+    $manager = $this->manager();
+    $labels = $manager->workspaceApplicabilityLabels();
+
+    $this->assertSame('All ticket holders', $labels[EventStudioQuestionTemplateManager::APPLIES_PER_TICKET]);
+    $this->assertSame('Specific ticket types', $labels[EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE]);
+  }
+
+  /**
+   * @covers ::validateRow
+   */
+  public function testValidateRowRequiresTicketTypesForPerTicketTypeApplicability(): void {
+    $manager = $this->manager();
+
+    $error = $manager->validateRow(
+      $this->createMock(NodeInterface::class),
+      [
+        'label' => 'VIP meal choice',
+        'type' => 'textfield',
+        'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'ticket_type_ids' => [],
+      ],
+      'VIP question',
+    );
+
+    $this->assertSame('VIP question must select at least one ticket type.', $error);
+  }
+
+  /**
+   * @covers ::validateImmutableQuestionMutation
+   */
+  public function testImmutableQuestionRejectsTicketTypeTargetingChangesAfterAnswersExist(): void {
+    $repository = $this->createMock(EventStudioQuestionAnswerExistenceRepository::class);
+    $repository->method('questionHasHistoricalAnswers')->willReturn(TRUE);
+    $manager = $this->manager($repository);
+
+    $error = $manager->validateImmutableQuestionMutation(
+      $this->createMock(NodeInterface::class),
+      $this->paragraph([
+        'field_question_type' => 'textfield',
+        'field_question_required' => 1,
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'field_question_ticket_types' => [
+          ['target_id' => 10],
+          ['target_id' => 20],
+        ],
+      ], TRUE),
+      [
+        'label' => 'VIP meal choice',
+        'type' => 'textfield',
+        'required' => TRUE,
+        'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'ticket_type_ids' => [10],
+      ],
+      'VIP question',
+    );
+
+    $this->assertSame('VIP question already has attendee answers, so its ticket type targeting cannot be changed. Archive it and add a new question instead.', $error);
+  }
+
+  /**
+   * @covers ::ticketTypeIdSetsEqual
+   * @covers ::validateImmutableQuestionMutation
+   */
+  public function testImmutableQuestionAllowsTicketTypeOrderChangesAfterAnswersExist(): void {
+    $repository = $this->createMock(EventStudioQuestionAnswerExistenceRepository::class);
+    $repository->method('questionHasHistoricalAnswers')->willReturn(TRUE);
+    $manager = $this->manager($repository);
+
+    $this->assertTrue($manager->ticketTypeIdSetsEqual([20, 10], [10, 20]));
+
+    $error = $manager->validateImmutableQuestionMutation(
+      $this->createMock(NodeInterface::class),
+      $this->paragraph([
+        'field_question_type' => 'textfield',
+        'field_question_required' => 1,
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'field_question_ticket_types' => [
+          ['target_id' => 20],
+          ['target_id' => 10],
+        ],
+      ], TRUE),
+      [
+        'label' => 'VIP meal choice',
+        'type' => 'textfield',
+        'required' => TRUE,
+        'applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'ticket_type_ids' => [10 => '10', 20 => '20'],
+      ],
+      'VIP question',
+    );
+
+    $this->assertNull($error);
+  }
+
+  /**
+   * @covers ::findLegacyTierQuestionSummary
+   */
+  public function testFindLegacyTierQuestionSummaryReturnsCountAndTicketNames(): void {
+    $manager = $this->manager();
+    $event = $this->eventWithLegacyTierQuestions();
+
+    $summary = $manager->findLegacyTierQuestionSummary($event);
+
+    $this->assertSame(2, $summary['total_count']);
+    $this->assertSame(['VIP', 'General Admission'], $summary['ticket_type_names']);
+    $this->assertSame(['VIP' => 1, 'General Admission' => 1], $summary['questions_per_ticket_type']);
+  }
+
   private function manager(?EventStudioQuestionAnswerExistenceRepository $repository = NULL): EventStudioQuestionTemplateManager {
     $registry = new QuestionFieldTypeRegistry();
     $registry->setStringTranslation($this->translator());
@@ -156,11 +272,26 @@ final class EventStudioQuestionTemplateManagerTest extends TestCase {
   /**
    * @param array<string, mixed> $values
    */
-  private function paragraph(array $values): ParagraphInterface {
+  private function paragraph(array $values, bool $ticketTypesUseGetValue = FALSE): ParagraphInterface {
     $paragraph = $this->createMock(ParagraphInterface::class);
     $paragraph->method('hasField')->willReturnCallback(static fn (string $field): bool => array_key_exists($field, $values));
-    $paragraph->method('get')->willReturnCallback(static function (string $field) use ($values): object {
-      return new class($values[$field] ?? NULL) {
+    $paragraph->method('get')->willReturnCallback(static function (string $field) use ($values, $ticketTypesUseGetValue): object {
+      $raw = $values[$field] ?? NULL;
+      if ($ticketTypesUseGetValue && $field === 'field_question_ticket_types') {
+        return new class($raw) {
+          public function __construct(public mixed $value) {}
+          public function isEmpty(): bool {
+            return $this->value === NULL || $this->value === [];
+          }
+          /**
+           * @return list<array{target_id: int}>
+           */
+          public function getValue(): array {
+            return is_array($this->value) ? $this->value : [];
+          }
+        };
+      }
+      return new class($raw) {
         public function __construct(public mixed $value) {}
         public function isEmpty(): bool {
           return $this->value === NULL || $this->value === '';
@@ -168,6 +299,74 @@ final class EventStudioQuestionTemplateManagerTest extends TestCase {
       };
     });
     return $paragraph;
+  }
+
+  private function eventWithLegacyTierQuestions(): NodeInterface {
+    $vip_question = $this->createMock(ParagraphInterface::class);
+    $vip_question->method('bundle')->willReturn('attendee_extra_field');
+    $ga_question = $this->createMock(ParagraphInterface::class);
+    $ga_question->method('bundle')->willReturn('attendee_extra_field');
+
+    $vip = $this->ticketTypeWithLegacyQuestions('VIP', [$vip_question]);
+    $ga = $this->ticketTypeWithLegacyQuestions('General Admission', [$ga_question]);
+    $disabled = $this->ticketTypeWithLegacyQuestions('Staff', [], FALSE);
+
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('hasField')->willReturnCallback(static fn (string $field): bool => $field === 'field_ticket_types');
+    $event->method('get')->willReturnCallback(static function (string $field) use ($vip, $ga, $disabled): object {
+      return new class([$vip, $ga, $disabled]) {
+        /**
+         * @param list<\Drupal\mel_ticket\Entity\TicketTypeInterface> $tickets
+         */
+        public function __construct(private readonly array $tickets) {}
+        public function isEmpty(): bool {
+          return $this->tickets === [];
+        }
+        /**
+         * @return list<\Drupal\mel_ticket\Entity\TicketTypeInterface>
+         */
+        public function referencedEntities(): array {
+          return $this->tickets;
+        }
+      };
+    });
+    return $event;
+  }
+
+  /**
+   * @param list<\Drupal\paragraphs\ParagraphInterface> $questions
+   */
+  private function ticketTypeWithLegacyQuestions(string $label, array $questions, bool $enabled = TRUE): TicketTypeInterface {
+    $ticket = $this->createMock(TicketTypeInterface::class);
+    $ticket->method('label')->willReturn($label);
+    $ticket->method('isArchived')->willReturn(FALSE);
+    $ticket->method('hasField')->willReturn(TRUE);
+    $ticket->method('get')->willReturnCallback(static function (string $field) use ($enabled, $questions): object {
+      if ($field === 'field_use_ticket_attendee_questions') {
+        return new class($enabled) {
+          public function __construct(public bool $value) {}
+          public function isEmpty(): bool {
+            return FALSE;
+          }
+        };
+      }
+      return new class($questions) {
+        /**
+         * @param list<\Drupal\paragraphs\ParagraphInterface> $questions
+         */
+        public function __construct(private readonly array $questions) {}
+        public function isEmpty(): bool {
+          return $this->questions === [];
+        }
+        /**
+         * @return list<\Drupal\paragraphs\ParagraphInterface>
+         */
+        public function referencedEntities(): array {
+          return $this->questions;
+        }
+      };
+    });
+    return $ticket;
   }
 
   private function translator(): TranslationInterface {


### PR DESCRIPTION
Full staging checkout QA still recommended before merge:
- save Specific ticket types question
- verify VIP/selected tier shows question at checkout
- verify non-selected tier does not
- verify answered question locks ticket-type targeting changes
- verify legacy tier-question banner on an event with mel_ticket-level questions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes question-template validation and immutability rules around ticket-type targeting, which can affect what questions appear at checkout for different ticket types. Risk is mitigated by added unit tests but still warrants end-to-end checkout QA.
> 
> **Overview**
> Checkout questions in Event Studio now use clearer, vendor-facing applicability labels (e.g. **“All ticket holders”** / **“Specific ticket types”**) and add helper copy to guide ticket-type targeting.
> 
> The questions form now detects legacy ticket-type-level question templates and shows a notice listing affected ticket types, and it updates targeting-related descriptions/copy.
> 
> Backend validation is tightened so per-ticket-type questions must select at least one ticket type, and questions with historical answers now also block changes to ticket-type targeting (order-insensitive), with new unit coverage for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52d55b78d2ddd4df8def540d0b0f2e00161559b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->