### PR TITLE
fix(theme): merge canonical URL cache tags for event card links

### DIFF
--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2891,7 +2891,8 @@ function myeventlane_theme_preprocess_views_view_fields(array &$variables): void
       }
       $variables['#cache']['tags'] = Cache::mergeTags(
         (array) ($variables['#cache']['tags'] ?? []),
-        $event_node->getCacheTags()
+        $event_node->getCacheTags(),
+        $canonical->getCacheTags()
       );
       $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
         (array) ($variables['#cache']['contexts'] ?? []),


### PR DESCRIPTION
Views field preprocess now includes path alias cache tags from the canonical URL object so cached event cards invalidate when Pathauto aliases change, matching EventCardViewModel cacheability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional cache tags in a views preprocess hook to ensure event card link caches invalidate when canonical/path alias metadata changes.
> 
> **Overview**
> Ensures event card links rendered via `preprocess_views_view_fields()` carry full cacheability metadata by merging cache tags from the canonical `Url` object (in addition to the event node tags).
> 
> This makes cached Views-based event cards correctly invalidate when the canonical URL/path alias changes, avoiding stale links in cached listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3afb662929a25eb29652bcf5d3eeb0f5346159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->