### PR TITLE
docs(help): verify organiser waitlist draft

### DIFF
--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -1,6 +1,6 @@
 # Next Help Centre batch — draft register
 
-**Date:** 2026-05-22  
+**Date:** 2026-05-23  
 **Folder:** `docs/content-audit/help-article-drafts/next-batch/`  
 **Importer:** Not run. Drupal nodes not created.
 
@@ -11,7 +11,7 @@
 | add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
 | missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
-| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Blocked until paid waitlist organiser UI/reporting and auto-offer claim flow are verified | See organiser-ticket-capacity-waitlist-verification.md |
+| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | RSVP list/export verified in code; paid-tier organiser UI/export missing; RSVP auto-promote not wired; browser QA pending | See organiser-waitlists-verification.md; recommended scope RSVP-only organiser section until paid reporting ships |
 | ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Exported in help-articles-batch-04-2026-05.yml; importer not run |
 | attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | No | No | — | Field types; archive behaviour; export columns | Privacy-first collection guidance |
 | check-in-attendees.md | vendor | /help/vendors/check-in-attendees | Yes | Yes | batch_06_2026_05 | Physical device camera QA optional | Exported in help-articles-batch-06-2026-05.yml; publish-ready after door/browser QA 2026-05-23; importer not run |

--- a/docs/content-audit/help-article-drafts/next-batch/organiser-manage-waitlists.md
+++ b/docs/content-audit/help-article-drafts/next-batch/organiser-manage-waitlists.md
@@ -6,53 +6,65 @@ product_area: capacity
 help_status: draft
 ai_allowed: true
 recommended_alias: /help/vendors/organiser-manage-waitlists
-source_evidence: myeventlane_event_attendees.waitlist_manage (RSVP); mel_ticket_type.waitlist_enabled; TicketTierWaitlistService; TicketSelectionForm; published "Joining a waitlist"
-needs_verification: Organiser UI to enable paid tier waitlist (not in Event Studio tier card payload); organiser view/export for mel_ticket_waitlist_entry; auto-offer email on staging; manual promote for paid tier waitlist
+source_evidence: myeventlane_event_attendees.waitlist_manage; myeventlane_event_attendees.waitlist_export; mel_ticket_type.waitlist_enabled; TicketTierWaitlistService; TicketSelectionForm; published "Joining a waitlist"
+needs_verification: Paid-tier organiser list/export; Event Studio waitlist toggles; paid auto-offer email on staging; RSVP auto-promote end-to-end; browser nav to waitlist page
 ---
 
 # Managing waitlists for your event
 
-When demand exceeds capacity, waitlists let you capture interest. **Paid ticket waitlists** and **free RSVP waitlists** work differently in MyEventLane — this page explains what organisers can verify today.
+When demand exceeds capacity, waitlists let you capture interest. **Free RSVP / attendance waitlists** and **paid ticket waitlists** use different data and screens in MyEventLane. This guide covers what organisers can rely on today.
 
 ## What this means
 
-**Paid ticket waitlist (buyers on the book page)**  
-A waitlist entry is **not** a ticket. For a **sold-out paid ticket type** where waitlist is enabled, buyers submit an email and how many places they want on the event **book** page. Entries are stored separately from RSVP guest lists.
+### RSVP and attendance waitlist (free events)
 
-**RSVP waitlist (free events)**  
-For RSVP-style events, waitlisted guests are tracked as attendees in **waitlist** status. You review them on the event **Waitlist** page in your organiser dashboard (for example `/vendor/event/{event}/waitlist`), not via the paid ticket waitlist entity.
+Waitlisted guests are stored as **event attendees** with status **waitlist** (not as paid ticket waitlist entries).
 
-Do not use the RSVP waitlist page to manage **paid** ticket waitlist sign-ups — that route lists RSVP attendees only (**verified in code**).
+- **Organiser list and export:** `/vendor/event/{event}/waitlist` and `/vendor/event/{event}/waitlist/export` — verified in code (`WaitlistManagementController`, `AttendanceWaitlistManager`).
+- **Public join:** guests can use `/event/{event}/waitlist/signup` when the event is full and a waitlist is offered (`WaitlistSignupForm`).
+- **Not on this page:** legacy **RSVP submissions** (`rsvp_submission`) may appear on **Manage RSVPs** (`/vendor/event/{event}/rsvps`) or check-in lists — that is a separate list from the waitlist page above.
+
+Optional event setting **`field_waitlist_capacity`** limits how many people can join the waitlist (leave empty for unlimited in the data model).
+
+### Paid ticket waitlist (buyers on the book page)
+
+A waitlist entry is **not** a ticket. For a **sold-out paid ticket type** where waitlist is enabled on that type, buyers submit email and quantity on the event **book** page. Entries live in **`mel_ticket_waitlist_entry`**, separate from RSVP attendee lists.
+
+- **Organisers:** there is **no verified vendor list or CSV export** for paid ticket waitlist entries at the time of this audit.
+- **Do not** use `/vendor/event/{event}/waitlist` for paid ticket waitlist emails — that route lists attendance waitlist guests only.
+
+See the attendee article *Joining a waitlist* for buyer steps (cross-link only; do not duplicate here).
 
 ## What to do next
 
-### RSVP waitlist (verified organiser paths)
+### RSVP waitlist — organiser steps (verified)
 
 1. Sign in to your organiser dashboard.
 2. Open the event and go to **Waitlist** (`/vendor/event/{event}/waitlist`).
-3. Review entries: name, email, position, and status where shown.
-4. Use **Export** on that page if you need a spreadsheet for your team.
-5. When places open, adjust RSVP capacity or promote guests according to your event settings and RSVP module behaviour.
+3. Review the table: position, name, email, date added, and status.
+4. Use **Export CSV** on that page when you need a spreadsheet for your team.
+5. When capacity opens, you may need to adjust event or RSVP capacity and follow up with guests manually — **automatic promotion email for attendance waitlist is not verified end-to-end** in this pass (see verification log). Do not assume guests are promoted without checking the list.
 
-### Paid ticket waitlist (configuration and limits)
+Guests who are full on the main RSVP booking flow may see a message to join the waitlist; the dedicated signup path is `/event/{event}/waitlist/signup`.
 
-1. Ensure each paid ticket type has a **capacity** and is configured for waitlist when sold out (**Waitlist when sold out** on the ticket type in the data model).
-2. Optionally enable **Auto-offer waitlist when tickets free up** on that ticket type so MyEventLane **may** email time-limited purchase offers when capacity returns — only where that option is enabled and working for your event.
-3. Tell buyers to use the public **book** page to join when a type is sold out — see the attendee article *Joining a waitlist* (do not repeat those steps here).
-4. When places open, capacity may return from cancellations, refunds, or capacity changes — **refunds restoring paid capacity are not verified** in this pass; confirm on your dashboard before relying on extra places.
-5. There is **no verified organiser list or export** for paid ticket waitlist entries (`mel_ticket_waitlist_entry`) in the vendor console at the time of this audit — plan manual communication or support if you need a spreadsheet of paid waitlist emails.
+### Paid ticket waitlist — what organisers can do today
+
+1. Ensure each paid ticket type has a **capacity** and, where your workflow allows, enable **Waitlist when sold out** and optional **Auto-offer waitlist when tickets free up** on that ticket type in the data model.
+2. **Event Studio tier cards** currently save title, price, and capacity only — **waitlist toggles are not in the Event Studio save payload** (`mel-event-studio.js`). Enabling paid waitlist may require another workflow or support until self-service controls ship.
+3. Tell buyers to use the public **book** page when a type is sold out — see *Joining a waitlist*.
+4. When places return (cancellations, refunds, or capacity changes), **auto-offer** may email time-limited purchase links **only** where **Auto-offer waitlist when tickets free up** is enabled on the type and the automation runs — **not verified on staging** in this pass. Buyers must still **complete checkout** to receive tickets.
+5. For a spreadsheet of paid waitlist emails, plan **manual outreach or support** — no organiser export route was found for `mel_ticket_waitlist_entry`.
 
 ## Good to know
 
-- Paid ticket waitlist join is only offered when the type is **sold out**, waitlist is **enabled** on that type, and the type has a finite capacity.
-- **Automatic offers** run only where **Auto-offer waitlist when tickets free up** is enabled on the ticket type. Offers are time-limited; buyers must still **complete checkout** to receive tickets. Do not promise every waitlisted buyer will receive an offer.
-- Active offers can **hold** capacity until they expire or are used — check ticket sales and the book page when reconciling numbers.
-- Event Studio tier cards currently save title, price, and capacity — **waitlist toggles for paid tiers were not found in the Event Studio organiser UI** during this audit. Enabling paid waitlist may require another workflow or support until self-service controls ship (**Needs verification**).
-- Treat waitlist emails and exports as **personal data**. Use them only for the relevant event and keep files secure.
+- Paid waitlist join appears only when the type is **sold out**, waitlist is **enabled** on that type, and the type has a finite capacity.
+- Active paid offers can **hold** capacity until they expire or are used — reconcile with ticket sales and the book page.
+- **Refunds restoring paid capacity** were not re-verified in this pass; confirm availability on your dashboard before promising extra places.
+- Treat waitlist exports and emails as **personal information**. Use them only for the relevant event; store CSV files securely; do not share in public channels.
 
 ## Related help
 
 - Joining a waitlist (attendees — public book page and offers)
 - Ticket sales and capacity
-- Having trouble checking out
+- Check-in attendees (RSVP check-in may show a separate legacy waitlist section)
 - Managing your event dashboard

--- a/docs/content-audit/help-article-drafts/next-batch/organiser-waitlists-verification.md
+++ b/docs/content-audit/help-article-drafts/next-batch/organiser-waitlists-verification.md
@@ -1,0 +1,176 @@
+# Organiser manage waitlists — QA verification log
+
+**Date:** 2026-05-23  
+**Branch:** `feature/help-verify-organiser-waitlists`  
+**Draft:** `organiser-manage-waitlists.md`  
+**Prior log:** `organiser-ticket-capacity-waitlist-verification.md` (2026-05-22)  
+**Environment:** DDEV local (`https://myeventlane.ddev.site`) — code audit, Drush/SQL, access callbacks; no browser E2E, no node import, no YAML export, no publish.
+
+## Scope
+
+- Verify organiser-facing help for **RSVP / attendance waitlists** vs **paid ticket tier waitlists**.
+- Document product truth only; do not claim organiser UI or notifications unless verified.
+- No code changes (verification-only pass).
+
+## Test data (local)
+
+| Item | Value |
+|------|--------|
+| Paid test event | **1666** — [MEL TEST] Event 8 - Paid |
+| Tier **245** | capacity 50, `waitlist_enabled=0` |
+| Tiers with waitlist enabled (sample) | **4**, **28**, **64**, **95** — `waitlist_enabled=1` (not all sold out locally) |
+| `mel_ticket_waitlist_entry` | **1** row — event **1584**, tier **95**, `status=offered`, `offer_reserved=1` |
+| `event_attendee` status `waitlist` | **0** rows |
+| `rsvp_submission` status `waitlist` | **0** rows |
+| `myeventlane_rsvp.settings` | `waitlist_enabled_default=1`, `auto_promote=1`, `notify_on_promotion=1` |
+
+## Product truth table
+
+| Capability | RSVP / attendance waitlist | Paid ticket tier waitlist |
+|---|---|---|
+| Customer can join | **Yes** — `/event/{node}/waitlist/signup` creates `event_attendee` with status `waitlist` (`WaitlistSignupForm`). Primary `RsvpPublicForm` throws at capacity and does **not** auto-enrol (message only). | **Yes** — sold-out paid tier with `waitlist_enabled` on book page (`TicketSelectionForm` → `TicketTierWaitlistService::joinWaitlist`). |
+| Organiser can view list | **Yes** — `/vendor/event/{node}/waitlist` lists `event_attendee` waitlist only (`WaitlistManagementController`). Legacy `rsvp_submission` waitlist appears on `/vendor/event/{event}/rsvps` and check-in, not on the waitlist page. | **No** — no vendor route for `mel_ticket_waitlist_entry`. |
+| Organiser can export | **Yes** — `/vendor/event/{node}/waitlist/export` CSV (name, email, position, status). | **No** |
+| Auto invite / offer | **No (not verified end-to-end)** — `RsvpPromotionManager` is **never invoked**; `WaitlistPromotionWorker` queue has **no producers** found; `AutomationScheduler::scanWaitlistInvites()` is a **stub** (`field_waitlist_auto_invite` not in `config/sync`); RSVP module `auto_promote` config does not apply to `RsvpSubmissionManager` (full events throw `CapacityExceededException`). | **Partial (code only)** — `auto_promote_waitlist` + `processAutoPromotions()` + `mel_ticket_waitlist_offer_mail` queue; **not** browser- or Mailpit-verified; organiser cannot toggle via Event Studio UI. |
+| Claim / booking flow | **Incomplete** — `WaitlistInviteWorker` references route `myeventlane_automation.waitlist_claim` **not found** in routing YAML. | **Yes (code)** — `/event/{node}/book/waitlist/{token}` (`TicketWaitlistClaimController`); not browser-verified. |
+| Vendor dashboard link | **Partial** — `VendorDashboardController` exposes `waitlist_url` → `/vendor/event/{id}/waitlist` (hardcoded string); theme templates for waitlist management not grep-verified in nav. | **No** organiser link |
+| Ready for help article (this draft) | **Partial** — organiser list/export steps only | **No** — configuration/reporting gaps |
+
+## RSVP waitlist findings
+
+### Data model and enablement
+
+- Organiser waitlist UI reads **`event_attendee`** entities with status **`waitlist`** (`AttendanceWaitlistManager`).
+- Event field in sync: **`field_waitlist_capacity`** (max waitlist size; optional/unlimited). **`field_waitlist_enabled`** is referenced in `AttendanceWaitlistManager::isWaitlistEnabled()` but **not exported** in `config/sync` (defaults to enabled when field absent).
+- Wizard / Event Studio schema exposes **`field_waitlist_capacity`** for RSVP/both modes (`EventWizardTicketsForm`).
+- Separate legacy entity **`rsvp_submission`** with status `waitlist` still counted on vendor RSVP dashboard (`VendorEventRsvpController`) and check-in PDF/HTML; **not** listed on `/vendor/event/{node}/waitlist`.
+
+### Public join
+
+| Route | Handler | Result |
+|-------|---------|--------|
+| `myeventlane_event_attendees.waitlist_signup` | `/event/{node}/waitlist/signup` | `WaitlistSignupForm` — creates `event_attendee`, shows FIFO position message |
+| `myeventlane_rsvp.public_rsvp_form` | `/event/{event}/rsvp` | Redirects to Commerce booking — not primary free-RSVP waitlist path |
+| `RsvpPublicForm` | Booking flow | On capacity exceeded: error “Join the waitlist?” — **no automatic waitlist enrolment** |
+
+`EventModeManager` links to `waitlist_signup` when appropriate for full events.
+
+### Organiser list / export
+
+| Route | Access | Data |
+|-------|--------|------|
+| `/vendor/event/{node}/waitlist` | Event owner, `field_event_vendor` team users, or `administer nodes` (`WaitlistManagementController::access`) | Table: position, name, email, date added, status; analytics cards |
+| `/vendor/event/{node}/waitlist/export` | Same | CSV: Position, Name, Email, Date Added, Status |
+
+**Access tested (Drush):** anonymous **forbidden**; event owner (uid 1) **allowed**.
+
+**UI gap:** Waitlist management template has **no** promote/remove actions — read-only list + export.
+
+### Related organiser RSVP routes (not the waitlist page)
+
+| Route | Path | Notes |
+|-------|------|-------|
+| `myeventlane_rsvp.vendor_event_rsvps` | `/vendor/event/{event}/rsvps` | RSVP dashboard; waitlist count includes `rsvp_submission` + commerce `event_attendee` waitlist |
+| `myeventlane_rsvp.export_csv` | `/vendor/event/{event}/rsvps/export` | RSVP export (separate from waitlist CSV) |
+| `myeventlane_rsvp.checkin_list` | `/vendor/event/{event}/rsvps/checkin` | Shows waitlist section for `rsvp_submission` |
+
+**Broken link:** `VendorEventRsvpController` builds promote URL to `myeventlane_rsvp.admin_promote` — **route not defined** in `myeventlane_rsvp.routing.yml`.
+
+### Auto-promote / notifications (RSVP)
+
+| Mechanism | Status |
+|-----------|--------|
+| `myeventlane_rsvp.settings` `auto_promote` / `notify_on_promotion` | Config present; **not wired** to live `RsvpSubmissionManager` submit path |
+| `RsvpPromotionManager::promoteNext()` | Service registered; **no callers** in codebase |
+| `myeventlane_waitlist_promotion` queue worker | Exists; **no `createItem` producers** found |
+| `automation_waitlist_invite` + `waitlist_invite` template | Worker sends email, but scheduler scan is **stub**; claim route **missing** |
+| `WaitlistNotificationService` | Promotion email for `event_attendee` exists; trigger path not verified |
+
+**Verdict:** Do **not** tell organisers that RSVP waitlist guests are auto-promoted or emailed unless product re-verifies after wiring fixes.
+
+## Paid ticket waitlist findings
+
+### Tier fields (`mel_ticket_type`)
+
+| Field | Label |
+|-------|-------|
+| `waitlist_enabled` | Waitlist when sold out |
+| `waitlist_capacity` | Waitlist capacity |
+| `auto_promote_waitlist` | Auto-offer waitlist when tickets free up |
+
+`TicketTierLifecycleService` can persist all three when present in API payload; **Event Studio** `buildDraftTierFromCard()` sends only title, kind, capacity, price — **no waitlist fields**.
+
+### Buyer join and offer (code-verified)
+
+- Join: `TicketSelectionForm` → `TicketTierWaitlistService::joinWaitlist()` — paid tier, sold out, finite capacity, `waitlist_enabled`.
+- Auto-offer: `processAutoPromotions()` when tier **active** (capacity available) and `auto_promote_waitlist` enabled; 48h TTL; holds capacity via `offer_reserved`.
+- Email: queue `mel_ticket_waitlist_offer_mail` → `TicketTierWaitlistOfferMailWorker` → messaging template `ticket_tier_waitlist_offer`.
+- Claim: `myeventlane_commerce.event_ticket_waitlist_claim` → `/event/{node}/book/waitlist/{token}`.
+- Cron: `myeventlane_commerce` cron → `runCronMaintenance()`.
+
+### Organiser management
+
+- **No** list, export, or dashboard route for `mel_ticket_waitlist_entry`.
+- `/vendor/event/{node}/waitlist` is **RSVP/attendance only** — using it for paid waitlist emails would be **wrong**.
+
+### Status
+
+**Buyer-only join/claim with limited organiser management** — backend entity and automation exist; organiser self-service configuration and reporting **incomplete**.
+
+## Route / access table
+
+| Route name | Path | Persona | Expected |
+|------------|------|---------|----------|
+| `myeventlane_event_attendees.waitlist_manage` | `/vendor/event/{node}/waitlist` | Event owner / vendor team / admin | 200 |
+| `myeventlane_event_attendees.waitlist_manage` | same | Anonymous / non-owner | 403 |
+| `myeventlane_event_attendees.waitlist_export` | `/vendor/event/{node}/waitlist/export` | Owner / team / admin | CSV download |
+| `myeventlane_event_attendees.waitlist_signup` | `/event/{node}/waitlist/signup` | Public (`access content`) | Form |
+| `myeventlane_commerce.event_ticket_waitlist_claim` | `/event/{node}/book/waitlist/{token}` | Public with valid token | Redirect to book |
+| `myeventlane_rsvp.vendor_event_rsvps` | `/vendor/event/{event}/rsvps` | Vendor access callback | RSVP list (includes legacy waitlist count) |
+
+## Notification / email findings
+
+| Path | Template / queue | Verified sent locally? |
+|------|------------------|------------------------|
+| Paid tier offer | `mel_ticket_waitlist_offer_mail` / `ticket_tier_waitlist_offer` | **No** (Mailpit not exercised) |
+| RSVP submission (legacy saver) | `mel_rsvp_waitlist_email` | Deprecated path |
+| Attendee promotion | `waitlist_promotion` / `email-waitlist-promotion` | Trigger not verified |
+| Automation invite | `waitlist_invite` | Scheduler stub; claim route missing |
+
+## Privacy notes
+
+- Waitlist CSV export includes **name and email** — treat as personal information; store securely; use only for the relevant event.
+- Paid tier waitlist stores email on `mel_ticket_waitlist_entry` (organisers have no UI to view).
+- Do not paste waitlist exports into public channels or unrelated tickets.
+
+## Article readiness decision
+
+| Question | Answer |
+|----------|--------|
+| Ready to publish? | **No** |
+| Ready to export? | **No** |
+| Recommended scope | **RSVP-only organiser section** (list + export on `/vendor/event/{event}/waitlist`) could be extracted later; **exclude** paid-tier organiser management until product ships list/config UI. Full draft should stay **blocked** or be split. |
+
+### Blockers
+
+1. Paid ticket waitlist: no organiser list/export; Event Studio cannot enable tier waitlist toggles.
+2. RSVP auto-promote / invite: multiple code paths **not wired** or **stub**; do not document auto-invite for organisers.
+3. Dual RSVP data stores (`event_attendee` vs `rsvp_submission`) — help must not blur routes.
+4. Browser QA not run: book-page join, offer email, claim URL, nav link to waitlist page.
+5. `myeventlane_rsvp.admin_promote` route missing (broken promote action on RSVP dashboard).
+
+### YAML export recommendation
+
+**Not recommended** for `organiser_manage_waitlists` in the next batch. Revisit when paid-tier organiser reporting exists or a **narrow RSVP-only** article is approved by editorial.
+
+## Commands run
+
+```bash
+git branch --show-current && git status --short
+ddev drush status --fields=bootstrap,uri
+ddev drush sqlq "SELECT status, COUNT(*) FROM mel_ticket_waitlist_entry GROUP BY status"
+ddev drush sqlq "SELECT id, waitlist_enabled, auto_promote_waitlist FROM mel_ticket_type WHERE waitlist_enabled=1 LIMIT 5"
+ddev drush ev # WaitlistManagementController::access + route paths
+```
+
+**Residual risk:** Local DB has no `event_attendee` waitlist rows; paid waitlist browser flow not exercised; production may differ where tiers were configured outside Event Studio.


### PR DESCRIPTION
## Summary

Verifies the organiser waitlist help draft and keeps it blocked.

## Findings

- RSVP waitlist list and export are available for organisers.
- Public RSVP waitlist signup exists.
- Paid ticket waitlist join and claim flows exist for buyers.
- Paid ticket waitlists do not yet have organiser list/export/admin surfaces.
- RSVP auto-promotion is not wired to live flows.
- Waitlist CSV contains personal information and needs privacy-safe wording.

## Decision

Do not export or publish `organiser-manage-waitlists.md` yet.

Recommended future content path:
- Either split a narrow RSVP-only organiser waitlist article
- Or revisit after paid ticket organiser reporting/list/export exists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes, but they adjust guidance about organiser waitlist capabilities and explicitly block publication/export until missing paid-tier tooling and RSVP auto-promotion wiring are verified.
> 
> **Overview**
> Clarifies `organiser-manage-waitlists.md` to **separate RSVP/attendance waitlists from paid ticket waitlists**, adding explicit verified routes (view/export/signup), and tightening language around *what is not yet supported* (no organiser paid-waitlist list/export, Event Studio can’t toggle paid waitlist fields, auto-promote/email flows not verified). It also adds privacy-focused wording for waitlist exports and updates “next batch” register notes to keep the article blocked.
> 
> Adds a new `organiser-waitlists-verification.md` QA log capturing the code-audit findings, verification scope, and explicit blockers for publishing/exporting this draft.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8c6a12407a3d8ab7826071b048ab94b8d3390f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->