### PR TITLE
Feature/event visibility studio UI

### DIFF
--- a/docs/audits/event-visibility-studio-ui-smoke-test.md
+++ b/docs/audits/event-visibility-studio-ui-smoke-test.md
@@ -1,0 +1,59 @@
+# Event Visibility Studio UI — Smoke Test
+
+Feature branch: `feature/event-visibility-studio-ui`
+
+## Functional Checks
+
+- [ ] **1. Public event appears in listings and direct URL works.**
+  Set visibility to Public, save. Confirm event appears in public listings, search, calendar, and category pages. Direct URL (`/event/{slug}`) loads for anonymous visitors.
+
+- [ ] **2. Unlisted event direct URL works but does not appear in listings/search/category/calendar.**
+  Set visibility to Unlisted, save. Direct URL works for anonymous. Event does not appear in public listings, search results, category pages, or calendar feeds. `noindex` header is present.
+
+- [ ] **3. Private event direct URL is denied for anonymous/non-owner.**
+  Set visibility to Private, save. Anonymous visitor receives access denied on direct URL. Owner, vendor team member, admin, and staff can still view.
+
+- [ ] **4. Passcode event redirects/gates anonymous direct visitor.**
+  Set visibility to Passcode protected, enter a passcode, save. Anonymous visitor on direct URL sees a passcode gate (redirect or interstitial). Event does not appear in public discovery.
+
+- [ ] **5. Correct passcode unlocks event.**
+  Enter the correct passcode at the gate. Event page loads. Booking flow is accessible after unlock.
+
+- [ ] **6. Booking route respects passcode unlock.**
+  Without unlocking, attempt to access the booking route for a passcode-protected event. Access is denied. After unlocking via passcode, booking route is accessible.
+
+- [ ] **7. Changing passcode replaces hash.**
+  Open Event Studio settings for a passcode-protected event. Enter a new passcode, save. Old passcode no longer works. New passcode unlocks correctly.
+
+- [ ] **8. Switching away from passcode clears or safely disables passcode hash.**
+  Change visibility from Passcode protected to Public (or any other), save. Confirm `field_event_passcode_hash` is cleared on the entity. Switching back to Passcode protected without entering a new passcode shows a validation error.
+
+- [ ] **9. Hash never appears in page source, JS payload, logs, API, or Twig.**
+  Inspect page source on the event page — no bcrypt hash string.
+  Inspect the Vendor Studio JSON payload (`settings_config`) — only `has_passcode: true/false`, `visibility`, `visibility_label` exposed. No `field_event_passcode_hash`.
+  Check Drupal logs — no passcode hash values logged.
+  Check JSON:API / REST responses if enabled — passcode hash field not exposed.
+
+- [ ] **10. Vendor can see current state in Studio.**
+  Open Event Studio settings section. Current visibility is shown with a clear label (Public / Unlisted / Private / Passcode protected). Radio selector matches the stored value. Help text is visible for all four options.
+
+## Security Checks
+
+- [ ] Only event owner, vendor team member, admin, or staff can edit visibility (anonymous cannot access save endpoints).
+- [ ] CSRF checks remain intact on both Studio form save and Vendor Studio JSON endpoint.
+- [ ] Passcode hash is not cache-leaked (check page cache headers, Drupal render cache).
+- [ ] No sensitive value (hash or plaintext passcode) appears in browser console, network tab responses, or server logs.
+
+## Validation Commands
+
+```bash
+composer validate
+find web/modules/custom/myeventlane_event web/modules/custom/myeventlane_event_studio web/modules/custom/myeventlane_vendor -name "*.php" -print0 | xargs -0 -n1 php -l
+npm run mel:lint
+npm run mel:build
+ddev drush cr
+ddev drush updb -y
+ddev drush cim -y
+ddev drush cr
+git status -sb
+```

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5084,3 +5084,59 @@
     justify-content: flex-end;
   }
 }
+
+/* ── Event Visibility Controls ── */
+
+.mel-visibility-section {
+  background: var(--mel-surface-bg, #fff);
+  border: 1px solid var(--mel-border-subtle, #e2e8f0);
+  border-radius: 8px;
+  padding: 20px 24px;
+  margin-block-end: 16px;
+}
+
+.mel-visibility-section__title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.mel-visibility-section__current {
+  font-size: 0.875rem;
+  color: var(--mel-text-secondary, #64748b);
+  margin: 0;
+}
+
+.mel-visibility-radios {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mel-visibility-help {
+  background: var(--mel-surface-muted, #f8fafc);
+  border: 1px solid var(--mel-border-subtle, #e2e8f0);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-block-end: 16px;
+}
+
+.mel-visibility-help__item {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--mel-text-secondary, #64748b);
+  margin: 0 0 6px;
+}
+
+.mel-visibility-help__item:last-child {
+  margin-block-end: 0;
+}
+
+.mel-visibility-passcode-input {
+  max-width: 320px;
+}
+
+.mel-visibility-passcode-status {
+  font-size: 0.875rem;
+  margin-block-end: 12px;
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -338,6 +338,7 @@ services:
       - '@?myeventlane_questions.template_cloner'
       - '@myeventlane_event_studio.operational_capability_studio_manager'
       - '@myeventlane_event_studio.event_page_style_resolver'
+      - '@myeventlane_event.passcode_access'
 
   myeventlane_event_studio.readiness:
     class: Drupal\myeventlane_event_studio\Service\EventReadinessService

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\node\NodeInterface;
 
 /**
@@ -35,6 +36,182 @@ final class EventSettingsForm extends EventStudioPublishForm {
   protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
     $this->messenger()->addStatus($saved->isPublished() ? $this->t('Event settings saved.') : $this->t('Event saved as draft.'));
     $form_state->setRedirect('myeventlane_event_studio.workspace_settings', ['node' => $saved->id()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $this->buildVisibilityControls($form, $node, $melDefaults);
+    parent::buildWizardStepContent($form, $form_state, $node, $melDefaults);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    parent::validateForm($form, $form_state);
+
+    $mel = $form_state->getValue('mel');
+    if (!is_array($mel)) {
+      return;
+    }
+
+    $visibility = trim((string) ($mel['field_event_visibility'] ?? ''));
+    if ($visibility !== PublicEventVisibility::VISIBILITY_PASSCODE) {
+      return;
+    }
+
+    $new_passcode = trim((string) ($mel['event_passcode'] ?? ''));
+    if ($new_passcode !== '') {
+      return;
+    }
+
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid > 0) {
+      $loaded = $this->entityTypeManager->getStorage('node')->load($nid);
+      if ($loaded instanceof NodeInterface
+        && $loaded->bundle() === 'event'
+        && $loaded->hasField('field_event_passcode_hash')
+        && !$loaded->get('field_event_passcode_hash')->isEmpty()
+        && (string) $loaded->get('field_event_passcode_hash')->value !== '') {
+        return;
+      }
+    }
+
+    $form_state->setErrorByName(
+      'mel][event_passcode',
+      $this->t('A passcode is required when visibility is set to passcode protected.'),
+    );
+  }
+
+  /**
+   * Builds the visibility radio selector and passcode input.
+   *
+   * @param array<string, mixed> $melDefaults
+   */
+  private function buildVisibilityControls(array &$form, NodeInterface $node, array $melDefaults): void {
+    $current_visibility = '';
+    if ($node->hasField('field_event_visibility') && !$node->get('field_event_visibility')->isEmpty()) {
+      $current_visibility = (string) $node->get('field_event_visibility')->value;
+    }
+    if ($current_visibility === '') {
+      $current_visibility = (string) ($melDefaults['field_event_visibility'] ?? PublicEventVisibility::VISIBILITY_PUBLIC);
+    }
+
+    $has_passcode = $node->hasField('field_event_passcode_hash')
+      && !$node->get('field_event_passcode_hash')->isEmpty()
+      && (string) $node->get('field_event_passcode_hash')->value !== '';
+
+    $visibility_labels = [
+      PublicEventVisibility::VISIBILITY_PUBLIC => $this->t('Public'),
+      PublicEventVisibility::VISIBILITY_UNLISTED => $this->t('Unlisted'),
+      PublicEventVisibility::VISIBILITY_PRIVATE => $this->t('Private'),
+      PublicEventVisibility::VISIBILITY_PASSCODE => $this->t('Passcode protected'),
+    ];
+
+    $form['mel']['visibility_section'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-visibility-section'],
+        'role' => 'region',
+        'aria-labelledby' => 'mel-visibility-title',
+      ],
+      '#weight' => -10,
+    ];
+
+    $form['mel']['visibility_section']['title'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h3',
+      '#value' => $this->t('Event visibility'),
+      '#attributes' => [
+        'id' => 'mel-visibility-title',
+        'class' => ['mel-visibility-section__title'],
+      ],
+    ];
+
+    $current_label = $visibility_labels[$current_visibility] ?? $this->t('Public');
+    $form['mel']['visibility_section']['current_state'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Current: <strong>@label</strong>', ['@label' => $current_label]),
+      '#attributes' => ['class' => ['mel-visibility-section__current']],
+    ];
+
+    $form['mel']['field_event_visibility'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Who can see this event?'),
+      '#options' => $visibility_labels,
+      '#default_value' => $current_visibility,
+      '#required' => TRUE,
+      '#attributes' => ['class' => ['mel-visibility-radios']],
+      '#weight' => -9,
+    ];
+
+    $form['mel']['visibility_help'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-visibility-help']],
+      '#weight' => -8,
+    ];
+    $form['mel']['visibility_help']['public_help'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('<strong>Public</strong> — appears in listings, search, calendar, categories, API, and SEO.'),
+      '#attributes' => ['class' => ['mel-visibility-help__item']],
+    ];
+    $form['mel']['visibility_help']['unlisted_help'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('<strong>Unlisted</strong> — direct link works, hidden from discovery and search engines (noindex).'),
+      '#attributes' => ['class' => ['mel-visibility-help__item']],
+    ];
+    $form['mel']['visibility_help']['private_help'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('<strong>Private</strong> — only the owner, team members, admins, and staff can view or book.'),
+      '#attributes' => ['class' => ['mel-visibility-help__item']],
+    ];
+    $form['mel']['visibility_help']['passcode_help'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('<strong>Passcode protected</strong> — hidden from discovery; direct visitors must enter a passcode before viewing or booking.'),
+      '#attributes' => ['class' => ['mel-visibility-help__item']],
+    ];
+
+    $passcode_description = $has_passcode
+      ? (string) $this->t('Leave blank to keep the existing passcode, or enter a new passcode to replace it.')
+      : (string) $this->t('Enter a passcode that visitors must provide to access this event.');
+
+    $form['mel']['event_passcode'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Event passcode'),
+      '#description' => $passcode_description,
+      '#attributes' => [
+        'class' => ['mel-input', 'mel-visibility-passcode-input'],
+        'autocomplete' => 'new-password',
+      ],
+      '#weight' => -7,
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[field_event_visibility]"]' => ['value' => PublicEventVisibility::VISIBILITY_PASSCODE],
+        ],
+      ],
+    ];
+
+    if ($has_passcode && $current_visibility === PublicEventVisibility::VISIBILITY_PASSCODE) {
+      $form['mel']['passcode_status'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('This event currently has a passcode set.'),
+        '#attributes' => ['class' => ['mel-visibility-passcode-status', 'messages', 'messages--status']],
+        '#weight' => -6,
+        '#states' => [
+          'visible' => [
+            ':input[name="mel[field_event_visibility]"]' => ['value' => PublicEventVisibility::VISIBILITY_PASSCODE],
+          ],
+        ],
+      ];
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -120,6 +120,8 @@ final class EventStudioMelPayloadService {
       'event_highlights' => $this->decodeAndNormalizeEventHighlightsFromMel($mel),
       'event_highlights_items_state' => trim((string) (($mel['event_highlights'] ?? [])['items_state'] ?? '')),
       'attendee_questions' => $attendee_questions,
+      'field_event_visibility' => trim((string) ($mel['field_event_visibility'] ?? '')),
+      'event_passcode' => trim((string) ($mel['event_passcode'] ?? '')),
     ];
 
     $eventNode = NULL;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_event_studio\Service;
 use Drupal\Component\Utility\Tags;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
@@ -35,7 +36,10 @@ final class EventStudioMelPayloadService {
     $venue_id = NULL;
     if ($choice === 'saved' && !empty($mel['venue_saved'])) {
       $raw = $mel['venue_saved'];
-      if (is_array($raw) && isset($raw[0]['target_id'])) {
+      if ($raw instanceof EntityInterface) {
+        $venue_id = (int) $raw->id();
+      }
+      elseif (is_array($raw) && isset($raw[0]['target_id'])) {
         $venue_id = (int) $raw[0]['target_id'];
       }
       elseif (is_numeric($raw)) {
@@ -379,6 +383,10 @@ final class EventStudioMelPayloadService {
   private function extractSingleEntityId(mixed $raw): ?int {
     if ($raw === NULL || $raw === '') {
       return NULL;
+    }
+    if ($raw instanceof EntityInterface) {
+      $id = (int) $raw->id();
+      return $id > 0 ? $id : NULL;
     }
     if (is_numeric($raw)) {
       $id = (int) $raw;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -14,6 +14,8 @@ use Drupal\Core\Image\ImageFactory;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
+use Drupal\myeventlane_event\Service\EventPasscodeAccess;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_questions\Entity\VendorQuestionInterface;
 use Drupal\myeventlane_questions\Service\QuestionTemplateCloner;
@@ -61,6 +63,7 @@ final class EventStudioSaveService {
     private readonly ?QuestionTemplateCloner $questionTemplateCloner = NULL,
     private readonly ?OperationalCapabilityStudioManager $operationalCapabilityStudioManager = NULL,
     private readonly ?EventPageStyleResolver $eventPageStyleResolver = NULL,
+    private readonly ?EventPasscodeAccess $passcodeAccess = NULL,
   ) {}
 
   /**
@@ -311,6 +314,11 @@ final class EventStudioSaveService {
     $attendee_errors = $this->syncAttendeeQuestions($node, $payload, $account);
     if ($attendee_errors !== []) {
       return ['node' => NULL, 'errors' => $attendee_errors];
+    }
+
+    $visibility_errors = $this->applyVisibilityPayload($node, $payload);
+    if ($visibility_errors !== []) {
+      return ['node' => NULL, 'errors' => $visibility_errors];
     }
 
     $capability_errors = $this->applyOperationalCapabilitiesPayload($node, $payload);
@@ -837,6 +845,52 @@ final class EventStudioSaveService {
         ],
       ]);
     }
+  }
+
+  /**
+   * Sets field_event_visibility and manages field_event_passcode_hash.
+   *
+   * @param array<string, mixed> $payload
+   *
+   * @return list<string>
+   */
+  private function applyVisibilityPayload(NodeInterface $node, array $payload): array {
+    if (!array_key_exists('field_event_visibility', $payload)) {
+      return [];
+    }
+
+    $visibility = trim((string) $payload['field_event_visibility']);
+    if ($visibility === '') {
+      return [];
+    }
+
+    $visibility = PublicEventVisibility::normalizeVisibilityValue($visibility);
+
+    if ($node->hasField('field_event_visibility')) {
+      $node->set('field_event_visibility', $visibility);
+    }
+
+    if (!$node->hasField('field_event_passcode_hash')) {
+      return [];
+    }
+
+    if ($visibility === PublicEventVisibility::VISIBILITY_PASSCODE) {
+      $new_passcode = trim((string) ($payload['event_passcode'] ?? ''));
+      if ($new_passcode !== '') {
+        if ($this->passcodeAccess === NULL) {
+          $this->logger->error('Event Studio: cannot hash passcode — EventPasscodeAccess service not injected for event @nid.', [
+            '@nid' => (string) ($node->id() ?? 'new'),
+          ]);
+          return ['Passcode service is temporarily unavailable.'];
+        }
+        $node->set('field_event_passcode_hash', $this->passcodeAccess->hashPasscode($new_passcode));
+      }
+    }
+    else {
+      $node->set('field_event_passcode_hash', NULL);
+    }
+
+    return [];
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -12,6 +12,8 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\EntityIdNormalizer;
+use Drupal\myeventlane_event\Service\EventPasscodeAccess;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\myeventlane_event_studio\DTO\MelEventData;
 use Drupal\myeventlane_event_studio\Service\EventRepository;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
@@ -57,6 +59,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
     private readonly ?TicketSalesService $ticketSalesService = NULL,
     private readonly ?RsvpStatsService $rsvpStatsService = NULL,
     private readonly ?EventMetricsServiceInterface $eventMetricsService = NULL,
+    private readonly ?EventPasscodeAccess $passcodeAccess = NULL,
   ) {
     parent::__construct($domainDetector, $currentUser, $messenger);
   }
@@ -79,6 +82,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       $container->has('myeventlane_vendor.service.ticket_sales') ? $container->get('myeventlane_vendor.service.ticket_sales') : NULL,
       $container->has('myeventlane_vendor.service.rsvp_stats') ? $container->get('myeventlane_vendor.service.rsvp_stats') : NULL,
       $container->has('myeventlane_metrics.service') ? $container->get('myeventlane_metrics.service') : NULL,
+      $container->has('myeventlane_event.passcode_access') ? $container->get('myeventlane_event.passcode_access') : NULL,
     );
   }
 
@@ -746,7 +750,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       }
 
       if (isset($payload['visibility']) && $event->hasField('field_event_visibility')) {
-        $visibility = \Drupal\myeventlane_event\Service\PublicEventVisibility::normalizeVisibilityValue((string) $payload['visibility']);
+        $visibility = PublicEventVisibility::normalizeVisibilityValue((string) $payload['visibility']);
         $current_visibility = (string) ($event->get('field_event_visibility')->value ?? '');
         if ($current_visibility !== $visibility) {
           $event->set('field_event_visibility', $visibility);
@@ -754,21 +758,30 @@ final class VendorStudioController extends VendorConsoleBaseController implement
         }
       }
 
-      if (isset($payload['passcode']) && $event->hasField('field_event_passcode_hash')) {
-        $passcode = trim((string) $payload['passcode']);
-        $visibility = $event->hasField('field_event_visibility')
-          ? (string) ($event->get('field_event_visibility')->value ?? '')
-          : '';
+      $effective_visibility = $event->hasField('field_event_visibility')
+        ? (string) ($event->get('field_event_visibility')->value ?? '')
+        : '';
 
+      if ($effective_visibility === PublicEventVisibility::VISIBILITY_PASSCODE) {
+        $passcode = isset($payload['passcode']) ? trim((string) $payload['passcode']) : '';
         if ($passcode !== '') {
-          $hash = password_hash($passcode, PASSWORD_BCRYPT);
-          $event->set('field_event_passcode_hash', $hash);
+          if ($this->passcodeAccess === NULL) {
+            $this->logger->error('Vendor Studio settings save: EventPasscodeAccess not available for nid=@nid', [
+              '@nid' => (int) $event->id(),
+            ]);
+            return new JsonResponse([
+              'success' => FALSE,
+              'message' => 'Passcode service is temporarily unavailable.',
+            ], 500);
+          }
+          $event->set('field_event_passcode_hash', $this->passcodeAccess->hashPasscode($passcode));
           $has_changes = TRUE;
         }
-        elseif ($visibility === 'passcode') {
-          $existing_hash = $event->get('field_event_passcode_hash')->isEmpty()
-            ? ''
-            : (string) $event->get('field_event_passcode_hash')->value;
+        else {
+          $existing_hash = $event->hasField('field_event_passcode_hash')
+            && !$event->get('field_event_passcode_hash')->isEmpty()
+            ? (string) $event->get('field_event_passcode_hash')->value
+            : '';
           if ($existing_hash === '') {
             return new JsonResponse([
               'success' => FALSE,
@@ -777,20 +790,10 @@ final class VendorStudioController extends VendorConsoleBaseController implement
           }
         }
       }
-      elseif (!isset($payload['passcode'])) {
-        $visibility = $event->hasField('field_event_visibility')
-          ? (string) ($event->get('field_event_visibility')->value ?? '')
-          : '';
-        if ($visibility === 'passcode' && $event->hasField('field_event_passcode_hash')) {
-          $existing_hash = $event->get('field_event_passcode_hash')->isEmpty()
-            ? ''
-            : (string) $event->get('field_event_passcode_hash')->value;
-          if ($existing_hash === '') {
-            return new JsonResponse([
-              'success' => FALSE,
-              'message' => 'A passcode is required when visibility is set to passcode. Include a "passcode" field in the payload.',
-            ], 422);
-          }
+      elseif ($event->hasField('field_event_passcode_hash')) {
+        if (!$event->get('field_event_passcode_hash')->isEmpty()) {
+          $event->set('field_event_passcode_hash', NULL);
+          $has_changes = TRUE;
         }
       }
 
@@ -1121,6 +1124,7 @@ final class VendorStudioController extends VendorConsoleBaseController implement
         'visibility' => $event->hasField('field_event_visibility')
           ? (string) ($event->get('field_event_visibility')->value ?? '')
           : '',
+        'visibility_label' => $this->resolveVisibilityLabel($event),
         'has_passcode' => $event->hasField('field_event_passcode_hash')
           && !$event->get('field_event_passcode_hash')->isEmpty()
           && (string) $event->get('field_event_passcode_hash')->value !== '',
@@ -1393,6 +1397,23 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       'review', 'needs_review' => 'review',
       'published', 'live' => 'published',
       default => 'draft',
+    };
+  }
+
+  /**
+   * Maps visibility value to a human label for the Studio payload.
+   */
+  protected function resolveVisibilityLabel(NodeInterface $event): string {
+    $visibility = $event->hasField('field_event_visibility') && !$event->get('field_event_visibility')->isEmpty()
+      ? (string) $event->get('field_event_visibility')->value
+      : '';
+
+    return match ($visibility) {
+      PublicEventVisibility::VISIBILITY_PUBLIC => (string) $this->t('Public'),
+      PublicEventVisibility::VISIBILITY_UNLISTED => (string) $this->t('Unlisted'),
+      PublicEventVisibility::VISIBILITY_PRIVATE => (string) $this->t('Private'),
+      PublicEventVisibility::VISIBILITY_PASSCODE => (string) $this->t('Passcode protected'),
+      default => (string) $this->t('Public'),
     };
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches passcode hashing, visibility persistence, and Vendor Studio JSON settings; security-sensitive but centralized on EventPasscodeAccess and avoids exposing hashes in API payloads.
> 
> **Overview**
> This PR adds **event visibility controls** to Event Studio settings and wires them through the shared save path and Vendor Studio JSON API.
> 
> **Event Studio settings UI** (`EventSettingsForm`) now shows Public / Unlisted / Private / Passcode protected radios, help text, current-state label, and a conditional password field (blank keeps an existing passcode). Validation requires a passcode when switching to passcode protected with no stored hash.
> 
> **Persistence**: `EventStudioMelPayloadService` includes `field_event_visibility` and `event_passcode`; `EventStudioSaveService` applies visibility via `PublicEventVisibility::normalizeVisibilityValue`, hashes new passcodes with injected `EventPasscodeAccess`, and **clears** `field_event_passcode_hash` when visibility is not passcode.
> 
> **Vendor Studio**: settings save uses the same hashing service (replacing inline `password_hash`), enforces passcode when visibility is passcode, clears the hash when leaving passcode mode, and exposes `visibility_label` and `has_passcode` in `settings_config` (not the hash).
> 
> Minor fixes: entity autocomplete payloads accept `EntityInterface` for venue/product IDs. New CSS for visibility blocks and a smoke-test checklist doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56eeafa54f5a8da2b2985dd02493a7586fdfd30d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->