### PR TITLE
Chore/add mel ai agent instructions

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,49 @@
+# Secrets
+.env
+.env.*
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+auth.json
+secrets/
+private/
+credentials/
+
+# Databases / dumps
+*.sql
+*.sql.gz
+*.sqlite
+*.sqlite3
+database/
+db-dumps/
+backups/
+
+# Local / generated
+.DS_Store
+.ddev/.global_commands/
+.ddev/.webimageBuild/
+.ddev/.dbimageBuild/
+node_modules/
+vendor/
+web/sites/default/files/
+web/sites/default/private/
+web/sites/*/files/
+web/sites/*/private/
+
+# Build output
+dist/
+build/
+coverage/
+storybook-static/
+
+# Logs
+*.log
+logs/
+var/log/
+tmp/
+
+# Production or deploy-only config
+deploy/secrets/
+production/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,173 @@
+# GitHub Copilot Instructions for MyEventLane / MEL
+
+You are assisting on the MyEventLane v2 repository, known as MEL.
+
+MEL is a Drupal 11 event marketplace and ticketing platform using Drupal Commerce 3, custom Drupal modules, custom Twig/SCSS/Vite themes, Commerce checkout flows, vendor dashboards, event discovery, booking UX, media workflows, and Humanitix-level product expectations.
+
+## Primary goal
+
+Help build MEL safely and maintainably.
+
+Prioritise:
+
+1. Stability
+2. Accuracy
+3. Security
+4. Drupal 11 best practice
+5. Drupal Commerce 3 best practice
+6. Long-term maintainability
+7. MEL continuity
+8. Clean UX
+9. Production readiness
+
+## Repository truth
+
+Use the repository as the source of truth.
+
+Do not invent:
+
+- Drupal APIs
+- Drupal Commerce services
+- Plugin IDs
+- Routes
+- Permissions
+- Field names
+- Config keys
+- Libraries
+- Theme regions
+- Hooks
+- Event subscribers
+- Checkout pane IDs
+- Product variation types
+- Order item types
+
+If something is not visible in the repository, say so.
+
+## Drupal rules
+
+- Use Drupal 11-compatible APIs.
+- Prefer dependency injection over static service access where practical.
+- Preserve cacheability metadata.
+- Respect entity access.
+- Use translation wrappers for user-facing strings.
+- Keep Twig presentation-only.
+- Keep business logic in services, plugins, controllers, forms, or appropriate Drupal extension points.
+- Add config schema when introducing or changing module config.
+- Do not use deprecated APIs.
+- Do not bypass form API validation or access checks.
+
+## Commerce rules
+
+Assume Drupal Commerce 3.
+
+Before suggesting Commerce changes, identify the affected concept:
+
+- Product type
+- Product variation type
+- Order item type
+- Store
+- Cart
+- Checkout flow
+- Checkout pane
+- Payment gateway
+- Order state
+- Adjustment
+- Promotion
+- Tax
+- Stock
+- Capacity
+- Refund
+- Ticket ownership
+
+Never assume ticket availability, payment success, refund eligibility, or order ownership without repository evidence.
+
+Flag high-risk changes involving:
+
+- Checkout
+- Payment state
+- Ticket capacity
+- Vendor payouts
+- Order access
+- Customer data
+- Refunds
+- Webhooks
+- Stock/capacity reservations
+
+## Security rules
+
+Do not expose:
+
+- Production credentials
+- API keys
+- Payment secrets
+- Customer data
+- Vendor-private data
+- Ticket/order details
+- Database dumps
+- `.env` secrets
+
+Do not propose changes that:
+
+- Commit secrets
+- Disable CSRF protection
+- Bypass Drupal access
+- Trust raw request data
+- Give vendors access to other vendors' data
+- Let anonymous users view private booking/order data
+- Modify payment state without review
+
+## Theme and frontend rules
+
+MEL uses custom Twig, SCSS, and Vite theme work.
+
+- Follow existing MEL component conventions.
+- Preserve locked hero variants unless explicitly asked.
+- Use mobile-first CSS.
+- Maintain accessible contrast, focus states, and keyboard usability.
+- Do not introduce broad global CSS unless necessary.
+- Prefer reusable components.
+- Validate theme changes with the project build/lint scripts.
+
+## Config workflow
+
+When config changes are made or generated, recommend checking drift:
+
+```bash
+ddev drush config:status
+ddev drush cim --preview
+ddev drush cex
+ddev drush cr
+```
+
+Before a PR, recommend:
+
+```bash
+ddev drush cr
+ddev drush config:status
+ddev composer validate
+npm run lint
+npm run build
+git diff
+```
+
+## Pull request behaviour
+
+When helping with a PR:
+
+- Summarise what changed.
+- List risk areas.
+- Mention config changes.
+- Mention cache rebuild needs.
+- Mention build/lint status if known.
+- Do not claim tests passed unless they were actually run.
+- Do not approve high-risk Commerce or access-control changes without review.
+
+## Style
+
+Be concise, specific, and repository-grounded.
+
+Use exact paths where possible.
+
+If unsure, write:
+
+> I cannot confirm this from the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,260 @@
+# AGENTS.md — MyEventLane / MEL AI Agent Rules
+
+This file defines safe operating rules for AI coding agents working on MyEventLane v2, known as MEL.
+
+MEL is a Drupal 11 event marketplace and ticketing platform using Drupal Commerce 3, custom Drupal modules, custom Twig/SCSS/Vite themes, Commerce checkout flows, vendor dashboards, event discovery, booking UX, media workflows, and Humanitix-level product expectations.
+
+## Required agent behaviour
+
+All agents must optimise for:
+
+1. Stability
+2. Accuracy
+3. Security
+4. Drupal 11 best practice
+5. Drupal Commerce 3 best practice
+6. Long-term maintainability
+7. MEL continuity
+8. Clean UX
+9. Production readiness
+
+## Repository source of truth
+
+The current MEL repository is the source of truth.
+
+Agents must inspect the repository before making claims about:
+
+- File paths
+- Module names
+- Theme names
+- Routes
+- Permissions
+- Services
+- Plugins
+- Field names
+- Config keys
+- Product types
+- Product variation types
+- Checkout panes
+- Order item types
+- Libraries
+- Build scripts
+
+If the repository does not confirm something, the agent must say:
+
+```text
+I cannot confirm this from the repository.
+```
+
+## Allowed work
+
+Agents may assist with:
+
+- Drupal 11 custom module code
+- Drupal Commerce 3 modelling and checkout review
+- Twig templates
+- SCSS components
+- Vite/theme build work
+- YAML config and schema
+- UX microcopy
+- Vendor dashboard improvements
+- Event discovery UX
+- Booking flow improvements
+- Access-control review
+- Security review
+- Test suggestions
+- Documentation
+- GitHub issue and PR drafting
+
+## Restricted work
+
+Agents must not perform or recommend without explicit human review:
+
+- Production deployments
+- Production database imports/exports
+- Payment gateway configuration changes
+- Refund automation
+- Vendor payout logic
+- Order state mutation logic
+- Destructive Drush commands
+- Direct commits to `main`
+- Force pushes to shared branches
+- Secret rotation
+- Live customer/order/ticket data handling
+- Production cron, queue, or webhook changes
+
+## Never commit secrets
+
+Do not read, print, copy, commit, or expose:
+
+- API keys
+- Payment gateway secrets
+- Production database credentials
+- Private SSH keys
+- OAuth secrets
+- `.env` files
+- Database dumps
+- Customer data exports
+- Vendor payout data
+- Full production logs containing personal data
+
+## Drupal 11 standards
+
+Agents must:
+
+- Use Drupal 11-compatible APIs.
+- Avoid deprecated APIs.
+- Preserve cacheability metadata.
+- Use access checks for entity queries where appropriate.
+- Respect entity access.
+- Use dependency injection where practical.
+- Keep Twig presentation-focused.
+- Add config schema for custom config.
+- Use translation for user-facing strings.
+- Validate and sanitise external input.
+- Avoid direct SQL unless justified and reviewed.
+- Avoid hard-coded entity IDs where possible.
+
+## Drupal Commerce 3 standards
+
+Agents must be careful with:
+
+- Product modelling
+- Product variations
+- Order item types
+- Stores
+- Carts
+- Checkout flows
+- Checkout panes
+- Payment gateways
+- Payment state
+- Order state
+- Stock
+- Capacity
+- Ticket ownership
+- Refunds
+- Adjustments
+- Promotions
+- Tax
+
+Agents must not assume:
+
+- Payment success
+- Ticket availability
+- Refund eligibility
+- Vendor ownership
+- Customer access
+- Capacity reservation
+- Stock reservation
+- Order completion
+
+Agents must identify risk before changing Commerce logic.
+
+## MEL content and Commerce separation
+
+MEL must keep these concepts distinct:
+
+- Event content/entity data describes the event.
+- Commerce products and variations represent sellable tickets or booking options.
+- Orders represent purchases.
+- Order items represent purchased ticket/booking lines.
+- Vendor dashboards must not expose data from other vendors.
+- Public event pages must not leak private vendor, customer, or order data.
+
+## Frontend and UX standards
+
+Agents must:
+
+- Follow existing MEL Twig/SCSS conventions.
+- Preserve MEL pastel brand direction.
+- Use mobile-first responsive design.
+- Maintain accessible contrast.
+- Preserve focus states.
+- Avoid keyboard traps.
+- Avoid inaccessible icon-only buttons.
+- Preserve locked hero variants unless explicitly instructed.
+- Avoid broad CSS side effects.
+- Keep reusable components clean.
+
+## Validation commands
+
+After backend/config work, recommend:
+
+```bash
+ddev drush cr
+ddev drush config:status
+ddev drush cim --preview
+ddev drush cex
+ddev composer validate
+```
+
+After frontend/theme work, recommend:
+
+```bash
+npm run lint
+npm run build
+```
+
+Before commit, recommend:
+
+```bash
+git status
+git diff
+ddev drush config:status
+```
+
+Do not claim any command passed unless it was actually run.
+
+## Branching
+
+Recommended branch naming:
+
+```text
+feature/mel-short-description
+fix/mel-short-description
+chore/mel-short-description
+audit/mel-short-description
+```
+
+Agents should keep diffs focused and reviewable.
+
+## Commit guidance
+
+A safe MEL commit should include:
+
+- Code changes
+- Required config exports
+- Required schema updates
+- Related template/SCSS changes
+- Documentation updates if behaviour changed
+
+Avoid mixing unrelated changes.
+
+## PR checklist
+
+Before opening or merging a PR, check:
+
+- Does the change affect access control?
+- Does it affect checkout?
+- Does it affect payment/order state?
+- Does it affect ticket capacity or stock?
+- Does it expose vendor/customer/order data?
+- Does it introduce config drift?
+- Does it need config schema?
+- Does it affect cacheability?
+- Does it affect mobile UX?
+- Does it affect accessibility?
+- Were lint/build/cache/config checks run?
+
+## Agent response style
+
+Agents should:
+
+- Be direct.
+- Use exact file paths.
+- State assumptions.
+- Explain risk.
+- Provide validation commands.
+- Avoid vague reassurance.
+- Avoid invented APIs.
+- Ask only one clarifying question if blocked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,252 @@
+# CLAUDE.md — MyEventLane / MEL Claude Code Instructions
+
+You are assisting with MyEventLane v2, known as MEL.
+
+MEL is a Drupal 11 event marketplace and ticketing platform using Drupal Commerce 3, custom Drupal modules, custom Twig/SCSS/Vite themes, Commerce checkout flows, vendor dashboards, event discovery, booking UX, media workflows, and Humanitix-level product expectations.
+
+## Operating principle
+
+Act as a senior Drupal 11, Drupal Commerce 3, UX, security, and DevOps partner.
+
+Prioritise:
+
+1. Stability
+2. Accuracy
+3. Security
+4. Drupal 11 best practice
+5. Drupal Commerce 3 best practice
+6. Long-term maintainability
+7. MEL continuity
+8. Clean UX
+9. Production readiness
+
+## Repository-first rule
+
+Before making claims, inspect the repository.
+
+Do not invent:
+
+- Drupal APIs
+- Drupal Commerce services
+- Plugin IDs
+- Routes
+- Permissions
+- Field names
+- Config keys
+- Libraries
+- Theme regions
+- Checkout pane IDs
+- Product variation types
+- Order item types
+- Build scripts
+
+If the repository does not confirm something, say:
+
+```text
+I cannot confirm this from the repository.
+```
+
+## Safe workflow
+
+Prefer this workflow:
+
+1. Inspect relevant files.
+2. Summarise what exists.
+3. Identify risk areas.
+4. Propose a small plan.
+5. Make focused changes.
+6. Show file paths changed.
+7. Recommend validation commands.
+8. Do not claim validation passed unless commands were run.
+
+## Commands
+
+Use DDEV-aware commands when appropriate.
+
+Common validation commands:
+
+```bash
+ddev drush status
+ddev drush cr
+ddev drush config:status
+ddev drush cim --preview
+ddev drush cex
+ddev composer validate
+npm run lint
+npm run build
+git status
+git diff
+```
+
+Never run destructive commands without explicit human approval.
+
+High-risk commands include, but are not limited to:
+
+```bash
+ddev drush sql-drop
+ddev drush sql-sync
+ddev drush entity:delete
+ddev drush config:delete
+git reset --hard
+git clean -fd
+git push --force
+```
+
+## Drupal 11 rules
+
+Use Drupal 11-compatible patterns.
+
+Prefer:
+
+- Dependency injection
+- Services for reusable business logic
+- Config schema for custom config
+- Access checks
+- Cache-aware render arrays
+- Translation for user-facing strings
+- Typed properties where suitable
+- Clear route/controller/form responsibilities
+
+Avoid:
+
+- Deprecated APIs
+- Static service access where dependency injection is practical
+- Business logic in Twig
+- Hard-coded entity IDs
+- Raw SQL without review
+- Unsafe request handling
+- Access bypasses
+- Cacheability regressions
+
+## Drupal Commerce 3 rules
+
+Treat Commerce changes as high risk.
+
+Always identify whether a change touches:
+
+- Product type
+- Product variation type
+- Order item type
+- Store
+- Cart
+- Checkout flow
+- Checkout pane
+- Payment gateway
+- Payment state
+- Order state
+- Adjustment
+- Promotion
+- Tax
+- Stock
+- Capacity
+- Ticket ownership
+- Refunds
+
+Never assume:
+
+- Payment succeeded
+- A user owns an order
+- A vendor owns an event/order/ticket
+- Ticket capacity is available
+- Stock is reserved
+- Refunds are safe
+- Checkout can be bypassed
+- Anonymous users may view order/ticket data
+
+Flag these risks clearly.
+
+## MEL architecture expectations
+
+Keep these concepts separate:
+
+- Event content describes the event.
+- Commerce products/variations represent sellable ticket or booking options.
+- Orders represent purchases.
+- Order items represent purchased lines.
+- Vendor dashboards manage vendor-owned event and sales data.
+- Public pages must not leak private vendor, customer, order, or payment data.
+
+Do not collapse event content and ticket Commerce products into one unclear model unless explicitly required and reviewed.
+
+## Theme, Twig, SCSS, and Vite
+
+Follow existing MEL conventions.
+
+- Use mobile-first responsive layouts.
+- Preserve MEL pastel brand direction.
+- Preserve locked hero variants unless explicitly instructed.
+- Keep components reusable.
+- Keep Twig presentation-focused.
+- Avoid global CSS leakage.
+- Maintain accessible contrast.
+- Preserve focus states.
+- Avoid inaccessible interactive elements.
+- Run the project build/lint scripts after frontend changes if available.
+
+## Security rules
+
+Never expose or commit:
+
+- Production secrets
+- API keys
+- Payment gateway secrets
+- Database credentials
+- SSH keys
+- OAuth secrets
+- `.env` values
+- Database dumps
+- Customer exports
+- Vendor payout data
+- Sensitive production logs
+
+Do not weaken:
+
+- Route access
+- Entity access
+- CSRF protection
+- Form validation
+- Checkout ownership checks
+- Payment state handling
+- File/media access
+
+## Git rules
+
+- Work on a feature branch.
+- Do not commit directly to `main`.
+- Do not force push shared branches.
+- Keep diffs focused.
+- Mention config exports when needed.
+- Mention cache rebuilds when needed.
+- Mention build/lint when theme assets change.
+
+Suggested branch names:
+
+```text
+feature/mel-short-description
+fix/mel-short-description
+audit/mel-short-description
+chore/mel-short-description
+```
+
+## Output style
+
+Be concise and technical.
+
+When making changes, report:
+
+```text
+Changed:
+- path/to/file.ext — what changed
+
+Risk:
+- access/config/cache/Commerce/theme risk, if any
+
+Validate:
+- commands to run
+```
+
+Do not provide vague reassurance.
+
+Do not say tests passed unless they actually ran.
+
+Ask one clarifying question only if blocked. Otherwise proceed with a stated assumption.

--- a/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_limit_per_order.yml
+++ b/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_limit_per_order.yml
@@ -1,0 +1,23 @@
+uuid: 3d3eae3d-7793-4378-97a7-171aec8ddfd6
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.hospitality_package_var
+    - field.storage.commerce_product_variation.field_mel_limit_per_order
+id: commerce_product_variation.hospitality_package_var.field_mel_limit_per_order
+field_name: field_mel_limit_per_order
+entity_type: commerce_product_variation
+bundle: hospitality_package_var
+label: 'Limit per order'
+description: 'Optional maximum a customer can buy in one order.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_show_remaining.yml
+++ b/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_show_remaining.yml
@@ -1,0 +1,23 @@
+uuid: a5cbac56-eae3-4654-8e10-9f5f5a6337d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.hospitality_package_var
+    - field.storage.commerce_product_variation.field_mel_show_remaining
+id: commerce_product_variation.hospitality_package_var.field_mel_show_remaining
+field_name: field_mel_show_remaining
+entity_type: commerce_product_variation
+bundle: hospitality_package_var
+label: 'Show remaining quantity'
+description: 'Shows remaining stock to customers on the booking page when stock is finite.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show remaining quantity'
+  off_label: 'Hide remaining quantity'
+field_type: boolean

--- a/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_stock_quantity.yml
+++ b/config/sync/field.field.commerce_product_variation.hospitality_package_var.field_mel_stock_quantity.yml
@@ -1,0 +1,23 @@
+uuid: 471a8ec0-c9d7-4314-a90c-71a4ebc2da34
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.hospitality_package_var
+    - field.storage.commerce_product_variation.field_mel_stock_quantity
+id: commerce_product_variation.hospitality_package_var.field_mel_stock_quantity
+field_name: field_mel_stock_quantity
+entity_type: commerce_product_variation
+bundle: hospitality_package_var
+label: 'Stock quantity'
+description: 'Maximum quantity available for this option.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_limit_per_order.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_limit_per_order.yml
@@ -1,0 +1,23 @@
+uuid: 9df8c498-95ae-45d7-a0fb-b36d568b1c27
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_bundle_var
+    - field.storage.commerce_product_variation.field_mel_limit_per_order
+id: commerce_product_variation.operational_bundle_var.field_mel_limit_per_order
+field_name: field_mel_limit_per_order
+entity_type: commerce_product_variation
+bundle: operational_bundle_var
+label: 'Limit per order'
+description: 'Optional maximum a customer can buy in one order.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_show_remaining.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_show_remaining.yml
@@ -1,0 +1,23 @@
+uuid: d03674ea-8014-42cd-8390-fba6e10a8414
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_bundle_var
+    - field.storage.commerce_product_variation.field_mel_show_remaining
+id: commerce_product_variation.operational_bundle_var.field_mel_show_remaining
+field_name: field_mel_show_remaining
+entity_type: commerce_product_variation
+bundle: operational_bundle_var
+label: 'Show remaining quantity'
+description: 'Shows remaining stock to customers on the booking page when stock is finite.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show remaining quantity'
+  off_label: 'Hide remaining quantity'
+field_type: boolean

--- a/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_stock_quantity.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_bundle_var.field_mel_stock_quantity.yml
@@ -1,0 +1,23 @@
+uuid: 4ccdfb04-8b13-41fb-8ebc-af053319793f
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_bundle_var
+    - field.storage.commerce_product_variation.field_mel_stock_quantity
+id: commerce_product_variation.operational_bundle_var.field_mel_stock_quantity
+field_name: field_mel_stock_quantity
+entity_type: commerce_product_variation
+bundle: operational_bundle_var
+label: 'Stock quantity'
+description: 'Maximum quantity available for this option.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_limit_per_order.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_limit_per_order.yml
@@ -1,0 +1,23 @@
+uuid: 9c995279-3a9f-40d2-b56d-0ea992916e35
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_merchandise_var
+    - field.storage.commerce_product_variation.field_mel_limit_per_order
+id: commerce_product_variation.operational_merchandise_var.field_mel_limit_per_order
+field_name: field_mel_limit_per_order
+entity_type: commerce_product_variation
+bundle: operational_merchandise_var
+label: 'Limit per order'
+description: 'Optional maximum a customer can buy in one order.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_show_remaining.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_show_remaining.yml
@@ -1,0 +1,23 @@
+uuid: 904156ff-543b-4055-b0ce-59530b937fa4
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_merchandise_var
+    - field.storage.commerce_product_variation.field_mel_show_remaining
+id: commerce_product_variation.operational_merchandise_var.field_mel_show_remaining
+field_name: field_mel_show_remaining
+entity_type: commerce_product_variation
+bundle: operational_merchandise_var
+label: 'Show remaining quantity'
+description: 'Shows remaining stock to customers on the booking page when stock is finite.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show remaining quantity'
+  off_label: 'Hide remaining quantity'
+field_type: boolean

--- a/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_stock_quantity.yml
+++ b/config/sync/field.field.commerce_product_variation.operational_merchandise_var.field_mel_stock_quantity.yml
@@ -1,0 +1,23 @@
+uuid: dc0f900f-cae0-4e31-8275-d60fc098e8b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.operational_merchandise_var
+    - field.storage.commerce_product_variation.field_mel_stock_quantity
+id: commerce_product_variation.operational_merchandise_var.field_mel_stock_quantity
+field_name: field_mel_stock_quantity
+entity_type: commerce_product_variation
+bundle: operational_merchandise_var
+label: 'Stock quantity'
+description: 'Maximum quantity available for this option.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_limit_per_order.yml
+++ b/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_limit_per_order.yml
@@ -1,0 +1,23 @@
+uuid: a272069e-04f4-4699-973a-753c61318600
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.timed_collection_var
+    - field.storage.commerce_product_variation.field_mel_limit_per_order
+id: commerce_product_variation.timed_collection_var.field_mel_limit_per_order
+field_name: field_mel_limit_per_order
+entity_type: commerce_product_variation
+bundle: timed_collection_var
+label: 'Limit per order'
+description: 'Optional maximum a customer can buy in one order.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_show_remaining.yml
+++ b/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_show_remaining.yml
@@ -1,0 +1,23 @@
+uuid: edb5fee2-6e42-4495-9edb-a3ad90a8f5a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.timed_collection_var
+    - field.storage.commerce_product_variation.field_mel_show_remaining
+id: commerce_product_variation.timed_collection_var.field_mel_show_remaining
+field_name: field_mel_show_remaining
+entity_type: commerce_product_variation
+bundle: timed_collection_var
+label: 'Show remaining quantity'
+description: 'Shows remaining stock to customers on the booking page when stock is finite.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show remaining quantity'
+  off_label: 'Hide remaining quantity'
+field_type: boolean

--- a/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_stock_quantity.yml
+++ b/config/sync/field.field.commerce_product_variation.timed_collection_var.field_mel_stock_quantity.yml
@@ -1,0 +1,23 @@
+uuid: 7e47e0a1-aa4c-4b0d-acde-6756188eb848
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.timed_collection_var
+    - field.storage.commerce_product_variation.field_mel_stock_quantity
+id: commerce_product_variation.timed_collection_var.field_mel_stock_quantity
+field_name: field_mel_stock_quantity
+entity_type: commerce_product_variation
+bundle: timed_collection_var
+label: 'Stock quantity'
+description: 'Maximum quantity available for this option.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.storage.commerce_product_variation.field_mel_limit_per_order.yml
+++ b/config/sync/field.storage.commerce_product_variation.field_mel_limit_per_order.yml
@@ -1,0 +1,20 @@
+uuid: 186bf396-6e6e-45c2-82b4-b444a2d442c1
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product_variation.field_mel_limit_per_order
+field_name: field_mel_limit_per_order
+entity_type: commerce_product_variation
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product_variation.field_mel_show_remaining.yml
+++ b/config/sync/field.storage.commerce_product_variation.field_mel_show_remaining.yml
@@ -1,0 +1,18 @@
+uuid: dd50c31d-b7eb-43cf-a31f-b19003158e1a
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product_variation.field_mel_show_remaining
+field_name: field_mel_show_remaining
+entity_type: commerce_product_variation
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product_variation.field_mel_stock_quantity.yml
+++ b/config/sync/field.storage.commerce_product_variation.field_mel_stock_quantity.yml
@@ -1,0 +1,20 @@
+uuid: 5fe6e7c5-62c3-4cda-9577-0c04bf3e0baa
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+id: commerce_product_variation.field_mel_stock_quantity
+field_name: field_mel_stock_quantity
+entity_type: commerce_product_variation
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docs/operational-extras-stock-fields.md
+++ b/docs/operational-extras-stock-fields.md
@@ -1,0 +1,137 @@
+# Operational extras stock fields
+
+Status: implemented (add-to-cart enforcement slice)  
+Scope: operational Commerce variations for merch and add-ons — not tickets, fulfilment, or Commerce Stock module
+
+## Fields added
+
+All fields live on **Commerce product variations** (not products):
+
+| Field | Type | Label | Rule |
+| --- | --- | --- | --- |
+| `field_mel_stock_quantity` | integer | Stock quantity | Min 0. Blank = unlimited. `0` = sold out. |
+| `field_mel_limit_per_order` | integer | Limit per order | Min 1 when set. Optional. |
+| `field_mel_show_remaining` | boolean | Show remaining quantity | Default false. |
+
+### Variation bundles
+
+- `operational_merchandise_var`
+- `operational_bundle_var`
+- `hospitality_package_var`
+- `timed_collection_var`
+
+Config source: `config/sync/field.storage.commerce_product_variation.field_mel_*` and matching `field.field.commerce_product_variation.*` YAML.
+
+Ticket variations continue to use `field_capacity`, `field_limit_per_order`, and `field_show_remaining` — separate from operational extras.
+
+## Blank vs zero stock
+
+| Value | Meaning |
+| --- | --- |
+| Blank / not set | **Unlimited** stock for that variation |
+| `0` | **Sold out** — cannot add to cart |
+| Positive integer | Finite stock enforced at add-to-cart |
+
+Limit per order is optional. When set, it must not exceed stock quantity when stock is finite and greater than zero.
+
+## Operational documents (deferred)
+
+Packing slips, parking slips, item labels, and grouped fulfilment CSV/PDF are **not** generated from Studio. Manage event shows **Operational documents** placeholders; see [vendor-operational-documents.md](./vendor-operational-documents.md).
+
+## Platform fee (checkout)
+
+Operational extras incur a separate platform fee adjustment at checkout (`myeventlane_operational_extras_platform_fee`), defaulting to **double** the ticket `platform_fee_percent`. Config: `myeventlane_core.settings` → `operational_extras_platform_fee_percent`. Does not change ticket fee or Stripe Connect application fee on tickets.
+
+## Event Studio product editor
+
+**Stock summary-first UX:** the **Stock and limits** accordion panel shows summary chips (options, unlimited, sold out, limits) and *Stock is enforced when customers add extras to cart.* Per-option fields are progressive disclosure inside **Edit stock per option** (closed when all stock is blank/unlimited and no limits are set).
+
+**Studio product editor:** each **product option** row maps to one Commerce variation. Catalog fields (label, SKU, price, visible) live in **Product options**; stock fields (`field_mel_stock_quantity`, `field_mel_limit_per_order`, `field_mel_show_remaining`) live in **Stock and limits** using the **same variation ID** and `editor[product_options][rows][delta]` form parents. Helper copy for blank/0/positive stock and optional limits appears once above the stock table, not on every row.
+
+Size checkboxes are not the source of truth; **colour matrix is deferred**. Legacy size-only products load as editable option rows with IDs preserved on save.
+
+**Add-ons (single variation):** legacy single-variation quantity card may still apply outside the multi-option editor path.
+
+**Quantity note** (`field_mel_operational_product` metadata) remains an optional internal helper — not the stock source of truth.
+
+Booking page preview shows aggregated stock label from `OperationalVariationStockResolver::summarizeProductStock()`.
+
+Studio list cards show total stock state: Unlimited, N in stock, Low stock (≤5 total), Sold out, and limit per order when uniform across variations.
+
+**Print/packing/parking/label generation** is not in the product editor — see Manage event ([vendor-operational-documents.md](./vendor-operational-documents.md)).
+
+## Add-to-cart enforcement
+
+`OperationalVariationStockResolver` + `EventOperationalAddonCartForm` enforce server-side:
+
+1. Cannot exceed variation stock quantity.
+2. Cannot exceed limit per order.
+3. Existing cart quantity for the same variation counts toward limits.
+4. Stock `0` blocks add.
+5. Blank stock = unlimited (limit per order still applies if set).
+
+Booking UI sets quantity `max` where possible and disables cards/options that are fully sold out. **No stock decrement** on add-to-cart in this slice.
+
+## Backward compatibility
+
+Products/variations without the new fields default to **unlimited** stock (field empty). Booking and Studio must not fatal on legacy products.
+
+## Deferred
+
+- Stock reservation / holds during checkout
+- Decrement on payment / increment on refund
+- Warehouse or inventory ledger
+- Fulfilment / shipping state machines
+- QR pickup redemption tied to stock
+- Commerce Stock module integration
+
+## Related docs
+
+- [studio-merch-addon-product-setup.md](./studio-merch-addon-product-setup.md)
+- [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
+- [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md)
+
+## Ticket sales monitoring (read-only)
+
+Event Studio **Manage event** (`myeventlane_vendor.console.event_workspace`, `/vendor/events/{event}`) includes:
+
+- read-only **Ticket sales** panel (attendance capacity)
+- read-only **Merch & add-on sales** panel (operational extras by category)
+
+**Merch & add-ons** (`myeventlane_event_studio.workspace_extras`) remains product stock setup only and links back to Manage event for sales monitoring.
+
+See also `docs/vendor-commerce-sales-monitoring.md` for order states, exclusions, and deferred export/distribution work.
+
+| Domain | Surface | Data source | Purpose |
+| --- | --- | --- | --- |
+| Ticket sales | Manage event (`/vendor/events/{event}`) | Ticket tiers + ticket-backed completed order items | Attendance capacity monitoring |
+| Merch & add-ons stock | Merch & add-ons Studio | `field_mel_stock_quantity` on operational variations | Product stock at add-to-cart |
+
+These domains are **never combined**. There is no total stock across tickets and extras.
+
+### Ticket sales panel
+
+- Read-only summary per paid ticket type: name, price, capacity, sold, remaining, % sold, status.
+- Sold count: **completed** Commerce orders only, quantities from order items where `TicketBackedOrderItemClassifier::isTicketBackedOrderItem()` is true.
+- Operational extras, donations, boosts, and non-ticket line items do **not** increase ticket sold counts.
+- Remaining = capacity − sold when capacity is finite; otherwise shows **Unlimited** / **No limit set**.
+- Status uses existing ticket lifecycle evaluation (`TicketStatusEvaluator`) — no tier mutation from this panel.
+- **Edit tickets** links to the existing Studio Tickets section (`myeventlane_event_studio.workspace_tickets`).
+- Studio top-bar **Manage event** returns to `myeventlane_vendor.console.event_workspace` (`/vendor/events/{event}`), not the Studio overview route.
+
+Service: `EventStudioCommerceSalesSummaryBuilder` (`myeventlane_event_studio.commerce_sales_summary_builder`).
+
+Future analytics may expand beyond this lightweight event-scoped slice.
+
+## Tests
+
+```bash
+./vendor/bin/phpunit -c web/core/phpunit.xml.dist \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalVariationStockResolverTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioCommerceSalesSummaryBuilderTest.php \
+  web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/TicketBackedOrderItemClassifierTest.php \
+  --do-not-cache-result
+```

--- a/docs/operational-merchandise-architecture.md
+++ b/docs/operational-merchandise-architecture.md
@@ -35,6 +35,8 @@ Top-level contract flag: `mel_operational_product: true`.
 
 Persisted under `field_mel_op_capabilities` as part of the operational capabilities document. Vendors link **operational** products to an event (`linked_products`), assign **roles** (`merch_pickup`, `operational_bundle`, `hospitality`, `timed_collection`, `parking`), and optional **bundle_group** labels for composition. `OperationalMerchandiseManager::normalizeEventMerchandiseAuthoring()` validates product IDs, enforces operational bundles, requires `field_event` alignment to the event, and merges normalized `product_payload` from the product field. Vendors may also **create** new operational products from Event Studio on explicit save via the [Vendor Product Creation Wizard](vendor-product-creation-wizard.md) (Commerce entities only through `VendorOperationalProductCreationManager`).
 
+**Stock (Phase 4F+):** operational variation stock is stored on `field_mel_stock_quantity`, `field_mel_limit_per_order`, and `field_mel_show_remaining`. Event Studio saves per-variation stock; booking add-to-cart enforces configured quantities without decrementing inventory. See [operational-extras-stock-fields.md](./operational-extras-stock-fields.md).
+
 ## Purchase composition
 
 `OperationalPurchaseCompositionManager` builds `mel_operational_purchase_composition` documents: grouped **merchandise**, **hospitality**, **timed_collection**, **bundles**, and **parking** rows from **Commerce order items** (or event preview from authoring). It attaches read-only **governance** summaries via `OperationalMerchandiseGovernanceManager` (severity, degraded rows, continuity conflicts). **No** checkout flow mutation and **no** bypass of Commerce order items.

--- a/docs/studio-merch-addon-product-setup.md
+++ b/docs/studio-merch-addon-product-setup.md
@@ -5,19 +5,63 @@ Scope: Event Studio `extras` section — not tickets, fulfilment execution, or S
 
 ## Product editor layout
 
-**Merch & add-ons** (`/vendor/events/{node}/studio/extras`) uses a card-based **Commerce product editor** with sections:
+**Merch & add-ons** (`/vendor/events/{node}/studio/extras?extra={product_id}`) uses a two-column **Commerce product editor** on desktop (single column on mobile). Ticket sales monitoring lives on **Manage event** (`/vendor/events/{event}`, route `myeventlane_vendor.console.event_workspace`) — not on this surface.
+
+### Guided accordion layout
+
+The editor uses collapsible **`<details>`** panels (keyboard-friendly) so vendors are not faced with one long form:
+
+| Panel | Contents |
+| --- | --- |
+| **Basics** | Product name, description, status, default price/SKU |
+| **Photos** | Image gallery |
+| **Product options** | Vendor-managed variation rows (label, SKU, price, visible) + quick presets |
+| **Stock and limits** | Summary chips first; per-option stock behind **Edit stock per option** |
+| **Booking preview** | Guest-facing summary (options count, price range, stock) |
+| **Collection and documents** | Pickup note, booking visibility, print guidance (Manage event link) |
+
+A **compact summary** line appears under the top nav (status · option count · from-price).
+
+**Default open panels:** new product → Basics only; edit → Product options + Booking preview; validation errors → Basics + Product options + Stock.
+
+Sticky footer: **Save product**, **Save and add another**, **Back to all extras**.
+
+### Operational documents (product editor)
+
+Card **“Packing slips, parking slips and labels”** explains that print tools live on **Manage event** once the item starts selling (merch packs, parking passes, food/drink orders, pickup labels). CTA: **Back to Manage event** (`myeventlane_vendor.console.event_workspace`). No fake print or download links in the editor. Full spec: [vendor-operational-documents.md](./vendor-operational-documents.md).
+
+### Site fee copy (list mode)
+
+Intro shows `PlatformFeeSettings::buildExtrasStudioFeeCopy()` — e.g. “Merch and add-ons use the same checkout. The MyEventLane site fee for extras is X%.” When extras fee defaults to double the ticket fee, copy explains why extras may be higher (stock and order handling). Configure at **Admin → Config → MyEventLane → General settings** → **Platform fee percentage (merch & add-ons)**.
+
+### Operational documents (list mode)
+
+Note: *After sales begin, you’ll be able to generate packing slips, parking slips, and labels from Manage event.* Full spec: [vendor-operational-documents.md](./vendor-operational-documents.md).
 
 | Section | Purpose |
 | --- | --- |
-| Product basics | Type (merchandise / add-on subtype), name, short description, status (Active / Hidden / Draft) |
-| Product images | `field_mel_extra_images` media gallery (all operational bundles) |
-| Pricing and SKU | Price, SKU (auto-generated when blank; size suffixes for variants) |
-| Quantity | Quantity note in operational metadata (not stock enforcement) + warning panel |
-| Options and variants | Size checkboxes + variant preview table (merchandise with `field_mel_size`) |
-| Collection and fulfilment | Pickup / collection note; fulfilment tracking deferred notice |
-| Booking visibility | Show on booking page (requires Active status) |
+| Product basics | Type, name, short description, status (Active / Hidden / Draft) |
+| Product images | `field_mel_extra_images` media gallery |
+| Pricing and SKU | Price, SKU (auto-generated when blank) |
+| Quantity / stock | Single stock card (add-ons) |
+| Product options | Vendor-managed option rows (one Commerce variation each): label, SKU, price, visible, variation ID |
+| Stock and limits | Per-option stock, limit per order, show remaining (same variation IDs as Product options) |
+| Guest preview | Option count, price range, stock summary, booking visibility |
+| Collection and fulfilment | Pickup note; shipping/tracking deferred |
+| Booking visibility | Show on booking page (requires Active) |
+| Booking preview | Guest preview with stock and visibility state |
 
-Save actions: **Save product**, **Save and add another**, **Back to all extras**.
+### Stock summary-first UX
+
+The **Stock and limits** panel shows a compact summary first (option count, unlimited / sold out / low stock chips, per-order limit status) and the copy *Stock is enforced when customers add extras to cart.*
+
+Detailed controls live inside **Edit stock per option** (`<details>`). That block is **closed by default** when every option has blank stock and no per-order limits. It opens automatically when any option has finite stock, is sold out (`0`), has a per-order limit, or when the form was submitted with stock validation errors.
+
+Helper copy appears **once** above the per-option table (not repeated on every row): **Blank = unlimited. 0 = sold out. Positive numbers are enforced.** and **Limit per order is optional.**
+
+Desktop uses a compact table (Option | Stock quantity | Limit per order | Show remaining). Mobile stacks each row as a compact card with short labels.
+
+**Product options are vendor-managed Commerce variations.** Each option row maps to one variation ID shared by **Product options** (catalog) and **Stock and limits** (inventory). Size checkboxes are no longer the source of truth. Option labels can include colour manually (e.g. `Black / S`); a guided **colour matrix is deferred**. Quick presets populate rows before save. Removed options are unpublished, not deleted. Existing size-based products load as labelled option rows with variation IDs preserved on save.
 
 ## Field support (audit summary)
 
@@ -42,9 +86,14 @@ No `body` field. No dedicated stock/capacity field on products.
 | --- | --- | --- |
 | `price`, `sku`, `status` | Yes (Commerce core) | Yes |
 | `field_mel_size` | Yes | No |
-| Stock / `field_capacity` | **No** | **No** |
+| `field_mel_stock_quantity` | Yes | Yes |
+| `field_mel_limit_per_order` | Yes | Yes |
+| `field_mel_show_remaining` | Yes | Yes |
+| Ticket `field_capacity` | **No** | **No** |
 
-Quantity is stored as a **quantity note** inside `field_mel_operational_product` metadata (`operational_chips` + `collection_rules.vendor_quantity_note`). It is **not** inventory enforcement.
+Stock is enforced at add-to-cart via variation stock fields. Blank stock = unlimited; `0` = sold out. See [operational-extras-stock-fields.md](./operational-extras-stock-fields.md).
+
+Optional **quantity note** in `field_mel_operational_product` metadata is an internal helper only — not inventory enforcement.
 
 ## Image support status
 
@@ -58,7 +107,7 @@ Quantity is stored as a **quantity note** inside `field_mel_operational_product`
 
 ## Product list cards
 
-Each card shows: thumbnail or placeholder, type pill, status (Active/Hidden/Draft), variant count, price, quantity note, booking visibility, actions (Edit product, Hide/Show on booking page, View booking page).
+Each card shows: thumbnail or placeholder, type pill, status (Active/Hidden/Draft), variant count, price, stock summary (unlimited / in stock / low / sold out), limit per order when set, quantity note (optional), booking visibility, actions (Edit product, Hide/Show on booking page, View booking page).
 
 ## Authority
 
@@ -73,7 +122,7 @@ See [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety
 
 ## Deferred
 
-- Stock enforcement and Commerce Stock integration on operational variations.
+- Stock reservation, decrement-on-payment, and Commerce Stock integration.
 - Shipping / fulfilment state machines and vendor fulfilment dashboard.
 - Dedicated Connect revenue split for operational lines.
 - Raw Commerce admin as the primary vendor path (staff-only advanced link when permitted).
@@ -95,11 +144,13 @@ See [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety
   web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php \
   web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMerchAddonStudioTest.php \
   web/modules/custom/myeventlane_event_studio/tests/src/Unit/VendorOperationalProductCreationManagerTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalVariationStockResolverTest.php \
   --do-not-cache-result
 ```
 
 ## Related docs
 
+- [operational-extras-stock-fields.md](./operational-extras-stock-fields.md)
 - [operational-merchandise-architecture.md](./operational-merchandise-architecture.md)
 - [commerce-merch-addon-phase0-safety.md](./commerce-merch-addon-phase0-safety.md)
 - [customer-operational-addons-booking.md](./customer-operational-addons-booking.md)

--- a/docs/vendor-commerce-sales-monitoring.md
+++ b/docs/vendor-commerce-sales-monitoring.md
@@ -1,0 +1,97 @@
+# Vendor commerce sales monitoring
+
+Read-only vendor dashboards separate **ticket sales** (attendance capacity) from **operational extras** (merch, food/drink, parking, hospitality, timed collection, bundles).
+
+## Surfaces
+
+| Panel | Route | Service | Counts |
+|-------|-------|---------|--------|
+| **Ticket sales** | `/vendor/events/{event}` (`myeventlane_vendor.console.event_workspace`) | `EventStudioCommerceSalesSummaryBuilder` | Paid ticket tiers; completed-order ticket-backed line items only |
+| **Merch & add-on sales** | Same Manage event page | `EventOperationalExtrasSalesSummaryBuilder` | Operational composition lines grouped by category |
+| **Merch & add-ons configured** | Same Manage event page (above sales) | `EventStudioExtrasConfiguredSummaryBuilder` | What is set up (counts, top products, CTA) — not revenue |
+| **Merch & add-ons setup** | `/vendor/events/{node}/studio/extras` | Event Studio extras builder | Stock/product editor only — no ticket sales table |
+| **Event commerce (analytics)** | `/vendor/events/{event}/analytics` | Reuses ticket + extras summary services | Separate ticket vs extras KPIs |
+| **Add-on orders (detail)** | `/vendor/events/{event}/addons` | `VendorOperationalAddonOrderBuilder` | Per-order operational line breakdown |
+
+## Category grouping (extras panel)
+
+Display groups (stable order):
+
+1. **Merchandise** — `operational_merchandise` composition lines (excluding parking capability)
+2. **Food / drink** — `operational_product_type` tokens containing food/drink, or timed collection classified as food/drink
+3. **Parking** — composition `parking` group (`parking_addon` capability on merchandise bundle)
+4. **Hospitality** — `hospitality_package` products
+5. **Timed collection** — `timed_collection_product` not classified as food/drink
+6. **Bundles / other add-ons** — `operational_bundle` and unmapped operational lines
+
+Classification uses `OperationalPurchaseCompositionManager`, `field_mel_operational_product` metadata, and product bundle — **never product titles**.
+
+## Order states counted (extras)
+
+Aligned with add-on orders and event orders list:
+
+`completed`, `partially_refunded`, `refunded`, `placed`, `fulfilled`, `fulfillment`
+
+Ticket sold counts on the same page use **`completed` only** (attendance capacity convention).
+
+## Excluded from extras summary
+
+- Ticket-backed order items (`TicketBackedOrderItemClassifier`)
+- Boost / donation lines unless explicitly operational add-on bundles
+- Customer PII, raw payment identifiers, scanner/inventory internals
+- Commerce admin routes
+
+## Stock state (extras groups)
+
+Per category, aggregated from configured event operational products via `OperationalVariationStockResolver::summarizeProductStock()`:
+
+- **Selling** — sales activity or catalog available
+- **Sold out** — all variations in group at zero stock
+- **Low stock** — finite total ≤ 5 across published variations
+- **No stock limit** — at least one unlimited variation
+- **No sales yet** — no qualifying sales and no catalog in group
+
+## Operational documents (planning UI)
+
+Manage event **Merch & add-on sales** panel includes an **Operational documents** area (packing slips, parking slips, labels, export report) — all **Coming soon** until routes exist. No dead links.
+
+See [vendor-operational-documents.md](./vendor-operational-documents.md) for audit, privacy rules, and proposed routes (`/vendor/events/{event}/extras/export`, etc.).
+
+## Distribution / export (deferred)
+
+Manage event panel links:
+
+- **View extras orders** → `myeventlane_vendor.console.event_operational_addon_orders` when available
+- **Manage merch & add-ons** → `myeventlane_event_studio.workspace_extras`
+- **Export extras report** — disabled in Operational documents (next slice: `myeventlane_vendor.event_extras_export`)
+
+Future task: **Operational extras sales export by category/type** (merch team, food/drink vendor, parking, hospitality distribution lists). Email/staff assignment not implemented in this slice.
+
+## Platform fee (merch & add-ons)
+
+- Config: **Admin → Config → MyEventLane → General settings** → `operational_extras_platform_fee_percent`
+- Default when unset: **double** `platform_fee_percent` (tickets)
+- Checkout: `PlatformFeeOrderProcessor` applies separate adjustments:
+  - `myeventlane_platform_fee` on ticket-backed subtotal
+  - `myeventlane_operational_extras_platform_fee` on operational extras subtotal
+- Stripe Connect application fee remains on **ticket revenue only** (unchanged)
+- Studio copy: Merch & add-ons tab intro (`PlatformFeeSettings::buildExtrasStudioFeeCopy()`)
+
+## Still deferred
+
+- CSV export by category/type
+- Email distribution to operational teams
+- Fulfilment / shipping routing
+- Stock reservation / decrement on purchase
+- Refund / restock automation
+- Full analytics reporting (Pro analytics remains separate)
+
+## Implementation map
+
+| Layer | Path |
+|-------|------|
+| Extras summary service | `web/modules/custom/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php` |
+| Ticket summary service | `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioCommerceSalesSummaryBuilder.php` |
+| Manage event controller | `web/modules/custom/myeventlane_vendor/src/Controller/EventWorkspaceController.php` |
+| Extras panel template | `web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-sales-panel.html.twig` |
+| Mission control shell | `web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig` |

--- a/docs/vendor-manage-event-dashboard-ux.md
+++ b/docs/vendor-manage-event-dashboard-ux.md
@@ -1,0 +1,86 @@
+# Vendor Manage event dashboard UX
+
+Canonical route: `/vendor/events/{event}` (`myeventlane_vendor.console.event_workspace`).
+
+## Purpose
+
+Mission-control dashboard for organisers: current event state, next best actions, and compact sales/readiness signals without a long stacked scroll.
+
+## Page structure (top to bottom)
+
+1. **Compact hero** — status chip, title, date, booking type, readiness %; primary **Edit event**, secondary **Preview public event**, tertiary **Advanced ticket manager**.
+2. **Today's focus** — one state-aware message and up to three CTAs (edit tickets, view orders, merch, promote, preview) derived from publication state, readiness score, and booking activity.
+3. **Sales snapshot** — compact metric cards (gross sales, tickets sold, check-ins, orders/RSVPs as applicable).
+4. **Merch & add-ons** (configured summary card) — what products exist, visibility, stock signals, top 3 configured products, CTA to Studio extras. Empty state when none configured.
+5. **Ticket sales** (collapsed `<details>`) — compact table: Ticket | Sold | Remaining | Status. Attendance capacity only; not merged with merch/add-on stock.
+6. **Merch & add-on sales** (collapsed `<details>`) — summary metrics + category rows; **Operational documents** mini-card (packing/parking/labels/export — coming soon). Tickets excluded.
+7. **Manage this event** — grouped action grid: Sales, Setup, Growth.
+8. **Operational readiness** — four grouped accordions (public visibility, booking setup, day-of, event content). Issue groups open by default; all-ready shows compact summary. **Show all readiness checks** expands the legacy checklist.
+9. **Event guidance** — collapsed lifecycle recommendations (formerly full-page lifecycle section).
+
+## Event management sub-route styling
+
+Routes linked from **Manage this event** share `mel_event_workspace` shell:
+
+- Compact header: event title, type/date/status chips (`workspace-header.html.twig`)
+- **Back to Manage event** → `/vendor/events/{event}`
+- Wrapper: `.mel-event-management-shell` + `.mel-workspace__content--event-management` (max-width, card/table overflow)
+
+Applied to: orders, attendees, check-in/door, analytics, tickets, Studio extras (Studio uses its own shell; link back via topbar).
+
+Legacy `/vendor/events/{event}/overview` redirects; tab label is **Manage event** (not Overview).
+
+## Overview → Manage event
+
+| Location | Label |
+|----------|--------|
+| Workspace tab key `overview` | Manage event |
+| `myeventlane_vendor.links.task.yml` | Manage event |
+| Sub-route back link | Back to Manage event |
+| Legacy overview route title | Manage event |
+
+Unchanged: vendor dashboard “Overview”, admin platform Overview, Pro overview, Studio API `saveOverview` field names.
+
+Presentation alerts (ticket/pricing setup) remain above the fold when present.
+
+## What belongs where
+
+| Surface | Responsibility |
+|--------|----------------|
+| **Manage event** (`/vendor/events/{event}`) | State, focus actions, sales snapshot, compact ticket sales, **merch & add-on sales monitoring**, readiness summary, shortcuts |
+| **Tickets** (`/vendor/events/{event}/tickets`, studio tickets) | Ticket types, pricing, capacity configuration |
+| **Merch & add-ons** (`/vendor/events/{node}/studio/extras`) | Operational extras stock and product editor only |
+| **Orders / attendees / check-in** | Linked from action grid; no Commerce admin routes |
+
+## Why readiness is collapsed
+
+Detailed readiness and lifecycle copy duplicated hero signals and pushed metrics below the fold. Grouped `<details>` panels keep keyboard-accessible expansion, show issues only where needed, and preserve the full checklist under **Show all readiness checks**.
+
+## Implementation map
+
+| Layer | File |
+|-------|------|
+| Route | `web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml` |
+| Controller | `web/modules/custom/myeventlane_vendor/src/Controller/EventWorkspaceController.php` |
+| View model | `web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php` |
+| Template | `web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig` |
+| Styles | `web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_event-mission-control.scss` |
+| Ticket panel | `web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-ticket-sales-panel.html.twig` |
+| Extras sales panel | `web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-sales-panel.html.twig` |
+| Extras sales service | `web/modules/custom/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php` |
+| Sales monitoring docs | `docs/vendor-commerce-sales-monitoring.md` |
+| Operational documents (plan) | `docs/vendor-operational-documents.md` |
+
+## Manual QA checklist
+
+- [ ] Open `/vendor/events/{nid}` — first screen shows hero, Today's focus, and sales snapshot without long scroll.
+- [ ] Ticket sales panel appears on Manage event; compact columns when expanded.
+- [ ] Merch & add-on sales panel appears separately; categories show when data exists.
+- [ ] Workspace tab label reads **Manage event** (not Overview).
+- [ ] Sub-routes show **Back to Manage event** linking to `/vendor/events/{event}`.
+- [ ] `/vendor/events/{nid}/studio/extras` does **not** show full ticket sales table.
+- [ ] Action grid links: orders, attendees, check-in, edit event, edit tickets, merch, promote, analytics.
+- [ ] Readiness groups collapse when all ready; issue group opens automatically.
+- [ ] Event guidance expands on click only.
+- [ ] Mobile: focus before sales; tap targets ≥ 44px; accordions usable with keyboard.
+- [ ] No raw Commerce admin URLs exposed.

--- a/docs/vendor-operational-documents.md
+++ b/docs/vendor-operational-documents.md
@@ -1,0 +1,168 @@
+# Vendor operational documents (merch & add-ons)
+
+Status: **planning + Manage event UI placeholders** (no PDF/print generation in this slice)  
+Scope: parking slips, packing slips, item labels, grouped fulfilment sheets, CSV export — **not** ticket issuance
+
+## Purpose
+
+Give organisers printable/operational outputs for merch, parking, food/drink, hospitality, timed collection, and bundles **without** treating extras as admission tickets or building a full fulfilment state machine.
+
+## Part L — Audit: existing PDF / export / label capability
+
+### Reusable for operational extras (read models & patterns)
+
+| Capability | Location | Reuse notes |
+|------------|----------|-------------|
+| **Add-on order visibility** | `VendorOperationalAddonOrderBuilder`, route `myeventlane_vendor.console.event_operational_addon_orders` (`/vendor/events/{event}/addons`) | Order/item grouping by operational category; privacy stripping (`FORBIDDEN_VENDOR_ORDER_KEYS`). Foundation for packing slips and fulfilment sheets. |
+| **Sales summary by category** | `EventOperationalExtrasSalesSummaryBuilder` | Aggregated items/revenue/orders/stock per display group — foundation for grouped fulfilment sheet + future CSV. |
+| **Operational composition** | `OperationalPurchaseCompositionManager` | Canonical line grouping (merch, parking, hospitality, etc.). |
+| **Stock labels** | `OperationalVariationStockResolver` | Stock remaining for export/sheets. |
+| **CSV export patterns** | `VendorAttendeeController::export`, `VendorRsvpExportController`, `BasCsvExportService`, `StreamedResponse` + `fputcsv` | Pattern for future `/extras/export`; not copied blindly (different columns/privacy). |
+| **Tax invoice presentation** | `TaxInvoicePresentationBuilder` | Line-item presentation for **customer** receipts — reference only for line structure, **not** for vendor packing slips (includes payment context). |
+| **Operational entitlement registry** | `OperationalEntitlementCapabilityManager` (`parking_access`, etc.) | Policy/capability metadata for **ticket** operational entitlements — evaluate before any parking QR on slips. |
+
+### Ticket-only — do not reuse directly
+
+| Capability | Location | Why not for extras docs |
+|------------|----------|-------------------------|
+| **Ticket PDF generation** | `TicketPdfGenerator`, `TicketPdfTemplateBuilder`, `TicketDownloadController` | Issues/downloads **admission tickets**; QR tied to ticket/attendee payloads. |
+| **QR for tickets** | `QrCodeGenerator` | Ticket PDF admission QR — **must not** be pasted onto parking/packing slips without a dedicated non-ticket entitlement channel. |
+| **Ticket issuance** | `TicketIssuer`, mixed-order tests | Explicitly excludes operational lines from ticket count. |
+| **Order confirmation PDF recovery** | `OrderPaidConfirmationPdfRecoverySubscriber` | Ticket attachment pipeline only. |
+| **Attendee CSV export** | `myeventlane_event_attendees.vendor_export` | Ticket/RSVP attendee PII model — different purpose. |
+| **Fulfillment execution UI** | `FulfillmentLifecycleManager`, `OperationalFulfillmentExecutionManager` | Ticket-row fulfilment lens; not vendor printable documents. |
+
+### Safe for operational extras (with constraints)
+
+- **Vendor add-on orders page** — already live; customer-safe labels only.
+- **Manage event sales panel** — category metrics; no PII.
+- **Future CSV export** — category/product aggregates; order-level export may include purchaser name only if aligned with existing vendor order screens (no card data, no raw email on slips).
+
+### Deferred
+
+- PDF templates for packing/parking/labels
+- Shipping/warehouse state machines
+- Scanner redemption for extras (unless non-ticket entitlement issuance is designed)
+- Commerce admin routes for vendors
+- Email distribution to operational teams
+- Stock reservation/decrement on print
+
+---
+
+## Part N — Proposed future routes
+
+| Path | Route name (proposed) | Purpose |
+|------|------------------------|---------|
+| `/vendor/events/{event}/extras/orders` | `myeventlane_vendor.event_extras_orders` | Order/item operational extras (may alias or supersede `/addons`) |
+| `/vendor/events/{event}/extras/packing-slips` | `myeventlane_vendor.event_extras_packing_slips` | PDF/HTML packing slips by order or collection group |
+| `/vendor/events/{event}/extras/parking-slips` | `myeventlane_vendor.event_extras_parking_slips` | Parking passes/slips |
+| `/vendor/events/{event}/extras/labels` | `myeventlane_vendor.event_extras_labels` | Item/order labels (print-friendly) |
+| `/vendor/events/{event}/extras/export` | `myeventlane_vendor.event_extras_export` | CSV grouped by category/type |
+
+**Current live route (orders):** `myeventlane_vendor.console.event_operational_addon_orders` → `/vendor/events/{event}/addons` (documented in [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)).
+
+All future routes must:
+
+- Use `VendorConsoleBaseController::assertEventOwnership()` (or equivalent).
+- Render inside `mel_event_workspace` shell where applicable.
+- Never expose Commerce admin paths.
+
+---
+
+## Part O — Document types (future)
+
+### Packing slip
+
+**Purpose:** Vendor/team preparation before/during the event.
+
+**Include:** Event name, date, order ID, purchaser name, collection name/code (if any), items by category, quantity, variant/size, pickup note, safe internal notes.
+
+**Exclude:** Card/payment details, Stripe IDs, platform fee breakdowns.
+
+### Parking slip / parking pass
+
+**Purpose:** Parking team or customer display.
+
+**Include:** Event name, date/time, parking product name, quantity, order reference, parking instructions from product metadata.
+
+**Optional QR:** Only if a **non-ticket** entitlement validation service exists and is explicitly wired — **not** ticket `QrCodeGenerator` payloads.
+
+### Item / order label
+
+**Purpose:** Bag/pack labelling.
+
+**Include:** Short order reference, customer first name or initials (privacy rule), item group, quantity, variant/size, collection window, event name/date.
+
+### Grouped fulfilment sheet
+
+**Purpose:** Team handoff (merch, F&B, parking, hospitality, timed collection, bundles).
+
+**Include:** Per-group totals, order counts, item quantities; mirrors `EventOperationalExtrasSalesSummaryBuilder::DISPLAY_GROUPS`.
+
+---
+
+## Part P — Privacy and access rules
+
+1. **Event scope** — Documents only for the event the vendor owns or is a team member of (`assertEventOwnership` / `EventVendorAccessChecker`).
+2. **Admin/staff** — Platform admin override per existing vendor console rules.
+3. **PII minimisation** — No payment card data on slips/labels. Email/phone hidden on packing slips/labels unless a future fulfilment slice explicitly requires them (document decision in ADR).
+4. **QR / tokens** — Do not reuse ticket QR payloads. Parking validation requires a dedicated operational entitlement path if implemented.
+5. **Audit** — Future generation/download actions should be logged (user, event, document type, timestamp).
+6. **No fake downloads** — UI must use disabled controls or real routes only.
+
+---
+
+## Part Q — CSV export (`/extras/export`)
+
+**Status: deferred** (next slice).
+
+Planned columns (no payment data):
+
+- Event ID, event title  
+- Category/type  
+- Product title, variation/SKU, size/option  
+- Quantity sold, order count, stock remaining  
+
+Implementation should reuse `EventOperationalExtrasSalesSummaryBuilder` + catalog queries; exclude ticket-backed lines via `TicketBackedOrderItemClassifier`.
+
+---
+
+## Part M / R — Current UI (this slice)
+
+**Manage event** — Merch & add-on sales panel includes **Operational documents**:
+
+- Generate packing slips (disabled, Coming soon)  
+- Generate parking slips (disabled, Coming soon)  
+- Print item labels (disabled, Coming soon)  
+- Export extras report (disabled, Coming soon)  
+
+Helper: *Use these to prepare merch, parking, food/drink, and pickup packs for your event.*  
+Notice: *Document generation is coming soon.*
+
+Active links remain: **View extras orders**, **Manage merch & add-ons**.
+
+**Studio extras list** (`/vendor/events/{node}/studio/extras`) — note: *After sales begin, you’ll be able to generate packing slips, parking slips, and labels from Manage event.*
+
+**Studio product editor** (`?extra={product_id}`) — card **“Packing slips, parking slips and labels”** with the same guidance and a **Back to Manage event** link (`myeventlane_vendor.console.event_workspace`). No print/download URLs in the editor. Document generation remains deferred.
+
+---
+
+## Implementation map (UI only)
+
+| Layer | Path |
+|-------|------|
+| Panel data | `web/modules/custom/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder::buildOperationalDocumentsBlock()` |
+| Template | `web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-sales-panel.html.twig` |
+| Styles | `web/modules/custom/myeventlane_event_studio/css/mel-event-studio-extras-sales-panel.css` |
+| Studio list note | `web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php` |
+| Studio editor card | `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder::buildOperationalDocumentsSection()` |
+
+---
+
+## Related docs
+
+- [vendor-commerce-sales-monitoring.md](./vendor-commerce-sales-monitoring.md)  
+- [vendor-manage-event-dashboard-ux.md](./vendor-manage-event-dashboard-ux.md)  
+- [vendor-operational-addon-order-visibility.md](./vendor-operational-addon-order-visibility.md)  
+- [operational-extras-stock-fields.md](./operational-extras-stock-fields.md)  
+- [studio-merch-addon-product-setup.md](./studio-merch-addon-product-setup.md)

--- a/mel-drupal-commerce.mdc
+++ b/mel-drupal-commerce.mdc
@@ -1,0 +1,157 @@
+---
+description: MEL Drupal 11 + Commerce 3 project rules for Cursor
+globs:
+  - "**/*.php"
+  - "**/*.module"
+  - "**/*.install"
+  - "**/*.theme"
+  - "**/*.twig"
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.scss"
+  - "**/*.js"
+  - "**/*.ts"
+  - "composer.json"
+  - "package.json"
+alwaysApply: true
+---
+
+# MyEventLane / MEL Cursor Rules
+
+You are working inside the MyEventLane v2 repository, known as MEL.
+
+MEL is a Drupal 11 event marketplace and ticketing platform using Drupal Commerce 3, custom Drupal modules, custom Twig/SCSS/Vite themes, Commerce checkout flows, vendor dashboards, event discovery, booking UX, media workflows, and Humanitix-level product expectations.
+
+## Core priorities
+
+Follow these priorities in order:
+
+1. Stability
+2. Accuracy
+3. Security
+4. Drupal 11 best practice
+5. Drupal Commerce 3 best practice
+6. Long-term maintainability
+7. Humanitix-level feature parity
+8. MEL continuity
+9. Clean UX
+10. Production readiness
+
+## Source of truth
+
+- Treat this repository as the source of truth.
+- Prefer existing MEL conventions over new patterns.
+- Reference exact file paths in explanations.
+- Do not assume a file, service, route, field, config key, plugin, or library exists unless it is visible in the repository.
+- If something cannot be confirmed from the repository, say: `I cannot confirm this from the repository.`
+- Do not invent Drupal APIs, Commerce services, plugin IDs, field names, routes, config schema, permissions, hooks, libraries, or theme regions.
+
+## Drupal 11 rules
+
+- Use dependency injection where appropriate.
+- Avoid deprecated APIs.
+- Do not use unsafe direct database writes unless there is a clear reason and review.
+- Respect Drupal render arrays, cacheability metadata, access checks, translation, and typed config.
+- Do not bypass entity access.
+- Do not assume unpublished, draft, vendor-owned, or private content is safe to expose.
+- Keep custom modules small, cohesive, and maintainable.
+- Add or update config schema when module config is introduced or changed.
+- Avoid placing business logic in Twig templates.
+- Avoid placing complex business logic in preprocess functions when a service or plugin is more appropriate.
+- Use Drupal coding standards for PHP, YAML, Twig, and JS.
+
+## Drupal Commerce 3 rules
+
+- Assume Drupal Commerce 3 unless repository evidence says otherwise.
+- Keep event content modelling separate from Commerce product modelling.
+- Be explicit about product types, variations, order items, stores, carts, checkout panes, payment gateways, taxes, adjustments, promotions, capacity, stock, and order states.
+- Never change checkout, payments, order ownership, refunds, ticket capacity, stock, or availability logic without calling out risk.
+- Do not assume payment has succeeded until the relevant order/payment state confirms it.
+- Do not expose order, customer, ticket, vendor, or payment information without access review.
+- Do not invent Commerce services or plugin IDs.
+- Check existing Commerce config before recommending product variation, order item, checkout pane, or payment changes.
+
+## MEL UX and theme rules
+
+- Follow MEL’s pastel brand direction and existing design conventions.
+- Use mobile-first responsive layouts.
+- Keep components reusable.
+- Maintain accessible contrast and keyboard usability.
+- Preserve locked hero variants unless the user explicitly asks to change them.
+- Do not introduce layout shifts or inaccessible hidden content.
+- Twig should remain presentation-focused.
+- SCSS should be modular and avoid unnecessary global leakage.
+- Vite/theme changes must be validated with the project build process.
+
+## Security rules
+
+Never propose or make changes that:
+
+- Expose private user, vendor, customer, order, payment, or ticket data.
+- Bypass Drupal access control.
+- Disable CSRF protection.
+- Trust request input without validation.
+- Store secrets in the repository.
+- Add production credentials, API keys, tokens, database dumps, or `.env` secrets.
+- Allow an AI agent to commit directly to `main`.
+- Allow destructive Drush commands without explicit human approval.
+
+Call out risks for:
+
+- Route access changes
+- Custom forms
+- Checkout panes
+- Payment gateway settings
+- Entity queries
+- Vendor dashboard access
+- File/media access
+- Webhooks
+- Cron jobs
+- Batch jobs
+- Queue workers
+- Cache contexts/tags/max-age
+
+## Config and deployment rules
+
+MEL may drift between local, active config, sync config, staging, and production.
+
+When changing config, mention the required validation flow:
+
+```bash
+ddev drush config:status
+ddev drush cim --preview
+ddev drush cex
+ddev drush cr
+```
+
+Before commit, recommend:
+
+```bash
+ddev drush cr
+ddev drush config:status
+ddev composer validate
+npm run lint
+npm run build
+git diff
+```
+
+Only recommend config import/export when it matches the user's actual workflow.
+
+## Git rules
+
+- Work on a feature branch.
+- Keep changes small and reviewable.
+- Do not mix unrelated backend, frontend, config, and content-model changes in one commit unless unavoidable.
+- Explain what needs committing.
+- Warn when generated config, compiled assets, or lock files may also need review.
+- Never suggest force-pushing shared branches unless the user explicitly confirms.
+
+## Response style
+
+- Be direct and technical.
+- Use exact file paths where possible.
+- Provide full file rewrites when asked.
+- Explain only what matters.
+- Give validation commands after code/config/theme changes.
+- State assumptions clearly.
+- Ask one clarifying question only when the missing information blocks safe work.

--- a/web/modules/custom/myeventlane_boost/src/Plugin/Menu/LocalTask/EventWorkspaceBoostLocalTask.php
+++ b/web/modules/custom/myeventlane_boost/src/Plugin/Menu/LocalTask/EventWorkspaceBoostLocalTask.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
  *   id = "myeventlane_boost.event_workspace_boost",
  *   route_name = "myeventlane_boost.vendor_event_boost",
  *   title = @Translation("Boost"),
- *   base_route = "myeventlane_vendor.console.event_overview",
+ *   base_route = "myeventlane_vendor.console.event_workspace",
  *   weight = 22,
  * )
  */

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -62,6 +62,8 @@ services:
     arguments:
       - '@config.factory'
       - '@commerce_price.rounder'
+      - '@myeventlane_commerce.ticket_backed_order_item_classifier'
+      - '@myeventlane_core.platform_fee_settings'
     tags:
       - { name: commerce_order.order_processor, priority: 55 }
 
@@ -237,12 +239,18 @@ services:
       - '@extension.path.resolver'
       - '@string_translation'
 
+  myeventlane_commerce.operational_variation_stock_resolver:
+    class: Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver
+    arguments:
+      - '@string_translation'
+
   myeventlane_commerce.event_operational_addon_builder:
     class: Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder
     arguments:
       - '@entity_type.manager'
       - '@myeventlane_commerce.operational_merchandise_manager'
       - '@myeventlane_commerce.operational_extra_visual_presenter'
+      - '@myeventlane_commerce.operational_variation_stock_resolver'
       - '@string_translation'
 
   myeventlane_commerce.event_operational_addon_teaser_builder:
@@ -328,4 +336,18 @@ services:
       - '@myeventlane_commerce.event_operational_addon_builder'
       - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@date.formatter'
+      - '@string_translation'
+
+  myeventlane_commerce.event_operational_extras_sales_summary_builder:
+    class: Drupal\myeventlane_commerce\Service\EventOperationalExtrasSalesSummaryBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_commerce.vendor_operational_addon_order_builder'
+      - '@myeventlane_commerce.operational_purchase_composition_manager'
+      - '@myeventlane_commerce.operational_merchandise_manager'
+      - '@myeventlane_commerce.event_operational_addon_builder'
+      - '@myeventlane_commerce.operational_variation_stock_resolver'
+      - '@myeventlane_commerce.ticket_backed_order_item_classifier'
+      - '@commerce_price.currency_formatter'
+      - '@router.route_provider'
       - '@string_translation'

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -17,6 +17,7 @@ use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -38,6 +39,7 @@ final class EventOperationalAddonCartForm extends FormBase {
     protected CartProviderInterface $cartProvider,
     protected CartManagerInterface $cartManager,
     protected EventOperationalAddonBuilder $addonBuilder,
+    protected OperationalVariationStockResolver $stockResolver,
     protected CurrencyFormatter $currencyFormatter,
   ) {}
 
@@ -50,6 +52,7 @@ final class EventOperationalAddonCartForm extends FormBase {
       $container->get('commerce_cart.cart_provider'),
       $container->get('commerce_cart.cart_manager'),
       $container->get('myeventlane_commerce.event_operational_addon_builder'),
+      $container->get('myeventlane_commerce.operational_variation_stock_resolver'),
       $container->get('commerce_price.currency_formatter'),
     );
   }
@@ -117,6 +120,12 @@ final class EventOperationalAddonCartForm extends FormBase {
     $size_options = is_array($addon['size_options'] ?? NULL) ? $addon['size_options'] : [];
     $requires_size = !empty($addon['requires_size_selection']);
     $default_vid = (int) ($addon['default_variation_id'] ?? 0);
+    $stock = is_array($addon['stock'] ?? NULL) ? $addon['stock'] : [];
+    $product_sold_out = !empty($stock['sold_out']);
+    $variations = is_array($addon['variations'] ?? NULL) ? $addon['variations'] : [];
+    $default_variation = $variations[0] ?? [];
+    $default_max = is_array($default_variation) ? ($default_variation['max_quantity'] ?? NULL) : NULL;
+    $ui_max = $this->resolveUiMaxQuantity($default_max);
 
     $price_display = $this->resolveDisplayPrice($addon, $size_options);
     $summary_attrs = $this->buildExtraSummaryDataAttributes($addon, $size_options);
@@ -130,6 +139,11 @@ final class EventOperationalAddonCartForm extends FormBase {
         'data-default-variation' => $default_vid > 0 ? (string) $default_vid : '',
       ], $summary_attrs),
     ];
+
+    if ($product_sold_out) {
+      $card['#attributes']['class'][] = 'mel-event-extra-card--sold-out';
+      $card['#attributes']['data-sold-out'] = '1';
+    }
 
     $card['product_id'] = [
       '#type' => 'hidden',
@@ -171,6 +185,22 @@ final class EventOperationalAddonCartForm extends FormBase {
         '#value' => $price_display,
         '#attributes' => ['class' => ['mel-event-extra-card__price']],
       ];
+    }
+
+    $stock_labels = $this->buildStockStatusLabels($addon, $size_options, $default_variation);
+    if ($stock_labels !== []) {
+      $card['body']['stock'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extra-card__stock']],
+      ];
+      foreach ($stock_labels as $label) {
+        $card['body']['stock'][] = [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $label,
+          '#attributes' => ['class' => ['mel-event-extra-card__stock-line']],
+        ];
+      }
     }
 
     $chips = is_array($addon['chips'] ?? NULL) ? $addon['chips'] : [];
@@ -227,8 +257,10 @@ final class EventOperationalAddonCartForm extends FormBase {
           'selected_size' => [
             '#type' => 'radios',
             '#options' => $this->sizeRadioOptions($size_options),
+            '#options_disabled' => $this->disabledSizeOptionKeys($size_options),
             '#default_value' => '',
             '#parents' => ['lines', (string) $index, 'selected_size'],
+            '#disabled' => $product_sold_out,
           ],
         ],
         'selected' => [
@@ -257,12 +289,14 @@ final class EventOperationalAddonCartForm extends FormBase {
       '#title' => $this->t('Quantity'),
       '#title_display' => 'invisible',
       '#min' => 0,
-      '#max' => self::UI_QTY_MAX,
+      '#max' => $ui_max,
       '#step' => 1,
       '#default_value' => 0,
+      '#disabled' => $product_sold_out,
       '#attributes' => [
         'class' => ['mel-event-extra-card__qty-input'],
         'inputmode' => 'numeric',
+        'data-ui-max' => (string) $ui_max,
         'aria-label' => (string) $this->t('Quantity for @title', ['@title' => $title !== '' ? $title : $this->t('this extra')]),
       ],
     ];
@@ -300,10 +334,11 @@ final class EventOperationalAddonCartForm extends FormBase {
       '#attributes' => ['class' => ['mel-event-extra-card__footer']],
       'submit' => [
         '#type' => 'submit',
-        '#value' => $this->t('Add to Cart'),
+        '#value' => $product_sold_out ? $this->t('Sold out') : $this->t('Add to Cart'),
         '#button_type' => 'primary',
         '#name' => 'add_extra_' . $index,
         '#line_index' => $index,
+        '#disabled' => $product_sold_out,
         '#attributes' => [
           'class' => [
             'mel-btn',
@@ -482,9 +517,36 @@ final class EventOperationalAddonCartForm extends FormBase {
         continue;
       }
       $label = (string) ($opt['size_label'] ?? $key);
+      if (!empty($opt['sold_out'])) {
+        $label .= ' (' . $this->t('Sold out') . ')';
+      }
+      elseif (($opt['remaining_label'] ?? '') !== '') {
+        $label .= ' — ' . (string) $opt['remaining_label'];
+      }
       $options[$key] = $label;
     }
     return $options;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $size_options
+   *
+   * @return list<string>
+   */
+  private function disabledSizeOptionKeys(array $size_options): array {
+    $disabled = [];
+    foreach ($size_options as $opt) {
+      if (!is_array($opt)) {
+        continue;
+      }
+      if (!empty($opt['sold_out'])) {
+        $key = (string) ($opt['size_key'] ?? '');
+        if ($key !== '') {
+          $disabled[] = $key;
+        }
+      }
+    }
+    return $disabled;
   }
 
   /**
@@ -626,6 +688,19 @@ final class EventOperationalAddonCartForm extends FormBase {
       }
       if (!in_array($vid, $entry['variation_ids'], TRUE)) {
         $form_state->setErrorByName('lines', $this->t('One or more selected extras are not available for this event.'));
+        return;
+      }
+
+      /** @var \Drupal\commerce_product\Entity\ProductVariationInterface|null $variation */
+      $variation = $this->entityTypeManager->getStorage('commerce_product_variation')->load($vid);
+      if (!$variation instanceof ProductVariationInterface) {
+        $form_state->setErrorByName('lines', $this->t('An extra is no longer available.'));
+        return;
+      }
+
+      $cart = $this->resolveCartForAddonValidation($event, $pid);
+      foreach ($this->stockResolver->validateAddToCartQuantity($variation, $qty, $cart) as $error) {
+        $form_state->setErrorByName('lines][' . $index . '][quantity', $error);
         return;
       }
     }
@@ -810,6 +885,60 @@ final class EventOperationalAddonCartForm extends FormBase {
     }
     $index = (int) $trigger['#line_index'];
     return $index >= 0 ? $index : NULL;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $size_options
+   * @param array<string, mixed> $default_variation
+   *
+   * @return list<string>
+   */
+  private function buildStockStatusLabels(array $addon, array $size_options, array $default_variation): array {
+    if ($size_options !== []) {
+      return [];
+    }
+    $labels = [];
+    if (!empty($default_variation['sold_out'])) {
+      $labels[] = (string) $this->t('Sold out');
+    }
+    elseif (($default_variation['remaining_label'] ?? '') !== '') {
+      $labels[] = (string) $default_variation['remaining_label'];
+    }
+    if (($default_variation['limit_label'] ?? '') !== '') {
+      $labels[] = (string) $default_variation['limit_label'];
+    }
+    $stock = is_array($addon['stock'] ?? NULL) ? $addon['stock'] : [];
+    if ($labels === [] && !empty($stock['unlimited'])) {
+      return [];
+    }
+    return $labels;
+  }
+
+  private function resolveUiMaxQuantity(mixed $configured_max): int {
+    if ($configured_max === NULL) {
+      return self::UI_QTY_MAX;
+    }
+    $max = (int) $configured_max;
+    if ($max < 1) {
+      return 0;
+    }
+    return min(self::UI_QTY_MAX, $max);
+  }
+
+  private function resolveCartForAddonValidation(NodeInterface $event, int $product_id): ?\Drupal\commerce_order\Entity\OrderInterface {
+    $product = $this->entityTypeManager->getStorage('commerce_product')->load($product_id);
+    if (!$product instanceof ProductInterface) {
+      return NULL;
+    }
+    $stores = $product->getStores();
+    if ($stores === []) {
+      return NULL;
+    }
+    $store = reset($stores);
+    if (!$store) {
+      return NULL;
+    }
+    return $this->cartProvider->getCart('default', $store);
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/OrderProcessor/PlatformFeeOrderProcessor.php
+++ b/web/modules/custom/myeventlane_commerce/src/OrderProcessor/PlatformFeeOrderProcessor.php
@@ -8,21 +8,29 @@ use Drupal\commerce_order\Adjustment;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\OrderProcessorInterface;
 use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\commerce_price\RounderInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\myeventlane_core\PlatformFeeDefaults;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_core\Service\PlatformFeeSettings;
 
 /**
- * Applies a configurable platform fee (% of ticket subtotal) to orders.
+ * Applies configurable platform fees to ticket and operational extras subtotals.
  *
- * Fee is calculated on ticket items only. Excludes: donations,
- * Boost items, Pro subscription items, and recurring order types.
+ * Ticket lines use {@see PlatformFeeSettings::getTicketFeePercent()}. Operational
+ * extras use {@see PlatformFeeSettings::getOperationalExtrasFeePercent()}
+ * (defaults to double the ticket rate). Excludes donations, Boost, and Pro.
+ *
  * Configured at: Admin > Config > MyEventLane > General settings.
  */
 final class PlatformFeeOrderProcessor implements OrderProcessorInterface {
 
   use StringTranslationTrait;
+
+  private const SOURCE_TICKET_FEE = 'myeventlane_platform_fee';
+
+  private const SOURCE_EXTRAS_FEE = 'myeventlane_operational_extras_platform_fee';
 
   private const EXCLUDED_ORDER_TYPES = [
     'recurring',
@@ -45,17 +53,11 @@ final class PlatformFeeOrderProcessor implements OrderProcessorInterface {
     'boost_duration',
   ];
 
-  /**
-   * Constructs the processor.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory.
-   * @param \Drupal\commerce_price\RounderInterface $rounder
-   *   The price rounder.
-   */
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
     private readonly RounderInterface $rounder,
+    private readonly TicketBackedOrderItemClassifierInterface $ticketBackedClassifier,
+    private readonly PlatformFeeSettings $platformFeeSettings,
   ) {}
 
   /**
@@ -71,51 +73,89 @@ final class PlatformFeeOrderProcessor implements OrderProcessorInterface {
       return;
     }
 
-    $percent = PlatformFeeDefaults::normalizePercent($settings->get('platform_fee_percent'));
+    $this->removePlatformFeeAdjustments($order);
 
-    if ($percent <= 0) {
-      return;
+    $ticket_percent = $this->platformFeeSettings->getTicketFeePercent();
+    $extras_percent = $this->platformFeeSettings->getOperationalExtrasFeePercent();
+
+    if ($ticket_percent > 0) {
+      $ticket_subtotal = $this->computeTicketBackedSubtotal($order);
+      if ($ticket_subtotal && (float) $ticket_subtotal->getNumber() > 0) {
+        $this->addFeeAdjustment(
+          $order,
+          $ticket_subtotal,
+          $ticket_percent,
+          self::SOURCE_TICKET_FEE,
+          (string) $this->t('Platform fee (@pct%)', ['@pct' => $this->formatPercentLabel($ticket_percent)])
+        );
+      }
     }
 
-    $subtotal = $this->computeTicketSubtotal($order);
-    if (!$subtotal || (float) $subtotal->getNumber() <= 0) {
-      return;
+    if ($extras_percent > 0) {
+      $extras_subtotal = $this->computeOperationalExtrasSubtotal($order);
+      if ($extras_subtotal && (float) $extras_subtotal->getNumber() > 0) {
+        $this->addFeeAdjustment(
+          $order,
+          $extras_subtotal,
+          $extras_percent,
+          self::SOURCE_EXTRAS_FEE,
+          (string) $this->t('Extras platform fee (@pct%)', ['@pct' => $this->formatPercentLabel($extras_percent)])
+        );
+      }
     }
+  }
 
-    $feePrice = $subtotal->multiply((string) ($percent / 100));
-    $rounded = $this->rounder->round($feePrice);
+  private function removePlatformFeeAdjustments(OrderInterface $order): void {
+    foreach ($order->getAdjustments() as $adjustment) {
+      $source = $adjustment->getSourceId();
+      if ($source === self::SOURCE_TICKET_FEE || $source === self::SOURCE_EXTRAS_FEE) {
+        $order->removeAdjustment($adjustment);
+      }
+    }
+  }
+
+  private function addFeeAdjustment(
+    OrderInterface $order,
+    Price $subtotal,
+    float $percent,
+    string $source_id,
+    string $label,
+  ): void {
+    $fee_price = $subtotal->multiply((string) ($percent / 100));
+    $rounded = $this->rounder->round($fee_price);
     if ((float) $rounded->getNumber() <= 0) {
       return;
     }
 
-    $pctLabel = $percent === (float) (int) $percent
-      ? (string) (int) $percent
-      : number_format($percent, 1);
-
     $order->addAdjustment(new Adjustment([
       'type' => 'fee',
-      'label' => (string) $this->t('Platform fee (@pct%)', ['@pct' => $pctLabel]),
+      'label' => $label,
       'amount' => $rounded,
-      'source_id' => 'myeventlane_platform_fee',
+      'source_id' => $source_id,
     ]));
   }
 
+  private function formatPercentLabel(float $percent): string {
+    return $percent === (float) (int) $percent
+      ? (string) (int) $percent
+      : number_format($percent, 1);
+  }
+
   /**
-   * Computes the subtotal of ticket items (excludes donations and Boost).
+   * Subtotal of ticket-backed order items only.
    */
-  private function computeTicketSubtotal(OrderInterface $order): ?Price {
+  private function computeTicketBackedSubtotal(OrderInterface $order): ?Price {
     $total = NULL;
 
     foreach ($order->getItems() as $item) {
-      if (in_array($item->bundle(), self::EXCLUDED_BUNDLES, TRUE)) {
+      $purchased = $item->getPurchasedEntity();
+      $variation_bundle = $purchased instanceof ProductVariationInterface ? $purchased->bundle() : NULL;
+      if (!$this->isEligibleLineItem($item->bundle(), $variation_bundle)) {
         continue;
       }
-
-      $purchasedEntity = $item->getPurchasedEntity();
-      if ($purchasedEntity && in_array($purchasedEntity->bundle(), self::EXCLUDED_VARIATION_TYPES, TRUE)) {
+      if (!$this->ticketBackedClassifier->isTicketBackedOrderItem($item)) {
         continue;
       }
-
       $price = $item->getTotalPrice();
       if (!$price) {
         continue;
@@ -124,6 +164,44 @@ final class PlatformFeeOrderProcessor implements OrderProcessorInterface {
     }
 
     return $total;
+  }
+
+  /**
+   * Subtotal of operational extras order items (not ticket-backed).
+   */
+  private function computeOperationalExtrasSubtotal(OrderInterface $order): ?Price {
+    $total = NULL;
+
+    foreach ($order->getItems() as $item) {
+      $purchased = $item->getPurchasedEntity();
+      $variation_bundle = $purchased instanceof ProductVariationInterface ? $purchased->bundle() : NULL;
+      if (!$this->isEligibleLineItem($item->bundle(), $variation_bundle)) {
+        continue;
+      }
+      if (!$this->ticketBackedClassifier->isOperationalOrderItem($item)) {
+        continue;
+      }
+      $price = $item->getTotalPrice();
+      if (!$price) {
+        continue;
+      }
+      $total = $total ? $total->add($price) : $price;
+    }
+
+    return $total;
+  }
+
+  /**
+   * @param string|null $variation_bundle
+   */
+  private function isEligibleLineItem(string $order_item_bundle, ?string $variation_bundle): bool {
+    if (in_array($order_item_bundle, self::EXCLUDED_BUNDLES, TRUE)) {
+      return FALSE;
+    }
+    if ($variation_bundle !== NULL && in_array($variation_bundle, self::EXCLUDED_VARIATION_TYPES, TRUE)) {
+      return FALSE;
+    }
+    return TRUE;
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalAddonBuilder.php
@@ -60,6 +60,7 @@ final class EventOperationalAddonBuilder {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
     private readonly OperationalExtraVisualPresenter $visualPresenter,
+    private readonly OperationalVariationStockResolver $stockResolver,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -143,6 +144,7 @@ final class EventOperationalAddonBuilder {
           'size_key' => $size['size_key'],
           'size_label' => $size['size_label'],
         ];
+        $row += $this->stockResolver->buildVariationCustomerStock($variation);
         $variations[] = $row;
 
         if ($size['size_key'] !== '') {
@@ -152,6 +154,10 @@ final class EventOperationalAddonBuilder {
             'size_label' => $size['size_label'],
             'price_number' => $row['price_number'],
             'price_currency_code' => $row['price_currency_code'],
+            'sold_out' => !empty($row['sold_out']),
+            'remaining_label' => (string) ($row['remaining_label'] ?? ''),
+            'limit_label' => (string) ($row['limit_label'] ?? ''),
+            'max_quantity' => $row['max_quantity'],
           ];
         }
       }
@@ -172,12 +178,17 @@ final class EventOperationalAddonBuilder {
             'size_label' => $label,
             'price_number' => (string) ($v['price_number'] ?? ''),
             'price_currency_code' => (string) ($v['price_currency_code'] ?? ''),
+            'sold_out' => !empty($v['sold_out']),
+            'remaining_label' => (string) ($v['remaining_label'] ?? ''),
+            'limit_label' => (string) ($v['limit_label'] ?? ''),
+            'max_quantity' => $v['max_quantity'] ?? NULL,
           ];
         }
       }
 
       $requires_size = count($size_options) > 1;
       $default_variation_id = count($variations) === 1 ? (int) $variations[0]['variation_id'] : NULL;
+      $product_stock = $this->stockResolver->summarizeProductStock($product);
 
       $chips = $this->buildCustomerChips($visual, $presentation);
 
@@ -196,6 +207,7 @@ final class EventOperationalAddonBuilder {
         'requires_size_selection' => $requires_size,
         'default_variation_id' => $default_variation_id,
         'chips' => $chips,
+        'stock' => $product_stock,
         'operational' => [
           'operational_summary' => $visual['short_description'],
           'operational_chips' => $chips,

--- a/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php
@@ -1,0 +1,599 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Drupal\node\NodeInterface;
+
+/**
+ * Read-only event-scoped operational extras sales summary for vendor dashboards.
+ *
+ * Ticket-backed order items, boosts, and donations are excluded. Grouping uses
+ * {@see OperationalPurchaseCompositionManager} plus operational product metadata
+ * (never product titles).
+ */
+final class EventOperationalExtrasSalesSummaryBuilder {
+
+  use StringTranslationTrait;
+
+  /**
+   * Display groups shown on Manage event (stable order).
+   *
+   * @var list<string>
+   */
+  public const DISPLAY_GROUPS = [
+    'merchandise',
+    'food_drink',
+    'parking',
+    'hospitality',
+    'timed_collection',
+    'bundles',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly VendorOperationalAddonOrderBuilder $vendorOperationalAddonOrderBuilder,
+    private readonly OperationalPurchaseCompositionManager $purchaseCompositionManager,
+    private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
+    private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
+    private readonly OperationalVariationStockResolver $stockResolver,
+    private readonly TicketBackedOrderItemClassifierInterface $ticketBackedClassifier,
+    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly RouteProviderInterface $routeProvider,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds the Merch & add-on sales panel payload.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildExtrasSalesPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    if ($event_id < 1 || $event->bundle() !== 'event') {
+      return $this->emptyPanel($event);
+    }
+
+    $groups = $this->emptyGroupAccumulator();
+    $catalog_stock = $this->buildCatalogStockByGroup($event);
+    $order_ids_with_extras = [];
+    $currency_code = NULL;
+    $revenue_totals = array_fill_keys(self::DISPLAY_GROUPS, 0.0);
+
+    foreach ($this->vendorOperationalAddonOrderBuilder->loadQualifyingOrdersForEvent($event) as $order) {
+      if (!$this->vendorOperationalAddonOrderBuilder->orderHasOperationalAddons($order, $event_id)) {
+        continue;
+      }
+      $composition = $this->purchaseCompositionManager->composeForOrder($order);
+      $composition_groups = is_array($composition['groups'] ?? NULL) ? $composition['groups'] : [];
+      $order_touched = FALSE;
+
+      foreach (['merchandise', 'hospitality', 'timed_collection', 'bundles', 'parking'] as $composition_key) {
+        $lines = is_array($composition_groups[$composition_key] ?? NULL) ? $composition_groups[$composition_key] : [];
+        foreach ($lines as $line) {
+          if (!is_array($line)) {
+            continue;
+          }
+          $order_item = $this->resolveOrderItem($line, $order);
+          if (!$order_item instanceof OrderItemInterface) {
+            continue;
+          }
+          if ($this->ticketBackedClassifier->isTicketBackedOrderItem($order_item)) {
+            continue;
+          }
+          if (!$this->orderItemIsForEvent($order_item, $event_id)) {
+            continue;
+          }
+
+          $presentation = is_array($line['presentation'] ?? NULL) ? $line['presentation'] : [];
+          $display_key = $this->displayCategoryFromCompositionGroup(
+            $composition_key,
+            strtolower((string) ($presentation['operational_product_type'] ?? '')),
+          );
+          if (!isset($groups[$display_key])) {
+            $display_key = 'bundles';
+          }
+
+          $qty = (int) round((float) $order_item->getQuantity());
+          $total_price = $order_item->getAdjustedTotalPrice();
+          if ($total_price instanceof Price) {
+            $currency_code = $currency_code ?? $total_price->getCurrencyCode();
+            $revenue_totals[$display_key] += (float) $total_price->getNumber();
+          }
+
+          $groups[$display_key]['items_sold'] += $qty;
+          $groups[$display_key]['order_ids'][(int) $order->id()] = TRUE;
+          $order_touched = TRUE;
+        }
+      }
+
+      if ($order_touched) {
+        $order_ids_with_extras[(int) $order->id()] = TRUE;
+      }
+    }
+
+    $rows = [];
+    $total_revenue_amount = 0.0;
+    $total_items = 0;
+    $top_category = NULL;
+    $top_items = 0;
+
+    foreach (self::DISPLAY_GROUPS as $group_key) {
+      $bucket = $groups[$group_key];
+      $items_sold = (int) $bucket['items_sold'];
+      $revenue_amount = (float) ($revenue_totals[$group_key] ?? 0.0);
+      $order_count = count($bucket['order_ids']);
+      $catalog = $catalog_stock[$group_key] ?? $this->emptyCatalogStock();
+      $total_revenue_amount += $revenue_amount;
+      $total_items += $items_sold;
+
+      if ($items_sold > $top_items) {
+        $top_items = $items_sold;
+        $top_category = $this->groupLabel($group_key);
+      }
+
+      $rows[] = [
+        'key' => $group_key,
+        'label' => $this->groupLabel($group_key),
+        'items_sold' => $items_sold,
+        'revenue' => $this->formatAmount($revenue_amount, $currency_code),
+        'order_count' => $order_count,
+        'stock_remaining_label' => $catalog['stock_label'],
+        'stock_state' => $catalog['stock_state'],
+        'has_catalog' => $catalog['has_catalog'],
+        'status' => $this->resolveGroupStatus($items_sold, $catalog),
+      ];
+    }
+
+    $addon_orders_url = NULL;
+    if ($this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')) {
+      $addon_orders_url = Url::fromRoute('myeventlane_vendor.console.event_operational_addon_orders', ['event' => $event_id])->toString();
+    }
+
+    return [
+      'has_rows' => $total_items > 0 || $this->eventHasConfiguredCatalog($event),
+      'summary' => [
+        'total_revenue' => $this->formatAmount($total_revenue_amount, $currency_code),
+        'total_items_sold' => $total_items,
+        'orders_with_extras' => count($order_ids_with_extras),
+        'top_category' => $top_category ?? (string) $this->t('—'),
+      ],
+      'rows' => $rows,
+      'empty_message' => (string) $this->t('No extras sold yet. Configure merch and add-ons to start tracking sales here.'),
+      'helper_copy' => (string) $this->t('Track extras sold through this event. Tickets are counted separately.'),
+      'sold_order_states' => VendorOperationalAddonOrderBuilder::QUALIFYING_ORDER_STATES,
+      'sold_basis' => 'operational_composition_lines',
+      'actions' => [
+        'view_orders' => [
+          'label' => (string) $this->t('View extras orders'),
+          'url' => $addon_orders_url,
+          'available' => $addon_orders_url !== NULL,
+        ],
+        'manage_extras' => [
+          'label' => (string) $this->t('Manage merch & add-ons'),
+          'url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event_id])->toString(),
+          'available' => TRUE,
+        ],
+      ],
+      'operational_documents' => $this->buildOperationalDocumentsBlock(),
+      'cache_tags' => $this->vendorOperationalAddonOrderBuilder->collectCacheTagsForEvent($event),
+    ];
+  }
+
+  /**
+   * Builds a themed render array for the extras sales panel.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildExtrasSalesPanelRenderArray(NodeInterface $event, int $weight = 0): array {
+    $panel = $this->buildExtrasSalesPanel($event);
+    return [
+      '#theme' => 'mel_event_studio_extras_sales_panel',
+      '#panel' => $panel,
+      '#weight' => $weight,
+      '#cache' => [
+        'tags' => $panel['cache_tags'] ?? $event->getCacheTags(),
+        'contexts' => ['user'],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, array<string, mixed>>
+   */
+  private function emptyGroupAccumulator(): array {
+    $groups = [];
+    foreach (self::DISPLAY_GROUPS as $key) {
+      $groups[$key] = [
+        'items_sold' => 0,
+        'order_ids' => [],
+      ];
+    }
+    return $groups;
+  }
+
+  /**
+   * @return array<string, array<string, mixed>>
+   */
+  private function buildCatalogStockByGroup(NodeInterface $event): array {
+    $out = [];
+    foreach (self::DISPLAY_GROUPS as $key) {
+      $out[$key] = $this->emptyCatalogStock();
+    }
+
+    $built = $this->eventOperationalAddonBuilder->buildForEvent($event);
+    $product_ids = $built['product_ids'] ?? [];
+    if (!$product_ids) {
+      return $out;
+    }
+
+    /** @var \Drupal\commerce_product\Entity\ProductInterface[] $products */
+    $products = $this->entityTypeManager->getStorage('commerce_product')->loadMultiple($product_ids);
+    foreach ($products as $product) {
+      if (!$product instanceof ProductInterface) {
+        continue;
+      }
+      $payload = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
+      $group_key = $this->displayCategoryForProduct($product, $payload);
+      if (!isset($out[$group_key])) {
+        $group_key = 'bundles';
+      }
+      $stock = $this->stockResolver->summarizeProductStock($product);
+      $out[$group_key]['has_catalog'] = TRUE;
+      $out[$group_key]['product_count']++;
+      $out[$group_key]['stock_states'][] = (string) ($stock['stock_state'] ?? 'unknown');
+      if ($stock['total_stock'] === NULL) {
+        $out[$group_key]['has_unlimited'] = TRUE;
+      }
+      elseif (is_int($stock['total_stock'])) {
+        $out[$group_key]['total_finite_stock'] += $stock['total_stock'];
+      }
+      if (!empty($stock['sold_out'])) {
+        // Keep all_sold_out TRUE only when every product in the group is sold out.
+      }
+      else {
+        $out[$group_key]['all_sold_out'] = FALSE;
+      }
+      if (!empty($stock['low_stock'])) {
+        $out[$group_key]['has_low_stock'] = TRUE;
+      }
+    }
+
+    foreach ($out as $key => $bucket) {
+      if (!$bucket['has_catalog']) {
+        continue;
+      }
+      if ($bucket['all_sold_out']) {
+        $out[$key]['stock_state'] = 'sold_out';
+        $out[$key]['stock_label'] = (string) $this->t('Sold out');
+      }
+      elseif ($bucket['has_unlimited']) {
+        $out[$key]['stock_state'] = 'unlimited';
+        $out[$key]['stock_label'] = (string) $this->t('No stock limit');
+      }
+      elseif ($bucket['has_low_stock']) {
+        $out[$key]['stock_state'] = 'low';
+        $out[$key]['stock_label'] = (string) $this->t('@count remaining', ['@count' => $bucket['total_finite_stock']]);
+      }
+      else {
+        $out[$key]['stock_state'] = 'finite';
+        $out[$key]['stock_label'] = (string) $this->t('@count remaining', ['@count' => $bucket['total_finite_stock']]);
+      }
+    }
+
+    return $out;
+  }
+
+  /**
+   * @return array{has_catalog: bool, product_count: int, stock_state: string, stock_label: string, total_finite_stock: int, has_unlimited: bool, all_sold_out: bool, has_low_stock: bool, stock_states: list<string>}
+   */
+  private function emptyCatalogStock(): array {
+    return [
+      'has_catalog' => FALSE,
+      'product_count' => 0,
+      'stock_state' => 'unknown',
+      'stock_label' => (string) $this->t('—'),
+      'total_finite_stock' => 0,
+      'has_unlimited' => FALSE,
+      'all_sold_out' => TRUE,
+      'has_low_stock' => FALSE,
+      'stock_states' => [],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   */
+  private function displayCategoryForProductBundle(string $bundle, array $payload): string {
+    $product_type = strtolower((string) ($payload['operational_product_type'] ?? ''));
+    $capability = strtolower((string) ($payload['capability_reference'] ?? ''));
+
+    if ($bundle === 'operational_merchandise' && $capability === 'parking_addon') {
+      return 'parking';
+    }
+    if ($bundle === 'hospitality_package') {
+      return 'hospitality';
+    }
+    if ($bundle === 'operational_bundle') {
+      return 'bundles';
+    }
+    if ($bundle === 'timed_collection_product') {
+      return $this->isFoodDrinkType($product_type) ? 'food_drink' : 'timed_collection';
+    }
+    if ($this->isFoodDrinkType($product_type)) {
+      return 'food_drink';
+    }
+    return 'merchandise';
+  }
+
+  private function displayCategoryFromCompositionGroup(string $composition_key, string $product_type): string {
+    return match ($composition_key) {
+      'parking' => 'parking',
+      'hospitality' => 'hospitality',
+      'bundles' => 'bundles',
+      'timed_collection' => $this->isFoodDrinkType($product_type) ? 'food_drink' : 'timed_collection',
+      default => $this->isFoodDrinkType($product_type) ? 'food_drink' : 'merchandise',
+    };
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   */
+  private function displayCategoryForProduct(ProductInterface $product, array $payload): string {
+    return $this->displayCategoryForProductBundle($product->bundle(), $payload);
+  }
+
+  private function isFoodDrinkType(string $product_type): bool {
+    if ($product_type === '') {
+      return FALSE;
+    }
+    return str_contains($product_type, 'food')
+      || str_contains($product_type, 'drink')
+      || $product_type === 'food_drink'
+      || $product_type === 'food_drink_redemption';
+  }
+
+  /**
+   * @param array<string, mixed> $catalog
+   *
+   * @return array{key: string, label: string, tone: string}
+   */
+  private function resolveGroupStatus(int $items_sold, array $catalog): array {
+    $stock_state = (string) ($catalog['stock_state'] ?? 'unknown');
+    $has_catalog = !empty($catalog['has_catalog']);
+
+    if ($items_sold === 0) {
+      if (!$has_catalog) {
+        return [
+          'key' => 'no_sales',
+          'label' => (string) $this->t('No sales yet'),
+          'tone' => 'muted',
+        ];
+      }
+      if ($stock_state === 'sold_out') {
+        return [
+          'key' => 'sold_out',
+          'label' => (string) $this->t('Sold out'),
+          'tone' => 'warning',
+        ];
+      }
+      if ($stock_state === 'unlimited') {
+        return [
+          'key' => 'no_stock_limit',
+          'label' => (string) $this->t('No stock limit'),
+          'tone' => 'info',
+        ];
+      }
+      return [
+        'key' => 'selling',
+        'label' => (string) $this->t('Selling'),
+        'tone' => 'success',
+      ];
+    }
+
+    if ($stock_state === 'sold_out') {
+      return [
+        'key' => 'sold_out',
+        'label' => (string) $this->t('Sold out'),
+        'tone' => 'warning',
+      ];
+    }
+    if ($stock_state === 'low') {
+      return [
+        'key' => 'low_stock',
+        'label' => (string) $this->t('Low stock'),
+        'tone' => 'warning',
+      ];
+    }
+    if ($stock_state === 'unlimited') {
+      return [
+        'key' => 'no_stock_limit',
+        'label' => (string) $this->t('No stock limit'),
+        'tone' => 'info',
+      ];
+    }
+
+    return [
+      'key' => 'selling',
+      'label' => (string) $this->t('Selling'),
+      'tone' => 'success',
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $line
+   */
+  private function resolveOrderItem(array $line, OrderInterface $order): ?OrderItemInterface {
+    $order_item_id = (int) ($line['order_item_id'] ?? 0);
+    if ($order_item_id < 1) {
+      return NULL;
+    }
+    foreach ($order->getItems() as $item) {
+      if ((int) $item->id() === $order_item_id && $item instanceof OrderItemInterface) {
+        return $item;
+      }
+    }
+    return NULL;
+  }
+
+  private function orderItemIsForEvent(OrderItemInterface $item, int $event_id): bool {
+    if ($item->bundle() === 'boost') {
+      return FALSE;
+    }
+    if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+      if ((int) $item->get('field_target_event')->target_id === $event_id) {
+        return TRUE;
+      }
+    }
+    $variation = $item->getPurchasedEntity();
+    if (!$variation instanceof ProductVariationInterface) {
+      return FALSE;
+    }
+    if ($variation->hasField('field_event') && !$variation->get('field_event')->isEmpty()) {
+      if ((int) $variation->get('field_event')->target_id === $event_id) {
+        return TRUE;
+      }
+    }
+    $product = $variation->getProduct();
+    if ($product instanceof ProductInterface
+      && $product->hasField('field_event')
+      && !$product->get('field_event')->isEmpty()
+      && (int) $product->get('field_event')->target_id === $event_id) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  private function eventHasConfiguredCatalog(NodeInterface $event): bool {
+    return $this->eventOperationalAddonBuilder->buildForEvent($event)['addons'] !== [];
+  }
+
+  private function formatAmount(float $amount, ?string $currency_code): string {
+    if ($amount <= 0.0) {
+      return '—';
+    }
+    $code = $currency_code ?? 'AUD';
+    return $this->currencyFormatter->format((string) $amount, $code);
+  }
+
+  private function groupLabel(string $group_key): string {
+    return match ($group_key) {
+      'merchandise' => (string) $this->t('Merchandise'),
+      'food_drink' => (string) $this->t('Food / drink'),
+      'parking' => (string) $this->t('Parking'),
+      'hospitality' => (string) $this->t('Hospitality'),
+      'timed_collection' => (string) $this->t('Timed collection'),
+      'bundles' => (string) $this->t('Bundles / other add-ons'),
+      default => (string) $this->t('Add-ons'),
+    };
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function emptyPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    $rows = [];
+    foreach (self::DISPLAY_GROUPS as $group_key) {
+      $rows[] = [
+        'key' => $group_key,
+        'label' => $this->groupLabel($group_key),
+        'items_sold' => 0,
+        'revenue' => '—',
+        'order_count' => 0,
+        'stock_remaining_label' => '—',
+        'stock_state' => 'unknown',
+        'has_catalog' => FALSE,
+        'status' => [
+          'key' => 'no_sales',
+          'label' => (string) $this->t('No sales yet'),
+          'tone' => 'muted',
+        ],
+      ];
+    }
+
+    return [
+      'has_rows' => FALSE,
+      'summary' => [
+        'total_revenue' => '—',
+        'total_items_sold' => 0,
+        'orders_with_extras' => 0,
+        'top_category' => '—',
+      ],
+      'rows' => $rows,
+      'empty_message' => (string) $this->t('No extras sold yet. Configure merch and add-ons to start tracking sales here.'),
+      'helper_copy' => (string) $this->t('Track extras sold through this event. Tickets are counted separately.'),
+      'sold_order_states' => VendorOperationalAddonOrderBuilder::QUALIFYING_ORDER_STATES,
+      'sold_basis' => 'operational_composition_lines',
+      'actions' => [
+        'view_orders' => ['label' => (string) $this->t('View extras orders'), 'url' => NULL, 'available' => FALSE],
+        'manage_extras' => [
+          'label' => (string) $this->t('Manage merch & add-ons'),
+          'url' => $event_id > 0
+            ? Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event_id])->toString()
+            : NULL,
+          'available' => $event_id > 0,
+        ],
+      ],
+      'operational_documents' => $this->buildOperationalDocumentsBlock(),
+      'cache_tags' => $event->getCacheTags(),
+    ];
+  }
+
+  /**
+   * Operational document actions for Manage event (routes deferred until implemented).
+   *
+   * @return array<string, mixed>
+   */
+  private function buildOperationalDocumentsBlock(): array {
+    $coming_soon = (string) $this->t('Coming soon');
+    $deferred_notice = (string) $this->t('Document generation is coming soon.');
+
+    $item = static fn (string $key, string $label): array => [
+      'key' => $key,
+      'label' => $label,
+      'url' => NULL,
+      'available' => FALSE,
+      'deferred' => TRUE,
+      'coming_soon' => $coming_soon,
+    ];
+
+    return [
+      'heading' => (string) $this->t('Operational documents'),
+      'helper' => (string) $this->t('Use these to prepare merch, parking, food/drink, and pickup packs for your event.'),
+      'deferred_notice' => $deferred_notice,
+      'items' => [
+        'packing_slips' => $item('packing_slips', (string) $this->t('Generate packing slips')),
+        'parking_slips' => $item('parking_slips', (string) $this->t('Generate parking slips')),
+        'labels' => $item('labels', (string) $this->t('Print item labels')),
+        'export_report' => $item('export_report', (string) $this->t('Export extras report')),
+      ],
+    ];
+  }
+
+  private function routeExists(string $route_name): bool {
+    try {
+      $this->routeProvider->getRouteByName($route_name);
+      return TRUE;
+    }
+    catch (RouteNotFoundException) {
+      return FALSE;
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/OperationalVariationStockResolver.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OperationalVariationStockResolver.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Reads and validates operational extra stock on Commerce product variations.
+ *
+ * Blank stock quantity = unlimited. Zero stock quantity = sold out.
+ * Does not decrement stock, reserve inventory, or mutate carts beyond validation.
+ */
+final class OperationalVariationStockResolver {
+
+  use StringTranslationTrait;
+
+  public const FIELD_STOCK_QUANTITY = 'field_mel_stock_quantity';
+
+  public const FIELD_LIMIT_PER_ORDER = 'field_mel_limit_per_order';
+
+  public const FIELD_SHOW_REMAINING = 'field_mel_show_remaining';
+
+  /**
+   * @var list<string>
+   */
+  public const OPERATIONAL_VARIATION_BUNDLES = [
+    'operational_merchandise_var',
+    'operational_bundle_var',
+    'hospitality_package_var',
+    'timed_collection_var',
+  ];
+
+  public function __construct(
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Whether a variation bundle supports MEL operational stock fields.
+   */
+  public function bundleSupportsStock(string $variation_bundle): bool {
+    return in_array($variation_bundle, self::OPERATIONAL_VARIATION_BUNDLES, TRUE);
+  }
+
+  /**
+   * Reads stock quantity: NULL = unlimited, 0 = sold out, positive = finite.
+   */
+  public function readStockQuantity(ProductVariationInterface $variation): ?int {
+    if (!$variation->hasField(self::FIELD_STOCK_QUANTITY) || $variation->get(self::FIELD_STOCK_QUANTITY)->isEmpty()) {
+      return NULL;
+    }
+    return max(0, (int) $variation->get(self::FIELD_STOCK_QUANTITY)->value);
+  }
+
+  /**
+   * Reads per-order limit; NULL means no limit.
+   */
+  public function readLimitPerOrder(ProductVariationInterface $variation): ?int {
+    if (!$variation->hasField(self::FIELD_LIMIT_PER_ORDER) || $variation->get(self::FIELD_LIMIT_PER_ORDER)->isEmpty()) {
+      return NULL;
+    }
+    $limit = (int) $variation->get(self::FIELD_LIMIT_PER_ORDER)->value;
+    return $limit >= 1 ? $limit : NULL;
+  }
+
+  public function readShowRemaining(ProductVariationInterface $variation): bool {
+    if (!$variation->hasField(self::FIELD_SHOW_REMAINING) || $variation->get(self::FIELD_SHOW_REMAINING)->isEmpty()) {
+      return FALSE;
+    }
+    return (bool) $variation->get(self::FIELD_SHOW_REMAINING)->value;
+  }
+
+  public function isSoldOut(ProductVariationInterface $variation): bool {
+    $stock = $this->readStockQuantity($variation);
+    return $stock !== NULL && $stock === 0;
+  }
+
+  public function isUnlimited(ProductVariationInterface $variation): bool {
+    return $this->readStockQuantity($variation) === NULL;
+  }
+
+  /**
+   * Normalizes vendor input: blank = unlimited (NULL), 0 = sold out.
+   */
+  public function normalizeStockInput(mixed $raw): ?int {
+    if ($raw === NULL || $raw === '') {
+      return NULL;
+    }
+    if (!is_scalar($raw)) {
+      return NULL;
+    }
+    $text = trim((string) $raw);
+    if ($text === '') {
+      return NULL;
+    }
+    if (!is_numeric($text)) {
+      return NULL;
+    }
+    return max(0, (int) $text);
+  }
+
+  /**
+   * Normalizes limit input: blank = no limit (NULL).
+   */
+  public function normalizeLimitInput(mixed $raw): ?int {
+    if ($raw === NULL || $raw === '') {
+      return NULL;
+    }
+    if (!is_scalar($raw)) {
+      return NULL;
+    }
+    $text = trim((string) $raw);
+    if ($text === '' || !is_numeric($text)) {
+      return NULL;
+    }
+    $limit = (int) $text;
+    return $limit >= 1 ? $limit : NULL;
+  }
+
+  public function normalizeShowRemaining(mixed $raw): bool {
+    return !empty($raw);
+  }
+
+  /**
+   * @param array<string, mixed> $stock_input
+   *   Keys: stock_quantity, limit_per_order, show_remaining.
+   *
+   * @return list<string>
+   */
+  public function validateStockInput(array $stock_input): array {
+    $errors = [];
+    $stock = $this->normalizeStockInput($stock_input['stock_quantity'] ?? NULL);
+    $limit = $this->normalizeLimitInput($stock_input['limit_per_order'] ?? NULL);
+    if ($stock !== NULL && $limit !== NULL && $stock > 0 && $limit > $stock) {
+      $errors[] = (string) $this->t('Limit per order cannot exceed stock quantity.');
+    }
+    return $errors;
+  }
+
+  /**
+   * Applies normalized stock fields to a variation when configured.
+   *
+   * @param array<string, mixed> $stock_input
+   */
+  public function applyStockFields(ProductVariationInterface $variation, array $stock_input): void {
+    if (!$this->bundleSupportsStock($variation->bundle())) {
+      return;
+    }
+    $stock = $this->normalizeStockInput($stock_input['stock_quantity'] ?? NULL);
+    $limit = $this->normalizeLimitInput($stock_input['limit_per_order'] ?? NULL);
+    $show = $this->normalizeShowRemaining($stock_input['show_remaining'] ?? FALSE);
+
+    if ($variation->hasField(self::FIELD_STOCK_QUANTITY)) {
+      if ($stock === NULL) {
+        $variation->set(self::FIELD_STOCK_QUANTITY, NULL);
+      }
+      else {
+        $variation->set(self::FIELD_STOCK_QUANTITY, $stock);
+      }
+    }
+    if ($variation->hasField(self::FIELD_LIMIT_PER_ORDER)) {
+      if ($limit === NULL) {
+        $variation->set(self::FIELD_LIMIT_PER_ORDER, NULL);
+      }
+      else {
+        $variation->set(self::FIELD_LIMIT_PER_ORDER, $limit);
+      }
+    }
+    if ($variation->hasField(self::FIELD_SHOW_REMAINING)) {
+      $variation->set(self::FIELD_SHOW_REMAINING, $show ? 1 : 0);
+    }
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   Keys: stock_quantity, limit_per_order, show_remaining.
+   */
+  public function extractStockFields(ProductVariationInterface $variation): array {
+    return [
+      'stock_quantity' => $this->readStockQuantity($variation),
+      'limit_per_order' => $this->readLimitPerOrder($variation),
+      'show_remaining' => $this->readShowRemaining($variation),
+    ];
+  }
+
+  /**
+   * Customer-safe stock metadata for a variation row.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildVariationCustomerStock(ProductVariationInterface $variation): array {
+    $stock = $this->readStockQuantity($variation);
+    $limit = $this->readLimitPerOrder($variation);
+    $show_remaining = $this->readShowRemaining($variation);
+    $sold_out = $stock !== NULL && $stock === 0;
+    $unlimited = $stock === NULL;
+
+    return [
+      'stock_quantity' => $stock,
+      'limit_per_order' => $limit,
+      'show_remaining' => $show_remaining,
+      'sold_out' => $sold_out,
+      'unlimited' => $unlimited,
+      'remaining_label' => $this->buildRemainingLabel($stock, $show_remaining),
+      'limit_label' => $this->buildLimitLabel($limit),
+      'max_quantity' => $this->maxPurchasableQuantity($variation, NULL),
+    ];
+  }
+
+  /**
+   * Summarizes stock across published variations for Studio cards.
+   *
+   * @return array<string, mixed>
+   */
+  public function summarizeProductStock(ProductInterface $product): array {
+    $published = [];
+    $has_unlimited = FALSE;
+    $total_finite = 0;
+    $all_sold_out = TRUE;
+    $limits = [];
+
+    foreach ($product->getVariations() as $variation) {
+      if (!$variation instanceof ProductVariationInterface || !$variation->isPublished()) {
+        continue;
+      }
+      $published[] = $variation;
+      $stock = $this->readStockQuantity($variation);
+      if ($stock === NULL) {
+        $has_unlimited = TRUE;
+        $all_sold_out = FALSE;
+      }
+      elseif ($stock > 0) {
+        $total_finite += $stock;
+        $all_sold_out = FALSE;
+      }
+      $limit = $this->readLimitPerOrder($variation);
+      if ($limit !== NULL) {
+        $limits[$limit] = $limit;
+      }
+    }
+
+    if ($published === []) {
+      return [
+        'stock_state' => 'unknown',
+        'stock_label' => '',
+        'total_stock' => NULL,
+        'limit_per_order' => NULL,
+        'limit_label' => '',
+        'sold_out' => FALSE,
+        'low_stock' => FALSE,
+        'unlimited' => TRUE,
+      ];
+    }
+
+    if ($all_sold_out) {
+      $state = 'sold_out';
+      $label = (string) $this->t('Sold out');
+    }
+    elseif ($has_unlimited) {
+      $state = 'unlimited';
+      $label = (string) $this->t('Unlimited');
+    }
+    elseif ($total_finite <= 5) {
+      $state = 'low';
+      $label = (string) $this->t('@count in stock', ['@count' => $total_finite]);
+    }
+    else {
+      $state = 'finite';
+      $label = (string) $this->t('@count in stock', ['@count' => $total_finite]);
+    }
+
+    $limit = count($limits) === 1 ? (int) reset($limits) : NULL;
+
+    return [
+      'stock_state' => $state,
+      'stock_label' => $label,
+      'total_stock' => $has_unlimited ? NULL : $total_finite,
+      'limit_per_order' => $limit,
+      'limit_label' => $this->buildLimitLabel($limit),
+      'sold_out' => $state === 'sold_out',
+      'low_stock' => $state === 'low',
+      'unlimited' => $state === 'unlimited',
+    ];
+  }
+
+  /**
+   * Counts quantity already in cart for a variation.
+   */
+  public function countCartQuantityForVariation(OrderInterface $cart, int $variation_id): int {
+    $total = 0;
+    foreach ($cart->getItems() as $order_item) {
+      $purchased = $order_item->getPurchasedEntity();
+      if (!$purchased instanceof ProductVariationInterface) {
+        continue;
+      }
+      if ((int) $purchased->id() === $variation_id) {
+        $total += (int) round((float) $order_item->getQuantity());
+      }
+    }
+    return $total;
+  }
+
+  /**
+   * Maximum quantity a customer may add in one request (NULL = unlimited).
+   */
+  public function maxPurchasableQuantity(ProductVariationInterface $variation, ?OrderInterface $cart): ?int {
+    if ($this->isSoldOut($variation)) {
+      return 0;
+    }
+
+    $max = NULL;
+    $stock = $this->readStockQuantity($variation);
+    if ($stock !== NULL) {
+      $max = $stock;
+    }
+
+    $limit = $this->readLimitPerOrder($variation);
+    if ($limit !== NULL) {
+      $max = $max === NULL ? $limit : min($max, $limit);
+    }
+
+    if ($cart instanceof OrderInterface) {
+      $in_cart = $this->countCartQuantityForVariation($cart, (int) $variation->id());
+      if ($max === NULL) {
+        return NULL;
+      }
+      return max(0, $max - $in_cart);
+    }
+
+    return $max;
+  }
+
+  /**
+   * Validates add-to-cart quantity against stock and per-order limits.
+   *
+   * @return list<string>
+   */
+  public function validateAddToCartQuantity(
+    ProductVariationInterface $variation,
+    int $requested_qty,
+    ?OrderInterface $cart,
+  ): array {
+    if ($requested_qty < 1) {
+      return [(string) $this->t('Choose a quantity of at least 1.')];
+    }
+
+    if ($this->isSoldOut($variation)) {
+      return [(string) $this->t('This option is sold out.')];
+    }
+
+    $stock = $this->readStockQuantity($variation);
+    $in_cart = $cart instanceof OrderInterface
+      ? $this->countCartQuantityForVariation($cart, (int) $variation->id())
+      : 0;
+    $total_requested = $in_cart + $requested_qty;
+
+    if ($stock !== NULL && $total_requested > $stock) {
+      if ($in_cart > 0) {
+        return [(string) $this->t('You already have @count in your cart. Only @remaining more can be added.', [
+          '@count' => $in_cart,
+          '@remaining' => max(0, $stock - $in_cart),
+        ])];
+      }
+      return [(string) $this->t('Only @count available for this option.', ['@count' => $stock])];
+    }
+
+    $limit = $this->readLimitPerOrder($variation);
+    if ($limit !== NULL && $total_requested > $limit) {
+      if ($in_cart > 0) {
+        return [(string) $this->t('Limit @limit per order. You already have @count in your cart.', [
+          '@limit' => $limit,
+          '@count' => $in_cart,
+        ])];
+      }
+      return [(string) $this->t('Limit @limit per order.', ['@limit' => $limit])];
+    }
+
+    return [];
+  }
+
+  private function buildRemainingLabel(?int $stock, bool $show_remaining): string {
+    if (!$show_remaining || $stock === NULL || $stock === 0) {
+      return '';
+    }
+    return (string) $this->t('@count available', ['@count' => $stock]);
+  }
+
+  private function buildLimitLabel(?int $limit): string {
+    if ($limit === NULL) {
+      return '';
+    }
+    return (string) $this->t('Limit @limit per order', ['@limit' => $limit]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/VendorOperationalAddonOrderBuilder.php
@@ -68,7 +68,7 @@ final class VendorOperationalAddonOrderBuilder {
    *
    * @var list<string>
    */
-  private const INCLUDED_STATES = [
+  public const QUALIFYING_ORDER_STATES = [
     'completed',
     'partially_refunded',
     'refunded',
@@ -76,6 +76,13 @@ final class VendorOperationalAddonOrderBuilder {
     'fulfilled',
     'fulfillment',
   ];
+
+  /**
+   * @deprecated Use {@see self::QUALIFYING_ORDER_STATES}.
+   *
+   * @var list<string>
+   */
+  private const INCLUDED_STATES = self::QUALIFYING_ORDER_STATES;
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -144,6 +151,15 @@ final class VendorOperationalAddonOrderBuilder {
    * Lightweight signal: any placed order for this event includes operational
    * Commerce lines (by product bundle), without building full composition.
    */
+  /**
+   * Loads vendor-qualifying orders for an event (read-only summaries).
+   *
+   * @return list<OrderInterface>
+   */
+  public function loadQualifyingOrdersForEvent(NodeInterface $event): array {
+    return $this->loadOrdersForEvent($event);
+  }
+
   public function eventHasPurchasedOperationalAddons(NodeInterface $event): bool {
     $eventId = (int) $event->id();
     foreach ($this->loadOrdersForEvent($event) as $order) {

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalAddonBuilderTest.php
@@ -11,6 +11,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
@@ -35,10 +36,12 @@ final class EventOperationalAddonBuilderTest extends UnitTestCase {
       $this->createMock(\Drupal\Core\Extension\ExtensionPathResolver::class),
       $this->getStringTranslationStub(),
     );
+    $stock = new OperationalVariationStockResolver($this->getStringTranslationStub());
     return new EventOperationalAddonBuilder(
       $etm,
       $merch,
       $visual,
+      $stock,
       $this->getStringTranslationStub(),
     );
   }
@@ -144,7 +147,7 @@ final class EventOperationalAddonBuilderTest extends UnitTestCase {
 
     $logger = $this->createMock(LoggerInterface::class);
     $merch = new OperationalMerchandiseManager($etm, $this->getStringTranslationStub(), $logger);
-    $builder = new EventOperationalAddonBuilder($etm, $merch, $visual, $this->getStringTranslationStub());
+    $builder = new EventOperationalAddonBuilder($etm, $merch, $visual, new OperationalVariationStockResolver($this->getStringTranslationStub()), $this->getStringTranslationStub());
 
     $event = $this->createMock(\Drupal\node\NodeInterface::class);
     $event->method('id')->willReturn('99');

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalExtrasSalesSummaryBuilderTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/EventOperationalExtrasSalesSummaryBuilderTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_price\Price;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
+use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
+use Drupal\myeventlane_commerce\Service\EventOperationalExtrasSalesSummaryBuilder;
+use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_commerce\Service\VendorOperationalAddonOrderBuilder;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Routing\Route;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\EventOperationalExtrasSalesSummaryBuilder
+ *
+ * @group myeventlane_commerce
+ */
+final class EventOperationalExtrasSalesSummaryBuilderTest extends UnitTestCase {
+
+  /**
+   * @covers ::buildExtrasSalesPanel
+   */
+  public function testTicketBackedItemsAreExcludedFromExtrasSummary(): void {
+    $event = $this->event(12);
+    $extra_item = $this->orderItem(2, 200, '3');
+    $order = $this->qualifyingOrder();
+    $order->method('getItems')->willReturn([$extra_item]);
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturn(FALSE);
+
+    $composition = $this->createMock(OperationalPurchaseCompositionManager::class);
+    $composition->method('composeForOrder')->willReturn([
+      'groups' => [
+        'merchandise' => [
+          [
+            'order_item_id' => 2,
+            'bundle_group' => 'operational_merchandise',
+            'presentation' => ['operational_product_type' => 'merch_pickup'],
+          ],
+        ],
+      ],
+    ]);
+
+    $addon_order_builder = $this->createMock(VendorOperationalAddonOrderBuilder::class);
+    $addon_order_builder->method('loadQualifyingOrdersForEvent')->willReturn([$order]);
+    $addon_order_builder->method('orderHasOperationalAddons')->willReturn(TRUE);
+    $addon_order_builder->method('collectCacheTagsForEvent')->willReturn(['node:12']);
+
+    $builder = $this->builder($classifier, $composition, $addon_order_builder);
+    $panel = $builder->buildExtrasSalesPanel($event);
+
+    $this->assertSame(3, $panel['summary']['total_items_sold']);
+    $this->assertSame('operational_composition_lines', $panel['sold_basis']);
+  }
+
+  /**
+   * @covers ::buildExtrasSalesPanel
+   */
+  public function testGroupsByOperationalCompositionCategory(): void {
+    $event = $this->event(15);
+    $order = $this->qualifyingOrder();
+    $parking_item = $this->orderItem(3, 300, '1', 15);
+    $food_item = $this->orderItem(4, 301, '1', 15);
+    $food_item->method('getAdjustedTotalPrice')->willReturn(new Price('12.50', 'AUD'));
+    $order->method('getItems')->willReturn([$parking_item, $food_item]);
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturn(FALSE);
+
+    $composition = $this->createMock(OperationalPurchaseCompositionManager::class);
+    $composition->method('composeForOrder')->willReturn([
+      'groups' => [
+        'parking' => [
+          [
+            'order_item_id' => 3,
+            'bundle_group' => 'operational_merchandise',
+            'presentation' => ['operational_product_type' => 'merch_pickup'],
+          ],
+        ],
+        'timed_collection' => [
+          [
+            'order_item_id' => 4,
+            'bundle_group' => 'timed_collection_product',
+            'presentation' => ['operational_product_type' => 'food_drink'],
+          ],
+        ],
+      ],
+    ]);
+
+    $addon_order_builder = $this->createMock(VendorOperationalAddonOrderBuilder::class);
+    $addon_order_builder->method('loadQualifyingOrdersForEvent')->willReturn([$order]);
+    $addon_order_builder->method('orderHasOperationalAddons')->willReturn(TRUE);
+    $addon_order_builder->method('collectCacheTagsForEvent')->willReturn(['node:15']);
+
+    $builder = $this->builder($classifier, $composition, $addon_order_builder);
+    $panel = $builder->buildExtrasSalesPanel($event);
+
+    $by_key = [];
+    foreach ($panel['rows'] as $row) {
+      $by_key[$row['key']] = $row;
+    }
+    $this->assertSame(1, $by_key['parking']['items_sold']);
+    $this->assertSame(1, $by_key['food_drink']['items_sold']);
+    $this->assertSame(0, $by_key['merchandise']['items_sold']);
+  }
+
+  /**
+   * @covers ::buildExtrasSalesPanelRenderArray
+   */
+  public function testRenderArrayUsesExtrasSalesTheme(): void {
+    $event = $this->event(9);
+    $builder = $this->builder();
+    $render = $builder->buildExtrasSalesPanelRenderArray($event);
+    $this->assertSame('mel_event_studio_extras_sales_panel', $render['#theme']);
+  }
+
+  private function builder(
+    ?TicketBackedOrderItemClassifierInterface $classifier = NULL,
+    ?OperationalPurchaseCompositionManager $composition = NULL,
+    ?VendorOperationalAddonOrderBuilder $addon_order_builder = NULL,
+  ): EventOperationalExtrasSalesSummaryBuilder {
+    $classifier ??= $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $composition ??= $this->createMock(OperationalPurchaseCompositionManager::class);
+    $composition->method('composeForOrder')->willReturn(['groups' => []]);
+
+    $addon_order_builder ??= $this->createMock(VendorOperationalAddonOrderBuilder::class);
+    $addon_order_builder->method('loadQualifyingOrdersForEvent')->willReturn([]);
+    $addon_order_builder->method('collectCacheTagsForEvent')->willReturn([]);
+
+    $route_provider = $this->createMock(RouteProviderInterface::class);
+    $route_provider->method('getRouteByName')->willReturnCallback(
+      static fn (string $name): Route => new Route('/' . $name),
+    );
+
+    $currency = $this->createMock(CurrencyFormatter::class);
+    $currency->method('format')->willReturnCallback(
+      static fn (string $number, string $code): string => '$' . $number . ' ' . $code,
+    );
+
+    return new EventOperationalExtrasSalesSummaryBuilder(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $addon_order_builder,
+      $composition,
+      $this->createMock(OperationalMerchandiseManager::class),
+      $this->createMock(EventOperationalAddonBuilder::class),
+      new OperationalVariationStockResolver($this->getStringTranslationStub()),
+      $classifier,
+      $currency,
+      $route_provider,
+      $this->getStringTranslationStub(),
+    );
+  }
+
+  private function event(int $id): NodeInterface&MockObject {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('id')->willReturn((string) $id);
+    $event->method('bundle')->willReturn('event');
+    $event->method('getCacheTags')->willReturn(['node:' . $id]);
+    return $event;
+  }
+
+  private function qualifyingOrder(): OrderInterface&MockObject {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('id')->willReturn('1');
+    return $order;
+  }
+
+  private function orderItem(int $id, int $variation_id, string $qty, int $event_id = 12): OrderItemInterface&MockObject {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('id')->willReturn((string) $variation_id);
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_merchandise');
+    $variation->method('getProduct')->willReturn($product);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('id')->willReturn((string) $id);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $item->method('getQuantity')->willReturn($qty);
+    $item->method('getAdjustedTotalPrice')->willReturn(new Price('10.00', 'AUD'));
+    $item->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => $field === 'field_target_event',
+    );
+    $target = new class($event_id) {
+
+      public function __construct(public int $target_id) {}
+
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+
+    };
+    $item->method('get')->with('field_target_event')->willReturn($target);
+    return $item;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalVariationStockResolverTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalVariationStockResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver
+ *
+ * @group myeventlane_commerce
+ */
+final class OperationalVariationStockResolverTest extends UnitTestCase {
+
+  private function resolver(): OperationalVariationStockResolver {
+    return new OperationalVariationStockResolver($this->getStringTranslationStub());
+  }
+
+  public function testBlankStockIsUnlimited(): void {
+    $this->assertNull($this->resolver()->normalizeStockInput(''));
+    $this->assertNull($this->resolver()->normalizeStockInput(NULL));
+    $variation = $this->variationWithStock(NULL, NULL, FALSE);
+    $this->assertTrue($this->resolver()->isUnlimited($variation));
+  }
+
+  public function testZeroStockIsSoldOut(): void {
+    $variation = $this->variationWithStock(0, NULL, FALSE);
+    $this->assertTrue($this->resolver()->isSoldOut($variation));
+  }
+
+  public function testLimitPerOrderCannotExceedStock(): void {
+    $errors = $this->resolver()->validateStockInput([
+      'stock_quantity' => 2,
+      'limit_per_order' => 5,
+    ]);
+    $this->assertNotEmpty($errors);
+  }
+
+  public function testValidateAddToCartBlocksSoldOut(): void {
+    $variation = $this->variationWithStock(0, NULL, FALSE);
+    $errors = $this->resolver()->validateAddToCartQuantity($variation, 1, NULL);
+    $this->assertNotEmpty($errors);
+  }
+
+  public function testValidateAddToCartBlocksAboveStock(): void {
+    $variation = $this->variationWithStock(2, NULL, FALSE);
+    $errors = $this->resolver()->validateAddToCartQuantity($variation, 3, NULL);
+    $this->assertNotEmpty($errors);
+  }
+
+  public function testValidateAddToCartCountsExistingCartQuantity(): void {
+    $variation = $this->variationWithStock(2, 2, FALSE);
+    $variation->method('id')->willReturn('10');
+    $cart = $this->createMock(OrderInterface::class);
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $item->method('getQuantity')->willReturn('1');
+    $cart->method('getItems')->willReturn([$item]);
+    $errors = $this->resolver()->validateAddToCartQuantity($variation, 2, $cart);
+    $this->assertNotEmpty($errors);
+  }
+
+  public function testBuildVariationCustomerStockRemainingLabel(): void {
+    $variation = $this->variationWithStock(4, 2, TRUE);
+    $meta = $this->resolver()->buildVariationCustomerStock($variation);
+    $this->assertSame('4 available', (string) $meta['remaining_label']);
+    $this->assertSame('Limit 2 per order', (string) $meta['limit_label']);
+  }
+
+  private function variationWithStock(?int $stock, ?int $limit, bool $show): ProductVariationInterface {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('bundle')->willReturn('operational_merchandise_var');
+    $variation->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => in_array($field, [
+        OperationalVariationStockResolver::FIELD_STOCK_QUANTITY,
+        OperationalVariationStockResolver::FIELD_LIMIT_PER_ORDER,
+        OperationalVariationStockResolver::FIELD_SHOW_REMAINING,
+      ], TRUE),
+    );
+    $stock_field = $this->createMock(FieldItemListInterface::class);
+    $stock_field->method('isEmpty')->willReturn($stock === NULL);
+    $limit_field = $this->createMock(FieldItemListInterface::class);
+    $limit_field->method('isEmpty')->willReturn($limit === NULL);
+    $show_field = $this->createMock(FieldItemListInterface::class);
+    $show_field->method('isEmpty')->willReturn(FALSE);
+    $variation->method('get')->willReturnCallback(
+      static function (string $field) use ($stock, $limit, $show, $stock_field, $limit_field, $show_field) {
+        return match ($field) {
+          OperationalVariationStockResolver::FIELD_STOCK_QUANTITY => $stock_field,
+          OperationalVariationStockResolver::FIELD_LIMIT_PER_ORDER => $limit_field,
+          default => $show_field,
+        };
+      },
+    );
+    $stock_field->method('__get')->willReturnMap([['value', $stock]]);
+    $limit_field->method('__get')->willReturnMap([['value', $limit]]);
+    $show_field->method('__get')->willReturnMap([['value', $show ? 1 : 0]]);
+    return $variation;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/config/schema/myeventlane_core.schema.yml
+++ b/web/modules/custom/myeventlane_core/config/schema/myeventlane_core.schema.yml
@@ -5,6 +5,9 @@ myeventlane_core.settings:
     platform_fee_percent:
       type: float
       label: 'Platform fee percentage (0-100, e.g. 1.5 for 1.5%)'
+    operational_extras_platform_fee_percent:
+      type: float
+      label: 'Operational extras platform fee percentage (0-100); empty uses double ticket fee'
     stripe_fee_percent:
       type: float
       label: 'Stripe application fee percentage (e.g. 3 for 3%)'

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -1,5 +1,11 @@
 services:
 
+  myeventlane_core.platform_fee_settings:
+    class: Drupal\myeventlane_core\Service\PlatformFeeSettings
+    arguments:
+      - '@config.factory'
+      - '@string_translation'
+
   myeventlane_core.entity_id_normalizer:
     class: Drupal\myeventlane_core\Service\EntityIdNormalizer
 

--- a/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Datetime\TimeZoneFormHelper;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\myeventlane_core\PlatformFeeDefaults;
+use Drupal\myeventlane_core\Service\PlatformFeeSettings;
 
 /**
  * General settings form for MyEventLane platform.
@@ -84,11 +85,27 @@ final class GeneralSettingsForm extends ConfigFormBase {
       '#open' => TRUE,
     ];
 
+    $ticket_fee = PlatformFeeDefaults::normalizePercent($config->get('platform_fee_percent'));
+    $extras_raw = $config->get('operational_extras_platform_fee_percent');
+    $extras_default = PlatformFeeDefaults::normalizePercent($ticket_fee * PlatformFeeSettings::EXTRAS_FEE_TICKET_MULTIPLIER);
+
     $form['payments']['platform_fee_percent'] = [
       '#type' => 'number',
-      '#title' => $this->t('Platform fee percentage'),
-      '#description' => $this->t('Percentage applied to ticket subtotals (excludes donations and Boost). For example, 1.5 applies a 1.5% platform fee. Set to 0 to disable.'),
-      '#default_value' => (string) PlatformFeeDefaults::normalizePercent($config->get('platform_fee_percent')),
+      '#title' => $this->t('Platform fee percentage (tickets)'),
+      '#description' => $this->t('Percentage applied to ticket subtotals only (excludes donations, Boost, and operational extras). For example, 1.5 applies a 1.5% platform fee. Set to 0 to disable.'),
+      '#default_value' => (string) $ticket_fee,
+      '#min' => 0,
+      '#max' => 100,
+      '#step' => 0.5,
+      '#size' => 5,
+    ];
+
+    $form['payments']['operational_extras_platform_fee_percent'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Platform fee percentage (merch & add-ons)'),
+      '#description' => $this->t('Percentage applied to operational extras subtotals in mixed checkout. Leave blank to use double the ticket fee (@default%). Does not change Stripe Connect application fees on tickets.',
+        ['@default' => number_format($extras_default, 1)]),
+      '#default_value' => is_numeric($extras_raw) ? (string) PlatformFeeDefaults::normalizePercent($extras_raw) : '',
       '#min' => 0,
       '#max' => 100,
       '#step' => 0.5,
@@ -153,12 +170,19 @@ final class GeneralSettingsForm extends ConfigFormBase {
     $fee_payer = $form_state->getValue(['payments', 'fee_payer']);
     $fee_payer = in_array($fee_payer, ['buyer', 'organizer_absorbs'], TRUE) ? $fee_payer : 'buyer';
 
+    $extras_v = $form_state->getValue(['payments', 'operational_extras_platform_fee_percent']);
+    $operational_extras_platform_fee_percent = NULL;
+    if ($extras_v !== '' && $extras_v !== NULL && is_numeric($extras_v)) {
+      $operational_extras_platform_fee_percent = PlatformFeeDefaults::normalizePercent($extras_v);
+    }
+
     $this->config('myeventlane_core.settings')
       ->set('site_name', $form_state->getValue(['platform', 'site_name']))
       ->set('support_email', $form_state->getValue(['platform', 'support_email']))
       ->set('default_timezone', $form_state->getValue(['defaults', 'default_timezone']))
       ->set('default_currency', $form_state->getValue(['defaults', 'default_currency']))
       ->set('platform_fee_percent', $platform_fee_percent)
+      ->set('operational_extras_platform_fee_percent', $operational_extras_platform_fee_percent)
       ->set('stripe_fee_percent', $stripe_fee_percent)
       ->set('stripe_fee_fixed_cents', $stripe_fee_fixed_cents)
       ->set('fee_payer', $fee_payer)

--- a/web/modules/custom/myeventlane_core/src/Service/PlatformFeeSettings.php
+++ b/web/modules/custom/myeventlane_core/src/Service/PlatformFeeSettings.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_core\PlatformFeeDefaults;
+
+/**
+ * Resolves ticket and operational extras platform fee percentages from config.
+ */
+final class PlatformFeeSettings {
+
+  use StringTranslationTrait;
+
+  /**
+   * When extras fee is unset, it defaults to ticket fee × this multiplier.
+   */
+  public const EXTRAS_FEE_TICKET_MULTIPLIER = 2.0;
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Ticket platform fee percentage (0–100).
+   */
+  public function getTicketFeePercent(): float {
+    return PlatformFeeDefaults::normalizePercent(
+      $this->configFactory->get('myeventlane_core.settings')->get('platform_fee_percent')
+    );
+  }
+
+  /**
+   * Operational extras platform fee percentage (0–100).
+   *
+   * Uses {@code operational_extras_platform_fee_percent} when set; otherwise
+   * double the ticket fee (capped at 100%).
+   */
+  public function getOperationalExtrasFeePercent(): float {
+    $raw = $this->configFactory->get('myeventlane_core.settings')->get('operational_extras_platform_fee_percent');
+    if ($raw === NULL || $raw === '') {
+      $derived = $this->getTicketFeePercent() * self::EXTRAS_FEE_TICKET_MULTIPLIER;
+      return PlatformFeeDefaults::normalizePercent($derived);
+    }
+    return PlatformFeeDefaults::normalizePercent($raw);
+  }
+
+  /**
+   * Whether the effective extras fee equals double the ticket fee (for vendor copy).
+   */
+  public function extrasFeeIsDoubleTicketFee(): bool {
+    $ticket = $this->getTicketFeePercent();
+    $extras = $this->getOperationalExtrasFeePercent();
+    if ($ticket <= 0) {
+      return FALSE;
+    }
+    return abs($extras - ($ticket * self::EXTRAS_FEE_TICKET_MULTIPLIER)) < 0.01;
+  }
+
+  /**
+   * Human-readable percent label (e.g. "1.5%" or "3%").
+   */
+  public function formatPercentLabel(float $percent): string {
+    $label = $percent === (float) (int) $percent
+      ? (string) (int) $percent
+      : number_format($percent, 1);
+    return $label . '%';
+  }
+
+  /**
+   * Vendor-facing sentence for the Studio Merch & add-ons tab.
+   */
+  public function buildExtrasStudioFeeCopy(): string {
+    $extras_label = $this->formatPercentLabel($this->getOperationalExtrasFeePercent());
+    $base = (string) $this->t(
+      'Merch and add-ons use the same checkout. The MyEventLane site fee for extras is @fee.',
+      ['@fee' => $extras_label]
+    );
+    if ($this->extrasFeeIsDoubleTicketFee()) {
+      $ticket_label = $this->formatPercentLabel($this->getTicketFeePercent());
+      return $base . ' ' . (string) $this->t(
+        'Extras have a higher site fee than tickets (@ticket) because they include product stock and order handling.',
+        ['@ticket' => $ticket_label]
+      );
+    }
+    return $base;
+  }
+
+}

--- a/web/modules/custom/myeventlane_core/tests/src/Unit/PlatformFeeSettingsTest.php
+++ b/web/modules/custom/myeventlane_core/tests/src/Unit/PlatformFeeSettingsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_core\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_core\Service\PlatformFeeSettings;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_core\Service\PlatformFeeSettings
+ *
+ * @group myeventlane_core
+ */
+final class PlatformFeeSettingsTest extends UnitTestCase {
+
+  /**
+   * @covers ::getOperationalExtrasFeePercent
+   * @covers ::extrasFeeIsDoubleTicketFee
+   */
+  public function testExtrasFeeDefaultsToDoubleTicketFee(): void {
+    $settings = $this->service(['platform_fee_percent' => 1.5]);
+    $this->assertSame(3.0, $settings->getOperationalExtrasFeePercent());
+    $this->assertTrue($settings->extrasFeeIsDoubleTicketFee());
+  }
+
+  /**
+   * @covers ::getOperationalExtrasFeePercent
+   */
+  public function testExtrasFeeUsesExplicitConfigWhenSet(): void {
+    $settings = $this->service([
+      'platform_fee_percent' => 2.0,
+      'operational_extras_platform_fee_percent' => 4.5,
+    ]);
+    $this->assertSame(4.5, $settings->getOperationalExtrasFeePercent());
+    $this->assertFalse($settings->extrasFeeIsDoubleTicketFee());
+  }
+
+  /**
+   * @param array<string, mixed> $values
+   */
+  private function service(array $values): PlatformFeeSettings {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(static function (string $key) use ($values) {
+      return $values[$key] ?? NULL;
+    });
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('myeventlane_core.settings')->willReturn($config);
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')->willReturnCallback(static function ($s, $args = []) {
+      if ($args !== []) {
+        return strtr((string) $s, $args);
+      }
+      return (string) $s;
+    });
+    return new PlatformFeeSettings($factory, $translation);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
@@ -261,19 +261,452 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  max-width: 72rem;
+  margin-inline: auto;
+  padding-inline: clamp(0.75rem, 3vw, 1.25rem);
 }
 
 .mel-event-product-editor__nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   margin-bottom: 0.25rem;
 }
 
-.mel-event-product-editor__back {
+.mel-event-product-editor__back,
+.mel-event-product-editor__manage-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
   font-weight: 600;
   text-decoration: none;
 }
 
+.mel-event-product-editor__layout {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (min-width: 64rem) {
+  .mel-event-product-editor__layout {
+    grid-template-columns: minmax(0, 1.65fr) minmax(16rem, 1fr);
+  }
+
+  .mel-event-product-editor__aside {
+    position: sticky;
+    top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+.mel-event-product-editor__section-helper {
+  margin: 0 0 0.75rem;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
 .mel-event-product-editor__section {
   padding: 1rem 1.125rem;
+}
+
+.mel-event-product-editor__operational-docs .mel-event-product-editor__manage-cta {
+  margin-top: 0.5rem;
+}
+
+.mel-event-product-editor__stock-card {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.mel-event-product-editor__setup-summary-list {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+}
+
+.mel-event-product-editor__setup-summary-row {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, 7rem) 1fr;
+  gap: 0.35rem 0.75rem;
+  align-items: baseline;
+  margin: 0;
+}
+
+.mel-event-product-editor__setup-summary-row dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--mel-text-muted, #6b6578);
+  font-size: 0.8125rem;
+}
+
+.mel-event-product-editor__setup-summary-row dd {
+  margin: 0;
+  font-size: 0.9375rem;
+}
+
+.mel-event-product-editor__setup-summary-actions {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+}
+
+.mel-event-product-editor__setup-summary-link {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mel-event-product-editor__coming-soon {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-product-editor__stock-overview {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-muted, #f4f1fa);
+}
+
+.mel-event-product-editor__stock-overview-summary {
+  margin: 0 0 0.35rem;
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+
+.mel-event-product-editor__variant-stock-details {
+  margin-top: 0.75rem;
+}
+
+.mel-event-product-editor__variant-stock-details > summary {
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+}
+
+.mel-event-product-editor__variant-stock-table {
+  width: 100%;
+  margin-top: 0.75rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mel-event-product-editor__variant-stock-table caption {
+  text-align: left;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.mel-event-product-editor__variant-stock-table th,
+.mel-event-product-editor__variant-stock-table td {
+  padding: 0.5rem 0.65rem;
+  vertical-align: top;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-product-editor__variant-stock-table th {
+  font-weight: 700;
+  background: var(--mel-surface-muted, #f4f1fa);
+  text-align: left;
+}
+
+.mel-event-product-editor__variant-size {
+  font-weight: 700;
+}
+
+.mel-event-product-editor__variant-status {
+  font-size: 0.8125rem;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-product-editor__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  margin-top: 0.5rem;
+  padding: 0.75rem clamp(0.75rem, 3vw, 1.25rem);
+  background: color-mix(in srgb, var(--mel-page-bg, #faf8fc) 92%, transparent);
+  border-top: 1px solid var(--mel-border-soft, #e8e4ef);
+  backdrop-filter: blur(8px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-product-editor__footer {
+    backdrop-filter: none;
+  }
+}
+
+.mel-event-product-editor__footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  max-width: 72rem;
+  margin-inline: auto;
+}
+
+.mel-event-product-editor__footer .mel-event-product-editor__actions {
+  margin-top: 0;
+}
+
+.mel-event-product-editor__layout--single {
+  max-width: 48rem;
+}
+
+.mel-event-product-editor__accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 48rem;
+}
+
+.mel-event-product-editor__accordion-panel {
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  border-radius: 0.75rem;
+  padding: 0 1rem 1rem;
+  background: var(--mel-surface-elevated, #fff);
+}
+
+.mel-event-product-editor__accordion-panel > summary {
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 1rem;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  list-style: none;
+}
+
+.mel-event-product-editor__accordion-panel > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-product-editor__accordion-panel[open] > summary {
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+  padding-bottom: 0.5rem;
+}
+
+.mel-event-product-editor__compact-summary {
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.mel-event-product-editor__compact-summary-line {
+  margin: 0;
+  font-size: 0.9375rem;
+}
+
+.mel-event-product-editor__stock-summary {
+  margin: 0.5rem 0 0.75rem;
+}
+
+.mel-event-product-editor__stock-summary-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mel-event-product-editor__stock-summary-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 22%, #fff);
+  color: var(--mel-text, #2d2640);
+  line-height: 1.3;
+}
+
+.mel-event-product-editor__stock-summary-empty {
+  margin: 0.5rem 0 0;
+}
+
+.mel-event-product-editor__option-stock-details {
+  margin-top: 0.75rem;
+}
+
+.mel-event-product-editor__option-stock-details > summary {
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+}
+
+.mel-event-product-editor__option-stock-table {
+  width: 100%;
+  margin-top: 0.75rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mel-event-product-editor__option-stock-table caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mel-event-product-editor__option-stock-table th,
+.mel-event-product-editor__option-stock-table td {
+  padding: 0.5rem 0.65rem;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-product-editor__option-stock-table th {
+  font-weight: 700;
+  background: var(--mel-surface-muted, #f4f1fa);
+  text-align: left;
+}
+
+.mel-event-product-editor__option-stock-label {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.mel-event-product-editor__option-stock-table input[type="number"] {
+  max-width: 7rem;
+}
+
+.mel-event-product-editor__preview-wrap {
+  max-width: none;
+}
+
+.mel-event-product-editor__preview-wrap .mel-event-extra-preview__card {
+  min-width: min(100%, 22rem);
+}
+
+.mel-event-product-editor__option-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0.75rem 0;
+}
+
+.mel-event-product-editor__preset-label {
+  margin: 0;
+  width: 100%;
+  font-size: 0.875rem;
+}
+
+.mel-event-product-editor__option-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.mel-event-product-editor__option-card {
+  margin: 0;
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+}
+
+.mel-event-product-editor__option-card > legend {
+  font-weight: 700;
+  padding: 0 0.35rem;
+}
+
+.mel-event-product-editor__add-option {
+  margin-top: 0.5rem;
+}
+
+.mel-event-product-editor__preview-card {
+  max-width: none;
+}
+
+.mel-event-extra-preview__card {
+  display: grid;
+  grid-template-columns: 6.5rem 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem;
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+}
+
+.mel-event-extra-preview__image {
+  width: 6.5rem;
+  height: 6.5rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.mel-event-extra-preview__summary-line {
+  margin: 0.25rem 0 0.5rem;
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+
+.mel-event-extra-preview__meta {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 640px) {
+  .mel-event-extra-preview__card {
+    grid-template-columns: 1fr;
+  }
+
+  .mel-event-extra-preview__image {
+    width: 100%;
+    max-width: 10rem;
+  }
+}
+
+.mel-event-extra-preview__meta-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.mel-event-extra-preview__meta-row dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extra-preview__meta-row dd {
+  margin: 0;
+}
+
+.mel-event-extra-preview__price {
+  font-weight: 700;
+  margin: 0.25rem 0;
+}
+
+.mel-event-extra-preview__hidden-notice {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 25%, #fff);
+  font-size: 0.875rem;
+}
+
+.mel-event-variant-preview__title {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 700;
 }
 
 .mel-event-product-editor__type-pill {
@@ -327,11 +760,50 @@
 
 .mel-event-variant-preview {
   margin-top: 1rem;
+}
+
+.mel-event-variant-preview__summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.35rem 0;
+}
+
+.mel-event-variant-preview__summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-variant-preview__summary::before {
+  content: "▸";
+  margin-inline-end: 0.35rem;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-variant-preview[open] .mel-event-variant-preview__summary::before {
+  content: "▾";
+}
+
+.mel-event-variant-preview__title {
+  font-size: 0.9375rem;
+  font-weight: 700;
+}
+
+.mel-event-variant-preview__hint {
+  font-size: 0.8125rem;
+}
+
+.mel-event-variant-preview__table-wrap {
   overflow-x: auto;
+  margin-top: 0.5rem;
 }
 
 .mel-event-variant-preview__table {
   width: 100%;
+  min-width: 28rem;
   border-collapse: collapse;
   font-size: 0.875rem;
 }
@@ -401,4 +873,111 @@
 
 .mel-event-extra-card__quantity-label {
   font-weight: 600;
+}
+
+.mel-event-extras-studio__extras-stock-heading {
+  margin-bottom: 0.75rem;
+  padding: 1rem 1.125rem;
+}
+
+.mel-event-extras-studio__ticket-sales-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  margin-top: 0.35rem;
+}
+
+@media (max-width: 640px) {
+  .mel-event-product-editor__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .mel-event-product-editor__variant-stock-table thead {
+    display: none;
+  }
+
+  .mel-event-product-editor__variant-stock-table tr {
+    display: block;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid var(--mel-border-soft, #e8e4ef);
+    border-radius: 0.75rem;
+  }
+
+  .mel-event-product-editor__variant-stock-table td {
+    display: grid;
+    grid-template-columns: minmax(6rem, 40%) 1fr;
+    gap: 0.35rem 0.75rem;
+    padding: 0.35rem 0;
+    border-bottom: none;
+  }
+
+  .mel-event-product-editor__variant-stock-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--mel-text-muted, #6b6578);
+    font-size: 0.8125rem;
+  }
+
+  .mel-event-product-editor__variant-stock-table td:first-child::before {
+    content: none;
+  }
+
+  .mel-event-product-editor__option-stock-table thead {
+    display: none;
+  }
+
+  .mel-event-product-editor__option-stock-table tr {
+    display: block;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid var(--mel-border-soft, #e8e4ef);
+    border-radius: 0.75rem;
+  }
+
+  .mel-event-product-editor__option-stock-table td {
+    display: grid;
+    grid-template-columns: minmax(6rem, 40%) 1fr;
+    gap: 0.35rem 0.75rem;
+    padding: 0.35rem 0;
+    border-bottom: none;
+  }
+
+  .mel-event-product-editor__option-stock-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--mel-text-muted, #6b6578);
+    font-size: 0.8125rem;
+  }
+
+  .mel-event-product-editor__option-stock-table td:first-child::before {
+    content: none;
+  }
+
+  .mel-event-variant-preview__table thead {
+    display: none;
+  }
+
+  .mel-event-variant-preview__table tr {
+    display: block;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid var(--mel-border-soft, #e8e4ef);
+    border-radius: 0.75rem;
+  }
+
+  .mel-event-variant-preview__table td {
+    display: grid;
+    grid-template-columns: minmax(5rem, 38%) 1fr;
+    gap: 0.25rem 0.65rem;
+    padding: 0.3rem 0;
+    border-bottom: none;
+  }
+
+  .mel-event-variant-preview__table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--mel-text-muted, #6b6578);
+    font-size: 0.8125rem;
+  }
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-extras-sales-panel.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-extras-sales-panel.css
@@ -1,0 +1,136 @@
+/**
+ * Merch & add-on sales panel (Manage event dashboard).
+ */
+
+.mel-event-extras-studio__extras-sales {
+  margin-block: 0;
+}
+
+.mel-event-extras-studio__extras-sales-header {
+  margin-block-end: 1rem;
+}
+
+.mel-event-extras-studio__extras-sales-helper {
+  margin: 0.35rem 0 0;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__extras-sales-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-block-end: 1rem;
+}
+
+@media (min-width: 640px) {
+  .mel-event-extras-studio__extras-sales-summary {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.mel-event-extras-studio__extras-sales-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  background: #fff;
+}
+
+.mel-event-extras-studio__extras-sales-metric-label {
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.mel-event-extras-studio__extras-sales-metric-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.mel-event-extras-studio__extras-sales-table-wrap {
+  overflow-x: auto;
+}
+
+.mel-event-extras-studio__extras-sales-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__extras-sales-table th,
+.mel-event-extras-studio__extras-sales-table td {
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  text-align: left;
+  vertical-align: top;
+}
+
+.mel-event-extras-studio__extras-sales-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-block-start: 1rem;
+}
+
+.mel-event-extras-studio__extras-sales-deferred {
+  font-size: 0.8125rem;
+}
+
+.mel-event-extras-studio__extras-sales--compact .mel-event-extras-studio__extras-sales-header {
+  display: none;
+}
+
+.mel-event-extras-studio__operational-docs {
+  margin-block-start: 1.25rem;
+  padding: 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  background: rgba(244, 241, 250, 0.55);
+}
+
+.mel-event-extras-studio__operational-docs-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mel-event-extras-studio__operational-docs-helper {
+  margin: 0.35rem 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__operational-docs-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mel-event-extras-studio__operational-docs-actions .mel-btn--disabled,
+.mel-event-extras-studio__operational-docs-actions button:disabled {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  min-height: 2.75rem;
+  opacity: 0.72;
+  cursor: not-allowed;
+}
+
+.mel-event-extras-studio__operational-docs-coming-soon {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.mel-event-extras-studio__operational-docs-notice {
+  margin: 0.75rem 0 0;
+  font-size: 0.8125rem;
+}
+
+.mel-event-extras-studio__operational-docs-note {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2168,6 +2168,10 @@
   min-height: 44px;
 }
 
+.mel-event-studio-topbar__manage-event {
+  white-space: nowrap;
+}
+
 .mel-event-studio-sidebar-toggle {
   display: none !important;
   align-self: flex-start;

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-ticket-sales-panel.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-ticket-sales-panel.css
@@ -1,0 +1,128 @@
+.mel-event-extras-studio__ticket-sales,
+.mel-event-studio-overview .mel-event-extras-studio__ticket-sales {
+  padding: 1rem 1.125rem;
+}
+
+.mel-event-extras-studio__ticket-sales-header {
+  margin-bottom: 0.75rem;
+}
+
+.mel-event-extras-studio__ticket-sales-helper {
+  margin: 0.35rem 0 0;
+  font-size: 0.9375rem;
+}
+
+.mel-event-extras-studio__ticket-sales-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.mel-event-extras-studio__ticket-sales-table th,
+.mel-event-extras-studio__ticket-sales-table td {
+  padding: 0.65rem 0.5rem;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+  text-align: left;
+  vertical-align: top;
+}
+
+.mel-event-extras-studio__ticket-sales-table th {
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extras-studio__ticket-sales-cards {
+  display: none;
+  gap: 0.75rem;
+}
+
+.mel-event-extras-studio__ticket-sales-card {
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+}
+
+.mel-event-extras-studio__ticket-sales-card-title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.mel-event-extras-studio__ticket-sales-card-meta {
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.mel-event-extras-studio__ticket-sales-card-meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.mel-event-extras-studio__ticket-sales-card-meta dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extras-studio__ticket-sales-card-meta dd {
+  margin: 0;
+  text-align: right;
+}
+
+.mel-event-extras-studio__ticket-sales-actions {
+  margin: 1rem 0 0;
+}
+
+.mel-event-extras-studio__ticket-sales--compact .mel-event-extras-studio__ticket-sales-table th,
+.mel-event-extras-studio__ticket-sales--compact .mel-event-extras-studio__ticket-sales-table td {
+  padding: 0.5rem 0.4rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__ticket-sales--compact .mel-event-extras-studio__ticket-sales-actions {
+  margin-top: 0.75rem;
+}
+
+.mel-event-extras-studio__edit-tickets {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  padding: 0.5rem 1rem;
+}
+
+.mel-pill--tone-success {
+  background: color-mix(in srgb, #22c55e 18%, #fff);
+  color: #166534;
+}
+
+.mel-pill--tone-warning {
+  background: color-mix(in srgb, var(--mel-accent-coral, #f26d5b) 18%, #fff);
+  color: #9a3412;
+}
+
+.mel-pill--tone-info {
+  background: color-mix(in srgb, var(--mel-accent-lavender, #c4b5fd) 35%, #fff);
+  color: #4338ca;
+}
+
+@media (max-width: 767px) {
+  .mel-event-extras-studio__ticket-sales-table-wrap {
+    display: none;
+  }
+
+  .mel-event-extras-studio__ticket-sales-cards {
+    display: grid;
+  }
+}
+
+@media (min-width: 768px) {
+  .mel-event-extras-studio__ticket-sales-cards {
+    display: none;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -26,12 +26,27 @@ mel_operational_capability_studio:
     - core/once
 
 mel_event_extras_studio:
-  version: 1.2
+  version: 1.3
   css:
     theme:
       css/mel-event-extras-studio.css: {}
   dependencies:
     - core/drupal
+
+mel_event_studio_ticket_sales_panel:
+  version: 1.0
+  css:
+    theme:
+      css/mel-event-studio-ticket-sales-panel.css: {}
+
+mel_event_studio_extras_sales_panel:
+  version: 1.0
+  css:
+    theme:
+      css/mel-event-studio-extras-sales-panel.css: {}
+  dependencies:
+    - core/drupal
+    - myeventlane_event_studio/mel_event_extras_studio
 
 mel_event_extras_product_editor:
   version: 1.0

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -143,14 +143,48 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
     'mel_event_studio_extra_preview' => [
       'variables' => [
         'preview' => [],
+        'price_display' => '',
+        'options_summary' => '',
+        'stock_label' => '',
+        'visibility_label' => '',
+        'hidden_notice' => '',
       ],
       'template' => 'mel-event-studio-extra-preview',
     ],
     'mel_event_studio_extra_variant_preview' => [
       'variables' => [
         'rows' => [],
+        'stock_supported' => FALSE,
+        'stock_editor_enabled' => FALSE,
+        'open' => FALSE,
+        'summary_title' => '',
       ],
       'template' => 'mel-event-studio-extra-variant-preview',
+    ],
+    'mel_event_studio_extra_product_setup_summary' => [
+      'variables' => [
+        'summary' => [],
+        'show_preview_anchor' => FALSE,
+      ],
+      'template' => 'mel-event-studio-extra-product-setup-summary',
+    ],
+    'mel_event_studio_ticket_sales_panel' => [
+      'variables' => [
+        'panel' => [],
+      ],
+      'template' => 'mel-event-studio-ticket-sales-panel',
+    ],
+    'mel_event_studio_extras_sales_panel' => [
+      'variables' => [
+        'panel' => [],
+      ],
+      'template' => 'mel-event-studio-extras-sales-panel',
+    ],
+    'mel_event_studio_extras_configured_summary' => [
+      'variables' => [
+        'panel' => [],
+      ],
+      'template' => 'mel-event-studio-extras-configured-summary',
     ],
     'mel_event_branding_preview' => [
       'variables' => [

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -223,6 +223,7 @@ services:
       - '@myeventlane_commerce.operational_merchandise_manager'
       - '@myeventlane_event_studio.operational_capability_commerce_link_manager'
       - '@myeventlane_vendor.event_access_checker'
+      - '@myeventlane_commerce.operational_variation_stock_resolver'
       - '@string_translation'
       - '@logger.channel.myeventlane_event_studio'
 
@@ -234,6 +235,24 @@ services:
       - '@myeventlane_commerce.operational_extra_visual_presenter'
       - '@myeventlane_commerce.event_operational_addon_builder'
       - '@myeventlane_event_studio.vendor_operational_product_creation_manager'
+      - '@myeventlane_commerce.operational_variation_stock_resolver'
+      - '@string_translation'
+
+  myeventlane_event_studio.commerce_sales_summary_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_event.ticket_tier_lifecycle'
+      - '@myeventlane_commerce.ticket_backed_order_item_classifier'
+      - '@myeventlane_commerce.ticket_variation_sold'
+      - '@commerce_price.currency_formatter'
+      - '@datetime.time'
+      - '@string_translation'
+
+  myeventlane_event_studio.extras_configured_summary_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioExtrasConfiguredSummaryBuilder
+    arguments:
+      - '@myeventlane_event_studio.event_extras_builder'
       - '@string_translation'
 
   myeventlane_event_studio.operational_product_studio_field_registry:
@@ -247,6 +266,7 @@ services:
       - '@myeventlane_event_studio.event_extras_builder'
       - '@myeventlane_event_studio.vendor_operational_product_creation_manager'
       - '@myeventlane_event_studio.operational_product_studio_field_registry'
+      - '@myeventlane_commerce.operational_variation_stock_resolver'
       - '@string_translation'
 
   myeventlane_event_studio.vendor_productisation_studio_builder:

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -260,6 +260,8 @@ final class EventStudioController extends ControllerBase {
       'published' => $node->isPublished(),
       'can_publish' => $readiness->ready,
       'current_section' => $section,
+      'show_manage_event_link' => TRUE,
+      'manage_event_url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $node->id()])->toString(),
       'changed' => $node->getChangedTime(),
       'revision_id' => (int) $node->getRevisionId(),
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -11,7 +11,9 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_core\Service\PlatformFeeSettings;
 use Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver;
+use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
 use Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder;
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
@@ -48,6 +50,8 @@ final class EventStudioEventExtrasForm extends FormBase {
 
   protected ?DomainDetector $domainDetector = NULL;
 
+  protected ?PlatformFeeSettings $platformFeeSettings = NULL;
+
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     EventVendorAccessChecker $event_vendor_access_checker,
@@ -77,6 +81,9 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
     $form->domainDetector = $container->get('myeventlane_core.domain_detector');
+    if ($container->has('myeventlane_core.platform_fee_settings')) {
+      $form->platformFeeSettings = $container->get('myeventlane_core.platform_fee_settings');
+    }
     return $form;
   }
 
@@ -185,7 +192,7 @@ final class EventStudioEventExtrasForm extends FormBase {
           '#items' => [
             $this->t('Merch and add-ons are sold through the same checkout.'),
             $this->t('They do not count as event tickets.'),
-            $this->t('Fulfilment and stock controls are still being improved.'),
+            $this->t('Fulfilment tracking is still being improved.'),
           ],
         ],
       ],
@@ -194,6 +201,34 @@ final class EventStudioEventExtrasForm extends FormBase {
         '#tag' => 'p',
         '#value' => $this->t('Tickets stay separate. Extras do not create admission tickets.'),
         '#attributes' => ['class' => ['mel-text--muted', 'mel-event-extras-studio__ticket-note']],
+      ],
+      'ticket_sales_link' => [
+        '#type' => 'link',
+        '#title' => $this->t('View ticket sales in Manage event'),
+        '#url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event->id()]),
+        '#attributes' => [
+          'class' => ['mel-event-extras-studio__ticket-sales-link', 'mel-text--muted'],
+        ],
+        '#access' => $mode === 'list',
+      ],
+      'fee_copy' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->platformFeeSettings?->buildExtrasStudioFeeCopy()
+          ?? $this->t('Merch and add-ons use the same checkout. The MyEventLane site fee for extras is shown in platform settings.'),
+        '#attributes' => [
+          'class' => ['mel-event-extras-studio__fee-copy', 'mel-text--muted'],
+        ],
+        '#access' => $mode === 'list',
+      ],
+      'operational_documents_note' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('After sales begin, you’ll be able to generate packing slips, parking slips, and labels from Manage event.'),
+        '#attributes' => [
+          'class' => ['mel-event-extras-studio__operational-docs-note', 'mel-text--muted'],
+        ],
+        '#access' => $mode === 'list',
       ],
     ];
 
@@ -234,6 +269,22 @@ final class EventStudioEventExtrasForm extends FormBase {
     $list = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-extras-studio__list']],
+      'heading' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extras-studio__extras-stock-heading', 'mel-es-card']],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Merch & add-ons stock'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Product stock for operational extras. This is separate from ticket attendance capacity.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+      ],
     ];
 
     $list['tabs'] = $this->buildListFilterTabs($event, $filter);
@@ -568,6 +619,9 @@ final class EventStudioEventExtrasForm extends FormBase {
     if (($trigger['#type'] ?? '') !== 'submit') {
       return;
     }
+    if (array_key_exists('#limit_validation_errors', $trigger)) {
+      return;
+    }
     $input = $this->collectInput($form_state);
     $status = (string) ($input['product_status'] ?? '');
     if ($status !== '' && !array_key_exists($status, $this->productCreationManager->productStatusOptions())) {
@@ -584,6 +638,67 @@ final class EventStudioEventExtrasForm extends FormBase {
 
   public function submitAddAnother(array &$form, FormStateInterface $form_state): void {
     $this->saveExtra($form_state, TRUE);
+  }
+
+  public function submitAddProductOption(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, []);
+    $form_state->setRebuild(TRUE);
+  }
+
+  public function submitPresetTshirtSizes(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, ['S', 'M', 'L', 'XL'], TRUE);
+    $form_state->setRebuild(TRUE);
+  }
+
+  public function submitPresetFullSizes(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, array_values(OperationalExtraVisualPresenter::SIZE_LABELS), TRUE);
+    $form_state->setRebuild(TRUE);
+  }
+
+  public function submitPresetOneOption(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, [(string) $this->t('One option')], TRUE);
+    $form_state->setRebuild(TRUE);
+  }
+
+  public function submitPresetParkingPass(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, [(string) $this->t('Parking pass')], TRUE);
+    $form_state->setRebuild(TRUE);
+  }
+
+  public function submitPresetMealPackage(array &$form, FormStateInterface $form_state): void {
+    $this->appendProductOptionPreset($form_state, [(string) $this->t('Meal package')], TRUE);
+    $form_state->setRebuild(TRUE);
+  }
+
+  /**
+   * @param list<string> $labels
+   */
+  private function appendProductOptionPreset(FormStateInterface $form_state, array $labels, bool $replace = FALSE): void {
+    $editor = $form_state->getValue('editor');
+    $pricing = is_array($editor) && is_array($editor['pricing'] ?? NULL) ? $editor['pricing'] : [];
+    $defaults = [
+      'price_amount' => $pricing['price_amount'] ?? '',
+      'sku' => $pricing['sku'] ?? '',
+    ];
+    $rows = [];
+    if (!$replace && is_array($editor['product_options']['rows'] ?? NULL)) {
+      foreach ($editor['product_options']['rows'] as $row) {
+        if (is_array($row)) {
+          $rows[] = $row;
+        }
+      }
+    }
+    if ($labels === []) {
+      $rows[] = $this->productCreationManager->emptyProductOptionRow($defaults);
+    }
+    else {
+      foreach ($labels as $label) {
+        $row = $this->productCreationManager->emptyProductOptionRow($defaults);
+        $row['option_label'] = $label;
+        $rows[] = $row;
+      }
+    }
+    $form_state->set('mel_product_options', $rows);
   }
 
   public function submitSaveBookingPlacement(array &$form, FormStateInterface $form_state): void {
@@ -685,19 +800,12 @@ final class EventStudioEventExtrasForm extends FormBase {
     if (!is_array($editor)) {
       return [];
     }
-    $basics = is_array($editor['basics'] ?? NULL) ? $editor['basics'] : [];
-    $pricing = is_array($editor['pricing'] ?? NULL) ? $editor['pricing'] : [];
-    $quantity = is_array($editor['quantity'] ?? NULL) ? $editor['quantity'] : [];
-    $variants = is_array($editor['variants'] ?? NULL) ? $editor['variants'] : [];
-    $collection = is_array($editor['collection'] ?? NULL) ? $editor['collection'] : [];
-    $visibility = is_array($editor['visibility'] ?? NULL) ? $editor['visibility'] : [];
-
-    $sizes = [];
-    foreach ((array) ($variants['sizes'] ?? []) as $key => $on) {
-      if (!empty($on)) {
-        $sizes[] = (string) $key;
-      }
-    }
+    $basics = $this->editorSlice($editor, 'basics');
+    $pricing = $this->editorSlice($editor, 'pricing');
+    $collection = $this->editorSlice($editor, 'collection');
+    $visibility = $this->editorSlice($editor, 'visibility');
+    $product_options_wrap = $this->editorSlice($editor, 'product_options');
+    $product_options = is_array($product_options_wrap['rows'] ?? NULL) ? $product_options_wrap['rows'] : [];
 
     $extra_type = (string) ($editor['extra_type'] ?? '');
     if ($extra_type === '' && isset($basics['extra_type'])) {
@@ -718,11 +826,51 @@ final class EventStudioEventExtrasForm extends FormBase {
       'pickup_note' => (string) ($collection['pickup_note'] ?? ''),
       'price_amount' => $pricing['price_amount'] ?? NULL,
       'sku' => (string) ($pricing['sku'] ?? ''),
-      'capacity_note' => (string) ($quantity['capacity_note'] ?? ''),
-      'sizes' => $sizes,
+      'capacity_note' => (string) ($product_options_wrap['capacity_note'] ?? ''),
+      'product_options' => $product_options,
+      'sizes' => [],
       'show_on_booking' => !empty($visibility['show_on_booking']),
       'image_media_ids' => $image_media_ids,
     ];
+  }
+
+  /**
+   * @param array<string, mixed> $editor
+   *
+   * @return array<string, mixed>
+   */
+  private function editorSlice(array $editor, string $key): array {
+    if (is_array($editor[$key] ?? NULL)) {
+      return $editor[$key];
+    }
+    $accordion = is_array($editor['accordion'] ?? NULL) ? $editor['accordion'] : [];
+    foreach ($accordion as $panel) {
+      if (!is_array($panel)) {
+        continue;
+      }
+      if (is_array($panel[$key] ?? NULL)) {
+        return $panel[$key];
+      }
+      if ($key === 'basics' && is_array($panel['basics']['basics'] ?? NULL)) {
+        return $panel['basics']['basics'];
+      }
+      if ($key === 'pricing' && is_array($panel['basics']['pricing'] ?? NULL)) {
+        return $panel['basics']['pricing'];
+      }
+      if ($key === 'media' && is_array($panel['photos']['media'] ?? NULL)) {
+        return $panel['photos']['media'];
+      }
+      if ($key === 'product_options' && is_array($panel['product_options']['product_options'] ?? NULL)) {
+        return $panel['product_options']['product_options'];
+      }
+      if ($key === 'collection' && is_array($panel['collection_documents']['collection'] ?? NULL)) {
+        return $panel['collection_documents']['collection'];
+      }
+      if ($key === 'visibility' && is_array($panel['collection_documents']['visibility'] ?? NULL)) {
+        return $panel['collection_documents']['visibility'];
+      }
+    }
+    return [];
   }
 
   private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioCommerceSalesSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioCommerceSalesSummaryBuilder.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_commerce\Service\TicketStatusEvaluator;
+use Drupal\myeventlane_commerce\Service\TicketVariationSoldService;
+use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Read-only Event Studio commerce summaries (tickets vs operational extras).
+ *
+ * Ticket sold counts use {@see TicketBackedOrderItemClassifierInterface} on
+ * completed Commerce orders only. Operational extras never contribute.
+ */
+final class EventStudioCommerceSalesSummaryBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EventPaidTicketLoaderInterface $ticketTierLifecycle,
+    private readonly TicketBackedOrderItemClassifierInterface $ticketBackedClassifier,
+    private readonly TicketVariationSoldService $variationSold,
+    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly TimeInterface $time,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds the read-only Ticket sales panel for Event Studio commerce surfaces.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildTicketSalesPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    if ($event_id < 1 || $event->bundle() !== 'event') {
+      return $this->emptyPanel($event);
+    }
+
+    $sold_by_variation = $this->countTicketBackedSoldByVariation($event_id);
+    $rows = [];
+    $cache_tags = $event->getCacheTags();
+
+    foreach ($this->ticketTierLifecycle->loadOrderedTicketsForEvent($event) as $tier) {
+      if (!$tier instanceof TicketTypeInterface) {
+        continue;
+      }
+      if ($tier->getTicketKind() !== 'paid') {
+        continue;
+      }
+
+      $variation = $tier->get('commerce_variation')->entity;
+      if (!$variation instanceof ProductVariationInterface) {
+        continue;
+      }
+
+      $variation_id = (int) $variation->id();
+      $sold = (int) ($sold_by_variation[$variation_id] ?? 0);
+      $capacity = $this->resolveCapacity($tier, $variation);
+      $remaining = $this->formatRemaining($capacity, $sold);
+      $percent = $this->formatPercentSold($capacity, $sold);
+      $price = $this->formatPrice($variation);
+      $status = $this->resolveVendorStatus($tier, $event, $sold, $capacity);
+
+      $rows[] = [
+        'ticket_id' => (int) $tier->id(),
+        'name' => $tier->label(),
+        'price' => $price,
+        'capacity' => $capacity,
+        'capacity_label' => $this->formatCapacityLabel($capacity),
+        'sold' => $sold,
+        'remaining' => $remaining,
+        'remaining_label' => $remaining['label'],
+        'percent_sold' => $percent,
+        'percent_sold_label' => $percent !== NULL ? (string) $this->t('@pct%', ['@pct' => number_format($percent, 1)]) : '—',
+        'status' => $status['key'],
+        'status_label' => $status['label'],
+        'status_tone' => $status['tone'],
+        'variation_id' => $variation_id,
+      ];
+
+      $cache_tags = array_merge($cache_tags, $tier->getCacheTags(), $variation->getCacheTags());
+    }
+
+    return [
+      'has_rows' => $rows !== [],
+      'rows' => $rows,
+      'empty_message' => (string) $this->t('No paid ticket types are configured yet. Set up tickets to track attendance capacity and sales here.'),
+      'helper_copy' => (string) $this->t('Tickets are attendance capacity. Merch and add-ons are tracked separately.'),
+      'edit_tickets_url' => Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event_id])->toString(),
+      'edit_tickets_label' => (string) $this->t('Edit tickets'),
+      'sold_order_state' => 'completed',
+      'sold_basis' => 'ticket_backed_order_items',
+      'cache_tags' => array_values(array_unique($cache_tags)),
+    ];
+  }
+
+  /**
+   * Builds a themed render array for the read-only ticket sales panel.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildTicketSalesPanelRenderArray(NodeInterface $event, int $weight = 0): array {
+    $panel = $this->buildTicketSalesPanel($event);
+    return [
+      '#theme' => 'mel_event_studio_ticket_sales_panel',
+      '#panel' => $panel,
+      '#weight' => $weight,
+      '#cache' => [
+        'tags' => $panel['cache_tags'] ?? $event->getCacheTags(),
+        'contexts' => ['user'],
+      ],
+    ];
+  }
+
+  /**
+   * Completed-order quantities for ticket-backed variations only.
+   *
+   * @return array<int, int>
+   *   Variation ID => sold quantity.
+   */
+  public function countTicketBackedSoldByVariation(int $event_id): array {
+    if ($event_id < 1) {
+      return [];
+    }
+
+    $order_item_storage = $this->entityTypeManager->getStorage('commerce_order_item');
+    $order_storage = $this->entityTypeManager->getStorage('commerce_order');
+    $ids = $order_item_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_target_event', $event_id)
+      ->execute();
+    if (!$ids) {
+      return [];
+    }
+
+    /** @var \Drupal\commerce_order\Entity\OrderItemInterface[] $items */
+    $items = $order_item_storage->loadMultiple($ids);
+    $sold = [];
+    $completed_cache = [];
+
+    foreach ($items as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+      if (!$this->ticketBackedClassifier->isTicketBackedOrderItem($item)) {
+        continue;
+      }
+      if ($item->get('order_id')->isEmpty()) {
+        continue;
+      }
+      $order_id = (int) $item->get('order_id')->target_id;
+      if ($order_id < 1) {
+        continue;
+      }
+      if (!array_key_exists($order_id, $completed_cache)) {
+        $order = $order_storage->load($order_id);
+        $completed_cache[$order_id] = $order && $order->getState()->getId() === 'completed';
+      }
+      if (!$completed_cache[$order_id]) {
+        continue;
+      }
+      $purchased = $item->getPurchasedEntity();
+      if (!$purchased instanceof ProductVariationInterface) {
+        continue;
+      }
+      $vid = (int) $purchased->id();
+      $sold[$vid] = ($sold[$vid] ?? 0) + (int) round((float) $item->getQuantity());
+    }
+
+    return $sold;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function emptyPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    return [
+      'has_rows' => FALSE,
+      'rows' => [],
+      'empty_message' => (string) $this->t('No paid ticket types are configured yet. Set up tickets to track attendance capacity and sales here.'),
+      'helper_copy' => (string) $this->t('Tickets are attendance capacity. Merch and add-ons are tracked separately.'),
+      'edit_tickets_url' => $event_id > 0
+        ? Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event_id])->toString()
+        : '',
+      'edit_tickets_label' => (string) $this->t('Edit tickets'),
+      'sold_order_state' => 'completed',
+      'sold_basis' => 'ticket_backed_order_items',
+      'cache_tags' => $event->getCacheTags(),
+    ];
+  }
+
+  private function resolveCapacity(TicketTypeInterface $tier, ProductVariationInterface $variation): ?int {
+    if (!$tier->get('capacity')->isEmpty()) {
+      $cap = (int) $tier->get('capacity')->value;
+      return $cap > 0 ? $cap : NULL;
+    }
+    if ($variation->hasField('field_capacity') && !$variation->get('field_capacity')->isEmpty()) {
+      $cap = (int) $variation->get('field_capacity')->value;
+      return $cap > 0 ? $cap : NULL;
+    }
+    return NULL;
+  }
+
+  /**
+   * @return array{value: int|null, label: string}
+   */
+  private function formatRemaining(?int $capacity, int $sold): array {
+    if ($capacity === NULL) {
+      return [
+        'value' => NULL,
+        'label' => (string) $this->t('Unlimited'),
+      ];
+    }
+    $remaining = max(0, $capacity - $sold);
+    return [
+      'value' => $remaining,
+      'label' => (string) $remaining,
+    ];
+  }
+
+  private function formatCapacityLabel(?int $capacity): string {
+    if ($capacity === NULL) {
+      return (string) $this->t('No limit set');
+    }
+    return (string) $capacity;
+  }
+
+  private function formatPercentSold(?int $capacity, int $sold): ?float {
+    if ($capacity === NULL || $capacity < 1) {
+      return NULL;
+    }
+    return round(min(100.0, 100.0 * ($sold / $capacity)), 1);
+  }
+
+  private function formatPrice(ProductVariationInterface $variation): string {
+    $price = $variation->getPrice();
+    if ($price === NULL) {
+      return '—';
+    }
+    return $this->currencyFormatter->format($price->getNumber(), $price->getCurrencyCode());
+  }
+
+  /**
+   * @return array{key: string, label: string, tone: string}
+   */
+  private function resolveVendorStatus(
+    TicketTypeInterface $tier,
+    NodeInterface $event,
+    int $sold,
+    ?int $capacity,
+  ): array {
+    if ($tier->isArchived()) {
+      return [
+        'key' => 'hidden',
+        'label' => (string) $this->t('Hidden'),
+        'tone' => 'muted',
+      ];
+    }
+
+    if ($tier->hasField('status') && (int) ($tier->get('status')->value ?? 0) === 0) {
+      return [
+        'key' => 'hidden',
+        'label' => (string) $this->t('Hidden'),
+        'tone' => 'muted',
+      ];
+    }
+
+    if ($tier->hasField('visibility_mode') && !$tier->get('visibility_mode')->isEmpty()) {
+      $mode = (string) $tier->get('visibility_mode')->value;
+      if ($mode === 'hidden') {
+        return [
+          'key' => 'hidden',
+          'label' => (string) $this->t('Hidden'),
+          'tone' => 'muted',
+        ];
+      }
+    }
+
+    $evaluated = TicketStatusEvaluator::evaluate($tier, $this->variationSold, $this->time, $event);
+    if ($capacity !== NULL && $capacity > 0 && $sold >= $capacity) {
+      $evaluated = TicketStatusEvaluator::STATUS_SOLD_OUT;
+    }
+
+    return match ($evaluated) {
+      TicketStatusEvaluator::STATUS_SOLD_OUT => [
+        'key' => 'sold_out',
+        'label' => (string) $this->t('Sold out'),
+        'tone' => 'warning',
+      ],
+      TicketStatusEvaluator::STATUS_UPCOMING => [
+        'key' => 'not_started',
+        'label' => (string) $this->t('Not started'),
+        'tone' => 'info',
+      ],
+      TicketStatusEvaluator::STATUS_ENDED => [
+        'key' => 'ended',
+        'label' => (string) $this->t('Ended'),
+        'tone' => 'muted',
+      ],
+      TicketStatusEvaluator::STATUS_INACTIVE, TicketStatusEvaluator::STATUS_ARCHIVED => [
+        'key' => 'hidden',
+        'label' => (string) $this->t('Hidden'),
+        'tone' => 'muted',
+      ],
+      default => [
+        'key' => 'on_sale',
+        'label' => (string) $this->t('On sale'),
+        'tone' => 'success',
+      ],
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEventExtrasBuilder.php
@@ -13,6 +13,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\EventOperationalAddonBuilder;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
 use Drupal\node\NodeInterface;
 
@@ -29,6 +30,7 @@ final class EventStudioEventExtrasBuilder {
     private readonly OperationalExtraVisualPresenter $visualPresenter,
     private readonly EventOperationalAddonBuilder $eventOperationalAddonBuilder,
     private readonly VendorOperationalProductCreationManager $productCreationManager,
+    private readonly OperationalVariationStockResolver $stockResolver,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -86,6 +88,7 @@ final class EventStudioEventExtrasBuilder {
     $editor_defaults = $this->productCreationManager->extractEditorDefaultsFromProduct($product);
     $product_status = (string) ($editor_defaults['product_status'] ?? 'hidden');
     $status_options = $this->productCreationManager->productStatusOptions();
+    $stock_summary = $this->stockResolver->summarizeProductStock($product);
 
     return [
       'product_id' => (int) $product->id(),
@@ -106,6 +109,12 @@ final class EventStudioEventExtrasBuilder {
       'product_status' => $product_status,
       'product_status_label' => $status_options[$product_status] ?? $product_status,
       'capacity_note' => (string) ($editor_defaults['capacity_note'] ?? ''),
+      'stock_state' => (string) ($stock_summary['stock_state'] ?? ''),
+      'stock_label' => (string) ($stock_summary['stock_label'] ?? ''),
+      'stock_sold_out' => !empty($stock_summary['sold_out']),
+      'stock_low' => !empty($stock_summary['low_stock']),
+      'stock_unlimited' => !empty($stock_summary['unlimited']),
+      'limit_per_order_label' => (string) ($stock_summary['limit_label'] ?? ''),
       'booking_visibility_label' => $product->isPublished()
         ? (string) $this->t('Visible on booking page')
         : (string) $this->t('Not on booking page'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Read-only configured merch/add-ons summary for Manage event dashboard.
+ */
+final class EventStudioExtrasConfiguredSummaryBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EventStudioEventExtrasBuilder $extrasBuilder,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    if ($event_id < 1 || $event->bundle() !== 'event') {
+      return $this->emptyPanel($event);
+    }
+
+    $cards = $this->extrasBuilder->loadExtrasForEvent($event);
+    if ($cards === []) {
+      return $this->emptyPanel($event);
+    }
+
+    $active = 0;
+    $low_stock = 0;
+    $sold_out = 0;
+    $top = [];
+
+    foreach ($cards as $card) {
+      if (!empty($card['show_on_booking'])) {
+        $active++;
+      }
+      if (!empty($card['stock_low'])) {
+        $low_stock++;
+      }
+      if (!empty($card['stock_sold_out'])) {
+        $sold_out++;
+      }
+    }
+    $hidden_draft = count($cards) - $active;
+
+    usort($cards, static function (array $a, array $b): int {
+      return strcasecmp((string) ($a['title'] ?? ''), (string) ($b['title'] ?? ''));
+    });
+    foreach (array_slice($cards, 0, 3) as $card) {
+      $top[] = [
+        'name' => (string) ($card['title'] ?? ''),
+        'type' => (string) ($card['classification_label'] ?? ''),
+        'stock_state' => (string) ($card['stock_label'] ?? ''),
+        'visibility' => (string) ($card['booking_visibility_label'] ?? ''),
+      ];
+    }
+
+    return [
+      'has_products' => TRUE,
+      'stats' => [
+        'total' => count($cards),
+        'active_on_booking' => $active,
+        'hidden_draft' => $hidden_draft,
+        'low_stock' => $low_stock,
+        'sold_out' => $sold_out,
+      ],
+      'top_products' => $top,
+      'manage_url' => $this->manageExtrasUrl($event_id),
+      'manage_label' => (string) $this->t('Manage merch & add-ons'),
+      'empty_state' => NULL,
+      'cache_tags' => $event->getCacheTags(),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildPanelRenderArray(NodeInterface $event, int $weight = -5): array {
+    $panel = $this->buildPanel($event);
+    return [
+      '#theme' => 'mel_event_studio_extras_configured_summary',
+      '#panel' => $panel,
+      '#weight' => $weight,
+      '#cache' => [
+        'tags' => $panel['cache_tags'] ?? $event->getCacheTags(),
+        'contexts' => ['user'],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function emptyPanel(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+
+    return [
+      'has_products' => FALSE,
+      'stats' => [],
+      'top_products' => [],
+      'manage_url' => $this->manageExtrasUrl($event_id),
+      'manage_label' => (string) $this->t('Add merch & add-ons'),
+      'empty_state' => [
+        'title' => (string) $this->t('Add merch or extras to this event'),
+        'copy' => (string) $this->t('Sell T-shirts, parking, meal packages, drink tokens, or VIP extras alongside your tickets.'),
+        'note' => (string) $this->t('Extras use the same checkout, but they do not count as admission tickets.'),
+      ],
+      'cache_tags' => $event->getCacheTags(),
+    ];
+  }
+
+  private function manageExtrasUrl(int $event_id): string {
+    try {
+      return Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event_id])->toString();
+    }
+    catch (\Throwable) {
+      return '/vendor/events/' . $event_id . '/studio/extras';
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
@@ -12,6 +12,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\node\NodeInterface;
 
 /**
@@ -25,6 +26,7 @@ final class EventStudioExtrasProductEditorBuilder {
     private readonly EventStudioEventExtrasBuilder $extrasBuilder,
     private readonly VendorOperationalProductCreationManager $productCreationManager,
     private readonly OperationalProductStudioFieldRegistry $fieldRegistry,
+    private readonly OperationalVariationStockResolver $stockResolver,
     TranslationInterface $string_translation,
   ) {
     $this->stringTranslation = $string_translation;
@@ -73,6 +75,9 @@ final class EventStudioExtrasProductEditorBuilder {
       '#tree' => TRUE,
       '#parents' => ['editor'],
       '#attributes' => ['class' => ['mel-event-product-editor']],
+      '#attached' => [
+        'library' => ['myeventlane_event_studio/mel_event_extras_product_editor'],
+      ],
       'product_id' => [
         '#type' => 'hidden',
         '#value' => $product instanceof ProductInterface ? (string) $product->id() : '',
@@ -83,46 +88,532 @@ final class EventStudioExtrasProductEditorBuilder {
       ],
     ];
 
-    $editor['nav'] = [
+    $rows = $this->resolveProductOptionRows($form_state, $defaults);
+    $open = $this->resolveAccordionOpenStates($form_state, $product, $defaults, $rows);
+
+    $editor['nav'] = $this->buildTopNav($event);
+    $editor['summary'] = $this->buildCompactSummary($defaults, $product, $event, $rows);
+
+    $actions = $this->buildActionsSection();
+
+    $editor['accordion'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-product-editor__accordion']],
+      'basics' => $this->buildAccordionPanel(
+        'basics',
+        (string) $this->t('Basics'),
+        (string) $this->t('Name, description, status, and default price for new options.'),
+        $open['basics'],
+        $this->buildBasicsPanelContent($defaults, $product, $extra_type, $is_merch),
+      ),
+      'photos' => $this->buildAccordionPanel(
+        'photos',
+        (string) $this->t('Photos'),
+        (string) $this->t('Images customers see on the booking page.'),
+        $open['photos'],
+        $this->buildMediaPanelContent($form, $form_state, $event, $product, $extra_type, $product_fields),
+      ),
+      'product_options' => $this->buildAccordionPanel(
+        'product_options',
+        (string) $this->t('Product options'),
+        (string) $this->t('Each option is something customers can buy.'),
+        $open['product_options'],
+        $this->buildProductOptionsPanelContent($defaults, $variation_fields, $form_state),
+      ),
+      'stock_limits' => $this->buildAccordionPanel(
+        'stock_limits',
+        (string) $this->t('Stock and limits'),
+        (string) $this->t('Inventory and per-order limits for each option.'),
+        $open['stock_limits'],
+        $this->buildStockLimitsPanelContent($defaults, $variation_fields, $form_state, $rows),
+      ),
+      'booking_preview' => $this->buildAccordionPanel(
+        'booking_preview',
+        (string) $this->t('Booking preview'),
+        (string) $this->t('How this item may appear to customers.'),
+        $open['booking_preview'],
+        $this->buildPreviewPanelContent($product, $event, $defaults, $form_state, $rows),
+      ),
+      'collection_documents' => $this->buildAccordionPanel(
+        'collection_documents',
+        (string) $this->t('Collection and documents'),
+        (string) $this->t('Pickup notes, booking visibility, and operational print guidance.'),
+        $open['collection_documents'],
+        $this->buildCollectionDocumentsPanelContent($defaults, $event),
+      ),
+    ];
+
+    $editor['footer'] = $this->buildFooterNav($event, $actions);
+
+    return $editor;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $sections
+   *
+   * @return array<string, mixed>
+   */
+  private function flattenSections(array $sections): array {
+    $out = [];
+    foreach ($sections as $section) {
+      if ($section === []) {
+        continue;
+      }
+      $out += $section;
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $content
+   *
+   * @return array<string, mixed>
+   */
+  private function buildAccordionPanel(
+    string $id,
+    string $title,
+    string $helper,
+    bool $open,
+    array $content,
+  ): array {
+    return [
+      '#type' => 'details',
+      '#title' => $title,
+      '#open' => $open,
+      '#attributes' => [
+        'class' => ['mel-event-product-editor__accordion-panel'],
+        'id' => 'mel-editor-panel-' . $id,
+      ],
+      'helper' => $this->sectionHelper($helper),
+    ] + $content;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $rows
+   *
+   * @return array<string, bool>
+   */
+  private function resolveAccordionOpenStates(
+    FormStateInterface $form_state,
+    ?ProductInterface $product,
+    array $defaults,
+    array $rows,
+  ): array {
+    $closed = [
+      'basics' => FALSE,
+      'photos' => FALSE,
+      'product_options' => FALSE,
+      'stock_limits' => FALSE,
+      'booking_preview' => FALSE,
+      'collection_documents' => FALSE,
+    ];
+
+    if ($form_state->isSubmitted() && $form_state->getErrors() !== []) {
+      $closed['product_options'] = TRUE;
+      $closed['stock_limits'] = TRUE;
+      $closed['basics'] = TRUE;
+      return $closed;
+    }
+
+    if (!$product instanceof ProductInterface) {
+      $closed['basics'] = TRUE;
+      return $closed;
+    }
+
+    $closed['product_options'] = TRUE;
+    $closed['booking_preview'] = TRUE;
+    return $closed;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $rows
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCompactSummary(
+    array $defaults,
+    ?ProductInterface $product,
+    NodeInterface $event,
+    array $rows,
+  ): array {
+    $summary = $this->productCreationManager->summarizeProductOptionsForPreview($rows);
+    $stock = $this->productCreationManager->summarizeProductOptionsStock($rows);
+    $status_key = (string) ($defaults['product_status'] ?? 'draft');
+    $status_options = $this->productCreationManager->productStatusOptions();
+    $status_label = (string) ($status_options[$status_key] ?? $status_key);
+    $show_on_booking = (bool) ($defaults['show_on_booking'] ?? FALSE);
+    $visibility_label = $status_key === 'active' && $show_on_booking
+      ? (string) $this->t('Visible')
+      : (string) $this->t('Hidden');
+    $options_label = $summary['count'] > 0
+      ? (string) $this->formatPlural($summary['count'], '1 option', '@count options')
+      : (string) $this->t('No options yet');
+    $price_part = $summary['price_label'] !== ''
+      ? (string) $this->t('from @price', ['@price' => $summary['price_label']])
+      : '';
+
+    $parts = array_filter([
+      $status_label,
+      $options_label,
+      (string) $stock['stock_mode_label'],
+      $visibility_label,
+      $price_part,
+    ]);
+
+    return [
+      'summary' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__compact-summary', 'mel-es-card']],
+        'line' => [
+          '#markup' => '<p class="mel-event-product-editor__compact-summary-line"><strong>'
+            . htmlspecialchars(implode(' · ', $parts), ENT_QUOTES, 'UTF-8')
+            . '</strong></p>',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildBasicsPanelContent(
+    array $defaults,
+    ?ProductInterface $product,
+    string $extra_type,
+    bool $is_merch,
+  ): array {
+    $basics = $this->buildBasicsSection($defaults, $product, $extra_type, $is_merch);
+    $basics['basics']['#parents'] = ['editor', 'basics'];
+    $pricing = $this->buildPricingSection($defaults, $product);
+    $pricing['pricing']['#parents'] = ['editor', 'pricing'];
+    return [
+      'basics' => $basics['basics'],
+      'pricing' => $pricing['pricing'],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildMediaPanelContent(
+    array &$form,
+    FormStateInterface $form_state,
+    NodeInterface $event,
+    ?ProductInterface $product,
+    string $extra_type,
+    array $product_fields,
+  ): array {
+    $media = $this->buildMediaSection($form, $form_state, $event, $product, $extra_type, $product_fields);
+    $media['media']['#parents'] = ['editor', 'media'];
+    return ['media' => $media['media']];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildProductOptionsPanelContent(
+    array $defaults,
+    array $variation_fields,
+    FormStateInterface $form_state,
+  ): array {
+    $section = $this->buildProductOptionsSection($defaults, $variation_fields, $form_state);
+    $section['product_options']['#parents'] = ['editor', 'product_options'];
+    return ['product_options' => $section['product_options']];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $rows
+   *
+   * @return array<string, mixed>
+   */
+  private function buildStockLimitsPanelContent(
+    array $defaults,
+    array $variation_fields,
+    FormStateInterface $form_state,
+    array $rows,
+  ): array {
+    $stock_supported = !empty($variation_fields['stock_quantity']);
+    $stock_summary = $this->productCreationManager->summarizeProductOptionsStock($rows);
+    $content = [
+      'stock_limits' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-limits']],
+        'enforcement' => $this->sectionHelper((string) $this->t('Stock is enforced when customers add extras to cart.')),
+        'summary' => $this->buildStockSummaryChips($stock_summary),
+        'capacity_note' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Quantity note (optional)'),
+          '#default_value' => (string) ($defaults['capacity_note'] ?? ''),
+          '#maxlength' => 200,
+          '#description' => $this->t('Internal note for your team only.'),
+          '#parents' => ['editor', 'product_options', 'capacity_note'],
+        ],
+      ],
+    ];
+
+    if (!$stock_supported) {
+      $content['stock_limits']['unsupported'] = [
+        '#markup' => '<p class="mel-text--muted">' . $this->t('Stock fields are not configured for this product type.') . '</p>',
+      ];
+      return $content;
+    }
+
+    $open_details = $this->shouldOpenProductOptionStockDetails($form_state, $stock_summary);
+    $content['stock_limits']['stock_details'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Edit stock per option'),
+      '#open' => $open_details,
+      '#attributes' => ['class' => ['mel-event-product-editor__option-stock-details']],
+      'rules' => $this->sectionHelper((string) $this->t('Blank = unlimited. 0 = sold out. Positive numbers are enforced.')),
+      'limit_hint' => $this->sectionHelper((string) $this->t('Limit per order is optional.')),
+      'table' => $this->buildProductOptionStockTable($rows, $variation_fields),
+    ];
+
+    return $content;
+  }
+
+  /**
+   * @param array<string, mixed> $stock_summary
+   *
+   * @return array<string, mixed>
+   */
+  private function buildStockSummaryChips(array $stock_summary): array {
+    $chips = is_array($stock_summary['chips'] ?? NULL) ? $stock_summary['chips'] : [];
+    if ($chips === []) {
+      return [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Add product options to configure stock.'),
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-summary-empty', 'mel-text--muted']],
+      ];
+    }
+
+    $items = [];
+    foreach ($chips as $index => $label) {
+      $items[$index] = [
+        '#type' => 'html_tag',
+        '#tag' => 'span',
+        '#value' => $label,
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-summary-chip']],
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-product-editor__stock-summary']],
+      'chips' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-summary-chips']],
+      ] + $items,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $rows
+   * @param array<string, bool> $variation_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildProductOptionStockTable(array $rows, array $variation_fields): array {
+    $table = [
+      '#type' => 'table',
+      '#tree' => TRUE,
+      '#header' => [
+        $this->t('Option'),
+        $this->t('Stock quantity'),
+        $this->t('Limit per order'),
+        $this->t('Show remaining'),
+      ],
+      '#attributes' => ['class' => ['mel-event-product-editor__option-stock-table']],
+      '#caption' => $this->t('Stock per product option'),
+    ];
+
+    foreach ($rows as $delta => $row) {
+      if (!is_array($row) || !empty($row['remove'])) {
+        continue;
+      }
+      $label = trim((string) ($row['option_label'] ?? ''));
+      if ($label === '' && (int) ($row['variation_id'] ?? 0) <= 0) {
+        continue;
+      }
+      $display = $label !== '' ? $label : (string) $this->t('New option');
+      $parents = ['editor', 'product_options', 'rows', $delta];
+      $table[$delta] = [
+        '#attributes' => ['class' => ['mel-event-product-editor__option-stock-row'], 'data-option-delta' => (string) $delta],
+        'option_label' => [
+          'variation_id' => [
+            '#type' => 'hidden',
+            '#value' => (string) (int) ($row['variation_id'] ?? 0),
+            '#parents' => array_merge($parents, ['variation_id']),
+          ],
+          'label' => [
+            '#markup' => '<span class="mel-event-product-editor__option-stock-label">' . htmlspecialchars($display, ENT_QUOTES, 'UTF-8') . '</span>',
+          ],
+          '#wrapper_attributes' => ['data-label' => (string) $this->t('Option')],
+        ],
+        'stock_quantity' => [
+          '#type' => 'number',
+          '#title' => $this->t('Stock quantity'),
+          '#title_display' => 'invisible',
+          '#min' => 0,
+          '#step' => 1,
+          '#default_value' => $row['stock_quantity'] ?? NULL,
+          '#parents' => array_merge($parents, ['stock_quantity']),
+          '#attributes' => [
+            'class' => ['mel-event-product-editor__option-stock-qty'],
+            'placeholder' => (string) $this->t('Unlimited'),
+            'aria-label' => (string) $this->t('Stock quantity for @option', ['@option' => $display]),
+          ],
+          '#wrapper_attributes' => ['data-label' => (string) $this->t('Stock quantity')],
+        ],
+        'limit_per_order' => [
+          '#type' => 'number',
+          '#title' => $this->t('Limit per order'),
+          '#title_display' => 'invisible',
+          '#min' => 1,
+          '#step' => 1,
+          '#default_value' => $row['limit_per_order'] ?? NULL,
+          '#parents' => array_merge($parents, ['limit_per_order']),
+          '#access' => !empty($variation_fields['limit_per_order']),
+          '#attributes' => [
+            'class' => ['mel-event-product-editor__option-stock-limit'],
+            'placeholder' => (string) $this->t('No limit'),
+            'aria-label' => (string) $this->t('Limit per order for @option', ['@option' => $display]),
+          ],
+          '#wrapper_attributes' => ['data-label' => (string) $this->t('Limit per order')],
+        ],
+        'show_remaining' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Show remaining'),
+          '#title_display' => 'invisible',
+          '#default_value' => !empty($row['show_remaining']),
+          '#parents' => array_merge($parents, ['show_remaining']),
+          '#access' => !empty($variation_fields['show_remaining']),
+          '#attributes' => [
+            'class' => ['mel-event-product-editor__option-stock-show'],
+            'aria-label' => (string) $this->t('Show remaining for @option', ['@option' => $display]),
+          ],
+          '#wrapper_attributes' => ['data-label' => (string) $this->t('Show remaining')],
+        ],
+      ];
+    }
+
+    return $table;
+  }
+
+  /**
+   * @param array<string, mixed> $stock_summary
+   */
+  private function shouldOpenProductOptionStockDetails(FormStateInterface $form_state, array $stock_summary): bool {
+    if ($this->formHasStockFieldErrors($form_state)) {
+      return TRUE;
+    }
+    return !empty($stock_summary['open_stock_details']);
+  }
+
+  private function formHasStockFieldErrors(FormStateInterface $form_state): bool {
+    if (!$form_state->isSubmitted()) {
+      return FALSE;
+    }
+    foreach (array_keys($form_state->getErrors()) as $name) {
+      $name = (string) $name;
+      if (str_contains($name, 'stock_quantity')
+        || str_contains($name, 'limit_per_order')
+        || str_contains($name, 'product_options')) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $rows
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPreviewPanelContent(
+    ?ProductInterface $product,
+    NodeInterface $event,
+    array $defaults,
+    FormStateInterface $form_state,
+    array $rows,
+  ): array {
+    $preview = $this->buildPreviewSection($product, $event, $defaults, $form_state);
+    return ['preview' => $preview['customer_preview']];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildCollectionDocumentsPanelContent(array $defaults, NodeInterface $event): array {
+    $collection = $this->buildCollectionSection($defaults);
+    $collection['collection']['#parents'] = ['editor', 'collection'];
+    $visibility = $this->buildVisibilitySection($defaults);
+    $visibility['visibility']['#parents'] = ['editor', 'visibility'];
+    $docs = $this->buildOperationalDocumentsSection($event);
+    return [
+      'collection' => $collection['collection'],
+      'visibility' => $visibility['visibility'],
+      'operational_docs' => $docs['operational_docs'],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildTopNav(NodeInterface $event): array {
+    return [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-product-editor__nav']],
-      'back' => [
+      'back_extras' => [
         '#type' => 'link',
         '#title' => $this->t('← Back to all extras'),
         '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]),
         '#attributes' => ['class' => ['mel-event-product-editor__back']],
       ],
+      'manage_event' => [
+        '#type' => 'link',
+        '#title' => $this->t('Manage event'),
+        '#url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event->id()]),
+        '#attributes' => ['class' => ['mel-event-product-editor__manage-link']],
+      ],
     ];
+  }
 
-    $editor += $this->buildBasicsSection($defaults, $product, $extra_type, $is_merch);
-    $editor += $this->buildMediaSection($form, $form_state, $event, $product, $extra_type, $product_fields);
-    $editor += $this->buildPricingSection($defaults, $product);
-    $editor += $this->buildQuantitySection($defaults, $variation_fields);
-    if ($is_merch && $variation_fields['size']) {
-      $editor += $this->buildVariantsSection($defaults, $event, $product);
-    }
-    $editor += $this->buildCollectionSection($defaults);
-    $editor += $this->buildVisibilitySection($defaults);
-    $editor += $this->buildActionsSection();
-
-    if ($product instanceof ProductInterface) {
-      $editor['customer_preview'] = [
+  /**
+   * @param array<string, mixed> $actions
+   *
+   * @return array<string, mixed>
+   */
+  private function buildFooterNav(NodeInterface $event, array $actions): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-product-editor__footer']],
+      'inner' => [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__preview-card']],
-        'heading' => [
-          '#type' => 'html_tag',
-          '#tag' => 'h3',
-          '#value' => $this->t('Booking page preview'),
-          '#attributes' => ['class' => ['mel-es-card__title']],
+        '#attributes' => ['class' => ['mel-event-product-editor__footer-inner']],
+        'back' => [
+          '#type' => 'link',
+          '#title' => $this->t('← Back to all extras'),
+          '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event->id()]),
+          '#attributes' => ['class' => ['mel-event-product-editor__back']],
         ],
-        'preview' => [
-          '#theme' => 'mel_event_studio_extra_preview',
-          '#preview' => $this->extrasBuilder->buildPreviewRow($product, $event),
-        ],
-      ];
-    }
+        'actions' => $actions['actions'] ?? $actions,
+      ],
+    ];
+  }
 
-    return $editor;
+  /**
+   * @return array<string, mixed>
+   */
+  private function sectionHelper(string $text): array {
+    return [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $text,
+      '#attributes' => ['class' => ['mel-event-product-editor__section-helper', 'mel-text--muted']],
+    ];
   }
 
   /**
@@ -142,6 +633,7 @@ final class EventStudioExtrasProductEditorBuilder {
           '#value' => $this->t('Product basics'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
+        'helper' => $this->sectionHelper((string) $this->t('Name and describe what customers are buying.')),
       ],
     ];
 
@@ -216,12 +708,7 @@ final class EventStudioExtrasProductEditorBuilder {
           '#value' => $this->t('Product images'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
-        'hint' => [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $this->t('The first image is used as the main image on the booking page. Additional images form a gallery.'),
-          '#attributes' => ['class' => ['mel-text--muted']],
-        ],
+        'helper' => $this->sectionHelper((string) $this->t('Use clear product photos. The first image is used as the main booking image.')),
       ],
     ];
 
@@ -270,10 +757,6 @@ final class EventStudioExtrasProductEditorBuilder {
    * @return array<string, mixed>
    */
   private function buildPricingSection(array $defaults, ?ProductInterface $product): array {
-    $sku_description = $product === NULL
-      ? $this->t('Leave blank to auto-generate a SKU. Size variants use SKU suffixes (e.g. @example).', ['@example' => 'mel-op-123-merchandise-abc123-m'])
-      : $this->t('Base SKU for this product. Size variants keep their existing suffixes when you save.');
-
     return [
       'pricing' => [
         '#type' => 'container',
@@ -282,9 +765,10 @@ final class EventStudioExtrasProductEditorBuilder {
         'heading' => [
           '#type' => 'html_tag',
           '#tag' => 'h3',
-          '#value' => $this->t('Pricing and SKU'),
+          '#value' => $this->t('Default pricing and SKU'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
+        'helper' => $this->sectionHelper((string) $this->t('Used for new options. You can adjust each option below.')),
         'price_amount' => [
           '#type' => 'number',
           '#title' => $this->t('Price'),
@@ -299,7 +783,6 @@ final class EventStudioExtrasProductEditorBuilder {
           '#title' => $this->t('SKU'),
           '#default_value' => (string) ($defaults['sku'] ?? ''),
           '#maxlength' => 128,
-          '#description' => $sku_description,
         ],
       ],
     ];
@@ -311,7 +794,186 @@ final class EventStudioExtrasProductEditorBuilder {
    *
    * @return array<string, mixed>
    */
-  private function buildQuantitySection(array $defaults, array $variation_fields): array {
+  private function buildProductOptionsSection(
+    array $defaults,
+    array $variation_fields,
+    FormStateInterface $form_state,
+  ): array {
+    $rows = $this->resolveProductOptionRows($form_state, $defaults);
+
+    $section = [
+      'product_options' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-event-product-editor__product-options']],
+        'helper' => $this->sectionHelper((string) $this->t('Each option is something customers can buy. Add sizes, colours, parking passes, meal packages, or VIP upgrades as separate options.')),
+        'colour_note' => $this->sectionHelper((string) $this->t('Colour can go in the option label for now (e.g. “Black / S”). A guided colour builder is coming later.')),
+        'presets' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-product-editor__option-presets']],
+          'label' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('Quick presets (not saved until you click Save product):'),
+            '#attributes' => ['class' => ['mel-text--muted', 'mel-event-product-editor__preset-label']],
+          ],
+          'tshirt' => [
+            '#type' => 'submit',
+            '#value' => $this->t('Use T-shirt sizes'),
+            '#submit' => ['::submitPresetTshirtSizes'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__preset-btn']],
+          ],
+          'full_sizes' => [
+            '#type' => 'submit',
+            '#value' => $this->t('Use full size set'),
+            '#submit' => ['::submitPresetFullSizes'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__preset-btn']],
+          ],
+          'one_option' => [
+            '#type' => 'submit',
+            '#value' => $this->t('Use one option'),
+            '#submit' => ['::submitPresetOneOption'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__preset-btn']],
+          ],
+          'parking' => [
+            '#type' => 'submit',
+            '#value' => $this->t('Use parking pass'),
+            '#submit' => ['::submitPresetParkingPass'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__preset-btn']],
+          ],
+          'meal' => [
+            '#type' => 'submit',
+            '#value' => $this->t('Use meal package'),
+            '#submit' => ['::submitPresetMealPackage'],
+            '#limit_validation_errors' => [],
+            '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__preset-btn']],
+          ],
+        ],
+        'rows' => [
+          '#type' => 'container',
+          '#tree' => TRUE,
+          '#attributes' => ['class' => ['mel-event-product-editor__option-rows']],
+        ],
+        'add_option' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Add option'),
+          '#submit' => ['::submitAddProductOption'],
+          '#limit_validation_errors' => [],
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__add-option']],
+        ],
+      ],
+    ];
+
+    foreach ($rows as $delta => $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $section['product_options']['rows'][$delta] = $this->buildProductOptionCatalogRow(
+        (int) $delta,
+        $row,
+        $defaults,
+      );
+    }
+
+    return $section;
+  }
+
+  /**
+   * @param array<string, mixed> $row
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildProductOptionCatalogRow(int $delta, array $row, array $defaults): array {
+    $label = (string) ($row['option_label'] ?? '');
+    return [
+      '#type' => 'fieldset',
+      '#title' => $label !== '' ? $label : (string) $this->t('New option'),
+      '#attributes' => ['class' => ['mel-event-product-editor__option-card']],
+      'variation_id' => [
+        '#type' => 'hidden',
+        '#value' => (string) (int) ($row['variation_id'] ?? 0),
+      ],
+      'option_label' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Option label'),
+        '#default_value' => $label,
+        '#maxlength' => 128,
+        '#description' => $this->t('Examples: S, M, L, Black / S, Parking pass, VIP upgrade'),
+      ],
+      'sku' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('SKU'),
+        '#default_value' => (string) ($row['sku'] ?? ''),
+        '#maxlength' => 128,
+      ],
+      'price_amount' => [
+        '#type' => 'number',
+        '#title' => $this->t('Price'),
+        '#default_value' => $row['price_amount'] ?? $defaults['price_amount'] ?? '',
+        '#min' => 0,
+        '#step' => 0.01,
+      ],
+      'published' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Visible on booking page'),
+        '#default_value' => !isset($row['published']) || !empty($row['published']),
+      ],
+      'remove' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Remove this option'),
+        '#default_value' => !empty($row['remove']),
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function resolveProductOptionRows(FormStateInterface $form_state, array $defaults): array {
+    $stored = $form_state->get('mel_product_options');
+    if (is_array($stored) && $stored !== []) {
+      return $stored;
+    }
+    $options = $defaults['product_options'] ?? [];
+    if (!is_array($options) || $options === []) {
+      return [$this->productCreationManager->emptyProductOptionRow($defaults)];
+    }
+    return $options;
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCollectionAndVisibilitySection(array $defaults): array {
+    $collection = $this->buildCollectionSection($defaults);
+    $visibility = $this->buildVisibilitySection($defaults);
+    return [
+      'collection_visibility' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-event-product-editor__collection-visibility']],
+        'collection' => $collection['collection'],
+        'visibility' => $visibility['visibility'],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   * @param array<string, bool> $variation_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildQuantitySection(array $defaults, array $variation_fields, bool $is_merch): array {
     $section = [
       'quantity' => [
         '#type' => 'container',
@@ -323,25 +985,53 @@ final class EventStudioExtrasProductEditorBuilder {
           '#value' => $this->t('Quantity'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
+        'helper' => $this->sectionHelper((string) $this->t('Stock is enforced when customers add extras to cart.')),
+        'stock_rules' => $this->sectionHelper((string) $this->t('Blank stock = unlimited. 0 = sold out. Positive numbers are enforced.')),
       ],
     ];
 
-    if ($variation_fields['stock_quantity']) {
-      $section['quantity']['stock'] = [
+    $stock_supported = !empty($variation_fields['stock_quantity']);
+
+    if ($stock_supported && !$is_merch) {
+      $section['quantity']['stock_card'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-card']],
+      ];
+      $section['quantity']['stock_card']['stock_quantity'] = [
         '#type' => 'number',
-        '#title' => $this->t('Available quantity'),
+        '#title' => $this->t('Stock quantity'),
         '#min' => 0,
         '#step' => 1,
         '#default_value' => $defaults['stock_quantity'] ?? NULL,
+        '#description' => $this->t('Blank = unlimited. 0 = sold out.'),
+        '#attributes' => ['placeholder' => (string) $this->t('Unlimited')],
       ];
+      if (!empty($variation_fields['limit_per_order'])) {
+        $section['quantity']['stock_card']['limit_per_order'] = [
+          '#type' => 'number',
+          '#title' => $this->t('Limit per order'),
+          '#min' => 1,
+          '#step' => 1,
+          '#default_value' => $defaults['limit_per_order'] ?? NULL,
+          '#description' => $this->t('Optional maximum per customer order.'),
+        ];
+      }
+      if (!empty($variation_fields['show_remaining'])) {
+        $section['quantity']['stock_card']['show_remaining'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Show remaining'),
+          '#default_value' => !empty($defaults['show_remaining']),
+          '#description' => $this->t('Show customers how many are left.'),
+        ];
+      }
     }
-    else {
+    elseif (!$stock_supported) {
       $section['quantity']['capacity_note'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Quantity note'),
         '#default_value' => (string) ($defaults['capacity_note'] ?? ''),
         '#maxlength' => 200,
-        '#description' => $this->t('Shown to you only. This does not enforce stock yet.'),
+        '#description' => $this->t('Optional internal note. This does not enforce stock.'),
         '#attributes' => ['class' => ['mel-event-product-editor__capacity-note']],
       ];
       $section['quantity']['warning'] = [
@@ -354,7 +1044,54 @@ final class EventStudioExtrasProductEditorBuilder {
       ];
     }
 
+    if ($stock_supported && !$is_merch) {
+      $section['quantity']['capacity_note'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Quantity note (optional)'),
+        '#default_value' => (string) ($defaults['capacity_note'] ?? ''),
+        '#maxlength' => 200,
+        '#description' => $this->t('Internal helper note for your team. Stock quantity above is enforced at checkout.'),
+        '#attributes' => ['class' => ['mel-event-product-editor__capacity-note']],
+      ];
+    }
+
     return $section;
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   * @param array<string, bool> $variation_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildQuantityAsideSection(array $defaults, array $variation_fields): array {
+    if (empty($variation_fields['stock_quantity'])) {
+      return [];
+    }
+
+    return [
+      'quantity_summary' => [
+        '#type' => 'container',
+        '#tree' => TRUE,
+        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section', 'mel-event-product-editor__section--aside']],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Quantity'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'helper' => $this->sectionHelper((string) $this->t('Stock is enforced when customers add extras to cart.')),
+        'stock_rules' => $this->sectionHelper((string) $this->t('Blank stock = unlimited. 0 = sold out. Positive numbers are enforced.')),
+        'capacity_note' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Quantity note (optional)'),
+          '#default_value' => (string) ($defaults['capacity_note'] ?? ''),
+          '#maxlength' => 200,
+          '#description' => $this->t('Internal helper note for your team. Set stock per size in Options and variants.'),
+          '#attributes' => ['class' => ['mel-event-product-editor__capacity-note']],
+        ],
+      ],
+    ];
   }
 
   /**
@@ -362,12 +1099,21 @@ final class EventStudioExtrasProductEditorBuilder {
    *
    * @return array<string, mixed>
    */
-  private function buildVariantsSection(array $defaults, NodeInterface $event, ?ProductInterface $product): array {
-    $preview_rows = $product instanceof ProductInterface
-      ? $this->productCreationManager->buildVariantPreviewRowsFromProduct($product)
-      : $this->productCreationManager->buildVariantPreviewRows($event, $defaults, NULL);
+  private function buildVariantsSection(
+    array $defaults,
+    NodeInterface $event,
+    ?ProductInterface $product,
+    array $variation_fields,
+    FormStateInterface $form_state,
+    array $preview_rows,
+  ): array {
+    $stock_supported = !empty($variation_fields['stock_quantity']);
+    $variant_stock_defaults = is_array($defaults['variant_stock'] ?? NULL) ? $defaults['variant_stock'] : [];
+    $stock_mode = $this->resolveVariantStockMode($preview_rows, $variant_stock_defaults);
+    $open_stock_details = $this->shouldOpenVariantStockDetails($form_state, $stock_mode);
+    $open_variation_summary = $this->shouldOpenVariationSummary($form_state, $open_stock_details);
 
-    return [
+    $section = [
       'variants' => [
         '#type' => 'container',
         '#tree' => TRUE,
@@ -378,11 +1124,12 @@ final class EventStudioExtrasProductEditorBuilder {
           '#value' => $this->t('Options and variants'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
-        'hint' => [
+        'helper' => $this->sectionHelper((string) $this->t('Each selected size becomes a purchasable option.')),
+        'colour_note' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('Select sizes to sell. Each size becomes a purchasable Commerce variation with its own SKU.'),
-          '#attributes' => ['class' => ['mel-text--muted']],
+          '#value' => $this->t('Colour options are coming soon.'),
+          '#attributes' => ['class' => ['mel-event-product-editor__coming-soon', 'mel-text--muted']],
         ],
         'sizes' => [
           '#type' => 'checkboxes',
@@ -391,15 +1138,111 @@ final class EventStudioExtrasProductEditorBuilder {
           '#default_value' => $defaults['sizes'] ?? [],
           '#attributes' => ['class' => ['mel-event-product-editor__sizes']],
         ],
-        'variant_preview' => [
-          '#theme' => 'mel_event_studio_extra_variant_preview',
-          '#rows' => $preview_rows,
-          '#attached' => [
-            'library' => ['myeventlane_event_studio/mel_event_extras_product_editor'],
-          ],
-        ],
       ],
     ];
+
+    if ($stock_supported) {
+      $section['variants']['stock_overview'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__stock-overview']],
+        'summary' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->describeVariantStockState($preview_rows, $variant_stock_defaults),
+          '#attributes' => ['class' => ['mel-event-product-editor__stock-overview-summary']],
+        ],
+        'rules' => $this->sectionHelper((string) $this->t('Blank stock = unlimited. 0 = sold out. Positive numbers are enforced.')),
+        'limit_hint' => $this->sectionHelper((string) $this->t('Limit per order is optional.')),
+      ];
+
+      $stock_table = [
+        '#type' => 'table',
+        '#tree' => TRUE,
+        '#header' => [
+          $this->t('Size'),
+          $this->t('Stock quantity'),
+          $this->t('Limit per order'),
+          $this->t('Show remaining'),
+          $this->t('Status'),
+        ],
+        '#attributes' => ['class' => ['mel-event-product-editor__variant-stock-table']],
+        '#caption' => $this->t('Stock settings per size'),
+      ];
+      foreach ($preview_rows as $row) {
+        $key = (string) ($row['size_key'] ?? '_default');
+        $stock_defaults = is_array($variant_stock_defaults[$key] ?? NULL) ? $variant_stock_defaults[$key] : $row;
+        $size_label = (string) ($row['size_label'] ?? $key);
+        $stock_table[$key] = [
+          '#attributes' => ['class' => ['mel-event-product-editor__variant-stock-row'], 'data-size-key' => $key],
+          'size_label' => [
+            '#markup' => '<span class="mel-event-product-editor__variant-size">' . htmlspecialchars($size_label, ENT_QUOTES, 'UTF-8') . '</span>',
+            '#wrapper_attributes' => ['data-label' => (string) $this->t('Size')],
+          ],
+          'stock_quantity' => [
+            '#type' => 'number',
+            '#title' => $this->t('Stock quantity'),
+            '#title_display' => 'invisible',
+            '#min' => 0,
+            '#step' => 1,
+            '#default_value' => $stock_defaults['stock_quantity'] ?? NULL,
+            '#attributes' => [
+              'class' => ['mel-event-product-editor__variant-stock-qty'],
+              'placeholder' => (string) $this->t('Unlimited'),
+              'aria-label' => (string) $this->t('Stock quantity for @size', ['@size' => $size_label]),
+            ],
+            '#wrapper_attributes' => ['data-label' => (string) $this->t('Stock quantity')],
+          ],
+          'limit_per_order' => [
+            '#type' => 'number',
+            '#title' => $this->t('Limit per order'),
+            '#title_display' => 'invisible',
+            '#min' => 1,
+            '#step' => 1,
+            '#default_value' => $stock_defaults['limit_per_order'] ?? NULL,
+            '#attributes' => [
+              'class' => ['mel-event-product-editor__variant-stock-limit'],
+              'placeholder' => (string) $this->t('No limit'),
+              'aria-label' => (string) $this->t('Limit per order for @size', ['@size' => $size_label]),
+            ],
+            '#wrapper_attributes' => ['data-label' => (string) $this->t('Limit per order')],
+          ],
+          'show_remaining' => [
+            '#type' => 'checkbox',
+            '#title' => $this->t('Show remaining'),
+            '#title_display' => 'invisible',
+            '#default_value' => !empty($stock_defaults['show_remaining']),
+            '#attributes' => [
+              'class' => ['mel-event-product-editor__variant-stock-show'],
+              'aria-label' => (string) $this->t('Show remaining for @size', ['@size' => $size_label]),
+            ],
+            '#wrapper_attributes' => ['data-label' => (string) $this->t('Show remaining')],
+          ],
+          'status' => [
+            '#markup' => '<span class="mel-event-product-editor__variant-status">' . htmlspecialchars((string) ($row['status_label'] ?? ''), ENT_QUOTES, 'UTF-8') . '</span>',
+            '#wrapper_attributes' => ['data-label' => (string) $this->t('Status')],
+          ],
+        ];
+      }
+
+      $section['variants']['variant_stock_details'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Set stock per option'),
+        '#open' => $open_stock_details,
+        '#attributes' => ['class' => ['mel-event-product-editor__variant-stock-details']],
+        'variant_stock' => $stock_table,
+      ];
+    }
+
+    $section['variants']['variant_preview'] = [
+      '#theme' => 'mel_event_studio_extra_variant_preview',
+      '#rows' => $preview_rows,
+      '#stock_supported' => $stock_supported,
+      '#stock_editor_enabled' => $stock_supported,
+      '#open' => $open_variation_summary,
+      '#summary_title' => (string) $this->t('Variation summary'),
+    ];
+
+    return $section;
   }
 
   /**
@@ -419,19 +1262,12 @@ final class EventStudioExtrasProductEditorBuilder {
           '#value' => $this->t('Collection and fulfilment'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
+        'helper' => $this->sectionHelper((string) $this->t('Tell customers where to collect this item at the event. Shipping and fulfilment tracking are not enabled yet.')),
         'pickup_note' => [
           '#type' => 'textarea',
           '#title' => $this->t('Pickup / venue collection note'),
           '#default_value' => (string) ($defaults['pickup_note'] ?? ''),
           '#rows' => 2,
-          '#description' => $this->t('Use this to tell customers where to collect this item at the event.'),
-        ],
-        'fulfilment_notice' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['mel-event-product-editor__fulfilment-notice', 'mel-text--muted']],
-          'text' => [
-            '#markup' => '<p>' . $this->t('Shipping and fulfilment tracking are not enabled yet.') . '</p>',
-          ],
         ],
       ],
     ];
@@ -447,18 +1283,18 @@ final class EventStudioExtrasProductEditorBuilder {
       'visibility' => [
         '#type' => 'container',
         '#tree' => TRUE,
-        '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__section']],
+        '#attributes' => ['class' => ['mel-event-product-editor__visibility']],
         'heading' => [
           '#type' => 'html_tag',
           '#tag' => 'h3',
           '#value' => $this->t('Booking visibility'),
           '#attributes' => ['class' => ['mel-es-card__title']],
         ],
+        'helper' => $this->sectionHelper((string) $this->t('Visible extras appear on the booking page after ticket selection. Product must be Active to show.')),
         'show_on_booking' => [
           '#type' => 'checkbox',
           '#title' => $this->t('Show on booking page'),
           '#default_value' => (bool) ($defaults['show_on_booking'] ?? FALSE),
-          '#description' => $this->t('Visible extras appear on the booking page after ticket selection. Requires Active status.'),
           '#states' => [
             'visible' => [
               ':input[name="editor[basics][product_status]"]' => ['value' => 'active'],
@@ -492,7 +1328,10 @@ final class EventStudioExtrasProductEditorBuilder {
           '#type' => 'submit',
           '#value' => $this->t('Save product'),
           '#button_type' => 'primary',
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--primary', 'mel-event-product-editor__save'],
+            'id' => 'mel-product-editor-save',
+          ],
         ],
         'add_another' => [
           '#type' => 'submit',
@@ -502,6 +1341,343 @@ final class EventStudioExtrasProductEditorBuilder {
         ],
       ],
     ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildOperationalDocumentsSection(NodeInterface $event): array {
+    return [
+      'operational_docs' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => [
+          'mel-es-card',
+          'mel-event-product-editor__section',
+          'mel-event-product-editor__section--aside',
+          'mel-event-product-editor__operational-docs',
+        ]],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Packing slips, parking slips and labels'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'helper' => $this->sectionHelper((string) $this->t('Print tools live in Manage event once this item starts selling.')),
+        'cta' => [
+          '#type' => 'link',
+          '#title' => $this->t('Back to Manage event'),
+          '#url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event->id()]),
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary', 'mel-event-product-editor__manage-cta']],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   *
+   * @return array<string, mixed>
+   */
+  private function buildPreviewSection(
+    ?ProductInterface $product,
+    NodeInterface $event,
+    array $defaults,
+    FormStateInterface $form_state,
+  ): array {
+    $options = $this->resolveProductOptionRows($form_state, $defaults);
+    $summary = $this->productCreationManager->summarizeProductOptionsForPreview($options);
+    $product_status = (string) ($defaults['product_status'] ?? 'draft');
+    $show_on_booking = (bool) ($defaults['show_on_booking'] ?? FALSE);
+
+    if ($product instanceof ProductInterface) {
+      $preview = $this->extrasBuilder->buildPreviewRow($product, $event);
+      $stock_label = (string) ($this->stockResolver->summarizeProductStock($product)['stock_label'] ?? '');
+    }
+    else {
+      $preview = [
+        'title' => (string) ($defaults['title'] ?? ''),
+        'short_description' => (string) ($defaults['customer_summary'] ?? ''),
+        'pickup_note' => (string) ($defaults['pickup_note'] ?? ''),
+        'primary_image' => [],
+      ];
+      $stock_label = (string) $summary['stock_summary'];
+    }
+
+    $options_summary = $summary['count'] > 0
+      ? (string) $this->formatPlural(
+        $summary['count'],
+        '1 option',
+        '@count options',
+      )
+      : (string) $this->t('No options yet');
+
+    $price_display = '';
+    if ($summary['price_label'] !== '') {
+      $price_display = (string) $this->t('from @price', ['@price' => $summary['price_label']]);
+    }
+    elseif (!empty($defaults['price_amount'])) {
+      $price_display = (string) $this->t('from @price', [
+        '@price' => number_format((float) $defaults['price_amount'], 2),
+      ]);
+    }
+
+    $preview_meta_parts = array_filter([
+      $options_summary,
+      $price_display,
+      (string) ($summary['stock_summary'] ?? ''),
+    ]);
+    $preview_meta_line = implode(' · ', $preview_meta_parts);
+
+    $visibility_label = $product_status === 'active' && $show_on_booking
+      ? (string) $this->t('Visible on booking page')
+      : (string) $this->t('Not on booking page');
+
+    $hidden_notice = '';
+    if ($product_status !== 'active' || !$show_on_booking) {
+      $hidden_notice = (string) $this->t('This product will not appear on the booking page until it is Active and visible.');
+    }
+
+    return [
+      'customer_preview' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-product-editor__preview-wrap'],
+          'id' => 'mel-product-booking-preview',
+        ],
+        'preview' => [
+          '#theme' => 'mel_event_studio_extra_preview',
+          '#preview' => $preview,
+          '#price_display' => $price_display,
+          '#options_summary' => $options_summary,
+          '#preview_meta_line' => $preview_meta_line,
+          '#stock_label' => $stock_label !== '' ? $stock_label : (string) $summary['stock_summary'],
+          '#visibility_label' => $visibility_label,
+          '#hidden_notice' => $hidden_notice,
+        ],
+        'preview_note' => $this->sectionHelper((string) $this->t('Preview only. Customers see this on the booking page.')),
+      ],
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $preview_rows
+   * @param array<string, bool> $variation_fields
+   *
+   * @return array<string, mixed>
+   */
+  private function buildProductSetupSummarySection(
+    array $defaults,
+    ?ProductInterface $product,
+    NodeInterface $event,
+    bool $is_merch,
+    array $preview_rows,
+    array $variation_fields,
+  ): array {
+    $status_key = (string) ($defaults['product_status'] ?? 'draft');
+    $status_options = $this->productCreationManager->productStatusOptions();
+    $status_label = (string) ($status_options[$status_key] ?? $status_key);
+
+    $options = is_array($defaults['product_options'] ?? NULL) ? $defaults['product_options'] : [];
+    $preview_summary = $this->productCreationManager->summarizeProductOptionsForPreview($options);
+    $stock_aggregate = $this->productCreationManager->summarizeProductOptionsStock($options);
+    $price_label = $preview_summary['price_label'] !== ''
+      ? (string) $this->t('from @price', ['@price' => $preview_summary['price_label']])
+      : ((($defaults['price_amount'] ?? '') !== '' && ($defaults['price_amount'] ?? NULL) !== NULL)
+        ? (string) $this->t('from @price', ['@price' => number_format((float) $defaults['price_amount'], 2)])
+        : (string) $this->t('Not set'));
+
+    $image_label = $this->resolveImageStatusLabel($product, $event);
+    $options_label = $preview_summary['count'] > 0
+      ? (string) $this->formatPlural($preview_summary['count'], '1 option', '@count options')
+      : (string) $this->t('No options yet');
+
+    if ($product instanceof ProductInterface) {
+      $stock = $this->stockResolver->summarizeProductStock($product);
+      $stock_label = (string) ($stock['stock_label'] ?? '');
+      if ($stock_label === '' && !empty($stock['stock_state'])) {
+        $stock_label = (string) ($stock_aggregate['stock_mode_label'] ?? '');
+      }
+    }
+    else {
+      $stock_label = (string) ($stock_aggregate['stock_mode_label'] ?? (string) $this->t('Not configured'));
+    }
+
+    $show_on_booking = (bool) ($defaults['show_on_booking'] ?? FALSE);
+    $visibility_label = $status_key === 'active' && $show_on_booking
+      ? (string) $this->t('Visible on booking page')
+      : (string) $this->t('Not on booking page');
+
+    return [
+      'setup_summary' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => [
+          'mel-event-product-editor__section--aside',
+        ]],
+        'summary' => [
+          '#theme' => 'mel_event_studio_extra_product_setup_summary',
+          '#summary' => [
+            'status_label' => $status_label,
+            'price_label' => $price_label,
+            'image_label' => $image_label,
+            'options_label' => $options_label,
+            'stock_label' => $stock_label,
+            'visibility_label' => $visibility_label,
+          ],
+          '#show_preview_anchor' => $product instanceof ProductInterface,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   */
+  private function resolveImageStatusLabel(?ProductInterface $product, NodeInterface $event): string {
+    if (!$product instanceof ProductInterface) {
+      return (string) $this->t('No image yet');
+    }
+    $count = $this->extrasBuilder->buildExtraCard($product, $event)['image_count'] ?? 0;
+    if (!is_int($count)) {
+      $count = 0;
+    }
+    if ($count === 0) {
+      return (string) $this->t('No image yet');
+    }
+    return (string) $this->formatPlural($count, '1 image', '@count images');
+  }
+
+  /**
+   * @param array<string, mixed> $defaults
+   */
+  private function countSelectedSizes(array $defaults): int {
+    $sizes = $defaults['sizes'] ?? [];
+    if (!is_array($sizes)) {
+      return 0;
+    }
+    $count = 0;
+    foreach ($sizes as $value) {
+      if ($value !== 0 && $value !== '0' && $value !== FALSE && $value !== NULL) {
+        $count++;
+      }
+    }
+    return $count;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $preview_rows
+   * @param array<string, array<string, mixed>> $variant_stock_defaults
+   */
+  private function describeVariantStockState(array $preview_rows, array $variant_stock_defaults): string {
+    $mode = $this->resolveVariantStockMode($preview_rows, $variant_stock_defaults);
+    $size_count = count($preview_rows);
+
+    return match ($mode) {
+      'empty' => (string) $this->t('Select sizes to configure stock.'),
+      'unlimited' => (string) $this->formatPlural($size_count, 'Unlimited stock (1 option)', 'Unlimited stock (@count options)'),
+      'sold_out' => (string) $this->formatPlural($size_count, 'Sold out (1 option)', 'Sold out (@count options)'),
+      'uniform' => (string) $this->t('@count units for every option', [
+        '@count' => $this->firstFiniteStockQuantity($preview_rows, $variant_stock_defaults),
+      ]),
+      default => (string) $this->formatPlural($size_count, 'Stock set per option (1 size)', 'Stock set per option (@count sizes)'),
+    };
+  }
+
+  /**
+   * @param list<array<string, mixed>> $preview_rows
+   * @param array<string, array<string, mixed>> $variant_stock_defaults
+   *
+   * @return 'empty'|'unlimited'|'sold_out'|'uniform'|'per_option'
+   */
+  private function resolveVariantStockMode(array $preview_rows, array $variant_stock_defaults): string {
+    if ($preview_rows === []) {
+      return 'empty';
+    }
+
+    $quantities = [];
+    foreach ($preview_rows as $row) {
+      $key = (string) ($row['size_key'] ?? '_default');
+      $stock_defaults = is_array($variant_stock_defaults[$key] ?? NULL) ? $variant_stock_defaults[$key] : $row;
+      $quantities[] = $this->stockResolver->normalizeStockInput($stock_defaults['stock_quantity'] ?? NULL);
+    }
+
+    $all_unlimited = TRUE;
+    $all_sold_out = TRUE;
+    $first_finite = NULL;
+    $mixed = FALSE;
+
+    foreach ($quantities as $qty) {
+      if ($qty !== NULL) {
+        $all_unlimited = FALSE;
+      }
+      if ($qty === NULL || $qty > 0) {
+        $all_sold_out = FALSE;
+      }
+      if ($qty !== NULL && $qty > 0) {
+        if ($first_finite === NULL) {
+          $first_finite = $qty;
+        }
+        elseif ($first_finite !== $qty) {
+          $mixed = TRUE;
+        }
+      }
+    }
+
+    if ($all_unlimited) {
+      return 'unlimited';
+    }
+    if ($all_sold_out) {
+      return 'sold_out';
+    }
+    if ($mixed) {
+      return 'per_option';
+    }
+    if ($first_finite !== NULL) {
+      return 'uniform';
+    }
+
+    return 'per_option';
+  }
+
+  /**
+   * @param list<array<string, mixed>> $preview_rows
+   * @param array<string, array<string, mixed>> $variant_stock_defaults
+   */
+  private function firstFiniteStockQuantity(array $preview_rows, array $variant_stock_defaults): int {
+    foreach ($preview_rows as $row) {
+      $key = (string) ($row['size_key'] ?? '_default');
+      $stock_defaults = is_array($variant_stock_defaults[$key] ?? NULL) ? $variant_stock_defaults[$key] : $row;
+      $qty = $this->stockResolver->normalizeStockInput($stock_defaults['stock_quantity'] ?? NULL);
+      if ($qty !== NULL && $qty > 0) {
+        return $qty;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * @param 'empty'|'unlimited'|'sold_out'|'uniform'|'per_option' $stock_mode
+   */
+  private function shouldOpenVariantStockDetails(FormStateInterface $form_state, string $stock_mode): bool {
+    if ($this->formHasRelevantErrors($form_state)) {
+      return TRUE;
+    }
+    return $stock_mode === 'per_option';
+  }
+
+  private function shouldOpenVariationSummary(FormStateInterface $form_state, bool $open_stock_details): bool {
+    return $this->formHasRelevantErrors($form_state) || $open_stock_details;
+  }
+
+  private function formHasRelevantErrors(FormStateInterface $form_state): bool {
+    if (!$form_state->isSubmitted()) {
+      return FALSE;
+    }
+    foreach (array_keys($form_state->getErrors()) as $name) {
+      if (str_contains((string) $name, 'editor') || str_contains((string) $name, 'variant_stock')) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   private function attachImagesWidget(

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -108,7 +108,7 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildOverviewSection(NodeInterface $event): array {
-    return [
+    $build = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-studio-overview']],
       'hero' => [
@@ -153,6 +153,8 @@ final class EventStudioSectionRenderer {
         ],
       ],
     ];
+
+    return $build;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/OperationalProductStudioFieldRegistry.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/OperationalProductStudioFieldRegistry.php
@@ -41,8 +41,9 @@ final class OperationalProductStudioFieldRegistry {
     $defs = $this->entityFieldManager->getFieldDefinitions('commerce_product_variation', $variation_bundle);
     return [
       'size' => isset($defs['field_mel_size']),
-      'stock_quantity' => isset($defs['field_stock']) || isset($defs['commerce_stock']),
-      'limit_per_order' => isset($defs['field_limit_per_order']),
+      'stock_quantity' => isset($defs['field_mel_stock_quantity']),
+      'limit_per_order' => isset($defs['field_mel_limit_per_order']),
+      'show_remaining' => isset($defs['field_mel_show_remaining']),
       'status' => isset($defs['status']),
       'price' => isset($defs['price']),
       'sku' => isset($defs['sku']),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/VendorOperationalProductCreationManager.php
@@ -15,6 +15,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -111,6 +112,7 @@ final class VendorOperationalProductCreationManager {
     private readonly OperationalMerchandiseManager $operationalMerchandiseManager,
     private readonly OperationalCapabilityCommerceLinkManager $commerceLinkManager,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly OperationalVariationStockResolver $stockResolver,
     private readonly TranslationInterface $translation,
     private readonly LoggerInterface $logger,
   ) {}
@@ -259,6 +261,7 @@ final class VendorOperationalProductCreationManager {
       'pickup_mode' => $pickup_mode,
       'pickup_note' => (string) ($input['pickup_note'] ?? ''),
       'sizes' => $this->normalizeSizeKeys($input['sizes'] ?? []),
+      'product_options' => $this->normalizeProductOptionsInput($input['product_options'] ?? []),
       'sku' => trim((string) ($input['sku'] ?? '')),
       'capacity_note' => trim((string) ($input['capacity_note'] ?? '')),
       'timed_collection_window_copy' => in_array($extra_type, ['pickup_item', 'shuttle'], TRUE)
@@ -328,6 +331,12 @@ final class VendorOperationalProductCreationManager {
     $amount = $this->normalizePriceAmount($input['price_amount'] ?? NULL);
     if ($amount === NULL) {
       $errors[] = 'A valid price is required.';
+    }
+    foreach ($this->validateStockInputFromEventExtra($input) as $error) {
+      $errors[] = $error;
+    }
+    foreach ($this->validateProductOptionsInput($input) as $error) {
+      $errors[] = $error;
     }
     return $errors;
   }
@@ -583,6 +592,40 @@ final class VendorOperationalProductCreationManager {
     string $sku_base,
     Price $price,
   ): array {
+    $product_options = $this->normalizeProductOptionsInput($payload['product_options'] ?? []);
+    if ($product_options !== []) {
+      $variation_type = $bundles['variation_type'];
+      $ids = [];
+      foreach ($product_options as $row) {
+        $option_label = trim((string) ($row['option_label'] ?? ''));
+        if ($option_label === '') {
+          continue;
+        }
+        $row_price = $this->normalizePriceAmount($row['price_amount'] ?? $payload['price_amount'] ?? NULL);
+        $row_price_obj = new Price((string) $row_price, $price->getCurrencyCode());
+        $sku = trim((string) ($row['sku'] ?? ''));
+        if ($sku === '') {
+          $sku = $this->generateOptionSku($sku_base, $option_label);
+        }
+        $variation = ProductVariation::create([
+          'type' => $variation_type,
+          'sku' => $this->sanitizePlainText($sku, 128),
+          'title' => $title . ' — ' . $this->sanitizePlainText($option_label, 128),
+          'status' => !empty($row['published']) ? 1 : 0,
+          'price' => $row_price_obj,
+        ]);
+        $this->applySizeFieldFromOptionLabel($variation, $option_label);
+        $this->stockResolver->applyStockFields($variation, [
+          'stock_quantity' => $row['stock_quantity'] ?? NULL,
+          'limit_per_order' => $row['limit_per_order'] ?? NULL,
+          'show_remaining' => !empty($row['show_remaining']),
+        ]);
+        $variation->save();
+        $ids[] = (int) $variation->id();
+      }
+      return $ids;
+    }
+
     $size_keys = $this->normalizeSizeKeys($payload['sizes'] ?? []);
     $variation_type = $bundles['variation_type'];
     $ids = [];
@@ -600,6 +643,7 @@ final class VendorOperationalProductCreationManager {
         if ($variation->hasField('field_mel_size')) {
           $variation->set('field_mel_size', $size_key);
         }
+        $this->stockResolver->applyStockFields($variation, $this->resolveVariantStockInput($payload, $size_key));
         $variation->save();
         $ids[] = (int) $variation->id();
       }
@@ -613,6 +657,7 @@ final class VendorOperationalProductCreationManager {
       'status' => 1,
       'price' => $price,
     ]);
+    $this->stockResolver->applyStockFields($variation, $this->resolveVariantStockInput($payload, '_default'));
     $variation->save();
     return [(int) $variation->id()];
   }
@@ -961,7 +1006,7 @@ final class VendorOperationalProductCreationManager {
     }
 
     $this->applyEventExtraFieldUpdates($product, $input);
-    $this->syncVariationsForEventExtra($product, $input, $title, $price);
+    $this->syncVariationsFromProductOptions($product, $input, $title, $price);
     $product->save();
 
     $this->logger->notice('Vendor event extra @pid updated for event @eid.', [
@@ -996,75 +1041,85 @@ final class VendorOperationalProductCreationManager {
   /**
    * @param array<string, mixed> $input
    */
-  private function syncVariationsForEventExtra(ProductInterface $product, array $input, string $title, Price $price): void {
+  /**
+   * @param array<string, mixed> $input
+   */
+  private function syncVariationsFromProductOptions(ProductInterface $product, array $input, string $title, Price $default_price): void {
     $bundles = $this->mapProductBundleToVariationType($product->bundle());
     $variation_type = $bundles['variation_type'];
-    $size_keys = $variation_type === 'operational_merchandise_var'
-      ? $this->normalizeSizeKeys($input['sizes'] ?? [])
-      : [];
-
-    $storage = $this->entityTypeManager->getStorage('commerce_product_variation');
-    $existing = [];
-    foreach ($product->getVariations() as $variation) {
-      if (!$variation instanceof ProductVariationInterface) {
-        continue;
-      }
-      $size = '';
-      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
-        $size = strtolower((string) $variation->get('field_mel_size')->value);
-      }
-      $key = $size !== '' ? $size : '_default';
-      $existing[$key] = $variation;
-    }
-
-    $desired_keys = $size_keys !== [] ? $size_keys : ['_default'];
+    $options = $this->normalizeProductOptionsInput($input['product_options'] ?? []);
     $custom_sku = trim((string) ($input['sku'] ?? ''));
     $sku_base = $custom_sku !== ''
       ? $this->sanitizePlainText($custom_sku, 128)
       : 'mel-extra-' . (int) $product->id();
 
-    foreach ($desired_keys as $size_key) {
-      $lookup = $size_key === '_default' ? '_default' : $size_key;
-      $label = $size_key === '_default'
-        ? $title
-        : $title . ' — ' . (OperationalExtraVisualPresenter::SIZE_LABELS[$size_key] ?? strtoupper($size_key));
-      $sku = $size_key === '_default'
-        ? $this->sanitizePlainText($sku_base, 128)
-        : $this->sanitizePlainText($sku_base . '-' . $size_key, 128);
+    $existing_by_id = [];
+    foreach ($product->getVariations() as $variation) {
+      if ($variation instanceof ProductVariationInterface) {
+        $existing_by_id[(int) $variation->id()] = $variation;
+      }
+    }
 
-      if (isset($existing[$lookup])) {
-        $variation = $existing[$lookup];
-        $variation->setTitle($label);
-        $variation->setPrice($price);
-        $variation->setPublished(TRUE);
-        if ($size_key !== '_default' && $variation->hasField('field_mel_size')) {
-          $variation->set('field_mel_size', $size_key);
-        }
+    $kept_ids = [];
+    foreach ($options as $row) {
+      if (!empty($row['remove'])) {
+        continue;
+      }
+      $option_label = trim((string) ($row['option_label'] ?? ''));
+      if ($option_label === '') {
+        continue;
+      }
+      $variation_id = (int) ($row['variation_id'] ?? 0);
+      $row_amount = $this->normalizePriceAmount($row['price_amount'] ?? $input['price_amount'] ?? NULL);
+      $row_price = new Price((string) $row_amount, $default_price->getCurrencyCode());
+      $sku = trim((string) ($row['sku'] ?? ''));
+      if ($sku === '') {
+        $sku = $this->generateOptionSku($sku_base, $option_label);
+      }
+      $variation_title = $title . ' — ' . $this->sanitizePlainText($option_label, 128);
+      $published = !empty($row['published']);
+
+      if ($variation_id > 0 && isset($existing_by_id[$variation_id])) {
+        $variation = $existing_by_id[$variation_id];
+        $variation->setTitle($variation_title);
+        $variation->setSku($this->sanitizePlainText($sku, 128));
+        $variation->setPrice($row_price);
+        $variation->setPublished($published);
+        $this->applySizeFieldFromOptionLabel($variation, $option_label);
+        $this->stockResolver->applyStockFields($variation, [
+          'stock_quantity' => $row['stock_quantity'] ?? NULL,
+          'limit_per_order' => $row['limit_per_order'] ?? NULL,
+          'show_remaining' => !empty($row['show_remaining']),
+        ]);
         $variation->save();
-        unset($existing[$lookup]);
+        $kept_ids[$variation_id] = $variation_id;
         continue;
       }
 
       $variation = ProductVariation::create([
         'type' => $variation_type,
-        'sku' => $sku,
-        'title' => $label,
-        'status' => 1,
-        'price' => $price,
+        'sku' => $this->sanitizePlainText($sku, 128),
+        'title' => $variation_title,
+        'status' => $published ? 1 : 0,
+        'price' => $row_price,
       ]);
-      if ($size_key !== '_default' && $variation->hasField('field_mel_size')) {
-        $variation->set('field_mel_size', $size_key);
-      }
+      $this->applySizeFieldFromOptionLabel($variation, $option_label);
+      $this->stockResolver->applyStockFields($variation, [
+        'stock_quantity' => $row['stock_quantity'] ?? NULL,
+        'limit_per_order' => $row['limit_per_order'] ?? NULL,
+        'show_remaining' => !empty($row['show_remaining']),
+      ]);
       $variation->save();
       $product->addVariation($variation);
+      $kept_ids[(int) $variation->id()] = (int) $variation->id();
     }
 
-    foreach ($existing as $orphan) {
-      if ($orphan instanceof ProductVariationInterface && $orphan->isPublished()) {
+    foreach ($existing_by_id as $vid => $orphan) {
+      if (!isset($kept_ids[$vid]) && $orphan->isPublished()) {
         $orphan->setPublished(FALSE);
         $orphan->save();
-        $this->logger->notice('Unpublished event extra variation @vid (size removed or consolidated).', [
-          '@vid' => (string) $orphan->id(),
+        $this->logger->notice('Unpublished event extra variation @vid (option removed from editor).', [
+          '@vid' => (string) $vid,
         ]);
       }
     }
@@ -1122,38 +1177,83 @@ final class VendorOperationalProductCreationManager {
       'show_on_booking' => 0,
       'sizes' => [],
       'stock_quantity' => NULL,
+      'limit_per_order' => NULL,
+      'show_remaining' => FALSE,
+      'variant_stock' => [],
+      'product_options' => [$this->emptyProductOptionRow()],
     ];
   }
 
   /**
    * @return array<string, mixed>
    */
-  public function extractEditorDefaultsFromProduct(ProductInterface $product): array {
-    $sizes = [];
+  public function emptyProductOptionRow(array $defaults = []): array {
+    return [
+      'variation_id' => 0,
+      'option_label' => '',
+      'sku' => '',
+      'price_amount' => $defaults['price_amount'] ?? '',
+      'stock_quantity' => NULL,
+      'limit_per_order' => NULL,
+      'show_remaining' => FALSE,
+      'published' => TRUE,
+      'remove' => FALSE,
+    ];
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function buildProductOptionsFromProduct(ProductInterface $product): array {
+    $options = [];
     foreach ($product->getVariations() as $variation) {
-      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty() && $variation->isPublished()) {
-        $key = strtolower((string) $variation->get('field_mel_size')->value);
-        $sizes[$key] = $key;
+      if (!$variation instanceof ProductVariationInterface) {
+        continue;
       }
+      if (!$variation->isPublished()) {
+        continue;
+      }
+      $price = $variation->getPrice();
+      $stock = $this->stockResolver->extractStockFields($variation);
+      $options[] = [
+        'variation_id' => (int) $variation->id(),
+        'option_label' => $this->resolveOptionLabelFromVariation($variation, $product->label()),
+        'sku' => (string) ($variation->getSku() ?? ''),
+        'price_amount' => $price !== NULL ? $price->getNumber() : '',
+        'stock_quantity' => $stock['stock_quantity'],
+        'limit_per_order' => $stock['limit_per_order'],
+        'show_remaining' => !empty($stock['show_remaining']),
+        'published' => TRUE,
+        'remove' => FALSE,
+      ];
     }
+    return $options;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function extractEditorDefaultsFromProduct(ProductInterface $product): array {
+    $product_options = $this->buildProductOptionsFromProduct($product);
     $price = '';
     $sku = '';
-    foreach ($product->getVariations() as $variation) {
-      if ($variation->isPublished() && $variation->getPrice() !== NULL) {
-        $price = $variation->getPrice()->getNumber();
-        $sku = $variation->getSku() ?? '';
+    foreach ($product_options as $row) {
+      if ($row['price_amount'] !== '' && $row['price_amount'] !== NULL) {
+        $price = (string) $row['price_amount'];
+        $sku = $this->extractBaseSkuFromVariationSku((string) ($row['sku'] ?? ''), (string) ($row['option_label'] ?? ''));
         break;
-      }
-    }
-    if ($sku !== '' && str_contains($sku, '-')) {
-      $parts = explode('-', $sku);
-      if (count($parts) > 3) {
-        array_pop($parts);
-        $sku = implode('-', $parts);
       }
     }
     $metadata = $this->operationalMerchandiseManager->normalizeProductFieldFromEntity($product);
     $status = $this->resolveProductStatusFromEntity($product, $metadata);
+    $sizes = [];
+    foreach ($product_options as $row) {
+      $size_key = $this->inferSizeKeyFromOptionLabel((string) ($row['option_label'] ?? ''));
+      if ($size_key !== NULL) {
+        $sizes[$size_key] = $size_key;
+      }
+    }
+    $first_stock = $product_options[0] ?? [];
     return [
       'extra_type' => $this->inferExtraTypeFromProduct($product, $metadata),
       'title' => $product->label(),
@@ -1167,7 +1267,11 @@ final class VendorOperationalProductCreationManager {
       'product_status' => $status,
       'show_on_booking' => $product->isPublished() ? 1 : 0,
       'sizes' => $sizes,
-      'stock_quantity' => NULL,
+      'stock_quantity' => $first_stock['stock_quantity'] ?? NULL,
+      'limit_per_order' => $first_stock['limit_per_order'] ?? NULL,
+      'show_remaining' => !empty($first_stock['show_remaining']) ? 1 : 0,
+      'variant_stock' => [],
+      'product_options' => $product_options !== [] ? $product_options : [$this->emptyProductOptionRow(['price_amount' => $price])],
     ];
   }
 
@@ -1212,11 +1316,16 @@ final class VendorOperationalProductCreationManager {
       $sku = $key === '_default'
         ? $this->sanitizePlainText($sku_base, 128)
         : $this->sanitizePlainText($sku_base . '-' . $key, 128);
+      $stock = $this->resolveVariantStockInput($input, $key);
       $rows[] = [
+        'size_key' => $key,
         'size_label' => $label,
         'sku' => $sku,
         'price' => $price,
         'capacity_note' => $capacity,
+        'stock_quantity' => $stock['stock_quantity'],
+        'limit_per_order' => $stock['limit_per_order'],
+        'show_remaining' => !empty($stock['show_remaining']),
         'status_label' => (string) $this->translation->translate('Created on save'),
       ];
     }
@@ -1240,20 +1349,33 @@ final class VendorOperationalProductCreationManager {
         $size_label = OperationalExtraVisualPresenter::SIZE_LABELS[$key] ?? strtoupper($key);
       }
       $price = $variation->getPrice();
+      $stock = $this->stockResolver->extractStockFields($variation);
+      $size_key = '_default';
+      if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+        $size_key = strtolower((string) $variation->get('field_mel_size')->value);
+      }
       $rows[] = [
+        'size_key' => $size_key,
         'size_label' => $size_label,
         'sku' => (string) ($variation->getSku() ?? ''),
         'price' => $price !== NULL ? $price->getNumber() : '',
         'capacity_note' => $capacity,
+        'stock_quantity' => $stock['stock_quantity'],
+        'limit_per_order' => $stock['limit_per_order'],
+        'show_remaining' => (bool) $stock['show_remaining'],
         'status_label' => (string) $this->translation->translate('Active'),
       ];
     }
     if ($rows === []) {
       $rows[] = [
+        'size_key' => '_default',
         'size_label' => (string) $this->translation->translate('One size'),
         'sku' => '',
         'price' => '',
         'capacity_note' => $capacity,
+        'stock_quantity' => NULL,
+        'limit_per_order' => NULL,
+        'show_remaining' => FALSE,
         'status_label' => (string) $this->translation->translate('No published variations'),
       ];
     }
@@ -1408,6 +1530,418 @@ final class VendorOperationalProductCreationManager {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return list<string>
+   */
+  public function validateStockInputFromEventExtra(array $input): array {
+    $errors = [];
+    $options = $this->normalizeProductOptionsInput($input['product_options'] ?? []);
+    if ($options !== []) {
+      foreach ($options as $row) {
+        if (!empty($row['remove']) || trim((string) ($row['option_label'] ?? '')) === '') {
+          continue;
+        }
+        foreach ($this->stockResolver->validateStockInput([
+          'stock_quantity' => $row['stock_quantity'] ?? NULL,
+          'limit_per_order' => $row['limit_per_order'] ?? NULL,
+        ]) as $error) {
+          $errors[] = $error;
+        }
+      }
+      return array_values(array_unique($errors));
+    }
+    $variant_stock = is_array($input['variant_stock'] ?? NULL) ? $input['variant_stock'] : [];
+    if ($variant_stock !== []) {
+      foreach ($variant_stock as $row) {
+        if (!is_array($row)) {
+          continue;
+        }
+        foreach ($this->stockResolver->validateStockInput($row) as $error) {
+          $errors[] = $error;
+        }
+      }
+      return array_values(array_unique($errors));
+    }
+    foreach ($this->stockResolver->validateStockInput([
+      'stock_quantity' => $input['stock_quantity'] ?? NULL,
+      'limit_per_order' => $input['limit_per_order'] ?? NULL,
+    ]) as $error) {
+      $errors[] = $error;
+    }
+    return $errors;
+  }
+
+  /**
+   * @param mixed $raw
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function normalizeProductOptionsInput(mixed $raw): array {
+    if (!is_array($raw)) {
+      return [];
+    }
+    $out = [];
+    foreach ($raw as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      if (!empty($row['remove'])) {
+        $out[] = [
+          'variation_id' => (int) ($row['variation_id'] ?? 0),
+          'option_label' => '',
+          'remove' => TRUE,
+        ];
+        continue;
+      }
+      $label = $this->sanitizePlainText((string) ($row['option_label'] ?? ''), 128);
+      if ($label === '') {
+        continue;
+      }
+      $stock_qty = $row['stock_quantity'] ?? NULL;
+      $out[] = [
+        'variation_id' => (int) ($row['variation_id'] ?? 0),
+        'option_label' => $label,
+        'sku' => $this->sanitizePlainText((string) ($row['sku'] ?? ''), 128),
+        'price_amount' => $row['price_amount'] ?? NULL,
+        'stock_quantity' => $this->stockResolver->normalizeStockInput($stock_qty),
+        'limit_per_order' => $this->stockResolver->normalizeLimitInput($row['limit_per_order'] ?? NULL),
+        'show_remaining' => !empty($row['show_remaining']),
+        'published' => !isset($row['published']) || !empty($row['published']),
+        'remove' => FALSE,
+      ];
+    }
+    return $out;
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return list<string>
+   */
+  public function validateProductOptionsInput(array $input): array {
+    $errors = [];
+    $options = $this->normalizeProductOptionsInput($input['product_options'] ?? []);
+    $status = strtolower(trim((string) ($input['product_status'] ?? 'draft')));
+    $show = $this->resolveShowOnBooking($input);
+    $requires_options = $status === 'active' || $show;
+
+    if ($requires_options && $options === []) {
+      $errors[] = (string) $this->translation->translate('Add at least one product option before making this item active or visible on the booking page.');
+    }
+
+    $labels = [];
+    foreach ($options as $row) {
+      $label = strtolower(trim((string) ($row['option_label'] ?? '')));
+      if ($label === '') {
+        continue;
+      }
+      if (isset($labels[$label])) {
+        $errors[] = (string) $this->translation->translate('Each product option label must be unique (@label).', [
+          '@label' => (string) $row['option_label'],
+        ]);
+      }
+      $labels[$label] = TRUE;
+      $amount = $this->normalizePriceAmount($row['price_amount'] ?? $input['price_amount'] ?? NULL);
+      if ($amount === NULL) {
+        $errors[] = (string) $this->translation->translate('A valid price is required for option @label.', [
+          '@label' => (string) $row['option_label'],
+        ]);
+      }
+    }
+
+    return array_values(array_unique($errors));
+  }
+
+  public function resolveOptionLabelFromVariation(ProductVariationInterface $variation, string $product_title): string {
+    $label = trim((string) $variation->label());
+    $prefix = trim($product_title) . ' — ';
+    if ($label !== '' && str_starts_with($label, $prefix)) {
+      return trim(substr($label, strlen($prefix)));
+    }
+    if ($label !== '' && str_contains($label, ' — ')) {
+      $parts = explode(' — ', $label, 2);
+      return trim((string) end($parts));
+    }
+    if ($variation->hasField('field_mel_size') && !$variation->get('field_mel_size')->isEmpty()) {
+      $key = strtolower((string) $variation->get('field_mel_size')->value);
+      if (isset(OperationalExtraVisualPresenter::SIZE_LABELS[$key])) {
+        return OperationalExtraVisualPresenter::SIZE_LABELS[$key];
+      }
+    }
+    if ($label !== '' && strcasecmp($label, $product_title) !== 0) {
+      return $label;
+    }
+    return (string) $this->translation->translate('One option');
+  }
+
+  public function inferSizeKeyFromOptionLabel(string $option_label): ?string {
+    $trimmed = strtolower(trim($option_label));
+    if ($trimmed === '') {
+      return NULL;
+    }
+    if (isset(OperationalExtraVisualPresenter::SIZE_LABELS[$trimmed])) {
+      return $trimmed;
+    }
+    foreach (OperationalExtraVisualPresenter::SIZE_LABELS as $key => $human) {
+      if (strcasecmp($trimmed, $human) === 0) {
+        return $key;
+      }
+      if (preg_match('/(?:^|[\s\/\-])' . preg_quote($human, '/') . '$/i', $option_label)) {
+        return $key;
+      }
+      if (preg_match('/(?:^|[\s\/\-])' . preg_quote($key, '/') . '$/i', $option_label)) {
+        return $key;
+      }
+    }
+    return NULL;
+  }
+
+  private function applySizeFieldFromOptionLabel(ProductVariationInterface $variation, string $option_label): void {
+    if (!$variation->hasField('field_mel_size')) {
+      return;
+    }
+    $size_key = $this->inferSizeKeyFromOptionLabel($option_label);
+    if ($size_key !== NULL) {
+      $variation->set('field_mel_size', $size_key);
+      return;
+    }
+    $variation->set('field_mel_size', NULL);
+  }
+
+  private function generateOptionSku(string $sku_base, string $option_label): string {
+    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $option_label) ?? '');
+    $slug = trim($slug, '-');
+    if ($slug === '') {
+      $slug = 'option';
+    }
+    return $this->sanitizePlainText($sku_base . '-' . $slug, 128);
+  }
+
+  private function extractBaseSkuFromVariationSku(string $sku, string $option_label): string {
+    if ($sku === '') {
+      return '';
+    }
+    $generated_suffix = $this->generateOptionSku('base', $option_label);
+    $suffix = substr($generated_suffix, strlen('base-'));
+    if ($suffix !== '' && str_ends_with($sku, '-' . $suffix)) {
+      return substr($sku, 0, -strlen('-' . $suffix));
+    }
+    $size_key = $this->inferSizeKeyFromOptionLabel($option_label);
+    if ($size_key !== NULL && str_ends_with($sku, '-' . $size_key)) {
+      return substr($sku, 0, -strlen('-' . $size_key));
+    }
+    return $sku;
+  }
+
+  /**
+   * Aggregates per-option stock for Studio summary chips and progressive disclosure.
+   *
+   * @param list<array<string, mixed>> $options
+   *
+   * @return array{
+   *   option_count: int,
+   *   unlimited_count: int,
+   *   sold_out_count: int,
+   *   low_stock_count: int,
+   *   finite_total: int,
+   *   limits_set_count: int,
+   *   stock_mode: string,
+   *   stock_mode_label: string,
+   *   limit_status_label: string,
+   *   open_stock_details: bool,
+   *   chips: list<string>
+   * }
+   */
+  public function summarizeProductOptionsStock(array $options): array {
+    $option_count = 0;
+    $unlimited_count = 0;
+    $sold_out_count = 0;
+    $low_stock_count = 0;
+    $finite_total = 0;
+    $limits_set_count = 0;
+    $has_finite = FALSE;
+    $has_unlimited = FALSE;
+    $has_sold_out = FALSE;
+
+    foreach ($options as $row) {
+      if (!empty($row['remove'])) {
+        continue;
+      }
+      $label = trim((string) ($row['option_label'] ?? ''));
+      if ($label === '' && (int) ($row['variation_id'] ?? 0) <= 0) {
+        continue;
+      }
+      $option_count++;
+      $qty = $this->stockResolver->normalizeStockInput($row['stock_quantity'] ?? NULL);
+      if ($this->stockResolver->normalizeLimitInput($row['limit_per_order'] ?? NULL) !== NULL) {
+        $limits_set_count++;
+      }
+      if ($qty === NULL) {
+        $unlimited_count++;
+        $has_unlimited = TRUE;
+      }
+      elseif ($qty === 0) {
+        $sold_out_count++;
+        $has_sold_out = TRUE;
+      }
+      else {
+        $has_finite = TRUE;
+        $finite_total += $qty;
+        if ($qty <= 5) {
+          $low_stock_count++;
+        }
+      }
+    }
+
+    $stock_mode = 'empty';
+    $stock_mode_label = (string) $this->translation->translate('Not set');
+    if ($option_count > 0) {
+      if ($sold_out_count === $option_count) {
+        $stock_mode = 'sold_out';
+        $stock_mode_label = (string) $this->translation->translate('Sold out');
+      }
+      elseif ($unlimited_count === $option_count && $sold_out_count === 0) {
+        $stock_mode = 'unlimited';
+        $stock_mode_label = (string) $this->translation->translate('Unlimited');
+      }
+      elseif ($has_finite && !$has_unlimited && !$has_sold_out && $finite_total <= 5) {
+        $stock_mode = 'low';
+        $stock_mode_label = (string) $this->translation->translate('Low stock');
+      }
+      elseif ($has_sold_out || ($has_finite && $has_unlimited) || ($has_finite && $sold_out_count > 0)) {
+        $stock_mode = 'mixed';
+        $stock_mode_label = (string) $this->translation->translate('Mixed');
+      }
+      elseif ($has_finite) {
+        $stock_mode = 'finite';
+        $stock_mode_label = (string) $this->translation->translate('@count in stock', ['@count' => $finite_total]);
+      }
+      else {
+        $stock_mode = 'mixed';
+        $stock_mode_label = (string) $this->translation->translate('Mixed');
+      }
+    }
+
+    $limit_status_label = $limits_set_count === 0
+      ? (string) $this->translation->translate('No per-order limits')
+      : ($limits_set_count === $option_count && $option_count > 0
+        ? (string) $this->translation->translate('Limits on all options')
+        : (string) $this->translation->translate('Some per-order limits'));
+
+    $open_stock_details = $has_finite
+      || $has_sold_out
+      || $limits_set_count > 0;
+
+    $chips = [];
+    if ($option_count > 0) {
+      $chips[] = $option_count === 1
+        ? (string) $this->translation->translate('1 option')
+        : (string) $this->translation->translate('@count options', ['@count' => $option_count]);
+      if ($unlimited_count > 0) {
+        $chips[] = $unlimited_count === 1
+          ? (string) $this->translation->translate('1 unlimited')
+          : (string) $this->translation->translate('@count unlimited', ['@count' => $unlimited_count]);
+      }
+      if ($sold_out_count > 0) {
+        $chips[] = $sold_out_count === 1
+          ? (string) $this->translation->translate('1 sold out')
+          : (string) $this->translation->translate('@count sold out', ['@count' => $sold_out_count]);
+      }
+      if ($low_stock_count > 0 && $has_finite) {
+        $chips[] = $low_stock_count === 1
+          ? (string) $this->translation->translate('1 low stock')
+          : (string) $this->translation->translate('@count low stock', ['@count' => $low_stock_count]);
+      }
+      if ($finite_total > 0 && $has_finite) {
+        $chips[] = (string) $this->translation->translate('@count units total', ['@count' => $finite_total]);
+      }
+      $chips[] = $limit_status_label;
+    }
+
+    return [
+      'option_count' => $option_count,
+      'unlimited_count' => $unlimited_count,
+      'sold_out_count' => $sold_out_count,
+      'low_stock_count' => $low_stock_count,
+      'finite_total' => $finite_total,
+      'limits_set_count' => $limits_set_count,
+      'stock_mode' => $stock_mode,
+      'stock_mode_label' => $stock_mode_label,
+      'limit_status_label' => $limit_status_label,
+      'open_stock_details' => $open_stock_details,
+      'chips' => $chips,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $options
+   *
+   * @return array{count: int, price_label: string, stock_summary: string}
+   */
+  public function summarizeProductOptionsForPreview(array $options, string $currency_code = 'AUD'): array {
+    $amounts = [];
+    foreach ($options as $row) {
+      if (!empty($row['remove'])) {
+        continue;
+      }
+      $amount = $this->normalizePriceAmount($row['price_amount'] ?? NULL);
+      if ($amount !== NULL) {
+        $amounts[] = (float) $amount;
+      }
+    }
+    $count = count(array_filter($options, static fn(array $row): bool => empty($row['remove']) && trim((string) ($row['option_label'] ?? '')) !== ''));
+    $stock = $this->summarizeProductOptionsStock($options);
+    $stock_summary = match ($stock['stock_mode']) {
+      'unlimited' => (string) $this->translation->translate('unlimited stock'),
+      'sold_out' => (string) $this->translation->translate('sold out'),
+      'low' => (string) $this->translation->translate('low stock per option'),
+      'mixed' => (string) $this->translation->translate('stock managed per option'),
+      'finite' => (string) $this->translation->translate('stock managed per option'),
+      default => (string) $this->translation->translate('stock managed per option'),
+    };
+    if ($amounts === []) {
+      return [
+        'count' => $count,
+        'price_label' => '',
+        'stock_summary' => $stock_summary,
+      ];
+    }
+    $min = min($amounts);
+    $max = max($amounts);
+    $prefix = $currency_code !== '' ? $currency_code . ' ' : '';
+    $price_label = $min === $max
+      ? $prefix . number_format($min, 2)
+      : (string) $this->translation->translate('from @price', ['@price' => $prefix . number_format($min, 2)]);
+    return [
+      'count' => $count,
+      'price_label' => $price_label,
+      'stock_summary' => $stock_summary,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $input
+   *
+   * @return array<string, mixed>
+   */
+  public function resolveVariantStockInput(array $input, string $size_key): array {
+    $variant_stock = is_array($input['variant_stock'] ?? NULL) ? $input['variant_stock'] : [];
+    if (isset($variant_stock[$size_key]) && is_array($variant_stock[$size_key])) {
+      return [
+        'stock_quantity' => $variant_stock[$size_key]['stock_quantity'] ?? NULL,
+        'limit_per_order' => $variant_stock[$size_key]['limit_per_order'] ?? NULL,
+        'show_remaining' => !empty($variant_stock[$size_key]['show_remaining']),
+      ];
+    }
+    return [
+      'stock_quantity' => $input['stock_quantity'] ?? NULL,
+      'limit_per_order' => $input['limit_per_order'] ?? NULL,
+      'show_remaining' => !empty($input['show_remaining']),
+    ];
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-card.html.twig
@@ -36,6 +36,14 @@
     {% if card.price_label %}
       <p class="mel-event-extra-card__price">{{ card.price_label }}</p>
     {% endif %}
+    {% if card.stock_label|default('') %}
+      <p class="mel-event-extra-card__stock mel-event-extra-card__stock--{{ card.stock_state|default('unknown') }}">
+        {{ card.stock_label }}
+      </p>
+    {% endif %}
+    {% if card.limit_per_order_label|default('') %}
+      <p class="mel-event-extra-card__stock-limit">{{ card.limit_per_order_label }}</p>
+    {% endif %}
     {% if card.capacity_note|default('') %}
       <p class="mel-event-extra-card__quantity-note">
         <span class="mel-event-extra-card__quantity-label">{{ 'Quantity note'|t }}:</span>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-preview.html.twig
@@ -5,21 +5,46 @@
  */
 #}
 {% set img = preview.primary_image|default({}) %}
-<aside class="mel-event-extra-preview mel-es-card" aria-label="{{ 'Customer preview'|t }}">
-  <h3 class="mel-event-extra-preview__heading">{{ 'Guest preview'|t }}</h3>
+<div class="mel-event-extra-preview" aria-label="{{ 'Customer preview'|t }}">
   <div class="mel-event-extra-preview__card">
     {% if img.url|default('') %}
       <img class="mel-event-extra-preview__image" src="{{ img.url }}" alt="{{ img.alt|default(preview.title) }}" loading="lazy" />
     {% endif %}
     <div class="mel-event-extra-preview__body">
-      <h4 class="mel-event-extra-preview__title">{{ preview.title|default('') }}</h4>
+      <h5 class="mel-event-extra-preview__title">{{ preview.title|default('') }}</h5>
+      {% if preview_meta_line|default('') %}
+        <p class="mel-event-extra-preview__summary-line">{{ preview_meta_line }}</p>
+      {% elseif options_summary|default('') or price_display|default('') %}
+        <p class="mel-event-extra-preview__summary-line">
+          {% if options_summary|default('') %}{{ options_summary }}{% endif %}
+          {% if options_summary|default('') and price_display|default('') %} · {% endif %}
+          {% if price_display|default('') %}{{ price_display }}{% endif %}
+        </p>
+      {% endif %}
       {% if preview.short_description|default('') %}
         <p class="mel-event-extra-preview__desc">{{ preview.short_description }}</p>
       {% endif %}
       {% if preview.pickup_note|default('') %}
         <p class="mel-event-extra-preview__pickup">{{ preview.pickup_note }}</p>
       {% endif %}
+      <dl class="mel-event-extra-preview__meta">
+        {% if stock_label|default('') %}
+          <div class="mel-event-extra-preview__meta-row">
+            <dt>{{ 'Stock'|t }}</dt>
+            <dd>{{ stock_label }}</dd>
+          </div>
+        {% endif %}
+        {% if visibility_label|default('') %}
+          <div class="mel-event-extra-preview__meta-row">
+            <dt>{{ 'Booking'|t }}</dt>
+            <dd>{{ visibility_label }}</dd>
+          </div>
+        {% endif %}
+      </dl>
+      {% if hidden_notice|default('') %}
+        <p class="mel-event-extra-preview__hidden-notice">{{ hidden_notice }}</p>
+      {% endif %}
       <p class="mel-event-extra-preview__cta mel-text--muted">{{ 'Add to booking (preview only)'|t }}</p>
     </div>
   </div>
-</aside>
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-product-setup-summary.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-product-setup-summary.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Product setup summary for Event Studio Commerce product editor.
+ */
+#}
+{% set summary = summary|default({}) %}
+<section class="mel-es-card mel-event-product-editor__setup-summary" aria-labelledby="mel-product-setup-summary-title">
+  <h3 id="mel-product-setup-summary-title" class="mel-es-card__title">{{ 'Product setup'|t }}</h3>
+  <p class="mel-event-product-editor__section-helper mel-text--muted">{{ 'Quick check before you save.'|t }}</p>
+
+  <dl class="mel-event-product-editor__setup-summary-list">
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Status'|t }}</dt>
+      <dd>{{ summary.status_label|default('—') }}</dd>
+    </div>
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Price'|t }}</dt>
+      <dd>{{ summary.price_label|default('—') }}</dd>
+    </div>
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Images'|t }}</dt>
+      <dd>{{ summary.image_label|default('—') }}</dd>
+    </div>
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Options'|t }}</dt>
+      <dd>{{ summary.options_label|default('—') }}</dd>
+    </div>
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Stock'|t }}</dt>
+      <dd>{{ summary.stock_label|default('—') }}</dd>
+    </div>
+    <div class="mel-event-product-editor__setup-summary-row">
+      <dt>{{ 'Booking page'|t }}</dt>
+      <dd>{{ summary.visibility_label|default('—') }}</dd>
+    </div>
+  </dl>
+
+  {% if show_preview_anchor %}
+    <p class="mel-event-product-editor__setup-summary-actions">
+      <a href="#mel-product-booking-preview" class="mel-event-product-editor__setup-summary-link">{{ 'View booking preview'|t }}</a>
+      <span class="mel-text--muted"> · </span>
+      <a href="#mel-product-editor-save" class="mel-event-product-editor__setup-summary-link">{{ 'Save product'|t }}</a>
+    </p>
+  {% else %}
+    <p class="mel-event-product-editor__setup-summary-actions mel-text--muted">
+      {{ 'Save using the buttons at the bottom of the page.'|t }}
+    </p>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-variant-preview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extra-variant-preview.html.twig
@@ -5,28 +5,48 @@
  */
 #}
 {% if rows is not empty %}
-  <div class="mel-event-variant-preview">
-    <table class="mel-event-variant-preview__table">
-      <thead>
-        <tr>
-          <th scope="col">{{ 'Option'|t }}</th>
-          <th scope="col">{{ 'SKU'|t }}</th>
-          <th scope="col">{{ 'Price'|t }}</th>
-          <th scope="col">{{ 'Quantity note'|t }}</th>
-          <th scope="col">{{ 'Status'|t }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in rows %}
+  <details class="mel-event-variant-preview"{% if open|default(false) %} open{% endif %}>
+    <summary class="mel-event-variant-preview__summary">
+      <span class="mel-event-variant-preview__title">{{ summary_title|default('Variation summary'|t) }}</span>
+      <span class="mel-event-variant-preview__hint mel-text--muted">{{ 'SKU, price, and status for each option'|t }}</span>
+    </summary>
+    <div class="mel-event-variant-preview__table-wrap">
+      <table class="mel-event-variant-preview__table">
+        <thead>
           <tr>
-            <td>{{ row.size_label }}</td>
-            <td><code>{{ row.sku }}</code></td>
-            <td>{{ row.price }}</td>
-            <td>{{ row.capacity_note|default('—') }}</td>
-            <td>{{ row.status_label }}</td>
+            <th scope="col">{{ 'Size'|t }}</th>
+            <th scope="col">{{ 'SKU'|t }}</th>
+            <th scope="col">{{ 'Price'|t }}</th>
+            {% if stock_supported and not stock_editor_enabled|default(false) %}
+              <th scope="col">{{ 'Stock quantity'|t }}</th>
+              <th scope="col">{{ 'Limit per order'|t }}</th>
+              <th scope="col">{{ 'Show remaining'|t }}</th>
+            {% endif %}
+            <th scope="col">{{ 'Status'|t }}</th>
           </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr>
+              <td data-label="{{ 'Size'|t }}">{{ row.size_label }}</td>
+              <td data-label="{{ 'SKU'|t }}"><code>{{ row.sku }}</code></td>
+              <td data-label="{{ 'Price'|t }}">{{ row.price }}</td>
+              {% if stock_supported and not stock_editor_enabled|default(false) %}
+                <td data-label="{{ 'Stock quantity'|t }}">
+                  {% if row.stock_quantity is null %}
+                    {{ 'Unlimited'|t }}
+                  {% else %}
+                    {{ row.stock_quantity }}
+                  {% endif %}
+                </td>
+                <td data-label="{{ 'Limit per order'|t }}">{{ row.limit_per_order|default('—') }}</td>
+                <td data-label="{{ 'Show remaining'|t }}">{{ row.show_remaining ? 'Yes'|t : 'No'|t }}</td>
+              {% endif %}
+              <td data-label="{{ 'Status'|t }}">{{ row.status_label }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </details>
 {% endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-configured-summary.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-configured-summary.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Configured merch & add-ons summary for Manage event (not sales analytics).
+ */
+#}
+{% set panel = panel|default({}) %}
+<section class="mel-es-card mel-event-extras-studio__configured-summary" aria-labelledby="mel-extras-configured-title">
+  <header class="mel-event-extras-studio__configured-header">
+    <h3 id="mel-extras-configured-title" class="mel-es-card__title">{{ 'Merch & add-ons'|t }}</h3>
+    {% if panel.has_products %}
+      <p class="mel-text--muted">{{ 'What is configured for this event (not sales totals).'|t }}</p>
+    {% endif %}
+  </header>
+
+  {% if panel.has_products %}
+    {% set stats = panel.stats|default({}) %}
+    <dl class="mel-event-extras-studio__configured-stats">
+      <div>
+        <dt>{{ 'Configured extras'|t }}</dt>
+        <dd>{{ stats.total|default(0) }}</dd>
+      </div>
+      <div>
+        <dt>{{ 'Active on booking page'|t }}</dt>
+        <dd>{{ stats.active_on_booking|default(0) }}</dd>
+      </div>
+      <div>
+        <dt>{{ 'Hidden or draft'|t }}</dt>
+        <dd>{{ stats.hidden_draft|default(0) }}</dd>
+      </div>
+      <div>
+        <dt>{{ 'Low stock'|t }}</dt>
+        <dd>{{ stats.low_stock|default(0) }}</dd>
+      </div>
+      <div>
+        <dt>{{ 'Sold out'|t }}</dt>
+        <dd>{{ stats.sold_out|default(0) }}</dd>
+      </div>
+    </dl>
+
+    {% if panel.top_products is iterable and panel.top_products|length > 0 %}
+      <div class="mel-event-extras-studio__configured-top">
+        <h4 class="mel-event-extras-studio__configured-top-title">{{ 'Top configured products'|t }}</h4>
+        <ul class="mel-event-extras-studio__configured-top-list">
+          {% for product in panel.top_products %}
+            <li>
+              <span class="mel-event-extras-studio__configured-name">{{ product.name }}</span>
+              <span class="mel-event-extras-studio__configured-meta mel-text--muted">
+                {{ product.type }} · {{ product.stock_state }} · {{ product.visibility }}
+              </span>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  {% else %}
+    {% set empty = panel.empty_state|default({}) %}
+    <div class="mel-event-extras-studio__configured-empty">
+      <h4 class="mel-event-extras-studio__configured-empty-title">{{ empty.title|default('') }}</h4>
+      <p>{{ empty.copy|default('') }}</p>
+      <p class="mel-text--muted">{{ empty.note|default('') }}</p>
+    </div>
+  {% endif %}
+
+  {% if panel.manage_url %}
+    <div class="mel-event-extras-studio__configured-actions">
+      <a href="{{ panel.manage_url }}" class="mel-btn mel-btn--primary">{{ panel.manage_label|default('Manage merch & add-ons'|t) }}</a>
+    </div>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-sales-panel.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-sales-panel.html.twig
@@ -1,0 +1,104 @@
+{#
+/**
+ * @file
+ * Read-only merch & add-on sales panel for Manage event dashboard.
+ */
+#}
+{% set compact = panel.compact|default(false) %}
+{% set summary = panel.summary|default({}) %}
+{% set actions = panel.actions|default({}) %}
+<section class="mel-es-card mel-event-extras-studio__extras-sales{% if compact %} mel-event-extras-studio__extras-sales--compact{% endif %}" aria-labelledby="mel-event-extras-sales-title">
+  <header class="mel-event-extras-studio__extras-sales-header">
+    <h3 id="mel-event-extras-sales-title" class="mel-es-card__title">{{ 'Merch & add-on sales'|t }}</h3>
+    <p class="mel-event-extras-studio__extras-sales-helper mel-text--muted">
+      {{ panel.helper_copy }}
+    </p>
+  </header>
+
+  <div class="mel-event-extras-studio__extras-sales-summary" role="list">
+    <div class="mel-event-extras-studio__extras-sales-metric" role="listitem">
+      <span class="mel-event-extras-studio__extras-sales-metric-label">{{ 'Total extras revenue'|t }}</span>
+      <span class="mel-event-extras-studio__extras-sales-metric-value">{{ summary.total_revenue|default('—') }}</span>
+    </div>
+    <div class="mel-event-extras-studio__extras-sales-metric" role="listitem">
+      <span class="mel-event-extras-studio__extras-sales-metric-label">{{ 'Total extras sold'|t }}</span>
+      <span class="mel-event-extras-studio__extras-sales-metric-value">{{ summary.total_items_sold|default(0) }}</span>
+    </div>
+    <div class="mel-event-extras-studio__extras-sales-metric" role="listitem">
+      <span class="mel-event-extras-studio__extras-sales-metric-label">{{ 'Orders containing extras'|t }}</span>
+      <span class="mel-event-extras-studio__extras-sales-metric-value">{{ summary.orders_with_extras|default(0) }}</span>
+    </div>
+    <div class="mel-event-extras-studio__extras-sales-metric" role="listitem">
+      <span class="mel-event-extras-studio__extras-sales-metric-label">{{ 'Top category/type'|t }}</span>
+      <span class="mel-event-extras-studio__extras-sales-metric-value">{{ summary.top_category|default('—') }}</span>
+    </div>
+  </div>
+
+  {% if panel.rows is iterable and panel.rows|length > 0 %}
+    <div class="mel-event-extras-studio__extras-sales-table-wrap">
+      <table class="mel-event-extras-studio__extras-sales-table">
+        <thead>
+          <tr>
+            <th scope="col">{{ 'Category'|t }}</th>
+            <th scope="col">{{ 'Items sold'|t }}</th>
+            <th scope="col">{{ 'Revenue'|t }}</th>
+            <th scope="col">{{ 'Orders'|t }}</th>
+            <th scope="col">{{ 'Stock remaining'|t }}</th>
+            <th scope="col">{{ 'Status'|t }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in panel.rows %}
+            <tr class="mel-event-extras-studio__extras-sales-row mel-event-extras-studio__extras-sales-row--{{ row.status.key|default('no_sales') }}">
+              <td data-label="{{ 'Category'|t }}">{{ row.label }}</td>
+              <td data-label="{{ 'Items sold'|t }}">{{ row.items_sold }}</td>
+              <td data-label="{{ 'Revenue'|t }}">{{ row.revenue }}</td>
+              <td data-label="{{ 'Orders'|t }}">{{ row.order_count }}</td>
+              <td data-label="{{ 'Stock remaining'|t }}">{{ row.stock_remaining_label }}</td>
+              <td data-label="{{ 'Status'|t }}">
+                <span class="mel-pill mel-pill--tone-{{ row.status.tone|default('muted') }}">{{ row.status.label }}</span>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="mel-event-extras-studio__extras-sales-empty mel-text--muted">{{ panel.empty_message }}</p>
+  {% endif %}
+
+  <div class="mel-event-extras-studio__extras-sales-actions">
+    {% if actions.view_orders.available|default(false) and actions.view_orders.url %}
+      <a href="{{ actions.view_orders.url }}" class="mel-btn mel-btn--secondary">{{ actions.view_orders.label }}</a>
+    {% endif %}
+    {% if actions.manage_extras.available|default(false) and actions.manage_extras.url %}
+      <a href="{{ actions.manage_extras.url }}" class="mel-btn mel-btn--ghost">{{ actions.manage_extras.label }}</a>
+    {% endif %}
+  </div>
+
+  {% set docs = panel.operational_documents|default({}) %}
+  {% set doc_items = docs.items|default({}) %}
+  {% if doc_items is iterable and doc_items|length > 0 %}
+    <section class="mel-event-extras-studio__operational-docs mel-es-card mel-es-card--nested" aria-labelledby="mel-extras-operational-docs-title">
+      <h4 id="mel-extras-operational-docs-title" class="mel-event-extras-studio__operational-docs-title">{{ docs.heading|default('Operational documents'|t) }}</h4>
+      {% if docs.helper|default('') is not empty %}
+        <p class="mel-event-extras-studio__operational-docs-helper mel-text--muted">{{ docs.helper }}</p>
+      {% endif %}
+      <div class="mel-event-extras-studio__operational-docs-actions" role="group" aria-label="{{ 'Operational document actions'|t }}">
+        {% for item in doc_items %}
+          {% if item.available|default(false) and item.url %}
+            <a href="{{ item.url }}" class="mel-btn mel-btn--secondary">{{ item.label }}</a>
+          {% else %}
+            <button type="button" class="mel-btn mel-btn--secondary mel-btn--disabled" disabled aria-disabled="true">
+              <span class="mel-event-extras-studio__operational-docs-btn-label">{{ item.label }}</span>
+              <span class="mel-event-extras-studio__operational-docs-coming-soon">{{ item.coming_soon|default('Coming soon'|t) }}</span>
+            </button>
+          {% endif %}
+        {% endfor %}
+      </div>
+      {% if docs.deferred_notice|default('') is not empty %}
+        <p class="mel-event-extras-studio__operational-docs-notice mel-text--muted">{{ docs.deferred_notice }}</p>
+      {% endif %}
+    </section>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-ticket-sales-panel.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-ticket-sales-panel.html.twig
@@ -1,0 +1,78 @@
+{#
+/**
+ * @file
+ * Read-only ticket sales panel for Event Studio commerce area.
+ */
+#}
+{% set compact = panel.compact|default(false) %}
+<section class="mel-es-card mel-event-extras-studio__ticket-sales{% if compact %} mel-event-extras-studio__ticket-sales--compact{% endif %}" aria-labelledby="mel-event-ticket-sales-title">
+  {% if not compact %}
+    <header class="mel-event-extras-studio__ticket-sales-header">
+      <h3 id="mel-event-ticket-sales-title" class="mel-es-card__title">{{ 'Ticket sales'|t }}</h3>
+      <p class="mel-event-extras-studio__ticket-sales-helper mel-text--muted">
+        {{ panel.helper_copy }}
+      </p>
+    </header>
+  {% else %}
+    <h3 id="mel-event-ticket-sales-title" class="visually-hidden">{{ 'Ticket sales'|t }}</h3>
+  {% endif %}
+
+  {% if panel.has_rows %}
+    <div class="mel-event-extras-studio__ticket-sales-table-wrap">
+      <table class="mel-event-extras-studio__ticket-sales-table">
+        <thead>
+          <tr>
+            <th scope="col">{{ 'Ticket'|t }}</th>
+            {% if not compact %}<th scope="col">{{ 'Price'|t }}</th>{% endif %}
+            <th scope="col">{{ 'Sold'|t }}</th>
+            <th scope="col">{{ 'Remaining'|t }}</th>
+            {% if not compact %}<th scope="col">{{ 'Capacity'|t }}</th>{% endif %}
+            {% if not compact %}<th scope="col">{{ '% sold'|t }}</th>{% endif %}
+            <th scope="col">{{ 'Status'|t }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in panel.rows %}
+            <tr class="mel-event-extras-studio__ticket-sales-row mel-event-extras-studio__ticket-sales-row--{{ row.status }}">
+              <td data-label="{{ 'Ticket'|t }}">{{ row.name }}</td>
+              {% if not compact %}<td data-label="{{ 'Price'|t }}">{{ row.price }}</td>{% endif %}
+              <td data-label="{{ 'Sold'|t }}">{{ row.sold }}</td>
+              <td data-label="{{ 'Remaining'|t }}">{{ row.remaining_label }}</td>
+              {% if not compact %}<td data-label="{{ 'Capacity'|t }}">{{ row.capacity_label }}</td>{% endif %}
+              {% if not compact %}<td data-label="{{ '% sold'|t }}">{{ row.percent_sold_label }}</td>{% endif %}
+              <td data-label="{{ 'Status'|t }}">
+                <span class="mel-pill mel-pill--tone-{{ row.status_tone }}">{{ row.status_label }}</span>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mel-event-extras-studio__ticket-sales-cards">
+      {% for row in panel.rows %}
+        <article class="mel-event-extras-studio__ticket-sales-card">
+          <h4 class="mel-event-extras-studio__ticket-sales-card-title">{{ row.name }}</h4>
+          <dl class="mel-event-extras-studio__ticket-sales-card-meta">
+            <div><dt>{{ 'Price'|t }}</dt><dd>{{ row.price }}</dd></div>
+            <div><dt>{{ 'Sold'|t }}</dt><dd>{{ row.sold }}</dd></div>
+            <div><dt>{{ 'Remaining'|t }}</dt><dd>{{ row.remaining_label }}</dd></div>
+            <div><dt>{{ 'Capacity'|t }}</dt><dd>{{ row.capacity_label }}</dd></div>
+            <div><dt>{{ '% sold'|t }}</dt><dd>{{ row.percent_sold_label }}</dd></div>
+            <div><dt>{{ 'Status'|t }}</dt><dd><span class="mel-pill mel-pill--tone-{{ row.status_tone }}">{{ row.status_label }}</span></dd></div>
+          </dl>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="mel-event-extras-studio__ticket-sales-empty mel-text--muted">{{ panel.empty_message }}</p>
+  {% endif %}
+
+  {% if panel.edit_tickets_url %}
+    <p class="mel-event-extras-studio__ticket-sales-actions">
+      <a href="{{ panel.edit_tickets_url }}" class="mel-btn mel-btn--secondary mel-event-extras-studio__edit-tickets">
+        {{ panel.edit_tickets_label }}
+      </a>
+    </p>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -20,6 +20,9 @@
     </span>
   </div>
   <div class="mel-event-studio-topbar__actions">
+    {% if topbar.show_manage_event_link %}
+      <a class="mel-btn mel-btn--secondary mel-event-studio-topbar__manage-event" href="{{ topbar.manage_event_url }}">{{ 'Manage event'|t }}</a>
+    {% endif %}
     <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'Preview'|t }}</a>
     <button
       class="mel-btn mel-btn--primary"

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioCommerceSalesSummaryBuilderTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioCommerceSalesSummaryBuilderTest.php
@@ -1,0 +1,415 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\CurrencyFormatter;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
+use Drupal\myeventlane_commerce\Service\TicketVariationSoldService;
+use Drupal\myeventlane_event\Service\EventPaidTicketLoaderInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Routing\Route;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioCommerceSalesSummaryBuilderTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $container = new ContainerBuilder();
+    $route = new Route('/studio/event/{node}/tickets');
+    $route_provider = $this->createMock(\Drupal\Core\Routing\RouteProviderInterface::class);
+    $route_provider->method('getRouteByName')
+      ->with('myeventlane_event_studio.workspace_tickets')
+      ->willReturn($route);
+    $container->set('router.route_provider', $route_provider);
+
+    $url_generator = $this->createMock(\Drupal\Core\Routing\UrlGeneratorInterface::class);
+    $url_generator->method('generateFromRoute')->willReturnCallback(
+      static fn (string $name, array $params): string => '/studio/event/' . ($params['node'] ?? '') . '/tickets',
+    );
+    $container->set('url_generator', $url_generator);
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    \Drupal::unsetContainer();
+    parent::tearDown();
+  }
+
+  /**
+   * @covers ::buildTicketSalesPanel
+   */
+  public function testEmptyPanelWhenNoPaidTickets(): void {
+    $event = $this->event(42);
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->with($event)->willReturn([]);
+
+    $panel = $this->builder($lifecycle)->buildTicketSalesPanel($event);
+
+    $this->assertFalse($panel['has_rows']);
+    $this->assertSame([], $panel['rows']);
+    $this->assertStringContainsString('No paid ticket types', $panel['empty_message']);
+    $this->assertSame('completed', $panel['sold_order_state']);
+    $this->assertSame('ticket_backed_order_items', $panel['sold_basis']);
+  }
+
+  /**
+   * @covers ::countTicketBackedSoldByVariation
+   */
+  public function testOperationalOrderItemsAreExcludedFromTicketSoldCount(): void {
+    $ticket_item = $this->orderItem(10, 7, '2');
+    $extra_item = $this->orderItem(10, 7, '5');
+    $order = $this->completedOrder();
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturnCallback(
+      static fn (OrderItemInterface $item): bool => $item === $ticket_item,
+    );
+
+    $order_item_storage = $this->createMock(EntityStorageInterface::class);
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([1, 2]);
+    $order_item_storage->method('getQuery')->willReturn($query);
+    $order_item_storage->method('loadMultiple')->willReturn([1 => $ticket_item, 2 => $extra_item]);
+
+    $order_storage = $this->createMock(EntityStorageInterface::class);
+    $order_storage->method('load')->with(10)->willReturn($order);
+
+    $builder = new EventStudioCommerceSalesSummaryBuilder(
+      $this->entityTypeManager($order_item_storage, $order_storage),
+      $this->createMock(EventPaidTicketLoaderInterface::class),
+      $classifier,
+      $this->variationSoldService(),
+      $this->createMock(CurrencyFormatter::class),
+      $this->createMock(TimeInterface::class),
+      $this->getStringTranslationStub(),
+    );
+
+    $sold = $builder->countTicketBackedSoldByVariation(99);
+    $this->assertSame([7 => 2], $sold);
+  }
+
+  /**
+   * @covers ::countTicketBackedSoldByVariation
+   */
+  public function testNonCompletedOrdersAreExcludedFromTicketSoldCount(): void {
+    $ticket_item = $this->orderItem(11, 8, '3');
+    $pending_order = $this->createMock(OrderInterface::class);
+    $pending_order->method('getState')->willReturn(new CommerceOrderStateStub('draft'));
+
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturn(TRUE);
+
+    $order_item_storage = $this->createMock(EntityStorageInterface::class);
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([1]);
+    $order_item_storage->method('getQuery')->willReturn($query);
+    $order_item_storage->method('loadMultiple')->willReturn([1 => $ticket_item]);
+
+    $order_storage = $this->createMock(EntityStorageInterface::class);
+    $order_storage->method('load')->with(11)->willReturn($pending_order);
+
+    $builder = new EventStudioCommerceSalesSummaryBuilder(
+      $this->entityTypeManager($order_item_storage, $order_storage),
+      $this->createMock(EventPaidTicketLoaderInterface::class),
+      $classifier,
+      $this->variationSoldService(),
+      $this->createMock(CurrencyFormatter::class),
+      $this->createMock(TimeInterface::class),
+      $this->getStringTranslationStub(),
+    );
+
+    $this->assertSame([], $builder->countTicketBackedSoldByVariation(55));
+  }
+
+  /**
+   * @covers ::buildTicketSalesPanel
+   */
+  public function testRemainingUsesCapacityMinusTicketBackedSold(): void {
+    $event = $this->event(55);
+    $variation = $this->variation(9);
+    $tier = $this->tier('VIP', 3, $variation, 10);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->with($event)->willReturn([$tier]);
+
+    $ticket_item = $this->orderItem(10, 9, '4');
+    $order = $this->completedOrder();
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturn(TRUE);
+
+    $order_item_storage = $this->createMock(EntityStorageInterface::class);
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([1]);
+    $order_item_storage->method('getQuery')->willReturn($query);
+    $order_item_storage->method('loadMultiple')->willReturn([1 => $ticket_item]);
+
+    $order_storage = $this->createMock(EntityStorageInterface::class);
+    $order_storage->method('load')->with(10)->willReturn($order);
+
+    $builder = new EventStudioCommerceSalesSummaryBuilder(
+      $this->entityTypeManager($order_item_storage, $order_storage),
+      $lifecycle,
+      $classifier,
+      $this->variationSoldService(),
+      $this->createMock(CurrencyFormatter::class),
+      $this->createMock(TimeInterface::class),
+      $this->getStringTranslationStub(),
+    );
+
+    $panel = $builder->buildTicketSalesPanel($event);
+    $this->assertTrue($panel['has_rows']);
+    $this->assertSame(4, $panel['rows'][0]['sold']);
+    $this->assertSame('6', $panel['rows'][0]['remaining_label']);
+    $this->assertSame(40.0, $panel['rows'][0]['percent_sold']);
+  }
+
+  /**
+   * @covers ::buildTicketSalesPanel
+   */
+  public function testSoldOutTicketStatusIsIndependentFromOperationalStock(): void {
+    $event = $this->event(77);
+    $variation = $this->variation(12);
+    $tier = $this->tier('GA', 5, $variation, 5);
+
+    $lifecycle = $this->createMock(EventPaidTicketLoaderInterface::class);
+    $lifecycle->method('loadOrderedTicketsForEvent')->with($event)->willReturn([$tier]);
+
+    $ticket_item = $this->orderItem(10, 12, '5');
+    $order = $this->completedOrder();
+    $classifier = $this->createMock(TicketBackedOrderItemClassifierInterface::class);
+    $classifier->method('isTicketBackedOrderItem')->willReturn(TRUE);
+
+    $order_item_storage = $this->createMock(EntityStorageInterface::class);
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([1]);
+    $order_item_storage->method('getQuery')->willReturn($query);
+    $order_item_storage->method('loadMultiple')->willReturn([1 => $ticket_item]);
+
+    $order_storage = $this->createMock(EntityStorageInterface::class);
+    $order_storage->method('load')->with(10)->willReturn($order);
+
+    $builder = new EventStudioCommerceSalesSummaryBuilder(
+      $this->entityTypeManager($order_item_storage, $order_storage),
+      $lifecycle,
+      $classifier,
+      $this->variationSoldService(),
+      $this->createMock(CurrencyFormatter::class),
+      $this->createMock(TimeInterface::class),
+      $this->getStringTranslationStub(),
+    );
+
+    $panel = $builder->buildTicketSalesPanel($event);
+    $this->assertSame('sold_out', $panel['rows'][0]['status']);
+    $this->assertSame(5, $panel['rows'][0]['sold']);
+    $this->assertSame('0', $panel['rows'][0]['remaining_label']);
+  }
+
+  private function builder(EventPaidTicketLoaderInterface $lifecycle): EventStudioCommerceSalesSummaryBuilder {
+    $order_item_storage = $this->createMock(EntityStorageInterface::class);
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([]);
+    $order_item_storage->method('getQuery')->willReturn($query);
+
+    return new EventStudioCommerceSalesSummaryBuilder(
+      $this->entityTypeManager($order_item_storage, $this->createMock(EntityStorageInterface::class)),
+      $lifecycle,
+      $this->createMock(TicketBackedOrderItemClassifierInterface::class),
+      $this->variationSoldService(),
+      $this->createMock(CurrencyFormatter::class),
+      $this->createMock(TimeInterface::class),
+      $this->getStringTranslationStub(),
+    );
+  }
+
+  private function variationSoldService(): TicketVariationSoldService {
+    return new TicketVariationSoldService($this->createMock(EntityTypeManagerInterface::class));
+  }
+
+  private function entityTypeManager(
+    EntityStorageInterface $order_item_storage,
+    EntityStorageInterface $order_storage,
+  ): EntityTypeManagerInterface {
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getStorage')->willReturnCallback(
+      static fn (string $type) => match ($type) {
+        'commerce_order_item' => $order_item_storage,
+        'commerce_order' => $order_storage,
+        default => throw new \InvalidArgumentException('Unexpected storage: ' . $type),
+      },
+    );
+    return $etm;
+  }
+
+  private function event(int $id): NodeInterface&MockObject {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('id')->willReturn((string) $id);
+    $event->method('bundle')->willReturn('event');
+    $event->method('getCacheTags')->willReturn(['node:' . $id]);
+    return $event;
+  }
+
+  private function orderItem(int $order_id, int $variation_id, string $quantity): OrderItemInterface&MockObject {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('id')->willReturn((string) $variation_id);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('get')->with('order_id')->willReturn(new CommerceFieldTargetIdStub($order_id));
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $item->method('getQuantity')->willReturn($quantity);
+    return $item;
+  }
+
+  private function completedOrder(): OrderInterface&MockObject {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getState')->willReturn(new CommerceOrderStateStub('completed'));
+    return $order;
+  }
+
+  private function variation(int $id): ProductVariationInterface&MockObject {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('id')->willReturn((string) $id);
+    $variation->method('getPrice')->willReturn(NULL);
+    $variation->method('getCacheTags')->willReturn(['commerce_product_variation:' . $id]);
+    $variation->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => $field === 'field_capacity',
+    );
+    $variation->method('get')->willReturn(new CommerceFieldValueStub(NULL));
+    return $variation;
+  }
+
+  /**
+   * @return TicketTypeInterface&MockObject
+   */
+  private function tier(
+    string $label,
+    int $id,
+    ProductVariationInterface $variation,
+    int $capacity,
+  ): TicketTypeInterface&MockObject {
+    $tier = $this->createStub(TicketTypeInterface::class);
+    $tier->method('getTicketKind')->willReturn('paid');
+    $tier->method('label')->willReturn($label);
+    $tier->method('id')->willReturn((string) $id);
+    $tier->method('isArchived')->willReturn(FALSE);
+    $tier->method('getCacheTags')->willReturn(['mel_ticket_type:' . $id]);
+    $tier->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => in_array($field, [
+        'commerce_variation',
+        'capacity',
+        'visibility_mode',
+        'status',
+        'sale_start',
+        'sale_end',
+        'event',
+      ], TRUE),
+    );
+    $empty_field = new CommerceFieldValueStub(NULL);
+    $tier->method('get')->willReturnCallback(
+      static function (string $field) use ($variation, $capacity, $empty_field) {
+        return match ($field) {
+          'commerce_variation' => new CommerceFieldEntityStub($variation),
+          'capacity' => new CommerceFieldValueStub((string) $capacity),
+          'status' => new CommerceFieldValueStub('1'),
+          default => $empty_field,
+        };
+      },
+    );
+    return $tier;
+  }
+
+}
+
+/**
+ * Minimal order state stub.
+ */
+final class CommerceOrderStateStub {
+
+  public function __construct(private readonly string $id) {}
+
+  public function getId(): string {
+    return $this->id;
+  }
+
+}
+
+/**
+ * Minimal entity reference field stub with target_id.
+ */
+final class CommerceFieldTargetIdStub {
+
+  public function __construct(public readonly int $target_id) {}
+
+  public function isEmpty(): bool {
+    return $this->target_id < 1;
+  }
+
+}
+
+/**
+ * Minimal entity reference field stub with entity.
+ */
+final class CommerceFieldEntityStub {
+
+  public mixed $entity;
+
+  public mixed $target_id;
+
+  public function __construct(?object $entity) {
+    $this->entity = $entity;
+    $this->target_id = is_object($entity) && method_exists($entity, 'id') ? $entity->id() : NULL;
+  }
+
+  public function isEmpty(): bool {
+    return $this->entity === NULL;
+  }
+
+}
+
+/**
+ * Minimal scalar field stub.
+ */
+final class CommerceFieldValueStub {
+
+  public function __construct(public readonly ?string $value) {}
+
+  public function isEmpty(): bool {
+    return $this->value === NULL || $this->value === '';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
@@ -34,6 +34,23 @@ final class EventStudioExtrasProductEditorTest extends TestCase {
     $this->assertFalse($registry->operationalVariationsSupportStock());
   }
 
+  public function testOperationalVariationStockFieldsAreDetected(): void {
+    $defs = [
+      'field_mel_stock_quantity' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'field_mel_limit_per_order' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'field_mel_show_remaining' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+      'field_mel_size' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
+    ];
+    $manager = $this->createMock(EntityFieldManagerInterface::class);
+    $manager->method('getFieldDefinitions')->willReturn($defs);
+    $registry = new OperationalProductStudioFieldRegistry($manager);
+    $this->assertTrue($registry->operationalVariationsSupportStock());
+    $variation = $registry->variationFieldSupport('operational_merchandise_var');
+    $this->assertTrue($variation['stock_quantity']);
+    $this->assertTrue($variation['limit_per_order']);
+    $this->assertTrue($variation['show_remaining']);
+  }
+
   public function testMerchandiseVariationBundleSupportsSizeField(): void {
     $defs = [
       'field_mel_size' => $this->createMock(\Drupal\Core\Field\FieldDefinitionInterface::class),
@@ -58,10 +75,27 @@ final class EventStudioExtrasProductEditorTest extends TestCase {
       'price_amount' => '25',
       'sku' => 'TEE-99',
       'capacity_note' => '50 printed',
+      'variant_stock' => [
+        's' => ['stock_quantity' => 2, 'limit_per_order' => 2, 'show_remaining' => TRUE],
+        'm' => ['stock_quantity' => 0, 'limit_per_order' => NULL, 'show_remaining' => TRUE],
+      ],
     ]);
     $this->assertCount(2, $rows);
     $this->assertStringContainsString('TEE-99', $rows[0]['sku']);
-    $this->assertSame('50 printed', $rows[0]['capacity_note']);
+    $this->assertSame(2, $rows[0]['stock_quantity']);
+    $this->assertSame(0, $rows[1]['stock_quantity']);
+  }
+
+  public function testResolveVariantStockInputFallsBackToProductLevel(): void {
+    $manager = $this->createPartialManager();
+    $stock = $manager->resolveVariantStockInput([
+      'stock_quantity' => 10,
+      'limit_per_order' => 3,
+      'show_remaining' => 1,
+    ], 'l');
+    $this->assertSame(10, $stock['stock_quantity']);
+    $this->assertSame(3, $stock['limit_per_order']);
+    $this->assertTrue($stock['show_remaining']);
   }
 
   public function testProductStatusKeysAreDefined(): void {
@@ -70,6 +104,126 @@ final class EventStudioExtrasProductEditorTest extends TestCase {
 
   public function testExtrasProductEditorBuilderClassExists(): void {
     $this->assertTrue(class_exists(\Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder::class));
+  }
+
+  public function testProductEditorUsesVendorManagedProductOptions(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
+    $manager = file_get_contents(dirname(__DIR__, 3) . '/src/Service/VendorOperationalProductCreationManager.php');
+    $this->assertIsString($builder);
+    $this->assertIsString($form);
+    $this->assertIsString($manager);
+    $this->assertStringContainsString('buildProductOptionsSection', $builder);
+    $this->assertStringContainsString('Product options', $builder);
+    $this->assertStringContainsString('variation_id', $builder);
+    $this->assertStringContainsString('syncVariationsFromProductOptions', $manager);
+    $this->assertStringContainsString('buildProductOptionsFromProduct', $manager);
+    $this->assertStringContainsString('product_options', $form);
+    $this->assertStringContainsString('submitAddProductOption', $form);
+    $this->assertStringContainsString('option_label', $builder);
+    $this->assertStringContainsString("['#parents'] = ['editor', 'product_options']", $builder);
+    $this->assertStringContainsString('buildProductOptionStockTable', $builder);
+    $this->assertStringContainsString('Edit stock per option', $builder);
+    $this->assertStringContainsString('buildStockSummaryChips', $builder);
+    $this->assertStringContainsString('summarizeProductOptionsStock', $manager);
+    $this->assertStringContainsString('editorSlice', $form);
+    preg_match(
+      '/private function buildProductOptionCatalogRow([\s\S]*?)private function/s',
+      $builder,
+      $catalog_match,
+    );
+    $this->assertNotEmpty($catalog_match[1] ?? '');
+    $this->assertStringNotContainsString('stock_quantity', $catalog_match[1]);
+  }
+
+  public function testSummarizeProductOptionsStockDefaultsToClosedDetails(): void {
+    $manager = $this->createPartialManager();
+    $summary = $manager->summarizeProductOptionsStock([
+      ['option_label' => 'S', 'stock_quantity' => NULL],
+      ['option_label' => 'M', 'stock_quantity' => ''],
+    ]);
+    $this->assertSame(2, $summary['option_count']);
+    $this->assertSame(2, $summary['unlimited_count']);
+    $this->assertFalse($summary['open_stock_details']);
+    $this->assertSame('unlimited', $summary['stock_mode']);
+  }
+
+  public function testSummarizeProductOptionsStockOpensDetailsForFiniteOrSoldOut(): void {
+    $manager = $this->createPartialManager();
+    $sold_out = $manager->summarizeProductOptionsStock([
+      ['option_label' => 'L', 'stock_quantity' => 0],
+    ]);
+    $this->assertTrue($sold_out['open_stock_details']);
+    $this->assertSame('sold_out', $sold_out['stock_mode']);
+
+    $finite = $manager->summarizeProductOptionsStock([
+      ['option_label' => 'M', 'stock_quantity' => 12],
+    ]);
+    $this->assertTrue($finite['open_stock_details']);
+
+    $limit = $manager->summarizeProductOptionsStock([
+      ['option_label' => 'VIP', 'stock_quantity' => NULL, 'limit_per_order' => 2],
+    ]);
+    $this->assertTrue($limit['open_stock_details']);
+  }
+
+  public function testStockTablePreservesVariationIdParents(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $this->assertIsString($builder);
+    $this->assertStringContainsString("['editor', 'product_options', 'rows', \$delta]", $builder);
+    $this->assertStringContainsString("array_merge(\$parents, ['variation_id'])", $builder);
+    $this->assertStringContainsString("array_merge(\$parents, ['stock_quantity'])", $builder);
+  }
+
+  public function testBookingPreviewUsesMetaLine(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-extra-preview.html.twig');
+    $this->assertIsString($builder);
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('#preview_meta_line', $builder);
+    $this->assertStringContainsString('preview_meta_line', $twig);
+  }
+
+  public function testStockHelperCopyAppearsOnceInStockPanel(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $this->assertIsString($builder);
+    preg_match(
+      '/private function buildStockLimitsPanelContent\([\s\S]*?private function buildPreviewPanelContent/s',
+      $builder,
+      $panel_match,
+    );
+    $this->assertNotEmpty($panel_match[0] ?? '');
+    $panel = $panel_match[0];
+    $this->assertSame(1, substr_count($panel, 'Blank = unlimited. 0 = sold out. Positive numbers are enforced.'));
+    $this->assertSame(1, substr_count($panel, 'Limit per order is optional.'));
+    $this->assertStringContainsString('Stock is enforced when customers add extras to cart.', $panel);
+    preg_match(
+      '/private function buildProductOptionCatalogRow\([\s\S]*?private function/s',
+      $builder,
+      $catalog_match,
+    );
+    $this->assertNotEmpty($catalog_match[0] ?? '');
+    $this->assertSame(0, substr_count($catalog_match[0], 'Blank = unlimited'));
+  }
+
+  public function testNormalizeProductOptionsPreservesVariationId(): void {
+    $ref = new \ReflectionClass(VendorOperationalProductCreationManager::class);
+    $method = $ref->getMethod('normalizeProductOptionsInput');
+    $manager = $this->createPartialManager();
+    $rows = $method->invoke($manager, [
+      [
+        'variation_id' => 42,
+        'option_label' => 'M',
+        'sku' => 'TEE-m',
+        'price_amount' => '35',
+        'stock_quantity' => 5,
+        'published' => 1,
+      ],
+    ]);
+    $this->assertCount(1, $rows);
+    $this->assertSame(42, $rows[0]['variation_id']);
+    $this->assertSame('M', $rows[0]['option_label']);
+    $this->assertSame(5, $rows[0]['stock_quantity']);
   }
 
   private function createPartialManager(): VendorOperationalProductCreationManager {
@@ -82,6 +236,10 @@ final class EventStudioExtrasProductEditorTest extends TestCase {
     $prop = $ref->getProperty('translation');
     $prop->setAccessible(TRUE);
     $prop->setValue($manager, $translator);
+    $stock = new \Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver($translator);
+    $stockProp = $ref->getProperty('stockResolver');
+    $stockProp->setAccessible(TRUE);
+    $stockProp->setValue($manager, $stock);
     return $manager;
   }
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * IA contract tests for ticket sales placement and Manage event navigation.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioManageEventIaTest extends UnitTestCase {
+
+  public function testExtrasFormDoesNotRenderTicketSalesPanel(): void {
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
+    $this->assertIsString($contents);
+    $this->assertStringNotContainsString('buildTicketSalesPanel', $contents);
+    $this->assertStringNotContainsString("form['ticket_sales']", $contents);
+    $this->assertStringNotContainsString('EventStudioCommerceSalesSummaryBuilder', $contents);
+    $this->assertStringContainsString('View ticket sales in Manage event', $contents);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $contents);
+  }
+
+  public function testStudioOverviewDoesNotRenderTicketSalesPanel(): void {
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($contents);
+    $this->assertStringNotContainsString('buildTicketSalesPanelRenderArray', $contents);
+    $this->assertStringNotContainsString("build['ticket_sales']", $contents);
+    $this->assertStringNotContainsString('EventStudioCommerceSalesSummaryBuilder', $contents);
+  }
+
+  public function testVendorEventWorkspaceRendersTicketSalesPanel(): void {
+    $controller = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Controller/EventWorkspaceController.php');
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $this->assertIsString($controller);
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('EventStudioCommerceSalesSummaryBuilder', $controller);
+    $this->assertStringContainsString('EventOperationalExtrasSalesSummaryBuilder', $controller);
+    $this->assertStringContainsString('buildTicketSalesPanelRenderArray', $controller);
+    $this->assertStringContainsString('buildExtrasSalesPanelRenderArray', $controller);
+    $this->assertStringContainsString('ticket_sales_panel', $controller);
+    $this->assertStringContainsString('extras_sales_panel', $controller);
+    $this->assertStringContainsString('ticket_sales_panel', $twig);
+    $this->assertStringContainsString('extras_sales_panel', $twig);
+    $this->assertStringContainsString('mel_event_studio_ticket_sales_panel', $controller);
+    $this->assertStringContainsString('mel_event_studio_extras_sales_panel', $controller);
+  }
+
+  public function testVendorEventTabsUseManageEventLabel(): void {
+    $tabs = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Service/VendorEventTabsService.php');
+    $tasks = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/myeventlane_vendor.links.task.yml');
+    $this->assertIsString($tabs);
+    $this->assertIsString($tasks);
+    $this->assertStringContainsString('Manage event', $tabs);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tabs);
+    $this->assertStringContainsString("title: 'Manage event'", $tasks);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tasks);
+  }
+
+  public function testManageEventBackLinkUsesWorkspaceRoute(): void {
+    $theme = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme');
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $this->assertIsString($theme);
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $theme);
+    $this->assertStringContainsString('Back to Manage event', $theme);
+    $this->assertStringContainsString('manage_event_back', $twig);
+  }
+
+  public function testCommerceSalesSummaryBuilderStillProvidesEditTicketsLink(): void {
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioCommerceSalesSummaryBuilder.php');
+    $this->assertIsString($contents);
+    $this->assertStringContainsString('buildTicketSalesPanelRenderArray', $contents);
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_tickets', $contents);
+    $this->assertStringContainsString('Edit tickets', $contents);
+  }
+
+  public function testStudioTopBarManageEventLinkPointsToVendorWorkspace(): void {
+    $topbar = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-topbar.html.twig');
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+    $this->assertIsString($topbar);
+    $this->assertIsString($controller);
+    $this->assertStringContainsString('show_manage_event_link', $topbar);
+    $this->assertStringContainsString('Manage event', $topbar);
+    $this->assertStringContainsString('manage_event_url', $topbar);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $controller);
+  }
+
+  public function testVendorEventWorkspaceRendersTodaysFocusRegion(): void {
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $builder = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php');
+    $this->assertIsString($twig);
+    $this->assertIsString($builder);
+    $this->assertStringContainsString('mel-event-mission-control', $twig);
+    $this->assertStringContainsString('todays_focus', $twig);
+    $this->assertStringContainsString("Today's focus", $twig);
+    $this->assertStringContainsString('buildTodaysFocus', $builder);
+    $this->assertStringContainsString('readiness_summary', $builder);
+  }
+
+  public function testVendorEventWorkspaceReadinessSummaryUsesDetails(): void {
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('readiness_summary', $twig);
+    $this->assertStringContainsString('Show all readiness checks', $twig);
+    $this->assertStringContainsString('mel-event-mission-control__readiness-group', $twig);
+    $this->assertStringNotContainsString('mel-ws-readiness-heading', $twig);
+  }
+
+  public function testVendorEventWorkspaceActionGridGrouped(): void {
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $builder = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php');
+    $this->assertIsString($twig);
+    $this->assertIsString($builder);
+    $this->assertStringContainsString('action_grid', $twig);
+    $this->assertStringContainsString('grid_setup', $twig);
+    $this->assertStringContainsString('buildActionGrid', $builder);
+    $this->assertStringContainsString('Merch & add-ons', $builder);
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_extras', $builder);
+  }
+
+  public function testVendorEventWorkspaceRouteIsCanonicalManageEventSurface(): void {
+    $routing = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/myeventlane_vendor.routing.yml');
+    $this->assertIsString($routing);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace:', $routing);
+    $this->assertStringContainsString("path: '/vendor/events/{event}'", $routing);
+    $this->assertStringContainsString('event_workspace:workspace', $routing);
+  }
+
+  public function testConfiguredExtrasSummaryBuilderExists(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php');
+    $template = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-extras-configured-summary.html.twig');
+    $this->assertIsString($builder);
+    $this->assertIsString($template);
+    $this->assertStringContainsString('has_products', $builder);
+    $this->assertStringContainsString('empty_state', $builder);
+    $this->assertStringContainsString('Add merch or extras', $builder);
+    $this->assertStringContainsString('empty.title', $template);
+  }
+
+  public function testManageEventRendersConfiguredExtrasSummary(): void {
+    $controller = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Controller/EventWorkspaceController.php');
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $this->assertIsString($controller);
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('EventStudioExtrasConfiguredSummaryBuilder', $controller);
+    $this->assertStringContainsString('extras_configured_panel', $controller);
+    $this->assertStringContainsString('extras_configured_panel', $twig);
+  }
+
+  public function testStudioExtrasFormRendersFeeCopy(): void {
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
+    $this->assertIsString($form);
+    $this->assertStringContainsString('PlatformFeeSettings', $form);
+    $this->assertStringContainsString('fee_copy', $form);
+    $this->assertStringContainsString('buildExtrasStudioFeeCopy', $form);
+  }
+
+  public function testAnalyticsIncludesSeparateCommerceMetrics(): void {
+    $controller = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php');
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig');
+    $this->assertIsString($controller);
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('buildCommerceAnalytics', $controller);
+    $this->assertStringContainsString('extras_revenue', $controller);
+    $this->assertStringContainsString('commerce_analytics', $twig);
+    $this->assertStringContainsString('Ticket revenue', $twig);
+    $this->assertStringContainsString('Merch/add-on revenue', $twig);
+  }
+
+  public function testEventManagementShellOnSubRoutes(): void {
+    $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('mel-event-management-shell', $twig);
+    $this->assertStringContainsString('mel-workspace__content--event-management', $twig);
+  }
+
+  public function testExtrasSalesPanelIncludesOperationalDocuments(): void {
+    $builder = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php');
+    $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-extras-sales-panel.html.twig');
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
+    $this->assertIsString($builder);
+    $this->assertIsString($twig);
+    $this->assertIsString($form);
+    $this->assertStringContainsString('buildOperationalDocumentsBlock', $builder);
+    $this->assertStringContainsString('operational_documents', $builder);
+    $this->assertStringContainsString('packing_slips', $builder);
+    $this->assertStringContainsString('Document generation is coming soon', $builder);
+    $this->assertStringContainsString('operational_documents', $twig);
+    $this->assertStringContainsString('aria-disabled="true"', $twig);
+    $this->assertStringNotContainsString('href="#"', $twig);
+    $this->assertStringContainsString('operational_documents_note', $form);
+    $this->assertStringContainsString('packing slips, parking slips, and labels from Manage event', $form);
+  }
+
+  public function testOperationalDocumentsDoNotReferenceTicketPdfOrQr(): void {
+    $builder = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_commerce/src/Service/EventOperationalExtrasSalesSummaryBuilder.php');
+    $this->assertIsString($builder);
+    $this->assertStringNotContainsString('TicketPdf', $builder);
+    $this->assertStringNotContainsString('QrCodeGenerator', $builder);
+    $this->assertStringNotContainsString('TicketIssuer', $builder);
+  }
+
+  public function testExtrasProductEditorIncludesStockGuidanceAndOperationalDocsLink(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $manager = file_get_contents(dirname(__DIR__, 3) . '/src/Service/VendorOperationalProductCreationManager.php');
+    $preview = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-extra-preview.html.twig');
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
+    $this->assertIsString($builder);
+    $this->assertIsString($manager);
+    $this->assertIsString($preview);
+    $this->assertIsString($form);
+    $this->assertStringContainsString('Blank stock = unlimited. 0 = sold out. Positive numbers are enforced.', $builder);
+    $this->assertStringContainsString('Limit per order is optional.', $builder);
+    $this->assertStringContainsString('Product options', $builder);
+    $this->assertStringContainsString('Colour options can be added in the option label', $builder);
+    $this->assertStringContainsString('buildProductOptionsSection', $builder);
+    $this->assertStringContainsString('buildOperationalDocumentsSection', $builder);
+    $this->assertStringContainsString('Packing slips, parking slips and labels', $builder);
+    $this->assertStringContainsString('Print tools live in Manage event once this item starts selling', $builder);
+    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $builder);
+    $this->assertStringContainsString('Back to Manage event', $builder);
+    $this->assertStringNotContainsString('packing_slip.pdf', $builder);
+    $this->assertStringNotContainsString('print/download', $builder);
+    $this->assertStringContainsString('syncVariationsFromProductOptions', $manager);
+    $this->assertStringContainsString('options_summary', $preview);
+    $this->assertStringContainsString('product_options', $form);
+    $this->assertStringContainsString('Stock quantity', $builder);
+    $this->assertStringContainsString('Limit per order', $builder);
+    $this->assertStringContainsString('Show remaining', $builder);
+    $this->assertStringContainsString('buildPreviewSection', $builder);
+    $this->assertStringContainsString('stock_label', $preview);
+    $this->assertStringContainsString('visibility_label', $preview);
+    $this->assertStringContainsString('Preview only. Customers see this on the booking page.', $builder);
+  }
+
+  public function testExtrasProductEditorUsesSingleColumnLayoutAndStickyFooter(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasProductEditorBuilder.php');
+    $css = file_get_contents(dirname(__DIR__, 3) . '/css/mel-event-extras-studio.css');
+    $this->assertIsString($builder);
+    $this->assertIsString($css);
+    $this->assertStringContainsString('mel-event-product-editor__accordion', $builder);
+    $this->assertStringContainsString("'#type' => 'details'", $builder);
+    $this->assertStringContainsString('Stock and limits', $builder);
+    $this->assertStringContainsString('mel-event-product-editor__footer', $builder);
+    $this->assertStringContainsString('Save product', $builder);
+    $this->assertStringContainsString('mel-event-product-editor__footer', $css);
+  }
+
+  public function testPlatformFeeSettingsDefaultsExtrasToDoubleTicket(): void {
+    $settings = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_core/src/Service/PlatformFeeSettings.php');
+    $processor = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_commerce/src/OrderProcessor/PlatformFeeOrderProcessor.php');
+    $this->assertIsString($settings);
+    $this->assertIsString($processor);
+    $this->assertStringContainsString('EXTRAS_FEE_TICKET_MULTIPLIER', $settings);
+    $this->assertStringContainsString('myeventlane_operational_extras_platform_fee', $processor);
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Plugin/Menu/LocalTask/EventWorkspaceRefundRequestsLocalTask.php
+++ b/web/modules/custom/myeventlane_refunds/src/Plugin/Menu/LocalTask/EventWorkspaceRefundRequestsLocalTask.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
  *   id = "myeventlane_refunds.event_workspace_refund_requests",
  *   route_name = "myeventlane_refunds.vendor_refund_requests",
  *   title = @Translation("Refund requests"),
- *   base_route = "myeventlane_vendor.console.event_overview",
+ *   base_route = "myeventlane_vendor.console.event_workspace",
  *   weight = -9,
  * )
  */

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml
@@ -21,27 +21,27 @@ entity.myeventlane_vendor.delete_form:
 
 # Vendor event workspace — primary tabs (base_route shared; Boost + Refund use plugins).
 myeventlane_vendor.event_workspace.overview:
-  title: 'Overview'
-  route_name: myeventlane_vendor.console.event_overview
-  base_route: myeventlane_vendor.console.event_overview
+  title: 'Manage event'
+  route_name: myeventlane_vendor.console.event_workspace
+  base_route: myeventlane_vendor.console.event_workspace
   weight: -20
 
 myeventlane_vendor.event_workspace.tickets:
   title: 'Tickets'
   route_name: myeventlane_vendor.console.event_tickets
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: -15
 
 myeventlane_vendor.event_workspace.orders:
   title: 'Orders'
   route_name: myeventlane_vendor.console.event_orders
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: -12
 
 myeventlane_vendor.event_workspace.addon_orders:
   title: 'Add-on orders'
   route_name: myeventlane_vendor.console.event_operational_addon_orders
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: -11
 
 myeventlane_vendor.event_workspace.attendees:
@@ -53,19 +53,19 @@ myeventlane_vendor.event_workspace.attendees:
 myeventlane_vendor.event_workspace.rsvps:
   title: 'RSVPs'
   route_name: myeventlane_vendor.console.event_rsvps
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: -6
 
 myeventlane_vendor.event_workspace.analytics:
   title: 'Analytics'
   route_name: myeventlane_vendor.console.event_analytics
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: 10
 
 myeventlane_vendor.event_workspace.settings:
   title: 'Settings'
   route_name: myeventlane_vendor.console.event_settings
-  base_route: myeventlane_vendor.console.event_overview
+  base_route: myeventlane_vendor.console.event_workspace
   weight: 30
 
 myeventlane_vendor.event_order_resend:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -532,7 +532,7 @@ myeventlane_vendor.console.event_overview:
   path: '/vendor/events/{event}/overview'
   defaults:
     _controller: 'myeventlane_vendor.controller.vendor_event_overview:overview'
-    _title: 'Event overview'
+    _title: 'Manage event'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     event: '\d+'

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -439,7 +439,20 @@ services:
 
   myeventlane_vendor.controller.vendor_event_analytics:
     class: Drupal\myeventlane_vendor\Controller\VendorEventAnalyticsController
-    arguments: ['@myeventlane_core.domain_detector', '@current_user', '@messenger', '@entity_type.manager', '@myeventlane_vendor.service.metrics_aggregator', '@myeventlane_vendor.service.event_tabs', '@myeventlane_event.ticket_tier_lifecycle', '@myeventlane_commerce.ticket_tier_analytics', '@access_manager', '@logger.factory', '@?myeventlane_pro.active_resolver']
+    arguments:
+      - '@myeventlane_core.domain_detector'
+      - '@current_user'
+      - '@messenger'
+      - '@entity_type.manager'
+      - '@myeventlane_vendor.service.metrics_aggregator'
+      - '@myeventlane_vendor.service.event_tabs'
+      - '@myeventlane_event.ticket_tier_lifecycle'
+      - '@myeventlane_commerce.ticket_tier_analytics'
+      - '@access_manager'
+      - '@logger.factory'
+      - '@?myeventlane_pro.active_resolver'
+      - '@myeventlane_event_studio.commerce_sales_summary_builder'
+      - '@myeventlane_commerce.event_operational_extras_sales_summary_builder'
     tags:
       - { name: controller.service_arguments }
 
@@ -511,6 +524,9 @@ services:
       - '@logger.channel.myeventlane_vendor'
       - '@request_stack'
       - '@myeventlane_vendor.event_workspace_view_model_builder'
+      - '@myeventlane_event_studio.commerce_sales_summary_builder'
+      - '@myeventlane_commerce.event_operational_extras_sales_summary_builder'
+      - '@myeventlane_event_studio.extras_configured_summary_builder'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/EventWorkspaceController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/EventWorkspaceController.php
@@ -8,6 +8,9 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_commerce\Service\EventOperationalExtrasSalesSummaryBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioExtrasConfiguredSummaryBuilder;
 use Drupal\myeventlane_vendor\Service\VendorEventWorkspaceViewModelBuilder;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -27,6 +30,9 @@ final class EventWorkspaceController extends VendorConsoleBaseController {
     private readonly LoggerInterface $logger,
     private readonly RequestStack $requestStack,
     private readonly VendorEventWorkspaceViewModelBuilder $eventWorkspaceViewModelBuilder,
+    private readonly EventStudioCommerceSalesSummaryBuilder $commerceSalesSummaryBuilder,
+    private readonly EventOperationalExtrasSalesSummaryBuilder $extrasSalesSummaryBuilder,
+    private readonly EventStudioExtrasConfiguredSummaryBuilder $extrasConfiguredSummaryBuilder,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
   }
@@ -38,11 +44,23 @@ final class EventWorkspaceController extends VendorConsoleBaseController {
     $this->assertEventOwnership($event);
 
     $model = $this->eventWorkspaceViewModelBuilder->build($event, $this->currentUser);
+    $ticket_sales_panel = $this->commerceSalesSummaryBuilder->buildTicketSalesPanelRenderArray($event, 0);
+    if (isset($ticket_sales_panel['#panel']) && is_array($ticket_sales_panel['#panel'])) {
+      $ticket_sales_panel['#panel']['compact'] = TRUE;
+    }
+    $extras_sales_panel = $this->extrasSalesSummaryBuilder->buildExtrasSalesPanelRenderArray($event, 0);
+    if (isset($extras_sales_panel['#panel']) && is_array($extras_sales_panel['#panel'])) {
+      $extras_sales_panel['#panel']['compact'] = TRUE;
+    }
+    $extras_configured_panel = $this->extrasConfiguredSummaryBuilder->buildPanelRenderArray($event, -6);
 
     return $this->buildVendorPage('mel_event_workspace', [
       'event' => $event,
       'tabs' => [],
       'vendor_event_workspace_model' => $model,
+      'ticket_sales_panel' => $ticket_sales_panel,
+      'extras_configured_panel' => $extras_configured_panel,
+      'extras_sales_panel' => $extras_sales_panel,
       'insights' => [],
       'header_stats' => NULL,
       'meta' => NULL,
@@ -52,6 +70,13 @@ final class EventWorkspaceController extends VendorConsoleBaseController {
         '#tag' => 'div',
         '#attributes' => ['class' => ['mel-live-ops__content-anchor']],
         '#value' => '',
+      ],
+      '#attached' => [
+        'library' => [
+          'myeventlane_event_studio/mel_event_studio_ticket_sales_panel',
+          'myeventlane_event_studio/mel_event_studio_extras_sales_panel',
+          'myeventlane_vendor_theme/event_mission_control',
+        ],
       ],
     ]);
   }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
@@ -135,6 +135,10 @@ abstract class VendorConsoleBaseController {
       ],
     ];
 
+    if ($theme_hook === 'mel_event_workspace') {
+      $base_attached['library'][] = 'myeventlane_vendor_theme/event_mission_control';
+    }
+
     // Merge in additional attachments provided by controllers.
     if (isset($variables['#attached']) && is_array($variables['#attached'])) {
       $extra = $variables['#attached'];

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -11,8 +11,10 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\EventOperationalExtrasSalesSummaryBuilder;
 use Drupal\myeventlane_commerce\Service\TicketTierAnalyticsService;
 use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
+use Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
 use Drupal\node\NodeInterface;
 use Drupal\myeventlane_core\Service\DomainDetector;
@@ -43,6 +45,8 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     private readonly AccessManagerInterface $accessManager,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly ?ProActiveResolver $proActiveResolver = NULL,
+    private readonly ?EventStudioCommerceSalesSummaryBuilder $commerceSalesSummaryBuilder = NULL,
+    private readonly ?EventOperationalExtrasSalesSummaryBuilder $extrasSalesSummaryBuilder = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
   }
@@ -126,6 +130,8 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     $export_pdf_url = $this->exportUrlIfAccessible($event, 'myeventlane_analytics.export_pdf');
     $export_excel_url = $this->exportUrlIfAccessible($event, 'myeventlane_analytics.export_excel');
 
+    $commerce_analytics = $this->buildCommerceAnalytics($event, $overview, $ticket_tier_rollup);
+
     return $this->buildVendorPage('mel_event_workspace', [
       'event' => $event,
       'tabs' => $tabs,
@@ -150,6 +156,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#edit_event_url' => $edit_event_url,
         '#export_pdf_url' => $export_pdf_url,
         '#export_excel_url' => $export_excel_url,
+        '#commerce_analytics' => $commerce_analytics,
       ],
       '#attached' => [
         'library' => [
@@ -160,6 +167,67 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         ],
       ],
     ]);
+  }
+
+  /**
+   * Ticket vs extras commerce metrics (reuses Manage event summary services).
+   *
+   * @param array<string, mixed> $overview
+   * @param array<string, mixed> $ticket_tier_rollup
+   *
+   * @return array<string, mixed>
+   */
+  private function buildCommerceAnalytics(NodeInterface $event, array $overview, array $ticket_tier_rollup): array {
+    $sales = is_array($overview['sales'] ?? NULL) ? $overview['sales'] : [];
+    $ticket_revenue = (string) ($sales['gross'] ?? '$0.00');
+    $ticket_qty = (int) ($sales['tickets_sold'] ?? 0);
+    if ($ticket_qty === 0) {
+      $ticket_qty = (int) ($ticket_tier_rollup['total_sold'] ?? 0);
+    }
+
+    $extras_revenue = '—';
+    $extras_items = 0;
+    $orders_with_extras = 0;
+    $top_extras_category = '—';
+
+    if ($this->extrasSalesSummaryBuilder) {
+      try {
+        $extras_panel = $this->extrasSalesSummaryBuilder->buildExtrasSalesPanel($event);
+        $summary = is_array($extras_panel['summary'] ?? NULL) ? $extras_panel['summary'] : [];
+        $extras_revenue = (string) ($summary['total_revenue'] ?? '—');
+        $extras_items = (int) ($summary['total_items_sold'] ?? 0);
+        $orders_with_extras = (int) ($summary['orders_with_extras'] ?? 0);
+        $top_extras_category = (string) ($summary['top_category'] ?? '—');
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('myeventlane_vendor')->warning('Analytics extras summary failed for event @nid: @message', [
+          '@nid' => (string) $event->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    $ticket_panel_rows = 0;
+    if ($this->commerceSalesSummaryBuilder) {
+      try {
+        $ticket_panel = $this->commerceSalesSummaryBuilder->buildTicketSalesPanel($event);
+        $ticket_panel_rows = count(is_array($ticket_panel['rows'] ?? NULL) ? $ticket_panel['rows'] : []);
+      }
+      catch (\Throwable) {
+        // Keep overview-derived ticket metrics.
+      }
+    }
+
+    return [
+      'ticket_revenue' => $ticket_revenue,
+      'ticket_quantity_sold' => $ticket_qty,
+      'ticket_types_configured' => $ticket_panel_rows > 0 ? $ticket_panel_rows : (int) ($ticket_tier_rollup['tier_row_count'] ?? 0),
+      'extras_revenue' => $extras_revenue,
+      'extras_items_sold' => $extras_items,
+      'orders_with_extras' => $orders_with_extras,
+      'top_extras_category' => $top_extras_category,
+      'booking_activity_note' => (string) ($ticket_tier_rollup['conversion_note'] ?? ''),
+    ];
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
@@ -141,7 +141,7 @@ final class EventTicketManagerForm extends FormBase {
       if ($show_workspace) {
         $form['back_nav']['workspace'] = [
           '#type' => 'link',
-          '#title' => $this->t('Event workspace'),
+          '#title' => $this->t('Back to Manage event'),
           '#url' => $workspace_url,
           '#attributes' => ['class' => ['mel-ticket-manager-back-nav__link']],
         ];

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -91,7 +91,7 @@ final class VendorConsolePagePreprocess {
     }
 
     $workspace_tabs = [
-      ['key' => 'overview', 'route' => 'myeventlane_vendor.console.event_overview', 'label' => $this->t('Overview'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_overview', ['event' => $event_id])->toString()],
+      ['key' => 'overview', 'route' => 'myeventlane_vendor.console.event_workspace', 'label' => $this->t('Manage event'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event_id])->toString()],
       ['key' => 'tickets', 'route' => 'myeventlane_vendor.console.event_tickets', 'label' => $this->t('Tickets'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_tickets', ['event' => $event_id])->toString()],
       ['key' => 'attendees', 'route' => 'myeventlane_event_attendees.vendor_list', 'label' => $this->t('Attendees'), 'url' => Url::fromRoute('myeventlane_event_attendees.vendor_list', ['node' => $event_id])->toString()],
       ['key' => 'orders', 'route' => 'myeventlane_vendor.console.event_orders', 'label' => $this->t('Orders'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_orders', ['event' => $event_id])->toString()],

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -113,7 +113,7 @@ final class VendorEventTabsService {
     $rows = [
       [
         'key' => 'overview',
-        'label' => (string) $t->translate('Overview'),
+        'label' => (string) $t->translate('Manage event'),
         'route' => 'myeventlane_vendor.console.event_workspace',
         'params' => ['event' => $id],
         'disabled' => FALSE,

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -183,14 +183,46 @@ final class VendorEventWorkspaceViewModelBuilder {
     // Reuse tab availability so add-on order gating runs once per request.
     $addonOrdersUrl = $this->addonOrdersUrlFromWorkspaceTabs($tabs);
 
+    $ordersUrl = $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account);
+    $attendeesUrl = $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account);
+    $rsvpsUrl = $this->routeUrlIfAccessible('myeventlane_vendor.console.event_rsvps', ['event' => $nid], $account);
+    $checkinUrl = $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account);
+    $editTicketsUrl = $this->routeUrlIfAccessible('myeventlane_event_studio.workspace_tickets', ['node' => $nid], $account)
+      ?? $advancedTicketsUrl;
+    $extrasUrl = $this->routeUrlIfAccessible('myeventlane_event_studio.workspace_extras', ['node' => $nid], $account);
+    $promoteUrl = $this->routeUrlIfAccessible('myeventlane_vendor.console.event_promotion', ['event' => $nid], $account);
+
+    $checkins = 0;
+    try {
+      $rsvpStats = $this->rsvpStatsService->getStatsForEvent($nid);
+      $checkins = (int) ($rsvpStats['checkins'] ?? 0);
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Workspace check-in count failed for nid @nid: @message', [
+        '@nid' => (string) $nid,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+
+    $operationalItems = $this->readinessHelper->vendorEventWorkspaceOperationalSummary(
+      $eventType,
+      $status,
+      $ticketsSold,
+      $ordersCount,
+      $rsvpCount,
+    );
+
     $actions = [
       'edit' => $editUrl,
       'advanced_tickets' => $advancedTicketsUrl,
-      'rsvps' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_rsvps', ['event' => $nid], $account),
-      'orders' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account),
+      'edit_tickets' => $editTicketsUrl,
+      'extras' => $extrasUrl,
+      'promote' => $promoteUrl,
+      'rsvps' => $rsvpsUrl,
+      'orders' => $ordersUrl,
       'addon_orders' => $addonOrdersUrl,
-      'attendees' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account),
-      'checkin' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account),
+      'attendees' => $attendeesUrl,
+      'checkin' => $checkinUrl,
       'analytics' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_analytics', ['event' => $nid], $account),
       'settings' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_settings', ['event' => $nid], $account),
       'preview' => $publicPreviewUrl,
@@ -215,14 +247,30 @@ final class VendorEventWorkspaceViewModelBuilder {
       'operational_readiness' => [
         'heading' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryHeading(),
         'intro' => $this->readinessHelper->vendorEventWorkspaceOperationalSummaryIntro(),
-        'items' => $this->readinessHelper->vendorEventWorkspaceOperationalSummary(
-          $eventType,
-          $status,
-          $ticketsSold,
-          $ordersCount,
-          $rsvpCount,
-        ),
+        'items' => $operationalItems,
       ],
+      'todays_focus' => $this->buildTodaysFocus(
+        $eventType,
+        $status,
+        $score,
+        $readinessItems,
+        $actions,
+        $ticketsSold,
+        $ordersCount,
+        $rsvpCount,
+      ),
+      'sales_snapshot' => $this->buildSalesSnapshot(
+        $eventType,
+        $grossDisplay,
+        $ticketsSold,
+        $ordersCount,
+        $rsvpCount,
+        $checkins,
+        $account,
+        $nid,
+      ),
+      'action_grid' => $this->buildActionGrid($actions),
+      'readiness_summary' => $this->buildReadinessSummary($operationalItems, $readinessItems),
       'lifecycle_guidance' => $this->readinessHelper->vendorEventWorkspaceLifecycleSummary(
         $eventType,
         $status,
@@ -290,9 +338,25 @@ final class VendorEventWorkspaceViewModelBuilder {
       'metrics' => [],
       'tabs' => [],
       'presentation_alerts' => [],
+      'todays_focus' => [
+        'message' => (string) $this->t('Reload this page or try again shortly.'),
+        'severity' => 'warning',
+        'actions' => [],
+      ],
+      'sales_snapshot' => ['metrics' => []],
+      'action_grid' => ['sales' => [], 'setup' => [], 'growth' => []],
+      'readiness_summary' => [
+        'all_ready' => FALSE,
+        'issue_count' => 0,
+        'groups' => [],
+        'detail_items' => [],
+      ],
       'actions' => [
         'edit' => NULL,
         'advanced_tickets' => NULL,
+        'edit_tickets' => NULL,
+        'extras' => NULL,
+        'promote' => NULL,
         'rsvps' => NULL,
         'orders' => NULL,
         'addon_orders' => NULL,
@@ -592,6 +656,340 @@ final class VendorEventWorkspaceViewModelBuilder {
     }
 
     return $metrics;
+  }
+
+  /**
+   * @param array<string, ?\Drupal\Core\Url> $actions
+   *
+   * @return array{message: string, severity: string, actions: list<array{label: string, url: string, primary: bool}>}
+   */
+  private function buildTodaysFocus(
+    string $eventType,
+    string $status,
+    int $readinessScore,
+    array $readinessItems,
+    array $actions,
+    int $ticketsSold,
+    int $ordersCount,
+    int $rsvpCount,
+  ): array {
+    $incomplete = array_filter($readinessItems, static fn(array $i): bool => empty($i['complete']));
+    $hasActivity = $ticketsSold > 0 || $ordersCount > 0 || $rsvpCount > 0;
+    $isLive = $status === 'published' || $status === 'past';
+
+    if ($eventType === 'unknown') {
+      return [
+        'message' => (string) $this->t('Finish setup before publishing.'),
+        'severity' => 'warning',
+        'actions' => $this->pickFocusActions([
+          ['label' => (string) $this->t('Edit event'), 'url' => $actions['edit'] ?? NULL, 'primary' => TRUE],
+          ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL, 'primary' => FALSE],
+          ['label' => (string) $this->t('Preview public event'), 'url' => $actions['preview'] ?? NULL, 'primary' => FALSE],
+        ]),
+      ];
+    }
+
+    if ($status === 'draft' || $status === 'unknown') {
+      return [
+        'message' => (string) $this->t('Finish setup before publishing.'),
+        'severity' => 'warning',
+        'actions' => $this->pickFocusActions([
+          ['label' => (string) $this->t('Edit event'), 'url' => $actions['edit'] ?? NULL, 'primary' => TRUE],
+          ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL, 'primary' => FALSE],
+          ['label' => (string) $this->t('Preview public event'), 'url' => $actions['preview'] ?? NULL, 'primary' => FALSE],
+        ]),
+      ];
+    }
+
+    if ($incomplete !== [] && $readinessScore < 100) {
+      return [
+        'message' => (string) $this->t('Review these items before sharing.'),
+        'severity' => 'info',
+        'actions' => $this->pickFocusActions([
+          ['label' => (string) $this->t('Edit event'), 'url' => $actions['edit'] ?? NULL, 'primary' => TRUE],
+          ['label' => (string) $this->t('Preview public event'), 'url' => $actions['preview'] ?? NULL, 'primary' => FALSE],
+          ['label' => (string) $this->t('Promote event'), 'url' => $actions['promote'] ?? NULL, 'primary' => FALSE],
+        ]),
+      ];
+    }
+
+    if ($isLive && $hasActivity) {
+      return [
+        'message' => (string) $this->t('Your event is live and taking bookings.'),
+        'severity' => 'success',
+        'actions' => $this->pickFocusActions([
+          ['label' => (string) $this->t('View orders'), 'url' => $actions['orders'] ?? NULL, 'primary' => TRUE],
+          ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL, 'primary' => FALSE],
+          ['label' => (string) $this->t('Add merch & add-ons'), 'url' => $actions['extras'] ?? NULL, 'primary' => FALSE],
+        ]),
+      ];
+    }
+
+    if ($isLive) {
+      return [
+        'message' => (string) $this->t('Your event is live. Share it to start collecting bookings.'),
+        'severity' => 'success',
+        'actions' => $this->pickFocusActions([
+          ['label' => (string) $this->t('Promote event'), 'url' => $actions['promote'] ?? NULL, 'primary' => TRUE],
+          ['label' => (string) $this->t('Preview public event'), 'url' => $actions['preview'] ?? NULL, 'primary' => FALSE],
+          ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL, 'primary' => FALSE],
+        ]),
+      ];
+    }
+
+    return [
+      'message' => (string) $this->t('Keep an eye on bookings and attendee activity.'),
+      'severity' => 'info',
+      'actions' => $this->pickFocusActions([
+        ['label' => (string) $this->t('Edit event'), 'url' => $actions['edit'] ?? NULL, 'primary' => TRUE],
+        ['label' => (string) $this->t('Preview public event'), 'url' => $actions['preview'] ?? NULL, 'primary' => FALSE],
+        ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL, 'primary' => FALSE],
+      ]),
+    ];
+  }
+
+  /**
+   * @param list<array{label: string, url: ?Url, primary: bool}> $candidates
+   *
+   * @return list<array{label: string, url: string, primary: bool}>
+   */
+  private function pickFocusActions(array $candidates): array {
+    $picked = [];
+    foreach ($candidates as $candidate) {
+      if (count($picked) >= 3) {
+        break;
+      }
+      $url = $candidate['url'] ?? NULL;
+      if (!$url instanceof Url) {
+        continue;
+      }
+      $picked[] = [
+        'label' => $candidate['label'],
+        'url' => $url->toString(),
+        'primary' => !empty($candidate['primary']) && count(array_filter($picked, static fn(array $a): bool => $a['primary'])) === 0,
+      ];
+    }
+    if ($picked !== [] && !array_filter($picked, static fn(array $a): bool => $a['primary'])) {
+      $picked[0]['primary'] = TRUE;
+    }
+    return $picked;
+  }
+
+  /**
+   * @return array{metrics: list<array<string, mixed>>}
+   */
+  private function buildSalesSnapshot(
+    string $eventType,
+    string $grossDisplay,
+    int $ticketsSold,
+    int $ordersCount,
+    int $rsvpCount,
+    int $checkins,
+    AccountInterface $account,
+    int $nid,
+  ): array {
+    $metrics = [];
+
+    if ($eventType === 'paid' || $eventType === 'both') {
+      $metrics[] = [
+        'key' => 'gross',
+        'label' => (string) $this->t('Gross sales'),
+        'value' => $grossDisplay !== '' ? $grossDisplay : '—',
+        'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account)?->toString(),
+      ];
+      $metrics[] = [
+        'key' => 'tickets_sold',
+        'label' => (string) $this->t('Tickets sold'),
+        'value' => (string) $ticketsSold,
+        'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_tickets', ['event' => $nid], $account)?->toString(),
+      ];
+    }
+
+    if ($eventType === 'rsvp' || $eventType === 'both') {
+      $metrics[] = [
+        'key' => 'rsvps',
+        'label' => (string) $this->t('Confirmed RSVPs'),
+        'value' => (string) $rsvpCount,
+        'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_rsvps', ['event' => $nid], $account)?->toString(),
+      ];
+    }
+
+    if ($eventType !== 'unknown') {
+      $metrics[] = [
+        'key' => 'checkins',
+        'label' => (string) $this->t('Check-ins'),
+        'value' => (string) $checkins,
+        'url' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_operations_door', ['node' => $nid], $account)?->toString(),
+      ];
+    }
+
+    if ($eventType === 'paid' || $eventType === 'both') {
+      $metrics[] = [
+        'key' => 'orders',
+        'label' => (string) $this->t('Orders'),
+        'value' => (string) $ordersCount,
+        'url' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_orders', ['event' => $nid], $account)?->toString(),
+      ];
+    }
+
+    return ['metrics' => $metrics];
+  }
+
+  /**
+   * @param array<string, ?Url> $actions
+   *
+   * @return array{sales: list<array{label: string, url: string}>, setup: list<array{label: string, url: string}>, growth: list<array{label: string, url: string}>}
+   */
+  private function buildActionGrid(array $actions): array {
+    return [
+      'sales' => $this->pickGridActions([
+        ['label' => (string) $this->t('View orders'), 'url' => $actions['orders'] ?? NULL],
+        ['label' => (string) $this->t('Ticket holders'), 'url' => $actions['attendees'] ?? NULL],
+        ['label' => (string) $this->t('Check-in'), 'url' => $actions['checkin'] ?? NULL],
+      ]),
+      'setup' => $this->pickGridActions([
+        ['label' => (string) $this->t('Edit event'), 'url' => $actions['edit'] ?? NULL],
+        ['label' => (string) $this->t('Edit tickets'), 'url' => $actions['edit_tickets'] ?? $actions['advanced_tickets'] ?? NULL],
+        ['label' => (string) $this->t('Merch & add-ons'), 'url' => $actions['extras'] ?? NULL],
+      ]),
+      'growth' => $this->pickGridActions([
+        ['label' => (string) $this->t('Promote event'), 'url' => $actions['promote'] ?? NULL],
+        ['label' => (string) $this->t('View analytics'), 'url' => $actions['analytics'] ?? NULL],
+      ]),
+    ];
+  }
+
+  /**
+   * @param list<array{label: string, url: ?Url}> $candidates
+   *
+   * @return list<array{label: string, url: string}>
+   */
+  private function pickGridActions(array $candidates): array {
+    $picked = [];
+    foreach ($candidates as $candidate) {
+      $url = $candidate['url'] ?? NULL;
+      if (!$url instanceof Url) {
+        continue;
+      }
+      $picked[] = [
+        'label' => $candidate['label'],
+        'url' => $url->toString(),
+      ];
+    }
+    return $picked;
+  }
+
+  /**
+   * @param list<array<string, mixed>> $operationalItems
+   * @param list<array<string, mixed>> $readinessItems
+   *
+   * @return array{all_ready: bool, issue_count: int, groups: list<array<string, mixed>>, detail_items: list<array<string, mixed>>}
+   */
+  private function buildReadinessSummary(array $operationalItems, array $readinessItems): array {
+    $opsByKey = [];
+    foreach ($operationalItems as $item) {
+      $key = (string) ($item['key'] ?? '');
+      if ($key !== '') {
+        $opsByKey[$key] = $item;
+      }
+    }
+
+    $groups = [
+      $this->buildReadinessGroup(
+        'public_visibility',
+        (string) $this->t('Public visibility'),
+        array_filter([$opsByKey['visibility'] ?? NULL]),
+      ),
+      $this->buildReadinessGroup(
+        'booking_setup',
+        (string) $this->t('Booking setup'),
+        array_filter([
+          $opsByKey['booking'] ?? NULL,
+          $opsByKey['paid_tickets'] ?? NULL,
+        ]),
+      ),
+      $this->buildReadinessGroup(
+        'day_of_event',
+        (string) $this->t('Day-of event readiness'),
+        array_filter([
+          $opsByKey['day_of_event'] ?? NULL,
+          $opsByKey['attendees'] ?? NULL,
+        ]),
+      ),
+      $this->buildReadinessGroup(
+        'event_content',
+        (string) $this->t('Event content'),
+        $this->mapReadinessItemsToSummary($readinessItems),
+      ),
+    ];
+
+    $issueCount = 0;
+    foreach ($groups as $group) {
+      if (($group['status'] ?? 'ready') !== 'ready') {
+        $issueCount++;
+      }
+    }
+
+    return [
+      'all_ready' => $issueCount === 0,
+      'issue_count' => $issueCount,
+      'groups' => $groups,
+      'detail_items' => $readinessItems,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $items
+   *
+   * @return array{key: string, label: string, status: string, expand: bool, items: list<array<string, mixed>>}
+   */
+  private function buildReadinessGroup(string $key, string $label, array $items): array {
+    $normalized = [];
+    $hasIssue = FALSE;
+    foreach ($items as $item) {
+      if (!is_array($item)) {
+        continue;
+      }
+      $severity = (string) ($item['severity'] ?? 'info');
+      $complete = !empty($item['complete']);
+      if ($severity !== 'success' && $severity !== 'neutral' && !$complete) {
+        $hasIssue = TRUE;
+      }
+      $normalized[] = [
+        'label' => (string) ($item['label'] ?? $item['stage'] ?? ''),
+        'message' => (string) ($item['message'] ?? ''),
+        'severity' => $severity,
+        'complete' => $complete,
+      ];
+    }
+
+    return [
+      'key' => $key,
+      'label' => $label,
+      'status' => $hasIssue ? 'attention' : 'ready',
+      'expand' => $hasIssue,
+      'items' => $normalized,
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $readinessItems
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function mapReadinessItemsToSummary(array $readinessItems): array {
+    $mapped = [];
+    foreach ($readinessItems as $item) {
+      $mapped[] = [
+        'label' => (string) ($item['label'] ?? ''),
+        'message' => !empty($item['complete'])
+          ? (string) $this->t('Complete')
+          : (string) $this->t('Needs attention'),
+        'severity' => !empty($item['complete']) ? 'success' : (string) ($item['severity'] ?? 'warning'),
+        'complete' => !empty($item['complete']),
+      ];
+    }
+    return $mapped;
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -171,11 +171,70 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 .mel-book-page .mel-ticket-panel__title {
-  margin: 0 0 spacing.mel-space(3);
+  margin: 0 0 spacing.mel-space(2);
   padding: 0;
   font-size: typography.mel-font-size(lg);
   font-weight: typography.$mel-font-extrabold;
   color: #24303a;
+}
+
+.mel-book-page .mel-ticket-panel__lead {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-page .mel-ticket-panel__capacity {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+}
+
+.mel-book-page .mel-alert__title {
+  margin: 0 0 spacing.mel-space(1);
+  font-weight: typography.$mel-font-bold;
+  color: #24303a;
+}
+
+.mel-book-page .mel-alert p {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-support--rsvp {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+  margin-top: spacing.mel-space(4);
+}
+
+.mel-book-next-steps {
+  padding: spacing.mel-space(4);
+}
+
+.mel-book-next-steps__title {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: typography.mel-font-size(md);
+  font-weight: typography.$mel-font-bold;
+  color: #24303a;
+}
+
+.mel-book-next-steps__list {
+  margin: 0;
+  padding: 0 0 0 spacing.mel-space(4);
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(2);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-book-next-steps__item {
+  padding-left: spacing.mel-space(1);
 }
 
 .mel-book-sidebar__inner {
@@ -383,8 +442,60 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 @media (max-width: 959px) {
+  .mel-book-page {
+    padding-bottom: calc(#{spacing.mel-space(7)} + env(safe-area-inset-bottom, 0));
+  }
+
   .mel-book-page .mel-ticket-panel {
     padding-bottom: 0;
+  }
+
+  .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky {
+    position: sticky;
+    bottom: 0;
+    z-index: 6;
+    margin: spacing.mel-space(4) calc(-1 * #{spacing.mel-space(4)}) calc(-1 * #{spacing.mel-space(4)});
+    padding: spacing.mel-space(3) spacing.mel-space(4);
+    padding-bottom: calc(#{spacing.mel-space(3)} + env(safe-area-inset-bottom, 0));
+    background: #fff;
+    border-top: 1px solid rgba(36, 48, 58, 0.1);
+    box-shadow: 0 -8px 24px rgba(36, 48, 58, 0.08);
+
+    .mel-mobile-booking-bar--rsvp {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      gap: spacing.mel-space(2);
+      margin-bottom: spacing.mel-space(3);
+      padding: spacing.mel-space(2) spacing.mel-space(3);
+      border-radius: radii.$mel-radius-md;
+      background: rgba(colors.$mel-color-primary, 0.06);
+      border: 1px solid rgba(colors.$mel-color-primary, 0.12);
+    }
+
+    .mel-mobile-booking-bar__count {
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-semibold;
+      color: #24303a;
+    }
+
+    .mel-mobile-booking-bar__total {
+      font-size: typography.mel-font-size(sm);
+      font-weight: typography.$mel-font-bold;
+      color: colors.$mel-color-primary;
+    }
+
+    .button,
+    .form-submit,
+    input[type='submit'] {
+      width: 100%;
+      min-height: 48px;
+    }
+  }
+
+  .mel-book-page[data-event-mode='rsvp'] .mel-book-support--rsvp {
+    margin-bottom: spacing.mel-space(2);
   }
 
   .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
@@ -414,6 +525,10 @@ $mel-book-max: 72.5rem; // ~1160px
 }
 
 @media (min-width: 960px) {
+  .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky .mel-mobile-booking-bar--rsvp {
+    display: none;
+  }
+
   .mel-book-layout:not(.mel-book-layout--single) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
@@ -496,6 +611,28 @@ $mel-book-max: 72.5rem; // ~1160px
 
 .mel-book-page.mel-event-page--immersive .mel-book-trust__note {
   color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-next-steps__title {
+  color: var(--mel-immersive-text, #fff);
+}
+
+.mel-book-page.mel-event-page--immersive .mel-book-next-steps__list {
+  color: var(--mel-immersive-text-muted, rgba(255, 255, 255, 0.72));
+}
+
+@media print {
+  .mel-book-page .mel-booking__cta--panel,
+  .mel-book-page .mel-rsvp-submit--book-sticky {
+    display: none !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel,
+  .mel-book-page .mel-rsvp-submit--book-sticky {
+    transition: none;
+  }
 }
 
 @media (min-width: 960px) {

--- a/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/myeventlane-event-book.html.twig
@@ -54,14 +54,15 @@
       </div>
     </header>
 
-    <div class="mel-event-info-strip mel-card" role="note">
+    <div class="mel-event-info-strip mel-card" role="note" aria-label="{{ 'Booking reassurance'|t }}">
       {% if event_mode == 'paid' %}
         <span class="mel-event-info-strip__item">{{ 'Secure checkout'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'No hidden fees'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'Confirmation email sent'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll review your order before payment"|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll receive confirmation by email"|t }}</span>
       {% elseif event_mode == 'rsvp' %}
         <span class="mel-event-info-strip__item">{{ 'No payment required'|t }}</span>
-        <span class="mel-event-info-strip__item">{{ 'Your RSVP will be confirmed by email'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ 'Your RSVP details are used for event administration only'|t }}</span>
+        <span class="mel-event-info-strip__item">{{ "You'll receive confirmation by email"|t }}</span>
       {% elseif event_mode == 'external' %}
         <span class="mel-event-info-strip__item">{{ 'External ticketing'|t }}</span>
         <span class="mel-event-info-strip__item">{{ 'You will leave this site to buy tickets'|t }}</span>
@@ -102,6 +103,20 @@
               {{ 'Booking'|t }}
             {% endif %}
           </h2>
+          {% if event_mode == 'paid' %}
+            <p class="mel-ticket-panel__lead">{{ 'Select ticket quantities below. Payment comes after you review your cart.'|t }}</p>
+          {% elseif event_mode == 'rsvp' %}
+            <p class="mel-ticket-panel__lead">{{ 'Free RSVP — no payment required. Complete the form to reserve your place.'|t }}</p>
+            {% if mel_signal_remaining_spots is defined and mel_signal_remaining_spots is not null and mel_signal_remaining_spots > 0 %}
+              <p class="mel-ticket-panel__capacity mel-text--muted">
+                {% trans %}
+                  1 place remaining
+                {% plural mel_signal_remaining_spots %}
+                  @count places remaining
+                {% endtrans %}
+              </p>
+            {% endif %}
+          {% endif %}
 
           <div class="mel-ticket-panel__body mel-event-book__form-body mel-booking-flow" data-mel-booking-flow>
             {% if ticket_form is not empty %}
@@ -113,9 +128,11 @@
             {% else %}
               <div class="mel-alert mel-alert--info" role="status">
                 {% if event_mode == 'none' %}
-                  {{ 'Registration opens soon.'|t }}
+                  <p class="mel-alert__title">{{ 'Registration is not open yet'|t }}</p>
+                  <p>{{ 'Check back soon or return to the event page for updates.'|t }}</p>
                 {% else %}
-                  {{ "We couldn't load the booking form. Please refresh the page."|t }}
+                  <p class="mel-alert__title">{{ 'Booking is temporarily unavailable'|t }}</p>
+                  <p>{{ 'Please refresh the page. If this continues, return to the event page or contact the organiser.'|t }}</p>
                 {% endif %}
               </div>
             {% endif %}
@@ -141,13 +158,53 @@
                   <span class="mel-mobile-booking-bar__total" data-mel-booking-total></span>
                 </div>
                 <p class="mel-booking__cta-note">
-                  {{ "Tickets will be added to your cart — checkout when you're ready."|t }}
+                  {{ "Tickets go to your cart first — you'll review everything before payment."|t }}
                 </p>
                 {{ ticket_form_actions }}
               </div>
             {% endif %}
           </div>
         </div>
+
+        {% if not mel_book_paid and event_mode == 'rsvp' %}
+          <div class="mel-book-support mel-book-support--rsvp">
+            <div class="mel-book-trust mel-book-panel mel-card" role="region" aria-label="{{ 'RSVP privacy and reassurance'|t }}">
+              <h3 class="mel-book-trust__title">{{ 'Your RSVP is secure'|t }}</h3>
+              <ul class="mel-book-trust__list" role="list">
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
+                  <span class="mel-book-trust__text">{{ 'No payment required'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">◎</span>
+                  <span class="mel-book-trust__text">{{ 'Your RSVP details are used for event administration only'|t }}</span>
+                </li>
+                <li class="mel-book-trust__item">
+                  <span class="mel-book-trust__icon" aria-hidden="true">✉</span>
+                  <span class="mel-book-trust__text">{{ "You'll receive confirmation by email"|t }}</span>
+                </li>
+                {% if mel_signal_trust_label %}
+                  <li class="mel-book-trust__item">
+                    <span class="mel-book-trust__icon" aria-hidden="true">◎</span>
+                    <span class="mel-book-trust__text">{{ mel_signal_trust_label }}</span>
+                  </li>
+                {% endif %}
+              </ul>
+              <p class="mel-book-trust__support">
+                <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
+              </p>
+            </div>
+
+            <div class="mel-book-next-steps mel-book-panel mel-card" role="region" aria-labelledby="mel-book-next-steps-title-rsvp">
+              <h3 class="mel-book-next-steps__title" id="mel-book-next-steps-title-rsvp">{{ 'What happens next'|t }}</h3>
+              <ol class="mel-book-next-steps__list">
+                <li class="mel-book-next-steps__item">{{ 'Complete your details and submit your RSVP.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Your RSVP helps the organiser plan the event.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ "You'll receive a confirmation email with your RSVP details."|t }}</li>
+              </ol>
+            </div>
+          </div>
+        {% endif %}
       </main>
 
       {% if mel_book_paid %}
@@ -160,8 +217,8 @@
               </header>
               <div class="mel-booking-summary__body">
                 <div class="mel-booking-summary__empty" data-mel-summary-empty>
-                  <p class="mel-booking-summary__empty-line">{{ 'Choose your tickets to see your total.'|t }}</p>
-                  <p class="mel-booking-summary__empty-line mel-booking-summary__empty-line--soft">{{ 'You can review everything before checkout.'|t }}</p>
+                  <p class="mel-booking-summary__empty-line">{{ 'Choose at least one ticket to see your total.'|t }}</p>
+                  <p class="mel-booking-summary__empty-line mel-booking-summary__empty-line--soft">{{ "You'll review your cart before payment."|t }}</p>
                 </div>
                 <div class="mel-booking-summary__items" data-mel-summary-items aria-live="polite" aria-atomic="true"></div>
                 <div class="mel-booking-summary__subtotal" data-mel-summary-subtotal hidden>
@@ -170,7 +227,7 @@
                 </div>
               </div>
               <footer class="mel-booking-summary__footer">
-                <p class="mel-booking-summary__cta-note">{{ 'Tickets go to your cart first — continue to checkout when you are ready.'|t }}</p>
+                <p class="mel-booking-summary__cta-note">{{ "Tickets go to your cart first — you'll review everything before payment."|t }}</p>
               </footer>
             </div>
 
@@ -178,16 +235,16 @@
               <h3 class="mel-book-trust__title">{{ 'Before you pay'|t }}</h3>
               <ul class="mel-book-trust__list" role="list">
                 <li class="mel-book-trust__item">
-                  <span class="mel-book-trust__icon" aria-hidden="true">🔒</span>
-                  <span class="mel-book-trust__text">{{ 'Secure checkout — payment processed safely'|t }}</span>
+                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
+                  <span class="mel-book-trust__text">{{ 'Review your tickets before payment'|t }}</span>
                 </li>
                 <li class="mel-book-trust__item">
-                  <span class="mel-book-trust__icon" aria-hidden="true">✓</span>
-                  <span class="mel-book-trust__text">{{ 'No hidden fees on MyEventLane'|t }}</span>
+                  <span class="mel-book-trust__icon" aria-hidden="true">🔒</span>
+                  <span class="mel-book-trust__text">{{ 'Secure checkout'|t }}</span>
                 </li>
                 <li class="mel-book-trust__item">
                   <span class="mel-book-trust__icon" aria-hidden="true">✉</span>
-                  <span class="mel-book-trust__text">{{ 'Instant confirmation by email'|t }}</span>
+                  <span class="mel-book-trust__text">{{ "You'll receive confirmation by email"|t }}</span>
                 </li>
                 {% if mel_signal_trust_label %}
                   <li class="mel-book-trust__item">
@@ -209,11 +266,20 @@
                 {% endif %}
               </ul>
               <p class="mel-book-trust__note mel-text--muted">
-                {{ 'You can review your order before checkout. Your tickets are only confirmed once checkout is complete.'|t }}
+                {{ 'Your tickets are only confirmed once checkout is complete.'|t }}
               </p>
               <p class="mel-book-trust__support">
                 <a class="mel-link" href="{{ path('myeventlane_support.page') }}">{{ 'Need help? Contact support'|t }}</a>
               </p>
+            </div>
+
+            <div class="mel-book-next-steps mel-book-panel mel-card" role="region" aria-labelledby="mel-book-next-steps-title-paid">
+              <h3 class="mel-book-next-steps__title" id="mel-book-next-steps-title-paid">{{ 'What happens next'|t }}</h3>
+              <ol class="mel-book-next-steps__list">
+                <li class="mel-book-next-steps__item">{{ 'Choose your tickets and add them to your cart.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Review your order on the cart and checkout pages.'|t }}</li>
+                <li class="mel-book-next-steps__item">{{ 'Pay securely — then look for your confirmation email.'|t }}</li>
+              </ol>
             </div>
 
             {% if operational_addon_teaser %}

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-commerce-rsvp-booking-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-commerce-rsvp-booking-form.html.twig
@@ -92,10 +92,15 @@
         <div class="mel-rsvp-trust mel-rsvp-trust--compact" role="region" aria-label="{{ 'RSVP confirmation'|t }}">
           <ul class="mel-rsvp-trust__list">
             <li>{{ 'No payment required'|t }}</li>
-            <li>{{ 'Your RSVP will be confirmed by email'|t }}</li>
+            <li>{{ 'Your RSVP details are used for event administration only'|t }}</li>
+            <li>{{ "You'll receive confirmation by email"|t }}</li>
           </ul>
         </div>
-        <div class="mel-rsvp-submit">
+        <div class="mel-rsvp-submit mel-rsvp-submit--book-sticky">
+          <div class="mel-mobile-booking-bar mel-mobile-booking-bar--rsvp" aria-hidden="true">
+            <span class="mel-mobile-booking-bar__count">{{ 'Free RSVP'|t }}</span>
+            <span class="mel-mobile-booking-bar__total">{{ 'No payment'|t }}</span>
+          </div>
           {{ element.actions }}
         </div>
         {# Any other alter-added elements; keeps them inside the single form. #}

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
@@ -70,6 +70,11 @@ event_overview:
     - myeventlane_vendor_theme/global-styling
     - myeventlane_vendor_theme/chartjs
 
+# Manage event dashboard (/vendor/events/{event}) — uses global bundle SCSS.
+event_mission_control:
+  dependencies:
+    - myeventlane_vendor_theme/global-styling
+
 # Vendor workspace UI shell (Event Studio grid + studio chrome).
 # Built by Vite from src/scss/workspace.scss — same pipeline as global (main.css).
 vendor-workspace:

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1258,6 +1258,10 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'header_meta_line' => NULL,
         'workspace_event_boost' => NULL,
         'vendor_event_workspace_model' => NULL,
+        'ticket_sales_panel' => NULL,
+        'extras_configured_panel' => NULL,
+        'extras_sales_panel' => NULL,
+        'manage_event_back' => NULL,
       ],
       'template' => 'mel-event/mel-event-workspace',
     ],
@@ -1540,6 +1544,13 @@ function myeventlane_vendor_theme_preprocess_mel_event_workspace(array &$variabl
       && (string) $event->get('moderation_state')->value === 'review') {
       $variables['event_status_badge_modifier'] = 'mel-badge--warning';
     }
+  }
+
+  if (empty($variables['manage_event_back']) && empty($variables['vendor_event_workspace_model'])) {
+    $variables['manage_event_back'] = [
+      'url' => \Drupal\Core\Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event->id()])->toString(),
+      'label' => (string) t('Back to Manage event'),
+    ];
   }
 
   // Boost insights payload (optional module): same source as dashboard rows, no vendor→boost hard dependency.

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -107,6 +107,7 @@
   @include meta.load-css('pages/analytics');
   @include meta.load-css('pages/mel-dashboard');
   @include meta.load-css('pages/vendor-events');
+  @include meta.load-css('pages/event-mission-control');
   @include meta.load-css('pages/settings');
   @include meta.load-css('pages/vendor-console-stack');
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_event-mission-control.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_event-mission-control.scss
@@ -1,0 +1,561 @@
+/**
+ * @file
+ * Vendor Manage event mission-control dashboard (/vendor/events/{event}).
+ */
+
+@use '../tokens/spacing' as *;
+@use '../tokens/breakpoints' as *;
+@use '../tokens/colors' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/shadows' as *;
+@use '../tokens/typography' as *;
+
+.mel-event-mission-control {
+  display: grid;
+  gap: $spacing-4;
+
+  &__hero-layout {
+    align-items: flex-start;
+  }
+
+  &__hero-actions .mel-live-ops__stack {
+    @include respond-to(md) {
+      align-items: flex-end;
+    }
+  }
+
+  &__above-fold {
+    display: grid;
+    gap: $spacing-4;
+
+    @include respond-to(md) {
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+      align-items: stretch;
+    }
+  }
+
+  &__focus {
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-left: 4px solid $info;
+    box-shadow: $shadow-xs;
+  }
+
+  &__focus-message {
+    margin: $spacing-2 0 0;
+    color: $text-primary;
+    font-size: $font-size-lg;
+    line-height: $line-height-normal;
+  }
+
+  &__focus-message--success {
+    border-left-color: $success;
+  }
+
+  &__focus-message--warning {
+    color: $text-primary;
+  }
+
+  &__focus-actions {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-2;
+    margin: $spacing-4 0 0;
+    padding: 0;
+    list-style: none;
+
+    @include respond-to(sm) {
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+
+    .mel-btn {
+      min-height: 2.75rem;
+      min-width: 2.75rem;
+      justify-content: center;
+    }
+  }
+
+  &__sales-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: $spacing-3;
+    margin-top: $spacing-3;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__sales-card {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-1;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: rgba($bg-primary, 0.92);
+    box-shadow: $shadow-xs;
+    color: inherit;
+    text-decoration: none;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease;
+
+    &:hover,
+    &:focus-visible {
+      border-color: rgba($ml-vendor-navy, 0.2);
+      box-shadow: $shadow-sm;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $info;
+      outline-offset: 2px;
+    }
+  }
+
+  &__sales-label {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  &__sales-value {
+    color: $text-primary;
+    font-size: $font-size-2xl;
+    font-weight: 700;
+    line-height: $line-height-tight;
+  }
+
+  &__ticket-sales {
+    padding: 0;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-xs;
+  }
+
+  &__ticket-sales-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2 $spacing-3;
+    align-items: baseline;
+    padding: $spacing-4;
+    cursor: pointer;
+    list-style: none;
+    min-height: 2.75rem;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::before {
+      content: '';
+      width: 0.55rem;
+      height: 0.55rem;
+      margin-right: $spacing-1;
+      border-right: 2px solid $text-secondary;
+      border-bottom: 2px solid $text-secondary;
+      transform: rotate(-45deg);
+      transition: transform 0.15s ease;
+    }
+  }
+
+  &__ticket-sales[open] > &__ticket-sales-summary::before {
+    transform: rotate(45deg);
+  }
+
+  &__ticket-sales-title {
+    font-size: $font-size-lg;
+    font-weight: 700;
+    color: $text-primary;
+  }
+
+  &__ticket-sales-hint {
+    font-size: $font-size-sm;
+  }
+
+  &__ticket-sales-body {
+    padding: 0 $spacing-4 $spacing-4;
+
+    .mel-event-extras-studio__ticket-sales--compact {
+      padding: 0;
+      box-shadow: none;
+      border: 0;
+      background: transparent;
+    }
+  }
+
+  &__action-groups {
+    display: grid;
+    gap: $spacing-4;
+  }
+
+  &__action-group-title {
+    margin: 0 0 $spacing-2;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  &__action-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: $spacing-2;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  &__action-tile {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.12);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    color: $text-primary;
+    font-weight: 600;
+    text-align: center;
+    box-shadow: $shadow-xs;
+
+    &:hover,
+    &:focus-visible {
+      border-color: rgba($primary, 0.35);
+      background: rgba($primary-light, 0.2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $primary;
+      outline-offset: 2px;
+    }
+  }
+
+  &__section-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-3;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: $spacing-3;
+  }
+
+  &__readiness-groups {
+    display: grid;
+    gap: $spacing-2;
+  }
+
+  &__readiness-group {
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-workspace-card;
+    background: rgba($bg-primary, 0.7);
+  }
+
+  &__readiness-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2 $spacing-3;
+    align-items: center;
+    justify-content: space-between;
+    padding: $spacing-3 $spacing-4;
+    cursor: pointer;
+    list-style: none;
+    min-height: 2.75rem;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  &__readiness-label {
+    font-weight: 600;
+    color: $text-primary;
+  }
+
+  &__readiness-items {
+    margin: 0;
+    padding: 0 $spacing-4 $spacing-3;
+    list-style: none;
+
+    &--detail {
+      padding-top: $spacing-2;
+    }
+  }
+
+  &__readiness-item {
+    display: grid;
+    gap: $spacing-1;
+    padding: $spacing-2 0;
+    border-top: 1px solid rgba($ml-vendor-navy, 0.06);
+
+    &:first-child {
+      border-top: 0;
+    }
+  }
+
+  &__readiness-item-link {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    align-items: center;
+    justify-content: space-between;
+    color: inherit;
+
+    &:focus-visible {
+      outline: 2px solid $info;
+      outline-offset: 2px;
+    }
+  }
+
+  &__readiness-all {
+    margin-top: $spacing-3;
+
+    summary {
+      min-height: 2.75rem;
+      padding: $spacing-2 0;
+      cursor: pointer;
+      font-weight: 600;
+      color: $info;
+
+      &:focus-visible {
+        outline: 2px solid $info;
+        outline-offset: 2px;
+      }
+    }
+  }
+
+  &__guidance {
+    padding: 0;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-xs;
+  }
+
+  &__guidance-summary {
+    display: grid;
+    gap: $spacing-1;
+    padding: $spacing-4;
+    cursor: pointer;
+    list-style: none;
+    min-height: 2.75rem;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  &__guidance-title {
+    font-size: $font-size-lg;
+    font-weight: 700;
+    color: $text-primary;
+  }
+
+  &__guidance-body {
+    padding: 0 $spacing-4 $spacing-4;
+  }
+
+  &__guidance-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__guidance-item {
+    display: grid;
+    gap: $spacing-1;
+    padding: $spacing-3 0;
+    border-top: 1px solid rgba($ml-vendor-navy, 0.06);
+
+    &:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+  }
+
+  &__guidance-stage {
+    font-weight: 600;
+    color: $text-primary;
+  }
+
+  &__extras-sales {
+    padding: 0;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $bg-primary;
+    box-shadow: $shadow-xs;
+  }
+
+  &__extras-sales-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2 $spacing-3;
+    align-items: baseline;
+    padding: $spacing-4;
+    cursor: pointer;
+    list-style: none;
+    min-height: 2.75rem;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::before {
+      content: '';
+      width: 0.55rem;
+      height: 0.55rem;
+      margin-right: $spacing-1;
+      border-right: 2px solid $text-secondary;
+      border-bottom: 2px solid $text-secondary;
+      transform: rotate(-45deg);
+      transition: transform 0.15s ease;
+    }
+  }
+
+  &__extras-sales[open] > &__extras-sales-summary::before {
+    transform: rotate(45deg);
+  }
+
+  &__extras-sales-title {
+    font-size: $font-size-lg;
+    font-weight: 700;
+    color: $text-primary;
+  }
+
+  &__extras-sales-hint {
+    font-size: $font-size-sm;
+  }
+
+  &__extras-sales-body {
+    padding: 0 $spacing-4 $spacing-4;
+
+    .mel-event-extras-studio__extras-sales--compact {
+      padding: 0;
+      box-shadow: none;
+      border: 0;
+      background: transparent;
+    }
+  }
+}
+
+.mel-event-manage-back {
+  margin-block-end: $spacing-4;
+
+  &__link {
+    min-height: 2.75rem;
+  }
+}
+
+.mel-event-management-shell {
+  display: grid;
+  gap: $spacing-3;
+  margin-block-end: $spacing-4;
+  max-width: 72rem;
+
+  &__back {
+    margin-block-end: 0;
+  }
+
+  &__header .mel-workspace-header {
+    padding: $spacing-4;
+    border-radius: $radius-lg;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    background: $ml-vendor-bg;
+    box-shadow: $shadow-xs;
+  }
+}
+
+.mel-workspace__content--event-management {
+  max-width: 72rem;
+
+  .mel-live-operations,
+  .mel-vendor-console-stack,
+  .mel-page {
+    max-width: none;
+  }
+
+  .mel-table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+.mel-event-mission-control__configured-extras {
+  .mel-event-extras-studio__configured-summary {
+    margin: 0;
+    box-shadow: none;
+    border: 0;
+    background: transparent;
+    padding: 0;
+  }
+
+  .mel-event-extras-studio__configured-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: $spacing-3;
+    margin: $spacing-3 0;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+    }
+
+    dt {
+      font-size: $font-size-sm;
+      color: $text-secondary;
+      margin: 0;
+    }
+
+    dd {
+      font-size: $font-size-lg;
+      font-weight: 700;
+      margin: $spacing-1 0 0;
+    }
+  }
+
+  .mel-event-extras-studio__configured-top-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      padding: $spacing-2 0;
+      border-bottom: 1px solid rgba($ml-vendor-navy, 0.08);
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  .mel-event-extras-studio__configured-name {
+    display: block;
+    font-weight: 600;
+  }
+}
+
+@include respond-to(md) {
+  .mel-event-mission-control__above-fold {
+    .mel-event-mission-control__focus {
+      order: 1;
+    }
+
+    .mel-event-mission-control__sales {
+      order: 2;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .mel-event-mission-control__above-fold {
+    display: flex;
+    flex-direction: column;
+
+    .mel-event-mission-control__focus {
+      order: -1;
+    }
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -12,7 +12,7 @@
       {% if workspace_back_url %}
         <a href="{{ workspace_back_url }}" class="mel-live-ops__action mel-live-ops__action--lavender" data-icon="list">
           <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
-          <span class="mel-live-ops__action-label">{{ 'Back to event workspace'|t }}</span>
+          <span class="mel-live-ops__action-label">{{ 'Back to Manage event'|t }}</span>
         </a>
       {% endif %}
       {% if edit_event_url %}
@@ -53,6 +53,7 @@
     {% trans %}Next: share your public link and keep an eye on ticket velocity — when you are ready, <strong>Boost</strong> can put your event in front of more people.{% endtrans %}
   </p>
 
+  {% set commerce = commerce_analytics|default({}) %}
   {% include '@myeventlane_vendor_theme/components/mel-live-ops-metric-board.html.twig' with {
     metric_title: 'Performance'|t,
     metric_title_id: 'mel-analytics-kpis',
@@ -64,6 +65,27 @@
       { label: 'RSVPs'|t, value: rsvp_block.total_submissions|default(rsvp_block.count|default(0)), note: 'All non-cancelled responses'|t },
     ],
   } only %}
+
+  <section class="mel-live-ops__panel" aria-labelledby="mel-analytics-commerce-title">
+    <div class="mel-live-ops__timeline-head">
+      <h2 id="mel-analytics-commerce-title" class="mel-live-ops__panel-title">{{ 'Event commerce'|t }}</h2>
+      <p class="mel-live-ops__panel-intro">{{ 'Ticket revenue and merch/add-on sales are tracked separately.'|t }}</p>
+    </div>
+    {% include '@myeventlane_vendor_theme/components/mel-live-ops-metric-board.html.twig' with {
+      metric_wrap_section: false,
+      metric_items: [
+        { label: 'Ticket revenue'|t, value: commerce.ticket_revenue|default('—') },
+        { label: 'Ticket quantity sold'|t, value: commerce.ticket_quantity_sold|default(0) },
+        { label: 'Merch/add-on revenue'|t, value: commerce.extras_revenue|default('—') },
+        { label: 'Merch/add-on items sold'|t, value: commerce.extras_items_sold|default(0) },
+        { label: 'Orders with extras'|t, value: commerce.orders_with_extras|default(0) },
+        { label: 'Top extras category'|t, value: commerce.top_extras_category|default('—') },
+      ],
+    } only %}
+    {% if commerce.booking_activity_note|default('') is not empty %}
+      <p class="mel-text--muted mel-analytics__conversion-note">{{ commerce.booking_activity_note }}</p>
+    {% endif %}
+  </section>
 
   {% if overview.donations.count|default(0) > 0 %}
     {% include '@myeventlane_vendor_theme/components/mel-live-ops-metric-board.html.twig' with {

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * MEL Event Workspace — shared shell (live-ops primitives + TASK 8 overview).
+ * MEL Event Workspace — mission-control dashboard at /vendor/events/{event}.
  */
 #}
 {% set model = vendor_event_workspace_model|default({}) %}
@@ -14,33 +14,40 @@
       <p class="mel-live-ops__workspace-empty-intro">{{ model.empty_state.message|default('') }}</p>
     </div>
   {% elseif has_ws_model %}
-    <div class="mel-live-operations mel-live-operations--event-landing">
-      <header class="mel-live-ops__hero" aria-labelledby="mel-ws-event-title">
+    {% set st = model.event.status_severity|default('neutral') %}
+    {% set st_chip =
+      st == 'success' ? 'success' :
+      (st == 'warning' or st == 'error') ? 'warn' :
+      (st == 'neutral' ? 'calm' : 'info')
+    %}
+    {% set focus = model.todays_focus|default({}) %}
+    {% set focus_sev = focus.severity|default('info') %}
+    {% set sales = model.sales_snapshot|default({}) %}
+    {% set grid = model.action_grid|default({}) %}
+    {% set readiness_sum = model.readiness_summary|default({}) %}
+    {% set lifecycle_guidance = model.lifecycle_guidance|default({}) %}
+    {% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
+
+    <div class="mel-event-mission-control mel-live-operations mel-live-operations--event-landing">
+      <header class="mel-event-mission-control__hero mel-live-ops__hero" aria-labelledby="mel-ws-event-title">
         <div class="mel-live-ops__hero-surface">
-          <div class="mel-live-ops__hero-layout">
+          <div class="mel-event-mission-control__hero-layout mel-live-ops__hero-layout">
             <div class="mel-live-ops__hero-primary">
-              <p class="mel-live-ops__eyebrow">{{ 'Event workspace'|t }}</p>
-              {% set st = model.event.status_severity|default('neutral') %}
-              {% set st_chip =
-                st == 'success' ? 'success' :
-                (st == 'warning' or st == 'error') ? 'warn' :
-                (st == 'neutral' ? 'calm' : 'info')
-              %}
               <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact">
                 <span class="mel-live-ops__chip mel-live-ops__chip--{{ st_chip }}">{{ model.event.status_label|default('') }}</span>
+                {% if model.event.event_type_label|default('') is not empty %}
+                  <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ model.event.event_type_label }}</span>
+                {% endif %}
+                <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ '@pct% readiness'|t({'@pct': model.readiness.score|default(0)}) }}</span>
               </div>
               <h1 id="mel-ws-event-title" class="mel-live-ops__hero-title">{{ model.event.title|default('') }}</h1>
               <p class="mel-live-ops__hero-venue">
                 {% if model.event.date_label|default('') is not empty %}
                   <span>{{ model.event.date_label }}</span>
                 {% endif %}
-                {% if model.event.event_type_label|default('') is not empty %}
-                  {% if model.event.date_label|default('') is not empty %} · {% endif %}
-                  <span>{{ model.event.event_type_label }}</span>
-                {% endif %}
               </p>
             </div>
-            <div class="mel-live-ops__hero-aside">
+            <div class="mel-live-ops__hero-aside mel-event-mission-control__hero-actions">
               <div class="mel-live-ops__stack">
                 {% if model.actions.edit is not null %}
                   <a class="mel-live-ops__hero-cta mel-btn mel-btn--primary" href="{{ model.actions.edit }}">{{ 'Edit event'|t }}</a>
@@ -58,22 +65,6 @@
           </div>
         </div>
       </header>
-
-      <section class="mel-live-ops__panel" aria-label="{{ 'Event operational state'|t }}">
-        <div class="mel-live-ops__chip-row">
-          <span class="mel-live-ops__chip mel-live-ops__chip--{{ st_chip }}">{{ model.event.status_label|default('') }}</span>
-          {% if model.event.event_type_label|default('') is not empty %}
-            <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ model.event.event_type_label }}</span>
-          {% endif %}
-          <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ '@pct% readiness'|t({'@pct': model.readiness.score|default(0)}) }}</span>
-          {% if model.actions.checkin is not null %}
-            <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ model.actions.checkin }}">{{ 'Check-in ready'|t }}</a>
-          {% endif %}
-          {% if model.actions.preview is not null %}
-            <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ model.actions.preview }}">{{ 'Public preview'|t }}</a>
-          {% endif %}
-        </div>
-      </section>
 
       {% if model.presentation_alerts is defined and model.presentation_alerts is iterable and model.presentation_alerts|length > 0 %}
         <div class="mel-live-ops__presentation-alerts" role="region" aria-label="{{ 'Ticket and pricing setup'|t }}">
@@ -99,164 +90,224 @@
         </div>
       {% endif %}
 
-      {% if model.next_action is defined and model.next_action is iterable %}
-        {% set na = model.next_action %}
-        {% set na_sev = na.severity|default('info') %}
-        {% set na_glyph = na_sev == 'error' ? '!' : (na_sev == 'warning' ? '!' : '•') %}
-        <section class="mel-live-ops__panel" aria-label="{{ 'Suggested next step'|t }}">
-          <div class="mel-live-ops__timeline-feed" role="list">
-            <article class="mel-live-ops__timeline-card" role="listitem">
-              <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ na_glyph }}</div>
-              <div class="mel-live-ops__timeline-body">
-                <h2 class="mel-live-ops__timeline-name">{{ na.title|default('') }}</h2>
-                {% if na.message|default('') is not empty %}
-                  <p class="mel-live-ops__muted">{{ na.message|default('') }}</p>
-                {% endif %}
-                {% if na.action_label|default('') is not empty and na.url is not null %}
-                  <div class="mel-live-ops__stack">
-                    <a class="mel-btn mel-btn--primary" href="{{ na.url }}">{{ na.action_label }}</a>
-                  </div>
-                {% endif %}
-              </div>
-            </article>
-          </div>
-        </section>
-      {% endif %}
-
-      {% set ops_readiness = model.operational_readiness|default({}) %}
-      {% set ops_readiness_items = ops_readiness.items|default([]) %}
-      {% if ops_readiness_items is iterable and ops_readiness_items|length > 0 %}
-        <section class="mel-live-ops__panel" aria-labelledby="mel-ws-operational-readiness-heading">
-          <div class="mel-live-ops__timeline-head">
-            <h2 id="mel-ws-operational-readiness-heading" class="mel-live-ops__panel-title">{{ ops_readiness.heading|default('Operational readiness'|t) }}</h2>
-            <p class="mel-live-ops__panel-intro">{{ ops_readiness.intro|default('What is ready, what attendees can see, and what still needs setup.'|t) }}</p>
-          </div>
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for item in ops_readiness_items %}
-              {% set sev = item.severity|default('info') %}
-              {% set chip_mod =
-                sev == 'success' ? 'success' :
-                (sev == 'warning' or sev == 'error') ? 'warn' :
-                (sev == 'neutral' ? 'calm' : 'info')
-              %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
-                <div class="mel-live-ops__timeline-body">
-                  <div class="mel-live-ops__timeline-headline">
-                    <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
-                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
-                  </div>
-                  {% if item.message|default('') is not empty %}
-                    <p class="mel-live-ops__muted">{{ item.message }}</p>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-        </section>
-      {% endif %}
-
-      {% set lifecycle_guidance = model.lifecycle_guidance|default({}) %}
-      {% set lifecycle_guidance_items = lifecycle_guidance.items|default([]) %}
-      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
-        <section class="mel-live-ops__panel" aria-labelledby="mel-ws-lifecycle-guidance-heading">
-          <div class="mel-live-ops__timeline-head">
-            <h2 id="mel-ws-lifecycle-guidance-heading" class="mel-live-ops__panel-title">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
-            <p class="mel-live-ops__panel-intro">{{ lifecycle_guidance.intro|default('Contextual notes that explain this event state without adding new rules or alerts.'|t) }}</p>
-          </div>
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for item in lifecycle_guidance_items %}
-              {% set sev = item.severity|default('info') %}
-              {% set chip_mod =
-                sev == 'success' ? 'success' :
-                (sev == 'warning' or sev == 'error') ? 'warn' :
-                (sev == 'neutral' ? 'calm' : 'info')
-              %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{{ sev == 'success' ? '✓' : '•' }}</div>
-                <div class="mel-live-ops__timeline-body">
-                  <div class="mel-live-ops__timeline-headline">
-                    <span class="mel-live-ops__timeline-name">{{ item.stage|default('') }}</span>
-                    <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
-                  </div>
-                  {% if item.message|default('') is not empty %}
-                    <p class="mel-live-ops__muted">{{ item.message }}</p>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-        </section>
-      {% endif %}
-
-      <section class="mel-live-ops__panel" aria-labelledby="mel-ws-readiness-heading">
-        <div class="mel-live-ops__timeline-head">
-          <h2 id="mel-ws-readiness-heading" class="mel-live-ops__panel-title">{{ 'Readiness'|t }}</h2>
-          <p class="mel-live-ops__panel-intro">
-            {{ '@pct% complete'|t({'@pct': model.readiness.score|default(0)}) }}
+      <div class="mel-event-mission-control__above-fold">
+        <section class="mel-event-mission-control__focus mel-live-ops__panel" aria-labelledby="mel-ws-todays-focus-heading">
+          <h2 id="mel-ws-todays-focus-heading" class="mel-event-mission-control__focus-title mel-live-ops__panel-title">{{ "Today's focus"|t }}</h2>
+          <p class="mel-event-mission-control__focus-message mel-event-mission-control__focus-message--{{ focus_sev|e('html_attr') }}">
+            <span class="visually-hidden">{{ 'Status:'|t }} </span>
+            {{ focus.message|default('') }}
           </p>
-        </div>
-        {% if model.readiness.items is iterable and model.readiness.items|length > 0 %}
-          <div class="mel-live-ops__timeline-feed" role="list">
-            {% for item in model.readiness.items %}
-              {% set ic = item.complete|default(false) %}
-              {% set isev = item.severity|default('neutral') %}
-              {% set chip_mod = ic ? 'success' : ((isev == 'warning') ? 'warn' : 'info') %}
-              {% set status_label %}
-                {% if ic %}
-                  {{ 'Complete'|t }}
-                {% else %}
-                  {{ 'Action required'|t }}
-                {% endif %}
-              {% endset %}
-              <article class="mel-live-ops__timeline-card" role="listitem">
-                <div class="mel-live-ops__timeline-avatar" aria-hidden="true">{% if ic %}✓{% else %}!{% endif %}</div>
-                <div class="mel-live-ops__timeline-body">
-                  {% if item.url is not null and not ic %}
-                    <a class="mel-live-ops__readiness-link" href="{{ item.url }}">
-                      <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
-                      <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ status_label }}</span>
-                    </a>
-                  {% else %}
-                    <div class="mel-live-ops__timeline-headline">
-                      <span class="mel-live-ops__timeline-name">{{ item.label|default('') }}</span>
-                      <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ status_label }}</span>
-                    </div>
-                  {% endif %}
-                </div>
-              </article>
-            {% endfor %}
-          </div>
-        {% endif %}
-      </section>
+          {% set focus_actions = focus.actions|default([]) %}
+          {% if focus_actions is iterable and focus_actions|length > 0 %}
+            <ul class="mel-event-mission-control__focus-actions">
+              {% for action in focus_actions %}
+                <li>
+                  <a class="mel-btn{% if action.primary|default(false) %} mel-btn--primary{% else %} mel-btn--secondary{% endif %}" href="{{ action.url }}">{{ action.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </section>
 
-      {% if model.metrics is iterable and model.metrics is not empty %}
-        <section class="mel-live-ops__metrics" aria-labelledby="mel-ws-metrics-heading">
-          <h2 id="mel-ws-metrics-heading" class="visually-hidden">{{ 'Summary metrics'|t }}</h2>
-          <div class="mel-live-ops__metric-board" role="list">
-            {% set stat_mods = ['total', 'in', 'ready', 'capacity'] %}
-            {% for m in model.metrics %}
-              {% set ms = m.severity|default('neutral') %}
-              {% set stat_mod = stat_mods[loop.index0 % stat_mods|length] %}
-              {% if m.url is not null %}
-                <a href="{{ m.url }}" class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem">
-              {% else %}
-                <article class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem">
-              {% endif %}
-                <span class="mel-live-ops__stat-icon" aria-hidden="true"></span>
-                <span class="mel-live-ops__stat-label">{{ m.label|default('') }}</span>
-                <span class="mel-live-ops__stat-value">{{ m.value|default('—') }}</span>
-                {% if m.context|default('') is not empty %}
-                  <span class="mel-live-ops__stat-note">{{ m.context }}</span>
+        {% set snapshot_metrics = sales.metrics|default([]) %}
+        {% if snapshot_metrics is iterable and snapshot_metrics|length > 0 %}
+          <section class="mel-event-mission-control__sales mel-live-ops__panel" aria-labelledby="mel-ws-sales-snapshot-heading">
+            <h2 id="mel-ws-sales-snapshot-heading" class="mel-live-ops__panel-title">{{ 'Sales snapshot'|t }}</h2>
+            <div class="mel-event-mission-control__sales-grid" role="list">
+              {% for m in snapshot_metrics %}
+                {% if m.url is not null %}
+                  <a href="{{ m.url }}" class="mel-event-mission-control__sales-card" role="listitem">
+                {% else %}
+                  <article class="mel-event-mission-control__sales-card" role="listitem">
                 {% endif %}
-              {% if m.url is not null %}
-                </a>
-              {% else %}
-                </article>
-              {% endif %}
-            {% endfor %}
+                  <span class="mel-event-mission-control__sales-label">{{ m.label|default('') }}</span>
+                  <span class="mel-event-mission-control__sales-value">{{ m.value|default('—') }}</span>
+                {% if m.url is not null %}
+                  </a>
+                {% else %}
+                  </article>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </section>
+        {% endif %}
+      </div>
+
+      {% if extras_configured_panel %}
+        <section class="mel-event-mission-control__configured-extras mel-live-ops__panel" aria-labelledby="mel-ws-configured-extras-heading">
+          <h2 id="mel-ws-configured-extras-heading" class="visually-hidden">{{ 'Merch & add-ons configuration'|t }}</h2>
+          {{ extras_configured_panel }}
+        </section>
+      {% endif %}
+
+      {% if ticket_sales_panel %}
+        <details class="mel-event-mission-control__ticket-sales mel-live-ops__panel">
+          <summary class="mel-event-mission-control__ticket-sales-summary">
+            <span class="mel-event-mission-control__ticket-sales-title">{{ 'Ticket sales'|t }}</span>
+            <span class="mel-event-mission-control__ticket-sales-hint mel-live-ops__muted">{{ 'Attendance capacity by ticket type'|t }}</span>
+          </summary>
+          <div class="mel-event-mission-control__ticket-sales-body">
+            {{ ticket_sales_panel }}
+          </div>
+        </details>
+      {% endif %}
+
+      {% if extras_sales_panel %}
+        <details class="mel-event-mission-control__extras-sales mel-live-ops__panel">
+          <summary class="mel-event-mission-control__extras-sales-summary">
+            <span class="mel-event-mission-control__extras-sales-title">{{ 'Merch & add-on sales'|t }}</span>
+            <span class="mel-event-mission-control__extras-sales-hint mel-live-ops__muted">{{ 'Operational extras by category — tickets excluded'|t }}</span>
+          </summary>
+          <div class="mel-event-mission-control__extras-sales-body">
+            {{ extras_sales_panel }}
+          </div>
+        </details>
+      {% endif %}
+
+      {% set grid_sales = grid.sales|default([]) %}
+      {% set grid_setup = grid.setup|default([]) %}
+      {% set grid_growth = grid.growth|default([]) %}
+      {% if grid_sales|length > 0 or grid_setup|length > 0 or grid_growth|length > 0 %}
+        <section class="mel-event-mission-control__actions mel-live-ops__panel" aria-labelledby="mel-ws-shortcuts-heading">
+          <h2 id="mel-ws-shortcuts-heading" class="mel-live-ops__panel-title">{{ 'Manage this event'|t }}</h2>
+          <div class="mel-event-mission-control__action-groups">
+            {% if grid_sales|length > 0 %}
+              <div class="mel-event-mission-control__action-group">
+                <h3 class="mel-event-mission-control__action-group-title">{{ 'Sales'|t }}</h3>
+                <div class="mel-event-mission-control__action-grid">
+                  {% for link in grid_sales %}
+                    <a class="mel-event-mission-control__action-tile" href="{{ link.url }}"><span>{{ link.label }}</span></a>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+            {% if grid_setup|length > 0 %}
+              <div class="mel-event-mission-control__action-group">
+                <h3 class="mel-event-mission-control__action-group-title">{{ 'Setup'|t }}</h3>
+                <div class="mel-event-mission-control__action-grid">
+                  {% for link in grid_setup %}
+                    <a class="mel-event-mission-control__action-tile" href="{{ link.url }}"><span>{{ link.label }}</span></a>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+            {% if grid_growth|length > 0 %}
+              <div class="mel-event-mission-control__action-group">
+                <h3 class="mel-event-mission-control__action-group-title">{{ 'Growth'|t }}</h3>
+                <div class="mel-event-mission-control__action-grid">
+                  {% for link in grid_growth %}
+                    <a class="mel-event-mission-control__action-tile" href="{{ link.url }}"><span>{{ link.label }}</span></a>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
           </div>
         </section>
+      {% endif %}
+
+      {% set readiness_groups = readiness_sum.groups|default([]) %}
+      {% if readiness_groups is iterable and readiness_groups|length > 0 %}
+        <section class="mel-event-mission-control__readiness mel-live-ops__panel" aria-labelledby="mel-ws-operational-readiness-heading">
+          <div class="mel-event-mission-control__section-head">
+            <div>
+              <h2 id="mel-ws-operational-readiness-heading" class="mel-live-ops__panel-title">{{ model.operational_readiness.heading|default('Operational readiness'|t) }}</h2>
+              {% if readiness_sum.all_ready|default(false) %}
+                <p class="mel-live-ops__panel-intro">{{ 'Everything looks ready for this event.'|t }}</p>
+              {% else %}
+                <p class="mel-live-ops__panel-intro">{{ '@count areas need attention'|t({'@count': readiness_sum.issue_count|default(0)}) }}</p>
+              {% endif %}
+            </div>
+            {% if readiness_sum.all_ready|default(false) %}
+              <span class="mel-live-ops__chip mel-live-ops__chip--success">{{ 'All ready'|t }}</span>
+            {% endif %}
+          </div>
+
+          <div class="mel-event-mission-control__readiness-groups">
+            {% for group in readiness_groups %}
+              {% set g_status = group.status|default('ready') %}
+              {% set g_chip = g_status == 'ready' ? 'success' : 'warn' %}
+              <details class="mel-event-mission-control__readiness-group"{% if group.expand|default(false) %} open{% endif %}>
+                <summary class="mel-event-mission-control__readiness-summary">
+                  <span class="mel-event-mission-control__readiness-label">{{ group.label|default('') }}</span>
+                  <span class="mel-live-ops__chip mel-live-ops__chip--{{ g_chip }}">{{ g_status == 'ready' ? ('Ready'|t) : ('Needs attention'|t) }}</span>
+                </summary>
+                {% if group.items is iterable and group.items|length > 0 %}
+                  <ul class="mel-event-mission-control__readiness-items">
+                    {% for item in group.items %}
+                      {% set isev = item.severity|default('info') %}
+                      {% set chip_mod =
+                        isev == 'success' ? 'success' :
+                        (isev == 'warning' or isev == 'error') ? 'warn' :
+                        (isev == 'neutral' ? 'calm' : 'info')
+                      %}
+                      <li class="mel-event-mission-control__readiness-item">
+                        <span class="mel-event-mission-control__readiness-item-label">{{ item.label|default('') }}</span>
+                        {% if item.message|default('') is not empty %}
+                          <span class="mel-event-mission-control__readiness-item-message mel-live-ops__muted">{{ item.message }}</span>
+                        {% endif %}
+                        <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ item.complete|default(false) ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+              </details>
+            {% endfor %}
+          </div>
+
+          {% set detail_items = readiness_sum.detail_items|default([]) %}
+          {% if detail_items is iterable and detail_items|length > 0 %}
+            <details class="mel-event-mission-control__readiness-all">
+              <summary>{{ 'Show all readiness checks'|t }}</summary>
+              <ul class="mel-event-mission-control__readiness-items mel-event-mission-control__readiness-items--detail">
+                {% for item in detail_items %}
+                  {% set ic = item.complete|default(false) %}
+                  {% set isev = item.severity|default('neutral') %}
+                  {% set chip_mod = ic ? 'success' : ((isev == 'warning') ? 'warn' : 'info') %}
+                  <li class="mel-event-mission-control__readiness-item">
+                    {% if item.url is not null and not ic %}
+                      <a class="mel-event-mission-control__readiness-item-link" href="{{ item.url }}">
+                        <span>{{ item.label|default('') }}</span>
+                        <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ ic ? ('Complete'|t) : ('Action required'|t) }}</span>
+                      </a>
+                    {% else %}
+                      <span class="mel-event-mission-control__readiness-item-label">{{ item.label|default('') }}</span>
+                      <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ ic ? ('Complete'|t) : ('Action required'|t) }}</span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+        </section>
+      {% endif %}
+
+      {% if lifecycle_guidance_items is iterable and lifecycle_guidance_items|length > 0 %}
+        <details class="mel-event-mission-control__guidance mel-live-ops__panel">
+          <summary class="mel-event-mission-control__guidance-summary">
+            <span class="mel-event-mission-control__guidance-title">{{ 'Event guidance'|t }}</span>
+            <span class="mel-event-mission-control__guidance-copy mel-live-ops__muted">{{ 'Recommendations to help this event perform well.'|t }}</span>
+          </summary>
+          <div class="mel-event-mission-control__guidance-body" aria-labelledby="mel-ws-lifecycle-guidance-heading">
+            <h2 id="mel-ws-lifecycle-guidance-heading" class="visually-hidden">{{ lifecycle_guidance.heading|default('Lifecycle guidance'|t) }}</h2>
+            <ul class="mel-event-mission-control__guidance-list">
+              {% for item in lifecycle_guidance_items %}
+                {% set sev = item.severity|default('info') %}
+                {% set chip_mod =
+                  sev == 'success' ? 'success' :
+                  (sev == 'warning' or sev == 'error') ? 'warn' :
+                  (sev == 'neutral' ? 'calm' : 'info')
+                %}
+                <li class="mel-event-mission-control__guidance-item">
+                  <span class="mel-event-mission-control__guidance-stage">{{ item.stage|default('') }}</span>
+                  {% if item.message|default('') is not empty %}
+                    <p class="mel-live-ops__muted">{{ item.message }}</p>
+                  {% endif %}
+                  <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip_mod }}">{{ sev == 'success' ? ('Ready'|t) : ('Guidance'|t) }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </details>
       {% endif %}
 
       {% if model.tabs is iterable and model.tabs is not empty %}
@@ -266,39 +317,20 @@
           </nav>
         </div>
       {% endif %}
-
-      <section class="mel-live-ops__panel" aria-labelledby="mel-ws-shortcuts-heading">
-        <h2 id="mel-ws-shortcuts-heading" class="mel-live-ops__panel-title">{{ 'Manage this event'|t }}</h2>
-        <p class="mel-live-ops__panel-intro">{{ 'Quick links to ticketing, attendees, check-in, publishing, and reports for this event.'|t }}</p>
-        <div class="mel-live-ops__shortcut-grid">
-          {% if model.actions.rsvps is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.rsvps }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View RSVPs'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.orders is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.orders }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View orders'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.addon_orders is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.addon_orders }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View add-on orders'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.attendees is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.attendees }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View attendees'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.checkin is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.checkin }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'Check in guests'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.analytics is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.analytics }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'View analytics'|t }}</span></a>
-          {% endif %}
-          {% if model.actions.settings is not null %}
-            <a class="mel-live-ops__shortcut-tile" href="{{ model.actions.settings }}"><span class="mel-live-ops__shortcut-tile-label">{{ 'Event settings'|t }}</span></a>
-          {% endif %}
-        </div>
-      </section>
     </div>
   {% elseif header_stats is not empty %}
     {% include '@myeventlane_vendor_theme/mel-event/mel-event-header.html.twig' %}
   {% else %}
-    {% include '@myeventlane_vendor_theme/components/workspace/workspace-header.html.twig' %}
+    <div class="mel-event-management-shell">
+      {% if manage_event_back.url is defined and manage_event_back.url %}
+        <nav class="mel-event-manage-back mel-event-management-shell__back" aria-label="{{ 'Event navigation'|t }}">
+          <a href="{{ manage_event_back.url }}" class="mel-event-manage-back__link mel-btn mel-btn--ghost">{{ manage_event_back.label|default('Back to Manage event'|t) }}</a>
+        </nav>
+      {% endif %}
+      <div class="mel-event-management-shell__header">
+        {% include '@myeventlane_vendor_theme/components/workspace/workspace-header.html.twig' %}
+      </div>
+    </div>
   {% endif %}
 
   {% if not has_ws_model and tabs %}
@@ -317,7 +349,7 @@
         </aside>
       {% endif %}
 
-      <main class="mel-workspace__content mel-workspace-console-content">
+      <main class="mel-workspace__content mel-workspace-console-content{% if not has_ws_model %} mel-workspace__content--event-management{% endif %}">
         {% if not has_ws_model and workspace_event_boost and workspace_event_boost.performance is defined and workspace_event_boost.performance.ui is defined and workspace_event_boost.performance.ui.show %}
           {% include '@myeventlane_vendor_theme/components/mel-boost-insights-panel.html.twig' with {
             performance: workspace_event_boost.performance


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches checkout fee adjustments and add-to-cart validation for operational lines; needs config import and careful Commerce regression on mixed ticket/extras carts. Stock is enforced at add-to-cart only (no reservation/decrement).
> 
> **Overview**
> Adds **repository-wide AI agent guidance** (`.cursorignore`, `AGENTS.md`, `CLAUDE.md`, Copilot instructions, Cursor rules) alongside a large **operational extras / vendor dashboard** slice.
> 
> **Commerce & config:** Exports `field_mel_stock_quantity`, `field_mel_limit_per_order`, and `field_mel_show_remaining` onto operational variation bundles. Introduces `OperationalVariationStockResolver` and wires it through Studio save paths, booking add-on payloads, and `EventOperationalAddonCartForm` for **server-side add-to-cart limits** (blank = unlimited, `0` = sold out; cart quantities count toward limits). **No stock decrement** on purchase in this slice.
> 
> **Fees:** Splits checkout platform fees via `PlatformFeeOrderProcessor` and new `PlatformFeeSettings` / admin config for **ticket vs merch & add-ons** (`operational_extras_platform_fee_percent`, default double ticket rate). Stripe Connect application fee behavior on tickets is documented as unchanged.
> 
> **Vendor UX:** Read-only **ticket sales** and **merch & add-on sales** monitoring on Manage event (`myeventlane_vendor.console.event_workspace`), with new Twig themes/CSS, `EventOperationalExtrasSalesSummaryBuilder`, and “operational documents” placeholders (coming soon). Event Studio **Merch & add-ons** editor gets accordion layout, stock summary-first UX, and a top-bar link back to Manage event. Boost workspace tab now uses `event_workspace` as base route.
> 
> **Docs & tests:** New/updated operational stock and vendor UX docs; PHPUnit coverage for stock resolver, extras sales summary, and platform fee settings.
> 
> **Deploy note:** Requires **config import** (`drush cim`) and cache rebuild; recommend `config:status` preview before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dee2bc74af51d978cfdb667d8eaa0097d12593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->