### PR TITLE
fix(deploy): prevent drush deploy exit 255 on low CLI memory

### DIFF
--- a/docs/staging-drush-memory-fix.md
+++ b/docs/staging-drush-memory-fix.md
@@ -60,8 +60,38 @@ php -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" vendor/bin/drush.php php:eval 'ech
 
 (DDEV may still cap `memory_limit` in the container; staging bare-metal CLI uses the `-d` values.)
 
+## `drush deploy` exit 255 after “No pending updates”
+
+Symptom on staging:
+
+```text
+The command ".../vendor/bin/drush updatedb --uri=default" failed.
+Exit Code: 255
+Error Output: [success] No pending updates.
+```
+
+**Cause:** `drush deploy` runs `updatedb` as a subprocess. With default options, `updatedb` calls `drupal_flush_all_caches()` even when there are no hook updates. On hosts with low CLI `memory_limit` (often 128M), that flush can fatal **after** the success line, so SiteProcess reports exit 255. `drush deploy` then runs `cache:rebuild` anyway, so the `updatedb` flush is redundant.
+
+**Repo fixes:**
+
+| Change | Purpose |
+|--------|---------|
+| [`drush/drush.yml`](../drush/drush.yml) | `updatedb` option `cache-clear: false` (deploy still runs `cache:rebuild`) |
+| [`scripts/deploy/mel-deploy.sh`](../scripts/deploy/mel-deploy.sh) | Manual deploy wrapper: `php -d memory_limit=1024M vendor/bin/drush.php deploy` + `SITE_URI` |
+| [`drush/sites/default.site.yml`](../drush/sites/default.site.yml) | Relative `root: ../web` (was a stale absolute path) |
+
+**On staging (after pulling the branch):**
+
+```bash
+cd ~/staging/current
+SITE_URI=https://staging.myeventlane.com.au bash scripts/deploy/mel-deploy.sh
+```
+
+Avoid bare `~/bin/drush512 deploy` without `-l` / `SITE_URI` (Drush defaults to `--uri=default`).
+
 ## Residual risk
 
 - `1024M` may still be insufficient for very large config imports; set `MEL_DRUSH_PHP_MEMORY=-1` if needed.
 - Removing pre-switch `drush cr` means caches are only rebuilt post-switch (intended trade-off for memory).
+- Manual `drush updb` no longer clears caches automatically; run `drush cr` afterward if needed.
 - Does not fix non-memory Drush failures (DB down, bad `cim`, etc.).

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,0 +1,9 @@
+# Project Drush config (see https://www.drush.org/latest/using-drush-configuration/)
+#
+# updatedb: skip cache flush — `drush deploy` runs cache:rebuild immediately after.
+# Avoids a second, memory-heavy drupal_flush_all_caches() during deploy on hosts
+# with low CLI memory_limit (common on staging; see docs/staging-drush-memory-fix.md).
+command:
+  updatedb:
+    options:
+      cache-clear: false

--- a/drush/sites/default.site.yml
+++ b/drush/sites/default.site.yml
@@ -1,3 +1,6 @@
+# Site alias for staging / manual Drush on the release tree (project root = parent of web/).
+# Use: drush @default status   or   drush --uri=https://staging.myeventlane.com.au …
+# Prefer scripts/deploy/mel-deploy.sh on the host (sets memory_limit + SITE_URI).
 default:
-  root: /home/myeventlanecom/staging/web
+  root: ../web
   uri: https://staging.myeventlane.com.au

--- a/scripts/deploy/mel-deploy.sh
+++ b/scripts/deploy/mel-deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run `drush deploy` on staging/production with the same CLI safeguards as remote-deploy.sh.
+#
+# Usage (from release root, e.g. ~/staging/current):
+#   bash scripts/deploy/mel-deploy.sh
+#   SITE_URI=https://staging.myeventlane.com.au bash scripts/deploy/mel-deploy.sh
+#
+# Do not use bare `drush deploy` on memory-constrained hosts: updatedb's default
+# cache flush plus deploy's cache:rebuild can exceed 128M CLI and exit 255 after
+# printing "[success] No pending updates." (drush/drush.yml disables updatedb cache-clear).
+set -euo pipefail
+
+ROOT="${1:-${PWD}}"
+SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
+MEL_DRUSH_PHP_MEMORY="${MEL_DRUSH_PHP_MEMORY:-1024M}"
+
+if [[ ! -f "$ROOT/vendor/bin/drush.php" ]]; then
+  echo "ERROR: vendor/bin/drush.php not found under $ROOT" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+
+mel_drush() {
+  php \
+    -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" \
+    -d opcache.enable_cli=0 \
+    vendor/bin/drush.php "$@"
+}
+
+echo "Drush deploy (uri=${SITE_URI}, memory_limit=${MEL_DRUSH_PHP_MEMORY})"
+php -r 'printf("  CLI memory_limit=%s max_execution_time=%s\n", ini_get("memory_limit"), ini_get("max_execution_time"));'
+
+mel_drush status --uri="$SITE_URI" | grep -E 'Drupal bootstrap|Drupal version|Site URI' || {
+  echo "ERROR: Drupal bootstrap failed before deploy." >&2
+  exit 1
+}
+
+mel_drush deploy -y -v --uri="$SITE_URI"
+
+echo "Deploy complete."


### PR DESCRIPTION
Disable updatedb cache-clear in drush/drush.yml because drush deploy already runs cache:rebuild; the extra drupal_flush_all_caches() could fatal after "No pending updates" on memory-constrained staging hosts. Add mel-deploy.sh wrapper and correct the default site alias root path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `updatedb` cache behavior for all Drush invocations and alters manual deploy paths on staging; low application-runtime risk but ops impact if someone relies on automatic post-updb cache clears outside `drush deploy`.
> 
> **Overview**
> Addresses staging **`drush deploy` exit 255** when `updatedb` prints success but dies on a redundant full cache flush under low CLI memory.
> 
> **`drush/drush.yml`** sets project-wide **`updatedb` → `cache-clear: false`**, so deploy no longer runs a second `drupal_flush_all_caches()` before `cache:rebuild`. **`scripts/deploy/mel-deploy.sh`** is a new host-side wrapper that runs `drush deploy` via `drush.php` with **`memory_limit=1024M`**, **`opcache.enable_cli=0`**, bootstrap check, and **`SITE_URI`**. **`drush/sites/default.site.yml`** fixes the site docroot to **`../web`** (replacing a stale absolute path). **`docs/staging-drush-memory-fix.md`** documents the failure mode, the table of fixes, staging usage, and that **manual `drush updb` no longer auto-clears caches** (run `drush cr` if needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634baaaa52af2c5cf3163d264a9682f12e2e7def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->