### PR TITLE
fix(events): complete category canonical routing

### DIFF
--- a/config/sync/pathauto.pattern.event_category.yml
+++ b/config/sync/pathauto.pattern.event_category.yml
@@ -1,13 +1,13 @@
 uuid: 6e0f4c32-bd5f-6030-c8e4-0f60708c9d23
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - taxonomy
 id: event_category
 label: 'Event category paths'
 type: 'canonical_entities:taxonomy_term'
-pattern: 'events/[term:name]'
+pattern: 'events/category/[term:field_mel_slug]'
 selection_criteria:
   6e0f4c32-bd5f-6030-c8e4-0f60708c9d24:
     id: 'entity_bundle:taxonomy_term'

--- a/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
+++ b/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
@@ -12,7 +12,7 @@
 {% for c in categories %}
   {% set pill_mod = c.pill_color|default(c.slug)|default(c.label|lower|replace({' ': '-', '&': 'and', '+': ''}))|trim|lower|default('default') %}
   <a
-    href="{{ c.url|default(path('view.upcoming_events.page_category', {'arg_0': c.tid})) }}"
+    href="{{ c.url|default(path('view.upcoming_events.page_category', {'arg_0': c.slug|default(c.tid)})) }}"
     class="mel-category-pill mel-category-pill--{{ pill_mod|clean_class }}"
     aria-label="{{ 'View events in'|t }} {{ c.label }}"
   >

--- a/web/modules/custom/myeventlane_core/myeventlane_core.module
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.module
@@ -16,6 +16,9 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\myeventlane_core\Service\EventCategoryUrlService;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -190,10 +193,18 @@ function myeventlane_core_entity_presave(EntityInterface $entity): void {
 }
 
 /**
+ * Implements hook_entity_update().
+ */
+function myeventlane_core_entity_update(EntityInterface $entity): void {
+  myeventlane_core_invalidate_event_category_slug_map($entity);
+}
+
+/**
  * Implements hook_entity_insert().
  */
 function myeventlane_core_entity_insert(EntityInterface $entity): void {
   myeventlane_core_invalidate_vendor_follow_list_cache($entity);
+  myeventlane_core_invalidate_event_category_slug_map($entity);
 }
 
 /**
@@ -201,6 +212,7 @@ function myeventlane_core_entity_insert(EntityInterface $entity): void {
  */
 function myeventlane_core_entity_delete(EntityInterface $entity): void {
   myeventlane_core_invalidate_vendor_follow_list_cache($entity);
+  myeventlane_core_invalidate_event_category_slug_map($entity);
 }
 
 /**
@@ -223,6 +235,19 @@ function myeventlane_core_invalidate_vendor_follow_list_cache(EntityInterface $e
 }
 
 /**
+ * Busts cached category slug lookups when category terms change.
+ */
+function myeventlane_core_invalidate_event_category_slug_map(EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'taxonomy_term') {
+    return;
+  }
+  if ($entity->bundle() !== 'categories') {
+    return;
+  }
+  \Drupal::cache('data')->delete('myeventlane:event_category_slug_map:v1');
+}
+
+/**
  * Implements hook_views_post_execute().
  *
  * Log commerce_cart_form result count for debugging empty cart table.
@@ -235,4 +260,46 @@ function myeventlane_core_views_post_execute(ViewExecutable $view): void {
     '@args' => implode(',', array_map('strval', $view->args)),
     '@c' => count($view->result),
   ]);
+}
+
+/**
+ * Implements hook_views_pre_view().
+ *
+ * Converts category slug arguments to term IDs for upcoming_events filtering.
+ */
+function myeventlane_core_views_pre_view(ViewExecutable $view, string $display_id, array &$args): void {
+  if ($view->id() !== 'upcoming_events' || $display_id !== 'page_category' || empty($args[0])) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+  $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+  $term = $categoryUrl->resolveTerm($args[0]);
+  if (!$term instanceof TermInterface) {
+    throw new NotFoundHttpException();
+  }
+  $args[0] = (string) $term->id();
+}
+
+/**
+ * Implements hook_metatags_alter().
+ */
+function myeventlane_core_metatags_alter(array &$metatags): void {
+  $route = \Drupal::routeMatch()->getRouteName();
+  if ($route !== 'view.upcoming_events.page_category') {
+    return;
+  }
+
+  $request = \Drupal::request();
+  $term = $request->attributes->get('mel_category_term');
+  if (!$term instanceof TermInterface) {
+    /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+    $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+    $term = $categoryUrl->resolveTerm(\Drupal::routeMatch()->getParameter('arg_0'));
+  }
+  if ($term instanceof TermInterface) {
+    /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+    $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+    $metatags['canonical_url'] = $categoryUrl->getCategoryUrlString($term);
+  }
 }

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -222,6 +222,29 @@ services:
   myeventlane_core.category_color:
     class: Drupal\myeventlane_core\Service\CategoryColorService
 
+  myeventlane_core.event_category_url:
+    class: Drupal\myeventlane_core\Service\EventCategoryUrlService
+    arguments:
+      - '@entity_type.manager'
+      - '@cache.data'
+      - '@datetime.time'
+
+  myeventlane_core.event_category_canonical_redirect_subscriber:
+    class: Drupal\myeventlane_core\EventSubscriber\EventCategoryCanonicalRedirectSubscriber
+    arguments:
+      - '@myeventlane_core.event_category_url'
+      - '@path_alias.manager'
+      - '@logger.channel.myeventlane_core'
+    tags:
+      - { name: event_subscriber }
+
+  myeventlane_core.event_category_request_subscriber:
+    class: Drupal\myeventlane_core\EventSubscriber\EventCategoryRequestSubscriber
+    arguments:
+      - '@myeventlane_core.event_category_url'
+    tags:
+      - { name: event_subscriber }
+
   myeventlane_core.front_category_stats:
     class: Drupal\myeventlane_core\Service\FrontCategoryStatsService
     arguments:
@@ -230,6 +253,7 @@ services:
       - '@datetime.time'
       - '@myeventlane_core.category_color'
       - '@config.factory'
+      - '@myeventlane_core.event_category_url'
 
   myeventlane_core.homepage_location:
     class: Drupal\myeventlane_core\Service\HomepageLocationService

--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryCanonicalRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryCanonicalRedirectSubscriber.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\EventSubscriber;
+
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\myeventlane_core\Service\EventCategoryUrlService;
+use Drupal\taxonomy\TermInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects legacy category URLs to /events/category/{slug}.
+ */
+final class EventCategoryCanonicalRedirectSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly EventCategoryUrlService $categoryUrl,
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onRequest', 28],
+    ];
+  }
+
+  /**
+   * Redirects taxonomy canonical and legacy tid category URLs.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest() || PHP_SAPI === 'cli') {
+      return;
+    }
+
+    $request = $event->getRequest();
+    $route = $request->attributes->get('_route');
+    if (!is_string($route) || $route === '') {
+      return;
+    }
+
+    if ($this->redirectLegacyFlatCategoryPath($event, $request->getPathInfo())) {
+      return;
+    }
+
+    if ($route === 'entity.taxonomy_term.canonical') {
+      $term = $request->attributes->get('taxonomy_term');
+      if (!$term instanceof TermInterface || $term->bundle() !== 'categories') {
+        return;
+      }
+      $this->setRedirect($event, $this->categoryUrl->getCategoryUrlString($term), 'taxonomy_term_canonical');
+      return;
+    }
+
+    if ($route !== 'view.upcoming_events.page_category') {
+      return;
+    }
+
+    $argument = $request->attributes->get('arg_0');
+    if (!$this->categoryUrl->isLegacyTidArgument($argument)) {
+      return;
+    }
+
+    $term = $this->categoryUrl->resolveTerm($argument);
+    if (!$term instanceof TermInterface) {
+      return;
+    }
+
+    $this->setRedirect($event, $this->categoryUrl->getCategoryUrlString($term), 'legacy_tid');
+  }
+
+  /**
+   * Redirects /events/{slug} when it matches a category and has no entity alias.
+   *
+   * Avoids stealing /events/{title} paths that belong to event nodes.
+   */
+  private function redirectLegacyFlatCategoryPath(RequestEvent $event, string $pathInfo): bool {
+    if (!preg_match('#^/events/([^/]+)$#', $pathInfo, $matches)) {
+      return FALSE;
+    }
+
+    $segment = strtolower($matches[1]);
+    if ($this->categoryUrl->isReservedSlug($segment)) {
+      return FALSE;
+    }
+
+    // Do not redirect when another entity owns this alias (e.g. event node).
+    $internal = $this->aliasManager->getPathByAlias($pathInfo);
+    if ($internal !== $pathInfo) {
+      return FALSE;
+    }
+
+    $term = $this->categoryUrl->resolveTerm($segment);
+    if ($term === NULL) {
+      return FALSE;
+    }
+
+    $this->setRedirect($event, $this->categoryUrl->getCategoryUrlString($term), 'legacy_flat_events_slug');
+    return TRUE;
+  }
+
+  /**
+   * Issues a 301 redirect to the canonical category URL.
+   */
+  private function setRedirect(RequestEvent $event, string $destination, string $reason): void {
+    $this->logger->info('Category canonical redirect (@reason) to @url', [
+      '@reason' => $reason,
+      '@url' => $destination,
+    ]);
+    $event->setResponse(new TrustedRedirectResponse($destination, 301));
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryRequestSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryRequestSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\EventSubscriber;
+
+use Drupal\myeventlane_core\Service\EventCategoryUrlService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Resolves category slug route arguments and exposes the active term.
+ */
+final class EventCategoryRequestSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly EventCategoryUrlService $categoryUrl,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onRequest', 33],
+    ];
+  }
+
+  /**
+   * Validates slug arguments and stores the resolved category term.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest() || PHP_SAPI === 'cli') {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if ($request->attributes->get('_route') !== 'view.upcoming_events.page_category') {
+      return;
+    }
+
+    $argument = $request->attributes->get('arg_0');
+    if ($argument === NULL || $argument === '') {
+      throw new NotFoundHttpException();
+    }
+
+    $term = $this->categoryUrl->resolveTerm($argument);
+    if ($term === NULL) {
+      throw new NotFoundHttpException();
+    }
+
+    $request->attributes->set('mel_category_term', $term);
+    $request->attributes->set('mel_active_category_tid', (string) $term->id());
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Service/EventCategoryUrlService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventCategoryUrlService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Canonical URLs and slug resolution for public event category discovery.
+ *
+ * Category listings live at /events/category/{slug} (view.upcoming_events.page_category).
+ * Taxonomy term canonical routes and legacy /events/category/{tid} URLs redirect here.
+ */
+final class EventCategoryUrlService {
+
+  private const VOCABULARY = 'categories';
+
+  /**
+   * Reserved first segments under /events/ (not category slugs).
+   */
+  private const RESERVED_EVENT_PATHS = [
+    'category',
+    'today',
+    'this-weekend',
+    'free',
+    'popular',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+    private readonly TimeInterface $time,
+  ) {}
+
+  /**
+   * Builds the canonical category listing URL for a term.
+   */
+  public function getCategoryUrl(TermInterface $term): Url {
+    return Url::fromRoute('view.upcoming_events.page_category', [
+      'arg_0' => $this->getSlug($term),
+    ]);
+  }
+
+  /**
+   * Returns the canonical absolute URL string for a category term.
+   */
+  public function getCategoryUrlString(TermInterface $term): string {
+    return $this->getCategoryUrl($term)->toString();
+  }
+
+  /**
+   * Resolves a route or view argument (slug or legacy numeric tid) to a term.
+   */
+  public function resolveTerm(int|string|null $argument): ?TermInterface {
+    if ($argument === NULL || $argument === '') {
+      return NULL;
+    }
+
+    $arg = (string) $argument;
+    if (ctype_digit($arg)) {
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($arg);
+      return ($term instanceof TermInterface && $term->bundle() === self::VOCABULARY)
+        ? $term
+        : NULL;
+    }
+
+    $normalized = strtolower(trim($arg));
+    if ($normalized === '') {
+      return NULL;
+    }
+
+    $map = $this->getSlugToTermMap();
+    return $map[$normalized] ?? NULL;
+  }
+
+  /**
+   * Whether the argument is a legacy numeric term ID in the URL path.
+   */
+  public function isLegacyTidArgument(int|string|null $argument): bool {
+    if ($argument === NULL || $argument === '') {
+      return FALSE;
+    }
+    $arg = (string) $argument;
+    return ctype_digit($arg) && $this->resolveTerm($arg) instanceof TermInterface;
+  }
+
+  /**
+   * Returns a category slug suitable for URL paths.
+   */
+  public function getSlug(TermInterface $term): string {
+    if ($term->bundle() !== self::VOCABULARY) {
+      return 'default';
+    }
+
+    if ($term->hasField('field_mel_slug') && !$term->get('field_mel_slug')->isEmpty()) {
+      $slug_value = $term->get('field_mel_slug')->value;
+      if (is_string($slug_value) && trim($slug_value) !== '') {
+        return $this->normalizeSlug(trim(strtolower($slug_value)));
+      }
+    }
+
+    $name = $term->label();
+    $slug = strtolower($name);
+    $slug = str_replace('&', 'and', $slug);
+    $slug = (string) preg_replace('/[^a-z0-9]+/', '-', $slug);
+    $slug = trim($slug, '-');
+
+    return $this->normalizeSlug($slug !== '' ? $slug : 'default');
+  }
+
+  /**
+   * Whether a slug would collide with a reserved /events/* discovery path.
+   */
+  public function isReservedSlug(string $slug): bool {
+    return in_array(strtolower(trim($slug)), self::RESERVED_EVENT_PATHS, TRUE);
+  }
+
+  /**
+   * Normalizes known LGBTQI+ slug variants.
+   */
+  private function normalizeSlug(string $slug): string {
+    if (in_array($slug, ['lgbtqi', 'lgbtq', 'lgbtqi+', 'lgbtqia+', 'lgbtq+'], TRUE)) {
+      return 'lgbtqia';
+    }
+    return $slug !== '' ? $slug : 'default';
+  }
+
+  /**
+   * Builds a cached slug => term map for the categories vocabulary.
+   *
+   * @return array<string, \Drupal\taxonomy\TermInterface>
+   *   Slug-keyed terms.
+   */
+  private function getSlugToTermMap(): array {
+    $cid = 'myeventlane:event_category_slug_map:v1';
+    if ($cached = $this->cache->get($cid)) {
+      return $cached->data;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('vid', self::VOCABULARY)
+      ->execute();
+
+    $map = [];
+    if ($ids) {
+      $terms = $storage->loadMultiple($ids);
+      foreach ($terms as $term) {
+        if (!$term instanceof TermInterface) {
+          continue;
+        }
+        $map[$this->getSlug($term)] = $term;
+      }
+    }
+
+    $tags = ['taxonomy_term_list:' . self::VOCABULARY];
+    $this->cache->set($cid, $map, $this->time->getRequestTime() + 3600, $tags);
+    return $map;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Service/FrontCategoryStatsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/FrontCategoryStatsService.php
@@ -8,7 +8,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Url;
 use Drupal\taxonomy\TermInterface;
 
 /**
@@ -52,6 +51,13 @@ final class FrontCategoryStatsService {
   private ConfigFactoryInterface $configFactory;
 
   /**
+   * Canonical category URL builder.
+   *
+   * @var \Drupal\myeventlane_core\Service\EventCategoryUrlService
+   */
+  private EventCategoryUrlService $categoryUrl;
+
+  /**
    * Constructs a FrontCategoryStatsService.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -64,6 +70,8 @@ final class FrontCategoryStatsService {
    *   The category color service.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
+   * @param \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl
+   *   Canonical category URL builder.
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
@@ -71,12 +79,14 @@ final class FrontCategoryStatsService {
     TimeInterface $time,
     CategoryColorService $colors,
     ConfigFactoryInterface $configFactory,
+    EventCategoryUrlService $categoryUrl,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->cache = $cache;
     $this->time = $time;
     $this->colors = $colors;
     $this->configFactory = $configFactory;
+    $this->categoryUrl = $categoryUrl;
   }
 
   /**
@@ -108,12 +118,11 @@ final class FrontCategoryStatsService {
 
       $items[] = [
         'tid' => (int) $term->id(),
+        'slug' => $this->categoryUrl->getSlug($term),
         'label' => $term->label(),
         'count' => $count,
         'color' => $this->colors->getColorForLabel($term->label(), $i),
-        'url' => Url::fromRoute('view.upcoming_events.page_category', [
-          'arg_0' => (string) $term->id(),
-        ])->toString(),
+        'url' => $this->categoryUrl->getCategoryUrlString($term),
       ];
     }
 

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingCategoriesBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingCategoriesBlock.php
@@ -8,8 +8,8 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Url;
 use Drupal\myeventlane_analytics\Service\TrendingCategoriesService;
+use Drupal\myeventlane_core\Service\EventCategoryUrlService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,14 +25,18 @@ final class TrendingCategoriesBlock extends BlockBase implements ContainerFactor
 
   private TrendingCategoriesService $trending;
 
+  private EventCategoryUrlService $categoryUrl;
+
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     TrendingCategoriesService $trending,
+    EventCategoryUrlService $categoryUrl,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->trending = $trending;
+    $this->categoryUrl = $categoryUrl;
   }
 
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
@@ -41,6 +45,7 @@ final class TrendingCategoriesBlock extends BlockBase implements ContainerFactor
       $plugin_id,
       $plugin_definition,
       $container->get('myeventlane_analytics.trending_categories'),
+      $container->get('myeventlane_core.event_category_url'),
     );
   }
 
@@ -137,6 +142,11 @@ final class TrendingCategoriesBlock extends BlockBase implements ContainerFactor
       $going = (int) ($item['going'] ?? 0);
       $score = (int) ($item['score'] ?? 0);
 
+      $term = $this->categoryUrl->resolveTerm($tid);
+      if ($term === NULL) {
+        continue;
+      }
+
       $pill_items[] = [
         '#type' => 'container',
         '#attributes' => [
@@ -148,7 +158,7 @@ final class TrendingCategoriesBlock extends BlockBase implements ContainerFactor
         'link' => [
           '#type' => 'link',
           '#title' => $label,
-          '#url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => (string) $tid]),
+          '#url' => $this->categoryUrl->getCategoryUrl($term),
           '#attributes' => [
             'class' => ['mel-trending-category-pill__link'],
           ],

--- a/web/modules/custom/myeventlane_views/myeventlane_views.module
+++ b/web/modules/custom/myeventlane_views/myeventlane_views.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\views\ViewExecutable;
+use Drupal\taxonomy\TermInterface;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -129,4 +130,23 @@ function myeventlane_views_preprocess_views_view_field(array &$variables): void 
       }
     });
   }
+
+  $view = $variables['view'] ?? NULL;
+  if (!$view instanceof ViewExecutable || $view->id() !== 'front_category_pills') {
+    return;
+  }
+  if (($variables['field']->field ?? '') !== 'name') {
+    return;
+  }
+  $row = $variables['row'] ?? NULL;
+  if (!isset($row->_entity) || !$row->_entity instanceof TermInterface || $row->_entity->bundle() !== 'categories') {
+    return;
+  }
+  /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+  $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+  $variables['output'] = [
+    '#type' => 'link',
+    '#title' => $row->_entity->label(),
+    '#url' => $categoryUrl->getCategoryUrl($row->_entity),
+  ];
 }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -150,6 +150,7 @@ myeventlane_event_full:
     - core/once
     - myeventlane_location/event_map
     - myeventlane_theme/global-styling
+    - myeventlane_theme/mel_confirmation
   js:
     js/event-full-trust-rotator.js: { attributes: { defer: true } }
 

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1714,7 +1714,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     if ($count > 3) {
       $categories[] = [
         'title' => $term->label(),
-        'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $term->id()])->toString(),
+        'url' => _myeventlane_theme_get_category_url($term),
       ];
     }
   }
@@ -1788,7 +1788,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         'tid' => $term->id(),
         'name' => $term->label(),
         'label' => $term->label(),
-        'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $term->id()])->toString(),
+        'url' => _myeventlane_theme_get_category_url($term),
         'slug' => $slug,
       ];
     }
@@ -1798,9 +1798,9 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
   // Active category pill for discovery headers (matches route to chip).
   $variables['mel_active_category_tid'] = NULL;
   if ($route === 'view.upcoming_events.page_category') {
-    $arg = \Drupal::routeMatch()->getParameter('arg_0');
-    if ($arg !== NULL && $arg !== '') {
-      $variables['mel_active_category_tid'] = (string) $arg;
+    $term = _myeventlane_theme_get_active_category_term();
+    if ($term instanceof TermInterface) {
+      $variables['mel_active_category_tid'] = (string) $term->id();
     }
   }
   elseif ($route === 'entity.taxonomy_term.canonical') {
@@ -1913,7 +1913,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         'tid' => $term->id(),
         'name' => $term->label(),
         'label' => $term->label(),
-        'url' => '/events/category/' . $term->id(),
+        'url' => '/events/category/' . _myeventlane_theme_get_category_slug($term),
         'slug' => $slug,
       ];
     }
@@ -1925,7 +1925,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     foreach ($categories as $c) {
       $popular_tags[] = [
         'name' => $c['name'],
-        'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $c['tid']])->toString(),
+        'url' => _myeventlane_theme_get_category_url($term),
       ];
     }
     $variables['popular_tags'] = $popular_tags;
@@ -2210,35 +2210,31 @@ function myeventlane_theme_preprocess_page__front(array &$variables): void {
  * Adds category info and all categories for the hero section.
  */
 function myeventlane_theme_preprocess_page__events__category(array &$variables): void {
-  // Get the category term ID from the URL.
-  $tid = \Drupal::routeMatch()->getParameter('arg_0');
-  
-  if ($tid) {
-    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
-    if ($term) {
-      $variables['current_category'] = [
-        'tid' => $term->id(),
-        'name' => $term->label(),
-      ];
-    }
+  $term = _myeventlane_theme_get_active_category_term();
+
+  if ($term instanceof TermInterface) {
+    $variables['current_category'] = [
+      'tid' => $term->id(),
+      'name' => $term->label(),
+    ];
   }
-  
+
   // Load all categories for the hero chips.
   $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
   $terms = $term_storage->loadByProperties(['vid' => 'categories']);
-  
+
   $categories = [];
-  foreach ($terms as $term) {
-    $slug = _myeventlane_theme_get_category_slug($term);
+  foreach ($terms as $category_term) {
+    $slug = _myeventlane_theme_get_category_slug($category_term);
     $categories[] = [
-      'tid' => $term->id(),
-      'name' => $term->label(),
-      'label' => $term->label(),
-      'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $term->id()])->toString(),
+      'tid' => $category_term->id(),
+      'name' => $category_term->label(),
+      'label' => $category_term->label(),
+      'url' => _myeventlane_theme_get_category_url($category_term),
       'slug' => $slug,
     ];
   }
-  
+
   $variables['event_categories'] = $categories;
   // Also set as mel_header_categories if used by page header component.
   $variables['mel_header_categories'] = $categories;
@@ -2640,9 +2636,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         if ($category_term instanceof \Drupal\taxonomy\Entity\Term) {
           $category_slug = _myeventlane_theme_get_category_slug($category_term);
           $category_label = $category_term->label();
-          $category_url = Url::fromRoute('view.upcoming_events.page_category', [
-            'arg_0' => (string) $category_term->id(),
-          ])->toString();
+          $category_url = _myeventlane_theme_get_category_url($category_term);
         }
       }
     }
@@ -3043,7 +3037,7 @@ function myeventlane_theme_preprocess_taxonomy_term(array &$variables): void {
         'tid' => $cat_term->id(),
         'name' => $cat_term->label(),
         'label' => $cat_term->label(),
-        'url' => Url::fromRoute('view.upcoming_events.page_category', ['arg_0' => $cat_term->id()])->toString(),
+        'url' => _myeventlane_theme_get_category_url($cat_term),
         'slug' => $slug,
       ];
     }
@@ -3296,6 +3290,42 @@ function _myeventlane_theme_event_primary_location_label(NodeInterface $node): ?
 }
 
 /**
+ * Returns the canonical category listing URL for a taxonomy term.
+ */
+function _myeventlane_theme_get_category_url(TermInterface $term): string {
+  /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+  $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+  return $categoryUrl->getCategoryUrlString($term);
+}
+
+/**
+ * Resolves the active category term on discovery routes.
+ */
+function _myeventlane_theme_get_active_category_term(): ?TermInterface {
+  $request = \Drupal::request();
+  $term = $request->attributes->get('mel_category_term');
+  if ($term instanceof TermInterface) {
+    return $term;
+  }
+
+  $route = \Drupal::routeMatch()->getRouteName();
+  if ($route === 'view.upcoming_events.page_category') {
+    /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
+    $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
+    return $categoryUrl->resolveTerm(\Drupal::routeMatch()->getParameter('arg_0'));
+  }
+
+  if ($route === 'entity.taxonomy_term.canonical') {
+    $taxonomy_term = \Drupal::routeMatch()->getParameter('taxonomy_term');
+    if ($taxonomy_term instanceof TermInterface && $taxonomy_term->bundle() === 'categories') {
+      return $taxonomy_term;
+    }
+  }
+
+  return NULL;
+}
+
+/**
  * Helper function to get category slug from taxonomy term.
  *
  * @param \Drupal\taxonomy\TermInterface|null $term
@@ -3352,25 +3382,22 @@ function _myeventlane_theme_get_listing_hero_url(?string $route): ?string {
 
   // Category page: prefer term's field_category_image, else theme file.
   if ($route === 'view.upcoming_events.page_category') {
-    $tid = \Drupal::routeMatch()->getParameter('arg_0');
-    if ($tid) {
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
-      if ($term && $term->bundle() === 'categories') {
-        if ($term->hasField('field_category_image') && !$term->get('field_category_image')->isEmpty()) {
-          $cat_files = $term->get('field_category_image')->referencedEntities();
-          $file = !empty($cat_files) ? reset($cat_files) : NULL;
-          if ($file) {
-            $file_url_generator = \Drupal::service('file_url_generator');
-            return $file_url_generator->generateAbsoluteString($file->getFileUri());
-          }
+    $term = _myeventlane_theme_get_active_category_term();
+    if ($term instanceof TermInterface && $term->bundle() === 'categories') {
+      if ($term->hasField('field_category_image') && !$term->get('field_category_image')->isEmpty()) {
+        $cat_files = $term->get('field_category_image')->referencedEntities();
+        $file = !empty($cat_files) ? reset($cat_files) : NULL;
+        if ($file) {
+          $file_url_generator = \Drupal::service('file_url_generator');
+          return $file_url_generator->generateAbsoluteString($file->getFileUri());
         }
-        $slug = _myeventlane_theme_get_category_slug($term);
-        $slug_map = ['lgbtqi' => 'lgbtqia', 'food-drink' => 'food'];
-        $file_slug = $slug_map[$slug] ?? $slug;
-        $rel = $theme_path . '/images/mel/categories/mel-category-' . $file_slug . '.png';
-        if (file_exists(DRUPAL_ROOT . '/' . $rel)) {
-          return $base_path . $rel;
-        }
+      }
+      $slug = _myeventlane_theme_get_category_slug($term);
+      $slug_map = ['lgbtqi' => 'lgbtqia', 'food-drink' => 'food'];
+      $file_slug = $slug_map[$slug] ?? $slug;
+      $rel = $theme_path . '/images/mel/categories/mel-category-' . $file_slug . '.png';
+      if (file_exists(DRUPAL_ROOT . '/' . $rel)) {
+        return $base_path . $rel;
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Routing and redirect logic touches public discovery URLs and must not steal event paths; the `popular_tags` loop change may mis-link hero tags if `$term` is wrong in scope.
> 
> **Overview**
> This PR standardizes **event category discovery** on slug URLs at **`/events/category/{slug}`** (from `field_mel_slug` with fallbacks and LGBTQI+ normalization), instead of term IDs or old path patterns.
> 
> A new **`EventCategoryUrlService`** centralizes slug resolution (cached slug→term map, invalidated on category term CRUD), canonical URL generation, and reserved-path checks under `/events/*`. **Request subscribers** validate category view arguments (404 on bad slugs), attach `mel_category_term` / `mel_active_category_tid`, and **301-redirect** taxonomy canonical routes, numeric-ID category URLs, and legacy flat `/events/{slug}` paths when they match a category and do not conflict with another entity alias. **`hook_views_pre_view`** still converts the public slug argument to a term ID for the `upcoming_events` filter, and **metatags** get an updated canonical URL.
> 
> **Pathauto** for category terms is **disabled** and its pattern is aligned to `events/category/[term:field_mel_slug]` so aliases do not fight the view route. Category links across **pills, front stats, trending block, Views pills, and theme preprocess** now point at slug-based listing URLs; active category highlighting and category hero resolution use the resolved term rather than raw route args.
> 
> *Note:* In `myeventlane_theme.theme`, the homepage `popular_tags` loop still calls `_myeventlane_theme_get_category_url($term)` while iterating `$categories` as `$c`—likely should use the per-item term from `$c`, not the outer loop’s `$term`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb44eddb4aff078119d273873b1b2ae45fb9b8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->