### PR TITLE
Cursor/card view mode 00581

### DIFF
--- a/config/sync/views.view.all_events.yml
+++ b/config/sync/views.view.all_events.yml
@@ -124,7 +124,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:

--- a/config/sync/views.view.featured_discover_recommended.yml
+++ b/config/sync/views.view.featured_discover_recommended.yml
@@ -148,7 +148,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:

--- a/config/sync/views.view.front_discover_events.yml
+++ b/config/sync/views.view.front_discover_events.yml
@@ -145,7 +145,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:
@@ -180,7 +180,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       display_extenders: {  }
       block_description: 'Front: Discover Events'
       block_category: MyEventLane

--- a/config/sync/views.view.front_recommended_events.yml
+++ b/config/sync/views.view.front_recommended_events.yml
@@ -162,7 +162,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:

--- a/config/sync/views.view.mel_saved_events.yml
+++ b/config/sync/views.view.mel_saved_events.yml
@@ -148,7 +148,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options: {  }

--- a/config/sync/views.view.new_events.yml
+++ b/config/sync/views.view.new_events.yml
@@ -173,7 +173,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.list_card
+    - core.entity_view_mode.node.compact_commerce
     - core.entity_view_mode.node.teaser
     - node.type.event
   module:
@@ -579,7 +579,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -389,7 +389,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: list_card
+          view_mode: compact_commerce
       query:
         type: views_query
         options:
@@ -655,7 +655,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         pager: false
         row: false
@@ -1452,7 +1452,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         pager: false
         row: false
@@ -1808,7 +1808,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         empty: false
         pager: false
@@ -2129,7 +2129,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         title: false
         pager: false
@@ -2524,7 +2524,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         empty: false
         pager: false
@@ -2842,7 +2842,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         title: false
         pager: false
@@ -3150,7 +3150,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: list_card
+          view_mode: compact_commerce
       defaults:
         title: false
         pager: false

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -355,6 +355,8 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   min-height: calc(1.25em * 2);
+  // WebKit line-clamp can clip the first/last glyph at the box edge (listing grids).
+  padding-inline: 1px;
 }
 
 .mel-event-card__when {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-cards.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-cards.scss
@@ -195,6 +195,46 @@
   }
 }
 
+// list_card in event grids: always stack (grid cells are too narrow for horizontal layout).
+// Container queries are a progressive enhancement; grids must not rely on them alone.
+.mel-grid--events .mel-event-card--list,
+.mel-event-grid.mel-grid--events .mel-event-card--list {
+  .mel-event-card__link {
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: unset;
+    gap: 0;
+    align-items: stretch;
+  }
+
+  .mel-event-card__image,
+  .mel-event-card__media {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    aspect-ratio: 4 / 3;
+    border-radius: mel.$mel-ds-radius-md mel.$mel-ds-radius-md 0 0;
+  }
+
+  .mel-event-card__body,
+  .mel-event-card__content {
+    position: static;
+    inset: auto;
+    flex: 1;
+    width: 100%;
+    min-width: 0;
+    padding: 14px 16px 16px;
+  }
+
+  .mel-event-card__title {
+    min-height: calc(1.25em * 2);
+  }
+
+  .mel-event-card__cta-row {
+    margin-top: auto;
+  }
+}
+
 // list_card listings share the event grid (1 → 2 → 4 columns); layout/_grid.scss + discovery.
 .mel-event-list {
   width: 100%;

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
@@ -25,7 +25,8 @@
   grid-template-columns: minmax(0, 1fr);
   width: 100%;
   min-width: 0;
-  overflow-x: clip;
+  // Avoid clipping card copy when a row was wider than its column (list_card horizontal layout).
+  overflow-x: visible;
 }
 
 .mel-discovery .mel-event-grid.mel-grid--events > *,

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -15,7 +15,7 @@
 {% set _variant_raw = variant|default(mel_event_card_variant|default('standard')) %}
 {% set _layout = layout|default(mel_event_card_layout|default('')) %}
 {% set _is_hero = _variant_raw in ['featured_hero', 'editorial'] or (_variant_raw == 'featured' and _layout == 'hero') %}
-{% set _variant = _variant_raw in ['featured_hero', 'editorial'] ? 'featured' : (_variant_raw == 'list' ? 'standard' : _variant_raw) %}
+{% set _variant = _variant_raw in ['featured_hero', 'editorial'] ? 'featured' : _variant_raw %}
 {% set _css_modifier = _variant_raw in ['featured_hero', 'editorial'] ? 'editorial' : (_variant_raw in ['compact', 'list'] ? _variant_raw : _variant) %}
 
 {% set _title = card_title|default(title|default('')) %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Saved events — list_card grid.
+ * Saved events — compact_commerce grid.
  */
 #}
 {% include '@myeventlane_theme/includes/mel-event-rows-wrapper.html.twig' with {

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--taxonomy-term.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--taxonomy-term.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Taxonomy term listing — event grid when view mode is list_card.
+ * Taxonomy term listing — event grid (compact_commerce).
  */
 #}
 {% include '@myeventlane_theme/includes/mel-event-rows-wrapper.html.twig' with {

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--page-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--page-events.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Upcoming Events — page_events: browse grid (list_card).
+ * Upcoming Events — page_events: browse grid (compact_commerce).
  */
 #}
 {% include '@myeventlane_theme/includes/mel-event-rows-wrapper.html.twig' with {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple high-traffic event listing views and shared card styling, so regressions would be user-visible across discovery/browse pages, but changes are limited to configuration and CSS/Twig presentation.
> 
> **Overview**
> Updates several Drupal Views that render event node rows to use the `compact_commerce` view mode instead of `list_card` (including discovery, recommended, upcoming, new, saved, and taxonomy term listings), and adjusts the `taxonomy_term` view’s config dependency accordingly.
> 
> Refines card presentation to match the new layouts: keeps the `list` variant as `list` in `mel-event-card.html.twig` (instead of normalizing it to `standard`), adds CSS rules to force `list_card` rows to stack vertically when used inside event grids, and tweaks overflow/title clipping to prevent truncated text in grid contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc1d133271f6b5cc5057dfb807088b80fd1b5e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->