### PR TITLE
fix(public): tighten event discovery seo and staging hygiene

### DIFF
--- a/web/modules/custom/myeventlane_api/src/Controller/PublicEventApiController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/PublicEventApiController.php
@@ -9,7 +9,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_api\Service\ApiResponseFormatter;
 use Drupal\myeventlane_api\Service\EventSerializer;
 use Drupal\myeventlane_api\Service\RateLimiterService;
-use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -28,7 +28,7 @@ final class PublicEventApiController extends ControllerBase {
     private readonly ApiResponseFormatter $responseFormatter,
     private readonly EventSerializer $eventSerializer,
     private readonly RateLimiterService $rateLimiter,
-    private readonly EventStateResolverInterface $eventStateResolver,
+    private readonly PublicEventVisibility $publicEventVisibility,
   ) {
     $this->entityTypeManager = $entityTypeManager;
   }
@@ -42,7 +42,7 @@ final class PublicEventApiController extends ControllerBase {
       $container->get('myeventlane_api.response_formatter'),
       $container->get('myeventlane_api.event_serializer'),
       $container->get('myeventlane_api.rate_limiter'),
-      $container->get('myeventlane_event_state.resolver'),
+      $container->get('myeventlane_event.public_visibility'),
     );
   }
 
@@ -145,17 +145,11 @@ final class PublicEventApiController extends ControllerBase {
 
     $events = $storage->loadMultiple($event_ids);
 
-    // Filter by visibility and state.
     $public_events = [];
     foreach ($events as $event) {
-      // Skip cancelled events unless explicitly requested.
-      $state = $this->eventStateResolver->resolveState($event);
-      if ($state === 'cancelled') {
+      if (!$this->publicEventVisibility->isPubliclyListable($event)) {
         continue;
       }
-
-      // @todo Add visibility check (public/unlisted/private) if field exists.
-      // For now, assume all published events are public.
       $public_events[] = $event;
     }
 
@@ -223,13 +217,12 @@ final class PublicEventApiController extends ControllerBase {
       return $this->responseFormatter->error('NOT_FOUND', 'Event not found.', 404);
     }
 
-    // Check state - skip cancelled unless explicitly requested.
-    $state = $this->eventStateResolver->resolveState($node);
-    if ($state === 'cancelled' && !$request->query->getBoolean('include_cancelled')) {
+    if (!$this->publicEventVisibility->isPubliclyListable($node)
+      && !($request->query->getBoolean('include_cancelled')
+        && $node->hasField('field_event_state')
+        && (string) $node->get('field_event_state')->value === 'cancelled')) {
       return $this->responseFormatter->error('NOT_FOUND', 'Event not found.', 404);
     }
-
-    // @todo Add visibility check (public/unlisted/private).
     try {
       $data = $this->eventSerializer->serializePublic($node);
       $response = $this->responseFormatter->success($data);

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -285,6 +285,9 @@ function myeventlane_auth_register_page_is_create_event_flow(Request $request): 
  * theme, including Gin Login on /user/register.
  */
 function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $is_vendor_registration = \Drupal::request()->query->get('vendor') === '1'
+    || str_contains((string) \Drupal::request()->query->get('destination', ''), '/vendor/onboard');
+
   foreach ([
     'user_picture',
     'contact',
@@ -296,6 +299,17 @@ function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateI
     if (isset($form[$key])) {
       $form[$key]['#access'] = FALSE;
     }
+  }
+
+  if ($is_vendor_registration) {
+    $form_state->set('is_vendor_registration', TRUE);
+    if (isset($form['account']['name'])) {
+      $form['account']['name']['#access'] = FALSE;
+    }
+    elseif (isset($form['name'])) {
+      $form['name']['#access'] = FALSE;
+    }
+    $form['#validate'][] = 'myeventlane_auth_vendor_register_set_username_from_mail';
   }
   foreach (['field_marketing', 'field_vendor'] as $key) {
     if (isset($form[$key])) {
@@ -358,6 +372,22 @@ function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateI
   ])));
 
   $form['actions']['submit']['#submit'][] = 'myeventlane_auth_user_register_form_post_save_redirect';
+}
+
+/**
+ * Sets username from email for vendor onboarding registration.
+ */
+function myeventlane_auth_vendor_register_set_username_from_mail(array &$form, FormStateInterface $form_state): void {
+  if (!$form_state->get('is_vendor_registration')) {
+    return;
+  }
+  $mail = trim((string) $form_state->getValue('mail'));
+  if ($mail === '') {
+    return;
+  }
+  $local = strstr($mail, '@', TRUE);
+  $base = preg_replace('/[^a-z0-9._-]+/i', '_', is_string($local) && $local !== '' ? $local : $mail) ?: 'vendor';
+  $form_state->setValue('name', substr($base, 0, 60));
 }
 
 /**

--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/StagingSecuritySubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/StagingSecuritySubscriber.php
@@ -57,21 +57,23 @@ final class StagingSecuritySubscriber implements EventSubscriberInterface {
       $is_staging = ($env_staging === '1' || $env_staging === 'true');
     }
 
-    // Auto-detect by hostname if not explicitly set.
+    // Auto-detect by hostname if not explicitly set (staging hosts only).
     if (!$is_staging && isset($_SERVER['HTTP_HOST'])) {
-      $host = $_SERVER['HTTP_HOST'];
-      $staging_patterns = [
-        '/staging\./i',
-        '/stage\./i',
-        '/test\./i',
-        '/dev\./i',
-        '/\.staging\./i',
+      $host = strtolower((string) $_SERVER['HTTP_HOST']);
+      $staging_hosts = [
+        'staging.myeventlane.com.au',
+        'vendor.staging.myeventlane.com.au',
+        'admin.staging.myeventlane.com.au',
+        'staging.myeventlane.com',
+        'vendor.staging.myeventlane.com',
+        'admin.staging.myeventlane.com',
       ];
-      foreach ($staging_patterns as $pattern) {
-        if (preg_match($pattern, $host)) {
-          $is_staging = TRUE;
-          break;
-        }
+      if (in_array($host, $staging_hosts, TRUE)) {
+        $is_staging = TRUE;
+      }
+      elseif (str_contains($host, 'staging.myeventlane.com.au')
+        || str_contains($host, 'staging.myeventlane.com')) {
+        $is_staging = TRUE;
       }
     }
 

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
@@ -155,7 +155,15 @@ final class HelpCentreController extends ControllerBase {
   /**
    * Renders the vendor Help Centre listing.
    */
-  public function vendorsIndex(): array {
+  public function vendorsIndex(): array|RedirectResponse {
+    $account = $this->currentUser();
+    if (!$account->isAuthenticated()) {
+      return $this->redirect('user.login', [], [
+        'query' => [
+          'destination' => '/help/vendors',
+        ],
+      ], 302);
+    }
     return $this->buildViewPage((string) $this->t('Organiser help'), 'mel_help_vendor_help', 'block_vendors', TRUE);
   }
 
@@ -304,7 +312,11 @@ final class HelpCentreController extends ControllerBase {
           ],
           [
             'title' => (string) $this->t('Vendor help'),
-            'url' => Url::fromRoute('myeventlane_help_centre.vendors_index')->toString(),
+            'url' => $this->currentUser()->isAuthenticated()
+              ? Url::fromRoute('myeventlane_help_centre.vendors_index')->toString()
+              : Url::fromRoute('user.login', [], [
+                'query' => ['destination' => '/help/vendors'],
+              ])->toString(),
             'excerpt' => (string) $this->t('Vendor profile, applications, and organiser console basics.'),
           ],
         ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes public event discovery rules and registration form behavior, which can affect SEO/indexability and user signup flows if the new gating logic is wrong. Also tightens staging environment detection, which could unintentionally apply noindex/no-cache headers on misclassified hosts.
> 
> **Overview**
> **Public event API now uses a single canonical visibility gate.** `PublicEventApiController` stops using the event-state resolver directly and instead filters both list and detail endpoints through `PublicEventVisibility::isPubliclyListable()`, with a narrow exception to allow cancelled events only when `include_cancelled=1` is explicitly requested.
> 
> **Vendor onboarding/help access is tightened.** The user registration form detects vendor onboarding via query/destination, hides the username field, and derives the username from the email via a new validator. Vendor Help Centre pages and IA links now redirect unauthenticated users to login with `destination=/help/vendors`.
> 
> **Staging hygiene is stricter.** `StagingSecuritySubscriber` replaces broad hostname regex detection with an allowlist/substring match for known staging hosts before adding `X-Robots-Tag` and no-cache headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2f2212a564d87beea84229f335a9aa246e0867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->