### PR TITLE
fix(check-in): align organiser scanner permissions and routes

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -22,7 +22,6 @@ label: 'Anonymous user'
 weight: -10
 is_admin: false
 permissions:
-  - 'access check-in'
   - 'access checkout'
   - 'access comments'
   - 'access commerce_order overview'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -30,7 +30,6 @@ label: 'Authenticated user'
 weight: -9
 is_admin: false
 permissions:
-  - 'access check-in'
   - 'access checkout'
   - 'access comments'
   - 'access commerce_order overview'
@@ -52,10 +51,8 @@ permissions:
   - 'manage own commerce_payment_method'
   - 'post comments'
   - request_refunds
-  - 'scan qr codes'
   - 'search content'
   - 'skip comment approval'
-  - 'toggle check-in status'
   - 'unflag event_save'
   - 'unflag follow_category'
   - 'update own customer profile'

--- a/config/sync/user.role.vendor.yml
+++ b/config/sync/user.role.vendor.yml
@@ -35,6 +35,7 @@ dependencies:
     - myeventlane_messaging
     - myeventlane_refunds
     - myeventlane_rsvp
+    - myeventlane_tickets
     - myeventlane_vendor
     - myeventlane_vendor_ai
     - myeventlane_venue
@@ -54,6 +55,9 @@ permissions:
   - 'access analytics dashboard'
   - 'access attendee repository'
   - 'access check-in'
+  - 'check in tickets'
+  - 'scan qr codes'
+  - 'toggle check-in status'
   - 'access checkout'
   - 'access commerce_order overview'
   - 'access content overview'

--- a/docs/audits/check-in-permission-route-parity-audit.md
+++ b/docs/audits/check-in-permission-route-parity-audit.md
@@ -1,0 +1,95 @@
+# Check-in permission and route parity audit
+
+**Date:** 2026-05-23  
+**Scope:** Vendor organiser event-day check-in, door mode, ticket scanner, RSVP check-in, legacy `myeventlane_checkin` routes.
+
+## Summary
+
+| Issue | Fix |
+|-------|-----|
+| Legacy routes required non-existent permissions (`myeventlane_checkin.*`) | Routes updated to use machine names from `myeventlane_checkin.permissions.yml` |
+| Vendor role lacked `check in tickets`, `scan qr codes`, `toggle check-in status` | Granted on `user.role.vendor` |
+| No role had `check in tickets` | Vendor role now has it; `EventTicketsAccess` still enforces event ownership |
+| Anonymous/authenticated had `access check-in` (and authenticated had scan/toggle) | Removed from anonymous and authenticated |
+| Legacy `/check-in/scan` referenced missing `js/scan.js` | Controller redirects 302 to canonical door route |
+| Vendor UI linked legacy check-in and ticket scanner without permission parity | UI links point to `/operations/door`; ticket scanner accessible with new vendor permissions |
+
+**Canonical organiser event-day path:** `/vendor/events/{node}/operations/door` (Door Mode: unified attendee + paid ticket scanner via `myeventlane_tickets/checkin_scanner` library).
+
+---
+
+## Route audit
+
+### Canonical vendor operations (myeventlane_event_attendees + myeventlane_checkout_flow)
+
+| Route | Path | Controller | Permission / access | Ownership check | Linked from UI | Status | Fix decision |
+|-------|------|------------|---------------------|-----------------|----------------|--------|--------------|
+| `myeventlane_event_attendees.vendor_operations` | `/vendor/events/{node}/operations` | `VendorEventOperationsController::page` | `VendorConsoleAccess` | `assertEventOwnership` | Operations tab, venue ops actions | OK | Keep canonical hub |
+| `myeventlane_event_attendees.vendor_operations_door` | `/vendor/events/{node}/operations/door` | `VendorEventOperationsController::doorPage` | `VendorConsoleAccess` | `assertEventOwnership` + `MelAttendeeOperationsAccess::canCheckInAttendees` | Dashboard quick actions, attendees, door CTA | OK | **Primary check-in surface** |
+| `myeventlane_event_attendees.vendor_operations_door_validate` | `/vendor/events/{node}/operations/door/validate` | `VendorEventOperationsController::doorValidate` | `VendorConsoleAccess` | Same as door page | Door Mode JS | OK | Keep; JSON mutation path |
+| `myeventlane_event_attendees.vendor_list` | `/vendor/events/{node}/attendees` | `VendorEventAttendeesController::attendees` | `VendorConsoleAccess` | `assertEventOwnership` | Workspace tabs, dashboard | OK | Keep |
+| `myeventlane_event_attendees.vendor_export` | `/vendor/events/{node}/attendees/export` | `VendorAttendeeController::export` | Custom `VendorAttendeeController::access` | Event ownership via access service | Operations export action | OK | Keep |
+| `myeventlane_event_attendees.vendor_checkin` | `/vendor/attendee/{event_attendee}/checkin` | `VendorAttendeeController::checkIn` | Custom `accessAttendee` | Row + event scoped | Operations list POST | OK | Keep |
+
+### Paid ticket scanner (myeventlane_tickets)
+
+| Route | Path | Controller | Permission / access | Ownership check | Linked from UI | Status | Fix decision |
+|-------|------|------------|---------------------|-----------------|----------------|--------|--------------|
+| `myeventlane_tickets.ticket_scan` | `/event/{event}/tickets/scan` | `TicketScanController::page` | `check in tickets` + `EventTicketsAccess` | Vendor console + workspace parity | Event Studio, event overview, ticket manager | Was 403 for vendors | **Grant `check in tickets` to vendor** |
+| `myeventlane_tickets.ticket_checkin` | `/event/{event}/tickets/checkin` | `TicketCheckinForm` | Same | Same | Ticket task tabs | Was 403 for vendors | Same fix |
+| `myeventlane_tickets.ticket_checkin_api_*` | `/event/{event}/tickets/checkin/api*` | API controllers | Same | Same | Scanner PWA | Was 403 for vendors | Same fix |
+
+Note: Door Mode also attaches `myeventlane_tickets/checkin_scanner` when the tickets module is enabled — preferred path for event-day scanning.
+
+### RSVP check-in (myeventlane_rsvp)
+
+| Route | Path | Controller | Permission / access | Ownership check | Linked from UI | Status | Fix decision |
+|-------|------|------------|---------------------|-----------------|----------------|--------|--------------|
+| `myeventlane_rsvp.checkin_list` | `/vendor/event/{event}/rsvps/checkin` | `RsvpCheckinController::checkinPage` | `VendorEventAccess` | `manage own event rsvps` + workspace parity | RSVP console tab | OK | Keep separate from ticket scanner |
+| `myeventlane_rsvp.checkin_list_pdf` | `/vendor/event/{event}/rsvps/checkin/pdf` | `RsvpCheckinController::pdf` | Same | Same | RSVP check-in page | OK | Keep |
+| `myeventlane_rsvp.checkin_scan` | `/vendor/event/{event}/scan` | `QrCheckinController::scanPage` | Same | Same | RSVP flows | OK | Keep (RSVP-specific QR) |
+| `myeventlane_rsvp.checkin_validate` | `/vendor/qr/validate` | `QrCheckinController::validate` | `manage own event rsvps` | POST endpoint | RSVP scan JS | OK | Keep |
+
+### Legacy combined check-in (myeventlane_checkin)
+
+| Route | Path | Controller | Permission / access | Ownership check | Linked from UI | Status | Fix decision |
+|-------|------|------------|---------------------|-----------------|----------------|--------|--------------|
+| `myeventlane_checkin.page` | `/vendor/events/{node}/check-in` | `CheckInController::page` | `access check-in` | `assertEventAccess` | **Removed from promoted UI** | Fixed permissions; not promoted | Keep for direct URLs only |
+| `myeventlane_checkin.scan` | `/vendor/events/{node}/check-in/scan` | `CheckInController::scan` | `scan qr codes` | `assertEventAccess` | Was linked from legacy page | **302 → operations/door** | Do not rebuild `scan.js` |
+| `myeventlane_checkin.list` | `/vendor/events/{node}/check-in/list` | `CheckInController::list` | `access check-in` | `assertEventAccess` | Legacy page | Fixed permissions | Not promoted |
+| `myeventlane_checkin.toggle` | `/vendor/events/{node}/check-in/toggle/{id}` | `CheckInController::toggle` | `toggle check-in status` | `assertEventAccess` | Legacy JS | Fixed permissions | Superseded by door/ops |
+| `myeventlane_checkin.search` | `/vendor/events/{node}/check-in/search` | `CheckInController::search` | `access check-in` | `assertEventAccess` | Legacy JS | Fixed permissions | Superseded by door validate |
+
+### Public door mode (myeventlane_event)
+
+| Route | Path | Controller | Permission / access | Ownership check | Linked from UI | Status | Fix decision |
+|-------|------|------------|---------------------|-----------------|----------------|--------|--------------|
+| `myeventlane_event.checkin_door` | `/event/{event}/checkin` | `CheckinController::doorMode` | Custom `checkAccess` (workspace parity / staff) | No anonymous | Staff/mobile door | OK | Separate from vendor console |
+| `myeventlane_event.checkin_validate` | `/event/{event}/checkin/validate` | `CheckinController::validate` | Same | Same | Public door JS | OK | Keep |
+
+---
+
+## Role config changes
+
+| Role | Before | After |
+|------|--------|-------|
+| **vendor** | `access check-in` only | + `check in tickets`, `scan qr codes`, `toggle check-in status`; module dep `myeventlane_tickets` |
+| **anonymous** | `access check-in` | Removed (unsafe; legacy routes could pass permission gate) |
+| **authenticated** | `access check-in`, `scan qr codes`, `toggle check-in status` | Removed (check-in is vendor/staff scoped via ownership checks) |
+| **administrator** | `is_admin: true` (bypass) | Unchanged |
+
+---
+
+## Scanner asset decision
+
+- **Legacy** `/vendor/events/{node}/check-in/scan` referenced `myeventlane_checkin/scan` library with missing `js/scan.js`.
+- **Decision:** Redirect route to `myeventlane_event_attendees.vendor_operations_door` (302). Door Mode uses existing `myeventlane_event/door_checkin`, `myeventlane_checkout_flow/mel_vendor_door_checkin`, and `myeventlane_tickets/checkin_scanner` — no duplicate scanner implementation.
+- Legacy `checkin-page.html.twig` scan button now links directly to door route.
+
+---
+
+## Residual risk
+
+- Legacy `/vendor/events/{node}/check-in` page remains reachable for vendors with `access check-in` who know the URL; it is not linked from primary UI.
+- `mel_pro` role does not inherit vendor check-in permissions; users need the vendor role (or staff admin perms) for door/scanner access.
+- Help article draft still references legacy `/check-in` path; update alias guidance after publish QA (draft not changed in this fix).

--- a/docs/content-audit/help-article-drafts/next-batch/check-in-attendees-verification.md
+++ b/docs/content-audit/help-article-drafts/next-batch/check-in-attendees-verification.md
@@ -1,0 +1,29 @@
+# Check-in attendees help article — publish QA verification
+
+**Date:** 2026-05-23  
+**Related draft:** `check-in-attendees.md`  
+**Code fix:** `docs/audits/check-in-permission-route-parity-audit.md`
+
+## Browser verification summary
+
+| Persona | Canonical door | Attendees list | Attendees export | Ticket scanner | Legacy `/check-in/scan` | RSVP check-in |
+|---------|----------------|----------------|------------------|----------------|-------------------------|---------------|
+| Anonymous | 403 | 403 | 403 | 403 | 403 | 403 |
+| Authenticated non-vendor | 403 | 403 | 403 | 403 | 403 | 403 |
+| Vendor event owner | 200 | 200 | 200 | 200 | 302 → door | 200 (when RSVPs enabled) |
+| Administrator | 200 | 200 | 200 | 200 | 302 → door | 200 |
+
+## Documentation updates required before publish
+
+1. **Canonical path:** Replace example `/vendor/events/{event}/check-in` with `/vendor/events/{node}/operations/door` for primary door check-in.
+2. **Operations hub:** Mention `/vendor/events/{node}/operations` for live attendee list, export, and manual lookup.
+3. **RSVP vs tickets:** RSVP check-in remains at `/vendor/event/{event}/rsvps/checkin`; paid ticket scanner at `/event/{event}/tickets/scan` (also embedded in Door Mode).
+4. **Do not document** legacy `/vendor/events/{node}/check-in/scan` (redirects to door).
+
+## Publish readiness
+
+**Not yet ready for publish QA** until a human re-walks the vendor event-day flow in the browser after config import (`drush cim` or role sync) and confirms Door Mode scanner behaviour on a real paid-ticket event.
+
+**Blockers cleared by code fix:** permission mismatch, vendor 403 on ticket scanner, broken legacy scan asset.
+
+**Remaining:** Help draft body and Batch 06 YAML still reference legacy routes — update in a separate content pass after browser sign-off.

--- a/web/modules/custom/myeventlane_checkin/myeventlane_checkin.routing.yml
+++ b/web/modules/custom/myeventlane_checkin/myeventlane_checkin.routing.yml
@@ -4,7 +4,7 @@ myeventlane_checkin.page:
     _controller: '\Drupal\myeventlane_checkin\Controller\CheckInController::page'
     _title: 'Check-in'
   requirements:
-    _permission: 'myeventlane_checkin.access'
+    _permission: 'access check-in'
     node: \d+
   options:
     parameters:
@@ -19,7 +19,7 @@ myeventlane_checkin.scan:
     _controller: '\Drupal\myeventlane_checkin\Controller\CheckInController::scan'
     _title: 'QR Scan Check-in'
   requirements:
-    _permission: 'myeventlane_checkin.scan'
+    _permission: 'scan qr codes'
     node: \d+
   options:
     parameters:
@@ -34,7 +34,7 @@ myeventlane_checkin.list:
     _controller: '\Drupal\myeventlane_checkin\Controller\CheckInController::list'
     _title: 'Attendee List'
   requirements:
-    _permission: 'myeventlane_checkin.access'
+    _permission: 'access check-in'
     node: \d+
   options:
     parameters:
@@ -48,7 +48,7 @@ myeventlane_checkin.toggle:
   defaults:
     _controller: '\Drupal\myeventlane_checkin\Controller\CheckInController::toggle'
   requirements:
-    _permission: 'myeventlane_checkin.toggle'
+    _permission: 'toggle check-in status'
     node: \d+
     attendee_id: \d+
   options:
@@ -63,7 +63,7 @@ myeventlane_checkin.search:
   defaults:
     _controller: '\Drupal\myeventlane_checkin\Controller\CheckInController::search'
   requirements:
-    _permission: 'myeventlane_checkin.access'
+    _permission: 'access check-in'
     node: \d+
   options:
     parameters:

--- a/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
+++ b/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_checkin\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
 use Drupal\myeventlane_checkin\Service\CheckInStorageInterface;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -64,20 +66,15 @@ final class CheckInController extends ControllerBase {
   }
 
   /**
-   * QR scan page.
+   * Legacy QR scan route — redirects to canonical Door Mode.
    */
-  public function scan(NodeInterface $node): array {
+  public function scan(NodeInterface $node): RedirectResponse {
     $this->assertEventAccess($node);
 
-    $build = [
-      '#theme' => 'myeventlane_checkin_scan',
-      '#event' => $node,
-      '#attached' => [
-        'library' => ['myeventlane_checkin/scan'],
-      ],
-    ];
-
-    return $build;
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+      302,
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkin/templates/checkin-page.html.twig
+++ b/web/modules/custom/myeventlane_checkin/templates/checkin-page.html.twig
@@ -23,7 +23,7 @@
   </div>
 
   <div class="checkin-actions">
-    <a href="{{ path('myeventlane_checkin.scan', {'node': event.id}) }}" class="button button--primary">{{ 'Scan QR Code'|t }}</a>
+    <a href="{{ path('myeventlane_event_attendees.vendor_operations_door', {'node': event.id}) }}" class="button button--primary">{{ 'Scan QR Code'|t }}</a>
     <a href="{{ path('myeventlane_checkin.list', {'node': event.id}) }}" class="button">{{ 'View List'|t }}</a>
   </div>
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorCheckInController.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Controller/VendorCheckInController.php
@@ -120,16 +120,16 @@ final class VendorCheckInController extends ControllerBase {
 
     if ($result['success'] && !$result['transitioned'] && $result['reason'] === 'already_checked_in') {
       $this->messenger()->addWarning($this->t('This attendee is already checked in.'));
-      return $this->redirect('myeventlane_checkin.page', ['node' => $event->id()], [], 302);
+      return $this->redirect('myeventlane_event_attendees.vendor_operations_door', ['node' => $event->id()], [], 302);
     }
 
     if (!$result['success']) {
       $this->messenger()->addError($this->t('Check-in could not be completed.'));
-      return $this->redirect('myeventlane_checkin.page', ['node' => $event->id()], [], 302);
+      return $this->redirect('myeventlane_event_attendees.vendor_operations_door', ['node' => $event->id()], [], 302);
     }
 
     $this->messenger()->addStatus($this->t('Attendee checked in successfully via QR code.'));
-    return $this->redirect('myeventlane_checkin.page', ['node' => $event->id()], [], 302);
+    return $this->redirect('myeventlane_event_attendees.vendor_operations_door', ['node' => $event->id()], [], 302);
   }
 
 }

--- a/web/modules/custom/myeventlane_checkout_flow/src/Form/CheckInForm.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Form/CheckInForm.php
@@ -136,10 +136,10 @@ final class CheckInForm extends FormBase {
     }
 
     try {
-      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_event_attendees.vendor_operations', ['node' => $event->id()]));
+      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $event->id()]));
     }
     catch (\Throwable $e) {
-      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_checkin.page', ['node' => $event->id()]));
+      $form_state->setRedirectUrl(Url::fromRoute('myeventlane_event_attendees.vendor_operations', ['node' => $event->id()]));
     }
   }
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
@@ -136,7 +136,6 @@ final class MelVenueOperationsViewModelBuilder {
       'export' => Url::fromRoute('myeventlane_event_attendees.vendor_export', ['node' => $eventId])->toString(),
       'operations' => $this->safeRouteUrl('myeventlane_event_attendees.vendor_operations', ['node' => $eventId]),
       'door_checkin' => $this->safeRouteUrl('myeventlane_event_attendees.vendor_operations_door', ['node' => $eventId]),
-      'legacy_checkin' => $this->safeRouteUrl('myeventlane_checkin.page', ['node' => $eventId]),
     ];
 
     $search = [

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-vendor-attendees-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-vendor-attendees-dashboard.html.twig
@@ -126,7 +126,7 @@
               </div>
             </div>
             <div class="mel-event-actions mel-mt-4">
-              <a href="{{ url('myeventlane_checkin.page', {'node': event_data.id}) }}" class="mel-btn mel-btn-primary">✓ {{ 'Check In'|t }}</a>
+              <a href="{{ url('myeventlane_event_attendees.vendor_operations_door', {'node': event_data.id}) }}" class="mel-btn mel-btn-primary">✓ {{ 'Check In'|t }}</a>
               <a href="{{ url('myeventlane_event_attendees.vendor_list', {'node': event_data.id}) }}" class="mel-btn mel-btn-secondary">{{ 'View Attendees'|t }}</a>
               <a href="{{ url('myeventlane_views.attendee_csv', [], {'query': {'download_csv': event_data.id}}) }}" class="mel-btn mel-btn-secondary" target="_blank">📥 {{ 'Export CSV'|t }}</a>
             </div>

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-vendor-event-attendees.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-vendor-event-attendees.html.twig
@@ -77,7 +77,7 @@
     <div class="mel-section-header">
       <h2 class="mel-section-title">Attendees ({{ attendees|length }})</h2>
       <div class="mel-section-actions">
-        <a href="{{ url('myeventlane_checkin.page', {'node': event.id()}) }}"
+        <a href="{{ url('myeventlane_event_attendees.vendor_operations_door', {'node': event.id()}) }}"
            class="mel-btn mel-btn-primary">
           ✓ Check In
         </a>

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -647,7 +647,7 @@ final class VendorDashboardViewModelBuilder {
         'orders' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_orders', ['event' => $nid]),
         'attendees' => $this->safeUrlFromRoute('myeventlane_event_attendees.vendor_list', ['node' => $nid]),
         'analytics' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $nid]),
-        'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account),
+        'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
         'share' => $published ? $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account) : NULL,
         'promote' => $this->promoteUrl($nid, $account),
         'support' => $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account),
@@ -800,7 +800,7 @@ final class VendorDashboardViewModelBuilder {
     $actions = [];
     $this->appendQuickAction($actions, 'edit', (string) $this->t('Edit event'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_studio.edit', ['node' => $nid], $account), 'settings');
     $this->appendQuickAction($actions, 'attendees', (string) $this->t('View attendees'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account), 'list');
-    $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account), 'scan');
+    $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account), 'scan');
     if ($published) {
       $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account), 'export');
       $this->appendQuickAction($actions, 'promote', (string) $this->t('Promote event'), $this->promoteUrl($nid, $account), 'search');

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -187,7 +187,7 @@ final class VendorEventWorkspaceViewModelBuilder {
       'orders' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account),
       'addon_orders' => $addonOrdersUrl,
       'attendees' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account),
-      'checkin' => $this->routeUrlIfAccessible('myeventlane_checkin.page', ['node' => $nid], $account),
+      'checkin' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
       'analytics' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_analytics', ['event' => $nid], $account),
       'settings' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_settings', ['event' => $nid], $account),
       'preview' => $previewUrl,


### PR DESCRIPTION
## Summary

Fixes organiser check-in route and permission parity so event owners can access the intended event-day check-in workflow safely.

## What changed

- Updated legacy check-in routes to use real permission machine names.
- Granted vendor role the required check-in permissions.
- Removed unsafe check-in permissions from anonymous and authenticated roles.
- Redirected the broken legacy scan route to the canonical operations door flow.
- Updated vendor UI links to point to `/vendor/events/{node}/operations/door`.
- Preserved ownership and vendor console access checks.

## Validation

- PHP lint passed for changed PHP files.
- `ddev drush cr` passed.
- `composer validate` passed.
- `npm run mel:lint` passed.
- `npm run mel:build` passed.
- `MelAttendeeOperationsAccessTest` passed: 6/6.
- Anonymous and non-owner access denied.
- Vendor owner can access door mode, attendees, export, ticket scan, and validate endpoint.
- Legacy scan route redirects to canonical door mode.

## Notes

The check-in Help Centre article remains draft-only. It should not be published until a browser walkthrough confirms the event-day workflow end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Drupal role permissions and route access requirements for check-in/ticket scanning, which can unintentionally grant or block organiser access if misconfigured. Redirecting legacy routes and updating UI links is straightforward but impacts event-day operations paths.
> 
> **Overview**
> Organiser check-in is consolidated onto the canonical Door Mode route (`/vendor/events/{node}/operations/door`) by updating vendor-facing links and redirects away from legacy `myeventlane_checkin` scan/check-in entry points.
> 
> Legacy `myeventlane_checkin` routes now require real permission machine names (`access check-in`, `scan qr codes`, `toggle check-in status`), the vendor role is granted the missing scanner/ticket check-in permissions (including `check in tickets`), and anonymous/authenticated roles have check-in-related permissions removed to avoid unintended access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8591afbd5ba47976185e47f2c964c337a57a3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->