### PR TITLE
Fix/deploy release prune permissions

### DIFF
--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -132,10 +132,57 @@ mel_check_disk_space() {
   fi
 }
 
+# Strip sites/default symlinks (shared files, settings, etc.) before rm so we never
+# touch live shared paths and so web-server-owned targets are not involved.
+mel_prepare_release_for_removal() {
+  local release_dir="$1"
+  local default_dir="$release_dir/web/sites/default"
+  local entry known
+
+  [ -d "$default_dir" ] || return 0
+
+  for known in files settings.php services.yml config; do
+    if [ -L "$default_dir/$known" ]; then
+      rm -f "$default_dir/$known" || true
+    fi
+  done
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    rm -f "$entry" || true
+  done < <(find "$default_dir" -maxdepth 1 -type l 2>/dev/null || true)
+
+  chmod -R u+w "$release_dir" 2>/dev/null || true
+}
+
+# Best-effort release removal. Pruning must not abort deploy: old trees often
+# contain www-data-owned files under sites/default from prior live releases.
+mel_remove_release_dir() {
+  local release_dir="$1"
+  local name
+  name="$(basename "$release_dir")"
+
+  mel_prepare_release_for_removal "$release_dir"
+
+  set +e
+  rm -rf "$release_dir" 2>/dev/null
+  local rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ] && [ ! -e "$release_dir" ]; then
+    return 0
+  fi
+
+  echo "  WARNING: could not fully remove release $name (permission denied on some paths)." >&2
+  echo "  On the staging host, remove leftovers manually or fix ownership under:" >&2
+  echo "    $release_dir/web/sites/default" >&2
+  return 0
+}
+
 mel_prune_old_releases() {
   local keep="${MEL_KEEP_RELEASES}"
   local releases_dir="$APP_PATH/releases"
-  local protected="" dir name candidates=() count i
+  local protected="" dir name candidates=() count i prune_failed=0
 
   [ -d "$releases_dir" ] || return 0
 
@@ -165,8 +212,17 @@ mel_prune_old_releases() {
   for ((i=keep; i<count; i++)); do
     name="$(basename "${candidates[$i]}")"
     echo "  Removing old release: $name"
-    rm -rf "${candidates[$i]}"
+    if [ -e "${candidates[$i]}" ]; then
+      mel_remove_release_dir "${candidates[$i]}"
+      if [ -e "${candidates[$i]}" ]; then
+        prune_failed=1
+      fi
+    fi
   done
+
+  if [ "$prune_failed" = "1" ]; then
+    echo "  NOTICE: Some old releases could not be pruned (non-fatal). Disk preflight will still run." >&2
+  fi
 }
 
 mel_deploy_cleanup() {

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -233,7 +233,7 @@ mel_deploy_cleanup() {
   echo "DEPLOY FAILED — cleanup: restoring previous release (if any) and clearing maintenance mode..." >&2
   if [ -n "${RELEASE_PATH:-}" ] && [ -d "$RELEASE_PATH" ]; then
     echo "  Removing failed partial release: $RELEASE_PATH" >&2
-    rm -rf "$RELEASE_PATH" || true
+    mel_remove_release_dir "$RELEASE_PATH"
   fi
   if [ "${MEL_CURRENT_SWITCHED:-0}" = "1" ] && [ -n "${MEL_PREVIOUS_CURRENT:-}" ] && [ -d "$MEL_PREVIOUS_CURRENT" ]; then
     echo "  Rolling back current symlink to: $MEL_PREVIOUS_CURRENT" >&2

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -24,6 +24,182 @@ final class EventStudioMelPayloadService {
   ) {}
 
   /**
+   * Normalizes hero fid + alt from `mel` or baseline fragments.
+   *
+   * Supports legacy `managed_file` values (`mel[field_event_image]` fid list),
+   * optional `mel[field_event_image_alt]`, and image / image_widget_crop widgets
+   * (`mel[field_event_image][0][fids]`, `…[0][alt]`).
+   *
+   * @param array<string, mixed> $fragment
+   *   Partial or full mel array containing `field_event_image` / `field_event_image_alt`.
+   *
+   * @return array{fid: int, alt: string}
+   */
+  public static function normalizeHeroFromMelFragment(array $fragment): array {
+    $explicit_alt = trim((string) ($fragment['field_event_image_alt'] ?? ''));
+    $fid = 0;
+    $delta_alt = '';
+
+    $raw = $fragment['field_event_image'] ?? NULL;
+    if (is_numeric($raw)) {
+      $fid = (int) $raw;
+    }
+    elseif (is_array($raw) && $raw !== []) {
+      $delta = self::imageWidgetDeltaFromRaw($raw);
+      $fid = self::firstPositiveIntFromFidsValue($delta['fids'] ?? NULL);
+      if ($fid < 1 && isset($delta['target_id'])) {
+        $fid = max(0, (int) $delta['target_id']);
+      }
+      if (isset($delta['alt'])) {
+        $delta_alt = trim((string) $delta['alt']);
+      }
+
+      if ($fid < 1) {
+        foreach ($raw as $item) {
+          if (is_array($item)) {
+            if (isset($item['target_id']) && is_numeric($item['target_id'])) {
+              $tid = (int) $item['target_id'];
+              if ($tid > 0) {
+                $fid = $tid;
+                if ($delta_alt === '' && isset($item['alt'])) {
+                  $delta_alt = trim((string) $item['alt']);
+                }
+                break;
+              }
+            }
+            if (isset($item['fids']) && is_array($item['fids'])) {
+              foreach ($item['fids'] as $maybe_fid) {
+                if (is_numeric($maybe_fid)) {
+                  $tid = (int) $maybe_fid;
+                  if ($tid > 0) {
+                    $fid = $tid;
+                    if ($delta_alt === '' && isset($item['alt'])) {
+                      $delta_alt = trim((string) $item['alt']);
+                    }
+                    break 2;
+                  }
+                }
+              }
+            }
+          }
+          elseif (is_numeric($item)) {
+            $tid = (int) $item;
+            if ($tid > 0) {
+              $fid = $tid;
+              break;
+            }
+          }
+        }
+        if ($fid < 1) {
+          $first = reset($raw);
+          if (is_numeric($first)) {
+            $fid = (int) $first;
+          }
+        }
+      }
+    }
+
+    $alt = $explicit_alt !== '' ? $explicit_alt : $delta_alt;
+
+    return [
+      'fid' => max(0, $fid),
+      'alt' => $alt,
+    ];
+  }
+
+  /**
+   * Unwraps an image field widget value to its first delta array.
+   *
+   * @param array<string, mixed> $raw
+   *
+   * @return array<string, mixed>
+   */
+  public static function imageWidgetDeltaFromRaw(array $raw): array {
+    if (isset($raw['widget']) && is_array($raw['widget'])) {
+      $raw = $raw['widget'];
+    }
+    if (isset($raw[0]) && is_array($raw[0])) {
+      return $raw[0];
+    }
+
+    return $raw;
+  }
+
+  /**
+   * Builds a `field_event_image` item from a mel fragment (branding widget save).
+   *
+   * @param array<string, mixed> $fragment
+   *
+   * @return array<string, mixed>|null
+   *   NULL when no file is selected.
+   */
+  public static function buildHeroFieldItemFromMelFragment(array $fragment): ?array {
+    $hero = self::normalizeHeroFromMelFragment($fragment);
+    if ($hero['fid'] < 1) {
+      return NULL;
+    }
+
+    $raw = $fragment['field_event_image'] ?? [];
+    if (!is_array($raw)) {
+      $raw = [];
+    }
+    $delta = self::imageWidgetDeltaFromRaw($raw);
+
+    $item = [
+      'target_id' => $hero['fid'],
+      'alt' => $hero['alt'],
+      'title' => trim((string) ($delta['title'] ?? '')),
+    ];
+
+    if (isset($delta['focal_point']) && trim((string) $delta['focal_point']) !== '') {
+      $item['focal_point'] = trim((string) $delta['focal_point']);
+    }
+
+    foreach (['width', 'height'] as $key) {
+      if (isset($delta[$key]) && $delta[$key] !== '' && $delta[$key] !== NULL) {
+        $item[$key] = $delta[$key];
+      }
+    }
+
+    return $item;
+  }
+
+  /**
+   * @return int
+   *   First positive file id from a managed_file / image widget fids value.
+   */
+  private static function firstPositiveIntFromFidsValue(mixed $fids): int {
+    if ($fids === NULL || $fids === '') {
+      return 0;
+    }
+    if (is_array($fids)) {
+      foreach ($fids as $value) {
+        $candidate = (int) $value;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+      return 0;
+    }
+    if (is_string($fids)) {
+      $parts = preg_split('/\s+/', trim($fids));
+      if (!is_array($parts)) {
+        return 0;
+      }
+      foreach ($parts as $part) {
+        if ($part === '') {
+          continue;
+        }
+        $candidate = (int) $part;
+        if ($candidate > 0) {
+          return $candidate;
+        }
+      }
+    }
+    return 0;
+  }
+
+  /**
    * @return array<string, mixed>
    */
   public function buildFromFormState(FormStateInterface $form_state, EntityTypeManagerInterface $entityTypeManager): array {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Deploy changes affect release cleanup and could leave orphaned release dirs on disk, but reduce deploy abort risk; hero parsing touches event save payloads across Studio flows.
> 
> **Overview**
> **Remote deploy** now removes old and failed releases through a **best-effort** path instead of a bare `rm -rf` that could abort the job. Before delete, it strips `sites/default` symlinks to shared assets (`files`, `settings.php`, etc.) and relaxes write bits on the release tree so deploy users are less likely to follow links into live shared paths or fight `www-data`-owned files. Partial prune failures emit warnings and a non-fatal notice; deploy continues and disk preflight still runs.
> 
> **Event Studio** adds shared static helpers on `EventStudioMelPayloadService` to normalize hero image **file id** and **alt** from heterogeneous `mel` shapes (legacy managed file lists, explicit alt, image/crop widget deltas with `fids`/`target_id`), and to build a full `field_event_image` field item (title, focal point, dimensions) for branding saves. `buildFromFormState` now routes hero fields through that normalizer so wizard/autosave/branding stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0502eecd579132396cb411b61c31f91a3a1f0fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->