### PR TITLE
fix(tickets): read booking access code from tree fieldset

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -130,6 +130,7 @@ final class TicketSelectionForm extends FormBase {
 
     $form['booking_access'] = [
       '#type' => 'fieldset',
+      '#tree' => TRUE,
       '#title' => $this->t('Access code'),
       '#description' => $this->t('If you have an organiser code, enter it here to reveal hidden or invite-only tickets for this browser session.'),
       '#attributes' => ['class' => ['mel-ticket-booking-access']],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Drupal Form API flag on the access-code fieldset; aligns structure with existing submit/validation paths with no broader booking logic changes.
> 
> **Overview**
> Sets **`#tree' => TRUE`** on the ticket selection form’s **`booking_access`** fieldset so submitted values nest under `booking_access` (e.g. `code`).
> 
> That matches **`applyAccessCode()`**, which reads **`$form_state->getValue(['booking_access', 'code'])`**, and the Apply button’s **`#limit_validation_errors`** path—without a tree, the access code field may not populate correctly on Apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cff2aaa697ad78931dfea4f0fe20f1d65fedc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->