### PR TITLE
docs(help): log batch 02 ticket access import

### DIFF
--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -2,15 +2,15 @@
 
 **Date:** 2026-05-23 (reconciled against import logs on `main`)  
 **Folder:** `docs/content-audit/help-article-drafts/next-batch/`  
-**Importer:** Batches 04, 05, and 06 live imports complete (see `help-articles-batch-04-import-log.md`, `help-articles-batch-05-import-log.md`, `help-articles-batch-06-import-log.md`). Batch 02 exported only — no import log.
+**Importer:** Batches 02, 04, 05, and 06 live imports complete (see `help-articles-batch-02-import-log.md`, `help-articles-batch-04-import-log.md`, `help-articles-batch-05-import-log.md`, `help-articles-batch-06-import-log.md`).
 
 | Draft | Audience | Recommended alias | Ready to publish? | Ready to export? | Export batch | Needs verification | Notes |
 |-------|----------|-------------------|-------------------|------------------|--------------|--------------------|-------|
-| how-to-access-your-tickets.md | public | /help/attendees/how-to-access-your-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** (no import log) |
-| how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** |
+| how-to-access-your-tickets.md | public | /help/attendees/how-to-access-your-tickets | **Imported** | Yes | batch_02_2026_05 | — | Imported batch 02 — nid **1670** (`help-articles-batch-02-import-log.md`); anonymous access **200**; expands “After you book a ticket” cluster |
+| how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | **Imported** | Yes | batch_02_2026_05 | — | Imported batch 02 — nid **1671**; anonymous access **200** |
 | add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy; duplicate of nid **1501** — merge/update, not new node |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
-| missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** |
+| missing-ticket-help.md | public | /help/attendees/missing-ticket-help | **Imported** | Yes | batch_02_2026_05 | — | Imported batch 02 — nid **1672**; anonymous access **200** |
 | organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | RSVP list/export verified in code; paid-tier organiser UI/export missing; RSVP auto-promote not wired; browser QA pending | See organiser-waitlists-verification.md; recommended scope RSVP-only organiser section until paid reporting ships |
 | ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | **Imported** | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Imported batch 04 — nid **1674** (`help-articles-batch-04-import-log.md`) |
 | attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | **Imported** | Yes | batch_05_2026_05 | — | Imported batch 05 — nid **1675** (`help-articles-batch-05-import-log.md`) |

--- a/docs/content-audit/help-article-exports/help-articles-batch-02-import-log.md
+++ b/docs/content-audit/help-article-exports/help-articles-batch-02-import-log.md
@@ -1,0 +1,104 @@
+# Help articles batch 02 import log
+
+## Scope
+
+Governance import for Batch 02 public post-purchase ticket access help articles:
+
+- `how_to_access_your_tickets`
+- `how_to_use_my_tickets`
+- `missing_ticket_help`
+
+Branch: `docs/help-batch-02-import-governance`  
+Date: 2026-05-23
+
+## Import file
+
+`docs/content-audit/help-article-exports/help-articles-batch-02-2026-05.yml`
+
+## Articles imported
+
+| Stable key | Title | Node | Alias | Audience | Status | AI allowed |
+|---|---|---:|---|---|---|---|
+| `how_to_access_your_tickets` | How to access your tickets | 1670 | `/help/attendees/how-to-access-your-tickets` | public | published | true |
+| `how_to_use_my_tickets` | How to use My tickets | 1671 | `/help/attendees/how-to-use-my-tickets` | public | published | true |
+| `missing_ticket_help` | Missing ticket or confirmation email | 1672 | `/help/attendees/missing-ticket-help` | public | published | true |
+
+All three nodes were already present before this governance pass (matched by `field_help_seed_key`). Live import made no field changes; this log closes the missing Batch 02 audit trail.
+
+## Product spot-check (Task C)
+
+Light verification against current product — no blockers logged.
+
+| Check | Result |
+|---|---|
+| My Tickets page (`/my-tickets`) | Present — `myeventlane_checkout_flow.my_tickets` |
+| Order / booking detail (`/my-tickets/order/{commerce_order}`) | Present — order access route and template |
+| My Tickets UI labels (Upcoming, Past, View booking) | Match article copy in `myeventlane-my-tickets.html.twig` |
+| Missing-ticket support guidance | Valid — inbox/My tickets/support steps align with published checkout and support articles |
+| Cluster overlap with “After you book a ticket” (nid **1497**, `/help/attendees/after-you-book-a-ticket`) | Intentional — Batch 02 articles expand the post-purchase cluster; cross-links in YAML bodies point to nid 1497 and related articles |
+
+Editorial notes (not blockers):
+
+- Calendar and wallet articles remain excluded from Batch 02 (see export notes).
+- Refund path on order detail uses conditional wording in `how_to_use_my_tickets` body (no exact path asserted).
+
+## Dry-run result
+
+```text
+0 created, 0 updated, 3 skipped, 0 errors
+```
+
+Per article:
+
+- `how_to_access_your_tickets`: skipped (`matched_by=seed_key`, nid=1670, no field changes)
+- `how_to_use_my_tickets`: skipped (`matched_by=seed_key`, nid=1671, no field changes)
+- `missing_ticket_help`: skipped (`matched_by=seed_key`, nid=1672, no field changes)
+
+No duplicate-create risk — importer matched existing nodes by stable seed key, not alias collision with legacy seed `how_to_access_tickets` in install config.
+
+## Live import result
+
+```text
+0 created, 0 updated, 3 skipped, 0 errors
+```
+
+Idempotent re-run confirms Batch 02 YAML is fully applied.
+
+## Search API
+
+`mel_content` after reindex and cache rebuild:
+
+- **69 / 69** indexed
+- **100%** complete
+
+Commands run:
+
+```bash
+ddev drush search-api:index mel_content
+ddev drush search-api:status mel_content
+ddev drush cr
+```
+
+## Anonymous access checks
+
+| URL | HTTP |
+|---|---|
+| `/help/attendees/how-to-access-your-tickets` | **200** |
+| `/help/attendees/how-to-use-my-tickets` | **200** |
+| `/help/attendees/missing-ticket-help` | **200** |
+
+Expected for public/attendee audience.
+
+## Overlap with “After you book a ticket”
+
+Published article nid **1497** (`/help/attendees/after-you-book-a-ticket`) remains the cluster entry point. Batch 02 adds three focused follow-ons:
+
+1. **Access** — where to find tickets (email, My tickets, links)
+2. **Use My tickets** — signed-in booking list and order detail workflow
+3. **Missing ticket** — troubleshooting when email or links fail
+
+Related-help links in all three Batch 02 bodies link to nid 1497 and to each other. No duplicate nodes created for the same aliases.
+
+## Blockers
+
+None. No code changes required for import or access verification.


### PR DESCRIPTION
Act as a senior Drupal 11 Help Centre content-governance reviewer for MyEventLane.

Goal:
Resolve calendar Help Centre duplicate governance before updating/importing the calendar article.

Scope rule:
If the product works, document it.
If the product does not work, log the blocker.
Only fix code if the broken product behaviour makes the help article impossible to verify.

This is a Help Centre governance task.
Do not create a third calendar article.
Do not run importer until duplicate handling is decided.
Do not change product code.
Do not alter calendar route behaviour.
Do not duplicate content.

Current branch:
docs/help-calendar-duplicate-governance

Known findings:
- nid 1501 exists:
  - title: Adding events to your calendar
  - alias: /node/1501 locally
  - body: one sentence stub
  - seed key: empty
  - audience field locally empty
  - published and AI allowed
- nid 1673 exists:
  - title: Adding an event to your calendar
  - alias: /help/attendees/add-event-to-calendar
  - seed key: add_event_to_calendar
  - full body copy
  - published
- Draft verified:
  docs/content-audit/help-article-drafts/next-batch/add-event-to-calendar.md
- QA log:
  docs/content-audit/help-article-drafts/next-batch/calendar-article-merge-qa.md

Task A — Confirm current DB truth

Using Drush/PHP/SQL, confirm both nodes:

For nid 1501 and nid 1673 record:
- title
- status
- alias
- field_help_seed_key
- field_audience / field_help_audience
- field_help_status
- field_help_ai_allowed
- body summary/body length
- changed date if useful

Task B — Decide canonical article

Use this decision unless DB evidence proves otherwise:

Canonical article should be:
- nid 1501
- title: Adding events to your calendar
- alias: /help/attendees/add-event-to-calendar
- seed key: add_event_to_calendar
- audience: public
- help_status: published
- ai_allowed: true

Duplicate nid 1673 should not remain independently published at the same topic.

Task C — Choose duplicate handling method

Recommend the safest approach for nid 1673:

Option 1:
Unpublish nid 1673 and remove its canonical alias, then assign alias/seed to nid 1501.

Option 2:
Change nid 1673 to an archived/draft status and add a redirect to nid 1501 if Redirect module is available.

Option 3:
If importer identity cannot safely target nid 1501 because seed key currently belongs to 1673, do not import yet. Instead create a manual migration/cleanup plan.

Do not perform destructive changes unless explicitly safe and reversible.

Task D — Create governance note

Create:

docs/content-audit/help-article-drafts/next-batch/calendar-duplicate-governance.md

Include:
- node comparison table
- canonical decision
- duplicate risk
- recommended duplicate handling
- exact pre-import cleanup steps
- whether importer can safely update nid 1501
- whether manual DB/content edit is needed
- rollback notes

Task E — Update register / QA docs

Update:
docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
docs/content-audit/help-article-drafts/next-batch/calendar-article-merge-qa.md

Make clear:
- Batch 02 is already imported/closed if register says otherwise
- Calendar article is ready for content update only after duplicate 1673 is retired/redirected
- Do not create new article
- Do not import calendar YAML while seed key belongs to nid 1673

Task F — Validation

Run:
git status --short
git diff --stat

Docs-only. No build required unless pre-commit runs it.

Task G — Commit

Stage only:
- docs/content-audit/help-article-drafts/next-batch/calendar-duplicate-governance.md
- docs/content-audit/help-article-drafts/next-batch/calendar-article-merge-qa.md
- docs/content-audit/help-article-drafts/next-batch/next-batch-register.md

Commit message:
docs(help): record calendar duplicate governance

Final response:
Return:
1. nid 1501 details
2. nid 1673 details
3. Canonical article decision
4. Duplicate handling recommendation
5. Whether importer can safely update nid 1501 now
6. Files changed
7. Commit hash
8. Next exact step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates audit/register metadata and adds an import log; no application code or runtime behavior is modified.
> 
> **Overview**
> Marks the Batch 02 public ticket-access drafts as **Imported** in `next-batch-register.md`, including node IDs and anonymous-access verification, and updates the importer note to include Batch 02.
> 
> Adds a new `help-articles-batch-02-import-log.md` documenting the Batch 02 governance import results (dry-run/live outcomes, seed-key matching, search reindex, and access checks) to close the previously missing audit trail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fb9149411ca68b9229f5cec3911cb990ff5652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->