### PR TITLE
Feature/studio inline access codes

### DIFF
--- a/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php
@@ -132,6 +132,7 @@ final class TicketSelectionForm extends FormBase {
       '#type' => 'fieldset',
       '#title' => $this->t('Access code'),
       '#description' => $this->t('If you have an organiser code, enter it here to reveal hidden or invite-only tickets for this browser session.'),
+      '#tree' => TRUE,
       '#attributes' => ['class' => ['mel-ticket-booking-access']],
       '#weight' => 25,
     ];

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -4964,3 +4964,123 @@
     box-sizing: border-box;
   }
 }
+
+/* -------------------------------------------------------------------------- */
+/* Access-code management panel (inline Studio)                                */
+/* -------------------------------------------------------------------------- */
+
+.mel-studio-access-codes {
+  margin-top: 20px;
+}
+
+.mel-studio-access-codes__header {
+  margin-bottom: 12px;
+}
+
+.mel-studio-access-codes__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.mel-studio-access-codes__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--mel-surface-card, #fff);
+  border: 1px solid var(--mel-es-panel-border, #e2e8f0);
+  border-radius: 10px;
+}
+
+.mel-studio-access-codes__info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.mel-studio-access-codes__code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--mel-studio-text, #0f172a);
+  letter-spacing: 0.03em;
+}
+
+.mel-studio-access-codes__status {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px;
+}
+
+.mel-studio-access-codes__status--active {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mel-studio-access-codes__status--inactive {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.mel-studio-access-codes__status--expired {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.mel-studio-access-codes__usage,
+.mel-studio-access-codes__expires {
+  font-size: 0.8125rem;
+  color: var(--mel-studio-text-muted, #64748b);
+}
+
+.mel-studio-access-codes__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.mel-studio-access-codes__empty {
+  text-align: center;
+  padding: 16px 0;
+}
+
+.mel-studio-access-codes__empty-text {
+  margin: 0 0 12px;
+  font-size: 0.875rem;
+  color: var(--mel-studio-text-muted, #64748b);
+}
+
+.mel-studio-access-codes__footer {
+  margin-top: 8px;
+}
+
+.mel-studio-access-codes--disabled .mel-studio-access-codes__disabled-hint {
+  font-style: italic;
+  color: var(--mel-studio-text-muted, #64748b);
+}
+
+/* Access-code badge on ticket cards */
+.mel-event-studio-card-badge--access-code {
+  background: #eff6ff;
+  color: #1e40af;
+}
+
+@media (max-width: 640px) {
+  .mel-studio-access-codes__row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .mel-studio-access-codes__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -96,6 +96,7 @@ services:
       - '@?myeventlane_capacity.service'
       - '@?myeventlane_metrics.service'
       - '@myeventlane_event_studio.event_ticket_preview_builder'
+      - '@?myeventlane_tickets.access_code_management_builder'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -469,6 +469,17 @@ final class EventStudioOperationalTicketsForm extends FormBase {
               'class' => ['mel-event-studio-card-badge', 'mel-event-studio-card-badge--accent'],
             ],
           ],
+          'access_code' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $this->t('Access code required'),
+            '#access' => $ticket->hasField('visibility_mode')
+              && !$ticket->get('visibility_mode')->isEmpty()
+              && (string) $ticket->get('visibility_mode')->value === 'access_code',
+            '#attributes' => [
+              'class' => ['mel-event-studio-card-badge', 'mel-event-studio-card-badge--access-code'],
+            ],
+          ],
         ],
       ],
       'attendee_preview' => [

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -235,7 +235,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         '#title' => $this->t('Visibility'),
         '#options' => $this->visibilityOptions(),
         '#default_value' => 'public',
-        '#description' => $this->t('Most events should use Public.'),
+        '#description' => $this->t('Access code tickets require codes to be created in Ticket Tools before customers can see them.'),
       ],
       'status' => [
         '#type' => 'checkbox',
@@ -567,6 +567,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
             '#default_value' => $ticket->hasField('visibility_mode') && !$ticket->get('visibility_mode')->isEmpty()
               ? (string) $ticket->get('visibility_mode')->value
               : 'public',
+            '#description' => $this->t('Access code tickets require codes to be created in Ticket Tools before customers can see them.'),
             '#parents' => ['tickets', $ticket_id, 'visibility_mode'],
           ],
         ],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -17,6 +17,7 @@ use Drupal\myeventlane_event_studio\Form\EventStudioTicketsForm;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
 use Drupal\myeventlane_event_studio\Support\MelSupportResolverInterface;
 use Drupal\myeventlane_metrics\Service\EventMetricsServiceInterface;
+use Drupal\myeventlane_tickets\Service\AccessCodeManagementBuilder;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 
@@ -38,6 +39,7 @@ final class EventStudioSectionRenderer {
     private readonly ?EventCapacityServiceInterface $capacityService = NULL,
     private readonly ?EventMetricsServiceInterface $metricsService = NULL,
     private readonly ?EventTicketPreviewBuilder $eventTicketPreviewBuilder = NULL,
+    private readonly ?AccessCodeManagementBuilder $accessCodeManagementBuilder = NULL,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -203,6 +205,14 @@ final class EventStudioSectionRenderer {
       ? (string) $event->get('field_event_type')->value
       : '';
     if (in_array($event_type, ['paid', 'both'], TRUE)) {
+      if ($this->accessCodeManagementBuilder instanceof AccessCodeManagementBuilder) {
+        $accessCodePanel = $this->accessCodeManagementBuilder->build($event);
+        if ($accessCodePanel !== []) {
+          $build['access_codes'] = $accessCodePanel;
+          $build['access_codes']['#weight'] = 15;
+        }
+      }
+
       $support = $this->supportResolver->buildCard($event, 'tickets');
       if ($support !== NULL) {
         $build['support'] = $support;

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -367,6 +367,13 @@ services:
     tags:
       - { name: access_check }
 
+  myeventlane_tickets.access_code_management_builder:
+    class: Drupal\myeventlane_tickets\Service\AccessCodeManagementBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_tickets'
+      - '@string_translation'
+
   myeventlane_tickets.operational_integrity_inspector:
     class: Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector
     arguments:

--- a/web/modules/custom/myeventlane_tickets/src/Service/AccessCodeManagementBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/AccessCodeManagementBuilder.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_tickets\Entity\AccessCode;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds a compact access-code management panel for Event Studio.
+ *
+ * Reuses existing mel_access_code entities, routes, and access checks.
+ * Does not duplicate any access-code logic, validation, hashing, or
+ * save systems — it only reads and presents.
+ */
+final class AccessCodeManagementBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds the access-code panel render array for a saved event.
+   *
+   * @return array<string, mixed>
+   *   Render array for the panel, or empty array if the event is unsaved.
+   */
+  public function build(NodeInterface $event): array {
+    if ($event->isNew() || $event->id() === NULL) {
+      return $this->buildUnsavedState();
+    }
+
+    try {
+      $codes = $this->loadAccessCodes($event);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Access code panel failed to load codes for event @event: @message', [
+        '@event' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return [];
+    }
+
+    $event_id = (int) $event->id();
+
+    $build = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-studio-access-codes']],
+      'header' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-studio-access-codes__header']],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Access codes'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Use access codes to reveal private ticket types to customers. Tickets with "Access code" visibility stay hidden on the booking page until a valid code is entered.'),
+          '#attributes' => ['class' => ['mel-es-card__hint']],
+        ],
+      ],
+    ];
+
+    if ($codes === []) {
+      $build['empty'] = $this->buildEmptyState($event_id);
+    }
+    else {
+      $build['list'] = $this->buildCodeList($codes, $event_id);
+      $build['create_action'] = $this->buildCreateAction($event_id);
+    }
+
+    $build['#cache'] = [
+      'tags' => array_merge(
+        $event->getCacheTags(),
+        ['mel_access_code_list'],
+      ),
+      'contexts' => ['user.permissions'],
+    ];
+
+    return $build;
+  }
+
+  /**
+   * @return \Drupal\myeventlane_tickets\Entity\AccessCode[]
+   */
+  private function loadAccessCodes(NodeInterface $event): array {
+    $storage = $this->entityTypeManager->getStorage('mel_access_code');
+    $ids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('event', $event->id())
+      ->sort('code', 'ASC')
+      ->execute();
+
+    if (!$ids) {
+      return [];
+    }
+
+    $entities = $storage->loadMultiple($ids);
+    return array_filter($entities, static fn($e) => $e instanceof AccessCode);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildUnsavedState(): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-studio-access-codes', 'mel-studio-access-codes--disabled']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Access codes'),
+        '#attributes' => ['class' => ['mel-es-card__title']],
+      ],
+      'message' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Save this event before adding access codes.'),
+        '#attributes' => ['class' => ['mel-es-card__hint', 'mel-studio-access-codes__disabled-hint']],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildEmptyState(int $event_id): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-studio-access-codes__empty']],
+      'message' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No access codes yet.'),
+        '#attributes' => ['class' => ['mel-studio-access-codes__empty-text']],
+      ],
+      'action' => [
+        '#type' => 'link',
+        '#title' => $this->t('Create access code'),
+        '#url' => Url::fromRoute('myeventlane_tickets.event_tickets_access_codes_add', [
+          'event' => $event_id,
+        ]),
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--primary', 'mel-studio-access-codes__cta'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param \Drupal\myeventlane_tickets\Entity\AccessCode[] $codes
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCodeList(array $codes, int $event_id): array {
+    $rows = [];
+    foreach ($codes as $code) {
+      $rows[] = $this->buildCodeRow($code, $event_id);
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-studio-access-codes__list']],
+      'items' => $rows,
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildCodeRow(AccessCode $code, int $event_id): array {
+    $raw = $code->getCode();
+    $masked = strlen($raw) > 4 ? '****' . substr($raw, -4) : '****';
+
+    $status_value = (string) $code->get('status')->value;
+    $status_label = match ($status_value) {
+      AccessCode::STATUS_ACTIVE => $this->t('Active'),
+      AccessCode::STATUS_INACTIVE => $this->t('Inactive'),
+      AccessCode::STATUS_EXPIRED => $this->t('Expired'),
+      default => $this->t('Unknown'),
+    };
+
+    $usage_count = (int) $code->get('usage_count')->value;
+    $usage_limit = $code->get('usage_limit')->isEmpty() ? NULL : (int) $code->get('usage_limit')->value;
+    $usage_text = $usage_limit !== NULL
+      ? $this->t('@count / @limit used', ['@count' => $usage_count, '@limit' => $usage_limit])
+      : $this->t('@count used', ['@count' => $usage_count]);
+
+    $status_class = match ($status_value) {
+      AccessCode::STATUS_ACTIVE => 'mel-studio-access-codes__status--active',
+      AccessCode::STATUS_INACTIVE => 'mel-studio-access-codes__status--inactive',
+      default => 'mel-studio-access-codes__status--expired',
+    };
+
+    $row = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-studio-access-codes__row']],
+      'info' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-studio-access-codes__info']],
+        'code' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $masked,
+          '#attributes' => ['class' => ['mel-studio-access-codes__code']],
+        ],
+        'status' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $status_label,
+          '#attributes' => ['class' => ['mel-studio-access-codes__status', $status_class]],
+        ],
+        'usage' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $usage_text,
+          '#attributes' => ['class' => ['mel-studio-access-codes__usage']],
+        ],
+      ],
+    ];
+
+    if (!$code->get('expires')->isEmpty()) {
+      $expires_raw = (string) $code->get('expires')->value;
+      if ($expires_raw !== '') {
+        $row['info']['expires'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $this->t('Expires @date', ['@date' => $expires_raw]),
+          '#attributes' => ['class' => ['mel-studio-access-codes__expires']],
+        ];
+      }
+    }
+
+    $row['actions'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-studio-access-codes__actions']],
+      'edit' => [
+        '#type' => 'link',
+        '#title' => $this->t('Edit'),
+        '#url' => Url::fromRoute('myeventlane_tickets.event_tickets_access_codes_edit', [
+          'event' => $event_id,
+          'mel_access_code' => $code->id(),
+        ]),
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--sm', 'mel-btn--secondary'],
+        ],
+      ],
+      'delete' => [
+        '#type' => 'link',
+        '#title' => $this->t('Delete'),
+        '#url' => Url::fromRoute('entity.mel_access_code.delete_form', [
+          'event' => $event_id,
+          'mel_access_code' => $code->id(),
+        ]),
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--sm', 'mel-btn--danger'],
+        ],
+      ],
+    ];
+
+    return $row;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildCreateAction(int $event_id): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-studio-access-codes__footer']],
+      'link' => [
+        '#type' => 'link',
+        '#title' => $this->t('Create access code'),
+        '#url' => Url::fromRoute('myeventlane_tickets.event_tickets_access_codes_add', [
+          'event' => $event_id,
+        ]),
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--primary', 'mel-studio-access-codes__cta'],
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-layer changes that reuse existing entities, routes, and access checks; the commerce form tree fix is a small behavioral correction for code entry.
> 
> **Overview**
> **Event Studio** now surfaces **access codes inline** on the tickets section for paid/both events: a new read-only panel lists `mel_access_code` rows (masked codes, status, usage, expiry) with links to existing add/edit/delete routes—no duplicate create/save logic.
> 
> **Operational ticket editing** adds an **“Access code required”** badge when visibility is `access_code`, and copy on visibility fields pointing organisers to create codes in Ticket Tools first.
> 
> **Booking** fixes the access-code fieldset with `#tree` so `booking_access[code]` submits correctly on **Apply code**.
> 
> Styling covers the Studio access-code panel and ticket-card badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40143bd150904095816bc1c0dd6c1680f1f3c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->