### PR TITLE
fix(tickets): restore vendor access code management routes

### DIFF
--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.routing.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.routing.yml
@@ -70,10 +70,10 @@ myeventlane_tickets.event_tickets_types:
 myeventlane_tickets.event_tickets_settings:
   path: '/vendor/events/{event}/tickets/settings'
   defaults:
-    _controller: 'myeventlane_event_studio.controller:redirectEventToTicketsWorkspace'
+    _controller: '\Drupal\myeventlane_tickets\Controller\EventTicketsController::settings'
     _title: 'Ticket settings'
   requirements:
-    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    _custom_access: 'myeventlane_tickets.access.event_tickets:access'
   options:
     parameters:
       event:
@@ -143,11 +143,13 @@ myeventlane_tickets.event_tickets_access_codes:
     _controller: '\Drupal\myeventlane_tickets\Controller\VendorEventAccessCodesController::list'
     _title: 'Access codes'
   requirements:
-    _permission: 'manage own events tickets'
+    _custom_access: 'myeventlane_tickets.access.event_tickets:access'
   options:
     parameters:
       event:
         type: entity:node
+        bundle:
+          - event
 
 myeventlane_tickets.event_tickets_access_codes_add:
   path: '/vendor/events/{event}/tickets/access-codes/add'

--- a/web/modules/custom/myeventlane_tickets/src/Controller/VendorEventAccessCodesController.php
+++ b/web/modules/custom/myeventlane_tickets/src/Controller/VendorEventAccessCodesController.php
@@ -81,15 +81,16 @@ final class VendorEventAccessCodesController extends VendorEventTicketsBaseContr
     // Add header action button.
     $header_actions = [
       [
-        'label' => $this->t('Add access code'),
+        'label' => $this->t('Create access code'),
         'url' => Url::fromRoute('myeventlane_tickets.event_tickets_access_codes_add', ['event' => $event->id()])->toString(),
-        'style' => 'primary',
+        'class' => 'mel-btn--cta',
       ],
     ];
 
     if (empty($codes)) {
       $build['empty'] = [
-        '#markup' => '<p>' . $this->t('No access codes have been created for this event.') . '</p>',
+        '#markup' => '<div class="mel-empty-state"><p>' . $this->t('No access codes have been created for this event.') . '</p>'
+          . '<a class="mel-btn mel-btn--primary" href="' . Url::fromRoute('myeventlane_tickets.event_tickets_access_codes_add', ['event' => $event->id()])->toString() . '">' . $this->t('Create access code') . '</a></div>',
       ];
     }
     else {
@@ -105,6 +106,11 @@ final class VendorEventAccessCodesController extends VendorEventTicketsBaseContr
       $rows = [];
       foreach ($codes as $code) {
         /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $code */
+        $raw_code = $code->getCode();
+        $masked = strlen($raw_code) > 4
+          ? '****' . substr($raw_code, -4)
+          : '****';
+
         $usage_count = (int) $code->get('usage_count')->value;
         $usage_limit = $code->get('usage_limit')->isEmpty() ? NULL : (int) $code->get('usage_limit')->value;
         if ($usage_limit !== NULL) {
@@ -127,7 +133,10 @@ final class VendorEventAccessCodesController extends VendorEventTicketsBaseContr
               ],
               'delete' => [
                 'title' => $this->t('Delete'),
-                'url' => $code->toUrl('delete-form', ['event' => $event->id()]),
+                'url' => Url::fromRoute('entity.mel_access_code.delete_form', [
+                  'event' => $event->id(),
+                  'mel_access_code' => $code->id(),
+                ]),
               ],
             ],
           ],
@@ -135,7 +144,7 @@ final class VendorEventAccessCodesController extends VendorEventTicketsBaseContr
 
         $rows[] = [
           'data' => [
-            $code->getCode(),
+            $masked,
             $code->get('status')->value,
             $usage_text,
             $operations,

--- a/web/modules/custom/myeventlane_tickets/src/Entity/AccessCode.php
+++ b/web/modules/custom/myeventlane_tickets/src/Entity/AccessCode.php
@@ -36,7 +36,7 @@ use Drupal\node\NodeInterface;
  *       "default" = "Drupal\myeventlane_tickets\Form\AccessCodeForm",
  *       "add" = "Drupal\myeventlane_tickets\Form\AccessCodeForm",
  *       "edit" = "Drupal\myeventlane_tickets\Form\AccessCodeForm",
- *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
+ *       "delete" = "Drupal\myeventlane_tickets\Form\AccessCodeDeleteForm"
  *     }
  *   },
  *   base_table = "mel_access_code",
@@ -48,7 +48,6 @@ use Drupal\node\NodeInterface;
  *     "label" = "code"
  *   },
  *   links = {
- *     "canonical" = "/vendor/events/{event}/tickets/access-codes/{mel_access_code}",
  *     "add-form" = "/vendor/events/{event}/tickets/access-codes/add",
  *     "edit-form" = "/vendor/events/{event}/tickets/access-codes/{mel_access_code}/edit",
  *     "delete-form" = "/vendor/events/{event}/tickets/access-codes/{mel_access_code}/delete"

--- a/web/modules/custom/myeventlane_tickets/src/Entity/EventTicketSettings.php
+++ b/web/modules/custom/myeventlane_tickets/src/Entity/EventTicketSettings.php
@@ -31,10 +31,7 @@ use Drupal\node\NodeInterface;
  *       "default" = "Drupal\myeventlane_tickets\Form\EventTicketSettingsForm",
  *       "edit" = "Drupal\myeventlane_tickets\Form\EventTicketSettingsForm"
  *     },
- *     "access" = "Drupal\myeventlane_tickets\EventTicketSettingsAccessControlHandler",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider"
- *     }
+ *     "access" = "Drupal\myeventlane_tickets\EventTicketSettingsAccessControlHandler"
  *   },
  *   base_table = "mel_event_ticket_settings",
  *   data_table = "mel_event_ticket_settings_field_data",
@@ -42,9 +39,6 @@ use Drupal\node\NodeInterface;
  *   entity_keys = {
  *     "id" = "id",
  *     "uuid" = "uuid"
- *   },
- *   links = {
- *     "edit-form" = "/vendor/events/{event}/tickets/settings"
  *   }
  * )
  */

--- a/web/modules/custom/myeventlane_tickets/src/EventTicketSettingsAccessControlHandler.php
+++ b/web/modules/custom/myeventlane_tickets/src/EventTicketSettingsAccessControlHandler.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_tickets;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -15,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Access control handler for Event Ticket Settings entities.
  */
-final class EventTicketSettingsAccessControlHandler extends EntityAccessControlHandler {
+final class EventTicketSettingsAccessControlHandler extends EntityAccessControlHandler implements EntityHandlerInterface {
 
   /**
    * Constructs EventTicketSettingsAccessControlHandler.

--- a/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeDeleteForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeDeleteForm.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Delete form for Access Code entities.
+ *
+ * Overrides the cancel URL to redirect back to the event access codes list.
+ */
+final class AccessCodeDeleteForm extends ContentEntityDeleteForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl(): Url {
+    /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $entity */
+    $entity = $this->getEntity();
+    $event_id = $entity->getEventId();
+
+    return Url::fromRoute('myeventlane_tickets.event_tickets_access_codes', [
+      'event' => $event_id,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+
+    /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $entity */
+    $entity = $this->getEntity();
+    $event_id = $entity->getEventId();
+
+    $form_state->setRedirect('myeventlane_tickets.event_tickets_access_codes', [
+      'event' => $event_id,
+    ]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeForm.php
@@ -29,13 +29,35 @@ final class AccessCodeForm extends ContentEntityForm {
   public function form(array $form, FormStateInterface $form_state): array {
     $form = parent::form($form, $form_state);
 
-    // Pre-populate event if not set (from route parameter).
     /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $entity */
     $entity = $this->entity;
-    if ($entity->isNew() && $entity->get('event')->isEmpty()) {
-      $event = $this->routeMatch->getParameter('event');
-      if ($event && $event->id()) {
-        $entity->set('event', $event->id());
+
+    if ($entity->isNew()) {
+      // Pre-populate event from route parameter.
+      if ($entity->get('event')->isEmpty()) {
+        $event = $this->routeMatch->getParameter('event');
+        if ($event && $event->id()) {
+          $entity->set('event', $event->id());
+        }
+      }
+
+      if (isset($form['code'])) {
+        $form['code']['widget'][0]['value']['#description'] = $this->t('The access code string. This will be shown only once after creation.');
+      }
+    }
+    else {
+      // Editing: show masked code, don't require re-entry.
+      if (isset($form['code'])) {
+        $current_code = $entity->getCode();
+        $masked = strlen($current_code) > 4
+          ? '****' . substr($current_code, -4)
+          : '****';
+        $form['code']['widget'][0]['value']['#default_value'] = '';
+        $form['code']['widget'][0]['value']['#required'] = FALSE;
+        $form['code']['widget'][0]['value']['#placeholder'] = $masked;
+        $form['code']['widget'][0]['value']['#description'] = $this->t('Current code: %masked. Leave blank to keep unchanged, or enter a new code to replace it.', [
+          '%masked' => $masked,
+        ]);
       }
     }
 
@@ -45,21 +67,41 @@ final class AccessCodeForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
-  public function save(array $form, FormStateInterface $form_state): void {
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $entity */
     $entity = $this->entity;
+
+    // On edit, if code field is left blank, restore the existing value.
+    if (!$entity->isNew()) {
+      $code_value = $form_state->getValue(['code', 0, 'value']);
+      if ($code_value === '' || $code_value === NULL) {
+        $entity->set('code', $entity->getCode());
+        $form_state->setValue(['code', 0, 'value'], $entity->getCode());
+      }
+    }
+
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state): void {
+    /** @var \Drupal\myeventlane_tickets\Entity\AccessCode $entity */
+    $entity = $this->entity;
+    $is_new = $entity->isNew();
+    $plaintext_code = $entity->getCode();
     $status = $entity->save();
 
     $event_id = $entity->getEventId();
 
     if ($status === SAVED_NEW) {
-      $this->messenger()->addStatus($this->t('Created the %label access code.', [
-        '%label' => $entity->getCode(),
+      $this->messenger()->addStatus($this->t('Access code created. The code is: %code — copy it now, it will not be shown again in full.', [
+        '%code' => $plaintext_code,
       ]));
     }
     else {
-      $this->messenger()->addStatus($this->t('Saved the %label access code.', [
-        '%label' => $entity->getCode(),
-      ]));
+      $this->messenger()->addStatus($this->t('Access code saved.'));
     }
 
     $form_state->setRedirect('myeventlane_tickets.event_tickets_access_codes', ['event' => $event_id]);


### PR DESCRIPTION
Root causes:
- Settings route used EventStudioAccess (requires node update + vendor context) instead of the tickets workspace access checker.
- EventTicketSettings entity had route_provider + links annotation that auto-generated a colliding entity route at the same path, which won the route match over the custom route.
- EventTicketSettingsAccessControlHandler lacked EntityHandlerInterface so DI constructor injection silently failed.
- Access-codes list route used a generic permission check without event bundle constraint or ownership check.
- Header actions used 'style' key but template expects 'class'.
- AccessCode entity had a canonical link without a corresponding route, causing the delete form's cancel link to crash.

Fixes:
- Settings + access-codes list routes now use event_tickets:access custom access checker (owner/vendor team/admin).
- Removed route_provider and links from EventTicketSettings entity.
- Added EntityHandlerInterface to access control handler.
- Fixed header_actions to use 'class' key and 'Create access code' label.
- Added empty-state "Create access code" button.
- Enhanced AccessCodeForm: one-time plaintext display on create, masked placeholder on edit, no code re-entry required.
- Created AccessCodeDeleteForm with proper cancel/redirect to list.
- Removed unreachable canonical link from AccessCode entity.
- Masked codes in list view (last 4 chars visible).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches route matching and custom access for vendor ticket pages plus access-code secret handling; scope is limited to the tickets module but affects who can reach settings/codes and how codes are displayed.
> 
> **Overview**
> Restores vendor **ticket settings** and **access codes** workspace pages by fixing route collisions, access checks, and access-code CRUD UX.
> 
> **Routing & access:** Ticket settings no longer redirects through Event Studio; it uses `EventTicketsController::settings` with `event_tickets:access` (same as other ticket tabs). The access-codes list drops the broad permission in favor of that checker and constrains the `{event}` parameter to the event bundle. **Event ticket settings** entity annotations drop `route_provider` / `links` so auto-generated routes no longer override the custom settings path; the settings access handler implements `EntityHandlerInterface` so `EventAccess` DI works.
> 
> **Access codes:** List UI uses CTA styling (`class` vs `style`), empty-state create button, masked codes in the table, and explicit delete route URLs. **AccessCode** uses a custom delete form with cancel/redirect to the list; canonical link removed. **AccessCodeForm** shows plaintext once on create, masked edit with optional rotation, and list masking aligns with reduced secret exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0adf0b2248297be2e5343cfc1a0b45ef6b2d8107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->