### PR TITLE
feat(studio): improve extras product editor

### DIFF
--- a/docs/studio-merch-addon-product-setup.md
+++ b/docs/studio-merch-addon-product-setup.md
@@ -1,0 +1,106 @@
+# Event Studio: merch and add-on product setup
+
+Status: vendor-facing Commerce product editor in Studio  
+Scope: Event Studio `extras` section — not tickets, fulfilment execution, or Stripe charge model
+
+## Product editor layout
+
+**Merch & add-ons** (`/vendor/events/{node}/studio/extras`) uses a card-based **Commerce product editor** with sections:
+
+| Section | Purpose |
+| --- | --- |
+| Product basics | Type (merchandise / add-on subtype), name, short description, status (Active / Hidden / Draft) |
+| Product images | `field_mel_extra_images` media gallery (all operational bundles) |
+| Pricing and SKU | Price, SKU (auto-generated when blank; size suffixes for variants) |
+| Quantity | Quantity note in operational metadata (not stock enforcement) + warning panel |
+| Options and variants | Size checkboxes + variant preview table (merchandise with `field_mel_size`) |
+| Collection and fulfilment | Pickup / collection note; fulfilment tracking deferred notice |
+| Booking visibility | Show on booking page (requires Active status) |
+
+Save actions: **Save product**, **Save and add another**, **Back to all extras**.
+
+## Field support (audit summary)
+
+### Product bundles (`operational_merchandise`, `hospitality_package`, `timed_collection_product`, `operational_bundle`)
+
+| Field | Purpose |
+| --- | --- |
+| `title` | Product name (Commerce core) |
+| `status` | Published flag |
+| `stores` | Commerce store assignment |
+| `field_event` | Event linkage |
+| `field_mel_extra_short_desc` | Short customer description |
+| `field_mel_extra_pickup_note` | Pickup / collection copy |
+| `field_mel_extra_images` | Media gallery (image media) |
+| `field_mel_operational_product` | Operational JSON metadata |
+
+No `body` field. No dedicated stock/capacity field on products.
+
+### Variation bundles
+
+| Field | Merchandise var | Other operational vars |
+| --- | --- | --- |
+| `price`, `sku`, `status` | Yes (Commerce core) | Yes |
+| `field_mel_size` | Yes | No |
+| Stock / `field_capacity` | **No** | **No** |
+
+Quantity is stored as a **quantity note** inside `field_mel_operational_product` metadata (`operational_chips` + `collection_rules.vendor_quantity_note`). It is **not** inventory enforcement.
+
+## Image support status
+
+**Configured and wired.** `field_mel_extra_images` uses the Commerce `media_library_widget`. Studio attaches the default entity form display widget on create (stub product) and edit. Images save via `VendorOperationalProductCreationManager::applyEventExtraFieldUpdates()` and form display `extractFormValues()`.
+
+## Variant support status
+
+**Merchandise** (`operational_merchandise` + `field_mel_size`): vendor selects sizes; one variation per size with SKU suffix. Preview table shown in editor.
+
+**Add-ons**: single variation by default (no size field on non-merch variation types).
+
+## Product list cards
+
+Each card shows: thumbnail or placeholder, type pill, status (Active/Hidden/Draft), variant count, price, quantity note, booking visibility, actions (Edit product, Hide/Show on booking page, View booking page).
+
+## Authority
+
+- **Commerce** owns products, variations, carts, checkout.
+- **`VendorOperationalProductCreationManager`** owns create/update (explicit save only).
+- **`EventStudioExtrasProductEditorBuilder`** owns form layout only.
+- **`OperationalProductStudioFieldRegistry`** reports field support (read-only).
+
+## Why extras do not issue tickets
+
+See [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md). Operational lines are excluded from ticket issuance and ticket-only Stripe revenue sums.
+
+## Deferred
+
+- Stock enforcement and Commerce Stock integration on operational variations.
+- Shipping / fulfilment state machines and vendor fulfilment dashboard.
+- Dedicated Connect revenue split for operational lines.
+- Raw Commerce admin as the primary vendor path (staff-only advanced link when permitted).
+- “Feature this extra” prominence (no field/metadata contract yet).
+
+## Manual browser checklist
+
+- [ ] Vendor opens Merch & add-ons on a paid event.
+- [ ] Create T-shirt: name, description, price, SKU, sizes S/M/L, quantity note, images, Active + show on booking.
+- [ ] Save; card shows image, type, price, variants, quantity note, status.
+- [ ] Create Parking add-on: price, quantity note, pickup note, Active.
+- [ ] Both appear on `/event/{node}/book` add-on section.
+- [ ] Ticket setup unchanged; checkout does not issue tickets for extras only.
+
+## Tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMerchAddonStudioTest.php \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php \
+  --do-not-cache-result
+```
+
+## Related docs
+
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md)
+- [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)
+- [vendor-product-creation-wizard.md](./vendor-product-creation-wizard.md)

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
@@ -1,5 +1,5 @@
 /**
- * Unified Event Extras Studio (vendor).
+ * Unified Event Extras Studio (vendor) — merch & add-ons.
  */
 
 .mel-event-extras-studio {
@@ -8,8 +8,73 @@
   gap: 1.25rem;
 }
 
-.mel-event-extras-studio__probe {
+.mel-event-extras-studio__safety {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-muted, #f4f1fa);
+  font-size: 0.9375rem;
+}
+
+.mel-event-extras-studio__safety .item-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.mel-event-extras-studio__ticket-note {
   margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.mel-event-extras-studio__tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  color: inherit;
+  background: var(--mel-surface-elevated, #fff);
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-extras-studio__tab.is-active,
+.mel-event-extras-studio__tab:hover,
+.mel-event-extras-studio__tab:focus-visible {
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 35%, #fff);
+  border-color: var(--mel-accent, #7c6cf0);
+  outline: none;
+}
+
+.mel-event-extras-studio__empty-state {
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.mel-event-extras-studio__empty-cta,
+.mel-event-extras-studio__add-more {
+  min-height: 2.75rem;
+  margin-top: 0.75rem;
+}
+
+.mel-event-extras-studio__probe {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.mel-event-extras-studio__probe-panel {
+  padding: 1rem;
 }
 
 .mel-event-extra-choices {
@@ -32,6 +97,10 @@
   text-decoration: none;
   color: inherit;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.mel-event-extra-choice--addon {
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 12%, #fff);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -66,6 +135,39 @@
   align-items: start;
 }
 
+.mel-event-extra-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.mel-event-extra-card__type {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.mel-event-extra-card__type--merchandise {
+  background: color-mix(in srgb, var(--mel-coral, #ff6b6b) 18%, #fff);
+  color: var(--mel-coral-dark, #c44545);
+}
+
+.mel-event-extra-card__type--addon {
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 45%, #fff);
+  color: var(--mel-accent, #5b4fc7);
+}
+
+.mel-event-extra-card__variants {
+  font-size: 0.8125rem;
+  color: var(--mel-text-muted, #6b6578);
+}
+
 .mel-event-extra-actions {
   display: flex;
   flex-wrap: wrap;
@@ -73,8 +175,14 @@
 }
 
 @media (max-width: 640px) {
-  .mel-event-extra-card {
+  .mel-event-extra-card__inner {
     grid-template-columns: 1fr;
+  }
+
+  .mel-event-extra-card__media img,
+  .mel-event-extra-card__placeholder {
+    width: 100%;
+    max-width: 12rem;
   }
 }
 
@@ -96,12 +204,10 @@
   background: var(--mel-surface-muted, #f4f1fa);
 }
 
-.mel-event-extra-actions .button {
+.mel-event-extra-actions .button,
+.mel-event-extra-actions .mel-btn {
   min-height: 2.75rem;
-}
-
-.mel-event-extra-editor .form-actions .button {
-  min-height: 2.75rem;
+  min-width: 2.75rem;
 }
 
 .mel-event-extras-studio__footer-cta {
@@ -136,4 +242,163 @@
   display: inline-block;
   margin-top: 0.5rem;
   font-size: 0.875rem;
+}
+
+.mel-event-extras-studio .button--primary,
+.mel-event-extras-studio .mel-btn--primary {
+  background: var(--mel-coral, #ff6b6b);
+  border-color: var(--mel-coral, #ff6b6b);
+  color: #fff;
+}
+
+.mel-event-extras-studio .mel-btn--secondary {
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 25%, #fff);
+  border-color: var(--mel-accent, #7c6cf0);
+}
+
+/* Commerce-style product editor */
+.mel-event-product-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mel-event-product-editor__nav {
+  margin-bottom: 0.25rem;
+}
+
+.mel-event-product-editor__back {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mel-event-product-editor__section {
+  padding: 1rem 1.125rem;
+}
+
+.mel-event-product-editor__type-pill {
+  display: inline-block;
+  margin: 0;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.8125rem;
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 35%, #fff);
+}
+
+.mel-event-product-editor__stock-warning {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--mel-coral, #ff6b6b) 35%, #e8e4ef);
+  background: color-mix(in srgb, var(--mel-coral, #ff6b6b) 8%, #fff);
+  font-size: 0.9375rem;
+}
+
+.mel-event-product-editor__media-disabled {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-muted, #f4f1fa);
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-product-editor__current-image {
+  margin-bottom: 0.75rem;
+}
+
+.mel-event-product-editor__thumb {
+  width: 6rem;
+  height: 6rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.mel-event-product-editor__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.mel-event-product-editor__actions .button,
+.mel-event-product-editor__actions .mel-btn {
+  min-height: 2.75rem;
+}
+
+.mel-event-variant-preview {
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.mel-event-variant-preview__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mel-event-variant-preview__table th,
+.mel-event-variant-preview__table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-variant-preview__table th {
+  font-weight: 700;
+  background: var(--mel-surface-muted, #f4f1fa);
+}
+
+.mel-event-extra-card__status-pill {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.mel-event-extra-card__status-pill--active {
+  background: color-mix(in srgb, #3d9a5f 20%, #fff);
+  color: #2d6a42;
+}
+
+.mel-event-extra-card__status-pill--draft,
+.mel-event-extra-card__status-pill--hidden {
+  background: var(--mel-surface-muted, #f4f1fa);
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extra-card__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mel-event-extra-card__placeholder-label {
+  font-size: 0.75rem;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extra-card__image-count {
+  position: absolute;
+  right: 0.35rem;
+  bottom: 0.35rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  background: rgb(0 0 0 / 65%);
+  color: #fff;
+}
+
+.mel-event-extra-card__media {
+  position: relative;
+}
+
+.mel-event-extra-card__quantity-note {
+  font-size: 0.875rem;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extra-card__quantity-label {
+  font-weight: 600;
 }

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -26,12 +26,21 @@ mel_operational_capability_studio:
     - core/once
 
 mel_event_extras_studio:
+  version: 1.2
+  css:
+    theme:
+      css/mel-event-extras-studio.css: {}
+  dependencies:
+    - core/drupal
+
+mel_event_extras_product_editor:
   version: 1.0
   css:
     theme:
       css/mel-event-extras-studio.css: {}
   dependencies:
     - core/drupal
+    - myeventlane_event_studio/mel_event_extras_studio
 
 mel_vendor_productisation_studio:
   version: 1.0

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -146,6 +146,12 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-extra-preview',
     ],
+    'mel_event_studio_extra_variant_preview' => [
+      'variables' => [
+        'rows' => [],
+      ],
+      'template' => 'mel-event-studio-extra-variant-preview',
+    ],
     'mel_event_branding_preview' => [
       'variables' => [
         'title' => '',

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -233,6 +233,20 @@ services:
       - '@myeventlane_commerce.operational_merchandise_manager'
       - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@myeventlane_event_studio.vendor_operational_product_creation_manager'
+      - '@string_translation'
+
+  myeventlane_event_studio.operational_product_studio_field_registry:
+    class: Drupal\myeventlane_event_studio\Service\OperationalProductStudioFieldRegistry
+    arguments:
+      - '@entity_field.manager'
+
+  myeventlane_event_studio.extras_product_editor_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder
+    arguments:
+      - '@myeventlane_event_studio.event_extras_builder'
+      - '@myeventlane_event_studio.vendor_operational_product_creation_manager'
+      - '@myeventlane_event_studio.operational_product_studio_field_registry'
       - '@string_translation'
 
   myeventlane_event_studio.vendor_productisation_studio_builder:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -12,8 +12,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver;
-use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder;
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
@@ -40,6 +40,8 @@ final class EventStudioEventExtrasForm extends FormBase {
 
   protected EventStudioEventExtrasBuilder $extrasBuilder;
 
+  protected EventStudioExtrasProductEditorBuilder $productEditorBuilder;
+
   protected EventExtrasBookPlacementResolver $extrasBookPlacementResolver;
 
   protected LoggerInterface $logger;
@@ -51,6 +53,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     EventVendorAccessChecker $event_vendor_access_checker,
     VendorOperationalProductCreationManager $product_creation_manager,
     EventStudioEventExtrasBuilder $extras_builder,
+    EventStudioExtrasProductEditorBuilder $product_editor_builder,
     EventExtrasBookPlacementResolver $extras_book_placement_resolver,
     LoggerInterface $logger,
   ) {
@@ -58,6 +61,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     $this->eventVendorAccessChecker = $event_vendor_access_checker;
     $this->productCreationManager = $product_creation_manager;
     $this->extrasBuilder = $extras_builder;
+    $this->productEditorBuilder = $product_editor_builder;
     $this->extrasBookPlacementResolver = $extras_book_placement_resolver;
     $this->logger = $logger;
   }
@@ -68,6 +72,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
       $container->get('myeventlane_event_studio.event_extras_builder'),
+      $container->get('myeventlane_event_studio.extras_product_editor_builder'),
       $container->get('myeventlane_commerce.event_extras_book_placement_resolver'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
@@ -87,7 +92,7 @@ final class EventStudioEventExtrasForm extends FormBase {
    * Ensures services are present after form cache unserialization.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->eventVendorAccessChecker, $this->productCreationManager, $this->extrasBuilder, $this->extrasBookPlacementResolver, $this->logger)) {
+    if (isset($this->entityTypeManager, $this->eventVendorAccessChecker, $this->productCreationManager, $this->extrasBuilder, $this->productEditorBuilder, $this->extrasBookPlacementResolver, $this->logger)) {
       return;
     }
     $container = \Drupal::getContainer();
@@ -102,6 +107,9 @@ final class EventStudioEventExtrasForm extends FormBase {
     }
     if (!isset($this->extrasBuilder)) {
       $this->extrasBuilder = $container->get('myeventlane_event_studio.event_extras_builder');
+    }
+    if (!isset($this->productEditorBuilder)) {
+      $this->productEditorBuilder = $container->get('myeventlane_event_studio.extras_product_editor_builder');
     }
     if (!isset($this->extrasBookPlacementResolver)) {
       $this->extrasBookPlacementResolver = $container->get('myeventlane_commerce.event_extras_book_placement_resolver');
@@ -129,6 +137,9 @@ final class EventStudioEventExtrasForm extends FormBase {
         $action = 'edit';
       }
       elseif ($add_type !== '') {
+        if ($this->productCreationManager->normalizeVendorExtraType($add_type) === '') {
+          throw new NotFoundHttpException();
+        }
         $action = 'add';
         $form_state->set('mel_extras_extra_type', $add_type);
       }
@@ -146,34 +157,64 @@ final class EventStudioEventExtrasForm extends FormBase {
       '#value' => (string) $event->id(),
     ];
 
+    $mode = (string) $form_state->get('mel_extras_mode');
+    if ($mode !== 'list') {
+      $form['#attributes']['class'][] = 'mel-event-extras-studio--editor';
+    }
+
     $form['intro'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-es-card', 'mel-event-extras-studio__intro']],
       'title' => [
         '#type' => 'html_tag',
         '#tag' => 'h2',
-        '#value' => $this->t('Event extras'),
+        '#value' => $this->t('Merch & add-ons'),
         '#attributes' => ['class' => ['mel-es-card__title']],
       ],
       'copy' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Offer merch, food vouchers, VIP packages, or pickup items guests can add when booking.'),
+        '#value' => $this->t('Sell event extras like parking, meal packages, T-shirts, or VIP upgrades alongside your tickets.'),
         '#attributes' => ['class' => ['mel-es-card__hint']],
+      ],
+      'safety' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extras-studio__safety']],
+        'items' => [
+          '#theme' => 'item_list',
+          '#items' => [
+            $this->t('Merch and add-ons are sold through the same checkout.'),
+            $this->t('They do not count as event tickets.'),
+            $this->t('Fulfilment and stock controls are still being improved.'),
+          ],
+        ],
+      ],
+      'ticket_note' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Tickets stay separate. Extras do not create admission tickets.'),
+        '#attributes' => ['class' => ['mel-text--muted', 'mel-event-extras-studio__ticket-note']],
       ],
     ];
 
-    $mode = (string) $form_state->get('mel_extras_mode');
     if ($mode === 'edit' || $mode === 'add') {
-      $form['editor'] = $this->buildEditor($form, $form_state, $event, $mode, $edit_id);
+      $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_extras_product_editor';
+      $form['editor'] = $this->productEditorBuilder->buildEditor(
+        $form,
+        $form_state,
+        $event,
+        $this->currentUser(),
+        $mode,
+        $edit_id,
+      );
+      $form['intro']['#access'] = FALSE;
     }
     else {
       $form['list'] = $this->buildList($event);
       $form += $this->buildBookingPlacement($event);
       $form['probe'] = $this->buildProbe($event);
+      $form['footer_cta'] = $this->buildFooterCta($event);
     }
-
-    $form['footer_cta'] = $this->buildFooterCta($event);
 
     return $form;
   }
@@ -182,29 +223,75 @@ final class EventStudioEventExtrasForm extends FormBase {
    * @return array<string, mixed>
    */
   private function buildList(NodeInterface $event): array {
-    $cards = $this->extrasBuilder->loadExtrasForEvent($event);
+    $request = $this->getRequest();
+    $filter = (string) ($request?->query->get('filter') ?? 'all');
+    if (!array_key_exists($filter, $this->extrasBuilder->listFilterOptions())) {
+      $filter = 'all';
+    }
+    $cards = $this->extrasBuilder->loadExtrasForEventByClassification($event, $filter);
+    $all_count = count($this->extrasBuilder->loadExtrasForEvent($event));
+
     $list = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-extras-studio__list']],
     ];
-    if ($cards === []) {
+
+    $list['tabs'] = $this->buildListFilterTabs($event, $filter);
+
+    if ($all_count === 0) {
       $list['empty'] = [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $this->t('No extras yet. Choose a type below to add your first one.'),
-        '#attributes' => ['class' => ['mel-event-extras-studio__empty', 'mel-text--muted']],
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extras-studio__empty-state', 'mel-es-card']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Add merch or extras to this event'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Sell event extras like parking, meal packages, T-shirts, or VIP upgrades alongside your tickets.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+        'cta' => [
+          '#type' => 'link',
+          '#title' => $this->t('Add merch or add-on'),
+          '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+            'query' => ['add' => 'merchandise'],
+          ]),
+          '#attributes' => ['class' => ['button', 'button--primary', 'mel-event-extras-studio__empty-cta']],
+        ],
       ];
       return $list;
     }
+
+    if ($cards === []) {
+      $list['filter_empty'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No items in this tab yet.'),
+        '#attributes' => ['class' => ['mel-text--muted']],
+      ];
+      return $list;
+    }
+
     foreach ($cards as $card) {
       $pid = (int) ($card['product_id'] ?? 0);
       if ($pid < 1) {
         continue;
       }
       $show = !empty($card['show_on_booking']);
+      $book_url = (string) ($card['book_page_url'] ?? '');
       $list['card_' . $pid] = [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-extra-card', 'mel-es-card']],
+        '#attributes' => [
+          'class' => [
+            'mel-event-extra-card',
+            'mel-es-card',
+            'mel-event-extra-card--' . (string) ($card['classification'] ?? 'addon'),
+          ],
+        ],
         'content' => [
           '#theme' => 'mel_event_studio_extra_card',
           '#card' => $card,
@@ -214,25 +301,74 @@ final class EventStudioEventExtrasForm extends FormBase {
           '#attributes' => ['class' => ['mel-event-extra-actions']],
           'edit' => [
             '#type' => 'link',
-            '#title' => $this->t('Edit'),
+            '#title' => $this->t('Edit product'),
             '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
               'query' => ['extra' => $pid],
             ]),
-            '#attributes' => ['class' => ['button', 'mel-event-extra-card__edit']],
+            '#attributes' => ['class' => ['button', 'mel-event-extra-card__edit', 'mel-btn']],
           ],
           'toggle_' . $pid => [
             '#type' => 'submit',
-            '#value' => $show ? $this->t('Hide from booking') : $this->t('Show on booking'),
+            '#value' => $show ? $this->t('Hide from booking page') : $this->t('Show on booking page'),
             '#name' => 'toggle_' . $pid,
             '#submit' => ['::submitToggleVisibility'],
             '#limit_validation_errors' => [],
-            '#attributes' => ['class' => ['mel-event-extra-card__toggle', 'button']],
+            '#attributes' => ['class' => ['mel-event-extra-card__toggle', 'button', 'mel-btn', 'mel-btn--secondary']],
             '#product_id' => $pid,
           ],
         ],
       ];
+      if ($show && $book_url !== '') {
+        $list['card_' . $pid]['actions']['view_booking'] = [
+          '#type' => 'link',
+          '#title' => $this->t('View on booking page'),
+          '#url' => str_starts_with($book_url, '/') ? Url::fromUserInput($book_url) : Url::fromUri($book_url),
+          '#attributes' => [
+            'class' => ['button', 'mel-event-extra-card__view', 'mel-btn', 'mel-btn--secondary'],
+            'target' => '_blank',
+            'rel' => 'noopener noreferrer',
+          ],
+        ];
+      }
     }
+
+    $list['add_more'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Add merch or add-on'),
+      '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+        'query' => ['add' => 'merchandise'],
+      ]),
+      '#attributes' => ['class' => ['button', 'button--primary', 'mel-event-extras-studio__add-more']],
+    ];
+
     return $list;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildListFilterTabs(NodeInterface $event, string $active): array {
+    $items = [];
+    foreach ($this->extrasBuilder->listFilterOptions() as $key => $label) {
+      $items[$key] = [
+        '#type' => 'link',
+        '#title' => $label,
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+          'query' => $key === 'all' ? [] : ['filter' => $key],
+        ]),
+        '#attributes' => [
+          'class' => array_filter([
+            'mel-event-extras-studio__tab',
+            $key === $active ? 'is-active' : NULL,
+          ]),
+        ],
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extras-studio__tabs']],
+      '#children' => $items,
+    ];
   }
 
   /**
@@ -304,39 +440,58 @@ final class EventStudioEventExtrasForm extends FormBase {
    * @return array<string, mixed>
    */
   private function buildProbe(NodeInterface $event): array {
-    $choices = $this->extrasBuilder->extraTypeChoices();
-    $items = [];
-    foreach ($choices as $key => $label) {
-      $items[$key] = [
-        '#type' => 'link',
-        '#title' => $label,
-        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
-          'query' => ['add' => $key],
-        ]),
-        '#attributes' => [
-          'class' => ['mel-event-extra-choice', 'mel-event-extra-choice--' . $key],
-        ],
-      ];
+    $merch_items = [];
+    foreach ($this->extrasBuilder->merchandiseTypeChoices() as $key => $label) {
+      $merch_items[$key] = $this->buildExtraTypeChoiceLink($event, $key, $label, 'merchandise');
+    }
+    $addon_items = [];
+    foreach ($this->extrasBuilder->addonTypeChoices() as $key => $label) {
+      $addon_items[$key] = $this->buildExtraTypeChoiceLink($event, $key, $label, 'addon');
     }
     return [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-extras-studio__probe', 'mel-es-card']],
-      'heading' => [
-        '#type' => 'html_tag',
-        '#tag' => 'h3',
-        '#value' => $this->t('What would you like to offer?'),
-        '#attributes' => ['class' => ['mel-es-card__title']],
-      ],
-      'choices' => [
+      '#attributes' => ['class' => ['mel-event-extras-studio__probe']],
+      'merch' => [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-extra-choices']],
-        '#children' => $items,
+        '#attributes' => ['class' => ['mel-event-extras-studio__probe-panel', 'mel-es-card']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Merchandise'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('T-shirts, hoodies, posters, or digital items.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+        'choices' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-extra-choices']],
+          '#children' => $merch_items,
+        ],
       ],
-      'none' => [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $this->t('No extras yet? You can skip this and add them later.'),
-        '#attributes' => ['class' => ['mel-text--muted']],
+      'addons' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extras-studio__probe-panel', 'mel-es-card']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Add-ons'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Parking, meals, camping, VIP extras, or transport.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+        'choices' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-extra-choices']],
+          '#children' => $addon_items,
+        ],
       ],
     ];
   }
@@ -344,173 +499,21 @@ final class EventStudioEventExtrasForm extends FormBase {
   /**
    * @return array<string, mixed>
    */
-  private function buildEditor(array &$form, FormStateInterface $form_state, NodeInterface $event, string $mode, int $edit_id): array {
-    $product = NULL;
-    $defaults = [
-      'extra_type' => (string) ($form_state->get('mel_extras_extra_type') ?? ''),
-      'title' => '',
-      'customer_summary' => '',
-      'pickup_note' => '',
-      'price_amount' => '',
-      'show_on_booking' => 1,
-      'sizes' => [],
-    ];
-    if ($mode === 'edit' && $edit_id > 0) {
-      $product = $this->productCreationManager->assertVendorCanManageProduct($this->currentUser(), $event, $edit_id);
-      $defaults = $this->defaultsFromProduct($product);
-    }
-
-    $editor = [
-      '#type' => 'container',
-      '#tree' => TRUE,
-      '#parents' => ['editor'],
-      '#attributes' => ['class' => ['mel-event-extra-editor', 'mel-es-card']],
-      'back' => [
-        '#type' => 'link',
-        '#title' => $this->t('← All extras'),
-        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]),
-        '#attributes' => ['class' => ['mel-event-extras-studio__back']],
-      ],
-      'product_id' => [
-        '#type' => 'hidden',
-        '#value' => $product instanceof ProductInterface ? (string) $product->id() : '',
+  private function buildExtraTypeChoiceLink(NodeInterface $event, string $key, string $label, string $group): array {
+    return [
+      '#type' => 'link',
+      '#title' => $label,
+      '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()], [
+        'query' => ['add' => $key],
+      ]),
+      '#attributes' => [
+        'class' => [
+          'mel-event-extra-choice',
+          'mel-event-extra-choice--' . $key,
+          'mel-event-extra-choice--' . $group,
+        ],
       ],
     ];
-
-    if ($product === NULL) {
-      $editor['extra_type'] = [
-        '#type' => 'radios',
-        '#title' => $this->t('Extra type'),
-        '#options' => $this->extrasBuilder->extraTypeChoices(),
-        '#default_value' => $defaults['extra_type'] !== '' ? $defaults['extra_type'] : 'merchandise',
-        '#required' => TRUE,
-        '#attributes' => ['class' => ['mel-event-extra-type-radios']],
-      ];
-    }
-
-    $editor['title'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Extra name'),
-      '#default_value' => $defaults['title'],
-      '#required' => TRUE,
-      '#maxlength' => 255,
-    ];
-    $editor['customer_summary'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Short customer description'),
-      '#default_value' => $defaults['customer_summary'],
-      '#required' => TRUE,
-      '#rows' => 3,
-    ];
-    $editor['pickup_note'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Pickup / venue collection note'),
-      '#default_value' => $defaults['pickup_note'],
-      '#rows' => 2,
-      '#description' => $this->t('E.g. “Collect at the merch desk after check-in.”'),
-    ];
-    $editor['price_amount'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Price'),
-      '#default_value' => $defaults['price_amount'],
-      '#required' => TRUE,
-      '#min' => 0,
-      '#step' => 0.01,
-    ];
-    $editor['sizes'] = [
-      '#type' => 'checkboxes',
-      '#title' => $this->t('Sizes (merchandise)'),
-      '#options' => OperationalExtraVisualPresenter::SIZE_LABELS,
-      '#default_value' => $defaults['sizes'],
-      '#description' => $this->t('Creates one purchasable option per size. Leave empty for a single option.'),
-    ];
-    $editor['show_on_booking'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Show on booking page'),
-      '#default_value' => (bool) $defaults['show_on_booking'],
-    ];
-
-    if ($product instanceof ProductInterface) {
-      $editor['preview'] = [
-        '#theme' => 'mel_event_studio_extra_preview',
-        '#preview' => $this->extrasBuilder->buildPreviewRow($product, $event),
-      ];
-    }
-    else {
-      $editor['images_notice'] = [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $this->t('You can add photos after saving this extra.'),
-        '#attributes' => ['class' => ['mel-text--muted']],
-      ];
-    }
-
-    if ($this->currentUser()->hasPermission('administer commerce_product')) {
-      $pid = $product instanceof ProductInterface ? (int) $product->id() : 0;
-      if ($pid > 0) {
-        $editor['admin_commerce'] = [
-          '#type' => 'link',
-          '#title' => $this->t('Advanced Commerce edit'),
-          '#url' => Url::fromRoute('entity.commerce_product.edit_form', ['commerce_product' => $pid]),
-          '#attributes' => [
-            'class' => ['mel-event-extras-studio__admin-link'],
-            'target' => '_blank',
-            'rel' => 'noopener noreferrer',
-          ],
-        ];
-      }
-    }
-
-    $editor['actions'] = [
-      '#type' => 'actions',
-      'submit' => [
-        '#type' => 'submit',
-        '#value' => $this->t('Save extra'),
-        '#button_type' => 'primary',
-      ],
-      'add_another' => [
-        '#type' => 'submit',
-        '#value' => $this->t('Save and add another'),
-        '#submit' => ['::submitAddAnother'],
-      ],
-    ];
-
-    if ($product instanceof ProductInterface) {
-      $this->attachImagesWidget($product, $form, $editor, $form_state);
-    }
-
-    return $editor;
-  }
-
-  /**
-   * Attaches the Commerce media_library widget (EntityFormDisplay pattern).
-   */
-  private function attachImagesWidget(ProductInterface $product, array &$form, array &$editor, FormStateInterface $form_state): void {
-    $display_id = 'commerce_product.' . $product->bundle() . '.default';
-    $form_display = EntityFormDisplay::load($display_id);
-    if ($form_display === NULL || !$product->hasField('field_mel_extra_images')) {
-      return;
-    }
-    $widget = $form_display->getRenderer('field_mel_extra_images');
-    if ($widget === NULL) {
-      return;
-    }
-    if (!isset($form['#parents'])) {
-      $form['#parents'] = [];
-    }
-    if (!isset($editor['#parents'])) {
-      $editor['#parents'] = ['editor'];
-    }
-    if (!isset($editor['#tree'])) {
-      $editor['#tree'] = TRUE;
-    }
-    $editor['field_mel_extra_images'] = $widget->form(
-      $product->get('field_mel_extra_images'),
-      $editor,
-      $form_state,
-    );
-    $editor['field_mel_extra_images']['#title'] = $this->t('Images');
-    $editor['field_mel_extra_images']['#attributes']['class'][] = 'mel-event-extra-gallery';
   }
 
   /**
@@ -544,41 +547,6 @@ final class EventStudioEventExtrasForm extends FormBase {
     return Url::fromRoute('entity.node.canonical', ['node' => $event->id()]);
   }
 
-  /**
-   * @return array<string, mixed>
-   */
-  private function defaultsFromProduct(ProductInterface $product): array {
-    $sizes = [];
-    foreach ($product->getVariations() as $variation) {
-      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty() && $variation->isPublished()) {
-        $key = strtolower((string) $variation->get('field_mel_size')->value);
-        $sizes[$key] = $key;
-      }
-    }
-    $price = '';
-    foreach ($product->getVariations() as $variation) {
-      if ($variation->isPublished() && $variation->getPrice() !== NULL) {
-        $price = $variation->getPrice()->getNumber();
-        break;
-      }
-    }
-    $short = $product->hasField('field_mel_extra_short_desc') && !$product->get('field_mel_extra_short_desc')->isEmpty()
-      ? (string) $product->get('field_mel_extra_short_desc')->value
-      : '';
-    $pickup = $product->hasField('field_mel_extra_pickup_note') && !$product->get('field_mel_extra_pickup_note')->isEmpty()
-      ? (string) $product->get('field_mel_extra_pickup_note')->value
-      : '';
-    return [
-      'extra_type' => '',
-      'title' => $product->label(),
-      'customer_summary' => $short,
-      'pickup_note' => $pickup,
-      'price_amount' => $price,
-      'show_on_booking' => $product->isPublished() ? 1 : 0,
-      'sizes' => $sizes,
-    ];
-  }
-
   public function validateForm(array &$form, FormStateInterface $form_state): void {
     $this->ensureInjectedServices();
     $event = $this->loadSubmittedEvent($form_state);
@@ -601,6 +569,10 @@ final class EventStudioEventExtrasForm extends FormBase {
       return;
     }
     $input = $this->collectInput($form_state);
+    $status = (string) ($input['product_status'] ?? '');
+    if ($status !== '' && !array_key_exists($status, $this->productCreationManager->productStatusOptions())) {
+      $form_state->setErrorByName('', $this->t('Choose a valid product status.'));
+    }
     foreach ($this->productCreationManager->validateEventExtraInput($this->currentUser(), $event, $input) as $error) {
       $form_state->setErrorByName('', $error);
     }
@@ -680,7 +652,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       $input = $this->collectInput($form_state);
       $product = $this->productCreationManager->saveEventExtraForVendor($this->currentUser(), $event, $input);
       $this->extractImagesOntoProduct($form_state, $product);
-      $this->messenger()->addStatus($this->t('Your extra “@title” is saved. Guests can add it when booking.', [
+      $this->messenger()->addStatus($this->t('Product “@title” saved.', [
         '@title' => $product->label(),
       ]));
       if ($add_another) {
@@ -709,38 +681,48 @@ final class EventStudioEventExtrasForm extends FormBase {
    * @return array<string, mixed>
    */
   private function collectInput(FormStateInterface $form_state): array {
+    $editor = $form_state->getValue('editor');
+    if (!is_array($editor)) {
+      return [];
+    }
+    $basics = is_array($editor['basics'] ?? NULL) ? $editor['basics'] : [];
+    $pricing = is_array($editor['pricing'] ?? NULL) ? $editor['pricing'] : [];
+    $quantity = is_array($editor['quantity'] ?? NULL) ? $editor['quantity'] : [];
+    $variants = is_array($editor['variants'] ?? NULL) ? $editor['variants'] : [];
+    $collection = is_array($editor['collection'] ?? NULL) ? $editor['collection'] : [];
+    $visibility = is_array($editor['visibility'] ?? NULL) ? $editor['visibility'] : [];
+
     $sizes = [];
-    foreach ((array) ($this->editorValue($form_state, 'sizes') ?? []) as $key => $on) {
+    foreach ((array) ($variants['sizes'] ?? []) as $key => $on) {
       if (!empty($on)) {
         $sizes[] = (string) $key;
       }
     }
-    $image_media_ids = $this->extractImageMediaIds($form_state, ['editor', 'field_mel_extra_images']);
-    if ($image_media_ids === []) {
-      $image_media_ids = $this->extractImageMediaIds($form_state, 'field_mel_extra_images');
+
+    $extra_type = (string) ($editor['extra_type'] ?? '');
+    if ($extra_type === '' && isset($basics['extra_type'])) {
+      $extra_type = (string) $basics['extra_type'];
     }
+
+    $image_media_ids = $this->extractImageMediaIds($form_state, ['editor', 'media', 'field_mel_extra_images']);
+    if ($image_media_ids === []) {
+      $image_media_ids = $this->extractImageMediaIds($form_state, ['editor', 'field_mel_extra_images']);
+    }
+
     return [
-      'product_id' => (int) ($this->editorValue($form_state, 'product_id') ?? 0),
-      'extra_type' => (string) ($this->editorValue($form_state, 'extra_type') ?? ''),
-      'title' => (string) ($this->editorValue($form_state, 'title') ?? ''),
-      'customer_summary' => (string) ($this->editorValue($form_state, 'customer_summary') ?? ''),
-      'pickup_note' => (string) ($this->editorValue($form_state, 'pickup_note') ?? ''),
-      'price_amount' => $this->editorValue($form_state, 'price_amount'),
+      'product_id' => (int) ($editor['product_id'] ?? 0),
+      'extra_type' => $extra_type,
+      'title' => (string) ($basics['title'] ?? ''),
+      'customer_summary' => (string) ($basics['customer_summary'] ?? ''),
+      'product_status' => (string) ($basics['product_status'] ?? 'draft'),
+      'pickup_note' => (string) ($collection['pickup_note'] ?? ''),
+      'price_amount' => $pricing['price_amount'] ?? NULL,
+      'sku' => (string) ($pricing['sku'] ?? ''),
+      'capacity_note' => (string) ($quantity['capacity_note'] ?? ''),
       'sizes' => $sizes,
-      'show_on_booking' => !empty($this->editorValue($form_state, 'show_on_booking')),
+      'show_on_booking' => !empty($visibility['show_on_booking']),
       'image_media_ids' => $image_media_ids,
     ];
-  }
-
-  /**
-   * Reads a value from the editor subtree (#tree + #parents).
-   */
-  private function editorValue(FormStateInterface $form_state, string $key): mixed {
-    $editor = $form_state->getValue('editor');
-    if (is_array($editor) && array_key_exists($key, $editor)) {
-      return $editor[$key];
-    }
-    return $form_state->getValue($key);
   }
 
   private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {
@@ -772,7 +754,15 @@ final class EventStudioEventExtrasForm extends FormBase {
       return;
     }
     $complete = $form_state->getCompleteForm();
-    if (!is_array($complete) || !isset($complete['editor']['field_mel_extra_images'])) {
+    if (!is_array($complete)) {
+      return;
+    }
+    if (isset($complete['editor']['media']['field_mel_extra_images'])) {
+      $form_display->extractFormValues($product, $complete['editor']['media'], $form_state);
+      $product->save();
+      return;
+    }
+    if (!isset($complete['editor']['field_mel_extra_images'])) {
       return;
     }
     $form_display->extractFormValues($product, $complete['editor'], $form_state);

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
@@ -7,11 +7,11 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Unified Event Extras authoring section.
+ * Unified merch and add-on product setup (Commerce-backed).
  */
 #[EventStudioSection(
   id: 'extras',
-  title: 'Extras',
+  title: 'Merch & add-ons',
   group: 'Commerce',
   routeName: 'myeventlane_event_studio.workspace_extras',
   section_state: 'active',

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
@@ -13,6 +13,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
 use Drupal\node\NodeInterface;
 
 /**
@@ -27,6 +28,7 @@ final class EventStudioEventExtrasBuilder {
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
     private readonly OperationalExtraVisualPresenter $visualPresenter,
     private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    private readonly VendorOperationalProductCreationManager $productCreationManager,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -56,6 +58,20 @@ final class EventStudioEventExtrasBuilder {
   }
 
   /**
+   * @return list<array<string, mixed>>
+   */
+  public function loadExtrasForEventByClassification(NodeInterface $event, string $filter): array {
+    $cards = $this->loadExtrasForEvent($event);
+    if ($filter === 'all' || $filter === '') {
+      return $cards;
+    }
+    return array_values(array_filter($cards, static function (array $card) use ($filter): bool {
+      $classification = (string) ($card['classification'] ?? '');
+      return $filter === $classification;
+    }));
+  }
+
+  /**
    * @return array<string, mixed>
    */
   public function buildExtraCard(ProductInterface $product, NodeInterface $event): array {
@@ -64,6 +80,12 @@ final class EventStudioEventExtrasBuilder {
     $visual = $this->visualPresenter->buildProductVisualDocument($product, $presentation);
     $sizes = $this->summarizeSizes($product);
     $price_label = $this->formatPriceRange($product);
+    $classification = $this->classificationForProduct($product);
+    $variant_count = $this->countPublishedVariations($product);
+    $book_url = $this->buildBookPageUrl($event);
+    $editor_defaults = $this->productCreationManager->extractEditorDefaultsFromProduct($product);
+    $product_status = (string) ($editor_defaults['product_status'] ?? 'hidden');
+    $status_options = $this->productCreationManager->productStatusOptions();
 
     return [
       'product_id' => (int) $product->id(),
@@ -75,6 +97,23 @@ final class EventStudioEventExtrasBuilder {
       'price_label' => $price_label,
       'show_on_booking' => $product->isPublished(),
       'bundle' => $product->bundle(),
+      'classification' => $classification,
+      'classification_label' => $this->classificationLabel($classification),
+      'variant_count' => $variant_count,
+      'variant_count_label' => $variant_count === 1
+        ? (string) $this->t('1 option')
+        : (string) $this->t('@count options', ['@count' => $variant_count]),
+      'product_status' => $product_status,
+      'product_status_label' => $status_options[$product_status] ?? $product_status,
+      'capacity_note' => (string) ($editor_defaults['capacity_note'] ?? ''),
+      'booking_visibility_label' => $product->isPublished()
+        ? (string) $this->t('Visible on booking page')
+        : (string) $this->t('Not on booking page'),
+      'status_label' => $product->isPublished()
+        ? (string) $this->t('Active on booking')
+        : (string) $this->t('Hidden from booking'),
+      'image_count' => $this->countProductImages($product),
+      'book_page_url' => $book_url,
       'edit_url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', [
         'node' => $event->id(),
       ], [
@@ -110,14 +149,71 @@ final class EventStudioEventExtrasBuilder {
   /**
    * @return array<string, string>
    */
-  public function extraTypeChoices(): array {
+  public function merchandiseTypeChoices(): array {
     return [
-      'merchandise' => (string) $this->t('Merchandise'),
-      'food_drink' => (string) $this->t('Food & drink'),
-      'vip_hospitality' => (string) $this->t('VIP / hospitality'),
-      'pickup_item' => (string) $this->t('Pickup item'),
-      'bundle' => (string) $this->t('Bundle / package'),
+      'merchandise' => (string) $this->t('Merchandise (T-shirt, hoodie, poster, digital item)'),
     ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function addonTypeChoices(): array {
+    return [
+      'parking' => (string) $this->t('Parking'),
+      'meal_package' => (string) $this->t('Meal package'),
+      'camping' => (string) $this->t('Camping'),
+      'vip_extra' => (string) $this->t('VIP extra'),
+      'shuttle' => (string) $this->t('Shuttle / transport'),
+      'other' => (string) $this->t('Other add-on'),
+    ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function extraTypeChoices(): array {
+    return $this->merchandiseTypeChoices() + $this->addonTypeChoices();
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function listFilterOptions(): array {
+    return [
+      'all' => (string) $this->t('All'),
+      'merchandise' => (string) $this->t('Merchandise'),
+      'addon' => (string) $this->t('Add-ons'),
+    ];
+  }
+
+  public function classificationForProduct(ProductInterface $product): string {
+    $mapped = OperationalProductBundles::classificationForProductBundle($product->bundle());
+    return $mapped !== '' ? $mapped : 'addon';
+  }
+
+  private function classificationLabel(string $classification): string {
+    return match ($classification) {
+      'merchandise' => (string) $this->t('Merchandise'),
+      default => (string) $this->t('Add-on'),
+    };
+  }
+
+  private function countPublishedVariations(ProductInterface $product): int {
+    $count = 0;
+    foreach ($product->getVariations() as $variation) {
+      if ($variation instanceof ProductVariationInterface && $variation->isPublished()) {
+        $count++;
+      }
+    }
+    return $count;
+  }
+
+  private function buildBookPageUrl(NodeInterface $event): string {
+    if ($event->isPublished()) {
+      return Url::fromRoute('myeventlane_commerce.event_book', ['node' => $event->id()])->toString();
+    }
+    return Url::fromRoute('entity.node.canonical', ['node' => $event->id()])->toString();
   }
 
   /**
@@ -135,6 +231,13 @@ final class EventStudioEventExtrasBuilder {
       }
     }
     return array_values(array_unique($out));
+  }
+
+  private function countProductImages(ProductInterface $product): int {
+    if (!$product->hasField('field_mel_extra_images') || $product->get('field_mel_extra_images')->isEmpty()) {
+      return 0;
+    }
+    return $product->get('field_mel_extra_images')->count();
   }
 
   private function formatPriceRange(ProductInterface $product): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
@@ -1,0 +1,540 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds the card-based Commerce product editor for Event Studio extras.
+ */
+final class EventStudioExtrasProductEditorBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EventStudioEventExtrasBuilder $extrasBuilder,
+    private readonly VendorOperationalProductCreationManager $productCreationManager,
+    private readonly OperationalProductStudioFieldRegistry $fieldRegistry,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildEditor(
+    array &$form,
+    FormStateInterface $form_state,
+    NodeInterface $event,
+    AccountInterface $account,
+    string $mode,
+    int $edit_id,
+  ): array {
+    $product = NULL;
+    $extra_type = (string) ($form_state->get('mel_extras_extra_type') ?? '');
+    if ($mode === 'edit' && $edit_id > 0) {
+      $product = $this->productCreationManager->assertVendorCanManageProduct(
+        $account,
+        $event,
+        $edit_id,
+      );
+    }
+    elseif ($extra_type === '') {
+      $extra_type = 'merchandise';
+    }
+
+    $defaults = $product instanceof ProductInterface
+      ? $this->productCreationManager->extractEditorDefaultsFromProduct($product)
+      : $this->productCreationManager->emptyEditorDefaults($extra_type);
+
+    $bundle = $product instanceof ProductInterface
+      ? $product->bundle()
+      : $this->productCreationManager->resolveCommerceProductBundleForExtraType($extra_type);
+    $variation_bundle = $this->fieldRegistry->variationBundleForProductBundle($bundle);
+    $product_fields = $this->fieldRegistry->productFieldSupport($bundle);
+    $variation_fields = $this->fieldRegistry->variationFieldSupport($variation_bundle);
+    $is_merch = $product instanceof ProductInterface
+      ? $this->extrasBuilder->classificationForProduct($product) === 'merchandise'
+      : $this->productCreationManager->isMerchandiseExtraType($extra_type);
+
+    $editor = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+      '#parents' => ['editor'],
+      '#attributes' => ['class' => ['mel-event-product-editor']],
+      'product_id' => [
+        '#type' => 'hidden',
+        '#value' => $product instanceof ProductInterface ? (string) $product->id() : '',
+      ],
+      'extra_type' => [
+        '#type' => 'hidden',
+        '#value' => $extra_type !== '' ? $extra_type : 'merchandise',
+      ],
+    ];
+
+    $editor['nav'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-product-editor__nav']],
+      'back' => [
+        '#type' => 'link',
+        '#title' => $this->t('← Back to all extras'),
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]),
+        '#attributes' => ['class' => ['mel-event-product-editor__back']],
+      ],
+    ];
+
+    $editor += $this->buildBasicsSection($defaults, $product, $extra_type, $is_merch);
+    $editor += $this->buildMediaSection($form, $form_state, $event, $product, $extra_type, $product_fields);
+    $editor += $this->buildPricingSection($defaults, $product);
+    $editor += $this->buildQuantitySection($defaults, $variation_fields);
+    if ($is_merch && $variation_fields['size']) {
+      $editor += $this->buildVariantsSection($defaults, $event, $product);
+    }
+    $editor += $this->buildCollectionSection($defaults);
+    $editor += $this->buildVisibilitySection($defaults);
+    $editor += $this->buildActionsSection();
+
+    if ($product instanceof ProductInterface) {
+      $editor['customer_preview'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__preview-card']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Booking page preview'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'preview' => [
+          '#theme' => 'mel_event_studio_extra_preview',
+          '#preview' => $this->extrasBuilder->buildPreviewRow($product, $event),
+        ],
+      ];
+    }
+
+    return $editor;
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildBasicsSection(array $defaults, ?ProductInterface $product, string $extra_type, bool $is_merch): array {
+    $section = [
+      'basics' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Product basics'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+      ],
+    ];
+
+    if ($product === NULL && !$is_merch) {
+      $section['basics']['extra_type'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Add-on type'),
+        '#options' => $this->extrasBuilder->addonTypeChoices(),
+        '#default_value' => $extra_type !== '' && $extra_type !== 'merchandise' ? $extra_type : 'parking',
+        '#required' => TRUE,
+        '#attributes' => ['class' => ['mel-event-product-editor__addon-type']],
+      ];
+    }
+    else {
+      $type_label = $is_merch
+        ? (string) $this->t('Merchandise')
+        : (string) ($this->extrasBuilder->addonTypeChoices()[$extra_type] ?? $this->t('Add-on'));
+      $section['basics']['type_display'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Product type'),
+        '#markup' => '<p class="mel-event-product-editor__type-pill">' . $type_label . '</p>',
+      ];
+    }
+
+    $section['basics']['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Product name'),
+      '#default_value' => (string) ($defaults['title'] ?? ''),
+      '#required' => TRUE,
+      '#maxlength' => 255,
+    ];
+    $section['basics']['customer_summary'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Short customer description'),
+      '#default_value' => (string) ($defaults['customer_summary'] ?? ''),
+      '#required' => TRUE,
+      '#rows' => 3,
+    ];
+    $section['basics']['product_status'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Product status'),
+      '#options' => $this->productCreationManager->productStatusOptions(),
+      '#default_value' => (string) ($defaults['product_status'] ?? 'draft'),
+      '#required' => TRUE,
+      '#description' => $this->t('Active products can appear on the booking page when visibility is enabled below.'),
+    ];
+
+    return $section;
+  }
+
+  /**
+   * @param array<string, bool> $product_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildMediaSection(
+    array &$form,
+    FormStateInterface $form_state,
+    NodeInterface $event,
+    ?ProductInterface $product,
+    string $extra_type,
+    array $product_fields,
+  ): array {
+    $section = [
+      'media' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Product images'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('The first image is used as the main image on the booking page. Additional images form a gallery.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+      ],
+    ];
+
+    if (!$product_fields['images']) {
+      $section['media']['disabled'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__media-disabled']],
+        'message' => [
+          '#markup' => '<p>' . $this->t('Product image support is not configured for this product type yet.') . '</p>',
+        ],
+      ];
+      return $section;
+    }
+
+    $media_product = $product ?? $this->productCreationManager->createStubProductForStudioForm($event, $extra_type);
+    $this->attachImagesWidget($media_product, $form, $section['media'], $form_state);
+
+    if ($product instanceof ProductInterface) {
+      $card = $this->extrasBuilder->buildExtraCard($product, $event);
+      if (!empty($card['primary_image']['url'])) {
+        $section['media']['current'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-product-editor__current-image']],
+          'label' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('Current main image'),
+            '#attributes' => ['class' => ['mel-text--muted']],
+          ],
+          'img' => [
+            '#theme' => 'image',
+            '#uri' => $card['primary_image']['url'],
+            '#alt' => $card['primary_image']['alt'] ?? $product->label(),
+            '#attributes' => ['class' => ['mel-event-product-editor__thumb']],
+          ],
+        ];
+      }
+    }
+
+    return $section;
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPricingSection(array $defaults, ?ProductInterface $product): array {
+    $sku_description = $product === NULL
+      ? $this->t('Leave blank to auto-generate a SKU. Size variants use SKU suffixes (e.g. @example).', ['@example' => 'mel-op-123-merchandise-abc123-m'])
+      : $this->t('Base SKU for this product. Size variants keep their existing suffixes when you save.');
+
+    return [
+      'pricing' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Pricing and SKU'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'price_amount' => [
+          '#type' => 'number',
+          '#title' => $this->t('Price'),
+          '#default_value' => $defaults['price_amount'] ?? '',
+          '#required' => TRUE,
+          '#min' => 0,
+          '#step' => 0.01,
+          '#attributes' => ['class' => ['mel-event-product-editor__price']],
+        ],
+        'sku' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('SKU'),
+          '#default_value' => (string) ($defaults['sku'] ?? ''),
+          '#maxlength' => 128,
+          '#description' => $sku_description,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   * @param array<string, bool> $variation_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildQuantitySection(array $defaults, array $variation_fields): array {
+    $section = [
+      'quantity' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Quantity'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+      ],
+    ];
+
+    if ($variation_fields['stock_quantity']) {
+      $section['quantity']['stock'] = [
+        '#type' => 'number',
+        '#title' => $this->t('Available quantity'),
+        '#min' => 0,
+        '#step' => 1,
+        '#default_value' => $defaults['stock_quantity'] ?? NULL,
+      ];
+    }
+    else {
+      $section['quantity']['capacity_note'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Quantity note'),
+        '#default_value' => (string) ($defaults['capacity_note'] ?? ''),
+        '#maxlength' => 200,
+        '#description' => $this->t('Shown to you only. This does not enforce stock yet.'),
+        '#attributes' => ['class' => ['mel-event-product-editor__capacity-note']],
+      ];
+      $section['quantity']['warning'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-warning']],
+        'text' => [
+          '#markup' => '<p><strong>' . $this->t('Stock enforcement is coming soon.') . '</strong> '
+            . $this->t('Do not oversell limited merch until stock controls are enabled.') . '</p>',
+        ],
+      ];
+    }
+
+    return $section;
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildVariantsSection(array $defaults, NodeInterface $event, ?ProductInterface $product): array {
+    $preview_rows = $product instanceof ProductInterface
+      ? $this->productCreationManager->buildVariantPreviewRowsFromProduct($product)
+      : $this->productCreationManager->buildVariantPreviewRows($event, $defaults, NULL);
+
+    return [
+      'variants' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Options and variants'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Select sizes to sell. Each size becomes a purchasable Commerce variation with its own SKU.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+        'sizes' => [
+          '#type' => 'checkboxes',
+          '#title' => $this->t('Sizes'),
+          '#options' => OperationalExtraVisualPresenter::SIZE_LABELS,
+          '#default_value' => $defaults['sizes'] ?? [],
+          '#attributes' => ['class' => ['mel-event-product-editor__sizes']],
+        ],
+        'variant_preview' => [
+          '#theme' => 'mel_event_studio_extra_variant_preview',
+          '#rows' => $preview_rows,
+          '#attached' => [
+            'library' => ['myeventlane_event_studio/mel_event_extras_product_editor'],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCollectionSection(array $defaults): array {
+    return [
+      'collection' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Collection and fulfilment'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'pickup_note' => [
+          '#type' => 'textarea',
+          '#title' => $this->t('Pickup / venue collection note'),
+          '#default_value' => (string) ($defaults['pickup_note'] ?? ''),
+          '#rows' => 2,
+          '#description' => $this->t('Use this to tell customers where to collect this item at the event.'),
+        ],
+        'fulfilment_notice' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-product-editor__fulfilment-notice', 'mel-text--muted']],
+          'text' => [
+            '#markup' => '<p>' . $this->t('Shipping and fulfilment tracking are not enabled yet.') . '</p>',
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildVisibilitySection(array $defaults): array {
+    return [
+      'visibility' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Booking visibility'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'show_on_booking' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Show on booking page'),
+          '#default_value' => (bool) ($defaults['show_on_booking'] ?? FALSE),
+          '#description' => $this->t('Visible extras appear on the booking page after ticket selection. Requires Active status.'),
+          '#states' => [
+            'visible' => [
+              ':input[name="editor[basics][product_status]"]' => ['value' => 'active'],
+            ],
+          ],
+        ],
+        'visibility_hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Set product status to Active to enable booking page visibility.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+          '#states' => [
+            'visible' => [
+              ':input[name="editor[basics][product_status]"]' => ['!value' => 'active'],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildActionsSection(): array {
+    return [
+      'actions' => [
+        '#type' => 'actions',
+        '#attributes' => ['class' => ['mel-event-product-editor__actions']],
+        'submit' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Save product'),
+          '#button_type' => 'primary',
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+        ],
+        'add_another' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Save and add another'),
+          '#submit' => ['::submitAddAnother'],
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary']],
+        ],
+      ],
+    ];
+  }
+
+  private function attachImagesWidget(
+    ProductInterface $product,
+    array &$form,
+    array &$section,
+    FormStateInterface $form_state,
+  ): void {
+    $display_id = 'commerce_product.' . $product->bundle() . '.default';
+    $form_display = EntityFormDisplay::load($display_id);
+    if ($form_display === NULL || !$product->hasField('field_mel_extra_images')) {
+      return;
+    }
+    $widget = $form_display->getRenderer('field_mel_extra_images');
+    if ($widget === NULL) {
+      return;
+    }
+    if (!isset($form['#parents'])) {
+      $form['#parents'] = [];
+    }
+    if (!isset($section['#parents'])) {
+      $section['#parents'] = ['editor', 'media'];
+    }
+    if (!isset($section['#tree'])) {
+      $section['#tree'] = TRUE;
+    }
+    $section['field_mel_extra_images'] = $widget->form(
+      $product->get('field_mel_extra_images'),
+      $section,
+      $form_state,
+    );
+    $section['field_mel_extra_images']['#title'] = $this->t('Images');
+    $section['field_mel_extra_images']['#attributes']['class'][] = 'mel-event-extra-gallery';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/OperationalProductStudioFieldRegistry.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/OperationalProductStudioFieldRegistry.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+
+/**
+ * Read-only registry of operational Commerce field support for Studio UI.
+ */
+final class OperationalProductStudioFieldRegistry {
+
+  public function __construct(
+    private readonly EntityFieldManagerInterface $entityFieldManager,
+  ) {}
+
+  /**
+   * @return array<string, bool>
+   *   Keys: images, short_description, pickup_note, operational_json, event, status.
+   */
+  public function productFieldSupport(string $product_bundle): array {
+    $defs = $this->entityFieldManager->getFieldDefinitions('commerce_product', $product_bundle);
+    return [
+      'images' => isset($defs['field_mel_extra_images']),
+      'short_description' => isset($defs['field_mel_extra_short_desc']),
+      'pickup_note' => isset($defs['field_mel_extra_pickup_note']),
+      'operational_json' => isset($defs['field_mel_operational_product']),
+      'event' => isset($defs['field_event']),
+      'status' => isset($defs['status']),
+      'stores' => isset($defs['stores']),
+    ];
+  }
+
+  /**
+   * @return array<string, bool>
+   *   Keys: size, stock_quantity, limit_per_order, status.
+   */
+  public function variationFieldSupport(string $variation_bundle): array {
+    $defs = $this->entityFieldManager->getFieldDefinitions('commerce_product_variation', $variation_bundle);
+    return [
+      'size' => isset($defs['field_mel_size']),
+      'stock_quantity' => isset($defs['field_stock']) || isset($defs['commerce_stock']),
+      'limit_per_order' => isset($defs['field_limit_per_order']),
+      'status' => isset($defs['status']),
+      'price' => isset($defs['price']),
+      'sku' => isset($defs['sku']),
+    ];
+  }
+
+  /**
+   * Whether any operational product bundle exposes gallery images.
+   */
+  public function operationalProductsSupportImages(): bool {
+    foreach (OperationalMerchandiseManager::OPERATIONAL_PRODUCT_BUNDLES as $bundle) {
+      if ($this->productFieldSupport($bundle)['images']) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Whether any operational variation bundle exposes enforced stock.
+   */
+  public function operationalVariationsSupportStock(): bool {
+    foreach ($this->operationalVariationBundles() as $variation_bundle) {
+      if ($this->variationFieldSupport($variation_bundle)['stock_quantity']) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function operationalVariationBundles(): array {
+    return [
+      'operational_merchandise_var',
+      'hospitality_package_var',
+      'timed_collection_var',
+      'operational_bundle_var',
+    ];
+  }
+
+  /**
+   * Maps a Commerce product bundle to its default variation bundle id.
+   */
+  public function variationBundleForProductBundle(string $product_bundle): string {
+    return match ($product_bundle) {
+      'hospitality_package' => 'hospitality_package_var',
+      'timed_collection_product' => 'timed_collection_var',
+      'operational_bundle' => 'operational_bundle_var',
+      default => 'operational_merchandise_var',
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -37,6 +37,13 @@ final class VendorOperationalProductCreationManager {
    */
   public const VENDOR_EXTRA_TYPE_MAP = [
     'merchandise' => VendorProductisationStudioManager::TYPE_MERCHANDISE,
+    'parking' => VendorProductisationStudioManager::TYPE_PARKING_ADDON,
+    'meal_package' => VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+    'camping' => VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE,
+    'vip_extra' => VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
+    'shuttle' => VendorProductisationStudioManager::TYPE_TIMED_COLLECTION,
+    'other' => VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE,
+    // Legacy keys (bookmarks / older Studio URLs).
     'food_drink' => VendorProductisationStudioManager::TYPE_TIMED_COLLECTION,
     'vip_hospitality' => VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
     'pickup_item' => VendorProductisationStudioManager::TYPE_TIMED_COLLECTION,
@@ -44,10 +51,34 @@ final class VendorOperationalProductCreationManager {
   ];
 
   /**
+   * Vendor-facing merchandise extra type keys.
+   *
+   * @var list<string>
+   */
+  public const VENDOR_MERCH_EXTRA_TYPES = [
+    'merchandise',
+  ];
+
+  /**
+   * Vendor-facing add-on extra type keys.
+   *
+   * @var list<string>
+   */
+  public const VENDOR_ADDON_EXTRA_TYPES = [
+    'parking',
+    'meal_package',
+    'camping',
+    'vip_extra',
+    'shuttle',
+    'other',
+  ];
+
+  /**
    * @var list<string>
    */
   public const VENDOR_EXTRA_TYPE_KEYS = [
-    'merchandise',
+    ...self::VENDOR_MERCH_EXTRA_TYPES,
+    ...self::VENDOR_ADDON_EXTRA_TYPES,
     'food_drink',
     'vip_hospitality',
     'pickup_item',
@@ -161,6 +192,16 @@ final class VendorOperationalProductCreationManager {
     if (!$product instanceof ProductInterface) {
       throw new \RuntimeException('Event extra product could not be loaded after create.');
     }
+    $this->applyProductStatusFromInput($product, $input);
+    $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $metadata = $this->mergeCapacityNoteIntoMetadata($metadata, (string) ($input['capacity_note'] ?? ''));
+    $metadata = $this->mergeVendorStudioStatusIntoMetadata($metadata, (string) ($input['product_status'] ?? 'draft'));
+    if ($product->hasField('field_mel_operational_product')) {
+      $product->set('field_mel_operational_product', json_encode(
+        $this->operationalMerchandiseManager->normalizeProductFieldValue($metadata),
+        JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE,
+      ));
+    }
     $this->applyEventExtraFieldUpdates($product, $input);
     $product->save();
     return $product;
@@ -189,18 +230,23 @@ final class VendorOperationalProductCreationManager {
     if ($currency_in === '') {
       $currency_in = $currency;
     }
-    $show = !array_key_exists('show_on_booking', $input) || !empty($input['show_on_booking']);
+    $show = $this->resolveShowOnBooking($input);
     $pickup_mode = match ($extra_type) {
-      'pickup_item' => 'collect',
-      'food_drink' => 'counter',
+      'pickup_item', 'parking' => 'collect',
+      'food_drink', 'meal_package' => 'counter',
+      'camping', 'other' => 'collect',
       default => 'counter',
     };
     $fulfillment = match ($productisation_type) {
       VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE => 'redeem',
       VendorProductisationStudioManager::TYPE_TIMED_COLLECTION => 'collect',
+      VendorProductisationStudioManager::TYPE_PARKING_ADDON => 'collect',
       default => 'collect',
     };
-    return $this->stripForbiddenFromPayload([
+    $parking_guidance = $extra_type === 'parking'
+      ? (string) ($input['pickup_note'] ?? $input['customer_summary'] ?? '')
+      : '';
+    $payload = [
       'productisation_type' => $productisation_type,
       'event_id' => (int) $event->id(),
       'title' => (string) ($input['title'] ?? ''),
@@ -213,10 +259,32 @@ final class VendorOperationalProductCreationManager {
       'pickup_mode' => $pickup_mode,
       'pickup_note' => (string) ($input['pickup_note'] ?? ''),
       'sizes' => $this->normalizeSizeKeys($input['sizes'] ?? []),
-      'timed_collection_window_copy' => $extra_type === 'pickup_item' ? (string) ($input['pickup_note'] ?? '') : '',
+      'sku' => trim((string) ($input['sku'] ?? '')),
+      'capacity_note' => trim((string) ($input['capacity_note'] ?? '')),
+      'timed_collection_window_copy' => in_array($extra_type, ['pickup_item', 'shuttle'], TRUE)
+        ? (string) ($input['pickup_note'] ?? '') : '',
       'hospitality_benefits_summary' => $productisation_type === VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE
         ? (string) ($input['customer_summary'] ?? '') : '',
-    ]);
+      'parking_guidance' => $parking_guidance,
+      'product_status' => strtolower(trim((string) ($input['product_status'] ?? 'draft'))),
+    ];
+    return $this->stripForbiddenFromPayload($payload);
+  }
+
+  /**
+   * Whether a vendor extra type key is merchandise (vs add-on).
+   */
+  public function isMerchandiseExtraType(string $extra_type): bool {
+    return in_array($this->normalizeVendorExtraType($extra_type), self::VENDOR_MERCH_EXTRA_TYPES, TRUE);
+  }
+
+  /**
+   * Whether a vendor extra type key is an add-on.
+   */
+  public function isAddonExtraType(string $extra_type): bool {
+    $key = $this->normalizeVendorExtraType($extra_type);
+    return in_array($key, self::VENDOR_ADDON_EXTRA_TYPES, TRUE)
+      || in_array($key, ['food_drink', 'vip_hospitality', 'pickup_item', 'bundle'], TRUE);
   }
 
   /**
@@ -355,15 +423,17 @@ final class VendorOperationalProductCreationManager {
     $sku = $sku_base !== '' ? $this->sanitizePlainText($sku_base, 128) : $this->generateSku($event, $type);
 
     $metadata = $this->buildOperationalMetadata($type, $payload, $summary);
+    $metadata = $this->mergeVendorStudioStatusIntoMetadata($metadata, (string) ($payload['product_status'] ?? 'draft'));
     $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
     $pickup_note = $this->sanitizePlainText((string) ($payload['pickup_note'] ?? ''), 400);
     $visibility = $this->normalizeVisibility((string) ($payload['customer_visibility'] ?? 'visible'));
+    $published = $visibility === 'visible';
 
     $product = CommerceProduct::create([
       'type' => $bundles['product_type'],
       'title' => $title,
-      'status' => $visibility === 'visible' ? 1 : 0,
+      'status' => $published ? 1 : 0,
       'stores' => [$store_id],
       'uid' => (int) $account->id(),
       'field_event' => ['target_id' => (int) $event->id()],
@@ -705,6 +775,10 @@ final class VendorOperationalProductCreationManager {
     if ($parking !== '') {
       $chips[] = ['label' => $parking, 'tone' => 'info'];
     }
+    $capacity_note = $this->sanitizePlainText((string) ($payload['capacity_note'] ?? ''), 200);
+    if ($capacity_note !== '') {
+      $chips[] = ['label' => (string) $this->translation->translate('Capacity note: @note', ['@note' => $capacity_note]), 'tone' => 'muted'];
+    }
     if ($type === VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE && $bundle_types !== []) {
       $chips[] = ['label' => implode(', ', array_map('strval', $bundle_types)), 'tone' => 'muted'];
     }
@@ -849,7 +923,7 @@ final class VendorOperationalProductCreationManager {
     $title = $this->sanitizePlainText((string) ($input['title'] ?? ''), 255);
     $summary = $this->sanitizePlainText((string) ($input['customer_summary'] ?? ''), 600);
     $pickup_note = $this->sanitizePlainText((string) ($input['pickup_note'] ?? ''), 400);
-    $show = !array_key_exists('show_on_booking', $input) || !empty($input['show_on_booking']);
+    $show = $this->resolveShowOnBooking($input);
     $currency = $this->normalizeCurrencyCode((string) ($input['currency_code'] ?? ''));
     if ($currency === '') {
       $store_id = $this->commerceLinkManager->resolveStoreIdForOperationalProductCreation($event);
@@ -867,7 +941,8 @@ final class VendorOperationalProductCreationManager {
     $price = new Price($amount, $currency);
 
     $product->setTitle($title);
-    $product->setPublished($show);
+    $this->applyProductStatusFromInput($product, $input);
+    $show = $product->isPublished();
     if ($product->hasField('field_mel_extra_short_desc')) {
       $product->set('field_mel_extra_short_desc', $summary);
     }
@@ -878,6 +953,8 @@ final class VendorOperationalProductCreationManager {
     $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
     $metadata['operational_summary'] = $summary;
     $metadata['customer_visibility'] = $show ? 'visible' : 'hidden';
+    $metadata = $this->mergeCapacityNoteIntoMetadata($metadata, (string) ($input['capacity_note'] ?? ''));
+    $metadata = $this->mergeVendorStudioStatusIntoMetadata($metadata, (string) ($input['product_status'] ?? ''));
     $encoded = json_encode($this->operationalMerchandiseManager->normalizeProductFieldValue($metadata), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     if ($product->hasField('field_mel_operational_product')) {
       $product->set('field_mel_operational_product', $encoded);
@@ -941,7 +1018,10 @@ final class VendorOperationalProductCreationManager {
     }
 
     $desired_keys = $size_keys !== [] ? $size_keys : ['_default'];
-    $sku_base = 'mel-extra-' . (int) $product->id();
+    $custom_sku = trim((string) ($input['sku'] ?? ''));
+    $sku_base = $custom_sku !== ''
+      ? $this->sanitizePlainText($custom_sku, 128)
+      : 'mel-extra-' . (int) $product->id();
 
     foreach ($desired_keys as $size_key) {
       $lookup = $size_key === '_default' ? '_default' : $size_key;
@@ -1012,6 +1092,310 @@ final class VendorOperationalProductCreationManager {
         'variation_type' => 'operational_merchandise_var',
       ],
     };
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function productStatusOptions(): array {
+    return [
+      'active' => (string) $this->translation->translate('Active'),
+      'hidden' => (string) $this->translation->translate('Hidden'),
+      'draft' => (string) $this->translation->translate('Draft'),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function emptyEditorDefaults(string $extra_type): array {
+    $extra_type = $this->normalizeVendorExtraType($extra_type) ?: 'merchandise';
+    return [
+      'extra_type' => $extra_type,
+      'title' => '',
+      'customer_summary' => '',
+      'pickup_note' => '',
+      'price_amount' => '',
+      'sku' => '',
+      'capacity_note' => '',
+      'product_status' => 'draft',
+      'show_on_booking' => 0,
+      'sizes' => [],
+      'stock_quantity' => NULL,
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function extractEditorDefaultsFromProduct(ProductInterface $product): array {
+    $sizes = [];
+    foreach ($product->getVariations() as $variation) {
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty() && $variation->isPublished()) {
+        $key = strtolower((string) $variation->get('field_mel_size')->value);
+        $sizes[$key] = $key;
+      }
+    }
+    $price = '';
+    $sku = '';
+    foreach ($product->getVariations() as $variation) {
+      if ($variation->isPublished() && $variation->getPrice() !== NULL) {
+        $price = $variation->getPrice()->getNumber();
+        $sku = $variation->getSku() ?? '';
+        break;
+      }
+    }
+    if ($sku !== '' && str_contains($sku, '-')) {
+      $parts = explode('-', $sku);
+      if (count($parts) > 3) {
+        array_pop($parts);
+        $sku = implode('-', $parts);
+      }
+    }
+    $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $status = $this->resolveProductStatusFromEntity($product, $metadata);
+    return [
+      'extra_type' => $this->inferExtraTypeFromProduct($product, $metadata),
+      'title' => $product->label(),
+      'customer_summary' => $product->hasField('field_mel_extra_short_desc') && !$product->get('field_mel_extra_short_desc')->isEmpty()
+        ? (string) $product->get('field_mel_extra_short_desc')->value : '',
+      'pickup_note' => $product->hasField('field_mel_extra_pickup_note') && !$product->get('field_mel_extra_pickup_note')->isEmpty()
+        ? (string) $product->get('field_mel_extra_pickup_note')->value : '',
+      'price_amount' => $price,
+      'sku' => $sku,
+      'capacity_note' => $this->extractCapacityNoteFromMetadata($metadata),
+      'product_status' => $status,
+      'show_on_booking' => $product->isPublished() ? 1 : 0,
+      'sizes' => $sizes,
+      'stock_quantity' => NULL,
+    ];
+  }
+
+  public function resolveCommerceProductBundleForExtraType(string $extra_type): string {
+    $extra_type = $this->normalizeVendorExtraType($extra_type) ?: 'merchandise';
+    $productisation = self::VENDOR_EXTRA_TYPE_MAP[$extra_type];
+    return $this->mapProductisationTypeToCommerceBundles($productisation)['product_type'];
+  }
+
+  public function createStubProductForStudioForm(NodeInterface $event, string $extra_type): ProductInterface {
+    $bundle = $this->resolveCommerceProductBundleForExtraType($extra_type);
+    return CommerceProduct::create([
+      'type' => $bundle,
+      'title' => '',
+      'field_event' => ['target_id' => (int) $event->id()],
+    ]);
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildVariantPreviewRows(NodeInterface $event, array $input, ?ProductInterface $product = NULL): array {
+    $sizes = $this->normalizeSizeKeys($input['sizes'] ?? []);
+    $sku_base = trim((string) ($input['sku'] ?? ''));
+    if ($sku_base === '' && $product instanceof ProductInterface) {
+      $sku_base = $this->extractBaseSkuFromProduct($product);
+    }
+    if ($sku_base === '') {
+      $extra_type = (string) ($input['extra_type'] ?? 'merchandise');
+      $sku_base = $this->generateSku($event, $extra_type);
+    }
+    $price = $this->normalizePriceAmount($input['price_amount'] ?? NULL) ?? '0.00';
+    $capacity = trim((string) ($input['capacity_note'] ?? ''));
+    $keys = $sizes !== [] ? $sizes : ['_default'];
+    $rows = [];
+    foreach ($keys as $key) {
+      $label = $key === '_default'
+        ? (string) $this->translation->translate('One size')
+        : (OperationalExtraVisualPresenter::SIZE_LABELS[$key] ?? strtoupper($key));
+      $sku = $key === '_default'
+        ? $this->sanitizePlainText($sku_base, 128)
+        : $this->sanitizePlainText($sku_base . '-' . $key, 128);
+      $rows[] = [
+        'size_label' => $label,
+        'sku' => $sku,
+        'price' => $price,
+        'capacity_note' => $capacity,
+        'status_label' => (string) $this->translation->translate('Created on save'),
+      ];
+    }
+    return $rows;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function buildVariantPreviewRowsFromProduct(ProductInterface $product): array {
+    $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+    $capacity = $this->extractCapacityNoteFromMetadata($metadata);
+    $rows = [];
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        continue;
+      }
+      $size_label = (string) $this->translation->translate('One size');
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+        $key = strtolower((string) $variation->get('field_mel_size')->value);
+        $size_label = OperationalExtraVisualPresenter::SIZE_LABELS[$key] ?? strtoupper($key);
+      }
+      $price = $variation->getPrice();
+      $rows[] = [
+        'size_label' => $size_label,
+        'sku' => (string) ($variation->getSku() ?? ''),
+        'price' => $price !== NULL ? $price->getNumber() : '',
+        'capacity_note' => $capacity,
+        'status_label' => (string) $this->translation->translate('Active'),
+      ];
+    }
+    if ($rows === []) {
+      $rows[] = [
+        'size_label' => (string) $this->translation->translate('One size'),
+        'sku' => '',
+        'price' => '',
+        'capacity_note' => $capacity,
+        'status_label' => (string) $this->translation->translate('No published variations'),
+      ];
+    }
+    return $rows;
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
+  public function applyProductStatusFromInput(ProductInterface $product, array $input): void {
+    $status = strtolower(trim((string) ($input['product_status'] ?? '')));
+    if (!array_key_exists($status, $this->productStatusOptions())) {
+      $status = $this->resolveShowOnBooking($input) ? 'active' : 'hidden';
+    }
+    $published = $status === 'active' && $this->resolveShowOnBooking($input);
+    $product->setPublished($published);
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   */
+  public function resolveShowOnBooking(array $input): bool {
+    $status = strtolower(trim((string) ($input['product_status'] ?? '')));
+    if ($status !== 'active') {
+      return FALSE;
+    }
+    return !array_key_exists('show_on_booking', $input) || !empty($input['show_on_booking']);
+  }
+
+  /**
+   * @param array<string, mixed> $metadata
+   */
+  private function extractCapacityNoteFromMetadata(array $metadata): string {
+    $chips = is_array($metadata['operational_chips'] ?? NULL) ? $metadata['operational_chips'] : [];
+    foreach ($chips as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = (string) ($chip['label'] ?? '');
+      if (str_starts_with($label, 'Capacity note:')) {
+        return trim(substr($label, strlen('Capacity note:')));
+      }
+    }
+    $rules = is_array($metadata['collection_rules'] ?? NULL) ? $metadata['collection_rules'] : [];
+    return trim((string) ($rules['vendor_quantity_note'] ?? ''));
+  }
+
+  /**
+   * @param array<string, mixed> $metadata
+   *
+   * @return array<string, mixed>
+   */
+  private function mergeCapacityNoteIntoMetadata(array $metadata, string $capacity_note): array {
+    $chips = is_array($metadata['operational_chips'] ?? NULL) ? $metadata['operational_chips'] : [];
+    $filtered = [];
+    foreach ($chips as $chip) {
+      if (!is_array($chip)) {
+        continue;
+      }
+      $label = (string) ($chip['label'] ?? '');
+      if (!str_starts_with($label, 'Capacity note:')) {
+        $filtered[] = $chip;
+      }
+    }
+    $capacity_note = $this->sanitizePlainText($capacity_note, 200);
+    if ($capacity_note !== '') {
+      $filtered[] = [
+        'label' => (string) $this->translation->translate('Capacity note: @note', ['@note' => $capacity_note]),
+        'tone' => 'muted',
+      ];
+    }
+    $metadata['operational_chips'] = $filtered;
+    $rules = is_array($metadata['collection_rules'] ?? NULL) ? $metadata['collection_rules'] : [];
+    if ($capacity_note !== '') {
+      $rules['vendor_quantity_note'] = $capacity_note;
+    }
+    else {
+      unset($rules['vendor_quantity_note']);
+    }
+    $metadata['collection_rules'] = $rules;
+    return $metadata;
+  }
+
+  /**
+   * @param array<string, mixed> $metadata
+   *
+   * @return array<string, mixed>
+   */
+  private function mergeVendorStudioStatusIntoMetadata(array $metadata, string $status): array {
+    $rules = is_array($metadata['collection_rules'] ?? NULL) ? $metadata['collection_rules'] : [];
+    $status = strtolower(trim($status));
+    if (in_array($status, ['active', 'hidden', 'draft'], TRUE)) {
+      $rules['vendor_studio_status'] = $status;
+    }
+    $metadata['collection_rules'] = $rules;
+    return $metadata;
+  }
+
+  /**
+   * @param array<string, mixed> $metadata
+   */
+  private function resolveProductStatusFromEntity(ProductInterface $product, array $metadata): string {
+    $rules = is_array($metadata['collection_rules'] ?? NULL) ? $metadata['collection_rules'] : [];
+    $stored = strtolower(trim((string) ($rules['vendor_studio_status'] ?? '')));
+    if (in_array($stored, ['active', 'hidden', 'draft'], TRUE)) {
+      return $stored;
+    }
+    return $product->isPublished() ? 'active' : 'hidden';
+  }
+
+  /**
+   * @param array<string, mixed> $metadata
+   */
+  private function inferExtraTypeFromProduct(ProductInterface $product, array $metadata): string {
+    $cap = strtolower(trim((string) ($metadata['capability_reference'] ?? '')));
+    foreach (self::VENDOR_EXTRA_TYPE_MAP as $key => $ptype) {
+      if ($ptype === $cap) {
+        return $key;
+      }
+    }
+    return $product->bundle() === 'operational_merchandise' ? 'merchandise' : 'other';
+  }
+
+  private function extractBaseSkuFromProduct(ProductInterface $product): string {
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface) {
+        continue;
+      }
+      $sku = trim((string) ($variation->getSku() ?? ''));
+      if ($sku === '') {
+        continue;
+      }
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+        $size = strtolower((string) $variation->get('field_mel_size')->value);
+        $suffix = '-' . $size;
+        if (str_ends_with($sku, $suffix)) {
+          return substr($sku, 0, -strlen($suffix));
+        }
+      }
+      return $sku;
+    }
+    return '';
   }
 
   private function productInStore(ProductInterface $product, int $store_id): bool {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Single event extra card (vendor list).
+ * Commerce-style product card for Event Studio extras list.
  */
 #}
 <div class="mel-event-extra-card__inner">
@@ -9,16 +9,38 @@
     {% if card.primary_image.url|default('') %}
       <img src="{{ card.primary_image.url }}" alt="{{ card.primary_image.alt|default(card.title) }}" class="mel-event-extra-card__image" loading="lazy" />
     {% else %}
-      <div class="mel-event-extra-card__placeholder" aria-hidden="true"></div>
+      <div class="mel-event-extra-card__placeholder" aria-hidden="true">
+        <span class="mel-event-extra-card__placeholder-label">{{ 'No image'|t }}</span>
+      </div>
+    {% endif %}
+    {% if card.image_count|default(0) > 1 %}
+      <span class="mel-event-extra-card__image-count">+{{ card.image_count - 1 }}</span>
     {% endif %}
   </div>
   <div class="mel-event-extra-card__body">
+    <div class="mel-event-extra-card__meta">
+      <span class="mel-event-extra-card__type mel-event-extra-card__type--{{ card.classification|default('addon') }}">
+        {{ card.classification_label|default('Add-on'|t) }}
+      </span>
+      <span class="mel-event-extra-card__status-pill mel-event-extra-card__status-pill--{{ card.product_status|default('hidden') }}">
+        {{ card.product_status_label|default(card.status_label) }}
+      </span>
+      {% if card.variant_count_label|default('') %}
+        <span class="mel-event-extra-card__variants">{{ card.variant_count_label }}</span>
+      {% endif %}
+    </div>
     <h3 class="mel-event-extra-card__title">{{ card.title }}</h3>
     {% if card.short_description %}
       <p class="mel-event-extra-card__desc">{{ card.short_description }}</p>
     {% endif %}
     {% if card.price_label %}
       <p class="mel-event-extra-card__price">{{ card.price_label }}</p>
+    {% endif %}
+    {% if card.capacity_note|default('') %}
+      <p class="mel-event-extra-card__quantity-note">
+        <span class="mel-event-extra-card__quantity-label">{{ 'Quantity note'|t }}:</span>
+        {{ card.capacity_note }}
+      </p>
     {% endif %}
     {% if card.sizes_summary is not empty %}
       <p class="mel-event-extra-card__sizes">
@@ -30,8 +52,8 @@
     {% if card.pickup_note %}
       <p class="mel-event-extra-card__pickup mel-text--muted">{{ card.pickup_note }}</p>
     {% endif %}
-    <p class="mel-event-extra-card__status">
-      {{ card.show_on_booking ? 'Shown on booking page'|t : 'Hidden from booking page'|t }}
+    <p class="mel-event-extra-card__booking">
+      {{ card.booking_visibility_label|default(card.status_label) }}
     </p>
   </div>
 </div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-variant-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-variant-preview.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Variant preview table for Event Studio product editor.
+ */
+#}
+{% if rows is not empty %}
+  <div class="mel-event-variant-preview">
+    <table class="mel-event-variant-preview__table">
+      <thead>
+        <tr>
+          <th scope="col">{{ 'Option'|t }}</th>
+          <th scope="col">{{ 'SKU'|t }}</th>
+          <th scope="col">{{ 'Price'|t }}</th>
+          <th scope="col">{{ 'Quantity note'|t }}</th>
+          <th scope="col">{{ 'Status'|t }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+          <tr>
+            <td>{{ row.size_label }}</td>
+            <td><code>{{ row.sku }}</code></td>
+            <td>{{ row.price }}</td>
+            <td>{{ row.capacity_note|default('—') }}</td>
+            <td>{{ row.status_label }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\OperationalProductStudioFieldRegistry;
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group myeventlane_event_studio
+ */
+#[Group('myeventlane_event_studio')]
+final class EventStudioExtrasProductEditorTest extends TestCase {
+
+  public function testOperationalProductsExposeGalleryImageField(): void {
+    $defs = [
+      'field_mel_extra_images' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'field_mel_extra_short_desc' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'field_event' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'status' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+    ];
+    $manager = $this->createMock(EntityFieldManagerInterface::class);
+    $manager->method('getFieldDefinitions')->willReturn($defs);
+    $registry = new OperationalProductStudioFieldRegistry($manager);
+    $this->assertTrue($registry->operationalProductsSupportImages());
+    $support = $registry->productFieldSupport('operational_merchandise');
+    $this->assertTrue($support['images']);
+    $this->assertTrue($support['short_description']);
+    $this->assertFalse($registry->operationalVariationsSupportStock());
+  }
+
+  public function testMerchandiseVariationBundleSupportsSizeField(): void {
+    $defs = [
+      'field_mel_size' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'sku' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'price' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+    ];
+    $manager = $this->createMock(EntityFieldManagerInterface::class);
+    $manager->method('getFieldDefinitions')->willReturn($defs);
+    $registry = new OperationalProductStudioFieldRegistry($manager);
+    $variation = $registry->variationFieldSupport('operational_merchandise_var');
+    $this->assertTrue($variation['size']);
+    $this->assertFalse($variation['stock_quantity']);
+  }
+
+  public function testVariantPreviewRowsForSizes(): void {
+    $manager = $this->createPartialManager();
+    $event = $this->createMock(\Drupal\node\NodeInterface::class);
+    $event->method('id')->willReturn(99);
+    $rows = $manager->buildVariantPreviewRows($event, [
+      'extra_type' => 'merchandise',
+      'sizes' => ['s', 'm'],
+      'price_amount' => '25',
+      'sku' => 'TEE-99',
+      'capacity_note' => '50 printed',
+    ]);
+    $this->assertCount(2, $rows);
+    $this->assertStringContainsString('TEE-99', $rows[0]['sku']);
+    $this->assertSame('50 printed', $rows[0]['capacity_note']);
+  }
+
+  public function testProductStatusKeysAreDefined(): void {
+    $this->assertSame(['active', 'hidden', 'draft'], ['active', 'hidden', 'draft']);
+  }
+
+  public function testExtrasProductEditorBuilderClassExists(): void {
+    $this->assertTrue(class_exists(\Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder::class));
+  }
+
+  private function createPartialManager(): VendorOperationalProductCreationManager {
+    $ref = new \ReflectionClass(VendorOperationalProductCreationManager::class);
+    /** @var VendorOperationalProductCreationManager $manager */
+    $manager = $ref->newInstanceWithoutConstructor();
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator->method('translate')->willReturnArgument(0);
+    $translator->method('translateString')->willReturnArgument(0);
+    $prop = $ref->getProperty('translation');
+    $prop->setAccessible(TRUE);
+    $prop->setValue($manager, $translator);
+    return $manager;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMerchAddonStudioTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMerchAddonStudioTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
+use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
+use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for unified merch & add-on Studio authoring.
+ *
+ * @group myeventlane_event_studio
+ */
+#[Group('myeventlane_event_studio')]
+final class EventStudioMerchAddonStudioTest extends TestCase {
+
+  public function testOperationalBundleClassificationsMatchStudioExpectations(): void {
+    $map = OperationalProductBundles::productBundleClassifications();
+    $this->assertSame('merchandise', $map['operational_merchandise']);
+    $this->assertSame('addon', $map['operational_bundle']);
+    $this->assertSame('addon', $map['hospitality_package']);
+    $this->assertSame('addon', $map['timed_collection_product']);
+  }
+
+  public function testVendorAddonTypesMapToProductisation(): void {
+    $map = VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP;
+    $this->assertSame(VendorProductisationStudioManager::TYPE_PARKING_ADDON, $map['parking']);
+    $this->assertSame(VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE, $map['meal_package']);
+    $this->assertSame(VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE, $map['camping']);
+    $this->assertSame(VendorProductisationStudioManager::TYPE_TIMED_COLLECTION, $map['shuttle']);
+  }
+
+  public function testMerchandiseAndAddonTypeGroupsAreDisjoint(): void {
+    $merch = VendorOperationalProductCreationManager::VENDOR_MERCH_EXTRA_TYPES;
+    $addons = VendorOperationalProductCreationManager::VENDOR_ADDON_EXTRA_TYPES;
+    $this->assertNotEmpty($merch);
+    $this->assertNotEmpty($addons);
+    $this->assertSame([], array_intersect($merch, $addons));
+  }
+
+  public function testExtrasSectionMetadataReferencesUnifiedForm(): void {
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Plugin/EventStudioSection/ExtrasSection.php');
+    $this->assertIsString($contents);
+    $this->assertStringContainsString("title: 'Merch & add-ons'", $contents);
+    $this->assertStringContainsString('EventStudioEventExtrasForm', $contents);
+    $this->assertStringContainsString("section_state: 'active'", $contents);
+  }
+
+  public function testMerchandiseAndAddonsWorkspaceRoutesRedirectToExtras(): void {
+    $routing = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.routing.yml');
+    $this->assertIsString($routing);
+    $this->assertStringContainsString('redirectToExtrasWorkspace', $routing);
+    $this->assertStringContainsString('workspace_merchandise:', $routing);
+    $this->assertStringContainsString('workspace_addons:', $routing);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSectionContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSectionContractTest.php
@@ -51,6 +51,7 @@ final class EventStudioSectionContractTest extends TestCase {
     $this->assertStringContainsString('form:' . $formClass, $contents);
     $this->assertStringContainsString("routeName: 'myeventlane_event_studio.workspace_extras'", $contents);
     $this->assertStringContainsString("id: 'extras'", $contents);
+    $this->assertStringContainsString("title: 'Merch & add-ons'", $contents);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php
@@ -32,6 +32,10 @@ final class VendorOperationalProductCreationManagerTest extends TestCase {
       VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['merchandise'],
     );
     $this->assertSame(
+      VendorProductisationStudioManager::TYPE_PARKING_ADDON,
+      VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['parking'],
+    );
+    $this->assertSame(
       VendorProductisationStudioManager::TYPE_HOSPITALITY_PACKAGE,
       VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['vip_hospitality'],
     );
@@ -39,6 +43,15 @@ final class VendorOperationalProductCreationManagerTest extends TestCase {
       VendorProductisationStudioManager::TYPE_OPERATIONAL_BUNDLE,
       VendorOperationalProductCreationManager::VENDOR_EXTRA_TYPE_MAP['bundle'],
     );
+  }
+
+  public function testIsMerchandiseAndAddonExtraTypeHelpers(): void {
+    $manager = $this->createPartialManager();
+    $this->assertTrue($manager->isMerchandiseExtraType('merchandise'));
+    $this->assertFalse($manager->isMerchandiseExtraType('parking'));
+    $this->assertTrue($manager->isAddonExtraType('parking'));
+    $this->assertTrue($manager->isAddonExtraType('meal_package'));
+    $this->assertFalse($manager->isAddonExtraType('merchandise'));
   }
 
   public function testStripForbiddenFromPayloadRemovesOperationalKeys(): void {


### PR DESCRIPTION
## Summary

Improves the Event Studio Merch & add-ons editor so vendors can set up event-linked Commerce products in a clearer product-editor flow.

## What changed

- Added a card-based Commerce product editor layout.
- Added sections for product basics, images, pricing/SKU, quantity note, variants, collection, and booking visibility.
- Wired existing `field_mel_extra_images` media gallery support on create/edit.
- Improved merchandise variant preview using size options.
- Improved product cards with status, type, image/placeholder, price, variants, quantity note, and booking visibility.
- Preserved Commerce ownership through VendorOperationalProductCreationManager.
- Kept ticket, Stripe, checkout, and fulfilment logic unchanged.

## Validation

- composer validate: pass
- php -l: pass
- npm run mel:lint: pass
- npm run mel:build: pass
- ddev drush cr: pass
- ddev drush config:status: in sync
- PHPUnit event studio unit tests: pass

## Deferred

- Real stock enforcement
- Shipping and fulfilment tracking
- Variation-level images
- Dedicated operational revenue split
- Full browser checkout matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendor-facing Commerce product create/update and published/booking visibility rules; checkout and ticket issuance are documented as unchanged, but misconfigured status vs list toggle could confuse booking visibility.
> 
> **Overview**
> Event Studio **Merch & add-ons** replaces the flat “event extras” editor with a **card-based Commerce product editor** and a richer list experience, while **create/update still flows through** `VendorOperationalProductCreationManager` (no ticket/checkout/Stripe changes).
> 
> The add/edit UI is built by new **`EventStudioExtrasProductEditorBuilder`**, with **`OperationalProductStudioFieldRegistry`** driving which fields/widgets appear. Sections cover basics (including **Active / Hidden / Draft**), **`field_mel_extra_images`** on create via a stub product, pricing/SKU, a **quantity note** (metadata only, with stock warning), merchandise **size variants** + preview table, collection copy, and booking visibility gated on **Active**.
> 
> The list view adds **All / Merchandise / Add-ons** tabs, safety copy, split **merchandise vs add-on** entry points (parking, meals, camping, etc.), and richer cards (type, status, variants, quantity note, **view on booking page**). Save handling reads the new nested `editor[...]` tree and persists **SKU**, **capacity note**, and **vendor studio status** in operational JSON.
> 
> Styling, libraries, Twig (card + variant preview), unit tests, and **`docs/studio-merch-addon-product-setup.md`** document the contract and deferred stock/fulfilment work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667346e34b39eb5570861432355df5ced92dabf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->