### PR TITLE
fix(tests): make path_alias.manager nullable in category redirect subscriber

### DIFF
--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -233,7 +233,7 @@ services:
     class: Drupal\myeventlane_core\EventSubscriber\EventCategoryCanonicalRedirectSubscriber
     arguments:
       - '@myeventlane_core.event_category_url'
-      - '@path_alias.manager'
+      - '@?path_alias.manager'
       - '@logger.channel.myeventlane_core'
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryCanonicalRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryCanonicalRedirectSubscriber.php
@@ -20,7 +20,7 @@ final class EventCategoryCanonicalRedirectSubscriber implements EventSubscriberI
 
   public function __construct(
     private readonly EventCategoryUrlService $categoryUrl,
-    private readonly AliasManagerInterface $aliasManager,
+    private readonly ?AliasManagerInterface $aliasManager,
     private readonly LoggerInterface $logger,
   ) {}
 
@@ -83,6 +83,10 @@ final class EventCategoryCanonicalRedirectSubscriber implements EventSubscriberI
    * Avoids stealing /events/{title} paths that belong to event nodes.
    */
   private function redirectLegacyFlatCategoryPath(RequestEvent $event, string $pathInfo): bool {
+    if ($this->aliasManager === NULL) {
+      return FALSE;
+    }
+
     if (!preg_match('#^/events/([^/]+)$#', $pathInfo, $matches)) {
       return FALSE;
     }


### PR DESCRIPTION
## Summary

- The `EventCategoryCanonicalRedirectSubscriber` hard-depended on `path_alias.manager`, but `myeventlane_core` doesn't declare `path_alias` as a module dependency
- Kernel tests that boot `myeventlane_core` without `path_alias` failed container compilation — **23 errors** across all governance kernel tests
- Fix: use `@?` nullable injection in services.yml and skip the flat-path alias guard when the service is absent

## Files changed

- `web/modules/custom/myeventlane_core/myeventlane_core.services.yml`
- `web/modules/custom/myeventlane_core/src/EventSubscriber/EventCategoryCanonicalRedirectSubscriber.php`

## Test plan

- [x] `phpunit -c phpunit-governance.xml` passes locally (180 tests, 0 errors)
- Production behavior unchanged — `path_alias` is always installed in production so the guard still fires

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DI and guard change; production still uses path_alias when present, with no auth or data-path impact.
> 
> **Overview**
> **`EventCategoryCanonicalRedirectSubscriber`** no longer requires **`path_alias.manager`** at container build time. The service is wired with **`@?path_alias.manager`**, and the constructor accepts a nullable **`AliasManagerInterface`**.
> 
> When the alias manager is missing (e.g. governance kernel tests booting **`myeventlane_core`** without the **`path_alias`** module), **`redirectLegacyFlatCategoryPath`** returns early and skips the **`/events/{slug}`** redirect that checks whether another entity owns the path. Taxonomy canonical and legacy tid redirects are unchanged.
> 
> Production behavior is unchanged where **`path_alias`** is installed: the alias guard still runs for flat legacy category URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fde825a83eaf72032f0e01746648ccdccb0b9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->