### PR TITLE
Feature/help verify organiser ticket capacity

### DIFF
--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -11,8 +11,8 @@
 | add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
 | missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
-| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Auto-offer config; RSVP vs paid waitlist UI | No auto-promotion promise |
-| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | No | — | Refund impact on sold counts; combined venue caps | Capacity rules may vary by setup |
+| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Paid tier organiser list/export missing; tier waitlist toggles not in Event Studio UI; RSVP route only for RSVP waitlist | See organiser-ticket-capacity-waitlist-verification.md |
+| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 (proposed) | Refund→sold count; lower capacity below sold | QA 2026-05-22: completed-order sold; analytics remaining may omit waitlist holds |
 | attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | No | No | — | Field types; archive behaviour; export columns | Privacy-first collection guidance |
 | check-in-attendees.md | vendor | /help/vendors/check-in-attendees | No | No | — | QR issuance coverage; RSVP check-in source | Does not claim every ticket has QR/PDF |
 | saved-question-templates.md | vendor | /help/vendors/saved-question-templates | No | No | — | Library permissions; edit vs clone semantics | Route `/vendor/questions` |

--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -11,8 +11,8 @@
 | add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
 | missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
-| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Paid tier organiser list/export missing; tier waitlist toggles not in Event Studio UI; RSVP route only for RSVP waitlist | See organiser-ticket-capacity-waitlist-verification.md |
-| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 (proposed) | Refund→sold count; lower capacity below sold | QA 2026-05-22: completed-order sold; analytics remaining may omit waitlist holds |
+| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Blocked until paid waitlist organiser UI/reporting and auto-offer claim flow are verified | See organiser-ticket-capacity-waitlist-verification.md |
+| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Exported in help-articles-batch-04-2026-05.yml; importer not run |
 | attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | No | No | — | Field types; archive behaviour; export columns | Privacy-first collection guidance |
 | check-in-attendees.md | vendor | /help/vendors/check-in-attendees | No | No | — | QR issuance coverage; RSVP check-in source | Does not claim every ticket has QR/PDF |
 | saved-question-templates.md | vendor | /help/vendors/saved-question-templates | No | No | — | Library permissions; edit vs clone semantics | Route `/vendor/questions` |

--- a/docs/content-audit/help-article-drafts/next-batch/organiser-manage-waitlists.md
+++ b/docs/content-audit/help-article-drafts/next-batch/organiser-manage-waitlists.md
@@ -6,38 +6,53 @@ product_area: capacity
 help_status: draft
 ai_allowed: true
 recommended_alias: /help/vendors/organiser-manage-waitlists
-source_evidence: /vendor/event/{node}/waitlist; waitlist export route; mel_ticket_type.waitlist_enabled; TicketTierWaitlist services; published "Joining a waitlist"
-needs_verification: Auto-offer configuration per ticket tier on staging; RSVP waitlist vs paid tier waitlist UI labels; manual promote/offer actions in waitlist UI
+source_evidence: myeventlane_event_attendees.waitlist_manage (RSVP); mel_ticket_type.waitlist_enabled; TicketTierWaitlistService; TicketSelectionForm; published "Joining a waitlist"
+needs_verification: Organiser UI to enable paid tier waitlist (not in Event Studio tier card payload); organiser view/export for mel_ticket_waitlist_entry; auto-offer email on staging; manual promote for paid tier waitlist
 ---
 
 # Managing waitlists for your event
 
-When a ticket type sells out, a waitlist lets buyers register interest. This page explains how organisers review waitlists and what buyers may experience next.
+When demand exceeds capacity, waitlists let you capture interest. **Paid ticket waitlists** and **free RSVP waitlists** work differently in MyEventLane — this page explains what organisers can verify today.
 
 ## What this means
 
-A waitlist entry is not a ticket. It records contact details and how many places the buyer wants if stock becomes available. Paid ticket waitlists on the book page are separate from free RSVP waitlists — **Needs verification** for how each appears in your dashboard.
+**Paid ticket waitlist (buyers on the book page)**  
+A waitlist entry is **not** a ticket. For a **sold-out paid ticket type** where waitlist is enabled, buyers submit an email and how many places they want on the event **book** page. Entries are stored separately from RSVP guest lists.
+
+**RSVP waitlist (free events)**  
+For RSVP-style events, waitlisted guests are tracked as attendees in **waitlist** status. You review them on the event **Waitlist** page in your organiser dashboard (for example `/vendor/event/{event}/waitlist`), not via the paid ticket waitlist entity.
+
+Do not use the RSVP waitlist page to manage **paid** ticket waitlist sign-ups — that route lists RSVP attendees only (**verified in code**).
 
 ## What to do next
 
+### RSVP waitlist (verified organiser paths)
+
 1. Sign in to your organiser dashboard.
-2. Open the event and go to its waitlist area (for example `/vendor/event/{event}/waitlist`).
-3. Review entries: email, quantity requested, and position if shown.
-4. Export the list if you need a spreadsheet for your team — an export option may be available from the waitlist page.
-5. When places open, you may release capacity by adjusting ticket availability or handling refunds and cancellations according to your event rules.
-6. If automatic offers are enabled for a sold-out ticket type, MyEventLane may send time-limited purchase offers when capacity allows — buyers must still complete checkout to receive tickets.
-7. Communicate clearly on your event page if you plan to contact waitlisted buyers manually.
+2. Open the event and go to **Waitlist** (`/vendor/event/{event}/waitlist`).
+3. Review entries: name, email, position, and status where shown.
+4. Use **Export** on that page if you need a spreadsheet for your team.
+5. When places open, adjust RSVP capacity or promote guests according to your event settings and RSVP module behaviour.
+
+### Paid ticket waitlist (configuration and limits)
+
+1. Ensure each paid ticket type has a **capacity** and is configured for waitlist when sold out (**Waitlist when sold out** on the ticket type in the data model).
+2. Optionally enable **Auto-offer waitlist when tickets free up** on that ticket type so MyEventLane **may** email time-limited purchase offers when capacity returns — only where that option is enabled and working for your event.
+3. Tell buyers to use the public **book** page to join when a type is sold out — see the attendee article *Joining a waitlist* (do not repeat those steps here).
+4. When places open, capacity may return from cancellations, refunds, or capacity changes — **refunds restoring paid capacity are not verified** in this pass; confirm on your dashboard before relying on extra places.
+5. There is **no verified organiser list or export** for paid ticket waitlist entries (`mel_ticket_waitlist_entry`) in the vendor console at the time of this audit — plan manual communication or support if you need a spreadsheet of paid waitlist emails.
 
 ## Good to know
 
-- Waitlists must be enabled on the ticket type and the type must be sold out before buyers can join on the book page.
-- Automatic promotion or email offers may run only where that option is enabled and verified for your event. Do not promise every waitlisted buyer will receive an offer.
-- Active waitlist offers can temporarily hold capacity until they expire or are used — check your ticket sales view when reconciling numbers.
-- Treat waitlist emails as personal data. Use them only for this event and keep exports secure.
+- Paid ticket waitlist join is only offered when the type is **sold out**, waitlist is **enabled** on that type, and the type has a finite capacity.
+- **Automatic offers** run only where **Auto-offer waitlist when tickets free up** is enabled on the ticket type. Offers are time-limited; buyers must still **complete checkout** to receive tickets. Do not promise every waitlisted buyer will receive an offer.
+- Active offers can **hold** capacity until they expire or are used — check ticket sales and the book page when reconciling numbers.
+- Event Studio tier cards currently save title, price, and capacity — **waitlist toggles for paid tiers were not found in the Event Studio organiser UI** during this audit. Enabling paid waitlist may require another workflow or support until self-service controls ship (**Needs verification**).
+- Treat waitlist emails and exports as **personal data**. Use them only for the relevant event and keep files secure.
 
 ## Related help
 
-- Joining a waitlist
+- Joining a waitlist (attendees — public book page and offers)
 - Ticket sales and capacity
 - Having trouble checking out
 - Managing your event dashboard

--- a/docs/content-audit/help-article-drafts/next-batch/organiser-ticket-capacity-waitlist-verification.md
+++ b/docs/content-audit/help-article-drafts/next-batch/organiser-ticket-capacity-waitlist-verification.md
@@ -1,0 +1,171 @@
+# Organiser ticket sales, capacity, and waitlist — QA verification log
+
+**Date:** 2026-05-22  
+**Branch:** `feature/help-verify-organiser-ticket-capacity`  
+**Scope:** `ticket-sales-and-capacity.md`, `organiser-manage-waitlists.md`  
+**Environment:** DDEV local (`https://myeventlane.ddev.site`) — code audit + targeted Drush/PHP checks; no browser E2E, no node import, no publish.
+
+## Test data (local)
+
+| Item | Value |
+|------|--------|
+| Paid test event | **1666** — [MEL TEST] Event 8 - Paid |
+| Tier (General admission) | **245** — capacity 50, `waitlist_enabled=0` |
+| Commerce variation | **4292** |
+| Sold (completed orders) | **0** (no order items for this variation) |
+| `TicketCapacityService::getRemaining` | **50** |
+| Legacy waitlist sample | Entry **1** on event **1584**, tier **95** — `status=offered`, `offer_reserved=1`; tier sold **2**, held **1**, remaining pool **47**, evaluator status **active** (not sold out) |
+| Tier waitlist table | `mel_ticket_waitlist_entry` — 1 row (`offered`) |
+
+**Routes referenced (code):**
+
+- Organiser dashboard / event list: `myeventlane_vendor.console.dashboard`, Studio navigator cards
+- Event overview KPIs: `myeventlane_vendor.console.event_overview` — labels **Gross sales**, **Tickets sold**, **Across all ticket types**
+- Event analytics (Pro): `myeventlane_vendor.console.event_analytics` — **Ticket tiers snapshot**: Tickets sold (tiers), Remaining, Active / sold out
+- Ticket workspace: `myeventlane_vendor.console.event_tickets` (`EventTicketManagerForm`)
+- Event Studio tickets: Studio tier cards (capacity per tier; no waitlist fields in JS payload)
+- Public book: `myeventlane_commerce.event_book` — `TicketSelectionForm`
+- Paid waitlist claim: `myeventlane_commerce.event_ticket_waitlist_claim` — `/event/{node}/book/waitlist/{token}`
+- **RSVP waitlist (organiser UI):** `myeventlane_event_attendees.waitlist_manage` — `/vendor/event/{node}/waitlist`
+- RSVP waitlist export: `myeventlane_event_attendees.waitlist_export`
+
+## Ticket sales and capacity findings
+
+### Per-tier capacity (verified in code)
+
+- Capacity lives on **`mel_ticket_type.capacity`** (ticket type / tier).
+- **Sold count:** `TicketVariationSoldService` — sums **Commerce order item quantities** where order state is **`completed`**, scoped by `field_target_event` + `purchased_entity` (variation).
+- **Sold-out (tier):** `TicketStatusEvaluator` — paid tier with finite capacity and `sold >= capacity` → `sold_out`.
+- **Public remaining pool (booking):** `TicketCapacityService::getRemaining` = `capacity - sold - held`, where **held** = sum of `offer_reserved` on active tier waitlist offers (`STATUS_OFFERED`, not expired).
+- **Organiser analytics remaining:** `TicketTierAnalyticsService::buildTierMetrics` — `remaining = capacity - sold` only (**does not subtract waitlist holds**). Event rollup sums tier remainings; mixed unlimited/finite tiers → display strings like **Tickets available**, **No limit**, or a numeric sum.
+
+### Event-level / venue capacity (separate, partial)
+
+- `myeventlane_capacity` `EventCapacityService` uses **`field_event_capacity_total`** or **`field_event_capacity`** on the **event** node.
+- Counts RSVPs + paid tickets together for event-level sold; enforced at checkout via `TicketAvailabilityService` + `TicketCapacityOrderSubscriber` (per-event lock).
+- **Not verified:** combined venue cap across all ticket types in organiser copy — tier caps and event caps are **separate mechanisms**; do not promise a single combined venue number unless both are set and tested for the event.
+
+### Per-order limit (may apply)
+
+- Commerce variation **`field_limit_per_order`** exposed in **Ticket workspace** (`EventTicketManagerForm`) and Event Studio tier “more” fields — optional per ticket type.
+
+### Dashboard counts (verified in code)
+
+| Surface | Label(s) | Source |
+|---------|----------|--------|
+| Studio / dashboard event cards | **Tickets**, **RSVPs**, **Revenue** | `TicketSalesService::getSalesSummary` (`tickets_sold`), `RsvpStatsService` |
+| Event overview | **Tickets sold** / **RSVPs**, **Gross sales** | `MetricsAggregator` → `TicketSalesService` (completed orders only) |
+| Pro analytics | **Tickets sold (tiers)**, **Remaining**, **Active / sold out** | `TicketTierAnalyticsService::buildEventTierRollup` |
+| Vendor dashboard KPIs | **Tickets Sold** | Completed-order ticket quantities (same family as above) |
+
+**Note:** Dashboard **tickets sold** aligns with **completed-order** logic, not waitlist holds. **Remaining** on analytics may be **higher** than buyer-facing availability when active waitlist offers hold seats.
+
+### Refund / cancel impact on sold count
+
+| Question | Result |
+|----------|--------|
+| Do refunds reduce **tickets sold** on dashboard? | **Unknown / likely no** unless order leaves `completed` state. `TicketVariationSoldService` only counts `completed`. `TicketSalesService` tracks refund **amounts** separately via `myeventlane_refund_log`; docblock says refunds excluded from revenue tallies but sold count still driven by completed line items. |
+| Does refund free tier capacity automatically? | **Not verified** in this pass. Auto-offer cron runs when tier returns to **active** (not sold out); refund→capacity path not exercised locally. |
+
+### Manual capacity changes
+
+- Event Studio and ticket workspace save **tier capacity** via `TicketTierLifecycleService`.
+- **Lowering capacity below sold:** no explicit validation found in lifecycle service — treat as **Needs verification** / may require support.
+
+## Sold-out behaviour
+
+- **Book page:** sold-out paid tier with `waitlist_enabled` → **Sold out — join a waitlist** block (`TicketSelectionForm`) with email + quantity + **Join waitlist**.
+- **Without waitlist:** tier hidden from purchasable list when sold out (waitlist section only lists eligible tiers).
+- **Buyer availability copy:** uses `capacity - sold - held` (“Only N left”, etc.) via `CustomerTicketTierDisplayBuilder`.
+
+## Waitlist settings findings
+
+### Paid ticket tier waitlist (Commerce / `mel_ticket_type`)
+
+| Setting | Entity field | Label (entity definition) |
+|---------|--------------|---------------------------|
+| Enable | `waitlist_enabled` | **Waitlist when sold out** |
+| Waitlist cap | `waitlist_capacity` | **Waitlist capacity** |
+| Auto-offer | `auto_promote_waitlist` | **Auto-offer waitlist when tickets free up** |
+
+**Join rules (code):** paid tier only; finite capacity; tier **sold out**; email + quantity stored on **`mel_ticket_waitlist_entry`** (`waiting` → `offered` → accepted/expired).
+
+**Organiser UI gap (critical):** Event Studio tier cards (`mel-event-studio.js` `buildDraftTierFromCard`) send **title, kind, capacity, price** only — **no waitlist fields**. Ticket workspace form has capacity / limit per order on **variations**, not tier waitlist toggles. Enabling paid waitlist today likely requires **non–Event Studio paths** (e.g. data migration, admin entity edit) — **not verified in organiser self-service UI**.
+
+**Organiser list/export for paid tier waitlist:** **No route found** — `/vendor/event/{node}/waitlist` is **RSVP only** (`AttendanceWaitlistManager` / `event_attendee` waitlist status).
+
+### RSVP waitlist (separate product path)
+
+| Item | Evidence |
+|------|----------|
+| Event fields | `field_waitlist_capacity`, `field_waitlist_enabled` (schema / wizard) |
+| Organiser UI | `/vendor/event/{node}/waitlist` — name, email, position, status; CSV export |
+| Public signup | `/event/{node}/waitlist/signup` |
+| Auto-promote | `myeventlane_rsvp` config `auto_promote` (RSVP module settings) — separate from tier `auto_promote_waitlist` |
+
+## Auto-offer / claim findings
+
+| Item | Status |
+|------|--------|
+| Auto-offer | `TicketTierWaitlistService::processAutoPromotions()` — requires `auto_promote_waitlist` on tier and tier status **active** (capacity available); creates **offered** entry, reserves quantity, queues **`mel_ticket_waitlist_offer_mail`** |
+| Offer TTL | **172800** seconds (48h) in service constant |
+| Claim | `TicketWaitlistClaimController` — token URL sets session claim, adds to cart, redirects to book flow |
+| Cron | `myeventlane_commerce` cron calls `runCronMaintenance()` on tier waitlist service |
+| Staging email content | **Not verified** in this pass (Mailpit not exercised) |
+
+## Access control findings
+
+| Surface | Rule |
+|---------|------|
+| Vendor console | `VendorConsoleBaseController::assertEventOwnership` — event owner, **field_event_vendor** team users, or **administer nodes** |
+| Waitlist manage `/vendor/event/{node}/waitlist` | Same pattern in `WaitlistManagementController::access` |
+| Event analytics (tier rollup) | **Pro subscription required** (`VendorEventAnalyticsController`) |
+| Anonymous / other vendors | **Forbidden** on ownership routes (kernel tests exist for console access) |
+
+## Article readiness
+
+| Draft | Ready to publish? | Ready to export? | Blockers |
+|-------|-------------------|------------------|----------|
+| `ticket-sales-and-capacity.md` | **No** | **Yes** (after draft wording pass) | Refund→sold count unverified; manual capacity-down unverified; analytics vs book **remaining** mismatch must stay in copy |
+| `organiser-manage-waitlists.md` | **No** | **No** | Paid-tier organiser UI/list not verified; `/vendor/event/.../waitlist` is RSVP-only; tier waitlist toggles not in Event Studio; auto-offer not browser-tested |
+
+## Wording constraints (for Help Assistant)
+
+**Ticket sales and capacity**
+
+- Say **completed orders** drive **tickets sold** on dashboard/overview/analytics.
+- Use **may** for refunds restoring availability — do not state refunds always free capacity or reduce sold counts.
+- Per-tier capacity is enforced separately; event-level caps (**field_event_capacity_total** / **field_capacity**) may also apply — do not claim one combined venue cap across types unless configured and tested.
+- **Remaining** on organiser analytics may not match the book page when waitlist offers hold seats.
+- Do not promise exact real-time counts during active checkout peaks.
+
+**Managing waitlists**
+
+- **Clearly separate** RSVP waitlist (`/vendor/event/{event}/waitlist`, attendee names) vs **paid ticket waitlist** (book page join, email offers, no organiser list route found).
+- Do not instruct organisers to use the waitlist page for **paid** tier entries unless product adds that UI.
+- Auto-offer: only when **Auto-offer waitlist when tickets free up** is enabled on the ticket type — **may** send time-limited email; buyers must complete checkout.
+- Do not duplicate steps from published **Joining a waitlist** (attendee article) — cross-link only.
+- Treat waitlist emails/exports as **personal data**.
+
+## Remaining blockers
+
+1. Browser QA: sold-out paid event with `waitlist_enabled` → Join waitlist → offer email → claim link (Mailpit).
+2. Product/doc alignment: organiser-facing controls and reporting for **`mel_ticket_waitlist_entry`**.
+3. Refund scenario: complete order → refund → observe sold count and tier remaining on dashboard vs book page.
+4. Confirm whether lowering tier capacity below sold is blocked in UI.
+
+## YAML batch 04 recommendation
+
+- **Include:** `ticket_sales_and_capacity` only, after draft tighten — **conditional yes** for `help-articles-batch-04-2026-05.yml`.
+- **Exclude for now:** `organiser_manage_waitlists` — blocked on organiser UI/route accuracy for paid tier waitlists.
+
+## Commands run
+
+```bash
+git status --short && git branch --show-current
+ddev describe
+ddev drush sqlq "..."  # mel_ticket_type, mel_ticket_waitlist_entry
+ddev drush php:eval "..."  # TicketCapacityService / TicketStatusEvaluator on tiers 245, 95
+```
+
+**Residual risk:** Local DB test events mostly have waitlist disabled; one legacy offered entry on event 1584. Production behaviour may differ where tiers have waitlist enabled via non-Studio configuration.

--- a/docs/content-audit/help-article-drafts/next-batch/ticket-sales-and-capacity.md
+++ b/docs/content-audit/help-article-drafts/next-batch/ticket-sales-and-capacity.md
@@ -6,34 +6,40 @@ product_area: tickets
 help_status: draft
 ai_allowed: true
 recommended_alias: /help/vendors/ticket-sales-and-capacity
-source_evidence: mel_ticket_type.capacity; TicketCapacityService; Event Studio tickets section; vendor event overview metrics
-needs_verification: Exact dashboard labels for sold/remaining; whether refunds reduce sold counts; multi-session or zone capacity rules if enabled
+source_evidence: mel_ticket_type.capacity; TicketCapacityService; TicketVariationSoldService; TicketTierAnalyticsService; vendor event overview and Pro analytics; Event Studio / ticket workspace tier capacity
+needs_verification: Whether refunds change completed-order sold counts; lowering capacity below tickets already sold; event-level capacity fields in use for a given event
 ---
 
 # Ticket sales and capacity
 
-Capacity tells you how many tickets you can sell for each ticket type. This page explains how sales counts relate to availability and waitlists.
+Capacity tells you how many tickets you can sell for each ticket type. This page explains how sales counts relate to availability, your dashboard, and waitlists.
 
 ## What this means
 
-Each paid ticket type may have a capacity (maximum tickets). As orders complete, sold numbers increase and remaining places drop. Some events also track RSVP limits separately from paid tickets.
+Each paid ticket type may have a **capacity** (maximum tickets for that type). MyEventLane tracks **tickets sold** from **completed** ticket orders and compares that to capacity to decide when a type is sold out.
+
+Some events also set an **overall event capacity** (separate fields on the event). That limit may apply across RSVPs and paid tickets together at checkout — it is not the same as adding up each ticket type’s capacity. **Needs verification** for your event setup.
+
+Free RSVP events use RSVP limits and waitlist settings, not paid ticket type capacity.
 
 ## What to do next
 
-1. Open your event in the organiser dashboard or Event Studio.
-2. Go to the tickets section for the event.
-3. Set or review **capacity** for each ticket type you sell.
-4. Publish or update ticket types only when pricing and Stripe connection (for paid events) are ready.
-5. Monitor sales from your event overview or orders list — labels may vary by screen.
-6. If a type sells out and you enabled a waitlist, buyers may join the waitlist on the book page instead of purchasing.
-7. Adjust capacity carefully near event day; lowering capacity below tickets already sold may be blocked or require support — **Needs verification** for your workflow.
+1. Sign in to your organiser dashboard or Event Studio.
+2. Open the event and go to **Tickets** (ticket workspace) or the tickets section in Event Studio.
+3. Set or review **capacity** for each paid ticket type you sell.
+4. Optionally set a **limit per order** on a ticket type if you want to cap how many tickets one buyer can purchase in a single order (when that field is available).
+5. Publish or update ticket types only when pricing and Stripe connection (for paid events) are ready.
+6. Monitor sales from your **event overview** (**Tickets sold**, **Gross sales**) or, if you have Pro analytics, the **Ticket tiers snapshot** on the analytics tab.
+7. If a type sells out and waitlist is enabled on that type, buyers may see **Join waitlist** on the public book page instead of purchasing — see *Managing waitlists for your event* and the attendee article *Joining a waitlist*.
 
 ## Good to know
 
-- Capacity is enforced per ticket type. Total event attendance may span several types — plan combined limits if you have a venue maximum.
-- Completed orders generally count toward sold totals. Cancellations and refunds may affect availability depending on order state — confirm in your dashboard before assuming extra places exist.
-- Active waitlist offers may reserve capacity until they expire or are purchased. That can make “remaining” look lower than expected for a short time.
-- Free RSVP events use different limits and waitlist settings than paid ticket types on the book page.
+- **Tickets sold** on dashboard and overview figures generally means quantities on **completed** Commerce orders for your event, not draft or unpaid carts.
+- **Sold out** for a paid ticket type means completed sales have reached that type’s capacity. The book page may also reserve places for active waitlist offers, so buyer-facing “only X left” can differ slightly from organiser **Remaining** on Pro analytics (analytics remaining is based on sold counts and may not subtract waitlist holds).
+- Capacity is enforced **per ticket type**. If you have a venue maximum, plan your type capacities (and any event-level capacity field) so they work together — do not assume the system enforces one combined cap across all types unless you have configured and tested that.
+- **Refunds and cancellations** are shown in sales summaries where applicable, but they **may not** reduce **tickets sold** unless the underlying order is no longer treated as completed — check your event’s orders before assuming capacity has reopened.
+- Active waitlist offers can temporarily hold capacity until they expire or are purchased. That can make availability look tighter on the book page for a short time.
+- Lowering capacity below tickets already sold **may be blocked or need support** — treat as **Needs verification** before you change caps near event day.
 
 ## Related help
 

--- a/docs/content-audit/help-article-exports/help-articles-batch-04-2026-05-notes.md
+++ b/docs/content-audit/help-article-exports/help-articles-batch-04-2026-05-notes.md
@@ -1,0 +1,55 @@
+# Help articles batch 04 — export notes
+
+**Date:** 2026-05-22  
+**YAML:** `docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml`
+
+## Article included
+
+| Stable key | Title | Alias | Audience |
+|------------|-------|-------|------------|
+| `ticket_sales_and_capacity` | Ticket sales and capacity | `/help/vendors/ticket-sales-and-capacity` | vendor |
+
+## Deliberately excluded
+
+**`organiser_manage_waitlists`** (draft `organiser-manage-waitlists.md`) is **not** in this batch because:
+
+- `/vendor/event/{node}/waitlist` manages **RSVP** waitlist attendees only, not paid tier waitlist entries (`mel_ticket_waitlist_entry`).
+- No verified organiser list/export UI for paid ticket waitlist entries.
+- Paid tier waitlist toggles were not found in Event Studio organiser tier save payload at QA time.
+- Auto-offer email and claim flow were not browser-verified on staging.
+
+Re-export when organiser-facing paid waitlist configuration and reporting are verified (see `organiser-ticket-capacity-waitlist-verification.md`).
+
+## Verification source
+
+- Draft: `docs/content-audit/help-article-drafts/next-batch/ticket-sales-and-capacity.md`
+- QA log: `docs/content-audit/help-article-drafts/next-batch/organiser-ticket-capacity-waitlist-verification.md`
+- Register: `docs/content-audit/help-article-drafts/next-batch/next-batch-register.md`
+
+Copy constraints preserved in YAML: completed-order **tickets sold**, per-tier capacity, analytics **Remaining** vs book-page availability with waitlist holds, cautious refund and combined-cap wording.
+
+## Import commands
+
+Use the YAML path as a **positional** argument (do not use `--file`).
+
+**Dry-run:**
+
+```bash
+ddev drush mel:help-import-priority docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml --dry-run
+```
+
+**Live import:**
+
+```bash
+ddev drush mel:help-import-priority docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml --yes
+```
+
+**Post-import:**
+
+```bash
+ddev drush search-api:index mel_content
+ddev drush search-api:status mel_content
+ddev drush cr
+```
+
+Importer was **not** run as part of this export task.

--- a/docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml
+++ b/docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml
@@ -1,0 +1,58 @@
+metadata:
+  exported_from: local
+  export_reason: organiser_ticket_capacity_batch_04
+  generated_at: '2026-05-22T20:10:47+10:00'
+  notes:
+    - 'ticket sales and capacity article verified from completed-order sales logic and ticket tier capacity services'
+    - 'organiser waitlist article deliberately excluded pending paid waitlist organiser UI/reporting verification'
+    - 'import identity should use stable key and/or alias'
+articles:
+  ticket_sales_and_capacity:
+    source_nid: null
+    title: 'Ticket sales and capacity'
+    alias: '/help/vendors/ticket-sales-and-capacity'
+    audience: vendor
+    article_type: guide
+    help_status: published
+    ai_allowed: true
+    summary:
+      format: basic_html
+      value: 'How ticket type capacity relates to tickets sold on your organiser dashboard, Pro analytics, and what buyers see on the book page — including waitlist holds and completed orders.'
+    body:
+      format: full_html
+      value: |-
+        <p>Capacity tells you how many tickets you can sell for each ticket type. This page explains how sales counts relate to availability, your dashboard, and waitlists.</p>
+
+        <h2>What this means</h2>
+        <p>Each paid ticket type may have a <strong>capacity</strong> (maximum tickets for that type). MyEventLane tracks <strong>tickets sold</strong> from <strong>completed</strong> ticket orders and compares that to capacity to decide when a type is sold out.</p>
+        <p>Some events also set an <strong>overall event capacity</strong> (separate fields on the event). That limit may apply across RSVPs and paid tickets together at checkout. It is not the same as adding up each ticket type&rsquo;s capacity. Check your event settings if you use both paid tickets and RSVPs.</p>
+        <p>Free RSVP events use RSVP limits and waitlist settings, not paid ticket type capacity.</p>
+
+        <h2>What to do next</h2>
+        <ol>
+          <li>Sign in to your organiser dashboard or Event Studio.</li>
+          <li>Open the event and go to <strong>Tickets</strong> (ticket workspace) or the tickets section in Event Studio.</li>
+          <li>Set or review <strong>capacity</strong> for each paid ticket type you sell.</li>
+          <li>Optionally set a <strong>limit per order</strong> on a ticket type if you want to cap how many tickets one buyer can purchase in a single order (when that field is available).</li>
+          <li>Publish or update ticket types only when pricing and Stripe connection (for paid events) are ready.</li>
+          <li>Monitor sales from your <strong>event overview</strong> (<strong>Tickets sold</strong>, <strong>Gross sales</strong>) or, if you have Pro analytics, the <strong>Ticket tiers snapshot</strong> on the analytics tab.</li>
+          <li>If a type sells out and waitlist is enabled on that type, buyers may see <strong>Join waitlist</strong> on the public book page instead of purchasing. See <em>Managing waitlists for your event</em> and the attendee article <a href="/help/attendees/joining-a-waitlist">Joining a waitlist</a>.</li>
+        </ol>
+
+        <h2>Good to know</h2>
+        <ul>
+          <li><strong>Tickets sold</strong> on dashboard and overview figures generally means quantities on <strong>completed</strong> Commerce orders for your event, not draft or unpaid carts.</li>
+          <li><strong>Sold out</strong> for a paid ticket type means completed sales have reached that type&rsquo;s capacity. The book page may also reserve places for active waitlist offers, so buyer-facing &ldquo;only X left&rdquo; can differ slightly from organiser <strong>Remaining</strong> on Pro analytics (analytics remaining is based on sold counts and may not subtract waitlist holds).</li>
+          <li>Capacity is enforced <strong>per ticket type</strong>. If you have a venue maximum, plan your type capacities (and any event-level capacity field) so they work together. Do not assume the system enforces one combined cap across all types unless you have configured and tested that for your event.</li>
+          <li><strong>Refunds and cancellations</strong> are shown in sales summaries where applicable, but they <strong>may not</strong> reduce <strong>tickets sold</strong> unless the underlying order is no longer treated as completed. Check your event&rsquo;s orders before assuming capacity has reopened.</li>
+          <li>Active waitlist offers can temporarily hold capacity until they expire or are purchased. That can make availability look tighter on the book page for a short time.</li>
+          <li>Lowering capacity below tickets already sold <strong>may</strong> be blocked or <strong>may</strong> need support. Check your ticket workspace or contact support before you change caps near event day.</li>
+        </ul>
+
+        <h2>Related help</h2>
+        <ul>
+          <li>Managing waitlists for your event</li>
+          <li><a href="/help/vendors/payouts-and-fees">Payouts and fees</a></li>
+          <li>Choosing RSVP or paid tickets</li>
+          <li>Managing your event dashboard</li>
+        </ul>

--- a/docs/content-audit/help-article-exports/help-articles-batch-04-import-log.md
+++ b/docs/content-audit/help-article-exports/help-articles-batch-04-import-log.md
@@ -1,0 +1,79 @@
+# Help articles batch 04 import log
+
+## Scope
+
+Imported Batch 04 organiser ticket capacity help article.
+
+## Import file
+
+`docs/content-audit/help-article-exports/help-articles-batch-04-2026-05.yml`
+
+## Article imported
+
+| Stable key | Title | Node | Alias | Audience |
+|---|---|---:|---|---|
+| `ticket_sales_and_capacity` | Ticket sales and capacity | 1674 | `/help/vendors/ticket-sales-and-capacity` | vendor |
+
+## Dry-run result
+
+Initial dry-run:
+
+- 1 created
+- 0 updated
+- 0 skipped
+- 0 errors
+
+After live import, repeat dry-run:
+
+- 0 created
+- 0 updated
+- 1 skipped
+- 0 errors
+- matched by `field_help_seed_key`
+- no field changes detected
+
+## Live import result
+
+Initial live import:
+
+- 1 created
+- 0 updated
+- 0 skipped
+- 0 errors
+
+Created node:
+
+- nid 1674
+- stable key `ticket_sales_and_capacity`
+
+Second live import:
+
+- 0 created
+- 0 updated
+- 1 skipped
+- 0 errors
+
+This confirms the importer is idempotent.
+
+## Search API
+
+`mel_content` status after import:
+
+- 66 / 66
+- 100%
+
+## Access check
+
+Anonymous request:
+
+`/help/vendors/ticket-sales-and-capacity`
+
+Result:
+
+- HTTP 403
+
+This is expected because the article audience is `vendor`.
+
+## Notes
+
+The organiser waitlist article remains excluded from Batch 04 because paid-tier waitlist organiser UI/reporting and auto-offer claim flow are not fully verified.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that add/adjust help article drafts and export artifacts; no production code paths are modified.
> 
> **Overview**
> Adds a new vendor-facing help article export (**Batch 04**) for **Ticket sales and capacity**, including the generated YAML (`help-articles-batch-04-2026-05.yml`) plus export notes and an import log validating importer idempotency and access (vendor audience returns 403 for anonymous).
> 
> Updates the vendor draft articles to reflect verified wording constraints: `ticket-sales-and-capacity.md` now explicitly ties **tickets sold** to **completed orders**, calls out analytics-vs-booking “remaining” differences due to waitlist holds, and adds cautions around refunds and lowering capacity; `organiser-manage-waitlists.md` is rewritten to clearly separate **RSVP** vs **paid ticket** waitlists and is flagged as blocked pending organiser UI/reporting verification.
> 
> Introduces a detailed QA verification log (`organiser-ticket-capacity-waitlist-verification.md`) capturing the evidence and remaining unknowns, and updates the `next-batch-register.md` to mark `ticket-sales-and-capacity.md` ready for export while keeping `organiser-manage-waitlists.md` blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43071f89a6d5595ab1b5372a923453b35b895ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->