### PR TITLE
fix(tests): integrate RegistersTicketBackedClassifierStubTrait into k…

### DIFF
--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalCoordinationStateConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalCoordinationStateConvergenceKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\myeventlane_tickets\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Service\OperationalCoordinationAuditProjector;
 use Drupal\myeventlane_tickets\Service\OperationalCoordinationProjectionBuilder;
 use Drupal\myeventlane_tickets\Service\OperationalCoordinationStateManager;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class OperationalCoordinationStateConvergenceKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -61,6 +64,7 @@ final class OperationalCoordinationStateConvergenceKernelTest extends KernelTest
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalFulfillmentExecutionKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/OperationalFulfillmentExecutionKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\myeventlane_tickets\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\myeventlane_tickets\Kernel\Traits\RegistersTicketBackedClassifierStubTrait;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\myeventlane_tickets\Service\OperationalFulfillmentExecutionManager;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
@@ -18,6 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 #[RunTestsInSeparateProcesses]
 final class OperationalFulfillmentExecutionKernelTest extends KernelTestBase {
+
+  use RegistersTicketBackedClassifierStubTrait;
 
   protected static $modules = [
     'system',
@@ -56,6 +59,7 @@ final class OperationalFulfillmentExecutionKernelTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $this->registerTicketBackedClassifierStub($container);
   }
 
   protected function setUp(): void {


### PR DESCRIPTION
…ernel tests

Added the RegistersTicketBackedClassifierStubTrait to both OperationalCoordinationStateConvergenceKernelTest and OperationalFulfillmentExecutionKernelTest, enhancing test functionality by allowing the registration of a ticket-backed classifier stub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only DI setup changes with no production code paths affected.
> 
> **Overview**
> Two operational **kernel tests** now use the shared `RegistersTicketBackedClassifierStubTrait` and call `registerTicketBackedClassifierStub()` from `register()` so the container gets a real `myeventlane_commerce.ticket_backed_order_item_classifier` test double when that service is not already defined.
> 
> This matches other ticket kernel tests and avoids relying on a bare `\stdClass` placeholder for commerce ticket classification during coordination and fulfillment execution smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf7dc96ef1528300c3ce19ee606376d1414b4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->