### PR TITLE
fix(public): tighten public UX hygiene and event visibility

### DIFF
--- a/config/sync/block.block.myeventlane_theme_homepage_free.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_free.yml
@@ -1,0 +1,30 @@
+uuid: 8c4f2a1b-9d3e-4f56-a7b2-1c9e0d8f6a3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.mel_home_events
+  module:
+    - system
+    - views
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_free
+theme: myeventlane_theme
+region: homepage_free
+weight: 0
+provider: null
+plugin: 'views_block:mel_home_events-under_20'
+settings:
+  id: 'views_block:mel_home_events-under_20'
+  label: 'Homepage Free & RSVP events'
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: null
+  exposed: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/views.view.mel_blog.yml
+++ b/config/sync/views.view.mel_blog.yml
@@ -209,20 +209,6 @@ display:
         options:
           offset: 0
           items_per_page: 3
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: true
-          content:
-            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No guides yet</h3><p class="mel-empty-state__what">Helpful organiser guides are coming soon.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/create-event">Create event</a> <a class="mel-link" href="/events">Explore events</a></p></div>'
-            format: full_html
-          tokenize: false
       filters:
         status:
           id: status

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1264,6 +1264,41 @@ function myeventlane_event_preprocess_node(array &$variables): void {
         ],
       ];
     }
+
+    if (!empty($variables['content']['body']) && $node->hasField('body') && !$node->get('body')->isEmpty()) {
+      $body_raw = (string) $node->get('body')->value;
+      if ($visibility->sanitizePublicDisplayText($body_raw) === NULL) {
+        $variables['content']['body'] = [
+          '#markup' => '<p>' . $fallback . '</p>',
+          '#cache' => [
+            'contexts' => ['languages:language_interface'],
+            'tags' => $node->getCacheTags(),
+          ],
+        ];
+      }
+    }
+
+    if ($node->hasField('field_event_highlights') && !$node->get('field_event_highlights')->isEmpty()) {
+      $public_highlights = [];
+      foreach ($node->get('field_event_highlights') as $ref) {
+        $paragraph = $ref->entity;
+        if (!$paragraph || !$paragraph->hasField('field_highlight_text') || $paragraph->get('field_highlight_text')->isEmpty()) {
+          continue;
+        }
+        $highlight_text = (string) $paragraph->get('field_highlight_text')->value;
+        if ($visibility->sanitizePublicDisplayText($highlight_text) === NULL) {
+          continue;
+        }
+        $icon_key = ($paragraph->hasField('field_highlight_icon') && !$paragraph->get('field_highlight_icon')->isEmpty())
+          ? (string) $paragraph->get('field_highlight_icon')->value
+          : '';
+        $public_highlights[] = [
+          'text' => strip_tags($highlight_text),
+          'icon' => $icon_key,
+        ];
+      }
+      $variables['mel_public_highlights'] = $public_highlights;
+    }
   }
 }
 

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -5,3 +5,10 @@ services:
       - '@entity_type.manager'
       - '@views.executable'
       - '@logger.factory'
+
+  myeventlane_front.homepage_section_visibility:
+    class: Drupal\myeventlane_front\Service\HomepageSectionVisibility
+    arguments:
+      - '@entity_type.manager'
+      - '@views.executable'
+      - '@myeventlane_front.featured_events_render_builder'

--- a/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
@@ -23,6 +23,34 @@ final class FeaturedEventsRenderBuilder {
   ) {}
 
   /**
+   * Whether the featured events View display has at least one row.
+   */
+  public function hasResults(): bool {
+    try {
+      $storage = $this->entityTypeManager
+        ->getStorage('view')
+        ->load(self::VIEW_ID);
+
+      if ($storage === NULL) {
+        return FALSE;
+      }
+
+      $view = $this->viewExecutableFactory->get($storage);
+      if (!$view->access(self::DISPLAY_ID)) {
+        return FALSE;
+      }
+
+      $view->setDisplay(self::DISPLAY_ID);
+      $view->execute();
+
+      return $view->result !== [];
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  /**
    * Builds the existing featured events View display.
    *
    * @return array
@@ -31,6 +59,10 @@ final class FeaturedEventsRenderBuilder {
    */
   public function build(): array {
     try {
+      if (!$this->hasResults()) {
+        return $this->emptyBuild();
+      }
+
       $storage = $this->entityTypeManager
         ->getStorage('view')
         ->load(self::VIEW_ID);
@@ -45,12 +77,6 @@ final class FeaturedEventsRenderBuilder {
 
       $view = $this->viewExecutableFactory->get($storage);
       if (!$view->access(self::DISPLAY_ID)) {
-        return $this->emptyBuild();
-      }
-
-      $view->setDisplay(self::DISPLAY_ID);
-      $view->execute();
-      if ($view->result === []) {
         return $this->emptyBuild();
       }
 

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\views\ViewExecutableFactory;
+
+/**
+ * Lightweight checks for whether homepage discovery sections have content.
+ *
+ * Avoids rendering section shells (headings) when a placed block would be empty.
+ */
+final class HomepageSectionVisibility {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly ViewExecutableFactory $viewExecutableFactory,
+    private readonly FeaturedEventsRenderBuilder $featuredEventsRenderBuilder,
+  ) {}
+
+  /**
+   * Whether at least one published blog post exists for the homepage guides rail.
+   */
+  public function hasPublicBlogPosts(): bool {
+    try {
+      $count = $this->entityTypeManager->getStorage('node')->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('type', 'blog_post')
+        ->condition('status', 1)
+        ->range(0, 1)
+        ->count()
+        ->execute();
+      return $count > 0;
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Whether promoted featured events exist for the homepage featured region.
+   */
+  public function hasFeaturedEvents(): bool {
+    return $this->featuredEventsRenderBuilder->hasResults();
+  }
+
+  /**
+   * Whether a View display returns at least one row (after access checks).
+   */
+  public function viewDisplayHasResults(string $viewId, string $displayId): bool {
+    try {
+      $storage = $this->entityTypeManager->getStorage('view')->load($viewId);
+      if ($storage === NULL) {
+        return FALSE;
+      }
+
+      $view = $this->viewExecutableFactory->get($storage);
+      if (!$view->access($displayId)) {
+        return FALSE;
+      }
+
+      $view->setDisplay($displayId);
+      $view->execute();
+
+      return $view->result !== [];
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Controller/HelpCentreController.php
@@ -389,15 +389,14 @@ final class HelpCentreController extends ControllerBase {
    */
   private function hasFeaturedArticles(): bool {
     try {
-      $count = $this->entityTypeManagerService->getStorage('node')->getQuery()
-        ->accessCheck(TRUE)
-        ->condition('type', 'help_article')
-        ->condition('status', 1)
-        ->condition('field_featured_help', 1)
-        ->range(0, 1)
-        ->count()
-        ->execute();
-      return $count > 0;
+      $view = Views::getView('mel_help_featured_articles');
+      if (!$view) {
+        return FALSE;
+      }
+      $view->setDisplay('block_featured');
+      _myeventlane_help_centre_apply_browse_listing_policy($view);
+      $view->execute();
+      return count($view->result) > 0;
     }
     catch (\Throwable $e) {
       $this->logger->warning('Could not count featured help articles: @message', [

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -62,6 +62,7 @@ entity.myeventlane_vendor.canonical:
     parameters:
       myeventlane_vendor:
         type: entity:myeventlane_vendor
+    _theme: myeventlane_theme
 
 # Vendor settings page (Field UI base route).
 myeventlane_vendor.settings:
@@ -84,6 +85,7 @@ myeventlane_vendor.public_list:
     _permission: 'access content'
   options:
     _maintenance_access: FALSE
+    _theme: myeventlane_theme
 
 # Alias for /organisers (points to same controller).
 myeventlane_vendor.organisers:
@@ -95,6 +97,7 @@ myeventlane_vendor.organisers:
     _permission: 'access content'
   options:
     _maintenance_access: FALSE
+    _theme: myeventlane_theme
 
 # Stripe Connect onboarding.
 myeventlane_vendor.stripe_connect:

--- a/web/modules/custom/myeventlane_vendor/src/Theme/VendorThemeNegotiator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Theme/VendorThemeNegotiator.php
@@ -44,9 +44,12 @@ final class VendorThemeNegotiator implements ThemeNegotiatorInterface {
       return TRUE;
     }
 
-    // Fallback for path-based routes (/vendor/* console, not /vendors directory).
+    // Vendor console lives under /vendor/* — not the public /vendors directory.
     $request = \Drupal::request();
     $path = $request->getPathInfo();
+    if (str_starts_with($path, '/vendors')) {
+      return FALSE;
+    }
 
     if (preg_match('#^/vendor(/|$)#', $path)) {
       return TRUE;

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
@@ -20,6 +20,7 @@ regions:
   homepage_categories: 'Homepage Categories'
   homepage_latest: 'Homepage Latest'
   homepage_tonight: 'Homepage Tonight'
+  homepage_free: 'Homepage Free & RSVP'
   homepage_nearby: 'Homepage Nearby'
   homepage_online: 'Homepage Online'
   homepage_host_cta: 'Homepage Host CTA'

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1755,6 +1755,21 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
 
   // mel_header_categories for listing pages (events, search, category).
   $route = \Drupal::routeMatch()->getRouteName();
+
+  // Public marketplace directory pages must never inherit vendor console chrome.
+  $public_marketplace_routes = [
+    'myeventlane_vendor.public_list',
+    'myeventlane_vendor.organisers',
+    'entity.myeventlane_vendor.canonical',
+  ];
+  if (is_string($route) && in_array($route, $public_marketplace_routes, TRUE)) {
+    $variables['mel_is_organiser'] = FALSE;
+    if (isset($variables['footer_context']) && is_array($variables['footer_context'])) {
+      $variables['footer_context']['is_vendor'] = FALSE;
+      unset($variables['footer_context']['vendor_console_urls']);
+    }
+  }
+
   $listing_routes = [
     'view.upcoming_events.page_events',
     'view.upcoming_events.page_category',
@@ -1929,8 +1944,32 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     if (isset($variables['page']['bottom_cta']) && is_array($variables['page']['bottom_cta'])) {
       $variables['mel_home_use_bottom_cta_region'] = count(Element::children($variables['page']['bottom_cta'])) > 0;
     }
+
+    // Homepage discovery rails: region truthiness is true when a block is placed,
+    // even if the View returns zero rows. Gate section shells on real content.
+    if (\Drupal::hasService('myeventlane_front.homepage_section_visibility')) {
+      /** @var \Drupal\myeventlane_front\Service\HomepageSectionVisibility $homepageVisibility */
+      $homepageVisibility = \Drupal::service('myeventlane_front.homepage_section_visibility');
+      $variables['mel_home_show_featured'] = $homepageVisibility->hasFeaturedEvents()
+        && isset($variables['page']['homepage_featured'])
+        && is_array($variables['page']['homepage_featured'])
+        && count(Element::children($variables['page']['homepage_featured'])) > 0;
+      $variables['mel_home_show_blog'] = $homepageVisibility->hasPublicBlogPosts()
+        && isset($variables['page']['homepage_blog'])
+        && is_array($variables['page']['homepage_blog'])
+        && count(Element::children($variables['page']['homepage_blog'])) > 0;
+      $variables['mel_home_show_free_rsvp'] = $homepageVisibility->viewDisplayHasResults('mel_home_events', 'under_20')
+        && isset($variables['page']['homepage_free'])
+        && is_array($variables['page']['homepage_free'])
+        && count(Element::children($variables['page']['homepage_free'])) > 0;
+    }
+    else {
+      $variables['mel_home_show_featured'] = FALSE;
+      $variables['mel_home_show_blog'] = FALSE;
+      $variables['mel_home_show_free_rsvp'] = FALSE;
+    }
   }
-  
+
   // MyEventLane Illustration System: Category-aware hero swaps.
   // Category pages MUST use category banners from /images/mel/categories/.
   // Homepage MUST ALWAYS use journey hero images.

--- a/web/themes/custom/myeventlane_theme/templates/help/help-centre-home.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/help/help-centre-home.html.twig
@@ -115,8 +115,8 @@
           <p class="mel-help-home__card-excerpt">{{ 'Running an event? Find practical guides for setup, ticketing, and attendee updates.'|t }}</p>
         </article>
         <article class="mel-help-home__card">
-          <h3 class="mel-help-home__card-title"><a href="/help/vendors">{{ 'Vendor help'|t }}</a></h3>
-          <p class="mel-help-home__card-excerpt">{{ 'Looking after your vendor profile and applications? This section keeps it simple.'|t }}</p>
+          <h3 class="mel-help-home__card-title"><a href="{% if logged_in %}/help/vendors{% else %}/user/login?destination=/help/vendors{% endif %}">{{ 'Vendor help'|t }}</a></h3>
+          <p class="mel-help-home__card-excerpt">{% if logged_in %}{{ 'Looking after your vendor profile and applications? This section keeps it simple.'|t }}{% else %}{{ 'Sign in to browse organiser console guides for your vendor profile and applications.'|t }}{% endif %}</p>
         </article>
       </div>
     </section>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -194,8 +194,8 @@
         {% set expect_text = expect_html|replace({'&nbsp;': ' ', '&#160;': ' '})|striptags|trim %}
 
         {# Highlights: render only when there are non-empty items (quick-scan list). #}
-        {% set highlights = [] %}
-        {% if node.hasField('field_event_highlights') and not node.field_event_highlights.isEmpty %}
+        {% set highlights = mel_public_highlights|default([]) %}
+        {% if highlights is empty and node.hasField('field_event_highlights') and not node.field_event_highlights.isEmpty %}
           {% for ref in node.field_event_highlights %}
             {% set p = ref.entity %}
             {% if p and p.hasField('field_highlight_text') and not p.field_highlight_text.isEmpty %}

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -26,7 +26,7 @@
 
   <div class="mel-page mel-page--home">
 
-    {% if page.homepage_featured %}
+    {% if mel_home_show_featured|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--featured',
         section_width_class: 'mel-section--wide',
@@ -69,6 +69,20 @@
       } %}
     {% endif %}
 
+    {% if mel_home_show_free_rsvp|default(false) %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--free-rsvp mel-section--discover',
+        section_width_class: 'mel-section--wide',
+        container_class: 'mel-container mel-container--wide',
+        title: 'Free & RSVP'|t,
+        subtitle: 'No ticket purchase needed — just turn up or RSVP.'|t,
+        link_url: path('view.upcoming_events.page_free'),
+        link_text: 'See all free events'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_free
+      } %}
+    {% endif %}
+
     {% if page.homepage_nearby %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--nearby',
@@ -97,7 +111,7 @@
       } %}
     {% endif %}
 
-    {% if page.homepage_blog %}
+    {% if mel_home_show_blog|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--blog',
         section_width_class: 'mel-section--wide',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes homepage section rendering logic and public event/vendor theming, which can affect cached output and user-facing navigation if any View IDs/displays or access checks are misconfigured.
> 
> **Overview**
> Homepage now conditionally renders discovery section shells only when their underlying content actually has results (featured events, blog guides, and a new **Free & RSVP** rail), avoiding empty headings when Views return zero rows.
> 
> Adds a `homepage_free` region and front-page block placement for `mel_home_events:under_20`, and removes the homepage blog block’s custom empty-state so absence can hide the section instead.
> 
> Tightens public UX hygiene: public event pages replace placeholder `body` text and filter highlights via preprocess (`mel_public_highlights`), vendor directory/detail routes are forced onto `myeventlane_theme`, and vendor-console chrome is prevented from leaking onto public `/vendors`/vendor canonical pages.
> 
> Help Centre featured-article detection now uses the configured View execution (including browse policy) rather than a raw node query, and the Help Centre homepage “Vendor help” card links/cta now prompts login for anonymous users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c9f664e6dc66493a72c8185660d70eaed1e62e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->