### PR TITLE
fix(booking): pluralize RSVP remaining spots on event book page

### DIFF
--- a/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
@@ -109,7 +109,11 @@
             <p class="mel-ticket-panel__lead">{{ 'Free RSVP — no payment required. Complete the form to reserve your place.'|t }}</p>
             {% if mel_signal_remaining_spots is defined and mel_signal_remaining_spots is not null and mel_signal_remaining_spots > 0 %}
               <p class="mel-ticket-panel__capacity mel-text--muted">
-                {{ '@count places remaining'|t({'@count': mel_signal_remaining_spots}) }}
+                {% trans %}
+                  1 place remaining
+                {% plural mel_signal_remaining_spots %}
+                  @count places remaining
+                {% endtrans %}
               </p>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
Use {% trans %}/{% plural %} so a count of 1 reads "1 place remaining" instead of "1 places remaining". The |t filter only substitutes placeholders and does not invoke formatPlural().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Twig-only copy/pluralization on the RSVP booking template; no changes to capacity services or checkout flow.
> 
> **Overview**
> On the RSVP event book page, the **remaining capacity** line no longer uses a single `|t` string with `@count`. It now uses Drupal’s **`{% trans %}` / `{% plural %}`** so copy follows proper singular/plural rules (e.g. **“1 place remaining”** instead of **“1 places remaining”**).
> 
> No booking logic or capacity calculation changes—only how that message is rendered in `myeventlane-event-book.html.twig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae442b6e32946bacd2f1f5dae005c84d3700de1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->