### PR TITLE
fix(vendor): route public event links to public domain

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
@@ -149,6 +149,35 @@ final class DomainDetector {
   }
 
   /**
+   * Builds a public-domain URL from an internal path.
+   *
+   * When the current request is on the vendor or admin domain and
+   * public_domain config is available, returns an absolute URL on the
+   * configured public host. Otherwise falls back to the relative path,
+   * which keeps single-domain local environments (DDEV) working.
+   *
+   * @param string $internal_path
+   *   A Drupal-generated relative path, e.g. /events/my-event.
+   *
+   * @return string
+   *   Absolute public URL or the original relative path.
+   */
+  public function publicUrl(string $internal_path): string {
+    $path = '/' . ltrim($internal_path, '/');
+
+    if ($this->isPublicDomain()) {
+      return $path;
+    }
+
+    try {
+      return $this->buildDomainUrl($path, 'public');
+    }
+    catch (\Throwable) {
+      return $path;
+    }
+  }
+
+  /**
    * Hostnames to consider for domain matching.
    *
    * Behind reverse proxies, Request::getHost() follows X-Forwarded-Host. Some

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -177,6 +177,7 @@ services:
       - '@myeventlane_event.public_visibility'
       - '@myeventlane_event.passcode_access'
       - '@current_user'
+      - '@myeventlane_core.domain_detector'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event\EventSubscriber;
 
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event\Service\EventPasscodeAccess;
 use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\node\NodeInterface;
@@ -26,6 +28,7 @@ final class EventPasscodeGateSubscriber implements EventSubscriberInterface {
     private readonly PublicEventVisibility $publicVisibility,
     private readonly EventPasscodeAccess $passcodeAccess,
     private readonly AccountProxyInterface $currentUser,
+    private readonly DomainDetector $domainDetector,
   ) {}
 
   public static function getSubscribedEvents(): array {
@@ -67,11 +70,18 @@ final class EventPasscodeGateSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $passcode_url = Url::fromRoute('myeventlane_event.passcode_gate', [
+    $relative_path = Url::fromRoute('myeventlane_event.passcode_gate', [
       'node' => $node->id(),
     ])->toString();
 
-    $event->setResponse(new RedirectResponse($passcode_url, 302));
+    $target = $this->domainDetector->publicUrl($relative_path);
+
+    if (str_starts_with($target, 'http://') || str_starts_with($target, 'https://')) {
+      $event->setResponse(new TrustedRedirectResponse($target, 302));
+    }
+    else {
+      $event->setResponse(new RedirectResponse($target, 302));
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
+++ b/web/modules/custom/myeventlane_event/src/Form/EventPasscodeForm.php
@@ -6,7 +6,9 @@ namespace Drupal\myeventlane_event\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event\Service\EventPasscodeAccess;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,11 +21,13 @@ final class EventPasscodeForm extends FormBase {
 
   public function __construct(
     private readonly EventPasscodeAccess $passcodeAccess,
+    private readonly DomainDetector $domainDetector,
   ) {}
 
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_event.passcode_access'),
+      $container->get('myeventlane_core.domain_detector'),
     );
   }
 
@@ -95,7 +99,7 @@ final class EventPasscodeForm extends FormBase {
 
     $form['back_url'] = [
       '#type' => 'value',
-      '#value' => Url::fromRoute('<front>')->toString(),
+      '#value' => $this->domainDetector->publicUrl(Url::fromRoute('<front>')->toString()),
     ];
 
     return $form;
@@ -129,9 +133,17 @@ final class EventPasscodeForm extends FormBase {
 
     $this->passcodeAccess->unlock($node);
 
-    $form_state->setRedirectUrl(
-      Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
-    );
+    $canonical_path = Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString();
+    $target = $this->domainDetector->publicUrl($canonical_path);
+
+    if (str_starts_with($target, 'http://') || str_starts_with($target, 'https://')) {
+      $form_state->setResponse(new TrustedRedirectResponse($target, 302));
+    }
+    else {
+      $form_state->setRedirectUrl(
+        Url::fromRoute('entity.node.canonical', ['node' => $node->id()])
+      );
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -105,6 +105,7 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
     'mel_event_studio_wizard_preview' => [
       'variables' => [
         'node' => NULL,
+        'preview_url' => NULL,
       ],
       'template' => 'mel-event-studio-wizard-preview',
     ],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -12,6 +12,7 @@ services:
       - '@myeventlane_event_studio.autosave'
       - '@plugin.manager.myeventlane_event_studio_section'
       - '@myeventlane_event_studio.section_renderer'
+      - '@myeventlane_core.domain_detector'
     tags:
       - { name: controller.service_arguments }
 
@@ -23,6 +24,7 @@ services:
       - '@myeventlane_onboarding.manager'
       - '@entity_type.manager'
       - '@request_stack'
+      - '@myeventlane_core.domain_detector'
 
   myeventlane_event_studio.vendor_mel_ticket_type_edit_redirect_subscriber:
     class: Drupal\myeventlane_event_studio\EventSubscriber\VendorMelTicketTypeEditRedirectSubscriber
@@ -300,6 +302,7 @@ services:
       - '@file_url_generator'
       - '@current_user'
       - '@string_translation'
+      - '@myeventlane_core.domain_detector'
 
   myeventlane_event_studio.event_ticket_preview_builder:
     class: Drupal\myeventlane_event_studio\Service\EventTicketPreviewBuilder

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
@@ -39,8 +40,8 @@ final class EventStudioController extends ControllerBase {
     private readonly EventStudioAutosaveService $autosaveService,
     private readonly EventStudioSectionManager $sectionManager,
     private readonly EventStudioSectionRenderer $sectionRenderer,
+    private readonly DomainDetector $domainDetector,
   ) {
-    // ControllerBase / EntityTypeManagerTrait already declare protected $entityTypeManager.
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -56,6 +57,7 @@ final class EventStudioController extends ControllerBase {
       $container->get('myeventlane_event_studio.autosave'),
       $container->get('plugin.manager.myeventlane_event_studio_section'),
       $container->get('myeventlane_event_studio.section_renderer'),
+      $container->get('myeventlane_core.domain_detector'),
     );
   }
 
@@ -253,7 +255,7 @@ final class EventStudioController extends ControllerBase {
       ], [
         'query' => ['restore_draft' => '1'],
       ])->toString(),
-      'preview_url' => Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString(),
+      'preview_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString()),
       'publish_url' => Url::fromRoute('myeventlane_event_studio.publish', ['node' => $node->id()])->toString(),
       'published' => $node->isPublished(),
       'can_publish' => $readiness->ready,

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPreviewController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPreviewController.php
@@ -6,13 +6,25 @@ namespace Drupal\myeventlane_event_studio\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Read-only preview step between description and publish.
  */
 final class EventStudioPreviewController extends ControllerBase {
+
+  public function __construct(
+    private readonly DomainDetector $domainDetector,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_core.domain_detector'),
+    );
+  }
 
   /**
    * @return array<string, mixed>
@@ -28,6 +40,9 @@ final class EventStudioPreviewController extends ControllerBase {
     $build = [
       '#theme' => 'mel_event_studio_wizard_preview',
       '#node' => $node,
+      '#preview_url' => $this->domainDetector->publicUrl(
+        Url::fromRoute('entity.node.canonical', ['node' => (int) $node->id()])->toString()
+      ),
       '#attached' => [
         'library' => ['myeventlane_event_studio/mel_event_studio'],
       ],

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
@@ -27,6 +28,7 @@ final class EventStudioPreprocess {
     private readonly OnboardingManager $onboardingManager,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly RequestStack $requestStack,
+    private readonly DomainDetector $domainDetector,
   ) {}
 
   /**
@@ -171,11 +173,18 @@ final class EventStudioPreprocess {
       && $node->isPublished()) {
       $variables['mel_publish_celebrate'] = TRUE;
 
-      $canonical_absolute = Url::fromRoute(
+      $canonical_path = Url::fromRoute(
         'entity.node.canonical',
         ['node' => (int) $node->id()],
-        ['absolute' => TRUE],
       )->toString();
+      $canonical_absolute = $this->domainDetector->publicUrl($canonical_path);
+      if (!str_starts_with($canonical_absolute, 'http')) {
+        $canonical_absolute = Url::fromRoute(
+          'entity.node.canonical',
+          ['node' => (int) $node->id()],
+          ['absolute' => TRUE],
+        )->toString();
+      }
 
       $variables['mel_publish_celebrate_share_url_absolute'] = $canonical_absolute;
       $variables['mel_publish_celebrate_dismiss_url'] = Url::fromRoute('myeventlane_event_studio.edit', ['node' => (int) $node->id()])->toString();

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
@@ -43,6 +44,8 @@ final class EventStudioEventExtrasForm extends FormBase {
 
   protected LoggerInterface $logger;
 
+  protected ?DomainDetector $domainDetector = NULL;
+
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     EventVendorAccessChecker $event_vendor_access_checker,
@@ -60,7 +63,7 @@ final class EventStudioEventExtrasForm extends FormBase {
   }
 
   public static function create(ContainerInterface $container): static {
-    return new static(
+    $form = new static(
       $container->get('entity_type.manager'),
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
@@ -68,6 +71,8 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('myeventlane_commerce.event_extras_book_placement_resolver'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
+    $form->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $form;
   }
 
   /**
@@ -518,7 +523,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       'preview_booking' => [
         '#type' => 'link',
         '#title' => $this->t('Preview booking page'),
-        '#url' => Url::fromRoute('entity.node.canonical', ['node' => $event->id()]),
+        '#url' => $this->buildPublicEventUrl($event),
         '#attributes' => ['class' => ['button', 'mel-event-extras-studio__cta']],
       ],
       'publish' => [
@@ -528,6 +533,15 @@ final class EventStudioEventExtrasForm extends FormBase {
         '#attributes' => ['class' => ['button', 'button--primary', 'mel-event-extras-studio__cta']],
       ],
     ];
+  }
+
+  private function buildPublicEventUrl(NodeInterface $event): Url {
+    $canonical_path = Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString();
+    $target = $this->domainDetector?->publicUrl($canonical_path) ?? $canonical_path;
+    if (str_starts_with($target, 'http://') || str_starts_with($target, 'https://')) {
+      return Url::fromUri($target);
+    }
+    return Url::fromRoute('entity.node.canonical', ['node' => $event->id()]);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioPublishForm.php
@@ -5,13 +5,24 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Wizard step: publishing (live / draft).
  */
 class EventStudioPublishForm extends EventStudioBaseForm {
+
+  private ?DomainDetector $domainDetector = NULL;
+
+  public static function create(ContainerInterface $container): static {
+    $form = parent::create($container);
+    $form->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $form;
+  }
 
   /**
    * {@inheritdoc}
@@ -69,7 +80,16 @@ class EventStudioPublishForm extends EventStudioBaseForm {
       return;
     }
     $this->messenger()->addStatus($this->t('Event saved.'));
-    $form_state->setRedirectUrl(Url::fromRoute('entity.node.canonical', ['node' => $saved->id()]));
+
+    $canonical_path = Url::fromRoute('entity.node.canonical', ['node' => $saved->id()])->toString();
+    $target = $this->domainDetector?->publicUrl($canonical_path) ?? $canonical_path;
+
+    if (str_starts_with($target, 'http://') || str_starts_with($target, 'https://')) {
+      $form_state->setResponse(new TrustedRedirectResponse($target, 302));
+    }
+    else {
+      $form_state->setRedirectUrl(Url::fromRoute('entity.node.canonical', ['node' => $saved->id()]));
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventBrandingPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventBrandingPreviewBuilder.php
@@ -12,6 +12,7 @@ use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\image\ImageStyleInterface;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event\Service\EventMediaPresenter;
 use Drupal\node\NodeInterface;
 
@@ -45,6 +46,7 @@ final class EventBrandingPreviewBuilder {
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
     private readonly AccountProxyInterface $currentUser,
     TranslationInterface $string_translation,
+    private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -141,6 +143,14 @@ final class EventBrandingPreviewBuilder {
     }
     catch (\Throwable) {
       return NULL;
+    }
+
+    if ($this->domainDetector !== NULL) {
+      $path = $url->toString();
+      $publicPath = $this->domainDetector->publicUrl($path);
+      if ($publicPath !== $path) {
+        $url = Url::fromUri($publicPath);
+      }
     }
 
     return [

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-wizard-preview.html.twig
@@ -11,7 +11,7 @@
     <h2 class="mel-wizard-preview-card__title">{{ node.label }}</h2>
     <p class="mel-wizard-preview-card__hint">{{ 'Review your event on the public page, or continue to publishing options.'|t }}</p>
     <p>
-      <a href="{{ url('entity.node.canonical', {'node': node.id}) }}" class="button button--primary" target="_blank" rel="noopener noreferrer">{{ 'View public page'|t }}</a>
+      <a href="{{ preview_url ?: url('entity.node.canonical', {'node': node.id}) }}" class="button button--primary" target="_blank" rel="noopener noreferrer">{{ 'View public page'|t }}</a>
     </p>
     <p>
       <a href="{{ path('myeventlane_event_studio.edit_publish', {'node': node.id}) }}" class="button">{{ 'Continue to publish'|t }}</a>

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -110,6 +110,7 @@ services:
     arguments:
       - '@current_route_match'
       - '@string_translation'
+      - '@myeventlane_core.domain_detector'
 
   myeventlane_vendor.vendor_store_subscriber:
     class: Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber
@@ -274,6 +275,7 @@ services:
       - '@myeventlane_vendor.vendor_event_removal'
       - '@myeventlane_surface.state_readiness_helper'
       - '@myeventlane_surface.data_presentation_manager'
+      - '@myeventlane_core.domain_detector'
 
   myeventlane_vendor.service.event_tabs:
     class: Drupal\myeventlane_vendor\Service\VendorEventTabsService
@@ -303,6 +305,7 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_core.domain_detector'
 
   # Vendor console controllers as services for DI.
   myeventlane_vendor.controller.vendor_dashboard:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventControllerBase.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventControllerBase.php
@@ -9,6 +9,7 @@ use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_vendor\Service\ManageEventNavigation;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -17,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Base controller for vendor event management pages.
  */
 abstract class ManageEventControllerBase extends ControllerBase {
+
+  protected ?DomainDetector $domainDetector = NULL;
 
   /**
    * Constructs ManageEventControllerBase.
@@ -29,9 +32,11 @@ abstract class ManageEventControllerBase extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static(
+    $instance = new static(
       $container->get('myeventlane_vendor.manage_event_navigation'),
     );
+    $instance->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $instance;
   }
 
   /**
@@ -108,10 +113,10 @@ abstract class ManageEventControllerBase extends ControllerBase {
     $status = $event->isPublished() ? 'Published' : 'Draft';
     $status_class = $event->isPublished() ? 'status-published' : 'status-draft';
 
-    // Build preview URL.
     $preview_url = NULL;
     if (!$event->isNew()) {
-      $preview_url = $event->toUrl('canonical');
+      $canonical = $event->toUrl('canonical')->toString();
+      $preview_url = $this->domainDetector?->publicUrl($canonical) ?? $canonical;
     }
 
     // Vendor edit: Event Studio only (legacy wizard is staff-only / redirected).

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventEditController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventEditController.php
@@ -28,9 +28,11 @@ final class ManageEventEditController extends ManageEventControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static(
+    $instance = new static(
       $container->get('myeventlane_vendor.manage_event_navigation'),
     );
+    $instance->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $instance;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
@@ -25,10 +25,12 @@ final class ManageEventPlaceholderController extends ManageEventControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static(
+    $instance = new static(
       $container->get('myeventlane_vendor.manage_event_navigation'),
       $container->get('current_route_match'),
     );
+    $instance->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $instance;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageSeriesInstancesController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageSeriesInstancesController.php
@@ -28,10 +28,12 @@ final class ManageSeriesInstancesController extends ManageEventControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static(
+    $instance = new static(
       $container->get('myeventlane_vendor.manage_event_navigation'),
       $container->get('myeventlane_event.recurrence_generator'),
     );
+    $instance->domainDetector = $container->get('myeventlane_core.domain_detector');
+    return $instance;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -105,7 +105,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       $boost_page_url = NULL;
     }
 
-    $public_event_url = Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString();
+    $public_event_url = $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString());
 
     $workspace_back_url = NULL;
     try {

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventOverviewController.php
@@ -285,7 +285,7 @@ final class VendorEventOverviewController extends VendorConsoleBaseController {
       ],
       [
         'label' => (string) $this->t('View page'),
-        'url' => Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString(),
+        'url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString()),
         'class' => 'mel-btn--secondary',
         'external' => TRUE,
       ],

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioController.php
@@ -1065,8 +1065,8 @@ final class VendorStudioController extends VendorConsoleBaseController implement
         'promotion_save_url' => $studio_endpoints['promotion_save'],
         'settings_save_url' => $studio_endpoints['settings_save'],
         'publish_url' => $studio_endpoints['publish'],
-        'preview_url' => Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString(),
-        'view_url' => Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString(),
+        'preview_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString()),
+        'view_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString()),
         'wizard_url' => Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event_id])->toString(),
         'active' => $active_event_id > 0 && $active_event_id === $event_id,
       ];
@@ -1131,8 +1131,8 @@ final class VendorStudioController extends VendorConsoleBaseController implement
       ],
       'checklist' => $checklist,
       'quick_actions' => [
-        'preview_url' => Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString(),
-        'view_url' => Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString(),
+        'preview_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString()),
+        'view_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString()),
         'duplicate_url' => NULL,
       ],
       'wizard_url' => Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event_id])->toString(),

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -8,6 +8,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\node\NodeInterface;
 
 /**
@@ -23,6 +24,7 @@ final class VendorConsolePagePreprocess {
   public function __construct(
     private readonly RouteMatchInterface $routeMatch,
     TranslationInterface $stringTranslation,
+    private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->setStringTranslation($stringTranslation);
   }
@@ -127,7 +129,7 @@ final class VendorConsolePagePreprocess {
       'quick_actions' => [
         [
           'label' => $this->t('View event page'),
-          'url' => Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString(),
+          'url' => $this->buildPublicEventUrl($event_id),
         ],
         [
           'label' => $this->t('Review attendees'),
@@ -139,6 +141,11 @@ final class VendorConsolePagePreprocess {
         ],
       ],
     ];
+  }
+
+  private function buildPublicEventUrl(int $event_id): string {
+    $path = Url::fromRoute('entity.node.canonical', ['node' => $event_id])->toString();
+    return $this->domainDetector?->publicUrl($path) ?? $path;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -14,6 +14,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
 use Drupal\myeventlane_surface\MelDataPresentationManager;
@@ -55,6 +56,7 @@ final class VendorDashboardViewModelBuilder {
     private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly MelReadinessHelper $readinessHelper,
     private readonly MelDataPresentationManager $dataPresentationManager,
+    private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -648,7 +650,7 @@ final class VendorDashboardViewModelBuilder {
         'attendees' => $this->safeUrlFromRoute('myeventlane_event_attendees.vendor_list', ['node' => $nid]),
         'analytics' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $nid]),
         'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
-        'share' => $published ? $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account) : NULL,
+        'share' => $published ? $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)) : NULL,
         'promote' => $this->promoteUrl($nid, $account),
         'support' => $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account),
       ],
@@ -802,7 +804,7 @@ final class VendorDashboardViewModelBuilder {
     $this->appendQuickAction($actions, 'attendees', (string) $this->t('View attendees'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account), 'list');
     $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account), 'scan');
     if ($published) {
-      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account), 'export');
+      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)), 'export');
       $this->appendQuickAction($actions, 'promote', (string) $this->t('Promote event'), $this->promoteUrl($nid, $account), 'search');
     }
     $this->appendQuickAction($actions, 'support', (string) $this->t('Open support'), $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account), 'search');
@@ -1289,6 +1291,21 @@ final class VendorDashboardViewModelBuilder {
     }
 
     return $this->safeUrlFromRoute($route, $parameters, $options);
+  }
+
+  /**
+   * Converts an internal Url to a public-domain Url when on a vendor host.
+   */
+  private function toPublicUrl(?Url $url): ?Url {
+    if (!$url instanceof Url || $this->domainDetector === NULL) {
+      return $url;
+    }
+    $path = $url->toString();
+    $publicPath = $this->domainDetector->publicUrl($path);
+    if ($publicPath !== $path) {
+      return Url::fromUri($publicPath);
+    }
+    return $url;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -15,6 +15,7 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\myeventlane_core\MelReadinessHelper;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -40,6 +41,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly MelReadinessHelper $readinessHelper,
+    private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -176,6 +178,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     $tabs = $this->vendorEventTabsService->buildWorkspaceTabs($event, 'overview', $account);
 
     $previewUrl = $this->routeUrlIfAccessible('entity.node.canonical', ['node' => $nid], $account);
+    $publicPreviewUrl = $this->toPublicUrl($previewUrl);
 
     // Reuse tab availability so add-on order gating runs once per request.
     $addonOrdersUrl = $this->addonOrdersUrlFromWorkspaceTabs($tabs);
@@ -190,7 +193,7 @@ final class VendorEventWorkspaceViewModelBuilder {
       'checkin' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
       'analytics' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_analytics', ['event' => $nid], $account),
       'settings' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_settings', ['event' => $nid], $account),
-      'preview' => $previewUrl,
+      'preview' => $publicPreviewUrl,
     ];
 
     return [
@@ -203,7 +206,7 @@ final class VendorEventWorkspaceViewModelBuilder {
         'date_label' => $dateLabel,
         'event_type' => $eventType,
         'event_type_label' => $eventTypeLabel,
-        'public_url' => $previewUrl,
+        'public_url' => $publicPreviewUrl,
       ],
       'readiness' => [
         'score' => $score,
@@ -650,6 +653,21 @@ final class VendorEventWorkspaceViewModelBuilder {
       ]);
       return NULL;
     }
+  }
+
+  /**
+   * Converts an internal Url to a public-domain Url when on a vendor host.
+   */
+  private function toPublicUrl(?Url $url): ?Url {
+    if (!$url instanceof Url || $this->domainDetector === NULL) {
+      return $url;
+    }
+    $path = $url->toString();
+    $publicPath = $this->domainDetector->publicUrl($path);
+    if ($publicPath !== $path) {
+      return Url::fromUri($publicPath);
+    }
+    return $url;
   }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many redirect and link surfaces across vendor/Event Studio and passcode flows; misconfigured `public_domain` could send users to wrong hosts, but logic is scoped to public URLs with safe fallbacks.
> 
> **Overview**
> Adds **`DomainDetector::publicUrl()`** so internal paths become absolute URLs on the configured **public** host when the request is on vendor or admin; on the public host or when config is missing it keeps the relative path (DDEV-friendly).
> 
> **Event passcode flow** injects `DomainDetector` and routes passcode gate redirects, unlock redirects, and the back link through `publicUrl`, using **`TrustedRedirectResponse`** for cross-host absolute targets.
> 
> **Event Studio and vendor console** wire `DomainDetector` into previews, publish/share redirects, branding links, wizard preview Twig (`preview_url`), dashboard/workspace share URLs, and manage-event preview strings so “view public page” / share links leave the vendor host.
> 
> **Risk:** redirect/open-redirect surface is limited to configured `public_domain` paths; behavior is UI/routing only per `DomainDetector` docs (not auth).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0b0e48eb1074d42e42fcf8d4a197d0c055432d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->