### PR TITLE
fix: prevent stale redirect caching and deduplicate toPublicUrl

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_core\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Url;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -175,6 +176,30 @@ final class DomainDetector {
     catch (\Throwable) {
       return $path;
     }
+  }
+
+  /**
+   * Converts a Drupal Url object to one pointing at the public domain.
+   *
+   * Returns the original Url unchanged when already on the public domain
+   * or when no domain configuration is available.
+   *
+   * @param \Drupal\Core\Url|null $url
+   *   A Url object, or NULL.
+   *
+   * @return \Drupal\Core\Url|null
+   *   A public-domain Url, or the original value.
+   */
+  public function publicUrlObject(?Url $url): ?Url {
+    if (!$url instanceof Url) {
+      return $url;
+    }
+    $path = $url->toString();
+    $publicPath = $this->publicUrl($path);
+    if ($publicPath !== $path) {
+      return Url::fromUri($publicPath);
+    }
+    return $url;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventPasscodeGateSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event\EventSubscriber;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
@@ -77,7 +78,11 @@ final class EventPasscodeGateSubscriber implements EventSubscriberInterface {
     $target = $this->domainDetector->publicUrl($relative_path);
 
     if (str_starts_with($target, 'http://') || str_starts_with($target, 'https://')) {
-      $event->setResponse(new TrustedRedirectResponse($target, 302));
+      $response = new TrustedRedirectResponse($target, 302);
+      $cacheable_metadata = new CacheableMetadata();
+      $cacheable_metadata->setCacheMaxAge(0);
+      $response->addCacheableDependency($cacheable_metadata);
+      $event->setResponse($response);
     }
     else {
       $event->setResponse(new RedirectResponse($target, 302));

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -650,7 +650,7 @@ final class VendorDashboardViewModelBuilder {
         'attendees' => $this->safeUrlFromRoute('myeventlane_event_attendees.vendor_list', ['node' => $nid]),
         'analytics' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $nid]),
         'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
-        'share' => $published ? $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)) : NULL,
+        'share' => $published ? $this->domainDetector?->publicUrlObject($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)) : NULL,
         'promote' => $this->promoteUrl($nid, $account),
         'support' => $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account),
       ],
@@ -804,7 +804,7 @@ final class VendorDashboardViewModelBuilder {
     $this->appendQuickAction($actions, 'attendees', (string) $this->t('View attendees'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account), 'list');
     $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account), 'scan');
     if ($published) {
-      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)), 'export');
+      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->domainDetector?->publicUrlObject($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)), 'export');
       $this->appendQuickAction($actions, 'promote', (string) $this->t('Promote event'), $this->promoteUrl($nid, $account), 'search');
     }
     $this->appendQuickAction($actions, 'support', (string) $this->t('Open support'), $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account), 'search');
@@ -1291,21 +1291,6 @@ final class VendorDashboardViewModelBuilder {
     }
 
     return $this->safeUrlFromRoute($route, $parameters, $options);
-  }
-
-  /**
-   * Converts an internal Url to a public-domain Url when on a vendor host.
-   */
-  private function toPublicUrl(?Url $url): ?Url {
-    if (!$url instanceof Url || $this->domainDetector === NULL) {
-      return $url;
-    }
-    $path = $url->toString();
-    $publicPath = $this->domainDetector->publicUrl($path);
-    if ($publicPath !== $path) {
-      return Url::fromUri($publicPath);
-    }
-    return $url;
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -178,7 +178,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     $tabs = $this->vendorEventTabsService->buildWorkspaceTabs($event, 'overview', $account);
 
     $previewUrl = $this->routeUrlIfAccessible('entity.node.canonical', ['node' => $nid], $account);
-    $publicPreviewUrl = $this->toPublicUrl($previewUrl);
+    $publicPreviewUrl = $this->domainDetector?->publicUrlObject($previewUrl) ?? $previewUrl;
 
     // Reuse tab availability so add-on order gating runs once per request.
     $addonOrdersUrl = $this->addonOrdersUrlFromWorkspaceTabs($tabs);
@@ -653,21 +653,6 @@ final class VendorEventWorkspaceViewModelBuilder {
       ]);
       return NULL;
     }
-  }
-
-  /**
-   * Converts an internal Url to a public-domain Url when on a vendor host.
-   */
-  private function toPublicUrl(?Url $url): ?Url {
-    if (!$url instanceof Url || $this->domainDetector === NULL) {
-      return $url;
-    }
-    $path = $url->toString();
-    $publicPath = $this->domainDetector->publicUrl($path);
-    if ($publicPath !== $path) {
-      return Url::fromUri($publicPath);
-    }
-    return $url;
   }
 
 }


### PR DESCRIPTION
1. EventPasscodeGateSubscriber: set cache max-age to 0 on the TrustedRedirectResponse so Dynamic Page Cache never serves a stale 302 to users who have already unlocked the event or have direct-view privileges.

2. DomainDetector: add publicUrlObject() as a Url-aware companion to the existing string-based publicUrl(). This eliminates duplicated private toPublicUrl() methods in VendorDashboardViewModelBuilder and VendorEventWorkspaceViewModelBuilder.

Resolves Bugbot findings on commit 4a0b0e4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fixes to redirect cache metadata and URL helper consolidation with no auth or data-model changes.
> 
> **Overview**
> Fixes **stale passcode redirects** by marking the passcode gate’s `TrustedRedirectResponse` as **non-cacheable** (`CacheMaxAge(0)`), so Dynamic Page Cache cannot reuse a 302 after access state changes.
> 
> Centralizes **public-domain share/preview URLs** in `DomainDetector::publicUrlObject()` and switches vendor dashboard/workspace view models to use it, removing duplicate private `toPublicUrl()` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84de836c7295931e19a007099d19369515b7fed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->