### PR TITLE
## feature/commerce-merch-addon-phase0-safety...origin/feature/commerce-merch-addon-phase0-safety

### DIFF
--- a/docs/commerce-merch-addon-phase0-safety.md
+++ b/docs/commerce-merch-addon-phase0-safety.md
@@ -1,0 +1,58 @@
+# Commerce merchandise and add-on Phase 0 safety
+
+Status: implemented safety slice  
+Scope: ticket issuance and Stripe Connect ticket revenue boundaries only
+
+## What was unsafe
+
+Before this slice:
+
+- `TicketIssuer` issued `myeventlane_ticket` rows for any Commerce variation with a resolvable event (variation `field_event`, product `field_event`, or order item `field_target_event`).
+- Operational merchandise and add-on products use the same event linkage fields, so parking, T-shirts, hospitality, and similar lines could create attendance tickets by mistake.
+- `StripeConnectPaymentService::calculateTicketRevenue()` summed all paid, non-donation, non-boost order items, so operational extras could inflate vendor Connect transfers and application-fee bases.
+
+## Ticket issuance guard
+
+`TicketIssuer` now injects `myeventlane_commerce.ticket_backed_order_item_classifier` (`TicketBackedOrderItemClassifier`).
+
+- `isOrderItemEligibleForTicketIssuance()` requires `TicketBackedOrderItemClassifierInterface::isTicketBackedOrderItem()` **and** existing event resolution.
+- `issueForOrder()` and `countExpectedIssuanceUnits()` use the same eligibility path.
+- RSVP flows are unchanged (no Commerce ticket issuer involvement).
+
+## Stripe ticket revenue guard
+
+`StripeConnectPaymentService::calculateTicketRevenue()` and `calculateTicketRevenueCentsForEvent()` include only line items where the ticket-backed classifier returns TRUE.
+
+- Donation and boost exclusions are unchanged (`OrderItemClassifier` / boost bundle checks run first).
+- No new Stripe API calls, webhook handlers, or charge-model changes.
+- **Deferred:** separate Connect transfer rules for operational merchandise/add-on revenue (document gap only; do not infer payout splits in this slice).
+
+## Classification ownership
+
+| Concern | Owner |
+| --- | --- |
+| Ticket-backed vs operational order items | `TicketBackedOrderItemClassifier` (`myeventlane_commerce`) |
+| Operational Commerce bundle allow-list | `OperationalProductBundles` (`myeventlane_core`) |
+| Bundle → canonical classification map | `OperationalProductBundles::productBundleClassifications()` |
+| Canonical classification metadata | `EventCommercePurchasableType` + `EventCommerceClassificationRegistry` (`myeventlane_event`) |
+| Read-only event/product grouping | `EventCommerceResolver` (pass explicit maps from `OperationalProductBundles`) |
+
+Operational bundle map (conservative):
+
+| Product bundle | Classification |
+| --- | --- |
+| `operational_merchandise` | `merchandise` |
+| `operational_bundle` | `addon` |
+| `hospitality_package` | `addon` |
+| `timed_collection_product` | `addon` |
+
+## Deferred
+
+- Fulfilment, operational inventory execution, and scanner flows.
+- Merch/add-on UX expansion beyond existing Phase 4D–4F surfaces.
+- Dedicated Connect transfer allocation for operational revenue.
+- Browser-level mixed-cart QA (see below).
+
+## Manual browser matrix (still required)
+
+Checkout path: **2 tickets + parking + T-shirt → paid → ticket count equals ticket quantity only** (operational lines must not increase `myeventlane_ticket` rows).

--- a/docs/event-commerce-acceptance-audit.md
+++ b/docs/event-commerce-acceptance-audit.md
@@ -4,6 +4,8 @@ Status: acceptance audit
 Scope: Event Commerce resolver, classification registry, purchasable classifications, and mixed-cart governance foundation  
 Date: 2026-05-11
 
+> **Note (2026-05-27):** This audit predates operational merchandise Phase 4D–4F (Studio authoring, customer add-ons on booking, purchase composition, checkout orchestration). It validates the passive governance layer only—not the full current operational Commerce feature inventory. Post–Phase 0 safety work is documented in [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md).
+
 ## Objective
 
 This audit validates that the event-commerce governance foundation is operationally passive. The reviewed layer may resolve existing relationships, classify existing purchasables from explicit metadata, and expose read-only groupings. It must not mutate carts, orders, checkout, products, ticket lifecycle, RSVP state, Stripe behavior, payment routing, capacities, or fulfilment state.

--- a/docs/event-commerce-classifications.md
+++ b/docs/event-commerce-classifications.md
@@ -34,7 +34,7 @@ Classifications are metadata. They do not create products, variations, order ite
 
 The event ticket product is classified as `ticket` when it is resolved from the event `field_product_target` relationship.
 
-Other products and purchasables may be classified only from explicit owning-domain maps, such as a product bundle to classification map supplied by future merchandise or add-on services. The resolver must not guess that a bundle is merchandise, add-on, donation, or upgrade without that owning-domain contract.
+Other products and purchasables may be classified only from explicit owning-domain maps, such as a product bundle to classification map supplied by owning services. Operational Commerce bundles use `Drupal\myeventlane_core\Commerce\OperationalProductBundles::productBundleClassifications()` as the single bundle map. The resolver must not guess that a bundle is merchandise, add-on, donation, or upgrade without that owning-domain contract.
 
 ## Resolver Behavior
 

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -10,6 +10,8 @@
 
 ## Commerce product types (architecture)
 
+Canonical bundle ids and bundle→classification map: `Drupal\myeventlane_core\Commerce\OperationalProductBundles` (see [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md)).
+
 Dedicated Commerce **product types** (and matching variation types) isolate non-ticket operational catalog from ticket entitlement products:
 
 - `operational_merchandise` — physical merch, pickup-oriented messaging.

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -55,6 +55,7 @@ services:
       - '@config.factory'
       - '@logger.channel.myeventlane_commerce'
       - '@myeventlane_commerce.order_item_classifier'
+      - '@myeventlane_commerce.ticket_backed_order_item_classifier'
 
   myeventlane_commerce.platform_fee_order_processor:
     class: Drupal\myeventlane_commerce\OrderProcessor\PlatformFeeOrderProcessor

--- a/web/modules/custom/myeventlane_commerce/src/Service/StripeConnectPaymentService.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/StripeConnectPaymentService.php
@@ -36,6 +36,8 @@ final class StripeConnectPaymentService {
    *   The logger.
    * @param \Drupal\myeventlane_commerce\Service\OrderItemClassifier $orderItemClassifier
    *   The order item classifier.
+   * @param \Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface $ticketBackedOrderItemClassifier
+   *   Ticket-backed line item classifier for Connect revenue boundaries.
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -43,6 +45,7 @@ final class StripeConnectPaymentService {
     private readonly ConfigFactoryInterface $configFactory,
     private readonly LoggerInterface $logger,
     private readonly OrderItemClassifier $orderItemClassifier,
+    private readonly TicketBackedOrderItemClassifierInterface $ticketBackedOrderItemClassifier,
   ) {}
 
   /**
@@ -167,7 +170,10 @@ final class StripeConnectPaymentService {
   }
 
   /**
-   * Calculates ticket revenue (excludes donations, boosts, and other non-ticket items).
+   * Calculates ticket revenue from ticket-backed order items only.
+   *
+   * Excludes donations, boosts, operational merchandise, and add-ons.
+   * Operational Connect transfer rules for non-ticket revenue are deferred.
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $order
    *   The order.
@@ -179,19 +185,20 @@ final class StripeConnectPaymentService {
     $ticketAmount = 0;
 
     foreach ($order->getItems() as $item) {
-      // Skip donation items (platform revenue, not vendor revenue).
       if ($this->orderItemClassifier->isDonation($item)) {
         continue;
       }
 
-      // Skip Boost items (they don't use Connect).
       if ($item->bundle() === 'boost') {
+        continue;
+      }
+
+      if (!$this->ticketBackedOrderItemClassifier->isTicketBackedOrderItem($item)) {
         continue;
       }
 
       $totalPrice = $item->getTotalPrice();
       if ($totalPrice) {
-        // Convert to cents.
         $ticketAmount += (int) round($totalPrice->getNumber() * 100);
       }
     }
@@ -202,9 +209,9 @@ final class StripeConnectPaymentService {
   /**
    * Ticket revenue in cents for one event on this order (excludes donations, boost).
    *
-   * Uses the same inclusion rules as calculateTicketRevenue(), scoped to
-   * field_target_event = $eventId. Used for vendor MEL percentage contribution
-   * accrual so the base matches Connect ticket revenue (not attendee donations).
+   * Uses the same ticket-backed inclusion rules as calculateTicketRevenue(),
+   * scoped to field_target_event = $eventId. Used for vendor MEL percentage
+   * contribution accrual so the base matches Connect ticket revenue.
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $order
    *   The order.
@@ -227,6 +234,10 @@ final class StripeConnectPaymentService {
       }
 
       if ($item->bundle() === 'boost') {
+        continue;
+      }
+
+      if (!$this->ticketBackedOrderItemClassifier->isTicketBackedOrderItem($item)) {
         continue;
       }
 

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketBackedOrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketBackedOrderItemClassifier.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
  * Operational merchandise must not flow through attendee creation, ticket
  * issuance integrity, or waitlist reconciliation.
  */
-final class TicketBackedOrderItemClassifier {
+final class TicketBackedOrderItemClassifier implements TicketBackedOrderItemClassifierInterface {
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,

--- a/web/modules/custom/myeventlane_commerce/src/Service/TicketBackedOrderItemClassifierInterface.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/TicketBackedOrderItemClassifierInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+
+/**
+ * Contract for classifying ticket-backed Commerce order items.
+ */
+interface TicketBackedOrderItemClassifierInterface {
+
+  /**
+   * Whether the line item is a ticket-backed purchase for a mapped event tier.
+   */
+  public function isTicketBackedOrderItem(OrderItemInterface $order_item): bool;
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/StripeConnectPaymentServiceTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/StripeConnectPaymentServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\Price;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
+use Drupal\myeventlane_commerce\Service\StripeConnectPaymentService;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\myeventlane_core\Service\StripeService;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\StripeConnectPaymentService
+ *
+ * @group myeventlane_commerce
+ */
+final class StripeConnectPaymentServiceTest extends UnitTestCase {
+
+  /**
+   * @covers ::calculateTicketRevenue
+   */
+  public function testCalculateTicketRevenueIncludesTicketBackedItemsOnly(): void {
+    $ticket_item = $this->orderItem('default', '50.00');
+    $merch_item = $this->orderItem('default', '20.00');
+    $donation_item = $this->orderItem('checkout_donation', '10.00');
+    $boost_item = $this->orderItem('boost', '5.00');
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getItems')->willReturn([$ticket_item, $merch_item, $donation_item, $boost_item]);
+
+    $service = $this->service([$ticket_item]);
+    $this->assertSame(5000, $service->calculateTicketRevenue($order));
+  }
+
+  /**
+   * @covers ::calculateTicketRevenueCentsForEvent
+   */
+  public function testCalculateTicketRevenueCentsForEventScopesTicketBackedItems(): void {
+    $ticket_item = $this->orderItem('default', '40.00', 42);
+    $other_event_ticket = $this->orderItem('default', '30.00', 99);
+    $addon_item = $this->orderItem('default', '15.00', 42);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getItems')->willReturn([$ticket_item, $other_event_ticket, $addon_item]);
+
+    $service = $this->service([$ticket_item]);
+    $this->assertSame(4000, $service->calculateTicketRevenueCentsForEvent($order, 42));
+  }
+
+  /**
+   * @param list<\Drupal\commerce_order\Entity\OrderItemInterface> $ticket_backed_items
+   */
+  private function service(array $ticket_backed_items): StripeConnectPaymentService {
+    $ticket_backed_ids = [];
+    foreach ($ticket_backed_items as $item) {
+      $ticket_backed_ids[spl_object_id($item)] = TRUE;
+    }
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturnCallback(
+      static fn (OrderItemInterface $item): bool => !empty($ticket_backed_ids[spl_object_id($item)]),
+    );
+
+    return new StripeConnectPaymentService(
+      $this->createMock(EntityTypeManagerInterface::class),
+      new StripeService(
+        $this->createMock(ConfigFactoryInterface::class),
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(LoggerChannelFactoryInterface::class),
+      ),
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->createMock(LoggerInterface::class),
+      new OrderItemClassifier(),
+      $classifier,
+    );
+  }
+
+  private function orderItem(string $bundle, string $amount, ?int $event_id = NULL): OrderItemInterface {
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn($bundle);
+    $item->method('getTotalPrice')->willReturn(new Price($amount, 'AUD'));
+
+    if ($event_id !== NULL) {
+      $target_event = new StripeConnectTestFieldItemList($event_id);
+      $item->method('hasField')->willReturnMap([
+        ['field_target_event', TRUE],
+      ]);
+      $item->method('get')->willReturnMap([
+        ['field_target_event', $target_event],
+      ]);
+    }
+    else {
+      $item->method('hasField')->willReturn(FALSE);
+    }
+
+    return $item;
+  }
+
+}
+
+/**
+ * Minimal field list stub for entity reference fields in unit tests.
+ */
+final class StripeConnectTestFieldItemList {
+
+  public function __construct(public readonly int $target_id) {}
+
+  public function isEmpty(): bool {
+    return $this->target_id <= 0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/src/Commerce/OperationalProductBundles.php
+++ b/web/modules/custom/myeventlane_core/src/Commerce/OperationalProductBundles.php
@@ -9,6 +9,9 @@ namespace Drupal\myeventlane_core\Commerce;
  *
  * Shared by capacity, commerce, and event studio so bundle lists cannot diverge
  * across modules with different dependency directions.
+ *
+ * Classification ids match
+ * \Drupal\myeventlane_event\Value\EventCommercePurchasableType constants.
  */
 final class OperationalProductBundles {
 
@@ -24,6 +27,31 @@ final class OperationalProductBundles {
 
   public static function isOperationalProductBundle(string $bundle): bool {
     return in_array($bundle, self::BUNDLES, TRUE);
+  }
+
+  /**
+   * Maps operational Commerce product bundles to canonical classifications.
+   *
+   * @return array<string, string>
+   *   Commerce product bundle id => classification id (merchandise, addon, …).
+   */
+  public static function productBundleClassifications(): array {
+    return [
+      'operational_merchandise' => 'merchandise',
+      // Grouped operational packages (parking bundles, VIP packages, etc.).
+      'operational_bundle' => 'addon',
+      'hospitality_package' => 'addon',
+      'timed_collection_product' => 'addon',
+    ];
+  }
+
+  /**
+   * Returns the canonical classification for an operational product bundle.
+   *
+   * Returns an empty string when the bundle is not operational or unmapped.
+   */
+  public static function classificationForProductBundle(string $bundle): string {
+    return self::productBundleClassifications()[$bundle] ?? '';
   }
 
 }

--- a/web/modules/custom/myeventlane_core/tests/src/Unit/OperationalProductBundlesTest.php
+++ b/web/modules/custom/myeventlane_core/tests/src/Unit/OperationalProductBundlesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_core\Unit;
+
+use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_core\Commerce\OperationalProductBundles
+ *
+ * @group myeventlane_core
+ */
+final class OperationalProductBundlesTest extends UnitTestCase {
+
+  /**
+   * @covers ::productBundleClassifications
+   * @covers ::classificationForProductBundle
+   */
+  public function testOperationalBundleClassificationMap(): void {
+    $map = OperationalProductBundles::productBundleClassifications();
+    $this->assertSame('merchandise', $map['operational_merchandise']);
+    $this->assertSame('addon', $map['operational_bundle']);
+    $this->assertSame('addon', $map['hospitality_package']);
+    $this->assertSame('addon', $map['timed_collection_product']);
+    $this->assertSame('merchandise', OperationalProductBundles::classificationForProductBundle('operational_merchandise'));
+    $this->assertSame('', OperationalProductBundles::classificationForProductBundle('default'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.info.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.info.yml
@@ -5,6 +5,7 @@ core_version_requirement: ^11
 package: 'Custom'
 dependencies:
   - mel_ticket:mel_ticket
+  - myeventlane_commerce:myeventlane_commerce
   - myeventlane_event:myeventlane_event
   - myeventlane_vendor:myeventlane_vendor
   - drupal:node

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -47,7 +47,8 @@ services:
     arguments: [
       '@entity_type.manager',
       '@myeventlane_tickets.ticket_code_generator',
-      '@logger.factory'
+      '@logger.factory',
+      '@myeventlane_commerce.ticket_backed_order_item_classifier',
     ]
 
   myeventlane_tickets.order_paid_subscriber:

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
@@ -6,9 +6,11 @@ namespace Drupal\myeventlane_tickets\Ticket;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\mel_ticket\Entity\TicketType;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\node\NodeInterface;
 
@@ -21,6 +23,7 @@ final class TicketIssuer {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TicketCodeGenerator $codeGenerator,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly TicketBackedOrderItemClassifierInterface $ticketBackedOrderItemClassifier,
   ) {}
 
   /**
@@ -36,14 +39,12 @@ final class TicketIssuer {
         continue;
       }
 
-      $purchased_entity = $order_item->getPurchasedEntity();
-      if (!$purchased_entity || $purchased_entity->getEntityTypeId() !== 'commerce_product_variation') {
+      if (!$this->isOrderItemEligibleForTicketIssuance($order_item)) {
         continue;
       }
 
-      if (!$this->resolveEventFromOrderItem($order_item)) {
-        continue;
-      }
+      /** @var \Drupal\commerce_product\Entity\ProductVariationInterface $purchased_entity */
+      $purchased_entity = $order_item->getPurchasedEntity();
 
       $qty = (int) $order_item->getQuantity();
       if ($qty < 1) {
@@ -61,7 +62,11 @@ final class TicketIssuer {
    */
   public function isOrderItemEligibleForTicketIssuance(OrderItemInterface $order_item): bool {
     $purchased_entity = $order_item->getPurchasedEntity();
-    if (!$purchased_entity || $purchased_entity->getEntityTypeId() !== 'commerce_product_variation') {
+    if (!$purchased_entity instanceof ProductVariationInterface) {
+      return FALSE;
+    }
+
+    if (!$this->ticketBackedOrderItemClassifier->isTicketBackedOrderItem($order_item)) {
       return FALSE;
     }
 
@@ -98,10 +103,12 @@ final class TicketIssuer {
         continue;
       }
 
-      $purchased_entity = $order_item->getPurchasedEntity();
-      if (!$purchased_entity || $purchased_entity->getEntityTypeId() !== 'commerce_product_variation') {
+      if (!$this->isOrderItemEligibleForTicketIssuance($order_item)) {
         continue;
       }
+
+      /** @var \Drupal\commerce_product\Entity\ProductVariationInterface $purchased_entity */
+      $purchased_entity = $order_item->getPurchasedEntity();
 
       $event = $this->resolveEventFromOrderItem($order_item);
       if (!$event) {

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
@@ -16,6 +16,7 @@ use Drupal\commerce_store\Entity\Store;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\EntitlementCapabilityRegistry;
 use Drupal\myeventlane_tickets\Service\FulfillmentAuditProjector;
@@ -38,6 +39,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class FulfillmentLifecycleConvergenceKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -89,6 +92,7 @@ final class FulfillmentLifecycleConvergenceKernelTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   protected function setUp(): void {

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/InventoryReservationGovernanceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/InventoryReservationGovernanceKernelTest.php
@@ -17,6 +17,7 @@ use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\InventoryReservationAuditProjector;
 use Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager;
@@ -38,6 +39,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class InventoryReservationGovernanceKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -92,6 +95,7 @@ final class InventoryReservationGovernanceKernelTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/IssuancePipelineConvergenceTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/IssuancePipelineConvergenceTest.php
@@ -17,6 +17,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_messaging\Service\OrderConfirmationAttachmentResolver;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
@@ -35,6 +36,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 #[RunTestsInSeparateProcesses]
 final class IssuancePipelineConvergenceTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   /**
    * {@inheritdoc}
@@ -94,6 +97,7 @@ final class IssuancePipelineConvergenceTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEntitlementCapabilityKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalEntitlementCapabilityKernelTest.php
@@ -17,6 +17,7 @@ use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\InventoryReservationGovernanceManager;
 use Drupal\myeventlane_tickets\Service\OperationalCapabilityAuditProjector;
@@ -39,6 +40,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class OperationalEntitlementCapabilityKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -93,6 +96,7 @@ final class OperationalEntitlementCapabilityKernelTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalIntegrityInspectorTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalIntegrityInspectorTest.php
@@ -16,6 +16,7 @@ use Drupal\commerce_store\Entity\Store;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_messaging\EventSubscriber\OrderPaidConfirmationPdfRecoverySubscriber;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\OperationalIntegrityInspector;
@@ -34,6 +35,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class OperationalIntegrityInspectorTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   /**
    * {@inheritdoc}
@@ -93,6 +96,7 @@ final class OperationalIntegrityInspectorTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalWorkspaceConvergenceKernelTest.php
@@ -17,6 +17,7 @@ use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Access\OperationalWorkspaceAccessChecker;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\myeventlane_tickets\Service\InventoryReservationAuditProjector;
@@ -41,6 +42,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class OperationalWorkspaceConvergenceKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -95,6 +98,7 @@ final class OperationalWorkspaceConvergenceKernelTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/Support/KernelTestTicketBackedOrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/Support/KernelTestTicketBackedOrderItemClassifier.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel\Support;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
+use Drupal\node\NodeInterface;
+
+/**
+ * Permissive ticket-backed classifier for ticket kernel tests without commerce.
+ *
+ * Treats event-linked variations as ticket-backed (pre-Phase-0 issuance tests).
+ * Excludes operational merchandise bundles so mixed-order safety tests can
+ * substitute the production classifier instead.
+ */
+final class KernelTestTicketBackedOrderItemClassifier implements TicketBackedOrderItemClassifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isTicketBackedOrderItem(OrderItemInterface $order_item): bool {
+    if (in_array($order_item->bundle(), ['boost', 'checkout_donation', 'platform_donation', 'rsvp_donation'], TRUE)) {
+      return FALSE;
+    }
+
+    $purchased = $order_item->getPurchasedEntity();
+    if (!$purchased instanceof ProductVariationInterface) {
+      return FALSE;
+    }
+
+    $product = $purchased->getProduct();
+    if ($product instanceof ProductInterface && OperationalProductBundles::isOperationalProductBundle($product->bundle())) {
+      return FALSE;
+    }
+
+    return $this->resolveEvent($order_item, $purchased) instanceof NodeInterface;
+  }
+
+  private function resolveEvent(OrderItemInterface $order_item, ProductVariationInterface $variation): ?NodeInterface {
+    if ($order_item->hasField('field_target_event') && !$order_item->get('field_target_event')->isEmpty()) {
+      $event = $order_item->get('field_target_event')->entity;
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        return $event;
+      }
+    }
+
+    if ($variation->hasField('field_event') && !$variation->get('field_event')->isEmpty()) {
+      $event = $variation->get('field_event')->entity;
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        return $event;
+      }
+    }
+
+    $product = $variation->getProduct();
+    if ($product instanceof ProductInterface && $product->hasField('field_event') && !$product->get('field_event')->isEmpty()) {
+      $event = $product->get('field_event')->entity;
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        return $event;
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/TicketIssuerMixedOrderKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/TicketIssuerMixedOrderKernelTest.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel;
+
+use Drupal\commerce_order\Entity\Order;
+use Drupal\commerce_order\Entity\OrderItem;
+use Drupal\commerce_order\Entity\OrderItemType;
+use Drupal\commerce_order\Entity\OrderType;
+use Drupal\commerce_price\Entity\Currency;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_product\Entity\ProductType;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_product\Entity\ProductVariationType;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Mixed-cart ticket issuance safety: operational extras must not issue tickets.
+ *
+ * @group myeventlane_tickets
+ */
+#[RunTestsInSeparateProcesses]
+final class TicketIssuerMixedOrderKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'link',
+    'path',
+    'path_alias',
+    'views',
+    'options',
+    'datetime',
+    'datetime_range',
+    'address',
+    'node',
+    'commerce',
+    'commerce_number_pattern',
+    'commerce_price',
+    'commerce_order',
+    'commerce_product',
+    'commerce_store',
+    'entity_reference_revisions',
+    'paragraphs',
+    'profile',
+    'state_machine',
+    'mel_ticket',
+    'myeventlane_vendor',
+    'myeventlane_tickets',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    foreach (array_keys($container->getDefinitions()) as $service_id) {
+      if (str_starts_with($service_id, 'myeventlane_vendor.') && $service_id !== 'myeventlane_vendor.event_access_checker') {
+        $container->removeDefinition($service_id);
+      }
+    }
+
+    $container->register('myeventlane_vendor.event_access_checker', EventVendorAccessChecker::class);
+    $container->register('myeventlane_onboarding.manager', \stdClass::class);
+    $container->register('myeventlane_core.vendor_follow', \stdClass::class);
+    $container->register('myeventlane_event_studio.save', \stdClass::class);
+    $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
+    $container->register('myeventlane_core.domain_detector', \stdClass::class);
+    $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
+    $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
+  }
+
+  /**
+   * Two ticket lines plus parking and T-shirt operational lines issue two tickets only.
+   */
+  public function testMixedOrderIssuesTicketsForTicketLinesOnly(): void {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('commerce_currency');
+    $this->installEntitySchema('profile');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_order');
+    $this->installEntitySchema('commerce_order_item');
+    $this->installEntitySchema('myeventlane_ticket');
+    $this->installConfig(['commerce_store', 'commerce_product', 'commerce_order', 'user']);
+
+    NodeType::create(['type' => 'event', 'name' => 'Event'])->save();
+    $this->ensureCatalogTypes('default', 'default');
+    $this->ensureCatalogTypes('operational_merchandise_var', 'operational_merchandise');
+    $this->ensureProductEventField('default');
+    $this->ensureProductEventField('operational_merchandise');
+    $this->ensureOrderItemTargetEventField();
+
+    if (!Currency::load('AUD')) {
+      Currency::create([
+        'currencyCode' => 'AUD',
+        'name' => 'Australian Dollar',
+        'numericCode' => '036',
+        'symbol' => '$',
+        'fractionDigits' => 2,
+      ])->save();
+    }
+
+    $store_type_storage = $this->container->get('entity_type.manager')->getStorage('commerce_store_type');
+    if (!$store_type_storage->load('online')) {
+      $store_type_storage->create(['id' => 'online', 'label' => 'Online'])->save();
+    }
+
+    $customer = User::create([
+      'name' => 'mixed_order_customer',
+      'mail' => 'mixed-order@example.test',
+      'status' => 1,
+    ]);
+    $customer->save();
+
+    $store = Store::create([
+      'type' => 'online',
+      'name' => 'Mixed Order Store',
+      'mail' => 'mixed-store@example.test',
+      'default_currency' => 'AUD',
+      'status' => 1,
+    ]);
+    $store->save();
+
+    if (!OrderItemType::load('default')) {
+      OrderItemType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'purchasableEntityType' => 'commerce_product_variation',
+        'orderType' => 'default',
+      ])->save();
+    }
+    if (!OrderType::load('default')) {
+      OrderType::create([
+        'id' => 'default',
+        'label' => 'Default',
+        'workflow' => 'order_default',
+      ])->save();
+    }
+
+    $event = Node::create([
+      'type' => 'event',
+      'title' => 'Mixed order event',
+      'uid' => $customer->id(),
+      'status' => 1,
+    ]);
+    $event->save();
+
+    $ticket_variation_a = $this->createVariation('default', 'TICKET-SKU-A', $store, $event, '25.00');
+    $ticket_variation_b = $this->createVariation('default', 'TICKET-SKU-B', $store, $event, '25.00');
+    $parking_variation = $this->createVariation('operational_merchandise_var', 'PARK-SKU', $store, $event, '12.00', 'operational_merchandise');
+    $shirt_variation = $this->createVariation('operational_merchandise_var', 'SHIRT-SKU', $store, $event, '30.00', 'operational_merchandise');
+
+    $order = Order::create([
+      'type' => 'default',
+      'store_id' => $store->id(),
+      'state' => 'completed',
+      'uid' => $customer->id(),
+      'mail' => 'mixed-order@example.test',
+      'placed' => time(),
+    ]);
+    $order->save();
+
+    $event_id = (int) $event->id();
+    $this->addOrderItem($order, $ticket_variation_a, 1, $event_id);
+    $this->addOrderItem($order, $ticket_variation_b, 1, $event_id);
+    $this->addOrderItem($order, $parking_variation, 1, $event_id);
+    $this->addOrderItem($order, $shirt_variation, 1, $event_id);
+    $order->save();
+
+    $issuer = $this->container->get('myeventlane_tickets.ticket_issuer');
+    $this->assertInstanceOf(TicketIssuer::class, $issuer);
+    $issuer->issueForOrder($order);
+
+    $this->assertSame(2, $this->countTicketsForOrder((int) $order->id()));
+  }
+
+  private function createVariation(
+    string $variation_type,
+    string $sku,
+    Store $store,
+    Node $event,
+    string $price,
+    string $product_type = 'default',
+  ): ProductVariation {
+    $product = Product::create([
+      'type' => $product_type,
+      'title' => $sku,
+      'stores' => [$store],
+      'field_event' => $event->id(),
+    ]);
+    $product->save();
+
+    $variation = ProductVariation::create([
+      'type' => $variation_type,
+      'sku' => $sku,
+      'title' => $sku,
+      'product_id' => $product->id(),
+      'price' => new Price($price, 'AUD'),
+      'status' => 1,
+    ]);
+    $variation->save();
+    return $variation;
+  }
+
+  private function addOrderItem(Order $order, ProductVariation $variation, int $qty, int $event_id): void {
+    $item = OrderItem::create([
+      'type' => 'default',
+      'purchased_entity' => $variation,
+      'quantity' => $qty,
+      'unit_price' => $variation->getPrice(),
+      'order_id' => $order->id(),
+    ]);
+    if ($item->hasField('field_target_event')) {
+      $item->set('field_target_event', $event_id);
+    }
+    $item->save();
+    $order->addItem($item);
+  }
+
+  private function countTicketsForOrder(int $order_id): int {
+    $storage = $this->container->get('entity_type.manager')->getStorage('myeventlane_ticket');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_id', $order_id)
+      ->execute();
+    return count($ids);
+  }
+
+  private function ensureCatalogTypes(string $variation_type, string $product_type): void {
+    if (!ProductType::load($product_type)) {
+      ProductType::create(['id' => $product_type, 'label' => $product_type])->save();
+    }
+    if (!ProductVariationType::load($variation_type)) {
+      ProductVariationType::create([
+        'id' => $variation_type,
+        'label' => $variation_type,
+        'generateTitle' => TRUE,
+      ])->save();
+    }
+  }
+
+  private function ensureOrderItemTargetEventField(): void {
+    if (FieldStorageConfig::loadByName('commerce_order_item', 'field_target_event')) {
+      return;
+    }
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_target_event',
+      'entity_type' => 'commerce_order_item',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_target_event',
+      'entity_type' => 'commerce_order_item',
+      'bundle' => 'default',
+      'label' => 'Target event',
+    ])->save();
+  }
+
+  private function ensureProductEventField(string $bundle): void {
+    if (!FieldStorageConfig::loadByName('commerce_product', 'field_event')) {
+      FieldStorageConfig::create([
+        'field_name' => 'field_event',
+        'entity_type' => 'commerce_product',
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'node'],
+      ])->save();
+    }
+
+    if (!FieldConfig::loadByName('commerce_product', $bundle, 'field_event')) {
+      FieldConfig::create([
+        'field_name' => 'field_event',
+        'entity_type' => 'commerce_product',
+        'bundle' => $bundle,
+        'label' => 'Event',
+      ])->save();
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/Traits/RegistersTicketBackedClassifierStubTrait.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/Traits/RegistersTicketBackedClassifierStubTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Kernel\Traits;
+
+use Drupal\Tests\myeventlane_tickets\Kernel\Support\KernelTestTicketBackedOrderItemClassifier;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Registers a permissive ticket-backed classifier for ticket kernel tests.
+ */
+trait RegistersTicketBackedClassifierStubTrait {
+
+  /**
+   * Registers the kernel-test classifier when commerce is not in the test stack.
+   */
+  protected function registerTicketBackedClassifierStub(ContainerBuilder $container): void {
+    if ($container->hasDefinition('myeventlane_commerce.ticket_backed_order_item_classifier')) {
+      return;
+    }
+
+    $container->register(
+      'myeventlane_commerce.ticket_backed_order_item_classifier',
+      KernelTestTicketBackedOrderItemClassifier::class,
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketIssuerEligibilityUnitTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketIssuerEligibilityUnitTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Unit;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_tickets\Ticket\TicketCodeGenerator;
+use Drupal\myeventlane_tickets\Ticket\TicketIssuer;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Ticket\TicketIssuer
+ *
+ * @group myeventlane_tickets
+ */
+final class TicketIssuerEligibilityUnitTest extends UnitTestCase {
+
+  /**
+   * @covers ::isOrderItemEligibleForTicketIssuance
+   */
+  public function testTicketBackedOrderItemIsEligible(): void {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $order_item->method('getPurchasedEntity')->willReturn($variation);
+
+    $target_event = new TicketIssuerTestFieldItemList($event);
+    $order_item->method('hasField')->willReturnMap([
+      ['field_target_event', TRUE],
+    ]);
+    $order_item->method('get')->willReturnMap([
+      ['field_target_event', $target_event],
+    ]);
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->expects($this->once())
+      ->method('isTicketBackedOrderItem')
+      ->with($order_item)
+      ->willReturn(TRUE);
+
+    $issuer = $this->issuer($classifier);
+    $this->assertTrue($issuer->isOrderItemEligibleForTicketIssuance($order_item));
+  }
+
+  /**
+   * @covers ::isOrderItemEligibleForTicketIssuance
+   */
+  public function testOperationalMerchandiseOrderItemIsNotEligible(): void {
+    $order_item = $this->createMock(OrderItemInterface::class);
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_merchandise');
+    $variation->method('getProduct')->willReturn($product);
+    $order_item->method('getPurchasedEntity')->willReturn($variation);
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->expects($this->once())
+      ->method('isTicketBackedOrderItem')
+      ->with($order_item)
+      ->willReturn(FALSE);
+
+    $issuer = $this->issuer($classifier);
+    $this->assertFalse($issuer->isOrderItemEligibleForTicketIssuance($order_item));
+  }
+
+  private function issuer(TicketBackedOrderItemClassifierInterface $classifier): TicketIssuer {
+    return new TicketIssuer(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(TicketCodeGenerator::class),
+      $this->createMock(LoggerChannelFactoryInterface::class),
+      $classifier,
+    );
+  }
+
+}
+
+/**
+ * Minimal field list stub for entity reference fields in unit tests.
+ */
+final class TicketIssuerTestFieldItemList {
+
+  public function __construct(public readonly ?NodeInterface $entity) {}
+
+  public function isEmpty(): bool {
+    return $this->entity === NULL;
+  }
+
+}


### PR DESCRIPTION
## Summary

This Phase 0 Commerce safety slice prevents operational merchandise and add-ons from being treated as attendance tickets or ticket revenue.

Changes:
- TicketIssuer now uses TicketBackedOrderItemClassifier before issuing myeventlane_ticket rows.
- StripeConnectPaymentService ticket revenue calculations now include ticket-backed order items only.
- OperationalProductBundles now exposes an explicit bundle-to-classification map.
- Added tests for ticket eligibility, mixed-order issuance, Stripe revenue guards, and bundle classification.
- Added Phase 0 safety documentation and updated commerce governance docs.

## Validation

- composer validate: pass
- php -l on custom modules: pass
- npm run mel:lint: pass
- npm run mel:build: pass
- ddev drush cr: pass
- ddev drush config:status: no differences
- PHPUnit targeted tests: pass

## Remaining risk

Manual browser matrix still required:
2 tickets + parking + T-shirt → paid checkout → ticket count equals ticket quantity only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ticket issuance eligibility and Stripe Connect transfer/fee bases; incorrect classification could block valid tickets or mis-route vendor payouts, though automated tests cover the main paths.
> 
> **Overview**
> **Phase 0 safety** stops operational merchandise and add-ons (parking, T-shirts, hospitality, etc.) from being treated as attendance tickets or as Stripe Connect “ticket” revenue when they share the same event linkage fields as real tiers.
> 
> `TicketIssuer` now requires `TicketBackedOrderItemClassifierInterface::isTicketBackedOrderItem()` plus event resolution for `issueForOrder()`, `countExpectedIssuanceUnits()`, and `isOrderItemEligibleForTicketIssuance()`. `myeventlane_tickets` depends on `myeventlane_commerce` for that classifier.
> 
> `StripeConnectPaymentService::calculateTicketRevenue()` and `calculateTicketRevenueCentsForEvent()` sum only ticket-backed lines (donation/boost exclusions unchanged). Connect payout rules for operational revenue remain **deferred**.
> 
> `OperationalProductBundles` adds a single bundle→classification map (`operational_merchandise` → `merchandise`, other operational bundles → `addon`). The classifier implements a new interface; docs describe ownership and the manual mixed-cart matrix still required in the browser.
> 
> Tests cover Stripe revenue guards, bundle map, issuer eligibility, mixed-order kernel issuance (two tickets + operational lines → two `myeventlane_ticket` rows), and kernel stubs when commerce is not in the test stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aedac9205777208b0aa2c68b66d242f129d4ddbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->