### PR TITLE
Fix/main access code followups

### DIFF
--- a/web/modules/custom/myeventlane_tickets/src/Service/AccessCodeManagementBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/AccessCodeManagementBuilder.php
@@ -84,9 +84,15 @@ final class AccessCodeManagementBuilder {
       $build['create_action'] = $this->buildCreateAction($event_id);
     }
 
+    $code_cache_tags = [];
+    foreach ($codes as $code) {
+      $code_cache_tags = array_merge($code_cache_tags, $code->getCacheTags());
+    }
+
     $build['#cache'] = [
       'tags' => array_merge(
         $event->getCacheTags(),
+        $code_cache_tags,
         ['mel_access_code_list'],
       ),
       'contexts' => ['user.permissions'],

--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -117,9 +117,6 @@ $mel_default_proxy_addresses = [
   '172.16.0.0/12',
   '192.168.0.0/16',
 ];
-if (getenv('IS_DDEV_PROJECT') !== 'true' && isset($_SERVER['REMOTE_ADDR']) && $_SERVER['REMOTE_ADDR'] !== '') {
-  $mel_default_proxy_addresses[] = $_SERVER['REMOTE_ADDR'];
-}
 $settings['reverse_proxy_addresses'] = array_values(array_unique(array_merge(
   $settings['reverse_proxy_addresses'] ?? [],
   $mel_default_proxy_addresses


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Reverse-proxy trust affects how Drupal reads client IP and scheme behind load balancers; misconfiguration could break sessions or logging, while the cache change is low-risk correctness.
> 
> **Overview**
> **Event Studio access codes:** The management panel’s render cache now merges each loaded `mel_access_code` entity’s cache tags with the event and `mel_access_code_list` tags, so edits to individual codes invalidate the panel instead of serving stale rows.
> 
> **Shared session / reverse proxy:** On non-DDEV environments, the app no longer appends the current request’s `REMOTE_ADDR` to `reverse_proxy_addresses`. Trusted proxies stay the fixed private ranges plus any addresses already configured elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522fedf269c7de9353a20b6d22ef155b0673814c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->