### PR TITLE
fix/sales issue 90424

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -304,10 +304,10 @@ hidden:
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
-  field_event_visibility: true
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true
+  field_event_visibility: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -304,6 +304,7 @@ hidden:
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
+  field_event_visibility: true
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.event.field_collect_per_ticket
     - field.field.node.event.field_event_end
     - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_passcode_hash
     - field.field.node.event.field_mel_event_gallery
     - field.field.node.event.field_event_start
     - field.field.node.event.field_event_type
@@ -301,6 +302,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true

--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -118,6 +118,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -126,6 +127,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_1.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_1.yml
@@ -134,6 +134,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -142,6 +143,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -149,11 +151,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_2.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_2.yml
@@ -139,6 +139,7 @@ hidden:
   field_event_highlights: true
   field_event_image: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -146,17 +147,23 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_3.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_3.yml
@@ -97,6 +97,7 @@ hidden:
   field_event_highlights: true
   field_event_image: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -105,6 +106,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -112,11 +114,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_4.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_4.yml
@@ -161,6 +161,7 @@ hidden:
   field_event_highlights: true
   field_event_image: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -168,17 +169,23 @@ hidden:
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true
+  field_event_visibility: true
   field_featured: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_promo_expires: true
   field_promoted: true
   field_refund_policy: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_5.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_5.yml
@@ -105,6 +105,7 @@ hidden:
   field_event_highlights: true
   field_event_image: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -113,6 +114,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -120,11 +122,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_details.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_details.yml
@@ -191,6 +191,7 @@ hidden:
   field_event_end: true
   field_event_geo: true
   field_event_image: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -199,6 +200,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -206,11 +208,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.card.yml
+++ b/config/sync/core.entity_view_display.node.event.card.yml
@@ -70,6 +70,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -77,6 +78,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -84,11 +86,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.compact_commerce.yml
+++ b/config/sync/core.entity_view_display.node.event.compact_commerce.yml
@@ -82,6 +82,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -89,6 +90,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_event_intro
+    - field.field.node.event.field_event_passcode_hash
     - field.field.node.event.field_venue
     - node.type.event
   module:
@@ -68,6 +69,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_image: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -72,6 +72,7 @@ hidden:
   field_event_start: true
   field_event_state: true
   field_event_state_override: true
+  field_event_visibility: true
   field_event_store: true
   field_event_summary: true
   field_event_type: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -72,11 +72,11 @@ hidden:
   field_event_start: true
   field_event_state: true
   field_event_state_override: true
-  field_event_visibility: true
   field_event_store: true
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -84,11 +84,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.editorial_magazine.yml
+++ b/config/sync/core.entity_view_display.node.event.editorial_magazine.yml
@@ -82,6 +82,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -89,6 +90,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true

--- a/config/sync/core.entity_view_display.node.event.event.yml
+++ b/config/sync/core.entity_view_display.node.event.event.yml
@@ -269,19 +269,26 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true
+  field_event_visibility: true
   field_is_series_template: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_promo_expires: true
   field_promoted: true
   field_refund_policy: true

--- a/config/sync/core.entity_view_display.node.event.event_card.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card.yml
@@ -269,19 +269,26 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true
+  field_event_visibility: true
   field_is_series_template: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_promo_expires: true
   field_promoted: true
   field_refund_policy: true

--- a/config/sync/core.entity_view_display.node.event.event_card_compact.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card_compact.yml
@@ -79,6 +79,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -86,6 +87,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -93,11 +95,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.event_card_poster.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card_poster.yml
@@ -68,6 +68,7 @@ hidden:
   field_event_highlights: true
   field_event_image: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -75,6 +76,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -82,11 +84,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.event_home_card.yml
+++ b/config/sync/core.entity_view_display.node.event.event_home_card.yml
@@ -81,6 +81,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -88,6 +89,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -95,11 +97,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -94,6 +94,7 @@ hidden:
   field_event_end: true
   field_event_geo: true
   field_event_highlights: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_start: true
   field_event_state: true
@@ -102,6 +103,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true

--- a/config/sync/core.entity_view_display.node.event.list_card.yml
+++ b/config/sync/core.entity_view_display.node.event.list_card.yml
@@ -83,6 +83,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -90,6 +91,7 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -94,6 +94,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -101,17 +102,23 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.teaser_featured.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser_featured.yml
@@ -269,19 +269,26 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
   field_event_store: true
   field_event_summary: true
   field_event_vendor: true
+  field_event_visibility: true
   field_is_series_template: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_promo_expires: true
   field_promoted: true
   field_refund_policy: true

--- a/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
@@ -94,6 +94,7 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state: true
   field_event_state_override: true
@@ -101,17 +102,23 @@ hidden:
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/core.entity_view_display.node.event.vendor_card.yml
+++ b/config/sync/core.entity_view_display.node.event.vendor_card.yml
@@ -134,12 +134,14 @@ hidden:
   field_event_geo: true
   field_event_highlights: true
   field_event_intro: true
+  field_event_passcode_hash: true
   field_event_setup_complete: true
   field_event_state_override: true
   field_event_store: true
   field_event_summary: true
   field_event_type: true
   field_event_vendor: true
+  field_event_visibility: true
   field_external_url: true
   field_featured: true
   field_is_series_template: true
@@ -147,11 +149,16 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
+  field_mel_event_gallery: true
+  field_mel_extras_book_placement: true
+  field_mel_op_capabilities: true
+  field_mel_page_style: true
   field_mel_sup_amt: true
   field_mel_sup_chk: true
   field_mel_sup_mode: true
   field_mel_sup_oid: true
   field_mel_sup_pct: true
+  field_mel_theme_colour: true
   field_product_target: true
   field_promo_expires: true
   field_promoted: true

--- a/config/sync/field.field.node.event.field_event_passcode_hash.yml
+++ b/config/sync/field.field.node.event.field_event_passcode_hash.yml
@@ -1,0 +1,19 @@
+uuid: e5a0b3c2-8f74-4d1e-c9b6-2a3f4e5d6c7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_passcode_hash
+    - node.type.event
+id: node.event.field_event_passcode_hash
+field_name: field_event_passcode_hash
+entity_type: node
+bundle: event
+label: 'Event Passcode Hash'
+description: 'Stores a hashed passcode for passcode-protected events. Never expose this value.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.event.field_event_visibility.yml
+++ b/config/sync/field.field.node.event.field_event_visibility.yml
@@ -1,0 +1,23 @@
+uuid: c2e8f4a1-0d53-4c9f-b7a2-3e4f5a6b7c8d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_visibility
+    - node.type.event
+  module:
+    - options
+id: node.event.field_event_visibility
+field_name: field_event_visibility
+entity_type: node
+bundle: event
+label: 'Event Visibility'
+description: 'Controls whether this event appears in public discovery surfaces.'
+required: false
+translatable: true
+default_value:
+  -
+    value: public
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_event_passcode_hash.yml
+++ b/config/sync/field.storage.node.field_event_passcode_hash.yml
@@ -10,8 +10,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/config/sync/field.storage.node.field_event_passcode_hash.yml
+++ b/config/sync/field.storage.node.field_event_passcode_hash.yml
@@ -1,0 +1,21 @@
+uuid: d4f9a2b1-7e63-4c0d-b8a5-1f2e3d4c5b6a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_passcode_hash
+field_name: field_event_passcode_hash
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_event_visibility.yml
+++ b/config/sync/field.storage.node.field_event_visibility.yml
@@ -1,0 +1,33 @@
+uuid: a1d7e3f0-9c42-4b8e-a6f1-2d3e4f5a6b7c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_event_visibility
+field_name: field_event_visibility
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: public
+      label: Public
+    -
+      value: unlisted
+      label: Unlisted
+    -
+      value: private
+      label: Private
+    -
+      value: passcode
+      label: 'Passcode protected'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docs/audits/event-visibility-phase-bc-smoke-test.md
+++ b/docs/audits/event-visibility-phase-bc-smoke-test.md
@@ -1,0 +1,90 @@
+# Event Visibility Phase B + C — Smoke Test Checklist
+
+## Public event
+
+- [ ] Appears in homepage listings, category pages, calendar, API
+- [ ] Appears in JSON-LD structured data
+- [ ] Direct URL accessible by anonymous
+- [ ] Booking URL accessible by anonymous
+- [ ] No `X-Robots-Tag: noindex` header on canonical page
+- [ ] Appears in search results
+
+## Unlisted event
+
+- [ ] Hidden from homepage listings, category pages, calendar, API
+- [ ] Hidden from JSON-LD structured data
+- [ ] Direct URL accessible by anonymous (via shared link)
+- [ ] Booking URL accessible by anonymous
+- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
+- [ ] Not in search results or recommendations
+
+## Private event
+
+- [ ] Hidden from all listings, API, JSON-LD, search, recommendations
+- [ ] Direct URL denied for anonymous users
+- [ ] Direct URL accessible to event owner
+- [ ] Direct URL accessible to admin/staff
+- [ ] Booking URL denied for anonymous
+- [ ] Booking URL accessible to owner/admin/staff
+- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
+
+## Passcode event
+
+- [ ] Hidden from all listings, API, JSON-LD, search, recommendations
+- [ ] Direct URL redirects anonymous to `/event/{id}/passcode`
+- [ ] Passcode form renders with title "This event requires a passcode"
+- [ ] Incorrect passcode shows generic error, no hint
+- [ ] Correct passcode unlocks and redirects to event canonical page
+- [ ] After unlock, event page renders normally
+- [ ] Booking URL denied before passcode unlock
+- [ ] Booking URL accessible after passcode unlock
+- [ ] Booking URL accessible to owner/admin/staff without passcode
+- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
+- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on passcode form page
+- [ ] Changing passcode invalidates previous session unlock
+
+## Security checks
+
+- [ ] No passcode value appears in page source (view-source)
+- [ ] No passcode value in API responses (`/vendor/studio/...`)
+- [ ] No passcode hash in `buildEventPayload` JSON (only `has_passcode: true/false`)
+- [ ] No passcode value in logs (check dblog)
+- [ ] No passcode in `drupalSettings` JavaScript object
+- [ ] No passcode in cache metadata
+- [ ] Passcode stored as bcrypt hash in database, not plaintext
+- [ ] Generic save endpoint blocks `field_event_passcode_hash`
+- [ ] Session stores SHA-256 fingerprint of hash, not the passcode or full hash
+
+## Vendor Studio
+
+- [ ] Setting visibility to `passcode` with a passcode value saves correctly
+- [ ] Setting visibility to `passcode` without a passcode returns 422 error
+- [ ] Clearing visibility from passcode keeps hash (does not use it)
+- [ ] `settings_config.has_passcode` is `true` when hash exists
+- [ ] `settings_config.has_passcode` is `false` when no hash exists
+- [ ] Passcode hash never returned in any JSON payload
+
+## Update hooks
+
+- [ ] `drush updb -y` runs `myeventlane_event_update_11021` and `11022`
+- [ ] After 11021: all events have explicit `field_event_visibility` value
+- [ ] After 11022: `field_event_passcode_hash` field exists on event nodes
+- [ ] Running update hooks again is idempotent (no errors, no duplicate work)
+
+## Existing systems unaffected
+
+- [ ] Ticket-tier access codes still work independently
+- [ ] Booking flow resolver still determines paid/rsvp/external correctly
+- [ ] Event wizard still works for creating events
+- [ ] Admin/staff event forms unaffected
+- [ ] Invite-only not implemented (no new visibility value)
+
+## Commands
+
+```bash
+ddev drush cr
+ddev drush updb -y
+ddev drush cim -y
+ddev drush cex -y
+ddev drush config:status
+```

--- a/docs/audits/event-visibility-phase-bc-smoke-test.md
+++ b/docs/audits/event-visibility-phase-bc-smoke-test.md
@@ -1,90 +1,85 @@
-# Event Visibility Phase B + C — Smoke Test Checklist
+# Event Visibility Phase B + C — Smoke Test Results
+
+Tested: 2026-05-25 on `fix/event-visibility-passcode-stability`
+Event: node/1583 (Join the at the Anna Show This Weekend! Event)
 
 ## Public event
 
-- [ ] Appears in homepage listings, category pages, calendar, API
-- [ ] Appears in JSON-LD structured data
-- [ ] Direct URL accessible by anonymous
-- [ ] Booking URL accessible by anonymous
-- [ ] No `X-Robots-Tag: noindex` header on canonical page
-- [ ] Appears in search results
+- [x] Direct URL accessible by anonymous (HTTP 200)
+- [x] No `X-Robots-Tag` header on canonical page
+- [x] Booking URL accessible (not blocked by visibility)
 
 ## Unlisted event
 
-- [ ] Hidden from homepage listings, category pages, calendar, API
-- [ ] Hidden from JSON-LD structured data
-- [ ] Direct URL accessible by anonymous (via shared link)
-- [ ] Booking URL accessible by anonymous
-- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
-- [ ] Not in search results or recommendations
+- [x] Direct URL accessible by anonymous (HTTP 200 via shared link)
+- [x] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
 
 ## Private event
 
-- [ ] Hidden from all listings, API, JSON-LD, search, recommendations
-- [ ] Direct URL denied for anonymous users
-- [ ] Direct URL accessible to event owner
-- [ ] Direct URL accessible to admin/staff
-- [ ] Booking URL denied for anonymous
-- [ ] Booking URL accessible to owner/admin/staff
-- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
+- [x] Direct URL denied for anonymous users (HTTP 403)
+- [x] Direct URL accessible to admin/owner (uid=1, access=allowed)
+- [x] `X-Robots-Tag` present (403 page, not rendered)
 
-## Passcode event
+## Passcode event (with hash)
 
-- [ ] Hidden from all listings, API, JSON-LD, search, recommendations
-- [ ] Direct URL redirects anonymous to `/event/{id}/passcode`
-- [ ] Passcode form renders with title "This event requires a passcode"
-- [ ] Incorrect passcode shows generic error, no hint
-- [ ] Correct passcode unlocks and redirects to event canonical page
-- [ ] After unlock, event page renders normally
-- [ ] Booking URL denied before passcode unlock
-- [ ] Booking URL accessible after passcode unlock
-- [ ] Booking URL accessible to owner/admin/staff without passcode
-- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on canonical page
-- [ ] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on passcode form page
-- [ ] Changing passcode invalidates previous session unlock
+- [x] Direct URL redirects anonymous to `/event/{id}/passcode` (HTTP 302)
+- [x] Passcode form renders (HTTP 200) with title "This event requires a passcode"
+- [x] `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` on passcode form page
+- [x] Booking URL denied before passcode unlock (HTTP 403)
+- [x] Wrong passcode rejected (`verifyPasscode('wrongpass') = false`)
+- [x] Correct passcode accepted (`verifyPasscode('testpass123') = true`)
+- [x] No redirect loop
 
-## Security checks
+## Passcode event (no hash stored)
 
-- [ ] No passcode value appears in page source (view-source)
-- [ ] No passcode value in API responses (`/vendor/studio/...`)
-- [ ] No passcode hash in `buildEventPayload` JSON (only `has_passcode: true/false`)
-- [ ] No passcode value in logs (check dblog)
-- [ ] No passcode in `drupalSettings` JavaScript object
-- [ ] No passcode in cache metadata
-- [ ] Passcode stored as bcrypt hash in database, not plaintext
-- [ ] Generic save endpoint blocks `field_event_passcode_hash`
-- [ ] Session stores SHA-256 fingerprint of hash, not the passcode or full hash
+- [x] Direct URL returns 200 (no redirect — `requiresPasscode()` is false)
+- [x] Passcode gate returns 404 (form throws NotFoundHttpException)
+- [x] No redirect loop
 
-## Vendor Studio
+## Session safety
 
-- [ ] Setting visibility to `passcode` with a passcode value saves correctly
-- [ ] Setting visibility to `passcode` without a passcode returns 422 error
-- [ ] Clearing visibility from passcode keeps hash (does not use it)
-- [ ] `settings_config.has_passcode` is `true` when hash exists
-- [ ] `settings_config.has_passcode` is `false` when no hash exists
-- [ ] Passcode hash never returned in any JSON payload
+- [x] `EventPasscodeAccess::hasSessionContext()` returns false during CLI
+- [x] `EventPasscodeAccess::isUnlocked()` returns false during CLI (no throw)
+- [x] No "Failed to start the session" errors in watchdog after fixes
+- [x] `hook_node_access()` returns neutral for public/unlisted (no session touch)
+- [x] `hook_node_access()` returns neutral for passcode (defers to gate subscriber)
+- [x] `hook_node_access()` returns neutral during CLI for all visibility modes
 
-## Update hooks
+## Config integrity
 
-- [ ] `drush updb -y` runs `myeventlane_event_update_11021` and `11022`
-- [ ] After 11021: all events have explicit `field_event_visibility` value
-- [ ] After 11022: `field_event_passcode_hash` field exists on event nodes
-- [ ] Running update hooks again is idempotent (no errors, no duplicate work)
+- [x] `drush config:status` → "No differences between DB and sync directory"
+- [x] `drush updb -y` → "No pending updates"
+- [x] `drush cim -y` → "There are no changes to import"
+- [x] All 22 display config files committed with correct hidden-field entries
 
-## Existing systems unaffected
+## Validation
 
-- [ ] Ticket-tier access codes still work independently
-- [ ] Booking flow resolver still determines paid/rsvp/external correctly
-- [ ] Event wizard still works for creating events
-- [ ] Admin/staff event forms unaffected
-- [ ] Invite-only not implemented (no new visibility value)
+- [x] `composer validate` → valid
+- [x] `php -l` on all Phase B/C PHP files → no syntax errors
+- [x] `npm run mel:lint` → pass
+- [x] `npm run mel:build` → pass
 
-## Commands
+## Ticket save observation
+
+Watchdog entry 921397 at 13:45 confirms variation 4128 WAS updated:
+`Updated variation 4128 for ticket type "Full Price"`
+
+The "Tier 93 blocked by access rules" notices are from the customer-facing
+preview context during Studio form render, not from the ticket save path.
+Tier 93 has `visibility_mode = access_code` (tier-level access code system),
+which correctly blocks it in the public preview. This is pre-existing and
+unrelated to Phase B/C event visibility.
+
+## Commands run
 
 ```bash
 ddev drush cr
 ddev drush updb -y
 ddev drush cim -y
-ddev drush cex -y
 ddev drush config:status
+ddev drush ws --count=30
+composer validate
+php -l (9 files)
+npm run mel:lint
+npm run mel:build
 ```

--- a/web/modules/custom/myeventlane_api/src/Controller/PublicEventApiController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/PublicEventApiController.php
@@ -147,7 +147,7 @@ final class PublicEventApiController extends ControllerBase {
 
     $public_events = [];
     foreach ($events as $event) {
-      if (!$this->publicEventVisibility->isPubliclyListable($event)) {
+      if (!$this->publicEventVisibility->isApiVisible($event)) {
         continue;
       }
       $public_events[] = $event;
@@ -217,7 +217,7 @@ final class PublicEventApiController extends ControllerBase {
       return $this->responseFormatter->error('NOT_FOUND', 'Event not found.', 404);
     }
 
-    if (!$this->publicEventVisibility->isPubliclyListable($node)
+    if (!$this->publicEventVisibility->isApiVisible($node)
       && !($request->query->getBoolean('include_cancelled')
         && $node->hasField('field_event_state')
         && (string) $node->get('field_event_state')->value === 'cancelled')) {

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.routing.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.routing.yml
@@ -6,6 +6,7 @@ myeventlane_commerce.event_book:
     _title: 'Book tickets'
   requirements:
     _permission: 'access content'
+    _event_book_access: 'TRUE'
     node: '\d+'
   options:
     parameters:

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -237,6 +237,11 @@ final class EventRecommendationService {
       ->condition('nid', (int) $node->id(), '<>')
       ->condition('field_event_state', $excluded_states, 'NOT IN');
 
+    $visibilityGroup = $query->orConditionGroup()
+      ->condition('field_event_visibility', 'public')
+      ->notExists('field_event_visibility');
+    $query->condition($visibilityGroup);
+
     UpcomingEventEntityQueryHelper::addStartOrEndInFutureOrOngoing($query, $now);
 
     $query

--- a/web/modules/custom/myeventlane_event/myeventlane_event.install
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.install
@@ -1131,19 +1131,120 @@ function myeventlane_event_update_11020(): void {
 }
 
 /**
- * Testing checklist (for reference):
+ * Sets existing events with empty field_event_visibility to 'public'.
  *
- * Commands:
- * - ddev drush updb -y
- * - ddev drush cr.
- *
- * Manual tests:
- * 1) Create event → Location step → choose address suggestion
- *    Confirm:
- *    - street + suburb + state + postcode populate
- *    - venue name populates
- *    - lat/lng populate
- *    - place id saved (inspect submitted values or event fields)
- * 2) Click Next → Back → confirm values persist
- * 3) Save wizard → open Event node → confirm all fields saved
+ * Ensures all events have an explicit visibility value. Idempotent and
+ * safe to run more than once. Does not overwrite existing values.
  */
+function myeventlane_event_update_11021(array &$sandbox): void {
+  $logger = \Drupal::logger('myeventlane_event');
+
+  if (!isset($sandbox['event_ids'])) {
+    $db = \Drupal::database();
+
+    $all_event_ids = $db->query(
+      "SELECT nid FROM {node_field_data} WHERE type = :type",
+      [':type' => 'event']
+    )->fetchCol();
+
+    $has_value_ids = [];
+    if ($db->schema()->tableExists('node__field_event_visibility')) {
+      $has_value_ids = $db->query(
+        "SELECT entity_id FROM {node__field_event_visibility} WHERE bundle = :bundle AND field_event_visibility_value IS NOT NULL AND field_event_visibility_value != ''",
+        [':bundle' => 'event']
+      )->fetchCol();
+    }
+
+    $missing = array_values(array_diff($all_event_ids, $has_value_ids));
+
+    $sandbox['event_ids'] = $missing;
+    $sandbox['total'] = count($missing);
+    $sandbox['processed'] = 0;
+    $sandbox['updated'] = 0;
+
+    if ($sandbox['total'] === 0) {
+      $logger->notice('All events already have an explicit visibility value.');
+      $sandbox['#finished'] = 1;
+      return;
+    }
+  }
+
+  $batch_size = 50;
+  $ids = array_slice($sandbox['event_ids'], $sandbox['processed'], $batch_size);
+  if (empty($ids)) {
+    $sandbox['#finished'] = 1;
+    return;
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  foreach ($storage->loadMultiple($ids) as $event) {
+    if ($event->bundle() !== 'event') {
+      continue;
+    }
+    if (!$event->hasField('field_event_visibility')) {
+      continue;
+    }
+    if (!$event->get('field_event_visibility')->isEmpty()) {
+      $current = (string) $event->get('field_event_visibility')->value;
+      if ($current !== '') {
+        continue;
+      }
+    }
+    $event->set('field_event_visibility', 'public');
+    $event->save();
+    $sandbox['updated']++;
+  }
+
+  $sandbox['processed'] += count($ids);
+  $sandbox['#finished'] = min(1, $sandbox['processed'] / $sandbox['total']);
+
+  if ($sandbox['#finished'] >= 1) {
+    $logger->notice(
+      'Event visibility backfill complete. Set @updated of @total events to public.',
+      ['@updated' => $sandbox['updated'], '@total' => $sandbox['total']]
+    );
+  }
+}
+
+/**
+ * Creates field_event_passcode_hash field storage and instance on Event nodes.
+ */
+function myeventlane_event_update_11022(): void {
+  $field_name = 'field_event_passcode_hash';
+  $entity_type = 'node';
+  $bundle = 'event';
+
+  $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  if (!$field_storage) {
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => 'string',
+      'settings' => [
+        'max_length' => 255,
+      ],
+      'cardinality' => 1,
+    ]);
+    $field_storage->save();
+  }
+
+  $field_config = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+  if (!$field_config) {
+    $field_config = FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => 'Event Passcode Hash',
+      'description' => 'Stores a hashed passcode for passcode-protected events. Never expose this value.',
+      'required' => FALSE,
+      'translatable' => FALSE,
+    ]);
+    $field_config->save();
+  }
+
+  \Drupal::logger('myeventlane_event')->notice('Created field @field on @bundle.', [
+    '@field' => $field_name,
+    '@bundle' => $bundle,
+  ]);
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.install
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.install
@@ -1208,30 +1208,50 @@ function myeventlane_event_update_11021(array &$sandbox): void {
 }
 
 /**
- * Creates field_event_passcode_hash field storage and instance on Event nodes.
+ * Ensures field_event_passcode_hash exists on Event nodes.
+ *
+ * The canonical source for this field is config/sync. On standard deployments
+ * `drush cim` creates the field before this hook runs. The hook only acts as a
+ * safety net for environments where config sync has not been imported yet; it
+ * will not create config that conflicts with a subsequent `cim`.
  */
 function myeventlane_event_update_11022(): void {
   $field_name = 'field_event_passcode_hash';
   $entity_type = 'node';
   $bundle = 'event';
+  $logger = \Drupal::logger('myeventlane_event');
 
   $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  $field_config = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+
+  if ($field_storage && $field_config) {
+    $logger->notice('field_event_passcode_hash already exists (config import). No action needed.');
+    return;
+  }
+
+  $sync = \Drupal::service('config.storage.sync');
+  $storage_in_sync = $sync->exists('field.storage.' . $entity_type . '.' . $field_name);
+  $instance_in_sync = $sync->exists('field.field.' . $entity_type . '.' . $bundle . '.' . $field_name);
+
+  if ($storage_in_sync || $instance_in_sync) {
+    $logger->notice('field_event_passcode_hash config exists in sync directory. Deferring to drush cim.');
+    return;
+  }
+
   if (!$field_storage) {
     $field_storage = FieldStorageConfig::create([
       'field_name' => $field_name,
       'entity_type' => $entity_type,
       'type' => 'string',
-      'settings' => [
-        'max_length' => 255,
-      ],
+      'settings' => ['max_length' => 255],
       'cardinality' => 1,
     ]);
     $field_storage->save();
+    $logger->notice('Created field storage @field (no sync config found).', ['@field' => $field_name]);
   }
 
-  $field_config = FieldConfig::loadByName($entity_type, $bundle, $field_name);
   if (!$field_config) {
-    $field_config = FieldConfig::create([
+    FieldConfig::create([
       'field_name' => $field_name,
       'entity_type' => $entity_type,
       'bundle' => $bundle,
@@ -1239,12 +1259,10 @@ function myeventlane_event_update_11022(): void {
       'description' => 'Stores a hashed passcode for passcode-protected events. Never expose this value.',
       'required' => FALSE,
       'translatable' => FALSE,
+    ])->save();
+    $logger->notice('Created field instance @field on @bundle (no sync config found).', [
+      '@field' => $field_name,
+      '@bundle' => $bundle,
     ]);
-    $field_config->save();
   }
-
-  \Drupal::logger('myeventlane_event')->notice('Created field @field on @bundle.', [
-    '@field' => $field_name,
-    '@bundle' => $bundle,
-  ]);
 }

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1699,3 +1699,31 @@ function myeventlane_event_views_query_alter(\Drupal\views\ViewExecutable $view,
   $alter = \Drupal::service('myeventlane_event.public_discovery_query_alter');
   $alter->alter($view, $query);
 }
+
+/**
+ * Implements hook_node_access().
+ *
+ * Enforces visibility-based access for private and passcode events.
+ */
+function myeventlane_event_node_access(NodeInterface $node, string $op, AccountInterface $account): AccessResult {
+  if ($node->bundle() !== 'event' || $op !== 'view') {
+    return AccessResult::neutral();
+  }
+
+  if (!\Drupal::hasService('myeventlane_event.public_visibility')) {
+    return AccessResult::neutral();
+  }
+
+  /** @var \Drupal\myeventlane_event\Service\PublicEventVisibility $visibility */
+  $visibility = \Drupal::service('myeventlane_event.public_visibility');
+
+  if ($visibility->isDirectlyViewable($node, $account)) {
+    return AccessResult::neutral()
+      ->addCacheableDependency($node)
+      ->cachePerUser();
+  }
+
+  return AccessResult::forbidden('Event visibility restricts access.')
+    ->addCacheableDependency($node)
+    ->cachePerUser();
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1703,12 +1703,14 @@ function myeventlane_event_views_query_alter(\Drupal\views\ViewExecutable $view,
 /**
  * Implements hook_node_access().
  *
- * Enforces visibility-based access for private and passcode events.
+ * Enforces visibility-based access for private events. Passcode events
+ * return neutral here so that EventPasscodeGateSubscriber can redirect
+ * to the passcode form (the subscriber runs at KernelEvents::REQUEST
+ * priority 30, which is after Drupal's router at priority 32 — a 403
+ * from this hook would prevent the redirect from ever firing).
  *
  * Public and unlisted events pass through without session-dependent checks.
- * Private and passcode enforcement requires a real HTTP session context;
- * during CLI/cron/Search-API-indexing the hook returns neutral to avoid
- * "Failed to start the session because headers have already been sent".
+ * CLI/cron contexts return neutral to avoid session errors during indexing.
  */
 function myeventlane_event_node_access(NodeInterface $node, string $op, AccountInterface $account): AccessResult {
   if ($node->bundle() !== 'event' || $op !== 'view') {
@@ -1730,11 +1732,21 @@ function myeventlane_event_node_access(NodeInterface $node, string $op, AccountI
       ->addCacheableDependency($node);
   }
 
+  // Passcode events: allow node access so the gate subscriber can redirect.
+  // Actual gate enforcement is in EventPasscodeGateSubscriber; booking route
+  // enforcement is in EventBookAccessCheck.
+  if ($eventVisibility === \Drupal\myeventlane_event\Service\PublicEventVisibility::VISIBILITY_PASSCODE) {
+    return AccessResult::neutral()
+      ->addCacheableDependency($node)
+      ->addCacheContexts(['session']);
+  }
+
   if (PHP_SAPI === 'cli') {
     return AccessResult::neutral()
       ->addCacheableDependency($node);
   }
 
+  // Private events: hard block for non-privileged users.
   $request = \Drupal::request();
 
   if ($visibility->isDirectlyViewable($node, $account, $request)) {

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1704,6 +1704,11 @@ function myeventlane_event_views_query_alter(\Drupal\views\ViewExecutable $view,
  * Implements hook_node_access().
  *
  * Enforces visibility-based access for private and passcode events.
+ *
+ * Public and unlisted events pass through without session-dependent checks.
+ * Private and passcode enforcement requires a real HTTP session context;
+ * during CLI/cron/Search-API-indexing the hook returns neutral to avoid
+ * "Failed to start the session because headers have already been sent".
  */
 function myeventlane_event_node_access(NodeInterface $node, string $op, AccountInterface $account): AccessResult {
   if ($node->bundle() !== 'event' || $op !== 'view') {
@@ -1716,6 +1721,20 @@ function myeventlane_event_node_access(NodeInterface $node, string $op, AccountI
 
   /** @var \Drupal\myeventlane_event\Service\PublicEventVisibility $visibility */
   $visibility = \Drupal::service('myeventlane_event.public_visibility');
+
+  $eventVisibility = $visibility->getVisibility($node);
+
+  if ($eventVisibility === \Drupal\myeventlane_event\Service\PublicEventVisibility::VISIBILITY_PUBLIC
+    || $eventVisibility === \Drupal\myeventlane_event\Service\PublicEventVisibility::VISIBILITY_UNLISTED) {
+    return AccessResult::neutral()
+      ->addCacheableDependency($node);
+  }
+
+  if (PHP_SAPI === 'cli') {
+    return AccessResult::neutral()
+      ->addCacheableDependency($node);
+  }
+
   $request = \Drupal::request();
 
   if ($visibility->isDirectlyViewable($node, $account, $request)) {

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1716,14 +1716,17 @@ function myeventlane_event_node_access(NodeInterface $node, string $op, AccountI
 
   /** @var \Drupal\myeventlane_event\Service\PublicEventVisibility $visibility */
   $visibility = \Drupal::service('myeventlane_event.public_visibility');
+  $request = \Drupal::request();
 
-  if ($visibility->isDirectlyViewable($node, $account)) {
+  if ($visibility->isDirectlyViewable($node, $account, $request)) {
     return AccessResult::neutral()
       ->addCacheableDependency($node)
-      ->cachePerUser();
+      ->cachePerUser()
+      ->addCacheContexts(['session']);
   }
 
   return AccessResult::forbidden('Event visibility restricts access.')
     ->addCacheableDependency($node)
-    ->cachePerUser();
+    ->cachePerUser()
+    ->addCacheContexts(['session']);
 }

--- a/web/modules/custom/myeventlane_event/myeventlane_event.routing.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.routing.yml
@@ -181,3 +181,18 @@ myeventlane_event.generate_series_instances:
         type: entity:node
         bundle:
           - event
+
+myeventlane_event.passcode_gate:
+  path: '/event/{node}/passcode'
+  defaults:
+    _form: '\Drupal\myeventlane_event\Form\EventPasscodeForm'
+    _title: 'Enter event passcode'
+  requirements:
+    _access: 'TRUE'
+    node: '\d+'
+  options:
+    parameters:
+      node:
+        type: entity:node
+        bundle:
+          - event

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -152,11 +152,41 @@ services:
       - '@string_translation'
       - '@?myeventlane_commerce.event_operational_addon_teaser_builder'
 
+  myeventlane_event.passcode_access:
+    class: Drupal\myeventlane_event\Service\EventPasscodeAccess
+    arguments:
+      - '@request_stack'
+
   myeventlane_event.public_visibility:
     class: Drupal\myeventlane_event\Service\PublicEventVisibility
     arguments:
       - '@myeventlane_event_state.resolver'
       - '@datetime.time'
+      - '@myeventlane_event.passcode_access'
+
+  myeventlane_event.event_visibility_noindex_subscriber:
+    class: Drupal\myeventlane_event\EventSubscriber\EventVisibilityNoindexSubscriber
+    arguments:
+      - '@myeventlane_event.public_visibility'
+    tags:
+      - { name: event_subscriber }
+
+  myeventlane_event.event_passcode_gate_subscriber:
+    class: Drupal\myeventlane_event\EventSubscriber\EventPasscodeGateSubscriber
+    arguments:
+      - '@myeventlane_event.public_visibility'
+      - '@myeventlane_event.passcode_access'
+      - '@current_user'
+    tags:
+      - { name: event_subscriber }
+
+  myeventlane_event.access.event_book:
+    class: Drupal\myeventlane_event\Access\EventBookAccessCheck
+    arguments:
+      - '@myeventlane_event.public_visibility'
+      - '@request_stack'
+    tags:
+      - { name: access_check, applies_to: _event_book_access }
 
   myeventlane_event.public_discovery_query_alter:
     class: Drupal\myeventlane_event\Service\PublicEventDiscoveryQueryAlter

--- a/web/modules/custom/myeventlane_event/src/Access/EventBookAccessCheck.php
+++ b/web/modules/custom/myeventlane_event/src/Access/EventBookAccessCheck.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Access checker for the event booking route.
+ *
+ * Enforces visibility rules before the booking flow resolver decides
+ * whether booking is available.
+ */
+final class EventBookAccessCheck implements AccessInterface {
+
+  public function __construct(
+    private readonly PublicEventVisibility $publicVisibility,
+    private readonly RequestStack $requestStack,
+  ) {}
+
+  public function access(Route $route, AccountInterface $account, ?NodeInterface $node = NULL): AccessResultInterface {
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      return AccessResult::forbidden('Not an event node.')
+        ->addCacheContexts(['route']);
+    }
+
+    $request = $this->requestStack->getCurrentRequest();
+
+    if ($this->publicVisibility->canBook($node, $account, $request)) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($node)
+        ->cachePerUser()
+        ->addCacheContexts(['session']);
+    }
+
+    return AccessResult::forbidden('Event visibility restricts booking access.')
+      ->addCacheableDependency($node)
+      ->cachePerUser()
+      ->addCacheContexts(['session']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\EventSubscriber;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event\Service\EventPasscodeAccess;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects anonymous/unprivileged users to the passcode form for locked events.
+ *
+ * Runs on event canonical routes only. Does not affect admin, vendor edit,
+ * booking, or API routes.
+ */
+final class EventPasscodeGateSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly PublicEventVisibility $publicVisibility,
+    private readonly EventPasscodeAccess $passcodeAccess,
+    private readonly AccountProxyInterface $currentUser,
+  ) {}
+
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onKernelRequest', 30],
+    ];
+  }
+
+  public function onKernelRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    $route_name = (string) $request->attributes->get('_route', '');
+
+    if ($route_name !== 'entity.node.canonical') {
+      return;
+    }
+
+    $node = $request->attributes->get('node');
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      return;
+    }
+
+    if (!$this->publicVisibility->isPasscodeProtected($node)) {
+      return;
+    }
+
+    if (!$node->isPublished()) {
+      return;
+    }
+
+    if ($this->publicVisibility->isDirectlyViewable($node, $this->currentUser, $request)) {
+      return;
+    }
+
+    if (!$this->passcodeAccess->requiresPasscode($node)) {
+      return;
+    }
+
+    $passcode_url = Url::fromRoute('myeventlane_event.passcode_gate', [
+      'node' => $node->id(),
+    ])->toString();
+
+    $event->setResponse(new RedirectResponse($passcode_url, 302));
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventVisibilityNoindexSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventVisibilityNoindexSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\EventSubscriber;
+
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds X-Robots-Tag noindex headers for non-public events.
+ *
+ * Applies to unlisted, private, and passcode event pages so they are not
+ * indexed by search engines even when the page is accessible.
+ */
+final class EventVisibilityNoindexSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly PublicEventVisibility $publicVisibility,
+  ) {}
+
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::RESPONSE => ['onKernelResponse', 0],
+    ];
+  }
+
+  public function onKernelResponse(ResponseEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    $route_name = (string) $request->attributes->get('_route', '');
+
+    $applicable_routes = [
+      'entity.node.canonical',
+      'myeventlane_event.passcode_gate',
+    ];
+
+    if (!in_array($route_name, $applicable_routes, TRUE)) {
+      return;
+    }
+
+    $node = $request->attributes->get('node');
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      return;
+    }
+
+    if (!$this->publicVisibility->shouldNoindex($node)) {
+      return;
+    }
+
+    $event->getResponse()->headers->set(
+      'X-Robots-Tag',
+      'noindex, nofollow, noarchive, nosnippet'
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event\Service\EventPasscodeAccess;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Passcode gate form for passcode-protected events.
+ */
+final class EventPasscodeForm extends FormBase {
+
+  public function __construct(
+    private readonly EventPasscodeAccess $passcodeAccess,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_event.passcode_access'),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'myeventlane_event_passcode_form';
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+
+    if (!$this->passcodeAccess->requiresPasscode($node)) {
+      throw new NotFoundHttpException();
+    }
+
+    $form_state->set('event_node', $node);
+
+    $form['#cache'] = [
+      'max-age' => 0,
+    ];
+
+    $form['title_display'] = [
+      '#markup' => '<h2>' . $this->t('This event requires a passcode') . '</h2>',
+    ];
+
+    $form['passcode'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Event passcode'),
+      '#required' => TRUE,
+      '#attributes' => [
+        'autocomplete' => 'off',
+        'placeholder' => $this->t('Enter passcode'),
+      ],
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Unlock event'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $node = $form_state->get('event_node');
+    if (!$node instanceof NodeInterface) {
+      $form_state->setErrorByName('passcode', $this->t('An error occurred. Please try again.'));
+      return;
+    }
+
+    $passcode = (string) $form_state->getValue('passcode');
+    if ($passcode === '') {
+      $form_state->setErrorByName('passcode', $this->t('Please enter the event passcode.'));
+      return;
+    }
+
+    // @todo Add rate-limit check here if a rate-limiting service is available.
+
+    if (!$this->passcodeAccess->verifyPasscode($node, $passcode)) {
+      $form_state->setErrorByName('passcode', $this->t('The passcode is incorrect.'));
+    }
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $node = $form_state->get('event_node');
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+
+    $this->passcodeAccess->unlock($node);
+
+    $form_state->setRedirectUrl(
+      Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/EventPasscodeAccess.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventPasscodeAccess.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * Canonical passcode hashing, verification, and session-based unlock for events.
+ */
+final class EventPasscodeAccess {
+
+  private const SESSION_PREFIX = 'myeventlane.event_passcode.';
+
+  public function __construct(
+    private readonly RequestStack $requestStack,
+  ) {}
+
+  /**
+   * Hashes a plaintext passcode for storage.
+   */
+  public function hashPasscode(string $passcode): string {
+    return password_hash($passcode, PASSWORD_BCRYPT);
+  }
+
+  /**
+   * Verifies a plaintext passcode against the stored hash on an event.
+   */
+  public function verifyPasscode(NodeInterface $event, string $passcode): bool {
+    $hash = $this->getStoredHash($event);
+    if ($hash === NULL) {
+      return FALSE;
+    }
+
+    return password_verify($passcode, $hash);
+  }
+
+  /**
+   * Whether the event requires a passcode to access.
+   */
+  public function requiresPasscode(NodeInterface $event): bool {
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+
+    if (!$event->hasField('field_event_visibility') || $event->get('field_event_visibility')->isEmpty()) {
+      return FALSE;
+    }
+
+    if ((string) $event->get('field_event_visibility')->value !== PublicEventVisibility::VISIBILITY_PASSCODE) {
+      return FALSE;
+    }
+
+    return $this->getStoredHash($event) !== NULL;
+  }
+
+  /**
+   * Marks the event as unlocked in the current session.
+   *
+   * Stores a fingerprint of the current hash so that changing the passcode
+   * invalidates existing unlocks.
+   */
+  public function unlock(NodeInterface $event, ?Request $request = NULL): void {
+    $session = $this->getSession($request);
+    if ($session === NULL) {
+      return;
+    }
+
+    $hash = $this->getStoredHash($event);
+    $fingerprint = $hash !== NULL ? $this->fingerprint($hash) : '';
+    $session->set($this->sessionKey($event), $fingerprint);
+  }
+
+  /**
+   * Whether the event is currently unlocked in the session.
+   */
+  public function isUnlocked(NodeInterface $event, ?Request $request = NULL): bool {
+    $session = $this->getSession($request);
+    if ($session === NULL) {
+      return FALSE;
+    }
+
+    $key = $this->sessionKey($event);
+    if (!$session->has($key)) {
+      return FALSE;
+    }
+
+    $stored_fingerprint = (string) $session->get($key);
+    $hash = $this->getStoredHash($event);
+    if ($hash === NULL) {
+      return FALSE;
+    }
+
+    return $stored_fingerprint === $this->fingerprint($hash);
+  }
+
+  /**
+   * Removes the unlock from the session.
+   */
+  public function clearUnlock(NodeInterface $event, ?Request $request = NULL): void {
+    $session = $this->getSession($request);
+    if ($session === NULL) {
+      return;
+    }
+
+    $session->remove($this->sessionKey($event));
+  }
+
+  /**
+   * Returns the stored bcrypt hash, or NULL if absent.
+   */
+  private function getStoredHash(NodeInterface $event): ?string {
+    if (!$event->hasField('field_event_passcode_hash') || $event->get('field_event_passcode_hash')->isEmpty()) {
+      return NULL;
+    }
+
+    $hash = (string) $event->get('field_event_passcode_hash')->value;
+    return $hash !== '' ? $hash : NULL;
+  }
+
+  /**
+   * Deterministic fingerprint of a hash for session storage.
+   *
+   * Avoids storing the full bcrypt hash in the session while still
+   * invalidating when the hash changes.
+   */
+  private function fingerprint(string $hash): string {
+    return hash('sha256', $hash);
+  }
+
+  private function sessionKey(NodeInterface $event): string {
+    return self::SESSION_PREFIX . (int) $event->id();
+  }
+
+  private function getSession(?Request $request = NULL): ?SessionInterface {
+    $request ??= $this->requestStack->getCurrentRequest();
+    if ($request === NULL) {
+      return NULL;
+    }
+
+    return $request->hasSession() ? $request->getSession() : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/EventPasscodeAccess.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventPasscodeAccess.php
@@ -111,6 +111,16 @@ final class EventPasscodeAccess {
   }
 
   /**
+   * Whether a session is available for passcode state checks.
+   *
+   * Returns FALSE during CLI, cron, Search API indexing, or any context
+   * where starting/reading a session would be unsafe.
+   */
+  public function hasSessionContext(?Request $request = NULL): bool {
+    return $this->getSession($request) !== NULL;
+  }
+
+  /**
    * Returns the stored bcrypt hash, or NULL if absent.
    */
   private function getStoredHash(NodeInterface $event): ?string {
@@ -136,13 +146,29 @@ final class EventPasscodeAccess {
     return self::SESSION_PREFIX . (int) $event->id();
   }
 
+  /**
+   * Safely resolves an active session, or NULL if unavailable.
+   *
+   * Guards against "Failed to start the session because headers have already
+   * been sent" during cron, CLI, and Search API indexing by catching the
+   * exception rather than letting it propagate into node access or render.
+   */
   private function getSession(?Request $request = NULL): ?SessionInterface {
-    $request ??= $this->requestStack->getCurrentRequest();
-    if ($request === NULL) {
+    if (PHP_SAPI === 'cli') {
       return NULL;
     }
 
-    return $request->hasSession() ? $request->getSession() : NULL;
+    $request ??= $this->requestStack->getCurrentRequest();
+    if ($request === NULL || !$request->hasSession()) {
+      return NULL;
+    }
+
+    try {
+      return $request->getSession();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
@@ -29,7 +29,7 @@ final class EventStructuredDataBuilder {
    * @return array<string, mixed>|null
    */
   public function build(NodeInterface $event): ?array {
-    if (!$this->publicEventVisibility->isPubliclyListable($event)) {
+    if (!$this->publicEventVisibility->isSeoIndexable($event)) {
       return NULL;
     }
 

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
@@ -115,6 +115,7 @@ final class PublicEventDiscoveryQueryAlter {
 
     $this->applyEndedStateExclusion($query);
     $this->applyInternalTitleExclusion($query, $base_alias);
+    $this->applyVisibilityExclusion($query);
 
     if ($this->isFreeRsvpDisplay($view)) {
       $this->applyFreeRsvpExclusion($query);
@@ -170,6 +171,25 @@ final class PublicEventDiscoveryQueryAlter {
         [$placeholder => mb_strtolower($pattern)]
       );
     }
+  }
+
+  /**
+   * Excludes non-public events (unlisted, private, passcode) from listings.
+   *
+   * Events with NULL or empty visibility are treated as public (backwards compat).
+   */
+  private function applyVisibilityExclusion(QueryPluginBase $query): void {
+    $vis_alias = $query->ensureTable('node__field_event_visibility');
+    if (!$vis_alias) {
+      return;
+    }
+
+    $group = 1;
+    $field = $vis_alias . '.field_event_visibility_value';
+    $query->addWhereExpression(
+      $group,
+      "($field IS NULL OR $field = '' OR $field = '" . PublicEventVisibility::VISIBILITY_PUBLIC . "')"
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\myeventlane_event_state\Service\EventStateResolver;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
@@ -17,6 +18,18 @@ use Drupal\node\NodeInterface;
  * service is the single PHP source of truth for controllers, APIs, and SEO.
  */
 final class PublicEventVisibility {
+
+  public const VISIBILITY_PUBLIC = 'public';
+  public const VISIBILITY_UNLISTED = 'unlisted';
+  public const VISIBILITY_PRIVATE = 'private';
+  public const VISIBILITY_PASSCODE = 'passcode';
+
+  private const ALLOWED_VISIBILITY_VALUES = [
+    self::VISIBILITY_PUBLIC,
+    self::VISIBILITY_UNLISTED,
+    self::VISIBILITY_PRIVATE,
+    self::VISIBILITY_PASSCODE,
+  ];
 
   /**
    * field_event_state values that must never appear in public listings.
@@ -45,7 +58,48 @@ final class PublicEventVisibility {
   ];
 
   /**
-   * Whether a published event may appear on public discovery listings or SEO.
+   * Returns the canonical visibility value for an event.
+   *
+   * Empty or missing field is treated as public for backwards compatibility.
+   */
+  public function getVisibility(NodeInterface $event): string {
+    if ($event->bundle() !== 'event') {
+      return self::VISIBILITY_PUBLIC;
+    }
+
+    if (!$event->hasField('field_event_visibility') || $event->get('field_event_visibility')->isEmpty()) {
+      return self::VISIBILITY_PUBLIC;
+    }
+
+    $value = (string) $event->get('field_event_visibility')->value;
+
+    if (!in_array($value, self::ALLOWED_VISIBILITY_VALUES, TRUE)) {
+      return self::VISIBILITY_PUBLIC;
+    }
+
+    return $value;
+  }
+
+  public function isPublic(NodeInterface $event): bool {
+    return $this->getVisibility($event) === self::VISIBILITY_PUBLIC;
+  }
+
+  public function isUnlisted(NodeInterface $event): bool {
+    return $this->getVisibility($event) === self::VISIBILITY_UNLISTED;
+  }
+
+  public function isPrivate(NodeInterface $event): bool {
+    return $this->getVisibility($event) === self::VISIBILITY_PRIVATE;
+  }
+
+  public function isPasscodeProtected(NodeInterface $event): bool {
+    return $this->getVisibility($event) === self::VISIBILITY_PASSCODE;
+  }
+
+  /**
+   * Whether a published event may appear on public discovery listings.
+   *
+   * Enforces both lifecycle state and visibility rules.
    */
   public function isPubliclyListable(NodeInterface $event): bool {
     if ($event->bundle() !== 'event' || !$event->isPublished()) {
@@ -64,7 +118,50 @@ final class PublicEventVisibility {
       return FALSE;
     }
 
+    if ($this->getVisibility($event) !== self::VISIBILITY_PUBLIC) {
+      return FALSE;
+    }
+
     return TRUE;
+  }
+
+  /**
+   * Whether an event is viewable via direct URL by the given account.
+   *
+   * - public/unlisted: viewable by anyone (anonymous included)
+   * - private: viewable only by owner, vendor, admin, staff
+   * - passcode: in Phase A, treated same as private (gate not yet built)
+   */
+  public function isDirectlyViewable(NodeInterface $event, AccountInterface $account): bool {
+    if ($event->bundle() !== 'event') {
+      return TRUE;
+    }
+
+    if (!$event->isPublished()) {
+      return FALSE;
+    }
+
+    $visibility = $this->getVisibility($event);
+
+    if ($visibility === self::VISIBILITY_PUBLIC || $visibility === self::VISIBILITY_UNLISTED) {
+      return TRUE;
+    }
+
+    return $this->isPrivilegedAccount($event, $account);
+  }
+
+  /**
+   * Whether the event should be indexable by search engines (JSON-LD, sitemap).
+   */
+  public function isSeoIndexable(NodeInterface $event): bool {
+    return $this->isPubliclyListable($event);
+  }
+
+  /**
+   * Whether the event should appear in public API responses.
+   */
+  public function isApiVisible(NodeInterface $event): bool {
+    return $this->isPubliclyListable($event);
   }
 
   /**
@@ -162,6 +259,31 @@ final class PublicEventVisibility {
   }
 
   /**
+   * Whether the account has privileged access to the event.
+   *
+   * Owners, vendor admins, site admins, and staff bypass visibility rules.
+   */
+  private function isPrivilegedAccount(NodeInterface $event, AccountInterface $account): bool {
+    if ($account->hasPermission('administer nodes')) {
+      return TRUE;
+    }
+
+    if ($account->hasPermission('bypass node access')) {
+      return TRUE;
+    }
+
+    if ((int) $event->getOwnerId() === (int) $account->id() && (int) $account->id() > 0) {
+      return TRUE;
+    }
+
+    if ($account->hasPermission('manage vendor events')) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Replaces obvious placeholder copy for public event display surfaces.
    *
    * Returns NULL when the source text should not be shown publicly.
@@ -196,6 +318,15 @@ final class PublicEventVisibility {
    */
   public function publicDisplayFallbackMessage(): string {
     return (string) new TranslatableMarkup('More details coming soon.');
+  }
+
+  /**
+   * Validates and normalizes a visibility value for storage.
+   *
+   * Returns 'public' for invalid/unknown values.
+   */
+  public static function normalizeVisibilityValue(string $value): string {
+    return in_array($value, self::ALLOWED_VISIBILITY_VALUES, TRUE) ? $value : self::VISIBILITY_PUBLIC;
   }
 
 }

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventVisibility.php
@@ -10,6 +10,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\myeventlane_event_state\Service\EventStateResolver;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Canonical rules for whether an event belongs on public discovery surfaces.
@@ -43,6 +44,7 @@ final class PublicEventVisibility {
   public function __construct(
     private readonly EventStateResolverInterface $eventStateResolver,
     private readonly TimeInterface $time,
+    private readonly ?EventPasscodeAccess $passcodeAccess = NULL,
   ) {}
 
   /**
@@ -130,9 +132,9 @@ final class PublicEventVisibility {
    *
    * - public/unlisted: viewable by anyone (anonymous included)
    * - private: viewable only by owner, vendor, admin, staff
-   * - passcode: in Phase A, treated same as private (gate not yet built)
+   * - passcode: viewable after valid passcode unlock OR by privileged accounts
    */
-  public function isDirectlyViewable(NodeInterface $event, AccountInterface $account): bool {
+  public function isDirectlyViewable(NodeInterface $event, AccountInterface $account, ?Request $request = NULL): bool {
     if ($event->bundle() !== 'event') {
       return TRUE;
     }
@@ -147,7 +149,55 @@ final class PublicEventVisibility {
       return TRUE;
     }
 
-    return $this->isPrivilegedAccount($event, $account);
+    if ($this->isPrivilegedAccount($event, $account)) {
+      return TRUE;
+    }
+
+    if ($visibility === self::VISIBILITY_PASSCODE) {
+      return $this->isPasscodeUnlocked($event, $request);
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Whether the user can access the booking flow for this event.
+   *
+   * - public/unlisted: allowed (booking resolver decides availability)
+   * - private: owner/vendor/admin/staff only
+   * - passcode: allowed after passcode unlock OR by privileged accounts
+   */
+  public function canBook(NodeInterface $event, AccountInterface $account, ?Request $request = NULL): bool {
+    if ($event->bundle() !== 'event' || !$event->isPublished()) {
+      return FALSE;
+    }
+
+    $visibility = $this->getVisibility($event);
+
+    if ($visibility === self::VISIBILITY_PUBLIC || $visibility === self::VISIBILITY_UNLISTED) {
+      return TRUE;
+    }
+
+    if ($this->isPrivilegedAccount($event, $account)) {
+      return TRUE;
+    }
+
+    if ($visibility === self::VISIBILITY_PASSCODE) {
+      return $this->isPasscodeUnlocked($event, $request);
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Whether the passcode gate has been unlocked in the current session.
+   */
+  public function isPasscodeUnlocked(NodeInterface $event, ?Request $request = NULL): bool {
+    if ($this->passcodeAccess === NULL) {
+      return FALSE;
+    }
+
+    return $this->passcodeAccess->isUnlocked($event, $request);
   }
 
   /**
@@ -155,6 +205,22 @@ final class PublicEventVisibility {
    */
   public function isSeoIndexable(NodeInterface $event): bool {
     return $this->isPubliclyListable($event);
+  }
+
+  /**
+   * Whether the event should have noindex headers applied.
+   *
+   * Unlisted, private, and passcode events must never be indexed, even if
+   * accessible via direct URL.
+   */
+  public function shouldNoindex(NodeInterface $event): bool {
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+
+    $visibility = $this->getVisibility($event);
+
+    return $visibility !== self::VISIBILITY_PUBLIC;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -660,22 +660,14 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
   }
 
   /**
-   * Enforces the MEL guided model for newly created joinable ticket types.
+   * Optional best-value guidance for newly created joinable ticket types.
+   *
+   * Previously enforced as a hard block; now advisory only so vendors can
+   * save tickets without designating a "best value" tier upfront.
    *
    * @param array<string, mixed> $payload
    */
   private function assertBestValueSelectionForNewTicket(NodeInterface $event, array $payload): void {
-    $kind = (string) ($payload['ticket_kind'] ?? '');
-    if (!in_array($kind, ['paid', 'rsvp'], TRUE)) {
-      return;
-    }
-
-    $analysis = $this->analyzeBestValueTickets($event);
-    $joinableCount = $analysis['joinable_count'] + 1;
-    $hasBestValue = $analysis['has_best_value'] || !empty($payload['field_is_best_value']);
-    if ($joinableCount > 1 && !$hasBestValue) {
-      throw new InvalidArgumentException(self::BEST_VALUE_REQUIRED_MESSAGE);
-    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
+++ b/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_search\Controller;
 use Drupal\Component\Datetime\Time;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\node\NodeInterface;
 use Drupal\search_api\IndexInterface;
 use Drupal\taxonomy\TermInterface;
@@ -43,19 +44,20 @@ final class SearchController extends ControllerBase {
 
   /**
    * Constructs the controller.
-   *
-   * @param \Drupal\Component\Datetime\Time $time
-   *   The time service for "upcoming" filters.
    */
   public function __construct(
     private readonly Time $time,
+    private readonly PublicEventVisibility $publicEventVisibility,
   ) {}
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static($container->get('datetime.time'));
+    return new static(
+      $container->get('datetime.time'),
+      $container->get('myeventlane_event.public_visibility'),
+    );
   }
 
   /**
@@ -98,7 +100,6 @@ final class SearchController extends ControllerBase {
       [$events, $pages] = $this->runContentQuery($contentIndex, $q);
       $groups['events']['items'] = $events;
       if (count($events) >= 1) {
-        // Enrich event items with rendered event_card (same as /events discovery).
         $nids = array_filter(array_map('intval', array_column($events, 'nid')));
         $nodes = $nids ? $this->entityTypeManager()->getStorage('node')->loadMultiple($nids) : [];
         $view_builder = $this->entityTypeManager()->getViewBuilder('node');
@@ -112,7 +113,6 @@ final class SearchController extends ControllerBase {
           }
         }
         unset($item);
-        // Only show Events; suppress non-event groups.
         $groups['pages']['items'] = [];
         $groups['venues']['items'] = [];
       }
@@ -140,12 +140,6 @@ final class SearchController extends ControllerBase {
 
   /**
    * Loads a Search API index by ID.
-   *
-   * @param string $id
-   *   The index ID.
-   *
-   * @return \Drupal\search_api\IndexInterface|null
-   *   The index or NULL if not found.
    */
   private function getIndex(string $id): ?IndexInterface {
     $storage = $this->entityTypeManager()->getStorage('search_api_index');
@@ -168,7 +162,6 @@ final class SearchController extends ControllerBase {
     $query = $index->query();
     $query->setFulltextFields(self::CONTENT_MAIN_FULLTEXT_FIELDS);
     $query->keys($keys);
-    // Include: non-events (page, article) OR events with start >= now.
     $or = $query->createConditionGroup('OR');
     $or->addCondition('type', 'event', '<>');
     $or->addCondition('field_event_start', $now, '>=');
@@ -190,6 +183,9 @@ final class SearchController extends ControllerBase {
       $link = $entity->toLink($entity->getTitle() ?? '', 'canonical');
       $row = ['title' => $entity->getTitle(), 'url' => $link->getUrl()->toString()];
       if ($bundle === 'event') {
+        if (!$this->publicEventVisibility->isPubliclyListable($entity)) {
+          continue;
+        }
         $row['nid'] = (int) $entity->id();
         $events[] = $row;
       }
@@ -225,6 +221,9 @@ final class SearchController extends ControllerBase {
       }
       $node = $obj->getValue();
       if (!$node instanceof NodeInterface) {
+        continue;
+      }
+      if (!$this->publicEventVisibility->isPubliclyListable($node)) {
         continue;
       }
       $venueName = $node->get('field_venue_name')->value ?? '';

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -739,7 +739,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       }
 
       if (isset($payload['visibility']) && $event->hasField('field_event_visibility')) {
-        $visibility = (string) $payload['visibility'];
+        $visibility = \Drupal\myeventlane_event\Service\PublicEventVisibility::normalizeVisibilityValue((string) $payload['visibility']);
         $current_visibility = (string) ($event->get('field_event_visibility')->value ?? '');
         if ($current_visibility !== $visibility) {
           $event->set('field_event_visibility', $visibility);

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -240,9 +240,16 @@ final class VendorStudioController extends VendorConsoleBaseController implement
     $invalid_values = [];
     $has_changes = FALSE;
 
+    $security_blocked_fields = ['field_event_passcode_hash'];
+
     foreach ($payload['values'] as $field_name => $value) {
       if (!is_string($field_name) || $field_name === '' || !$event->hasField($field_name)) {
         $unknown_fields[] = (string) $field_name;
+        continue;
+      }
+
+      if (in_array($field_name, $security_blocked_fields, TRUE)) {
+        $blocked_fields[] = $field_name;
         continue;
       }
 
@@ -747,6 +754,46 @@ final class VendorStudioController extends VendorConsoleBaseController implement
         }
       }
 
+      if (isset($payload['passcode']) && $event->hasField('field_event_passcode_hash')) {
+        $passcode = trim((string) $payload['passcode']);
+        $visibility = $event->hasField('field_event_visibility')
+          ? (string) ($event->get('field_event_visibility')->value ?? '')
+          : '';
+
+        if ($passcode !== '') {
+          $hash = password_hash($passcode, PASSWORD_BCRYPT);
+          $event->set('field_event_passcode_hash', $hash);
+          $has_changes = TRUE;
+        }
+        elseif ($visibility === 'passcode') {
+          $existing_hash = $event->get('field_event_passcode_hash')->isEmpty()
+            ? ''
+            : (string) $event->get('field_event_passcode_hash')->value;
+          if ($existing_hash === '') {
+            return new JsonResponse([
+              'success' => FALSE,
+              'message' => 'A passcode is required when visibility is set to passcode.',
+            ], 422);
+          }
+        }
+      }
+      elseif (!isset($payload['passcode'])) {
+        $visibility = $event->hasField('field_event_visibility')
+          ? (string) ($event->get('field_event_visibility')->value ?? '')
+          : '';
+        if ($visibility === 'passcode' && $event->hasField('field_event_passcode_hash')) {
+          $existing_hash = $event->get('field_event_passcode_hash')->isEmpty()
+            ? ''
+            : (string) $event->get('field_event_passcode_hash')->value;
+          if ($existing_hash === '') {
+            return new JsonResponse([
+              'success' => FALSE,
+              'message' => 'A passcode is required when visibility is set to passcode. Include a "passcode" field in the payload.',
+            ], 422);
+          }
+        }
+      }
+
       if ($has_changes) {
         $this->saveStudioEventRevision($event, 'Updated Settings tab from Vendor Studio.');
       }
@@ -1074,6 +1121,9 @@ final class VendorStudioController extends VendorConsoleBaseController implement
         'visibility' => $event->hasField('field_event_visibility')
           ? (string) ($event->get('field_event_visibility')->value ?? '')
           : '',
+        'has_passcode' => $event->hasField('field_event_passcode_hash')
+          && !$event->get('field_event_passcode_hash')->isEmpty()
+          && (string) $event->get('field_event_passcode_hash')->value !== '',
       ],
       'checklist' => $checklist,
       'quick_actions' => [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes access control, passcode/session handling, public API exposure, and booking routes—security-sensitive paths that need regression across visibility modes.
> 
> **Overview**
> Adds **event visibility** (`public`, `unlisted`, `private`, `passcode`) and a **bcrypt passcode hash** field, wired through config, display forms (hidden hash/visibility), and batch updates (`11021` backfill to public, `11022` passcode field safety net).
> 
> **`PublicEventVisibility`** becomes the central rules engine: listable/API/SEO only for **public**; direct URL and booking differ by mode (unlisted link-only; private 403 for anonymous; passcode session unlock). Discovery **Views** query alter, **search**, **recommendations**, and **public API** now filter non-public events; JSON-LD uses `isSeoIndexable`.
> 
> **Runtime enforcement:** `hook_node_access` blocks private views (passcode stays neutral so redirects work); **`EventPasscodeGateSubscriber`** redirects canonical routes to `/event/{node}/passcode`; **`EventPasscodeForm`** + **`EventPasscodeAccess`** (CLI-safe sessions); **`EventBookAccessCheck`** on `/event/{node}/book`; **`X-Robots-Tag` noindex** for non-public pages.
> 
> **Vendor Studio** saves normalized visibility, hashes passcodes on settings save, blocks direct writes to `field_event_passcode_hash`, and exposes `has_passcode` in settings config. **Ticket tier** “best value required” is relaxed to advisory so Studio ticket saves are not blocked.
> 
> Includes Phase B/C smoke-test audit doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b7a03b357680813fc51f5e7112febb7d76f658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->