### PR TITLE
Protect staging from search indexing: add runbook (X-Robots-Tag + Basic Auth guidance)

### DIFF
--- a/STAGING_INDEXING_PROTECTION.md
+++ b/STAGING_INDEXING_PROTECTION.md
@@ -1,0 +1,99 @@
+# Staging indexing protection (`staging.myeventlane.com.au`)
+
+This runbook applies **only** to staging and must never be applied to production (`myeventlane.com.au`).
+
+## 1) Server-level `X-Robots-Tag` (required)
+
+Add the header at the web server / edge layer for `staging.myeventlane.com.au` with `always` semantics so it is present on:
+
+- HTML responses
+- Drupal routes
+- static files (including PDFs)
+- error pages (403/404)
+
+### Nginx example
+
+```nginx
+server {
+  server_name staging.myeventlane.com.au;
+
+  add_header X-Robots-Tag "noindex, nofollow" always;
+
+  # Optional additional hardening.
+  add_header Cache-Control "no-store" always;
+}
+```
+
+### Apache vhost example
+
+```apache
+<VirtualHost *:443>
+  ServerName staging.myeventlane.com.au
+
+  Header always set X-Robots-Tag "noindex, nofollow"
+</VirtualHost>
+```
+
+## 2) Optional additional protection: HTTP Basic Auth
+
+If supported by hosting, add Basic Auth only on staging (recommended).
+
+Do not commit plaintext credentials. Generate/pass secrets from environment/hosting secret manager.
+
+### Nginx sketch (staging only)
+
+```nginx
+server {
+  server_name staging.myeventlane.com.au;
+
+  auth_basic "Restricted staging";
+  auth_basic_user_file /etc/nginx/htpasswd/staging;
+}
+```
+
+Provision `/etc/nginx/htpasswd/staging` from deployment secret material (not from git).
+
+## 3) Drupal sitemap safety check (do not rely on robots.txt alone)
+
+This repository does not currently include sitemap module config (`simple_sitemap` / `xmlsitemap`) in `config/sync`.
+
+Verify in staging DB during deploy:
+
+```bash
+drush pml --status=enabled --type=module | grep -E 'simple_sitemap|xmlsitemap'
+```
+
+If either module is enabled on staging, disable sitemap generation/submission there only (do **not** change production behavior), e.g.:
+
+```bash
+drush pm:uninstall simple_sitemap xmlsitemap -y
+```
+
+If uninstall is not appropriate, set module-specific staging-only config to disable generation/submission.
+
+## 4) Verification commands
+
+Run after deployment:
+
+```bash
+curl -I https://staging.myeventlane.com.au
+```
+
+Expected header:
+
+- `X-Robots-Tag: noindex, nofollow`
+
+Production must not include the staging directive:
+
+```bash
+curl -I https://myeventlane.com.au
+```
+
+Expected:
+
+- no `X-Robots-Tag: noindex, nofollow` staging header on production.
+
+## Notes
+
+- `web/robots.txt` may remain present, but it is not the primary control.
+- Server/edge header and optional Basic Auth are the primary protection layers.


### PR DESCRIPTION
### Motivation
- Ensure `staging.myeventlane.com.au` is not indexed by search engines by applying server/edge-level controls rather than relying only on `robots.txt` or Drupal runtime config. 
- Provide a safe, staging-only rollout that covers HTML, static files (PDFs), Drupal routes and error pages, and that avoids changing production behavior. 
- Recommend an additional access layer (HTTP Basic Auth) where the hosting stack supports it, using deployment-managed secrets rather than committing credentials. 

### Description
- Add `STAGING_INDEXING_PROTECTION.md` documenting required server-level header (`X-Robots-Tag: noindex, nofollow`) with `always` semantics and example snippets for Nginx and Apache. 
- Include optional HTTP Basic Auth guidance for staging-only enforcement with instructions to store credentials in deployment/hosting secrets (no plaintext in git). 
- Include Drupal sitemap safety checks (`simple_sitemap` / `xmlsitemap`) with `drush` commands to detect and disable sitemap generation on staging only. 
- Commit the runbook on branch `staging-protection-search-indexing` so operators have clear deployment instructions when no host vhost config is present in the repo. 

### Testing
- Searched the repo for relevant configuration and code with `rg` and confirmed no committed production/staging vhost/edge config; found existing Drupal `StagingSecuritySubscriber` but opted for server/edge-runbook to avoid forcing runtime changes. 
- Created and committed `STAGING_INDEXING_PROTECTION.md` on branch `staging-protection-search-indexing` which succeeded. 
- Ran verification commands `curl -I -s https://staging.myeventlane.com.au` and `curl -I -s https://myeventlane.com.au` from this environment and both returned `HTTP/1.1 403 Forbidden` from the Envoy edge, so the presence of the header could not be validated here and must be re-checked after host-level config is applied. 
- Searched `config/sync` for sitemap module config and found none, and included `drush` checks in the runbook for operators to run on staging to ensure sitemap generation/submission is disabled if the modules are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117091fbb48328b991d6a0ce14820d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation and does not change runtime code or configuration. The main risk is operational (misapplying the guidance to production).
> 
> **Overview**
> Adds `STAGING_INDEXING_PROTECTION.md`, a staging-only runbook instructing operators to set an edge/server `X-Robots-Tag: noindex, nofollow` header (with `always` semantics) to cover HTML, Drupal routes, static assets, and error pages.
> 
> The doc also recommends optional staging-only HTTP Basic Auth, includes `drush` commands to detect/disable `simple_sitemap`/`xmlsitemap` on staging, and provides `curl -I` verification steps to ensure production is unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21fda4bb17fd415a4d24f03dabcb00963a9309e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->