### PR TITLE
fix(public): tighten public UX hygiene and event visibility

### DIFF
--- a/config/sync/views.view.mel_blog.yml
+++ b/config/sync/views.view.mel_blog.yml
@@ -57,7 +57,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No guides yet</h3><p class="mel-empty-state__what">Organiser guides are coming soon. Start by browsing events or creating your first listing.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/create-event">Create an event</a> <a class="mel-link" href="/events">Explore events</a></p></div>'
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">Guides are coming soon</h3><p class="mel-empty-state__what">We''re preparing practical guides for better nights out and smoother event hosting.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Browse events</a> <a class="mel-link" href="/help">Visit Help Centre</a></p></div>'
             format: full_html
           tokenize: false
       sorts:

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -970,7 +970,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">Nothing listed for tonight yet</h3><p class="mel-empty-state__what">Explore upcoming events or check back as hosts publish new plans.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Explore events</a> <a class="mel-link" href="/events/this-weekend">Browse this weekend</a></p></div>'
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">Nothing on tonight yet</h3><p class="mel-empty-state__what">Browse upcoming events across MyEventLane — new listings land throughout the day.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Browse upcoming events</a></p></div>'
             format: full_html
           tokenize: false
       filters:

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -891,6 +891,8 @@ function myeventlane_event_entity_view_alter(array &$build, EntityInterface $ent
 
 /**
  * Implements hook_preprocess_node().
+ *
+ * Event bundle: CTA/state, media, recommendations, and public placeholder hygiene.
  */
 function myeventlane_event_preprocess_node(array &$variables): void {
   if (empty($variables['node']) || !$variables['node'] instanceof NodeInterface) {
@@ -1226,6 +1228,43 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     $view_mode,
     $bookingAvailability
   );
+
+  // Hide obvious placeholder strings on public event teasers and summaries.
+  $public_visibility_modes = [
+    'full',
+    'teaser',
+    'teaser_featured',
+    'teaser_tonight',
+    'compact_commerce',
+    'list_card',
+    'editorial_magazine',
+  ];
+  if (in_array($view_mode, $public_visibility_modes, TRUE) && \Drupal::hasService('myeventlane_event.public_visibility')) {
+    /** @var \Drupal\myeventlane_event\Service\PublicEventVisibility $visibility */
+    $visibility = \Drupal::service('myeventlane_event.public_visibility');
+    $fallback = $visibility->publicDisplayFallbackMessage();
+
+    foreach (['field_event_intro', 'field_event_summary'] as $field_name) {
+      if (empty($variables['content'][$field_name])) {
+        continue;
+      }
+
+      $raw = $node->hasField($field_name) && !$node->get($field_name)->isEmpty()
+        ? (string) $node->get($field_name)->value
+        : NULL;
+      if ($visibility->sanitizePublicDisplayText($raw) !== NULL) {
+        continue;
+      }
+
+      $variables['content'][$field_name] = [
+        '#markup' => $fallback,
+        '#cache' => [
+          'contexts' => ['languages:language_interface'],
+          'tags' => $node->getCacheTags(),
+        ],
+      ];
+    }
+  }
 }
 
 /**
@@ -1609,4 +1648,19 @@ function myeventlane_event_preprocess_views_view(array &$variables): void {
     $context = $node;
   }
   $variables['default_chip'] = $service->getDefaultChip($context);
+}
+
+/**
+ * Implements hook_views_query_alter().
+ *
+ * Applies canonical public discovery hygiene to whitelisted View displays.
+ */
+function myeventlane_event_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query): void {
+  if (!\Drupal::hasService('myeventlane_event.public_discovery_query_alter')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_event\Service\PublicEventDiscoveryQueryAlter $alter */
+  $alter = \Drupal::service('myeventlane_event.public_discovery_query_alter');
+  $alter->alter($view, $query);
 }

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -158,6 +158,11 @@ services:
       - '@myeventlane_event_state.resolver'
       - '@datetime.time'
 
+  myeventlane_event.public_discovery_query_alter:
+    class: Drupal\myeventlane_event\Service\PublicEventDiscoveryQueryAlter
+    arguments:
+      - '@myeventlane_event.public_visibility'
+
   myeventlane_event.structured_data_builder:
     class: Drupal\myeventlane_event\Service\EventStructuredDataBuilder
     arguments:

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\myeventlane_event_state\Service\EventStateResolver;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Applies canonical public discovery filters to whitelisted Views queries.
+ *
+ * Keeps admin/vendor dashboard Views unchanged by display ID allow-listing.
+ */
+final class PublicEventDiscoveryQueryAlter {
+
+  /**
+   * Public discovery Views and display IDs that receive hygiene filters.
+   *
+   * @var array<string, list<string>>
+   */
+  private const PUBLIC_DISCOVERY_DISPLAYS = [
+    'upcoming_events' => [
+      'page_events',
+      'page_free',
+      'page_today',
+      'page_this_weekend',
+      'page_popular',
+      'page_category',
+      'homepage_latest',
+      'homepage_tonight',
+    ],
+    'front_featured_events' => [
+      'block_featured',
+    ],
+    'mel_home_events' => [
+      'discover',
+      'tonight',
+      'under_20',
+      'near_you',
+    ],
+    'featured_events' => [
+      'block_spotlight',
+      'block_featured',
+    ],
+    'featured_events_carousel' => [
+      'featured_events_carousel',
+    ],
+    'front_discover_events' => [
+      'block_discover',
+    ],
+    'front_recommended_events' => [
+      'block_1',
+    ],
+    'featured_discover_recommended' => [
+      'default',
+      'block_1',
+    ],
+    'new_events' => [
+      'block_1',
+      'page_1',
+    ],
+    'events_calendar' => [
+      'page_1',
+      'block_1',
+    ],
+  ];
+
+  /**
+   * Displays that must only list RSVP/free events (no paid ticket commerce).
+   *
+   * @var array<string, list<string>>
+   */
+  private const FREE_RSVP_DISPLAYS = [
+    'upcoming_events' => [
+      'page_free',
+    ],
+    'mel_home_events' => [
+      'under_20',
+    ],
+  ];
+
+  public function __construct(
+    private readonly PublicEventVisibility $publicVisibility,
+  ) {}
+
+  /**
+   * Whether hygiene filters should apply to this View display.
+   */
+  public function applies(ViewExecutable $view): bool {
+    $view_id = $view->id();
+    $display_id = $view->current_display ?? '';
+
+    if (!is_string($view_id) || !is_string($display_id) || $display_id === '') {
+      return FALSE;
+    }
+
+    return in_array($display_id, self::PUBLIC_DISCOVERY_DISPLAYS[$view_id] ?? [], TRUE);
+  }
+
+  /**
+   * Alters the View SQL query for public discovery hygiene.
+   */
+  public function alter(ViewExecutable $view, QueryPluginBase $query): void {
+    if (!$this->applies($view)) {
+      return;
+    }
+
+    if (!$query->ensureTable('node_field_data')) {
+      return;
+    }
+
+    $base_alias = $query->getTableInfo('node_field_data')['alias'] ?? 'node_field_data';
+
+    $this->applyEndedStateExclusion($query);
+    $this->applyInternalTitleExclusion($query, $base_alias);
+
+    if ($this->isFreeRsvpDisplay($view)) {
+      $this->applyFreeRsvpExclusion($query);
+    }
+  }
+
+  /**
+   * Whether this display is the Free & RSVP surface.
+   */
+  private function isFreeRsvpDisplay(ViewExecutable $view): bool {
+    $view_id = $view->id();
+    $display_id = $view->current_display ?? '';
+    if (!is_string($view_id) || !is_string($display_id)) {
+      return FALSE;
+    }
+
+    return in_array($display_id, self::FREE_RSVP_DISPLAYS[$view_id] ?? [], TRUE);
+  }
+
+  /**
+   * Excludes lifecycle state "ended" (Views config often omits this value).
+   */
+  private function applyEndedStateExclusion(QueryPluginBase $query): void {
+    $state_alias = $query->ensureTable('node__field_event_state');
+    if (!$state_alias) {
+      return;
+    }
+
+    $group = 1;
+    $field = $state_alias . '.field_event_state_value';
+    $query->addWhereExpression(
+      $group,
+      "($field IS NULL OR $field = '' OR $field <> '" . EventStateResolver::STATE_ENDED . "')"
+    );
+  }
+
+  /**
+   * Excludes obvious internal staging titles when no better field exists.
+   */
+  private function applyInternalTitleExclusion(QueryPluginBase $query, string $base_alias): void {
+    $title_field = $base_alias . '.title';
+    $patterns = $this->publicVisibility->getInternalTitleSqlLikePatterns();
+    if ($patterns === []) {
+      return;
+    }
+
+    $group = 1;
+    foreach ($patterns as $pattern) {
+      $query->addWhereExpression(
+        $group,
+        "LOWER($title_field) NOT LIKE :mel_title_pattern",
+        [':mel_title_pattern' => mb_strtolower($pattern)]
+      );
+    }
+  }
+
+  /**
+   * Ensures paid ticket events do not appear on Free & RSVP listings.
+   */
+  private function applyFreeRsvpExclusion(QueryPluginBase $query): void {
+    $type_alias = $query->ensureTable('node__field_event_type');
+    if (!$type_alias) {
+      return;
+    }
+
+    $group = 1;
+    $type_field = $type_alias . '.field_event_type_value';
+    $query->addWhere($group, $type_field, 'paid', '<>');
+
+    $product_alias = $query->ensureTable('node__field_product_target');
+    if (!$product_alias) {
+      return;
+    }
+
+    $product_field = $product_alias . '.field_product_target_target_id';
+    $query->addWhereExpression(
+      $group,
+      "($type_field <> 'both' OR $product_field IS NULL OR $product_field = 0)"
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\myeventlane_event_state\Service\EventStateResolver;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
 use Drupal\node\NodeInterface;
@@ -32,6 +33,18 @@ final class PublicEventVisibility {
   ) {}
 
   /**
+   * Obvious internal staging markers in titles (fallback when no status field).
+   *
+   * @var list<string>
+   */
+  private const INTERNAL_TITLE_MARKERS = [
+    'test',
+    'demo',
+    'copy',
+    'untitled',
+  ];
+
+  /**
    * Whether a published event may appear on public discovery listings or SEO.
    */
   public function isPubliclyListable(NodeInterface $event): bool {
@@ -47,7 +60,53 @@ final class PublicEventVisibility {
       return FALSE;
     }
 
+    if ($this->hasInternalMarkerTitle($event->label())) {
+      return FALSE;
+    }
+
     return TRUE;
+  }
+
+  /**
+   * Whether a title contains obvious internal staging markers.
+   */
+  public function hasInternalMarkerTitle(string $title): bool {
+    $normalized = trim(mb_strtolower($title));
+    if ($normalized === '') {
+      return TRUE;
+    }
+
+    foreach (self::INTERNAL_TITLE_MARKERS as $marker) {
+      if ($normalized === $marker) {
+        return TRUE;
+      }
+      if (str_starts_with($normalized, $marker . ' ')
+        || str_starts_with($normalized, $marker . '-')
+        || str_contains($normalized, ' ' . $marker . ' ')
+        || str_contains($normalized, ' ' . $marker)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * SQL LIKE patterns for excluding internal marker titles in Views queries.
+   *
+   * @return list<string>
+   */
+  public function getInternalTitleSqlLikePatterns(): array {
+    $patterns = [];
+    foreach (self::INTERNAL_TITLE_MARKERS as $marker) {
+      $patterns[] = $marker;
+      $patterns[] = $marker . ' %';
+      $patterns[] = $marker . '-%';
+      $patterns[] = '% ' . $marker;
+      $patterns[] = '% ' . $marker . ' %';
+    }
+
+    return $patterns;
   }
 
   /**
@@ -100,6 +159,43 @@ final class PublicEventVisibility {
     }
 
     return $this->eventStateResolver->resolveState($event) === EventStateResolver::STATE_ENDED;
+  }
+
+  /**
+   * Replaces obvious placeholder copy for public event display surfaces.
+   *
+   * Returns NULL when the source text should not be shown publicly.
+   */
+  public function sanitizePublicDisplayText(?string $text): ?string {
+    if ($text === NULL || trim($text) === '') {
+      return NULL;
+    }
+
+    $plain = trim(strip_tags($text));
+    if ($plain === '') {
+      return NULL;
+    }
+
+    $markers = [
+      '[date]',
+      '[time]',
+      '[venue]',
+      'lorem ipsum',
+    ];
+    foreach ($markers as $marker) {
+      if (stripos($plain, $marker) !== FALSE) {
+        return NULL;
+      }
+    }
+
+    return $text;
+  }
+
+  /**
+   * Fallback copy when public teaser/highlight text is withheld.
+   */
+  public function publicDisplayFallbackMessage(): string {
+    return (string) new TranslatableMarkup('More details coming soon.');
   }
 
 }

--- a/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
@@ -48,6 +48,12 @@ final class FeaturedEventsRenderBuilder {
         return $this->emptyBuild();
       }
 
+      $view->setDisplay(self::DISPLAY_ID);
+      $view->execute();
+      if ($view->result === []) {
+        return $this->emptyBuild();
+      }
+
       return $view->buildRenderable(self::DISPLAY_ID);
     }
     catch (\Throwable $e) {

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
@@ -63,6 +63,8 @@ final class HelpCentreController extends ControllerBase {
 
     $melPayload = $this->melSupportSettingsBuilder->buildDrupalSettings('hub', TRUE);
 
+    $featuredArticlesHasContent = $this->hasFeaturedArticles();
+
     $build = [
       '#theme' => 'help_centre_home',
       '#context' => $isVendorContext ? 'vendor' : NULL,
@@ -71,7 +73,10 @@ final class HelpCentreController extends ControllerBase {
         'value' => $searchValue,
         'placeholder' => $this->t('Search help articles...'),
       ],
-      '#featured_articles' => $this->buildView('mel_help_featured_articles', 'block_featured'),
+      '#featured_articles_has_content' => $featuredArticlesHasContent,
+      '#featured_articles' => $featuredArticlesHasContent
+        ? $this->buildView('mel_help_featured_articles', 'block_featured')
+        : [],
       '#vendors' => $isVendorContext ? $this->buildView('mel_help_vendor_help', 'block_vendors') : [],
       '#faq_listing' => $this->buildView('mel_help_faq', 'block_faq'),
       '#ia_sections' => $isVendorContext ? [] : $this->buildHelpCentreIaSections(),
@@ -377,6 +382,29 @@ final class HelpCentreController extends ControllerBase {
     }
 
     return $build;
+  }
+
+  /**
+   * Whether published featured help articles exist for the hub section.
+   */
+  private function hasFeaturedArticles(): bool {
+    try {
+      $count = $this->entityTypeManagerService->getStorage('node')->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('type', 'help_article')
+        ->condition('status', 1)
+        ->condition('field_featured_help', 1)
+        ->range(0, 1)
+        ->count()
+        ->execute();
+      return $count > 0;
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Could not count featured help articles: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Theme/VendorThemeNegotiator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Theme/VendorThemeNegotiator.php
@@ -22,6 +22,7 @@ final class VendorThemeNegotiator implements ThemeNegotiatorInterface {
     'myeventlane_event_studio.create',
     'myeventlane_vendor.public_list',
     'myeventlane_vendor.organisers',
+    'entity.myeventlane_vendor.canonical',
   ];
 
   /**
@@ -43,11 +44,11 @@ final class VendorThemeNegotiator implements ThemeNegotiatorInterface {
       return TRUE;
     }
 
-    // Fallback for path-based routes.
+    // Fallback for path-based routes (/vendor/* console, not /vendors directory).
     $request = \Drupal::request();
     $path = $request->getPathInfo();
 
-    if (str_starts_with($path, '/vendor')) {
+    if (preg_match('#^/vendor(/|$)#', $path)) {
       return TRUE;
     }
 

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2139,6 +2139,33 @@ function _myeventlane_theme_get_calendar_data($year = NULL, $month = NULL): arra
 }
 
 /**
+ * Implements hook_preprocess_page() for the homepage.
+ *
+ * Hides guide/blog section shell when no published articles exist.
+ */
+function myeventlane_theme_preprocess_page__front(array &$variables): void {
+  if (!isset($variables['page']['homepage_blog'])) {
+    return;
+  }
+
+  try {
+    $count = (int) \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->range(0, 1)
+      ->count()
+      ->execute();
+    if ($count === 0) {
+      unset($variables['page']['homepage_blog']);
+    }
+  }
+  catch (\Throwable) {
+    unset($variables['page']['homepage_blog']);
+  }
+}
+
+/**
  * Implements hook_preprocess_page() for category pages.
  *
  * Adds category info and all categories for the hero section.

--- a/web/themes/custom/myeventlane_theme/templates/help/help-centre-home.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/help/help-centre-home.html.twig
@@ -122,16 +122,14 @@
     </section>
   {% endif %}
 
+  {% if featured_articles_has_content|default(false) %}
   <section class="mel-help-home__section" aria-labelledby="mel-popular-articles-title">
     <div class="mel-help-home__section-head">
       <h2 id="mel-popular-articles-title">{{ 'Featured articles'|t }}</h2>
     </div>
-    {% if featured_articles is empty %}
-      <p class="mel-help-home__empty">{{ 'No help content available.'|t }}</p>
-    {% else %}
-      {{ featured_articles }}
-    {% endif %}
+    {{ featured_articles }}
   </section>
+  {% endif %}
 
   {% if is_vendor_context %}
     <section class="mel-help-home__section mel-help-home__section--vendor-list" aria-labelledby="mel-vendor-guides-title">

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
@@ -12,13 +12,4 @@
       </div>
     {% endfor %}
   </div>
-{% else %}
-  {% include '@myeventlane_theme/components/empty-state.html.twig' with {
-    title: 'No guides yet'|t,
-    text: 'Helpful organiser guides are coming soon.'|t,
-    cta_primary_url: '/create-event',
-    cta_primary_label: 'Create event'|t,
-    cta_secondary_url: '/events',
-    cta_secondary_label: 'Explore events'|t
-  } %}
 {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -149,7 +149,8 @@ function myeventlane_vendor_theme_page_attachments_alter(array &$attachments): v
  * Includes /vendor/* and core user auth paths served on the vendor host.
  */
 function _myeventlane_vendor_theme_is_vendor_scoped_path(string $path): bool {
-  if (str_starts_with($path, '/vendor')) {
+  // Match /vendor and /vendor/* only — not the public directory /vendors.
+  if (preg_match('#^/vendor(/|$)#', $path)) {
     return TRUE;
   }
   $auth = ['/user/login', '/user/register', '/user/password'];
@@ -817,6 +818,16 @@ function _myeventlane_vendor_theme_build_wizard_steps(\Drupal\node\NodeInterface
 function myeventlane_vendor_theme_theme_suggestions_page_alter(array &$suggestions, array $variables): void {
   // Add page suggestions based on route.
   $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Public marketplace vendor routes use the default MEL shell, not console chrome.
+  $public_marketplace_routes = [
+    'myeventlane_vendor.public_list',
+    'myeventlane_vendor.organisers',
+    'entity.myeventlane_vendor.canonical',
+  ];
+  if (is_string($route_name) && in_array($route_name, $public_marketplace_routes, TRUE)) {
+    return;
+  }
 
   if (is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor')) {
     $suggestions[] = 'page__vendor';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes query-level filtering on multiple public event discovery Views and alters event teaser field rendering, which can affect what content is shown/hidden site-wide.
> 
> **Overview**
> Tightens *public event discovery hygiene* by introducing `PublicEventDiscoveryQueryAlter` and wiring it via `hook_views_query_alter()` to apply extra filters on an allow-listed set of public View displays (excluding ended events, excluding obvious internal/staging titles, and keeping paid-ticket events off “Free & RSVP” surfaces).
> 
> Improves *public-facing placeholders and empty states*: event teasers/summaries now replace placeholder text (e.g. template tokens/lorem ipsum) with a translated fallback message, homepage featured events and blog/help sections are hidden when empty (via `FeaturedEventsRenderBuilder`, `myeventlane_theme_preprocess_page__front`, and Help Centre featured-article gating), and several Views/Twig empty-state messages/CTAs are updated. Vendor/public theme routing is also tightened to match `/vendor` paths (not `/vendors`) and keep marketplace vendor routes on the public theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b01bb43a43f574b6ea48c0326bbdde7d6e5a9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->