### PR TITLE
Fix/bugbot event card cache and schema availability

### DIFF
--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -82,6 +82,7 @@ final class EventCardViewModel {
     }
 
     $cacheability = CacheableMetadata::createFromObject($node);
+    $this->addCategoryCacheability($node, $cacheability);
     $canView = $node->access('view', $this->currentUser);
     $url = $canView ? $node->toUrl()->toString() : '';
 
@@ -518,6 +519,21 @@ final class EventCardViewModel {
       ],
       '#create_placeholder' => TRUE,
     ];
+  }
+
+  /**
+   * Ensures category pill data invalidates when the referenced term changes.
+   */
+  private function addCategoryCacheability(NodeInterface $node, CacheableMetadata $cacheability): void {
+    if (!$node->hasField('field_category') || $node->get('field_category')->isEmpty()) {
+      return;
+    }
+    foreach ($node->get('field_category')->referencedEntities() as $term) {
+      if ($term !== NULL) {
+        $cacheability->addCacheableDependency($term);
+        return;
+      }
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
@@ -154,7 +154,7 @@ final class EventStructuredDataBuilder {
     $offer = [
       '@type' => 'Offer',
       'url' => $bookUrl,
-      'availability' => 'https://schema.org/InStock',
+      'availability' => $this->resolveOfferAvailability($event),
     ];
 
     if ($mode === BookingFlowResolver::MODE_RSVP) {
@@ -178,6 +178,14 @@ final class EventStructuredDataBuilder {
     $offer['priceCurrency'] = $lowest->getCurrencyCode();
 
     return $offer;
+  }
+
+  private function resolveOfferAvailability(NodeInterface $event): string {
+    if ($this->bookingFlowResolver->getAvailabilityState($event) === BookingFlowResolver::AVAILABILITY_SOLD_OUT) {
+      return 'https://schema.org/SoldOut';
+    }
+
+    return 'https://schema.org/InStock';
   }
 
   private function formatTimestamp(int $timestamp): string {

--- a/web/modules/custom/myeventlane_theme_settings/src/Form/HeroSettingsForm.php
+++ b/web/modules/custom/myeventlane_theme_settings/src/Form/HeroSettingsForm.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_theme_settings\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\FileInterface;
 use Drupal\file\FileUsage\FileUsageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -33,23 +35,27 @@ final class HeroSettingsForm extends ConfigFormBase {
   ];
 
   /**
-   * The file usage service.
+   * Constructs HeroSettingsForm.
    */
-  private FileUsageInterface $fileUsage;
-
-  /**
-   * The entity type manager.
-   */
-  private EntityTypeManagerInterface $entityTypeManager;
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config_manager,
+    protected FileUsageInterface $fileUsage,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($config_factory, $typed_config_manager);
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    $instance = parent::create($container);
-    $instance->fileUsage = $container->get('file.usage');
-    $instance->entityTypeManager = $container->get('entity_type.manager');
-    return $instance;
+    return new static(
+      $container->get('config.factory'),
+      $container->get('config.typed'),
+      $container->get('file.usage'),
+      $container->get('entity_type.manager'),
+    );
   }
 
   /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/base/_reset.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/base/_reset.scss
@@ -55,9 +55,12 @@ body.mel-vendor a {
   transition: color 0.15s ease-in-out;
 
   &:hover,
-  &:focus {
+  &:focus,
+  &:focus-visible,
+  &:active,
+  &:visited {
     color: $primary-dark;
-    text-decoration: underline;
+    text-decoration: none;
   }
 }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -110,3 +110,14 @@
   @include meta.load-css('pages/settings');
   @include meta.load-css('pages/vendor-console-stack');
 }
+
+// No underline on vendor console links (wins over component hover rules).
+body.mel-vendor a:any-link,
+body.mel-vendor a:hover,
+body.mel-vendor a:active,
+body.mel-vendor a:focus,
+body.mel-vendor a:focus-visible,
+body.mel-vendor a:visited {
+  text-decoration: none !important;
+  text-decoration-line: none !important;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect Drupal render caching and SEO JSON-LD output for event pages, which can impact content freshness and search indexing but are small and localized.
> 
> **Overview**
> Fixes event card caching by adding referenced `field_category` term(s) as cacheable dependencies in `EventCardViewModel`, ensuring the category pill updates when the taxonomy term changes.
> 
> Updates event JSON-LD offer generation to set schema.org `availability` to `SoldOut` when the booking flow resolver reports a sold-out state (otherwise `InStock`).
> 
> Refactors `HeroSettingsForm` to use constructor dependency injection instead of late property assignment, and adjusts vendor theme link styles to prevent underlines across link states (including via a global override in `main.scss`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10a31eb8a3fb9727dccba202490a780f8925e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->