### PR TITLE
ux(event-studio): add checkout question readiness warnings

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -344,6 +344,7 @@ services:
       - '@myeventlane_event.ticket_type_manager'
       - '@myeventlane_vendor.publish_requirements_gate'
       - '@myeventlane_vendor.paid_publish_stripe_gate'
+      - '@myeventlane_event_studio.question_template_manager'
       - '@string_translation'
 
   myeventlane_event_studio.autosave:

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -26,6 +26,7 @@ final class EventReadinessService {
     private readonly TicketTypeManager $ticketTypeManager,
     private readonly VendorPublishRequirementsGate $publishRequirementsGate,
     private readonly PaidPublishStripeGate $paidPublishStripeGate,
+    private readonly EventStudioQuestionTemplateManager $questionTemplateManager,
     TranslationInterface $stringTranslation,
   ) {
     $this->stringTranslation = $stringTranslation;
@@ -103,6 +104,7 @@ final class EventReadinessService {
     }
 
     $this->addOptionalRecommendations($event, $recommendations);
+    $this->mergeQuestionReadinessFindings($event, $errors, $warnings);
 
     $errors = array_values(array_unique($errors));
     $warnings = array_values(array_unique($warnings));
@@ -197,6 +199,24 @@ final class EventReadinessService {
       return '';
     }
     return (string) $event->get('field_event_type')->value;
+  }
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   */
+  private function mergeQuestionReadinessFindings(NodeInterface $event, array &$errors, array &$warnings): void {
+    foreach ($this->questionTemplateManager->buildQuestionReadinessFindings($event) as $finding) {
+      $message = trim((string) ($finding['message'] ?? ''));
+      if ($message === '') {
+        continue;
+      }
+      if (($finding['severity'] ?? '') === 'blocker') {
+        $errors[] = $message;
+        continue;
+      }
+      $warnings[] = $message;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioQuestionTemplateManager.php
@@ -75,6 +75,79 @@ final class EventStudioQuestionTemplateManager {
    *   questions_per_ticket_type: array<string, int>
    * }
    */
+  /**
+   * Publish-readiness findings for Event Studio checkout questions.
+   *
+   * @return list<array{severity: string, code: string, message: string}>
+   */
+  public function buildQuestionReadinessFindings(NodeInterface $event): array {
+    $findings = [];
+    $paid_event = $this->eventHasPaidBooking($event);
+
+    $has_missing_ticket_types = FALSE;
+    $has_per_order = FALSE;
+    $has_locked_questions = FALSE;
+
+    if ($event->hasField('field_attendee_questions') && !$event->get('field_attendee_questions')->isEmpty()) {
+      foreach ($event->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+        if (!$paragraph instanceof ParagraphInterface || $paragraph->bundle() !== 'attendee_extra_field') {
+          continue;
+        }
+        if ($this->paragraphStatus($paragraph) === self::STATUS_ARCHIVED) {
+          continue;
+        }
+
+        $applicability = $this->paragraphApplicability($paragraph);
+        if ($paid_event
+          && $applicability === self::APPLIES_PER_TICKET_TYPE
+          && $this->paragraphTicketTypeIds($paragraph) === []) {
+          $has_missing_ticket_types = TRUE;
+        }
+        if ($applicability === self::APPLIES_PER_ORDER) {
+          $has_per_order = TRUE;
+        }
+        if ($this->questionHasHistoricalAnswers($event, $paragraph)) {
+          $has_locked_questions = TRUE;
+        }
+      }
+    }
+
+    if ($has_missing_ticket_types) {
+      $findings[] = [
+        'severity' => 'blocker',
+        'code' => 'ticket_question_missing_ticket_types',
+        'message' => (string) $this->t('A ticket-specific checkout question has no ticket types selected.'),
+      ];
+    }
+
+    if ($has_per_order) {
+      $findings[] = [
+        'severity' => 'warning',
+        'code' => 'checkout_question_per_order_inactive',
+        'message' => (string) $this->t('Per-order checkout questions are not active in checkout yet.'),
+      ];
+    }
+
+    if ($has_locked_questions) {
+      $findings[] = [
+        'severity' => 'warning',
+        'code' => 'checkout_question_historical_answers',
+        'message' => (string) $this->t('Some checkout questions already have attendee answers. Archive them instead of changing type, options, or ticket targeting.'),
+      ];
+    }
+
+    $legacy = $this->findLegacyTierQuestionSummary($event);
+    if (($legacy['total_count'] ?? 0) > 0) {
+      $findings[] = [
+        'severity' => 'warning',
+        'code' => 'legacy_ticket_type_questions',
+        'message' => (string) $this->t('This event has ticket-level questions stored on ticket types. They still work at checkout, but new questions should be managed from Checkout questions.'),
+      ];
+    }
+
+    return $findings;
+  }
+
   public function findLegacyTierQuestionSummary(NodeInterface $event): array {
     $total_count = 0;
     $ticket_type_names = [];
@@ -488,6 +561,13 @@ final class EventStudioQuestionTemplateManager {
   /**
    * @return list<\Drupal\mel_ticket\Entity\TicketTypeInterface>
    */
+  private function eventHasPaidBooking(NodeInterface $event): bool {
+    if (!$event->hasField('field_event_type') || $event->get('field_event_type')->isEmpty()) {
+      return FALSE;
+    }
+    return in_array((string) $event->get('field_event_type')->value, ['paid', 'both'], TRUE);
+  }
+
   private function loadEventTickets(NodeInterface $event): array {
     if (!$event->hasField('field_ticket_types') || $event->get('field_ticket_types')->isEmpty()) {
       return [];

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioQuestionTemplateManagerTest.php
@@ -242,6 +242,99 @@ final class EventStudioQuestionTemplateManagerTest extends TestCase {
   }
 
   /**
+   * @covers ::buildQuestionReadinessFindings
+   */
+  public function testBuildQuestionReadinessFindingsFlagsMissingTicketTypesOnPaidEvents(): void {
+    $manager = $this->manager();
+    $event = $this->eventWithCheckoutQuestions([
+      $this->checkoutQuestionParagraph([
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'field_question_ticket_types' => [],
+      ], TRUE),
+    ], 'paid');
+
+    $findings = $manager->buildQuestionReadinessFindings($event);
+
+    $this->assertCount(1, $findings);
+    $this->assertSame('blocker', $findings[0]['severity']);
+    $this->assertSame('ticket_question_missing_ticket_types', $findings[0]['code']);
+    $this->assertSame('A ticket-specific checkout question has no ticket types selected.', $findings[0]['message']);
+  }
+
+  /**
+   * @covers ::buildQuestionReadinessFindings
+   */
+  public function testBuildQuestionReadinessFindingsSkipsMissingTicketTypesOnRsvpEvents(): void {
+    $manager = $this->manager();
+    $event = $this->eventWithCheckoutQuestions([
+      $this->checkoutQuestionParagraph([
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET_TYPE,
+        'field_question_ticket_types' => [],
+      ], TRUE),
+    ], 'rsvp');
+
+    $this->assertSame([], $manager->buildQuestionReadinessFindings($event));
+  }
+
+  /**
+   * @covers ::buildQuestionReadinessFindings
+   */
+  public function testBuildQuestionReadinessFindingsWarnsForPerOrderQuestions(): void {
+    $manager = $this->manager();
+    $event = $this->eventWithCheckoutQuestions([
+      $this->checkoutQuestionParagraph([
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_ORDER,
+      ]),
+    ]);
+
+    $findings = $manager->buildQuestionReadinessFindings($event);
+
+    $this->assertCount(1, $findings);
+    $this->assertSame('warning', $findings[0]['severity']);
+    $this->assertSame('checkout_question_per_order_inactive', $findings[0]['code']);
+    $this->assertSame('Per-order checkout questions are not active in checkout yet.', $findings[0]['message']);
+  }
+
+  /**
+   * @covers ::buildQuestionReadinessFindings
+   */
+  public function testBuildQuestionReadinessFindingsWarnsForHistoricalAnswers(): void {
+    $repository = $this->createMock(EventStudioQuestionAnswerExistenceRepository::class);
+    $repository->method('questionHasHistoricalAnswers')->willReturn(TRUE);
+    $manager = $this->manager($repository);
+    $event = $this->eventWithCheckoutQuestions([
+      $this->checkoutQuestionParagraph([
+        'field_question_applicability' => EventStudioQuestionTemplateManager::APPLIES_PER_TICKET,
+      ]),
+    ]);
+
+    $findings = $manager->buildQuestionReadinessFindings($event);
+
+    $this->assertCount(1, $findings);
+    $this->assertSame('warning', $findings[0]['severity']);
+    $this->assertSame('checkout_question_historical_answers', $findings[0]['code']);
+    $this->assertSame('Some checkout questions already have attendee answers. Archive them instead of changing type, options, or ticket targeting.', $findings[0]['message']);
+  }
+
+  /**
+   * @covers ::buildQuestionReadinessFindings
+   */
+  public function testBuildQuestionReadinessFindingsWarnsForLegacyTierQuestions(): void {
+    $manager = $this->manager();
+    $event = $this->eventWithLegacyTierQuestions();
+
+    $findings = $manager->buildQuestionReadinessFindings($event);
+
+    $legacy = array_values(array_filter(
+      $findings,
+      static fn (array $finding): bool => ($finding['code'] ?? '') === 'legacy_ticket_type_questions',
+    ));
+    $this->assertCount(1, $legacy);
+    $this->assertSame('warning', $legacy[0]['severity']);
+    $this->assertSame('This event has ticket-level questions stored on ticket types. They still work at checkout, but new questions should be managed from Checkout questions.', $legacy[0]['message']);
+  }
+
+  /**
    * @covers ::findLegacyTierQuestionSummary
    */
   public function testFindLegacyTierQuestionSummaryReturnsCountAndTicketNames(): void {
@@ -298,6 +391,51 @@ final class EventStudioQuestionTemplateManagerTest extends TestCase {
         }
       };
     });
+    return $paragraph;
+  }
+
+  /**
+   * @param list<\Drupal\paragraphs\ParagraphInterface> $questions
+   */
+  private function eventWithCheckoutQuestions(array $questions, string $eventType = 'paid'): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('hasField')->willReturnCallback(static fn (string $field): bool => in_array($field, ['field_attendee_questions', 'field_event_type'], TRUE));
+    $event->method('get')->willReturnCallback(static function (string $field) use ($questions, $eventType): object {
+      if ($field === 'field_event_type') {
+        return new class($eventType) {
+          public function __construct(public string $value) {}
+          public function isEmpty(): bool {
+            return FALSE;
+          }
+        };
+      }
+      return new class($questions) {
+        /**
+         * @param list<\Drupal\paragraphs\ParagraphInterface> $questions
+         */
+        public function __construct(private readonly array $questions) {}
+        public function isEmpty(): bool {
+          return $this->questions === [];
+        }
+        /**
+         * @return list<\Drupal\paragraphs\ParagraphInterface>
+         */
+        public function referencedEntities(): array {
+          return $this->questions;
+        }
+      };
+    });
+    return $event;
+  }
+
+  /**
+   * @param array<string, mixed> $values
+   */
+  private function checkoutQuestionParagraph(array $values, bool $ticketTypesUseGetValue = FALSE): ParagraphInterface {
+    $paragraph = $this->paragraph(array_merge([
+      'field_question_status' => EventStudioQuestionTemplateManager::STATUS_ACTIVE,
+    ], $values), $ticketTypesUseGetValue);
+    $paragraph->method('bundle')->willReturn('attendee_extra_field');
     return $paragraph;
   }
 


### PR DESCRIPTION
Adds Event Studio readiness warnings for checkout questions:
- blocks paid/both events when ticket-specific questions have no ticket types selected
- warns for per-order questions because they are not active in checkout yet
- warns when historical answers exist and archive-only workflow should be used
- warns when legacy mel_ticket-level questions exist

No checkout, answer storage, access, cart, or ticket purchase logic changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Event Studio publish-readiness evaluation to surface new checkout-question blockers/warnings, which could prevent publishing for some paid events if questions are misconfigured. Logic is localized but touches the publish gating UX path.
> 
> **Overview**
> Event Studio publish-readiness now incorporates *checkout question* findings: it **blocks** paid/both events when an active per-ticket-type question has no ticket types selected, and adds **warnings** for per-order questions (not active yet), questions with historical answers (encourage archive-only changes), and events still using legacy ticket-type question storage.
> 
> This wires `EventStudioQuestionTemplateManager` into `EventReadinessService`, adds `buildQuestionReadinessFindings()` (plus paid/both detection), and expands unit tests to cover the new readiness scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e09b3feccb82ca18005c6e18d7e08814b097891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->