### PR TITLE
fix(staging): preserve https scheme behind proxy

### DIFF
--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -113,8 +113,13 @@ $settings['reverse_proxy'] = TRUE;
 $mel_default_proxy_addresses = [
   '127.0.0.1',
   '::1',
+  '10.0.0.0/8',
   '172.16.0.0/12',
+  '192.168.0.0/16',
 ];
+if (getenv('IS_DDEV_PROJECT') !== 'true' && isset($_SERVER['REMOTE_ADDR']) && $_SERVER['REMOTE_ADDR'] !== '') {
+  $mel_default_proxy_addresses[] = $_SERVER['REMOTE_ADDR'];
+}
 $settings['reverse_proxy_addresses'] = array_values(array_unique(array_merge(
   $settings['reverse_proxy_addresses'] ?? [],
   $mel_default_proxy_addresses


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which client IPs may influence forwarded headers (scheme/host/port), which affects URL generation and can be security-sensitive if untrusted clients can reach the app directly.
> 
> **Overview**
> Expands Drupal **reverse proxy** trust so staging behind a load balancer correctly honors **X-Forwarded-Proto** (and related headers), keeping generated URLs on **HTTPS** instead of HTTP.
> 
> Adds private-network CIDRs **`10.0.0.0/8`** and **`192.168.0.0/16`** to the default trusted proxy list (alongside existing loopback and **`172.16.0.0/12`**). Outside DDEV, it also appends the current request’s **`REMOTE_ADDR`** when set, so the immediate upstream (e.g. the proxy hop Drupal sees) is trusted without hard-coding staging IPs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909a4608cec535d817bbac676725ef76fdcd7143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->