### PR TITLE
fix(tickets): remove duplicate evaluateTimedEntryForScan on main

### DIFF
--- a/web/modules/custom/myeventlane_tickets/src/Service/VenueOperationPolicyManager.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/VenueOperationPolicyManager.php
@@ -531,44 +531,6 @@ final class VenueOperationPolicyManager {
   }
 
   /**
-   * Timed entry gate for the canonical scanner path (before mutations).
-   *
-   * @param int|null $parsed_qr_expires_at
-   *   Structured QR `exp` cap when present; null otherwise.
-   *
-   * @return array{allow: bool, result_token: string, message: string}
-   *   When allow is TRUE, result_token and message are empty strings.
-   */
-  public function evaluateTimedEntryForScan(Ticket $ticket, int $now, ?int $parsed_qr_expires_at): array {
-    $policy = $this->timedEntryPolicyManager->evaluate($ticket, $now, $parsed_qr_expires_at);
-    /** @var array<string, mixed> $scanner */
-    $scanner = is_array($policy['scanner'] ?? NULL) ? $policy['scanner'] : [];
-    $allowed = (bool) ($scanner['allowed_now'] ?? TRUE);
-    if ($allowed) {
-      return [
-        'allow' => TRUE,
-        'result_token' => '',
-        'message' => '',
-      ];
-    }
-
-    $state = (string) ($scanner['state'] ?? 'expired');
-    if ($state === 'not_started') {
-      return [
-        'allow' => FALSE,
-        'result_token' => 'invalid',
-        'message' => 'Entry is not open yet.',
-      ];
-    }
-
-    return [
-      'allow' => FALSE,
-      'result_token' => 'expired',
-      'message' => 'Entry window has closed or entitlement has expired.',
-    ];
-  }
-
-  /**
    * Interprets a denied scan for structured conflict metadata (machine-only).
    *
    * @return array<string, mixed>


### PR DESCRIPTION
Merge PR #356 left two definitions of evaluateTimedEntryForScan in VenueOperationPolicyManager, causing a PHP fatal error during kernel tests and blocking governance CI/deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only fix for a duplicate method; runtime scan policy follows the remaining canonical implementation with no new logic.
> 
> **Overview**
> Removes a **duplicate** `evaluateTimedEntryForScan` method from `VenueOperationPolicyManager` that was accidentally reintroduced after merging PR #356. PHP cannot declare the same method twice, which caused a fatal error and blocked kernel tests and governance CI/deploy.
> 
> The **canonical** implementation earlier in the class is unchanged: it still composes timed entry and session entitlement gates, returns `policy` metadata, and uses fail-closed scanner checks. No scanner behavior change beyond restoring a single definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38cae636b9ea66853797f2f9d93708c04ae83645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->