### PR TITLE
fix(tests): pass OperationalVariationStockResolver in kernel helpers

### DIFF
--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -23,6 +23,7 @@ use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseGovernanceManager;
 use Drupal\myeventlane_commerce\Service\OperationalMerchandiseManager;
 use Drupal\myeventlane_commerce\Service\OperationalPurchaseCompositionManager;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
 use Drupal\myeventlane_event_studio\Service\OperationalCapabilityCommerceLinkManager;
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
 use Drupal\myeventlane_event_studio\Service\VendorProductisationStudioManager;
@@ -438,6 +439,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
         $this->container->get('extension.path.resolver'),
         $this->container->get('string_translation'),
       ),
+      new OperationalVariationStockResolver($this->container->get('string_translation')),
       $this->container->get('string_translation'),
     );
   }
@@ -774,6 +776,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
       $merch,
       $this->commerceWizardLinkManager(),
       new EventVendorAccessChecker(),
+      new OperationalVariationStockResolver($this->container->get('string_translation')),
       $this->container->get('string_translation'),
       $this->container->get('logger.factory')->get('test'),
     );


### PR DESCRIPTION
Kernel tests manually construct EventOperationalAddonBuilder and VendorOperationalProductCreationManager but still used the pre-merge constructor arity, passing TranslationManager where stockResolver is required after OperationalVariationStockResolver was added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only constructor fixes with no production or runtime behavior changes.
> 
> **Overview**
> Updates **kernel test wiring** so manually built services match the new constructor signatures after **`OperationalVariationStockResolver`** was introduced.
> 
> In `OperationalMerchandiseKernelTest`, **`EventOperationalAddonBuilder`** and **`VendorOperationalProductCreationManager`** now receive a `OperationalVariationStockResolver` backed by `string_translation`, instead of passing translation in the wrong slot and breaking arity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d2a77e18d6800f2a0c12fdfe29bae3dacdf541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->