### PR TITLE
fix(vendor): restore share URL when domain detector is absent

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -650,7 +650,7 @@ final class VendorDashboardViewModelBuilder {
         'attendees' => $this->safeUrlFromRoute('myeventlane_event_attendees.vendor_list', ['node' => $nid]),
         'analytics' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_analytics', ['event' => $nid]),
         'checkin' => $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
-        'share' => $published ? $this->domainDetector?->publicUrlObject($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)) : NULL,
+        'share' => $published ? $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)) : NULL,
         'promote' => $this->promoteUrl($nid, $account),
         'support' => $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account),
       ],
@@ -804,7 +804,7 @@ final class VendorDashboardViewModelBuilder {
     $this->appendQuickAction($actions, 'attendees', (string) $this->t('View attendees'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account), 'list');
     $this->appendQuickAction($actions, 'checkin', (string) $this->t('Open check-in'), $this->safeUrlFromRouteIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account), 'scan');
     if ($published) {
-      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->domainDetector?->publicUrlObject($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)), 'export');
+      $this->appendQuickAction($actions, 'share', (string) $this->t('Share event'), $this->toPublicUrl($this->safeUrlFromRouteIfAccessible('entity.node.canonical', ['node' => $nid], $account)), 'export');
       $this->appendQuickAction($actions, 'promote', (string) $this->t('Promote event'), $this->promoteUrl($nid, $account), 'search');
     }
     $this->appendQuickAction($actions, 'support', (string) $this->t('Open support'), $this->safeUrlFromRouteIfAccessible('myeventlane_help_centre.vendors_index', [], $account), 'search');
@@ -1291,6 +1291,15 @@ final class VendorDashboardViewModelBuilder {
     }
 
     return $this->safeUrlFromRoute($route, $parameters, $options);
+  }
+
+  /**
+   * Converts an internal Url to a public-domain Url when on a vendor host.
+   *
+   * Falls back to the original Url when domain detection is unavailable.
+   */
+  private function toPublicUrl(?Url $url): ?Url {
+    return $this->domainDetector?->publicUrlObject($url) ?? $url;
   }
 
 }


### PR DESCRIPTION
Reintroduce toPublicUrl() with a null-coalescing fallback so published events keep share links and quick actions when DomainDetector is not injected, matching VendorEventWorkspaceViewModelBuilder behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small URL-building fix in vendor dashboard view models with no auth or data-handling changes.
> 
> **Overview**
> Fixes a regression where **Share event** links and quick actions disappeared for published events when `DomainDetector` is not injected.
> 
> `VendorDashboardViewModelBuilder` now routes share URLs through a new `toPublicUrl()` helper that uses `publicUrlObject()` when domain detection is available and **falls back to the canonical internal URL** otherwise, instead of returning `null` from a bare optional call. Event **links** and **quick actions** both use this helper, aligning with the null-coalescing pattern already used in `VendorEventWorkspaceViewModelBuilder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89912c23b230592d65e6950ac8dabf83e7a6ce20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->