### PR TITLE
fix(commerce): harden waitlist claim cart population

### DIFF
--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -190,6 +190,7 @@ services:
       - '@commerce_cart.cart_provider'
       - '@commerce_cart.cart_manager'
       - '@myeventlane_commerce.ticket_availability'
+      - '@myeventlane_capacity.order_inspector'
       - '@myeventlane_commerce.ticket_capacity'
       - '@logger.channel.myeventlane_commerce'
     tags:

--- a/web/modules/custom/myeventlane_commerce/src/Controller/TicketWaitlistClaimController.php
+++ b/web/modules/custom/myeventlane_commerce/src/Controller/TicketWaitlistClaimController.php
@@ -14,6 +14,7 @@ use Drupal\Core\Url;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\mel_ticket\Entity\TicketWaitlistEntry;
 use Drupal\myeventlane_capacity\Exception\CapacityExceededException;
+use Drupal\myeventlane_capacity\Service\CapacityOrderInspector;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
 use Drupal\myeventlane_commerce\Service\TicketBookingSessionService;
 use Drupal\myeventlane_commerce\Service\TicketCapacityService;
@@ -35,6 +36,7 @@ final class TicketWaitlistClaimController extends ControllerBase {
     private readonly CartProviderInterface $cartProvider,
     private readonly CartManagerInterface $cartManager,
     private readonly TicketAvailabilityService $ticketAvailability,
+    private readonly CapacityOrderInspector $orderInspector,
     private readonly ?TicketCapacityService $ticketCapacity,
     private readonly LoggerInterface $logger,
   ) {}
@@ -49,6 +51,7 @@ final class TicketWaitlistClaimController extends ControllerBase {
       $container->get('commerce_cart.cart_provider'),
       $container->get('commerce_cart.cart_manager'),
       $container->get('myeventlane_commerce.ticket_availability'),
+      $container->get('myeventlane_capacity.order_inspector'),
       $container->has('myeventlane_commerce.ticket_capacity')
         ? $container->get('myeventlane_commerce.ticket_capacity')
         : NULL,
@@ -91,15 +94,21 @@ final class TicketWaitlistClaimController extends ControllerBase {
 
     $this->bookingSession->setWaitlistClaimEntryId((int) $node->id(), (int) $entry->id());
 
-    $cart = $this->populateCartFromOffer($node, $entry);
-    if ($cart instanceof OrderInterface && $this->orderHasLineItems($cart)) {
+    $result = $this->populateCartFromOffer($node, $entry);
+    if ($result !== NULL && $result['tickets_ready']) {
       $this->messenger()->addStatus(
-        $this->t('Your reserved tickets were added to your cart. Complete checkout before your offer expires.')
+        $result['added']
+          ? $this->t('Your reserved tickets were added to your cart. Complete checkout before your offer expires.')
+          : $this->t('Your reserved tickets are already in your cart. Complete checkout before your offer expires.')
       );
       $checkoutUrl = Url::fromRoute('commerce_checkout.form', [
-        'commerce_order' => $cart->id(),
+        'commerce_order' => $result['cart']->id(),
       ], ['absolute' => TRUE])->toString();
       return new RedirectResponse($checkoutUrl);
+    }
+
+    if ($result === NULL) {
+      return new RedirectResponse($bookUrl);
     }
 
     $this->messenger()->addStatus(
@@ -110,8 +119,11 @@ final class TicketWaitlistClaimController extends ControllerBase {
 
   /**
    * Adds the waitlist offer tier and reserved quantity to the active cart.
+   *
+   * @return array{cart: \Drupal\commerce_order\Entity\OrderInterface, tickets_ready: bool, added: bool}|null
+   *   Cart state when reserved tickets are in the cart; NULL on failure.
    */
-  private function populateCartFromOffer(NodeInterface $event, TicketWaitlistEntry $entry): ?OrderInterface {
+  private function populateCartFromOffer(NodeInterface $event, TicketWaitlistEntry $entry): ?array {
     $tier = $entry->get('ticket_type')->entity;
     if (!$tier instanceof TicketTypeInterface) {
       $this->logger->error('Waitlist claim cart: missing ticket type for entry @id.', ['@id' => (string) $entry->id()]);
@@ -141,39 +153,96 @@ final class TicketWaitlistClaimController extends ControllerBase {
     }
     $store = reset($stores);
 
-    $quantity = (int) ($entry->get('offer_reserved')->value ?? 0);
-    if ($quantity < 1) {
-      $quantity = max(1, (int) ($entry->get('quantity')->value ?? 1));
+    $offerQuantity = (int) ($entry->get('offer_reserved')->value ?? 0);
+    if ($offerQuantity < 1) {
+      $offerQuantity = max(1, (int) ($entry->get('quantity')->value ?? 1));
     }
     if ($this->ticketCapacity instanceof TicketCapacityService) {
-      $quantity = min(
-        $quantity,
+      $offerQuantity = min(
+        $offerQuantity,
         $this->ticketCapacity->getBuyerLimitForOffer($event, $tier, (int) $variation->id(), $entry),
       );
     }
-    if ($quantity < 1) {
+    if ($offerQuantity < 1) {
       $this->messenger()->addWarning($this->t('Your reserved tickets are no longer available. Please return to the event page.'));
-      return NULL;
-    }
-
-    try {
-      $this->ticketAvailability->assertPaidVariationLineConstraints($event, $product, $variation, $quantity);
-    }
-    catch (CapacityExceededException $exception) {
-      $this->messenger()->addWarning($exception->getMessage());
       return NULL;
     }
 
     try {
       $cart = $this->cartProvider->getCart('default', $store)
         ?: $this->cartProvider->createCart('default', $store);
-      $orderItem = $this->cartManager->addEntity($cart, $variation, $quantity, TRUE);
-      if ($orderItem && $orderItem->hasField('field_target_event')) {
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Waitlist claim cart: could not load cart for entry @id: @message', [
+        '@id' => (string) $entry->id(),
+        '@message' => $exception->getMessage(),
+      ]);
+      $this->messenger()->addError($this->t('We could not add your reserved tickets to the cart. Please try again from the booking page.'));
+      return NULL;
+    }
+
+    $pending = $this->getPendingCartTicketTotals($event, $cart);
+    $variationId = (int) $variation->id();
+    $existingLine = (int) ($pending['variation'][$variationId] ?? 0);
+    $quantityToAdd = max(0, $offerQuantity - $existingLine);
+    $combinedLine = $existingLine + $quantityToAdd;
+
+    try {
+      $this->ticketAvailability->assertPaidVariationLineConstraints($event, $product, $variation, $combinedLine);
+      $this->ticketAvailability->assertEventTotalBookable(
+        $event,
+        $pending['event_total'] + $quantityToAdd,
+      );
+    }
+    catch (CapacityExceededException $exception) {
+      $this->messenger()->addWarning($exception->getMessage());
+      return NULL;
+    }
+
+    if ($quantityToAdd < 1) {
+      if ($existingLine >= $offerQuantity && $existingLine > 0) {
+        return [
+          'cart' => $cart,
+          'tickets_ready' => TRUE,
+          'added' => FALSE,
+        ];
+      }
+      $this->messenger()->addWarning($this->t('Your reserved tickets are no longer available. Please return to the event page.'));
+      return NULL;
+    }
+
+    try {
+      $orderItem = $this->cartManager->addEntity($cart, $variation, $quantityToAdd, TRUE);
+      if ($orderItem === NULL) {
+        $this->logger->error('Waitlist claim cart: addEntity returned no order item for entry @id.', [
+          '@id' => (string) $entry->id(),
+        ]);
+        $this->messenger()->addError($this->t('We could not add your reserved tickets to the cart. Please try again from the booking page.'));
+        return NULL;
+      }
+      if ($orderItem->hasField('field_target_event')) {
         $orderItem->set('field_target_event', ['target_id' => $event->id()]);
         $orderItem->save();
       }
       $cart->save();
-      return $cart;
+
+      $after = $this->getPendingCartTicketTotals($event, $cart);
+      $lineAfter = (int) ($after['variation'][$variationId] ?? 0);
+      if ($lineAfter < $offerQuantity) {
+        $this->logger->error('Waitlist claim cart: cart line quantity @qty below offer @offer for entry @id.', [
+          '@qty' => (string) $lineAfter,
+          '@offer' => (string) $offerQuantity,
+          '@id' => (string) $entry->id(),
+        ]);
+        $this->messenger()->addError($this->t('We could not add your reserved tickets to the cart. Please try again from the booking page.'));
+        return NULL;
+      }
+
+      return [
+        'cart' => $cart,
+        'tickets_ready' => TRUE,
+        'added' => TRUE,
+      ];
     }
     catch (\Throwable $exception) {
       $this->logger->error('Waitlist claim cart failed for entry @id: @message', [
@@ -185,13 +254,19 @@ final class TicketWaitlistClaimController extends ControllerBase {
     }
   }
 
-  private function orderHasLineItems(OrderInterface $order): bool {
-    foreach ($order->getItems() as $orderItem) {
-      if ((float) $orderItem->getQuantity() > 0) {
-        return TRUE;
-      }
-    }
-    return FALSE;
+  /**
+   * Ticket quantities already in the cart for this event.
+   *
+   * @return array{event_total: int, variation: array<int, int>}
+   */
+  private function getPendingCartTicketTotals(NodeInterface $event, OrderInterface $cart): array {
+    $eid = (int) $event->id();
+    $by_variation = $this->orderInspector->extractEventVariationQuantities($cart);
+    $event_totals = $this->orderInspector->extractEventQuantities($cart);
+    return [
+      'event_total' => (int) ($event_totals[$eid] ?? 0),
+      'variation' => $by_variation[$eid] ?? [],
+    ];
   }
 
 }


### PR DESCRIPTION
Account for tickets already in the cart when validating and adding waitlist offers, require a successful add (or existing offer line) before checkout redirect, and stop showing a success message when cart population fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ticket waitlist claim flow and cart mutation/validation logic, which can affect purchase paths and capacity enforcement. Risk is mitigated by additional error handling but should be exercised across edge cases (existing cart lines, partial adds, capacity limits).
> 
> **Overview**
> **Waitlist claim now verifies reserved tickets are actually in the cart before sending users to checkout.** `TicketWaitlistClaimController` changes `populateCartFromOffer()` to consider existing cart quantities for the same event/variation, only add the *delta* needed, and validate both per-variation constraints and overall event bookable totals using `CapacityOrderInspector`.
> 
> The controller now distinguishes between *tickets added*, *tickets already present*, and *failure* (no longer showing a success message or redirecting to checkout when cart population fails), adds extra safeguards/logging when `addEntity()` returns `NULL` or the post-add cart quantity is still below the offer, and wires in the new `myeventlane_capacity.order_inspector` dependency via services.yml.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3432b99378feeaeda5b85ee2dc383e1b34533123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->