### PR TITLE
Docs/restore batch 05 export yaml

### DIFF
--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -1,21 +1,21 @@
 # Next Help Centre batch — draft register
 
-**Date:** 2026-05-23 (register updated after batch 06 import)  
+**Date:** 2026-05-23 (reconciled against import logs on `main`)  
 **Folder:** `docs/content-audit/help-article-drafts/next-batch/`  
-**Importer:** Batch 06 live import complete (see `help-articles-batch-06-import-log.md`). Other rows unchanged unless noted.
+**Importer:** Batches 04, 05, and 06 live imports complete (see `help-articles-batch-04-import-log.md`, `help-articles-batch-05-import-log.md`, `help-articles-batch-06-import-log.md`). Batch 02 exported only — no import log.
 
 | Draft | Audience | Recommended alias | Ready to publish? | Ready to export? | Export batch | Needs verification | Notes |
 |-------|----------|-------------------|-------------------|------------------|--------------|--------------------|-------|
-| how-to-access-your-tickets.md | public | /help/attendees/how-to-access-your-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; seed merge on import |
-| how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
-| add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy |
+| how-to-access-your-tickets.md | public | /help/attendees/how-to-access-your-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** (no import log) |
+| how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** |
+| add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy; duplicate of nid **1501** — merge/update, not new node |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
-| missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
+| missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** |
 | organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | RSVP list/export verified in code; paid-tier organiser UI/export missing; RSVP auto-promote not wired; browser QA pending | See organiser-waitlists-verification.md; recommended scope RSVP-only organiser section until paid reporting ships |
-| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Exported in help-articles-batch-04-2026-05.yml; importer not run |
-| attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | No | No | — | Field types; archive behaviour; export columns | Privacy-first collection guidance |
-| check-in-attendees.md | vendor | /help/vendors/check-in-attendees | **Imported** | Yes | batch_06_2026_05 | Physical device camera QR not verified | Imported 2026-05-23; node **1677** `/help/vendors/check-in-attendees`; publish-ready QA 2026-05-23; physical-camera QA still optional |
-| saved-question-templates.md | vendor | /help/vendors/saved-question-templates | No | No | — | Library permissions; edit vs clone semantics | Route `/vendor/questions` |
+| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | **Imported** | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Imported batch 04 — nid **1674** (`help-articles-batch-04-import-log.md`) |
+| attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | **Imported** | Yes | batch_05_2026_05 | — | Imported batch 05 — nid **1675** (`help-articles-batch-05-import-log.md`) |
+| check-in-attendees.md | vendor | /help/vendors/check-in-attendees | **Imported** | Yes | batch_06_2026_05 | Physical device camera QR not verified | Imported batch 06 — nid **1677** (`help-articles-batch-06-import-log.md`); physical-camera QA still optional |
+| saved-question-templates.md | vendor | /help/vendors/saved-question-templates | **Imported** | Yes | batch_05_2026_05 | — | Imported batch 05 — nid **1676** (`help-articles-batch-05-import-log.md`) |
 
 ## Publish order suggestion
 

--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-status-sweep.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-status-sweep.md
@@ -1,0 +1,78 @@
+# Next-batch Help Centre — status sweep
+
+**Date:** 2026-05-23 (reconciled against committed import logs on `main`)  
+**Scope:** Docs/status reconciliation only. No YAML export, import, publish, or product changes.  
+**Sources:** `next-batch-register.md`, `help-articles-batch-*-import-log.md`, `help-articles-batch-*-notes.md`, verification logs in this folder.
+
+## Reconciliation notes (2026-05-23)
+
+- Import logs **on `main`:** batch 04 (`help-articles-batch-04-import-log.md`), batch 06 (`help-articles-batch-06-import-log.md`), batch 05 (`help-articles-batch-05-import-log.md`, restored from `feature/help-verify-attendee-questions-docs` commit `21842c52`).
+- Import logs **missing:** batch 02, batch 03 — batch 02 trio remains **exported only** (YAML + export notes; no import log in any branch).
+- Prior sweep (commit `eb8f8cf6` on branch `docs/help-next-batch-register-sweep`, not merged) incorrectly recommended `attendee-questions-for-organisers.md` for verification — batch 05 import log shows both attendee-questions articles already imported.
+
+## Current status table
+
+| Draft | Governance status | Export batch | Evidence |
+|-------|-------------------|--------------|----------|
+| `how-to-access-your-tickets.md` | **Exported but not imported** | batch_02_2026_05 | `help-articles-batch-02-2026-05.yml`; export notes 2026-05-22; **no import log** |
+| `how-to-use-my-tickets.md` | **Exported but not imported** | batch_02_2026_05 | Same as above |
+| `missing-ticket-help.md` | **Exported but not imported** | batch_02_2026_05 | Same as above |
+| `ticket-sales-and-capacity.md` | **Published/imported** | batch_04_2026_05 | `help-articles-batch-04-import-log.md` — nid **1674**, alias `/help/vendors/ticket-sales-and-capacity` |
+| `attendee-questions-for-organisers.md` | **Published/imported** | batch_05_2026_05 | `help-articles-batch-05-import-log.md` — nid **1675**, alias `/help/vendors/attendee-questions-for-organisers` |
+| `saved-question-templates.md` | **Published/imported** | batch_05_2026_05 | `help-articles-batch-05-import-log.md` — nid **1676**, alias `/help/vendors/saved-question-templates` |
+| `check-in-attendees.md` | **Published/imported** | batch_06_2026_05 | `help-articles-batch-06-import-log.md` — nid **1677**, alias `/help/vendors/check-in-attendees` |
+| `organiser-manage-waitlists.md` | **Verified but blocked** | — | `organiser-waitlists-verification.md`; paid-tier organiser UI/reporting missing; RSVP-only partial truth |
+| `add-event-to-calendar.md` | **Duplicate/covered** + **Needs verification** | — | Live article **“Adding events to your calendar”** (nid **1501**, published); draft alias differs — prefer editorial merge/update, not new node |
+| `wallet-passes-explained.md` | **Needs verification** | — | `publish-prep/ticket-confirmation-verification.md` — wallet UI/email not browser-tested on staging |
+
+## Completed items
+
+- **Ticket sales and capacity** — imported batch 04, nid 1674.
+- **Attendee questions + saved question templates** — imported batch 05, nids 1675 and 1676.
+- **Check-in attendees** — imported batch 06, nid 1677.
+- **Post-purchase public cluster (export only)** — access tickets, use My tickets, missing ticket — YAML batch 02 ready; export-time verification complete; **import pending** (no import log).
+
+## Blocked items
+
+| Draft | Blocker |
+|-------|---------|
+| `organiser-manage-waitlists.md` | Paid ticket waitlist organiser list/config/export not shipped; `/vendor/event/{event}/waitlist` is RSVP-only; auto-promote/offer flows not E2E-verified for organiser copy |
+| `wallet-passes-explained.md` | Config-gated wallet buttons; staging purchase + device QA required before export |
+| `add-event-to-calendar.md` | **Do not add a second calendar article** — update nid 1501 after `/ics` and My Tickets parity verified |
+
+## Recommended next article
+
+**`how-to-access-your-tickets.md`** — lead article for **batch 02 import governance**
+
+## Reason for recommendation
+
+1. **Not imported** — batch 02 YAML is ready but no import log exists; this is the highest-value remaining public cluster gap.
+2. **Verification already done at export** — `post-purchase-ticket-access-verification.md` and batch 02 export notes; next action is import prep / spot-check, not greenfield QA.
+3. **Cluster fit** — first step in the public post-purchase sequence (access → use My tickets → missing ticket) aligned with published “After you book a ticket”.
+4. **Lower risk than** waitlist (blocked), wallet (browser/config), calendar (duplicate nid 1501), or re-opening batch 05/06 (import logs prove completion).
+
+## Next three safest actions (not all verification)
+
+1. **Batch 02 import governance** — `how-to-access-your-tickets.md`, `how-to-use-my-tickets.md`, `missing-ticket-help.md` (single import pass; log results).
+2. **`add-event-to-calendar.md`** — verify `/ics` and My Tickets parity, then **merge/update nid 1501** (not a new node).
+3. **`wallet-passes-explained.md`** — after staging wallet enablement and order-state browser QA.
+
+## Articles to avoid for now
+
+| Draft | Why |
+|-------|-----|
+| `add-event-to-calendar.md` | Duplicate of published nid 1501 unless scoped as editorial merge |
+| `organiser-manage-waitlists.md` | Paid-tier organiser product gaps; RSVP-only article needs explicit scope split |
+| `wallet-passes-explained.md` | Staging wallet enablement and order-state eligibility unverified |
+| `attendee-questions-for-organisers.md` | **Imported** batch 05 — do not re-verify or re-export |
+| `saved-question-templates.md` | **Imported** batch 05 — do not re-verify or re-export |
+| `check-in-attendees.md` | **Imported** batch 06 — optional physical-camera QA only |
+| `ticket-sales-and-capacity.md` | **Imported** batch 04 |
+
+## Register sync (2026-05-23)
+
+- `ticket-sales-and-capacity.md` — marked imported (nid 1674).
+- `attendee-questions-for-organisers.md` — marked imported (nid 1675).
+- `saved-question-templates.md` — marked imported (nid 1676).
+- `check-in-attendees.md` — marked imported (nid 1677); unchanged from prior register.
+- Batch 02 trio — exported only; importer **not run** (no import log).

--- a/docs/content-audit/help-article-exports/help-articles-batch-05-2026-05-notes.md
+++ b/docs/content-audit/help-article-exports/help-articles-batch-05-2026-05-notes.md
@@ -1,0 +1,59 @@
+# Help articles batch 05 — export notes
+
+**Date:** 2026-05-22  
+**YAML:** `docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml`
+
+## Articles included
+
+| Stable key | Title | Alias | Audience |
+|------------|-------|-------|----------|
+| `attendee_questions_for_organisers` | Collecting attendee questions at checkout | `/help/vendors/attendee-questions-for-organisers` | vendor |
+| `saved_question_templates` | Saved question templates | `/help/vendors/saved-question-templates` | vendor |
+
+## Verification source
+
+- Drafts: `docs/content-audit/help-article-drafts/next-batch/attendee-questions-for-organisers.md`, `saved-question-templates.md`
+- QA log: `docs/content-audit/help-article-drafts/next-batch/attendee-questions-template-verification.md`
+- Register: `docs/content-audit/help-article-drafts/next-batch/next-batch-register.md`
+
+## Privacy constraints applied in YAML
+
+- Organisers should **collect only what they need** to run the event.
+- Custom answers may contain **personal information**; exports and attendee lists should be handled accordingly.
+- Do not encourage collecting sensitive data (medical histories, government IDs, payment card details, passwords) without lawful basis and secure handling.
+- Explicit note that MyEventLane does **not** automatically block sensitive questions.
+
+## Known limitations (preserved in article copy)
+
+- **Per order** applicability can be configured in Event Studio but is **not collected at checkout yet**.
+- Saved library templates are **cloned** onto events; editing the library does **not** update existing event questions or past answers.
+- Library templates do **not** include ticket type targeting — set **Applies to** and ticket types on the event copy in **Checkout questions**.
+- Library field types are a subset of Event Studio checkout question types (no radio, email, or number in the library).
+- CSV export uses a single **Custom answers** column, not one column per question.
+- Legacy questions may still exist on individual ticket types; new questions should use the **Checkout questions** workspace.
+
+## Import commands
+
+Use the YAML path as a **positional** argument (do not use `--file`).
+
+**Dry-run:**
+
+```bash
+ddev drush mel:help-import-priority docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml --dry-run
+```
+
+**Live import:**
+
+```bash
+ddev drush mel:help-import-priority docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml --yes
+```
+
+**Post-import:**
+
+```bash
+ddev drush search-api:index mel_content
+ddev drush search-api:status mel_content
+ddev drush cr
+```
+
+Importer was **not** run as part of this export task.

--- a/docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml
+++ b/docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml
@@ -1,0 +1,111 @@
+metadata:
+  exported_from: local
+  export_reason: organiser_attendee_questions_batch_05
+  generated_at: '2026-05-22T20:26:04+10:00'
+  notes:
+    - 'attendee question articles verified from Event Studio checkout question workspace and saved question template library'
+    - 'import identity should use stable key and/or alias'
+    - 'saved question templates are copied into events; editing the library template does not update existing event questions'
+articles:
+  attendee_questions_for_organisers:
+    source_nid: null
+    title: 'Collecting attendee questions at checkout'
+    alias: '/help/vendors/attendee-questions-for-organisers'
+    audience: vendor
+    article_type: guide
+    help_status: published
+    ai_allowed: true
+    summary:
+      format: basic_html
+      value: 'How to add checkout questions in Event Studio, target ticket types, review answers, and export attendee data — while collecting only the personal information you need.'
+    body:
+      format: full_html
+      value: |-
+        <p>You can ask buyers short questions during checkout when they enter ticket holder details. Use this to collect useful logistics information without gathering more personal data than you need.</p>
+
+        <h2>What this means</h2>
+        <p>Attendee questions are custom fields attached to your <strong>event</strong> (and, for older setups, sometimes to individual ticket types). Answers are stored with each ticket holder on the booking so you can plan catering, accessibility, or session choices. Custom answers may contain <strong>personal information</strong> — treat exports and attendee lists accordingly. Keep most questions optional unless you truly need an answer to admit someone or run the session safely.</p>
+
+        <h2>What to do next</h2>
+        <ol>
+          <li>Open the event in <strong>Event Studio</strong>.</li>
+          <li>Go to <strong>Checkout questions</strong> (<code>/vendor/events/{event}/studio/questions</code>). Older links such as <code>/vendor/event/{event}/checkout-questions</code> redirect here.</li>
+          <li>Add a clear <strong>Question</strong> label — buyers should understand why you are asking.</li>
+          <li>Choose a <strong>Type</strong> (short text, long text, email, number, dropdown, checkbox, or radio). For choice types, add one option per line.</li>
+          <li>Set <strong>Required</strong> only when you need every answer.</li>
+          <li>Under <strong>Applies to</strong>, choose <strong>All ticket holders</strong> or <strong>Specific ticket types</strong> when a question only applies to some tiers.</li>
+          <li>Leave new questions <strong>Active</strong>. Use <strong>Archived</strong> to retire a question without deleting past answers.</li>
+          <li>Save, then preview checkout as a buyer before you publish.</li>
+          <li>After sales, review answers on your attendee list or export attendees — custom answers appear in a <strong>Custom answers</strong> column in the CSV export.</li>
+        </ol>
+
+        <h2>Good to know</h2>
+        <ul>
+          <li><strong>Collect only what you need</strong> to run the event. Avoid sensitive data such as full medical histories, government ID numbers, payment card details, or passwords unless you have a lawful reason and secure handling. MyEventLane does not automatically block sensitive questions — you are responsible for what you ask.</li>
+          <li>Tell buyers how you will use their answers and how long you will keep them. Follow your privacy policy and applicable law.</li>
+          <li><strong>Per order</strong> questions can be configured in Event Studio but are <strong>not collected at checkout yet</strong> — use per-ticket or ticket-type questions instead.</li>
+          <li><strong>First name, last name, and email</strong> are collected separately for each ticket holder. Do not duplicate those unless your process truly requires it.</li>
+          <li>If buyers have already answered a question, the system <strong>locks</strong> field type, choices, ticket targeting, and required rules. You can still tidy the label or help text, change order, or <strong>archive</strong> the question and add a new one — do not rewrite the meaning of a question that already has answers.</li>
+          <li>Events with a long-standing setup may still have questions stored on <strong>ticket types</strong>; those continue to work at checkout, but new questions should be managed from <strong>Checkout questions</strong>.</li>
+        </ul>
+
+        <h2>Related help</h2>
+        <ul>
+          <li><a href="/help/vendors/saved-question-templates">Saved question templates</a></li>
+          <li>Managing attendees and orders for your event</li>
+          <li><a href="/help/vendors/ticket-sales-and-capacity">Ticket sales and capacity</a></li>
+          <li>Community guidelines</li>
+        </ul>
+  saved_question_templates:
+    source_nid: null
+    title: 'Saved question templates'
+    alias: '/help/vendors/saved-question-templates'
+    audience: vendor
+    article_type: guide
+    help_status: published
+    ai_allowed: true
+    summary:
+      format: basic_html
+      value: 'How to build a reusable organiser question library, copy templates onto events, and set ticket-type targeting on the event copy — without changing live events when you edit the library.'
+    body:
+      format: full_html
+      value: |-
+        <p>Reuse common checkout questions across events by saving them to your organiser question library. This saves time and keeps wording consistent.</p>
+
+        <h2>What this means</h2>
+        <p>A saved question template is a reusable definition (label, field type, options, and whether it is required) stored for your <strong>organiser account</strong> (Commerce store). Templates are <strong>not</strong> shown to buyers until you add them to an event. Adding a template <strong>copies</strong> it onto the event as its own question — it is not a live link. Answers on live bookings may contain personal information once buyers respond.</p>
+
+        <h2>What to do next</h2>
+        <ol>
+          <li>Sign in to your organiser account.</li>
+          <li>Open your question library at <code>/vendor/questions</code> (you need permission to view the library).</li>
+          <li>Select <strong>Add question</strong> and enter a clear label buyers will understand.</li>
+          <li>Choose the field type: <strong>Text field</strong>, <strong>Textarea</strong>, <strong>Select (dropdown)</strong>, or <strong>Checkbox</strong>. For select or checkbox, enter one option per line.</li>
+          <li>Optionally mark the template as <strong>Required</strong> and add help text.</li>
+          <li>Save the template.</li>
+          <li>On the event, either:
+            <ul>
+              <li>In <strong>Event Studio</strong>, use <strong>Reuse from library</strong> on the tickets/attendee area and <strong>Add from library</strong>, then open <strong>Checkout questions</strong> to set ticket targeting; or</li>
+              <li>In <strong>Checkout questions</strong> (<code>/vendor/events/{event}/studio/questions</code>), recreate or adjust questions manually to match your template.</li>
+            </ul>
+          </li>
+          <li>Set <strong>Applies to</strong> and ticket types on the <strong>event copy</strong> if needed, then preview checkout before publishing.</li>
+        </ol>
+
+        <h2>Good to know</h2>
+        <ul>
+          <li>Templates belong to your organiser store. Another organiser cannot see or edit your library.</li>
+          <li><strong>Editing a saved template does not change</strong> questions already on live events or answers buyers submitted. Update the library for future events, or archive the event question and add a new one.</li>
+          <li>The library supports fewer field types than <strong>Checkout questions</strong> on an event (for example, radio, email, and number are event-only).</li>
+          <li>Saved templates do not include <strong>ticket type targeting</strong> — set that on the event after the question is attached.</li>
+          <li><strong>Collect only what you need</strong> in reusable templates. Do not store unnecessary sensitive data in the library. MyEventLane does not automatically block sensitive questions.</li>
+          <li>If buyers have already answered a question on the event, treat changes like any other checkout question: archive and add anew rather than changing type or choices.</li>
+          <li>Keep the library small. Long lists of rarely used fields slow checkout.</li>
+        </ul>
+
+        <h2>Related help</h2>
+        <ul>
+          <li><a href="/help/vendors/attendee-questions-for-organisers">Collecting attendee questions at checkout</a></li>
+          <li>Managing your event dashboard</li>
+          <li>Community guidelines</li>
+        </ul>

--- a/docs/content-audit/help-article-exports/help-articles-batch-05-import-log.md
+++ b/docs/content-audit/help-article-exports/help-articles-batch-05-import-log.md
@@ -1,0 +1,50 @@
+# Help articles batch 05 import log
+
+## Scope
+
+Imported Batch 05 organiser help articles for attendee questions and saved question templates.
+
+## Import file
+
+`docs/content-audit/help-article-exports/help-articles-batch-05-2026-05.yml`
+
+## Articles imported
+
+| Stable key | Title | Node | Alias | Audience |
+|---|---|---:|---|---|
+| `attendee_questions_for_organisers` | Collecting attendee questions at checkout | 1675 | `/help/vendors/attendee-questions-for-organisers` | vendor |
+| `saved_question_templates` | Saved question templates | 1676 | `/help/vendors/saved-question-templates` | vendor |
+
+## Dry-run result
+
+- 2 created
+- 0 updated
+- 0 skipped
+- 0 errors
+
+## Live import result
+
+- 2 created
+- 0 updated
+- 0 skipped
+- 0 errors
+
+## Search API
+
+`mel_content` after import:
+
+- 68 / 68
+- 100%
+
+## Access checks
+
+Anonymous requests:
+
+- `/help/vendors/attendee-questions-for-organisers` → HTTP 403
+- `/help/vendors/saved-question-templates` → HTTP 403
+
+This is expected because both articles are vendor audience.
+
+## Notes
+
+Privacy-first wording was preserved. The articles explain that organisers should collect only what they need and that saved templates are copied into events rather than live-linked.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes that add/restore batch 05 export/import artifacts and update tracking registers; no product or code behavior changes.
> 
> **Overview**
> Restores the **Batch 05** Help Centre export artifacts by adding `help-articles-batch-05-2026-05.yml` plus accompanying export notes and an import log documenting created nodes (**1675/1676**) and access checks.
> 
> Updates `next-batch-register.md` to reconcile statuses against committed import logs (marking batches 04–06 as imported, and batch 02 items as *exported-only/import pending*), and adds `next-batch-status-sweep.md` to capture the reconciliation rationale, blockers, and recommended next governance actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc39de4cb5aa63e7adb947164ade2f7967355bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->