### PR TITLE
Cursor/cursor prompts a94b5

### DIFF
--- a/docs/ai/chatgpt-cursor-prompt-framing.md
+++ b/docs/ai/chatgpt-cursor-prompt-framing.md
@@ -1,0 +1,43 @@
+You are helping Anna frame Cursor prompts for MyEventLane / MEL.
+
+MEL is a Drupal 11 + Drupal Commerce 3 event marketplace with custom modules, Twig, SCSS, Vite, DDEV, config sync, vendor dashboards, checkout, ticketing, RSVP, media, help centre, SEO, and event discovery.
+
+When writing Cursor prompts for me, always follow these rules:
+
+1. Treat the MEL repository as the source of truth.
+2. Do not invent Drupal APIs, Commerce services, field names, routes, permissions, plugin IDs, config keys, theme regions, or file paths.
+3. If something is uncertain, instruct Cursor to inspect the repo first and say: “I cannot confirm this from the repository.”
+4. Always make Cursor work in phases:
+   - Audit first
+   - Explain findings
+   - Identify risks
+   - Propose the smallest safe plan
+   - Implement only after the plan is clear
+   - Validate
+5. Tell Cursor not to duplicate code, services, templates, styles, or logic.
+6. Tell Cursor to preserve existing MEL architecture and reuse existing services/patterns.
+7. For Commerce work, force Cursor to check checkout, order state, payment state, store ownership, product variation types, order item types, ticket capacity, stock, and vendor access.
+8. For Drupal work, force Cursor to check access control, cacheability, config schema, entity access, routes, permissions, and typed config.
+9. For frontend work, force Cursor to follow the MEL style guide:
+   - mobile-first
+   - soft pastel surfaces
+   - coral primary CTA
+   - one clear primary action per screen
+   - Nunito typography
+   - 44x44 tap targets
+   - visible focus states
+   - no default Drupal-looking UI
+   - no duplicate CTAs or nav
+10. Cursor prompts must include exact deliverables:
+   - branch name
+   - files to inspect
+   - files likely to change
+   - files not to touch
+   - validation commands
+   - commit instructions
+11. Cursor must not run destructive commands.
+12. Cursor must not run `drush cim`, `drush cex`, `git reset --hard`, `git clean -fd`, or `git push --force` without explicit approval.
+13. Cursor must not claim tests, lint, build, Drush, or config commands passed unless it actually ran them.
+14. Every prompt should end with a clear “Stop and report” instruction if Cursor finds unexpected architecture, dirty worktree issues, security risk, or config drift.
+
+Write Cursor prompts in a strict, practical format that Anna can paste directly into Cursor.

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-extras-studio.css
@@ -8,6 +8,118 @@
   gap: 1.25rem;
 }
 
+.mel-event-extras-studio__layout {
+  display: grid;
+  gap: 1.25rem;
+  align-items: start;
+  width: 100%;
+  min-width: 0;
+}
+
+.mel-event-extras-studio__main,
+.mel-event-extras-studio__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.mel-event-extras-studio__aside .mel-event-extras-studio__configured-summary,
+.mel-event-extras-studio__aside .mel-event-extras-studio__booking-preview,
+.mel-event-extras-studio__aside .mel-event-extras-studio__next-steps {
+  margin: 0;
+}
+
+.mel-event-extras-studio__booking-preview-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-extras-studio__booking-preview--empty {
+  text-align: center;
+  padding: 1.25rem 1rem;
+}
+
+.mel-event-extras-studio__configured-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 0.75rem 0 0;
+}
+
+.mel-event-extras-studio__configured-stats > div {
+  margin: 0;
+}
+
+.mel-event-extras-studio__configured-stats dt {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--mel-text-muted, #6b6578);
+}
+
+.mel-event-extras-studio__configured-stats dd {
+  margin: 0.2rem 0 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.mel-event-extras-studio__configured-top-list {
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-event-extras-studio__configured-top-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--mel-border-soft, #e8e4ef);
+}
+
+.mel-event-extras-studio__configured-top-list li:last-child {
+  border-bottom: 0;
+}
+
+.mel-event-extras-studio__configured-name {
+  display: block;
+  font-weight: 600;
+}
+
+.mel-event-extras-studio__next-steps {
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--mel-border-soft, #e8e4ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface-elevated, #fff);
+}
+
+@media (min-width: 64rem) {
+  .mel-event-extras-studio__layout {
+    grid-template-columns: minmax(0, 1.65fr) minmax(16rem, 1fr);
+  }
+
+  .mel-event-extras-studio__aside {
+    position: sticky;
+    top: 1rem;
+  }
+
+  .mel-event-extras-studio__configured-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 24.375rem) {
+  .mel-event-extras-studio__layout {
+    gap: 1rem;
+  }
+
+  .mel-event-extras-studio__configured-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .mel-event-extras-studio__booking-preview--empty {
+    padding: 1rem 0.75rem;
+  }
+}
+
 .mel-event-extras-studio__safety {
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
@@ -288,6 +400,26 @@
   display: grid;
   gap: 1rem;
   align-items: start;
+  width: 100%;
+  min-width: 0;
+}
+
+.mel-event-product-editor__main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.mel-event-product-editor__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.mel-event-product-editor__aside-preview {
+  padding: 1rem 1.125rem;
 }
 
 @media (min-width: 64rem) {
@@ -298,9 +430,6 @@
   .mel-event-product-editor__aside {
     position: sticky;
     top: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
   }
 }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioEventExtrasForm.php
@@ -15,6 +15,7 @@ use Drupal\myeventlane_core\Service\PlatformFeeSettings;
 use Drupal\myeventlane_commerce\Service\EventExtrasBookPlacementResolver;
 use Drupal\myeventlane_commerce\Service\OperationalExtraVisualPresenter;
 use Drupal\myeventlane_event_studio\Service\EventStudioEventExtrasBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioExtrasConfiguredSummaryBuilder;
 use Drupal\myeventlane_event_studio\Service\EventStudioExtrasProductEditorBuilder;
 use Drupal\myeventlane_event_studio\Service\VendorOperationalProductCreationManager;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
@@ -44,6 +45,8 @@ final class EventStudioEventExtrasForm extends FormBase {
 
   protected EventStudioExtrasProductEditorBuilder $productEditorBuilder;
 
+  protected EventStudioExtrasConfiguredSummaryBuilder $extrasConfiguredSummaryBuilder;
+
   protected EventExtrasBookPlacementResolver $extrasBookPlacementResolver;
 
   protected LoggerInterface $logger;
@@ -58,6 +61,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     VendorOperationalProductCreationManager $product_creation_manager,
     EventStudioEventExtrasBuilder $extras_builder,
     EventStudioExtrasProductEditorBuilder $product_editor_builder,
+    EventStudioExtrasConfiguredSummaryBuilder $extras_configured_summary_builder,
     EventExtrasBookPlacementResolver $extras_book_placement_resolver,
     LoggerInterface $logger,
   ) {
@@ -66,6 +70,7 @@ final class EventStudioEventExtrasForm extends FormBase {
     $this->productCreationManager = $product_creation_manager;
     $this->extrasBuilder = $extras_builder;
     $this->productEditorBuilder = $product_editor_builder;
+    $this->extrasConfiguredSummaryBuilder = $extras_configured_summary_builder;
     $this->extrasBookPlacementResolver = $extras_book_placement_resolver;
     $this->logger = $logger;
   }
@@ -77,6 +82,7 @@ final class EventStudioEventExtrasForm extends FormBase {
       $container->get('myeventlane_event_studio.vendor_operational_product_creation_manager'),
       $container->get('myeventlane_event_studio.event_extras_builder'),
       $container->get('myeventlane_event_studio.extras_product_editor_builder'),
+      $container->get('myeventlane_event_studio.extras_configured_summary_builder'),
       $container->get('myeventlane_commerce.event_extras_book_placement_resolver'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
     );
@@ -99,7 +105,7 @@ final class EventStudioEventExtrasForm extends FormBase {
    * Ensures services are present after form cache unserialization.
    */
   private function ensureInjectedServices(): void {
-    if (isset($this->entityTypeManager, $this->eventVendorAccessChecker, $this->productCreationManager, $this->extrasBuilder, $this->productEditorBuilder, $this->extrasBookPlacementResolver, $this->logger)) {
+    if (isset($this->entityTypeManager, $this->eventVendorAccessChecker, $this->productCreationManager, $this->extrasBuilder, $this->productEditorBuilder, $this->extrasConfiguredSummaryBuilder, $this->extrasBookPlacementResolver, $this->logger)) {
       return;
     }
     $container = \Drupal::getContainer();
@@ -117,6 +123,9 @@ final class EventStudioEventExtrasForm extends FormBase {
     }
     if (!isset($this->productEditorBuilder)) {
       $this->productEditorBuilder = $container->get('myeventlane_event_studio.extras_product_editor_builder');
+    }
+    if (!isset($this->extrasConfiguredSummaryBuilder)) {
+      $this->extrasConfiguredSummaryBuilder = $container->get('myeventlane_event_studio.extras_configured_summary_builder');
     }
     if (!isset($this->extrasBookPlacementResolver)) {
       $this->extrasBookPlacementResolver = $container->get('myeventlane_commerce.event_extras_book_placement_resolver');
@@ -245,10 +254,21 @@ final class EventStudioEventExtrasForm extends FormBase {
       $form['intro']['#access'] = FALSE;
     }
     else {
-      $form['list'] = $this->buildList($event);
-      $form += $this->buildBookingPlacement($event);
-      $form['probe'] = $this->buildProbe($event);
-      $form['footer_cta'] = $this->buildFooterCta($event);
+      $form['#attributes']['class'][] = 'mel-event-extras-studio--list';
+      $placement = $this->buildBookingPlacement($event);
+      $form['layout'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-extras-studio__layout']],
+        'main' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-extras-studio__main']],
+          'list' => $this->buildList($event),
+        ] + $placement + [
+          'probe' => $this->buildProbe($event),
+          'footer_cta' => $this->buildFooterCta($event),
+        ],
+        'aside' => $this->extrasConfiguredSummaryBuilder->buildStudioAsideRenderArray($event),
+      ];
     }
 
     return $form;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php
@@ -89,6 +89,38 @@ final class EventStudioExtrasConfiguredSummaryBuilder {
    */
   public function buildPanelRenderArray(NodeInterface $event, int $weight = -5): array {
     $panel = $this->buildPanel($event);
+    return $this->buildConfiguredSummaryRenderArray($panel, $event, $weight);
+  }
+
+  /**
+   * Right-rail summary for the Merch & add-ons Studio section (list mode).
+   *
+   * @return array<string, mixed>
+   */
+  public function buildStudioAsideRenderArray(NodeInterface $event): array {
+    $panel = $this->buildPanel($event);
+    $panel['hide_manage_cta'] = TRUE;
+    $panel['studio_context'] = TRUE;
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-extras-studio__aside']],
+      'summary' => $this->buildConfiguredSummaryRenderArray($panel, $event, 0),
+      'booking_preview' => $this->buildListBookingPreviewRenderArray($event),
+      'next_steps' => $this->buildExtrasNextStepsCard($event, $panel),
+      '#cache' => [
+        'tags' => $panel['cache_tags'] ?? $event->getCacheTags(),
+        'contexts' => ['user'],
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $panel
+   *
+   * @return array<string, mixed>
+   */
+  private function buildConfiguredSummaryRenderArray(array $panel, NodeInterface $event, int $weight): array {
     return [
       '#theme' => 'mel_event_studio_extras_configured_summary',
       '#panel' => $panel,
@@ -98,6 +130,144 @@ final class EventStudioExtrasConfiguredSummaryBuilder {
         'contexts' => ['user'],
       ],
     ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function buildListBookingPreviewRenderArray(NodeInterface $event): array {
+    $cards = $this->extrasBuilder->loadExtrasForEvent($event);
+    $featured = $this->selectListPreviewCard($cards);
+
+    if ($featured === NULL) {
+      return [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => [
+            'mel-es-card',
+            'mel-event-extras-studio__booking-preview',
+            'mel-event-extras-studio__booking-preview--empty',
+          ],
+        ],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Booking preview'),
+          '#attributes' => ['class' => ['mel-es-card__title']],
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Add a merch item or add-on to see how guests may see it on your booking page.'),
+          '#attributes' => ['class' => ['mel-text--muted']],
+        ],
+      ];
+    }
+
+    $preview = is_array($featured['preview'] ?? NULL) ? $featured['preview'] : [];
+    $preview_meta_parts = array_filter([
+      (string) ($featured['variant_count_label'] ?? ''),
+      (string) ($featured['price_label'] ?? ''),
+      (string) ($featured['stock_label'] ?? ''),
+    ]);
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-es-card', 'mel-event-extras-studio__booking-preview']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Booking preview'),
+        '#attributes' => ['class' => ['mel-es-card__title']],
+      ],
+      'hint' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Sample of how a configured extra may appear to guests.'),
+        '#attributes' => ['class' => ['mel-text--muted', 'mel-event-extras-studio__booking-preview-hint']],
+      ],
+      'preview' => [
+        '#theme' => 'mel_event_studio_extra_preview',
+        '#preview' => $preview,
+        '#preview_meta_line' => implode(' · ', $preview_meta_parts),
+        '#stock_label' => (string) ($featured['stock_label'] ?? ''),
+        '#visibility_label' => (string) ($featured['booking_visibility_label'] ?? ''),
+        '#hidden_notice' => empty($featured['show_on_booking'])
+          ? (string) $this->t('This product is not visible on the booking page yet.')
+          : '',
+      ],
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $panel
+   *
+   * @return array<string, mixed>
+   */
+  private function buildExtrasNextStepsCard(NodeInterface $event, array $panel): array {
+    $event_id = (int) $event->id();
+    $items = [];
+
+    if (empty($panel['has_products'])) {
+      $items[] = [
+        '#type' => 'link',
+        '#title' => $this->t('Add your first merch or add-on'),
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_extras', ['node' => $event_id], [
+          'query' => ['add' => 'merchandise'],
+        ]),
+      ];
+      $items[] = (string) $this->t('Choose Active status and show on booking when you are ready to sell.');
+    }
+    else {
+      $items[] = (string) $this->t('Review stock and booking visibility for each product.');
+      $items[] = [
+        '#type' => 'link',
+        '#title' => $this->t('Preview booking page'),
+        '#url' => Url::fromRoute(
+          $event->isPublished() ? 'myeventlane_commerce.event_book' : 'entity.node.canonical',
+          ['node' => $event_id],
+        ),
+      ];
+    }
+
+    $items[] = [
+      '#type' => 'link',
+      '#title' => $this->t('Continue to publish'),
+      '#url' => Url::fromRoute('myeventlane_event_studio.edit_publish', ['node' => $event_id]),
+    ];
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-studio-next-steps', 'mel-event-extras-studio__next-steps']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Suggested next steps'),
+        '#attributes' => ['class' => ['mel-event-studio-next-steps__title']],
+      ],
+      'items' => [
+        '#theme' => 'item_list',
+        '#items' => $items,
+        '#attributes' => ['class' => ['mel-event-studio-next-steps__list']],
+      ],
+    ];
+  }
+
+  /**
+   * @param list<array<string, mixed>> $cards
+   *
+   * @return array<string, mixed>|null
+   */
+  private function selectListPreviewCard(array $cards): ?array {
+    if ($cards === []) {
+      return NULL;
+    }
+    foreach ($cards as $card) {
+      if (!empty($card['show_on_booking'])) {
+        return $card;
+      }
+    }
+    return $cards[0];
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioExtrasProductEditorBuilder.php
@@ -96,51 +96,78 @@ final class EventStudioExtrasProductEditorBuilder {
 
     $actions = $this->buildActionsSection();
 
-    $editor['accordion'] = [
+    $setup_summary = $this->buildProductSetupSummarySection(
+      $defaults,
+      $product,
+      $event,
+      $is_merch,
+      $rows,
+      $variation_fields,
+    );
+    $preview = $this->buildPreviewSection($product, $event, $defaults, $form_state);
+
+    $editor['layout'] = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-product-editor__accordion']],
-      'basics' => $this->buildAccordionPanel(
-        'basics',
-        (string) $this->t('Basics'),
-        (string) $this->t('Name, description, status, and default price for new options.'),
-        $open['basics'],
-        $this->buildBasicsPanelContent($defaults, $product, $extra_type, $is_merch),
-      ),
-      'photos' => $this->buildAccordionPanel(
-        'photos',
-        (string) $this->t('Photos'),
-        (string) $this->t('Images customers see on the booking page.'),
-        $open['photos'],
-        $this->buildMediaPanelContent($form, $form_state, $event, $product, $extra_type, $product_fields),
-      ),
-      'product_options' => $this->buildAccordionPanel(
-        'product_options',
-        (string) $this->t('Product options'),
-        (string) $this->t('Each option is something customers can buy.'),
-        $open['product_options'],
-        $this->buildProductOptionsPanelContent($defaults, $variation_fields, $form_state),
-      ),
-      'stock_limits' => $this->buildAccordionPanel(
-        'stock_limits',
-        (string) $this->t('Stock and limits'),
-        (string) $this->t('Inventory and per-order limits for each option.'),
-        $open['stock_limits'],
-        $this->buildStockLimitsPanelContent($defaults, $variation_fields, $form_state, $rows),
-      ),
-      'booking_preview' => $this->buildAccordionPanel(
-        'booking_preview',
-        (string) $this->t('Booking preview'),
-        (string) $this->t('How this item may appear to customers.'),
-        $open['booking_preview'],
-        $this->buildPreviewPanelContent($product, $event, $defaults, $form_state, $rows),
-      ),
-      'collection_documents' => $this->buildAccordionPanel(
-        'collection_documents',
-        (string) $this->t('Collection and documents'),
-        (string) $this->t('Pickup notes, booking visibility, and operational print guidance.'),
-        $open['collection_documents'],
-        $this->buildCollectionDocumentsPanelContent($defaults, $event),
-      ),
+      '#attributes' => ['class' => ['mel-event-product-editor__layout']],
+      'main' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__main']],
+        'accordion' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-event-product-editor__accordion']],
+          'basics' => $this->buildAccordionPanel(
+            'basics',
+            (string) $this->t('Basics'),
+            (string) $this->t('Name, description, status, and default price for new options.'),
+            $open['basics'],
+            $this->buildBasicsPanelContent($defaults, $product, $extra_type, $is_merch),
+          ),
+          'photos' => $this->buildAccordionPanel(
+            'photos',
+            (string) $this->t('Photos'),
+            (string) $this->t('Images customers see on the booking page.'),
+            $open['photos'],
+            $this->buildMediaPanelContent($form, $form_state, $event, $product, $extra_type, $product_fields),
+          ),
+          'product_options' => $this->buildAccordionPanel(
+            'product_options',
+            (string) $this->t('Product options'),
+            (string) $this->t('Each option is something customers can buy.'),
+            $open['product_options'],
+            $this->buildProductOptionsPanelContent($defaults, $variation_fields, $form_state),
+          ),
+          'stock_limits' => $this->buildAccordionPanel(
+            'stock_limits',
+            (string) $this->t('Stock and limits'),
+            (string) $this->t('Inventory and per-order limits for each option.'),
+            $open['stock_limits'],
+            $this->buildStockLimitsPanelContent($defaults, $variation_fields, $form_state, $rows),
+          ),
+          'collection_documents' => $this->buildAccordionPanel(
+            'collection_documents',
+            (string) $this->t('Collection and documents'),
+            (string) $this->t('Pickup notes, booking visibility, and operational print guidance.'),
+            $open['collection_documents'],
+            $this->buildCollectionDocumentsPanelContent($defaults, $event),
+          ),
+        ],
+      ],
+      'aside' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-product-editor__aside']],
+        'setup_summary' => $setup_summary['setup_summary'],
+        'booking_preview' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['mel-es-card', 'mel-event-product-editor__aside-preview']],
+          'title' => [
+            '#type' => 'html_tag',
+            '#tag' => 'h3',
+            '#value' => $this->t('Booking preview'),
+            '#attributes' => ['class' => ['mel-es-card__title']],
+          ],
+          'preview' => $preview['customer_preview'],
+        ],
+      ],
     ];
 
     $editor['footer'] = $this->buildFooterNav($event, $actions);

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-configured-summary.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-extras-configured-summary.html.twig
@@ -62,7 +62,7 @@
     </div>
   {% endif %}
 
-  {% if panel.manage_url %}
+  {% if panel.manage_url and not panel.hide_manage_cta|default(false) %}
     <div class="mel-event-extras-studio__configured-actions">
       <a href="{{ panel.manage_url }}" class="mel-btn mel-btn--primary">{{ panel.manage_label|default('Manage merch & add-ons'|t) }}</a>
     </div>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioExtrasProductEditorTest.php
@@ -182,6 +182,9 @@ final class EventStudioExtrasProductEditorTest extends TestCase {
     $this->assertIsString($twig);
     $this->assertStringContainsString('#preview_meta_line', $builder);
     $this->assertStringContainsString('preview_meta_line', $twig);
+    $this->assertStringContainsString('mel-event-product-editor__layout', $builder);
+    $this->assertStringContainsString('mel-event-product-editor__aside', $builder);
+    $this->assertStringContainsString('buildProductSetupSummarySection', $builder);
   }
 
   public function testStockHelperCopyAppearsOnceInStockPanel(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -132,11 +132,17 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
   public function testConfiguredExtrasSummaryBuilderExists(): void {
     $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioExtrasConfiguredSummaryBuilder.php');
     $template = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-extras-configured-summary.html.twig');
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioEventExtrasForm.php');
     $this->assertIsString($builder);
     $this->assertIsString($template);
+    $this->assertIsString($form);
     $this->assertStringContainsString('has_products', $builder);
     $this->assertStringContainsString('empty_state', $builder);
     $this->assertStringContainsString('Add merch or extras', $builder);
+    $this->assertStringContainsString('buildStudioAsideRenderArray', $builder);
+    $this->assertStringContainsString('mel-event-extras-studio__layout', $form);
+    $this->assertStringContainsString('buildStudioAsideRenderArray', $form);
+    $this->assertStringContainsString('hide_manage_cta', $template);
     $this->assertStringContainsString('empty.title', $template);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation and form structure only; no changes to Commerce save, stock enforcement, or checkout paths.
> 
> **Overview**
> Adds **internal documentation** for how to write Cursor prompts for MEL (`docs/ai/chatgpt-cursor-prompt-framing.md`).
> 
> **Merch & add-ons Studio (list mode)** is reorganized into a **main + sticky aside** layout: the list, placement, probes, and footer stay in the main column; the aside is built by `EventStudioExtrasConfiguredSummaryBuilder` via new `buildStudioAsideRenderArray()` (configured summary, a **booking preview** card with empty/live states, and **suggested next steps**). The form wires this through `EventStudioEventExtrasForm` and injects the summary builder service (including form-cache unserialization).
> 
> The **configured summary** Twig hides the “Manage merch & add-ons” CTA when `hide_manage_cta` is set (already on the Studio page). SCSS adds grid, stats, preview, and next-steps styling for list and product-editor layouts.
> 
> **Product editor** moves **booking preview** and a **setup summary** into a sticky right rail (`mel-event-product-editor__layout`); accordion panels remain on the left without a separate booking-preview accordion section.
> 
> Unit tests are updated to assert the new layout/aside contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e86ac2adaa2909fc9abb41f36675ad70b32984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->