### PR TITLE
fix(commerce): complete ticket waitlist claim cart flow

### DIFF
--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -187,6 +187,11 @@ services:
     arguments:
       - '@myeventlane_commerce.ticket_tier_waitlist'
       - '@myeventlane_commerce.ticket_booking_session'
+      - '@commerce_cart.cart_provider'
+      - '@commerce_cart.cart_manager'
+      - '@myeventlane_commerce.ticket_availability'
+      - '@myeventlane_commerce.ticket_capacity'
+      - '@logger.channel.myeventlane_commerce'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_commerce/src/Controller/TicketWaitlistClaimController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/TicketWaitlistClaimController.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_commerce\Controller;
 
+use Drupal\commerce_cart\CartManagerInterface;
+use Drupal\commerce_cart\CartProviderInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\mel_ticket\Entity\TicketWaitlistEntry;
+use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
+use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\myeventlane_commerce\Service\TicketBookingSessionService;
+use Drupal\myeventlane_commerce\Service\TicketCapacityService;
 use Drupal\myeventlane_commerce\Service\TicketTierWaitlistService;
 use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -22,6 +32,11 @@ final class TicketWaitlistClaimController extends ControllerBase {
   public function __construct(
     private readonly TicketTierWaitlistService $tierWaitlist,
     private readonly TicketBookingSessionService $bookingSession,
+    private readonly CartProviderInterface $cartProvider,
+    private readonly CartManagerInterface $cartManager,
+    private readonly TicketAvailabilityService $ticketAvailability,
+    private readonly ?TicketCapacityService $ticketCapacity,
+    private readonly LoggerInterface $logger,
   ) {}
 
   /**
@@ -31,11 +46,18 @@ final class TicketWaitlistClaimController extends ControllerBase {
     return new static(
       $container->get('myeventlane_commerce.ticket_tier_waitlist'),
       $container->get('myeventlane_commerce.ticket_booking_session'),
+      $container->get('commerce_cart.cart_provider'),
+      $container->get('commerce_cart.cart_manager'),
+      $container->get('myeventlane_commerce.ticket_availability'),
+      $container->has('myeventlane_commerce.ticket_capacity')
+        ? $container->get('myeventlane_commerce.ticket_capacity')
+        : NULL,
+      $container->get('logger.channel.myeventlane_commerce'),
     );
   }
 
   /**
-   * Claims a waitlist offer and redirects back to the book page.
+   * Claims a waitlist offer, adds reserved tickets to the cart, and redirects.
    */
   public function claim(NodeInterface $node, string $token): RedirectResponse {
     if ($node->bundle() !== 'event') {
@@ -68,9 +90,108 @@ final class TicketWaitlistClaimController extends ControllerBase {
     }
 
     $this->bookingSession->setWaitlistClaimEntryId((int) $node->id(), (int) $entry->id());
-    $this->messenger()->addStatus($this->t('Your waitlist spot is active for this event. You can complete your purchase on this device — the booking page will only unlock the tier linked to this offer.'));
 
+    $cart = $this->populateCartFromOffer($node, $entry);
+    if ($cart instanceof OrderInterface && $this->orderHasLineItems($cart)) {
+      $this->messenger()->addStatus(
+        $this->t('Your reserved tickets were added to your cart. Complete checkout before your offer expires.')
+      );
+      $checkoutUrl = Url::fromRoute('commerce_checkout.form', [
+        'commerce_order' => $cart->id(),
+      ], ['absolute' => TRUE])->toString();
+      return new RedirectResponse($checkoutUrl);
+    }
+
+    $this->messenger()->addStatus(
+      $this->t('Your waitlist spot is active for this event. Choose your reserved tickets on the booking page, then continue to checkout.')
+    );
     return new RedirectResponse($bookUrl);
+  }
+
+  /**
+   * Adds the waitlist offer tier and reserved quantity to the active cart.
+   */
+  private function populateCartFromOffer(NodeInterface $event, TicketWaitlistEntry $entry): ?OrderInterface {
+    $tier = $entry->get('ticket_type')->entity;
+    if (!$tier instanceof TicketTypeInterface) {
+      $this->logger->error('Waitlist claim cart: missing ticket type for entry @id.', ['@id' => (string) $entry->id()]);
+      return NULL;
+    }
+
+    if ($tier->get('commerce_variation')->isEmpty()) {
+      $this->logger->error('Waitlist claim cart: tier @tid has no commerce variation.', ['@tid' => (string) $tier->id()]);
+      return NULL;
+    }
+
+    $variation = $tier->get('commerce_variation')->entity;
+    if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+      $this->logger->error('Waitlist claim cart: variation missing or unpublished for entry @id.', ['@id' => (string) $entry->id()]);
+      return NULL;
+    }
+
+    $product = $variation->getProduct();
+    if (!$product instanceof ProductInterface) {
+      return NULL;
+    }
+
+    $stores = $product->getStores();
+    if ($stores === []) {
+      $this->logger->error('Waitlist claim cart: no store for product @pid.', ['@pid' => (string) $product->id()]);
+      return NULL;
+    }
+    $store = reset($stores);
+
+    $quantity = (int) ($entry->get('offer_reserved')->value ?? 0);
+    if ($quantity < 1) {
+      $quantity = max(1, (int) ($entry->get('quantity')->value ?? 1));
+    }
+    if ($this->ticketCapacity instanceof TicketCapacityService) {
+      $quantity = min(
+        $quantity,
+        $this->ticketCapacity->getBuyerLimitForOffer($event, $tier, (int) $variation->id(), $entry),
+      );
+    }
+    if ($quantity < 1) {
+      $this->messenger()->addWarning($this->t('Your reserved tickets are no longer available. Please return to the event page.'));
+      return NULL;
+    }
+
+    try {
+      $this->ticketAvailability->assertPaidVariationLineConstraints($event, $product, $variation, $quantity);
+    }
+    catch (CapacityExceededException $exception) {
+      $this->messenger()->addWarning($exception->getMessage());
+      return NULL;
+    }
+
+    try {
+      $cart = $this->cartProvider->getCart('default', $store)
+        ?: $this->cartProvider->createCart('default', $store);
+      $orderItem = $this->cartManager->addEntity($cart, $variation, $quantity, TRUE);
+      if ($orderItem && $orderItem->hasField('field_target_event')) {
+        $orderItem->set('field_target_event', ['target_id' => $event->id()]);
+        $orderItem->save();
+      }
+      $cart->save();
+      return $cart;
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Waitlist claim cart failed for entry @id: @message', [
+        '@id' => (string) $entry->id(),
+        '@message' => $exception->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('We could not add your reserved tickets to the cart. Please try again from the booking page.'));
+      return NULL;
+    }
+  }
+
+  private function orderHasLineItems(OrderInterface $order): bool {
+    foreach ($order->getItems() as $orderItem) {
+      if ((float) $orderItem->getQuantity() > 0) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the waitlist-claim flow to automatically create/populate a Commerce cart and redirect to checkout, touching purchasing and capacity enforcement paths. Risk is moderate due to potential edge cases around cart state, quantity limits, and unavailable/unpublished variations.
> 
> **Overview**
> Updates the waitlist-offer claim controller to **automatically add the offered ticket tier/quantity to the active Commerce cart** (creating one if needed), validate availability/capacity limits, and then **redirect to `commerce_checkout.form`** instead of always sending users back to the booking page.
> 
> Adds new DI dependencies (`CartProvider`, `CartManager`, `TicketAvailabilityService`, optional `TicketCapacityService`, logger), introduces defensive logging/messaging for missing/unpublished variations or store resolution failures, and sets `field_target_event` on the created order item when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c885ee79be33dfe0061a41c87bd3fcd3a2e43959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->