### PR TITLE
fix(public): resolve Bugbot-reported issues in discovery and event di…

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
@@ -162,11 +162,12 @@ final class PublicEventDiscoveryQueryAlter {
     }
 
     $group = 1;
-    foreach ($patterns as $pattern) {
+    foreach ($patterns as $idx => $pattern) {
+      $placeholder = ':mel_title_pattern_' . $idx;
       $query->addWhereExpression(
         $group,
-        "LOWER($title_field) NOT LIKE :mel_title_pattern",
-        [':mel_title_pattern' => mb_strtolower($pattern)]
+        "LOWER($title_field) NOT LIKE $placeholder",
+        [$placeholder => mb_strtolower($pattern)]
       );
     }
   }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1913,7 +1913,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         'tid' => $term->id(),
         'name' => $term->label(),
         'label' => $term->label(),
-        'url' => '/events/category/' . _myeventlane_theme_get_category_slug($term),
+        'url' => _myeventlane_theme_get_category_url($term),
         'slug' => $slug,
       ];
     }
@@ -1925,7 +1925,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     foreach ($categories as $c) {
       $popular_tags[] = [
         'name' => $c['name'],
-        'url' => _myeventlane_theme_get_category_url($term),
+        'url' => $c['url'],
       ];
     }
     $variables['popular_tags'] = $popular_tags;

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -23,7 +23,7 @@
 {% if mel_cta_text|striptags|trim is empty and event_cta is defined and event_cta.label|default('')|striptags|trim is not empty %}
   {% set mel_cta_text = event_cta.label %}
 {% endif %}
-{% if mel_cta_text|striptags|trim is empty and cta_type is defined and cta_type == 'none' and (mel_event_state is not defined or mel_event_state not in ['ended', 'cancelled']) %}
+{% if mel_cta_text|striptags|trim is empty and cta_type is defined and cta_type == 'none' and (mel_event_state is not defined or mel_event_state not in ['ended', 'cancelled']) and (event_ui is not defined or event_ui.show_cta|default(true)) %}
   {% set mel_cta_text = 'Booking coming soon'|t %}
 {% endif %}
 
@@ -205,7 +205,7 @@
 
         {# Highlights: render only when there are non-empty items (quick-scan list). #}
         {% set highlights = mel_public_highlights|default([]) %}
-        {% if highlights is empty and node.hasField('field_event_highlights') and not node.field_event_highlights.isEmpty %}
+        {% if mel_public_highlights is not defined and node.hasField('field_event_highlights') and not node.field_event_highlights.isEmpty %}
           {% for ref in node.field_event_highlights %}
             {% set p = ref.entity %}
             {% if p and p.hasField('field_highlight_text') and not p.field_highlight_text.isEmpty %}
@@ -683,7 +683,7 @@
   {% if _mel_mobile_price is empty and cta_type is defined and cta_type == 'rsvp' %}
     {% set _mel_mobile_price = 'Free RSVP'|t %}
   {% endif %}
-  {% set mel_show_mobile_sticky = mel_cta_text|striptags|trim|length > 0 %}
+  {% set mel_show_mobile_sticky = mel_show_booking_cta and mel_cta_text|striptags|trim|length > 0 %}
   {% if mel_show_mobile_sticky %}
     <div class="mel-mobile-cta" role="region" aria-label="{{ 'Ticket actions'|t }}">
       <div class="mel-mobile-cta__inner">


### PR DESCRIPTION
…splay

- Fix homepage popular_tags using stale $term instead of loop variable $c
- Replace hardcoded /events/category/ path with canonical URL service helper
- Use unique SQL placeholders per pattern in internal title exclusion query
- Prevent highlight fallback from bypassing sanitization when all items filtered
- Gate mobile sticky CTA bar and "Booking coming soon" on show_cta setting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fixes to Views query binding, category URL helpers, and Twig display guards with no auth or payment changes.
> 
> **Overview**
> Fixes several **public discovery and event display** bugs: duplicate SQL bind names on internal-title exclusion, wrong homepage category links, and CTA/highlights behavior on the event full page.
> 
> **Discovery query:** Internal staging title filters now use **unique placeholders** per pattern (`:mel_title_pattern_0`, …) instead of reusing `:mel_title_pattern`, so multi-pattern `NOT LIKE` clauses bind correctly.
> 
> **Homepage:** Category chips and **popular_tags** use the canonical **`_myeventlane_theme_get_category_url()`** helper (not a hardcoded `/events/category/` path). **popular_tags** now takes each category’s **`url` from the loop** instead of a stale `$term` from the last iteration.
> 
> **Event full (Twig):** **“Booking coming soon”** and the **mobile sticky CTA** respect **`event_ui.show_cta`**. **Highlights** only fall back to raw field data when **`mel_public_highlights` is undefined**, so an intentionally empty sanitized list is not rebuilt from unsanitized paragraphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ae40cef67b0df2881e1be2837100b5953a66e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->