### PR TITLE
fix(events): style passcode gate page

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
@@ -46,8 +46,31 @@ final class EventPasscodeForm extends FormBase {
       'max-age' => 0,
     ];
 
-    $form['title_display'] = [
-      '#markup' => '<h2>' . $this->t('This event requires a passcode') . '</h2>',
+    $form['event_title'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h1',
+      '#value' => $node->label(),
+      '#attributes' => [
+        'class' => ['mel-passcode-gate__event-title'],
+      ],
+    ];
+
+    $form['gate_heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('This event is passcode protected'),
+      '#attributes' => [
+        'class' => ['mel-passcode-gate__heading'],
+      ],
+    ];
+
+    $form['gate_description'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Enter the passcode from the organiser to continue.'),
+      '#attributes' => [
+        'class' => ['mel-passcode-gate__description'],
+      ],
     ];
 
     $form['passcode'] = [
@@ -68,6 +91,11 @@ final class EventPasscodeForm extends FormBase {
       '#type' => 'submit',
       '#value' => $this->t('Unlock event'),
       '#button_type' => 'primary',
+    ];
+
+    $form['back_url'] = [
+      '#type' => 'value',
+      '#value' => Url::fromRoute('<front>')->toString(),
     ];
 
     return $form;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-passcode-gate.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-passcode-gate.scss
@@ -1,0 +1,224 @@
+// ==========================================================================
+// Event Passcode Gate
+// ==========================================================================
+// Centered card for passcode-protected event entry.
+// Follows the mel-auth-* pattern from _auth.scss.
+
+@use '../tokens/colors';
+@use '../tokens/typography';
+@use '../tokens/spacing';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/breakpoints';
+
+.mel-passcode-gate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: spacing.mel-space(6) spacing.mel-space(4);
+}
+
+.mel-passcode-gate__container {
+  width: 100%;
+  max-width: 460px;
+}
+
+.mel-passcode-gate__card {
+  background: colors.$mel-color-surface;
+  border-radius: radii.$mel-radius-xl;
+  padding: spacing.mel-space(6);
+  box-shadow: shadows.$mel-shadow-lg;
+  text-align: center;
+
+  @include breakpoints.mel-break(md) {
+    padding: spacing.mel-space(8);
+  }
+}
+
+// Lock icon
+.mel-passcode-gate__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  margin: 0 auto spacing.mel-space(5);
+  border-radius: radii.$mel-radius-full;
+  background: colors.$mel-color-surface-alt;
+  color: colors.$mel-color-primary;
+}
+
+// Header section: title + explanation
+.mel-passcode-gate__header {
+  margin-bottom: spacing.mel-space(6);
+}
+
+.mel-passcode-gate__event-title {
+  font-size: typography.mel-font-size(xl);
+  font-weight: typography.$mel-font-bold;
+  color: colors.$mel-color-text;
+  margin: 0 0 spacing.mel-space(3) 0;
+  line-height: typography.$mel-leading-tight;
+
+  @include breakpoints.mel-break(md) {
+    font-size: typography.mel-font-size(2xl);
+  }
+}
+
+.mel-passcode-gate__heading {
+  font-size: typography.mel-font-size(base);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text;
+  margin: 0 0 spacing.mel-space(2) 0;
+}
+
+.mel-passcode-gate__description {
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  margin: 0;
+  line-height: typography.$mel-leading-relaxed;
+}
+
+// Password field
+.mel-passcode-gate__fields {
+  text-align: left;
+  margin-bottom: spacing.mel-space(5);
+
+  .form-item {
+    margin-bottom: 0;
+
+    label {
+      display: block;
+      margin-bottom: spacing.mel-space(2);
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-semibold;
+      color: colors.$mel-color-text;
+    }
+
+    input[type='password'] {
+      width: 100%;
+      padding: spacing.mel-space(3) spacing.mel-space(4);
+      border: 2px solid colors.$mel-color-border;
+      border-radius: radii.$mel-radius-md;
+      font-size: typography.mel-font-size(base);
+      font-family: typography.$mel-font-family;
+      color: colors.$mel-color-text;
+      background: colors.$mel-color-surface;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+      min-height: 44px;
+
+      &::placeholder {
+        color: colors.$mel-color-text-light;
+      }
+
+      &:hover {
+        border-color: colors.$mel-color-border-strong;
+      }
+
+      &:focus {
+        outline: none;
+        border-color: colors.$mel-color-secondary;
+        box-shadow: 0 0 0 3px rgba(colors.$mel-color-secondary, 0.15);
+      }
+
+      &.error {
+        border-color: colors.$mel-color-error;
+
+        &:focus {
+          box-shadow: 0 0 0 3px rgba(colors.$mel-color-error, 0.15);
+        }
+      }
+    }
+  }
+}
+
+// Submit button
+.mel-passcode-gate__actions {
+  margin-bottom: spacing.mel-space(5);
+
+  .form-actions {
+    margin: 0;
+    padding: 0;
+  }
+
+  .button,
+  .form-submit,
+  input[type='submit'] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: spacing.mel-space(3) spacing.mel-space(6);
+    min-height: 52px;
+    font-family: typography.$mel-font-family;
+    font-size: typography.mel-font-size(md);
+    font-weight: typography.$mel-font-semibold;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    border: 2px solid transparent;
+    border-radius: radii.$mel-radius-lg;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    background-color: colors.$mel-color-primary;
+    color: colors.$mel-color-text-inverse;
+
+    &:hover {
+      background-color: colors.$mel-color-primary-hover;
+    }
+
+    &:active {
+      background-color: colors.$mel-color-primary-active;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      @include colors.mel-focus-ring;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+  }
+}
+
+// Back link
+.mel-passcode-gate__footer {
+  padding-top: spacing.mel-space(4);
+  border-top: 1px solid colors.$mel-color-border;
+}
+
+.mel-passcode-gate__back-link {
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  text-decoration: none;
+  font-weight: typography.$mel-font-medium;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: colors.$mel-color-primary;
+    text-decoration: underline;
+  }
+}
+
+// Error messages within the gate
+.mel-passcode-gate__form {
+  .messages--error {
+    max-width: 460px;
+    margin: spacing.mel-space(4) auto;
+    padding: spacing.mel-space(3) spacing.mel-space(4);
+    background: colors.$mel-color-error-bg;
+    border: 1px solid colors.$mel-color-error;
+    border-radius: radii.$mel-radius-md;
+    color: colors.$mel-color-error;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-medium;
+    text-align: center;
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -204,6 +204,7 @@
 @use 'components/studio-inspector';
 @use 'components/vendor-studio-layout';
 @use 'components/event-studio';
+@use 'components/event-passcode-gate';
 
 // ---------------------------------------------------------------------------
 // 6. Pages

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-event-passcode-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-event-passcode-form.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Passcode gate form — styled card for passcode-protected events.
+ *
+ * Wraps the EventPasscodeForm in a centered card matching MEL auth styling.
+ * Template suggestion: form__myeventlane_event_passcode_form.
+ *
+ * @see \Drupal\myeventlane_event\Form\EventPasscodeForm
+ */
+#}
+<form{{ attributes.addClass('mel-passcode-gate__form') }}>
+  {% if element is defined and element is iterable %}
+    {{ element.form_build_id }}
+    {{ element.form_token }}
+    {{ element.form_id }}
+
+    <div class="mel-passcode-gate">
+      <div class="mel-passcode-gate__container">
+        <div class="mel-passcode-gate__card">
+
+          <div class="mel-passcode-gate__icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          </div>
+
+          <div class="mel-passcode-gate__header">
+            {{ element.event_title }}
+            {{ element.gate_heading }}
+            {{ element.gate_description }}
+          </div>
+
+          <div class="mel-passcode-gate__fields">
+            {{ element.passcode }}
+          </div>
+
+          <div class="mel-passcode-gate__actions">
+            {{ element.actions }}
+          </div>
+
+          {% if element.back_url is defined and element.back_url['#value'] is defined %}
+            <div class="mel-passcode-gate__footer">
+              <a href="{{ element.back_url['#value'] }}" class="mel-passcode-gate__back-link">
+                &larr; {{ 'Browse events'|t }}
+              </a>
+            </div>
+          {% endif %}
+
+        </div>
+      </div>
+    </div>
+  {% else %}
+    {{ children }}
+  {% endif %}
+</form>


### PR DESCRIPTION
Adds styled passcode gate page for passcode-protected events. No access, validation, session, or hash logic changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to form markup, theme template, and SCSS; no access, validation, or session logic touched.
> 
> **Overview**
> Replaces the bare passcode form markup with a **centered “gate” card** aligned to existing MEL auth styling, without changing passcode verification, unlock, or redirects.
> 
> `EventPasscodeForm` now exposes structured copy (event **h1**, protected heading, organiser instructions) and a hidden **front-page URL** for a “Browse events” footer link. A dedicated Twig override (`form--myeventlane-event-passcode-form.html.twig`) wraps the form in a lock icon, card layout, and explicit field regions. New `_event-passcode-gate.scss` styles the gate and is wired in via `main.scss`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc0057dcd58b8576a8faee636ac7ea4b1bc374d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->