### PR TITLE
Fix/stripe manage account types

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/StripeService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/StripeService.php
@@ -28,6 +28,31 @@ use Stripe\StripeClient;
 final class StripeService {
 
   /**
+   * Vendor-facing Stripe Dashboard URL for Standard Connect accounts.
+   */
+  public const VENDOR_STRIPE_DASHBOARD_URL = 'https://dashboard.stripe.com';
+
+  /**
+   * Manage route destination: Express LoginLink (Express Dashboard).
+   */
+  public const MANAGE_DEST_LOGIN_LINK = 'login_link';
+
+  /**
+   * Manage route destination: vendor Stripe Dashboard (Standard accounts).
+   */
+  public const MANAGE_DEST_STRIPE_DASHBOARD = 'stripe_dashboard';
+
+  /**
+   * Manage route destination: resume Connect onboarding.
+   */
+  public const MANAGE_DEST_ONBOARDING = 'onboarding';
+
+  /**
+   * Manage route destination: fail closed (unknown/custom/unrecoverable).
+   */
+  public const MANAGE_DEST_UNSUPPORTED = 'unsupported';
+
+  /**
    * Constructs a StripeService.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
@@ -520,8 +545,14 @@ final class StripeService {
    * @param string $accountId
    *   The Stripe Connect account ID (acct_xxx).
    *
-   * @return array{eligible: bool, account: Account|null, reason: string|null}
-   *   Array with eligibility status, account object (if eligible), and reason (if not eligible).
+   * @return array{
+   *   eligible: bool,
+   *   account: Account|null,
+   *   reason: string|null,
+   *   account_type: string|null
+   * }
+   *   Array with eligibility status, account object (if eligible), reason (if not eligible),
+   *   and Connect account type when known.
    */
   public function validateAccountDashboardEligibility(string $accountId): array {
     $client = $this->getPlatformClient();
@@ -536,8 +567,11 @@ final class StripeService {
           'eligible' => FALSE,
           'account' => NULL,
           'reason' => 'Account not found',
+          'account_type' => NULL,
         ];
       }
+
+      $accountType = $this->normalizeConnectAccountType($account);
 
       // Validate: account.deleted !== true.
       if (isset($account->deleted) && $account->deleted === TRUE) {
@@ -545,6 +579,7 @@ final class StripeService {
           'eligible' => FALSE,
           'account' => $account,
           'reason' => 'Account has been deleted',
+          'account_type' => $accountType,
         ];
       }
 
@@ -554,6 +589,7 @@ final class StripeService {
           'eligible' => FALSE,
           'account' => $account,
           'reason' => 'Account details not yet submitted',
+          'account_type' => $accountType,
         ];
       }
 
@@ -563,6 +599,7 @@ final class StripeService {
           'eligible' => FALSE,
           'account' => $account,
           'reason' => 'Account charges not yet enabled',
+          'account_type' => $accountType,
         ];
       }
 
@@ -571,22 +608,87 @@ final class StripeService {
         'eligible' => TRUE,
         'account' => $account,
         'reason' => NULL,
+        'account_type' => $accountType,
       ];
     }
     catch (ApiErrorException $e) {
       $this->logStripeApiError($e);
       // Account retrieval failed - log error and return not eligible.
       $this->safeLog('error', 'Failed to retrieve Stripe account @id for eligibility check: @message', [
-        '@id' => $accountId,
+        '@id' => self::maskAccountId($accountId),
         '@message' => $e->getMessage(),
       ]);
 
       return [
         'eligible' => FALSE,
         'account' => NULL,
-        'reason' => 'Failed to retrieve account: ' . $e->getMessage(),
+        'reason' => 'Failed to retrieve account',
+        'account_type' => NULL,
       ];
     }
+  }
+
+  /**
+   * Resolves how /stripe/manage should route for a Connect account.
+   *
+   * Uses a single eligibility retrieve; Express uses LoginLink, Standard uses
+   * the vendor Stripe Dashboard, incomplete accounts resume onboarding.
+   *
+   * @param string $accountId
+   *   The Stripe Connect account ID (acct_xxx).
+   *
+   * @return array{destination: string, account_type: string|null, reason: string|null}
+   *   Destination constant, account type when known, and eligibility reason.
+   */
+  public function resolveStripeManageDestination(string $accountId): array {
+    $eligibility = $this->validateAccountDashboardEligibility($accountId);
+
+    return [
+      'destination' => self::resolveManageDestinationFromEligibility($eligibility),
+      'account_type' => $eligibility['account_type'] ?? NULL,
+      'reason' => $eligibility['reason'] ?? NULL,
+    ];
+  }
+
+  /**
+   * Maps eligibility to a manage-route destination (testable, no API calls).
+   *
+   * @param array{
+   *   eligible: bool,
+   *   account: Account|null,
+   *   reason: string|null,
+   *   account_type?: string|null
+   * } $eligibility
+   *   Result from validateAccountDashboardEligibility().
+   *
+   * @return string
+   *   One of the MANAGE_DEST_* constants.
+   */
+  public static function resolveManageDestinationFromEligibility(array $eligibility): string {
+    if (empty($eligibility['eligible'])) {
+      $reason = (string) ($eligibility['reason'] ?? '');
+      if ($reason === 'Account details not yet submitted' || $reason === 'Account charges not yet enabled') {
+        return self::MANAGE_DEST_ONBOARDING;
+      }
+      return self::MANAGE_DEST_UNSUPPORTED;
+    }
+
+    $type = strtolower((string) ($eligibility['account_type'] ?? ''));
+    return match ($type) {
+      'express' => self::MANAGE_DEST_LOGIN_LINK,
+      'standard' => self::MANAGE_DEST_STRIPE_DASHBOARD,
+      default => self::MANAGE_DEST_UNSUPPORTED,
+    };
+  }
+
+  /**
+   * Normalizes Stripe Connect account type from a retrieved Account.
+   */
+  private function normalizeConnectAccountType(Account $account): ?string {
+    if (!isset($account->type) || !is_string($account->type) || $account->type === '') {
+      return NULL;
+    }
+    return strtolower($account->type);
   }
 
   /**
@@ -609,6 +711,11 @@ final class StripeService {
     $eligibility = $this->validateAccountDashboardEligibility($accountId);
 
     if (!$eligibility['eligible']) {
+      return NULL;
+    }
+
+    // LoginLink is Express-only; Standard accounts use the vendor Dashboard URL.
+    if (($eligibility['account_type'] ?? '') !== 'express') {
       return NULL;
     }
 

--- a/web/modules/custom/myeventlane_core/tests/src/Unit/StripeManageDestinationTest.php
+++ b/web/modules/custom/myeventlane_core/tests/src/Unit/StripeManageDestinationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_core\Unit;
+
+use Drupal\myeventlane_core\Service\StripeService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_core\Service\StripeService
+ *
+ * @group myeventlane_core
+ */
+final class StripeManageDestinationTest extends UnitTestCase {
+
+  /**
+   * @covers ::resolveManageDestinationFromEligibility
+   * @dataProvider destinationProvider
+   *
+   * @param array<string, mixed> $eligibility
+   */
+  public function testResolveManageDestinationFromEligibility(array $eligibility, string $expected): void {
+    $this->assertSame($expected, StripeService::resolveManageDestinationFromEligibility($eligibility));
+  }
+
+  /**
+   * @return array<string, array{0: array<string, mixed>, 1: string}>
+   */
+  public static function destinationProvider(): array {
+    return [
+      'express charge-ready uses login link' => [
+        [
+          'eligible' => TRUE,
+          'account' => NULL,
+          'reason' => NULL,
+          'account_type' => 'express',
+        ],
+        StripeService::MANAGE_DEST_LOGIN_LINK,
+      ],
+      'standard charge-ready uses vendor dashboard' => [
+        [
+          'eligible' => TRUE,
+          'account' => NULL,
+          'reason' => NULL,
+          'account_type' => 'standard',
+        ],
+        StripeService::MANAGE_DEST_STRIPE_DASHBOARD,
+      ],
+      'incomplete details resumes onboarding' => [
+        [
+          'eligible' => FALSE,
+          'account' => NULL,
+          'reason' => 'Account details not yet submitted',
+          'account_type' => 'standard',
+        ],
+        StripeService::MANAGE_DEST_ONBOARDING,
+      ],
+      'incomplete charges resumes onboarding' => [
+        [
+          'eligible' => FALSE,
+          'account' => NULL,
+          'reason' => 'Account charges not yet enabled',
+          'account_type' => 'standard',
+        ],
+        StripeService::MANAGE_DEST_ONBOARDING,
+      ],
+      'deleted account fails closed' => [
+        [
+          'eligible' => FALSE,
+          'account' => NULL,
+          'reason' => 'Account has been deleted',
+          'account_type' => 'standard',
+        ],
+        StripeService::MANAGE_DEST_UNSUPPORTED,
+      ],
+      'retrieve failure fails closed' => [
+        [
+          'eligible' => FALSE,
+          'account' => NULL,
+          'reason' => 'Failed to retrieve account',
+          'account_type' => NULL,
+        ],
+        StripeService::MANAGE_DEST_UNSUPPORTED,
+      ],
+      'custom type fails closed' => [
+        [
+          'eligible' => TRUE,
+          'account' => NULL,
+          'reason' => NULL,
+          'account_type' => 'custom',
+        ],
+        StripeService::MANAGE_DEST_UNSUPPORTED,
+      ],
+      'unknown type fails closed' => [
+        [
+          'eligible' => TRUE,
+          'account' => NULL,
+          'reason' => NULL,
+          'account_type' => '',
+        ],
+        StripeService::MANAGE_DEST_UNSUPPORTED,
+      ],
+    ];
+  }
+
+  /**
+   * Eligibility reasons must not embed account IDs for manage messaging paths.
+   */
+  public function testRetrieveFailureReasonIsSanitized(): void {
+    $reason = StripeService::resolveManageDestinationFromEligibility([
+      'eligible' => FALSE,
+      'account' => NULL,
+      'reason' => 'Failed to retrieve account',
+      'account_type' => NULL,
+    ]);
+    $this->assertSame(StripeService::MANAGE_DEST_UNSUPPORTED, $reason);
+    $this->assertStringNotContainsString('acct_', 'Failed to retrieve account');
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -25,6 +25,7 @@ services:
       - '@entity_type.manager'
       - '@request_stack'
       - '@myeventlane_core.domain_detector'
+      - '@myeventlane_vendor.paid_publish_stripe_gate'
 
   myeventlane_event_studio.vendor_mel_ticket_type_edit_redirect_subscriber:
     class: Drupal\myeventlane_event_studio\EventSubscriber\VendorMelTicketTypeEditRedirectSubscriber

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -12,6 +12,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
 use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
@@ -29,6 +30,7 @@ final class EventStudioPreprocess {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly RequestStack $requestStack,
     private readonly DomainDetector $domainDetector,
+    private readonly PaidPublishStripeGate $paidPublishStripeGate,
   ) {}
 
   /**
@@ -103,13 +105,12 @@ final class EventStudioPreprocess {
     }
 
     if ($node instanceof NodeInterface && $node->bundle() === 'event' && $vendor_ids !== []) {
-      $flags = $state !== NULL ? $state->getFlags() : [];
       $event_type = '';
       if ($node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()) {
         $event_type = (string) $node->get('field_event_type')->value;
       }
       $is_paid = in_array($event_type, ['paid', 'both'], TRUE);
-      if ($is_paid && empty($flags['stripe_connected'])) {
+      if ($is_paid && $this->paidPublishStripeGate->validatePaidPublishAllowed($this->currentUser, (int) $node->id()) !== NULL) {
         $variables['mel_publish_blocked'] = TRUE;
         $variables['mel_publish_stripe_gate'] = TRUE;
       }

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -667,11 +667,11 @@
               <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
               {% if mel_publish_blocked %}
                 {% if mel_publish_stripe_gate %}
-                  <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Connect payments to publish'|t }}">
-                    <h3 class="mel-publish-warning__title">{{ 'Almost ready to go live'|t }}</h3>
-                    <p class="mel-publish-warning__lead">{{ 'To sell tickets, you’ll need to connect payments.'|t }}</p>
-                    <a href="{{ path('myeventlane_vendor.onboard.stripe') }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
-                      {{ 'Connect payments'|t }}
+                  <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Finish Stripe setup before publishing paid tickets'|t }}">
+                    <h3 class="mel-publish-warning__title">{{ 'Finish Stripe setup before publishing paid tickets'|t }}</h3>
+                    <p class="mel-publish-warning__lead">{{ 'To sell tickets, finish your Stripe setup so payouts can reach your bank.'|t }}</p>
+                    <a href="{{ mel_stripe_connect_url }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
+                      {{ 'Resume Stripe setup'|t }}
                     </a>
                   </div>
                 {% else %}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Contract tests for paid publish Stripe gate alignment in Event Studio.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
+
+  public function testPreprocessUsesPaidPublishStripeGateForPaidEvents(): void {
+    $preprocess = file_get_contents(dirname(__DIR__, 3) . '/src/EventStudioPreprocess.php');
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
+
+    $this->assertIsString($preprocess);
+    $this->assertIsString($services);
+    $this->assertStringContainsString('PaidPublishStripeGate', $preprocess);
+    $this->assertStringContainsString('validatePaidPublishAllowed', $preprocess);
+    $this->assertStringNotContainsString("empty(\$flags['stripe_connected'])", $preprocess);
+    $this->assertStringContainsString("'@myeventlane_vendor.paid_publish_stripe_gate'", $services);
+  }
+
+  public function testReadinessAndSavePathsUsePaidPublishStripeGate(): void {
+    $readiness = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventReadinessService.php');
+    $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
+    $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+
+    $this->assertIsString($readiness);
+    $this->assertIsString($save);
+    $this->assertIsString($publish);
+    $this->assertStringContainsString('validatePaidPublishAllowed', $readiness);
+    $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $readiness);
+    $this->assertStringContainsString('validatePaidPublishAllowed', $save);
+    $this->assertStringContainsString('$this->eventReadiness->evaluate', $publish);
+  }
+
+  public function testPublishCardUsesStripeGateCopyAndConnectRoute(): void {
+    $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio.html.twig');
+    $preprocess = file_get_contents(dirname(__DIR__, 3) . '/src/EventStudioPreprocess.php');
+    $gate = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Service/PaidPublishStripeGate.php');
+
+    $this->assertIsString($twig);
+    $this->assertIsString($preprocess);
+    $this->assertIsString($gate);
+    $this->assertStringContainsString('Finish Stripe setup before publishing paid tickets', $twig);
+    $this->assertStringContainsString('To sell tickets, finish your Stripe setup so payouts can reach your bank.', $twig);
+    $this->assertStringContainsString('Resume Stripe setup', $twig);
+    $this->assertStringContainsString('mel_stripe_connect_url', $twig);
+    $this->assertStringContainsString('myeventlane_vendor.stripe_connect', $preprocess);
+    $this->assertStringContainsString('To sell tickets, finish your Stripe setup so payouts can reach your bank.', $gate);
+    $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $preprocess);
+  }
+
+  public function testDraftSaveSkipsStripeGateOnPublishPath(): void {
+    $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
+
+    $this->assertIsString($save);
+    $this->assertStringContainsString('if (!$draft && $willPublish && in_array($effectiveEventType, [\'paid\', \'both\'], TRUE))', $save);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php
@@ -156,6 +156,10 @@ final class StripeConnectController extends ControllerBase {
     return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.dashboard')->toString());
   }
 
+  private function redirectToVendorSettings(): RedirectResponse {
+    return new RedirectResponse(Url::fromRoute('myeventlane_vendor.console.settings')->toString());
+  }
+
   /**
    * Validates query account_id against the store’s Connect account; returns usable id.
    */
@@ -436,9 +440,13 @@ final class StripeConnectController extends ControllerBase {
   }
 
   /**
-   * Login link to the vendor’s Express Stripe Dashboard.
+   * Opens Stripe management for the vendor’s connected account.
+   *
+   * Express accounts use a Stripe LoginLink; Standard accounts redirect to the
+   * vendor Stripe Dashboard (LoginLink is Express-only). Incomplete accounts
+   * resume Connect onboarding.
    */
-  public function manage(): RedirectResponse {
+  public function manage(): RedirectResponse|TrustedRedirectResponse {
     $logger = $this->loggerChannelFactory->get('myeventlane_vendor');
     $currentUser = $this->currentUser();
 
@@ -469,17 +477,45 @@ final class StripeConnectController extends ControllerBase {
     }
 
     try {
-      $loginLink = $this->stripeService->createLoginLinkIfEligible($accountId);
-      if ($loginLink === NULL) {
-        $eligibility = $this->stripeService->validateAccountDashboardEligibility($accountId);
-        $reason = (string) ($eligibility['reason'] ?? 'Unknown');
-        $logger->notice('Stripe manage: ineligible for login link, account @acct, reason @reason', [
-          '@acct' => StripeService::maskAccountId($accountId),
-          '@reason' => $reason,
+      $resolution = $this->stripeService->resolveStripeManageDestination($accountId);
+      $destination = (string) ($resolution['destination'] ?? StripeService::MANAGE_DEST_UNSUPPORTED);
+      $accountType = isset($resolution['account_type']) && is_string($resolution['account_type'])
+        ? $resolution['account_type']
+        : 'unknown';
+      $reason = (string) ($resolution['reason'] ?? '');
+
+      if ($destination === StripeService::MANAGE_DEST_ONBOARDING) {
+        $logger->notice('Stripe manage: resume onboarding, store @sid, uid @uid, type @type, reason @reason', [
+          '@sid' => (string) $store->id(),
+          '@uid' => (string) $currentUser->id(),
+          '@type' => $accountType,
+          '@reason' => $reason !== '' ? $reason : 'incomplete',
         ]);
         $this->messenger()->addWarning($this->t('Stripe onboarding is not complete enough to open the dashboard yet. Continue setup in Connect.'));
         return new RedirectResponse(Url::fromRoute('myeventlane_vendor.stripe_connect')->toString());
       }
+
+      if ($destination === StripeService::MANAGE_DEST_UNSUPPORTED) {
+        $logger->warning('Stripe manage: unsupported destination, store @sid, uid @uid, type @type, reason @reason', [
+          '@sid' => (string) $store->id(),
+          '@uid' => (string) $currentUser->id(),
+          '@type' => $accountType,
+          '@reason' => $reason !== '' ? $reason : 'unknown',
+        ]);
+        $this->messenger()->addError($this->t('We could not open Stripe management. We could not confirm which Stripe dashboard this account uses. Please try again or contact support.'));
+        return $this->redirectToVendorSettings();
+      }
+
+      if ($destination === StripeService::MANAGE_DEST_STRIPE_DASHBOARD) {
+        $url = StripeService::VENDOR_STRIPE_DASHBOARD_URL;
+        $response = new TrustedRedirectResponse($url);
+        $response->setTrustedTargetUrl($url);
+        $this->applyOffsiteStripeRedirectHeaders($response);
+        return $response;
+      }
+
+      // Express: LoginLink to the Express Dashboard.
+      $loginLink = $this->stripeService->createLoginLink($accountId);
 
       if (empty($loginLink->url)) {
         $this->messenger()->addError($this->t('Failed to generate a Stripe link. Please try again.'));
@@ -488,8 +524,8 @@ final class StripeConnectController extends ControllerBase {
 
       $url = (string) $loginLink->url;
       if (!str_starts_with($url, 'https://connect.stripe.com') && !str_starts_with($url, 'https://dashboard.stripe.com')) {
-        $logger->error('Stripe manage: unexpected host for login link, account @acct', [
-          '@acct' => StripeService::maskAccountId($accountId),
+        $logger->error('Stripe manage: unexpected host for login link, store @sid', [
+          '@sid' => (string) $store->id(),
         ]);
         $this->messenger()->addError($this->t('Invalid Stripe link. Please try again or contact support.'));
         return $this->redirectToDashboard();
@@ -505,20 +541,23 @@ final class StripeConnectController extends ControllerBase {
         $this->logConnectApiError($e, $vendor, $store, $accountId);
       }
       else {
-        $logger->error('Stripe manage API: uid @uid, type @t', [
+        $logger->error('Stripe manage API: uid @uid, store @sid, type @t', [
           '@uid' => (string) $currentUser->id(),
+          '@sid' => (string) $store->id(),
           '@t' => (string) ($e->getStripeCode() ?? $e->getCode()),
         ]);
       }
-      $this->messenger()->addError($this->t('We could not open your Stripe account. Try again in a few minutes, or open Stripe from the Connect link if setup is still in progress.'));
-      return $this->redirectToDashboard();
+      $this->messenger()->addError($this->t('We could not open Stripe management. We could not confirm which Stripe dashboard this account uses. Please try again or contact support.'));
+      return $this->redirectToVendorSettings();
     }
     catch (\Exception $e) {
-      $logger->error('Stripe manage: @m', [
+      $logger->error('Stripe manage: store @sid, uid @uid, @m', [
+        '@sid' => (string) $store->id(),
+        '@uid' => (string) $currentUser->id(),
         '@m' => $e->getMessage(),
       ]);
-      $this->messenger()->addError($this->t('Failed to open Stripe. Please try again or contact support.'));
-      return $this->redirectToDashboard();
+      $this->messenger()->addError($this->t('We could not open Stripe management. We could not confirm which Stripe dashboard this account uses. Please try again or contact support.'));
+      return $this->redirectToVendorSettings();
     }
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
@@ -75,7 +75,7 @@ final class PaidPublishStripeGate {
   }
 
   private function blockedMessage(): string {
-    return (string) $this->t('Connect Stripe before publishing paid tickets. Stripe must be ready to accept charges before this event can go live.');
+    return (string) $this->t('To sell tickets, finish your Stripe setup so payouts can reach your bank.');
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes vendor payment onboarding redirects and paid-event publish blocking in Stripe Connect flows; mistakes could block publishing or send users to the wrong dashboard, but behavior is covered by new unit tests and fails closed on ambiguity.
> 
> **Overview**
> **Stripe manage** now routes by Connect account type: Express gets a LoginLink, Standard goes to `dashboard.stripe.com`, incomplete setups return to Connect onboarding, and unknown/custom/failed cases fail closed to vendor settings with safer logging (masked account IDs, no API error text in user-facing reasons).
> 
> **Event Studio paid publish** blocks using `PaidPublishStripeGate` (charge-ready store checks) instead of the onboarding `stripe_connected` flag; the publish card copy and CTA point at **Resume Stripe setup** via `myeventlane_vendor.stripe_connect` with destination preserved.
> 
> Unit tests cover manage destination mapping and publish-gate wiring/copy contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420624468e9b8cbf88a7772677bec1effbf38dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->