### PR TITLE
Cursor/event layout main 566f1

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-cinematic-convergence.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-cinematic-convergence.scss
@@ -26,8 +26,8 @@
   --mel-editorial-muted-leading: 1.5;
 }
 
-// Main column: one vertical cadence (replaces stacked mel-mt-5 jumps). Event-full primary owns layout.
-.mel-event--v2 .mel-event-layout__main:not(.mel-event-full__primary) {
+// Main column: one vertical cadence (replaces stacked mel-mt-5 jumps). Event-full layout owns grid.
+.mel-event--v2 .mel-event-layout__main:not(.mel-event-full__main) {
   display: flex;
   flex-direction: column;
   gap: var(--mel-editorial-section-gap);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -2856,9 +2856,9 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   margin-inline: auto;
 }
 
-// Desktop + tablet: main column stacks hero + content; sidebar aligns to hero top (col 2).
-.mel-event-page--classic.mel-event--v2 .mel-event-full__primary,
-.mel-event-page--immersive.mel-event--v2 .mel-event-full__primary {
+// Desktop + tablet: full-width hero, then main + sidebar (avoids row-1 height = max(hero, sidebar) gap).
+.mel-event-page--classic.mel-event--v2 .mel-event-full__layout,
+.mel-event-page--immersive.mel-event--v2 .mel-event-full__layout {
   display: grid;
   gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
@@ -2877,6 +2877,26 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
     gap: 32px;
     align-items: start;
   }
+
+  @media (width >= 768px) {
+    .mel-event-full__main--hero {
+      grid-column: 1 / -1;
+      grid-row: 1;
+    }
+
+    .mel-event-full__main--content {
+      grid-column: 1;
+      grid-row: 2;
+    }
+
+    .mel-event-full__sidebar {
+      grid-column: 2;
+      grid-row: 2;
+      align-self: start;
+      position: sticky;
+      top: var(--mel-sticky-offset, 5.5rem);
+    }
+  }
 }
 
 .mel-event-full__main,
@@ -2886,20 +2906,6 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   flex-direction: column;
   gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
-
-  @media (width >= 1100px) {
-    grid-column: 1;
-  }
-}
-
-@media (width >= 1100px) {
-  .mel-event-full__main--hero {
-    grid-row: 1;
-  }
-
-  .mel-event-full__main--content {
-    grid-row: 2;
-  }
 }
 
 .mel-event-full__sidebar {
@@ -2907,14 +2913,6 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   flex-direction: column;
   gap: var(--mel-full-stack-gap, 20px);
   min-width: 0;
-
-  @media (width >= 1100px) {
-    grid-column: 2;
-    grid-row: 1;
-    align-self: start;
-    position: sticky;
-    top: var(--mel-sticky-offset, 5.5rem);
-  }
 }
 
 .mel-event-full .mel-event-sidebar-rail {
@@ -3259,7 +3257,7 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   border-top: 0;
 }
 
-// Help links — after main content in DOM; desktop grid places in right column below sidebar.
+// Help links — after main content in DOM; desktop grid stacks in right column below sidebar.
 .mel-event-full__support.mel-event-support-zone {
   margin-top: 0;
   padding: 12px 16px;
@@ -3269,7 +3267,7 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   box-shadow: none;
   color: var(--mel-full-text-secondary, #5b6670);
 
-  @media (width >= 1100px) {
+  @media (width >= 768px) {
     grid-column: 2;
     grid-row: 2;
     align-self: start;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-page-themes.scss
@@ -713,7 +713,7 @@ main.mel-main:has(.mel-event-page--immersive.mel-event--v2) {
     }
   }
 
-  .mel-event-layout__main:not(.mel-event-full__primary),
+  .mel-event-layout__main:not(.mel-event-full__main),
   .mel-event-layout__sidebar:not(.mel-event-full__sidebar) {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only SCSS for event full layouts; no PHP or booking logic, but layout regressions on classic/immersive event pages are worth a quick visual check at 768px and 1100px.
> 
> **Overview**
> This PR retunes **v2 event full page** layout in SCSS so the hero, main column, and sidebar behave correctly on tablet/desktop.
> 
> **Grid on `mel-event-full__layout`** (classic + immersive): the responsive grid now applies to the layout wrapper instead of a single primary column. From **768px**, the hero spans full width (row 1), body content sits in column 1 (row 2), and the **sticky** sidebar aligns to column 2 (row 2)—fixing the old pattern where row 1 height followed `max(hero, sidebar)` and left a large gap under the hero.
> 
> **Selector rename**: editorial/immersive “don’t double-stack flex on event-full” rules now exclude **`mel-event-full__main`** instead of **`mel-event-full__primary`**, matching the Twig structure.
> 
> **Support zone**: help links in the right column use the same grid placement from **768px** (was **1100px**), with duplicate per-breakpoint grid rules on main/sidebar consolidated under the layout block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac7293b41d0146d4346c6b6b4f126e03e5394c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->