### PR TITLE
polish(booking): improve ticket and RSVP booking flow trust

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -171,11 +171,70 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 .mel-book-page .mel-ticket-panel__title {
-  margin: 0 0 spacing.mel-space(3);
+  margin: 0 0 spacing.mel-space(2);
   padding: 0;
   font-size: typography.mel-font-size(lg);
   font-weight: typography.$mel-font-extrabold;
   color: #24303a;
+}
+
+.mel-book-page .mel-ticket-panel__lead {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-page .mel-ticket-panel__capacity {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+}
+
+.mel-book-page .mel-alert__title {
+  margin: 0 0 spacing.mel-space(1);
+  font-weight: typography.$mel-font-bold;
+  color: #24303a;
+}
+
+.mel-book-page .mel-alert p {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-support--rsvp {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+  margin-top: spacing.mel-space(4);
+}
+
+.mel-book-next-steps {
+  padding: spacing.mel-space(4);
+}
+
+.mel-book-next-steps__title {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(md);
+  font-weight: typography.$mel-font-bold;
+  color: #24303a;
+}
+
+.mel-book-next-steps__list {
+  margin: 0;
+  padding: 0 0 0 spacing.mel-space(4);
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(2);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-next-steps__item {
+  padding-left: spacing.mel-space(1);
 }
 
 .mel-book-sidebar__inner {
@@ -383,8 +442,60 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 @media (max-width: 959px) {
+  .mel-book-page {
+    padding-bottom: calc(#{spacing.mel-space(7)} + env(safe-area-inset-bottom, 0));
+  }
+
   .mel-book-page .mel-ticket-panel {
     padding-bottom: 0;
+  }
+
+  .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky {
+    position: sticky;
+    bottom: 0;
+    z-index: 6;
+    margin: spacing.mel-space(4) calc(-1 * #{spacing.mel-space(4)}) calc(-1 * #{spacing.mel-space(4)});
+    padding: spacing.mel-space(3) spacing.mel-space(4);
+    padding-bottom: calc(#{spacing.mel-space(3)} + env(safe-area-inset-bottom, 0));
+    background: #fff;
+    border-top: 1px solid rgba(36, 48, 58, 0.1);
+    box-shadow: 0 -8px 24px rgba(36, 48, 58, 0.08);
+
+    .mel-mobile-booking-bar--rsvp {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      gap: spacing.mel-space(2);
+      margin-bottom: spacing.mel-space(3);
+      padding: spacing.mel-space(2) spacing.mel-space(3);
+      border-radius: radii.$mel-radius-md;
+      background: rgba(colors.$mel-color-primary, 0.06);
+      border: 1px solid rgba(colors.$mel-color-primary, 0.12);
+    }
+
+    .mel-mobile-booking-bar__count {
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-semibold;
+      color: #24303a;
+    }
+
+    .mel-mobile-booking-bar__total {
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-bold;
+      color: colors.$mel-color-primary;
+    }
+
+    .button,
+    .form-submit,
+    input[type='submit'] {
+      width: 100%;
+      min-height: 48px;
+    }
+  }
+
+  .mel-book-page[data-event-mode='rsvp'] .mel-book-support--rsvp {
+    margin-bottom: spacing.mel-space(2);
   }
 
   .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
@@ -414,6 +525,10 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 @media (min-width: 960px) {
+  .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky .mel-mobile-booking-bar--rsvp {
+    display: none;
+  }
+
   .mel-book-layout:not(.mel-book-layout--single) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
@@ -496,6 +611,28 @@ $mel-book-max: 72.5rem; // ~1160px
 
 .mel-book-page.mel-event-page--immersive .mel-book-trust__note {
   color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-next-steps__title {
+  color: var(--mel-immersive-text, #fff);
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-next-steps__list {
+  color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+@media print {
+  .mel-book-page .mel-booking__cta--panel,
+  .mel-book-page .mel-rsvp-submit--book-sticky {
+    display: none !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel,
+  .mel-book-page .mel-rsvp-submit--book-sticky {
+    transition: none;
+  }
 }
 
 @media (min-width: 960px) {

--- a/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
@@ -54,14 +54,15 @@
       </div>
     </header>
 
-    <div class="mel-event-info-strip mel-card" role="note">
+    <div class="mel-event-info-strip mel-card" role="note" aria-label="{{ 'Booking reassurance'|t }}">
       {% if event_mode == 'paid' %}
         <span class="mel-event-info-strip__item">{{ 'Secure checkout'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'No hidden fees'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'Confirmation email sent'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll review your order before payment"|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll receive confirmation by email"|t }}</span>
       {% elseif event_mode == 'rsvp' %}
         <span class="mel-event-info-strip__item">{{ 'No payment required'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'Your RSVP will be confirmed by email'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'Your RSVP details are used for event administration only'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll receive confirmation by email"|t }}</span>
       {% elseif event_mode == 'external' %}
         <span class="mel-event-info-strip__item">{{ 'External ticketing'|t }}</span>
         <span class="mel-event-info-strip__item">{{ 'You will leave this site to buy tickets'|t }}</span>
@@ -102,6 +103,16 @@
               {{ 'Booking'|t }}
             {% endif %}
           </h2>
+          {% if event_mode == 'paid' %}
+            <p class="mel-ticket-panel__lead">{{ 'Select ticket quantities below. Payment comes after you review your cart.'|t }}</p>
+          {% elseif event_mode == 'rsvp' %}
+            <p class="mel-ticket-panel__lead">{{ 'Free RSVP — no payment required. Complete the form to reserve your place.'|t }}</p>
+            {% if mel_signal_remaining_spots is defined and mel_signal_remaining_spots is not null and mel_signal_remaining_spots > 0 %}
+              <p class="mel-ticket-panel__capacity mel-text--muted">
+                {{ '@count places remaining'|t({'@count': mel_signal_remaining_spots}) }}
+              </p>
+            {% endif %}
+          {% endif %}
 
           <div class="mel-ticket-panel__body mel-event-book__form-body mel-booking-flow" data-mel-booking-flow>
             {% if ticket_form is not empty %}
@@ -113,9 +124,11 @@
             {% else %}
               <div class="mel-alert mel-alert--info" role="status">
                 {% if event_mode == 'none' %}
-                  {{ 'Registration opens soon.'|t }}
+                  <p class="mel-alert__title">{{ 'Registration is not open yet'|t }}</p>
+                  <p>{{ 'Check back soon or return to the event page for updates.'|t }}</p>
                 {% else %}
-                  {{ "We couldn't load the booking form. Please refresh the page."|t }}
+                  <p class="mel-alert__title">{{ 'Booking is temporarily unavailable'|t }}</p>
+                  <p>{{ 'Please refresh the page. If this continues, return to the event page or contact the organiser.'|t }}</p>
                 {% endif %}
               </div>
             {% endif %}
@@ -141,13 +154,53 @@
                   <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
                 </div>
                 <p class="mel-booking__cta-note">
-                  {{ "Tickets will be added to your cart — checkout when you're ready."|t }}
+                  {{ "Tickets go to your cart first — you'll review everything before payment."|t }}
                 </p>
                 {{ ticket_form_actions }}
               </div>
             {% endif %}
           </div>
         </div>
+
+        {% if not mel_book_paid and event_mode == 'rsvp' %}
+          <div class="mel-book-support mel-book-support--rsvp">
+            <div class="mel-book-trust mel-book-panel mel-card" role="region" aria-label="{{ 'RSVP privacy and reassurance'|t }}">
+              <h3 class="mel-book-trust__title">{{ 'Your RSVP is secure'|t }}</h3>
+              <ul class="mel-book-trust__list" role="list">
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
+                  <span class="mel-book-trust__text">{{ 'No payment required'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">◎</span>
+                  <span class="mel-book-trust__text">{{ 'Your RSVP details are used for event administration only'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✉</span>
+                  <span class="mel-book-trust__text">{{ "You'll receive confirmation by email"|t }}</span>
+                </li>
+                {% if mel_signal_trust_label %}
+                  <li class="mel-book-trust__item">
+                    <span class="mel-book-trust__icon" aria-hidden="true">◎</span>
+                    <span class="mel-book-trust__text">{{ mel_signal_trust_label }}</span>
+                  </li>
+                {% endif %}
+              </ul>
+              <p class="mel-book-trust__support">
+                <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
+              </p>
+            </div>
+
+            <div class="mel-book-next-steps mel-book-panel mel-card" role="region" aria-labelledby="mel-book-next-steps-title-rsvp">
+              <h3 class="mel-book-next-steps__title" id="mel-book-next-steps-title-rsvp">{{ 'What happens next'|t }}</h3>
+              <ol class="mel-book-next-steps__list">
+                <li class="mel-book-next-steps__item">{{ 'Complete your details and submit your RSVP.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Your RSVP helps the organiser plan the event.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ "You'll receive a confirmation email with your RSVP details."|t }}</li>
+              </ol>
+            </div>
+          </div>
+        {% endif %}
       </main>
 
       {% if mel_book_paid %}
@@ -160,8 +213,8 @@
               </header>
               <div class="mel-booking-summary__body">
                 <div class="mel-booking-summary__empty" data-mel-summary-empty>
-                  <p class="mel-booking-summary__empty-line">{{ 'Choose your tickets to see your total.'|t }}</p>
-                  <p class="mel-booking-summary__empty-line mel-booking-summary__empty-line--soft">{{ 'You can review everything before checkout.'|t }}</p>
+                  <p class="mel-booking-summary__empty-line">{{ 'Choose at least one ticket to see your total.'|t }}</p>
+                  <p class="mel-booking-summary__empty-line mel-booking-summary__empty-line--soft">{{ "You'll review your cart before payment."|t }}</p>
                 </div>
                 <div class="mel-booking-summary__items" data-mel-summary-items aria-live="polite" aria-atomic="true"></div>
                 <div class="mel-booking-summary__subtotal" data-mel-summary-subtotal hidden>
@@ -170,7 +223,7 @@
                 </div>
               </div>
               <footer class="mel-booking-summary__footer">
-                <p class="mel-booking-summary__cta-note">{{ 'Tickets go to your cart first — continue to checkout when you are ready.'|t }}</p>
+                <p class="mel-booking-summary__cta-note">{{ "Tickets go to your cart first — you'll review everything before payment."|t }}</p>
               </footer>
             </div>
 
@@ -178,16 +231,16 @@
               <h3 class="mel-book-trust__title">{{ 'Before you pay'|t }}</h3>
               <ul class="mel-book-trust__list" role="list">
                 <li class="mel-book-trust__item">
-                  <span class="mel-book-trust__icon" aria-hidden="true">🔒</span>
-                  <span class="mel-book-trust__text">{{ 'Secure checkout — payment processed safely'|t }}</span>
+                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
+                  <span class="mel-book-trust__text">{{ 'Review your tickets before payment'|t }}</span>
                 </li>
                 <li class="mel-book-trust__item">
-                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
-                  <span class="mel-book-trust__text">{{ 'No hidden fees on MyEventLane'|t }}</span>
+                  <span class="mel-book-trust__icon" aria-hidden="true">🔒</span>
+                  <span class="mel-book-trust__text">{{ 'Secure checkout'|t }}</span>
                 </li>
                 <li class="mel-book-trust__item">
                   <span class="mel-book-trust__icon" aria-hidden="true">✉</span>
-                  <span class="mel-book-trust__text">{{ 'Instant confirmation by email'|t }}</span>
+                  <span class="mel-book-trust__text">{{ "You'll receive confirmation by email"|t }}</span>
                 </li>
                 {% if mel_signal_trust_label %}
                   <li class="mel-book-trust__item">
@@ -209,11 +262,20 @@
                 {% endif %}
               </ul>
               <p class="mel-book-trust__note mel-text--muted">
-                {{ 'You can review your order before checkout. Your tickets are only confirmed once checkout is complete.'|t }}
+                {{ 'Your tickets are only confirmed once checkout is complete.'|t }}
               </p>
               <p class="mel-book-trust__support">
                 <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
               </p>
+            </div>
+
+            <div class="mel-book-next-steps mel-book-panel mel-card" role="region" aria-labelledby="mel-book-next-steps-title-paid">
+              <h3 class="mel-book-next-steps__title" id="mel-book-next-steps-title-paid">{{ 'What happens next'|t }}</h3>
+              <ol class="mel-book-next-steps__list">
+                <li class="mel-book-next-steps__item">{{ 'Choose your tickets and add them to your cart.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Review your order on the cart and checkout pages.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Pay securely — then look for your confirmation email.'|t }}</li>
+              </ol>
             </div>
 
             {% if operational_addon_teaser %}

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-commerce-rsvp-booking-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-commerce-rsvp-booking-form.html.twig
@@ -92,10 +92,15 @@
         <div class="mel-rsvp-trust mel-rsvp-trust--compact" role="region" aria-label="{{ 'RSVP confirmation'|t }}">
           <ul class="mel-rsvp-trust__list">
             <li>{{ 'No payment required'|t }}</li>
-            <li>{{ 'Your RSVP will be confirmed by email'|t }}</li>
+            <li>{{ 'Your RSVP details are used for event administration only'|t }}</li>
+            <li>{{ "You'll receive confirmation by email"|t }}</li>
           </ul>
         </div>
-        <div class="mel-rsvp-submit">
+        <div class="mel-rsvp-submit mel-rsvp-submit--book-sticky">
+          <div class="mel-mobile-booking-bar mel-mobile-booking-bar--rsvp" aria-hidden="true">
+            <span class="mel-mobile-booking-bar__count">{{ 'Free RSVP'|t }}</span>
+            <span class="mel-mobile-booking-bar__total">{{ 'No payment'|t }}</span>
+          </div>
           {{ element.actions }}
         </div>
         {# Any other alter-added elements; keeps them inside the single form. #}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Theme-only Twig/SCSS and copy changes on the booking surface; no auth, payment, or form submission logic is modified.
> 
> **Overview**
> This PR **polishes the event book page** (paid tickets and free RSVP) with clearer reassurance copy, new layout blocks, and mobile UX—without changing Commerce form logic.
> 
> **Copy and structure:** The info strip, ticket panel leads, cart/checkout notes, and trust bullets now stress *review before payment*, *email confirmation*, and (for RSVP) *administration-only* use of details instead of older “no hidden fees” style messaging. Paid and RSVP flows gain **“What happens next”** step lists; RSVP also gets a dedicated **trust panel** and support link in the main column when there is no paid sidebar. Empty/unavailable booking states use titled alerts; RSVP can show **remaining places** when `mel_signal_remaining_spots` is set.
> 
> **RSVP form:** Compact trust bullets align with the book page; submit is wrapped in **`mel-rsvp-submit--book-sticky`** with a decorative mobile bar (“Free RSVP” / “No payment”).
> 
> **Styles:** New rules for panel lead/capacity, alerts, next-steps, and RSVP support; **sticky bottom submit** on small screens for `data-event-mode='rsvp'` (safe-area padding, full-width button); immersive theming for next-steps; **print** hides sticky CTAs; **reduced-motion** disables transitions on sticky regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556e63fa27ab074968b52507d35d2a2bccb7e076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->