### PR TITLE
Cursor/2026 05 29 eino bdc72

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,6 +90,21 @@ jobs:
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
             "echo CONNECTED"
 
+      - name: Preflight staging disk space
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/id_ed25519 \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            'set -euo pipefail
+             APP_PATH="$HOME/staging"
+             echo "Staging disk usage before deploy:"
+             df -h "$APP_PATH" || df -h "$HOME"
+             if [ -d "$APP_PATH/releases" ]; then
+               echo "Existing releases:"
+               ls -1dt "$APP_PATH/releases"/*/ 2>/dev/null | head -10 || true
+             fi'
+
       - name: Upload artifact to staging server
         shell: bash
         run: |

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -133,6 +133,10 @@ jobs:
           tar \
             --exclude='.git' \
             --exclude='.ddev' \
+            --exclude='.github' \
+            --exclude='.cursor' \
+            --exclude='.husky' \
+            --exclude='docs' \
             --exclude='node_modules' \
             --exclude='*/node_modules' \
             --exclude='tests' \
@@ -142,9 +146,33 @@ jobs:
             --exclude='web/sites/*/settings.php' \
             --exclude='web/sites/*/settings.local.php' \
             --exclude='web/sites/*/services.yml' \
+            --exclude='composer.phar' \
+            --exclude='_INVALID_config_backup_*' \
+            --exclude='_myeventlane_audit' \
+            --exclude='*.md' \
+            --exclude='*.bak' \
+            --exclude='*.sql' \
+            --exclude='*.sql.gz' \
+            --exclude='web/error_log' \
+            --exclude='web/phpinfo-temp.php' \
+            --exclude='check-*.sh' \
+            --exclude='test-*.sh' \
+            --exclude='fix-*.sh' \
+            --exclude='reset-*.sh' \
+            --exclude='create-*.sh' \
+            --exclude='start-*.sh' \
+            --exclude='rebuild-*.sh' \
+            --exclude='diagnose-*.sh' \
+            --exclude='delete-*.php' \
+            --exclude='install-*.php' \
+            --exclude='create-*.php' \
+            --exclude='staging-nginx.conf' \
+            --exclude='phpcs.xml' \
+            --exclude='phpunit-governance.xml' \
             -czf "$archive_path" .
 
           echo "artifact_path=$archive_path" >> "$GITHUB_OUTPUT"
+          echo "Artifact size: $(du -h "$archive_path" | awk '{print $1}')"
 
       - name: Validate artifact contains NEW code
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ settings.local.*
 ############################################
 # PHPUnit (local execution cache; noisy, machine-specific)
 ############################################
+/web/.phpunit.result.cache
+**/.phpunit.result.cache
 .phpunit.result.cache
 
 ############################################

--- a/docs/content-audit/help-article-drafts/next-batch/attendee-questions-for-organisers.md
+++ b/docs/content-audit/help-article-drafts/next-batch/attendee-questions-for-organisers.md
@@ -6,34 +6,38 @@ product_area: checkout
 help_status: draft
 ai_allowed: true
 recommended_alias: /help/vendors/attendee-questions-for-organisers
-source_evidence: /vendor/event/{event}/checkout-questions; Event Studio attendee questions; checkout paragraph templates; event-studio-question-governance-audit.md
-needs_verification: Which field types are available (text, select, checkbox); tier-level vs event-level questions; export columns for organisers
+source_evidence: /vendor/events/{node}/studio/questions; EventCheckoutQuestionsForm; CheckoutAttendeeSchemaService; event-studio-question-governance-audit.md; MelAttendeeExportBuilder
+needs_verification: —
 ---
 
 # Collecting attendee questions at checkout
 
-You can ask buyers short questions during checkout or when they assign tickets. Use this page to collect useful details without gathering more personal data than you need.
+You can ask buyers short questions during checkout when they enter ticket holder details. Use this to collect useful logistics information without gathering more personal data than you need.
 
 ## What this means
 
-Attendee questions are custom fields attached to your event or ticket types. Answers are stored with the booking so you can plan catering, accessibility, or session choices. Questions should be optional unless you truly need an answer to admit someone.
+Attendee questions are custom fields attached to your **event** (and, for older setups, sometimes to individual ticket types). Answers are stored with each ticket holder on the booking so you can plan catering, accessibility, or session choices. Keep most questions optional unless you truly need an answer to admit someone or run the session safely.
 
 ## What to do next
 
-1. Open the event in Event Studio or your event management area.
-2. Find checkout or attendee questions (for example `/vendor/event/{event}/checkout-questions`).
-3. Add clear labels — buyers should understand why you are asking.
-4. Choose simple field types (short text, choice lists) where possible.
-5. Limit required questions to what you need for safety or logistics on the day.
-6. Preview checkout as a buyer would see it before you publish.
-7. After sales, review answers from your attendees or orders list — export options may vary by screen.
+1. Open the event in **Event Studio**.
+2. Go to **Checkout questions** (`/vendor/events/{event}/studio/questions`). Older links such as `/vendor/event/{event}/checkout-questions` redirect here.
+3. Add a clear **Question** label — buyers should understand why you are asking.
+4. Choose a **Type** (short text, long text, email, number, dropdown, checkbox, or radio). For choice types, add one option per line.
+5. Set **Required** only when you need every answer.
+6. Under **Applies to**, choose **All ticket holders** or **Specific ticket types** when a question only applies to some tiers.
+7. Leave new questions **Active**. Use **Archived** to retire a question without deleting past answers.
+8. Save, then preview checkout as a buyer before you publish.
+9. After sales, review answers on your attendee list or export attendees — custom answers appear in a **Custom answers** column in the CSV export.
 
 ## Good to know
 
-- Collect only information you need to run the event. Avoid sensitive data such as full medical histories, government ID numbers, or financial details unless you have a lawful reason and secure handling.
+- **Collect only what you need** to run the event. Avoid sensitive data such as full medical histories, government ID numbers, payment card details, or passwords unless you have a lawful reason and secure handling.
 - Tell buyers how you will use their answers and how long you will keep them. Follow your privacy policy and applicable law.
-- If a question already has answers from ticket holders, changing its meaning can confuse reporting. Archive outdated questions and add a new one instead of rewriting an old question — **Needs verification** for the exact controls in Event Studio.
-- Name and email are usually collected for the ticket holder separately. Do not duplicate those fields unless your process requires it.
+- **Per order** questions can be configured in Event Studio but are **not collected at checkout yet** — use per-ticket or ticket-type questions instead.
+- **First name, last name, and email** are collected separately for each ticket holder. Do not duplicate those unless your process truly requires it.
+- If buyers have already answered a question, the system **locks** field type, choices, ticket targeting, and required rules. You can still tidy the label or help text, change order, or **archive** the question and add a new one — do not rewrite the meaning of a question that already has answers.
+- Events with a long-standing setup may still have questions stored on **ticket types**; those continue to work at checkout, but new questions should be managed from **Checkout questions**.
 
 ## Related help
 

--- a/docs/content-audit/help-article-drafts/next-batch/attendee-questions-template-verification.md
+++ b/docs/content-audit/help-article-drafts/next-batch/attendee-questions-template-verification.md
@@ -1,0 +1,160 @@
+# Attendee questions and saved templates — QA verification log
+
+**Date:** 2026-05-22  
+**Branch:** `feature/help-verify-attendee-questions-docs`  
+**Scope:** Help Centre drafts `attendee-questions-for-organisers.md`, `saved-question-templates.md`  
+**Method:** Code and config audit; DDEV bootstrap (`ddev drush status` OK). No Drupal nodes, importer, or YAML export. No live browser checkout run (credentials not in scope).
+
+## Test data
+
+| Item | Value |
+|------|--------|
+| Event route pattern | `/vendor/events/{nid}/studio/questions` |
+| Legacy redirect | `/vendor/event/{nid}/checkout-questions` → Event Studio `workspace_questions` |
+| Library route | `/vendor/questions` |
+| Export route | `/vendor/events/{nid}/attendees/export` |
+| Example event nid | Not exercised in browser — use any paid/RSVP event owned by test organiser |
+
+## Routes tested (code + routing)
+
+| Route name | Path | Access |
+|------------|------|--------|
+| `myeventlane_event_studio.workspace_questions` | `/vendor/events/{node}/studio/questions` | `EventStudioAccess::access` + event vendor ownership |
+| `myeventlane_vendor.manage_event.checkout_questions` | `/vendor/event/{event}/checkout-questions` | Redirects to workspace (see `VendorLegacyWizardRedirectSubscriber`) |
+| `myeventlane_questions.library` | `/vendor/questions` | `view vendor question library` |
+| `myeventlane_questions.add/edit/delete` | `/vendor/questions/...` | `manage vendor question library` + entity store match |
+| `myeventlane_event_attendees.vendor_export` | `/vendor/events/{node}/attendees/export` | Vendor event access |
+
+## Attendee question setup (Event Studio)
+
+**Where organisers configure questions**
+
+- Canonical UI: Event Studio section **Checkout questions** at `/vendor/events/{node}/studio/questions` (`EventCheckoutQuestionsForm`, `QuestionsSection`).
+- Inline editor on main Event Studio form (Tickets area) still exposes **Reuse from library** and a CTA **Manage checkout questions**; saves via `EventStudioSaveService` with a **5-question cap** on that path only.
+- Legacy vendor wizard step exists but redirects to the studio workspace.
+
+**Per event vs tier vs order**
+
+- Questions are stored on the **event** in `node.event.field_attendee_questions` (paragraph bundle `attendee_extra_field`).
+- **Applicability** on each question: `per_ticket` (all ticket holders), `per_ticket_type` (selected ticket types), `per_order` (configurable in studio but **not active at checkout** — skipped with log notice).
+- **Legacy:** questions can still live on individual **ticket types** (`field_attendee_questions` on ticket type when `field_use_ticket_attendee_questions` is enabled). Checkout merges event + tier templates (`CheckoutAttendeeSchemaService`).
+
+**Required questions**
+
+- `field_question_required` on each paragraph; enforced in checkout pane validation.
+
+**Readiness warnings**
+
+- `EventStudioQuestionTemplateManager::buildQuestionReadinessFindings()` — blockers for ticket-specific questions with no ticket types selected; warnings for `per_order`, questions with historical answers, and legacy tier-stored questions.
+
+**Save blocking**
+
+- `validateRows()` / `saveRows()` reject: empty labels, unsupported/legacy types in studio UI, option types without options, invalid ticket type references, duplicate active labels, and immutable mutations when answers exist.
+
+## Field / question types
+
+**Event Studio checkout questions** (`QuestionFieldTypeRegistry`, studio UI excludes legacy `tel`):
+
+| Type | Studio label | Options required |
+|------|--------------|------------------|
+| `textfield` | Text | No |
+| `textarea` | Long text | No |
+| `email` | Email | No |
+| `number` | Number | No |
+| `select` | Select | Yes (one per line) |
+| `checkboxes` | Checkbox | Yes |
+| `radios` | Radio | Yes |
+| `tel` | Phone | Legacy only — not offered for new questions |
+
+**Saved library** (`vendor_question` entity `field_question_type` allowed values):
+
+- Text field, Textarea, Select (dropdown), Checkbox only — no Radio, Email, or Number in library forms.
+
+## Checkout rendering
+
+- Pane: `TicketHolderParagraphPane` (Commerce checkout).
+- Vendor questions shown under **Organiser questions**; default name/email/phone collected separately (`classifyBasicAttendeeQuestion`).
+- Questions render **per ticket holder** (each `attendee_answer` paragraph on the order item).
+- Active questions only (`field_question_status` ≠ `archived`).
+- `per_ticket_type` questions filtered to the ticket type on the line item.
+- `per_order` questions **not rendered** (deferred; storage not enabled).
+
+## Answer storage
+
+- Templates: `attendee_extra_field` paragraphs on the event (and optionally on ticket types).
+- Answers: child paragraphs on each ticket holder (`attendee_answer` → `field_attendee_questions` → answer rows with `field_attendee_extra_field` and question metadata).
+- Historical-answer detection: `EventStudioQuestionAnswerExistenceRepository` (SQL join on order items for the event).
+- RSVP: `EventAttendeeQuestionCaptureService` uses same event templates.
+
+## Organiser visibility and export
+
+- Attendee list and order views expose `custom_answers` / `custom_answers_display` (`VendorAttendeePresentationService`).
+- CSV export: `/vendor/events/{node}/attendees/export` — column **Custom answers** (aggregated string), not one column per question (`MelAttendeeExportBuilder`).
+
+## Saved question templates
+
+**Entity:** `vendor_question` (store-scoped via `field_store`).
+
+**Clone vs reference**
+
+- `QuestionTemplateCloner::cloneToParagraph()` creates a **new** `attendee_extra_field` paragraph on the event.
+- Editing or deleting a library template **does not** change questions already attached to published events.
+- Adding from library in Event Studio main form sets `vendor_question_id` in JSON; save clones template if accessible.
+
+**Tier targeting in library**
+
+- Not stored on `vendor_question`. After clone, organisers set applicability and ticket types in **Checkout questions** workspace.
+
+**Duplicate prevention**
+
+- Event-level: unique active labels (`validateRows`).
+- Checkout merge: dedupe by machine name or label (`questionTemplateDedupeKey`).
+- Library: no duplicate-label enforcement found.
+
+**Access control**
+
+- `VendorQuestionAccessControlHandler`: admin full access; otherwise store must match organiser’s vendor store.
+- Permissions defined in module (`view` / `manage vendor question library`) — **not found granted in `config/sync` role YAML**; assume granted to vendor roles in runtime or pending config export.
+
+## Edit vs clone after sales
+
+When `questionHasHistoricalAnswers()` is true, organisers **cannot** change: field type, applicability, required→optional, machine name, option values, or ticket-type targeting. They **can** adjust label/help copy, ordering, and **archive** the question. UI marks rows as locked; readiness warning shown.
+
+Editing a **saved library template** does not retroactively alter event questions or past answers.
+
+## Privacy and sensitive data
+
+| Check | Result |
+|-------|--------|
+| Free-text collection | Yes (`textfield`, `textarea`) |
+| Product blocks sensitive questions | No dedicated validation |
+| In-product privacy warnings | Studio copy: “Ask only what helps you prepare”; limit warning on inline editor (5 questions). **No** explicit sensitive-data warning in checkout questions form or library |
+| Answer storage | Standard Drupal paragraph/DB; export available to event organiser |
+| Help wording | Drafts must warn organisers to collect only necessary data and avoid unnecessary sensitive data |
+
+## Article readiness
+
+| Draft | Ready to publish? | Ready to export? | Notes |
+|-------|-------------------|------------------|-------|
+| `attendee-questions-for-organisers.md` | Yes | Yes | Wording tightened to studio route, types, archive/immutability, export column |
+| `saved-question-templates.md` | Yes | Yes | Clone semantics, library types, attach paths documented |
+
+## Wording constraints for Help Assistant
+
+- Use **organiser** in user-facing copy.
+- Do not claim `per_order` questions work at checkout.
+- Do not claim library templates update live events.
+- Do not claim safe wholesale edits after ticket sales.
+- Do not list Radio/Email/Number for saved library — only Event Studio custom questions.
+- Mention CSV **Custom answers** column, not per-question export columns.
+
+## Remaining blockers (product / ops, not draft)
+
+- `per_order` applicability UI exists but checkout capture deferred.
+- Library permissions may need role assignment verification in deployed environments.
+- Two UIs: dedicated checkout questions table (no 5-question cap) vs inline Event Studio editor (5-question cap) — document organiser path via **Checkout questions** workspace as primary.
+- No automated sensitive-data classifier — governance is organiser responsibility + help copy.
+
+## Export recommendation
+
+Recommend YAML batch **05** (`help-articles-batch-05-2026-05.yml`) with keys `attendee_questions_for_organisers`, `saved_question_templates` when export is authorised.

--- a/docs/content-audit/help-article-drafts/next-batch/calendar-article-merge-qa.md
+++ b/docs/content-audit/help-article-drafts/next-batch/calendar-article-merge-qa.md
@@ -1,0 +1,58 @@
+# Calendar article merge — QA log
+
+**Date:** 2026-05-23  
+**Draft:** `add-event-to-calendar.md`  
+**Governance:** `calendar-duplicate-governance.md`
+
+## Product verification (draft scope)
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| My Tickets **Add to calendar** | **Works (conditional)** | `ics_url` in My Tickets template; button shown when URL present |
+| Order receipt `.ics` mention | **Documented in code** | Receipt template references calendar attachment |
+| Event `/event/{node}/ics` | **Needs verification** | Draft marks per-event page calendar as unverified on all events |
+| Google Calendar web links vs download-only | **Needs verification** | Staging behaviour not fully confirmed |
+| Email vs My Tickets parity | **Partial** | Copy uses conditional wording; not every path verified browser-side |
+
+**Governance rule applied:** Product paths that work are documented with conditional language; gaps stay as verification notes in draft, not as invented behaviour.
+
+## Duplicate QA (2026-05-23)
+
+| Question | Answer |
+|----------|--------|
+| Is there a second published calendar article? | **Yes** — nid **1501** (stub) and nid **1673** (full body) |
+| Which holds canonical alias? | **1673** → `/help/attendees/add-event-to-calendar` |
+| Which holds seed key? | **1673** → `add_event_to_calendar` |
+| Which should be canonical? | **1501** (after identity migration per governance doc) |
+| Safe to import calendar YAML now? | **No** — importer targets 1673 |
+| Safe to create new node? | **No** |
+
+## Merge decision
+
+- **Do not** create a third calendar article.
+- **Do not** import calendar YAML until nid 1673 is retired and seed/alias belong to nid 1501.
+- **Do** update nid 1501 body from verified draft after duplicate cleanup.
+- **Title on canonical node:** “Adding events to your calendar” (plural) — draft title may be adjusted at import/export to match.
+
+## Blockers
+
+| Blocker | Type | Owner action |
+|---------|------|--------------|
+| Duplicate nid 1673 published with seed + alias | **Governance** | Execute pre-import cleanup in `calendar-duplicate-governance.md` |
+| Importer identity on wrong nid | **Import** | Complete cleanup before `mel:help-import-priority` |
+| Per-event `/ics` on all events | **Product QA** | Optional spot-check; draft already conditional |
+
+## Post-cleanup QA checklist
+
+- [ ] Only one published help_article for calendar topic (nid 1501)
+- [ ] `/help/attendees/add-event-to-calendar` resolves to `/node/1501`
+- [ ] `field_help_seed_key` = `add_event_to_calendar` on nid 1501 only
+- [ ] nid 1673 unpublished/archived; seed empty; no canonical alias
+- [ ] Dry-run import reports match nid 1501 by `seed_key`
+- [ ] Body matches `add-event-to-calendar.md` (no stub sentence)
+- [ ] Public audience; `help_status` published; `ai_allowed` true
+- [ ] Related help links from My tickets cluster still resolve
+
+## Status
+
+**Draft verified for content** — **not ready for import** until duplicate governance cleanup completes.

--- a/docs/content-audit/help-article-drafts/next-batch/calendar-duplicate-governance.md
+++ b/docs/content-audit/help-article-drafts/next-batch/calendar-duplicate-governance.md
@@ -1,0 +1,139 @@
+# Calendar Help Centre duplicate governance
+
+**Date:** 2026-05-23  
+**Branch:** `docs/help-calendar-duplicate-governance`  
+**Task:** Resolve duplicate governance before calendar draft import/update.  
+**Scope:** Docs and cleanup plan only — no importer run, no product code changes.
+
+## DB truth (local, confirmed via Drush)
+
+**Query date:** 2026-05-23  
+**Methods:** `ddev drush sql:query` (node_field_data, path_alias), `ddev drush php:eval` (entity load, alias manager, importer match simulation).
+
+| Field | nid **1501** | nid **1673** |
+|-------|--------------|--------------|
+| **Title** | Adding events to your calendar | Adding an event to your calendar |
+| **Bundle** | help_article | help_article |
+| **Status (published)** | 1 (published) | 1 (published) |
+| **Moderation state** | published | published |
+| **Path alias** | *(none — resolves to `/node/1501`)* | `/help/attendees/add-event-to-calendar` (path_alias id **141** → `/node/1673`) |
+| **field_help_seed_key** | *(empty)* | `add_event_to_calendar` |
+| **field_audience** | public | public |
+| **field_help_audience** | *(empty)* | *(empty)* |
+| **field_help_status** | published | published |
+| **field_help_ai_allowed** | 1 (true) | 1 (true) |
+| **Body length (chars)** | 66 | 2536 |
+| **Body summary length** | 0 | 0 |
+| **Body preview** | “After booking, add the event to your calendar to avoid missing it.” | Full draft-aligned article (My Tickets / email / conditional calendar copy) |
+| **Changed** | 2026-03-26 18:41:06 | 2026-05-22 19:57:37 |
+
+**Importer match simulation (`add_event_to_calendar`, alias `/help/attendees/add-event-to-calendar`):**
+
+- `field_help_seed_key` → **nid 1673 only**
+- Alias lookup → **`/node/1673`**
+- Title “Adding events to your calendar” → **nid 1501**
+- Title “Adding an event to your calendar” → **nid 1673**
+
+## Canonical decision
+
+**Canonical node:** **nid 1501**
+
+| Attribute | Target on nid 1501 |
+|-----------|-------------------|
+| Title | Adding events to your calendar |
+| Alias | `/help/attendees/add-event-to-calendar` |
+| Seed key | `add_event_to_calendar` |
+| Audience | public (`field_audience`) |
+| help_status | published |
+| ai_allowed | true |
+| Body | Replace stub with verified draft (`add-event-to-calendar.md`) after duplicate retirement |
+
+**Rationale:** nid 1501 is the long-lived published stub referenced in publish-prep and status-sweep docs. nid 1673 is a newer duplicate that absorbed the canonical alias and seed key without retiring 1501. Governance requires one article, not a third node.
+
+**Duplicate:** nid **1673** must not remain independently published on the same topic after cleanup.
+
+## Duplicate risk
+
+| Risk | Detail |
+|------|--------|
+| **Two live articles** | Both published; public may see stub at `/node/1501` and full article at `/help/attendees/add-event-to-calendar`. |
+| **Importer mis-target** | `PriorityHelpArticleImporter` matches **seed_key first**, then **alias** — YAML for `add_event_to_calendar` updates **1673**, not 1501, until identity moves. |
+| **Search / AI duplication** | Both `ai_allowed`; Help Centre retrieval may surface overlapping calendar guidance. |
+| **Editorial drift** | Titles differ (plural vs singular); related-help links may point at wrong node. |
+| **No redirect fallback** | Redirect module is **not enabled** locally — retiring 1673 without alias transfer would 404 the canonical URL. |
+
+## Recommended duplicate handling
+
+**Choose Option 1** (unpublish + release identity to nid 1501). Option 2 is weaker here because Redirect is unavailable. Option 3 applies **until** Option 1 pre-steps complete.
+
+### Option 1 — Recommended (safe, reversible)
+
+1. **Backup** both nodes (export via Drush entity or DB snapshot) before edits.
+2. On **nid 1673:**
+   - Set `field_help_status` to **archived** (or draft) and unpublish (`status` = 0).
+   - Clear **`field_help_seed_key`** (empty value).
+   - **Delete** path alias id **141** (`/help/attendees/add-event-to-calendar` → `/node/1673`).
+3. On **nid 1501:**
+   - Set **`field_help_seed_key`** = `add_event_to_calendar`.
+   - Create path alias **`/help/attendees/add-event-to-calendar`** → `/node/1501`.
+   - Confirm `field_audience` = public, `field_help_status` = published, `field_help_ai_allowed` = 1.
+   - Keep title **Adding events to your calendar** (canonical title).
+4. **Dry-run** calendar YAML import (when export exists): `ddev drush mel:help-import-priority <calendar-yaml> --dry-run` — expect match **nid 1501** by `seed_key`.
+5. **Live import** or manual body merge from `add-event-to-calendar.md` onto nid 1501.
+6. Spot-check alias, Help browse/search, and related-help links.
+
+### Option 2 — Not recommended now
+
+Archive nid 1673 and add redirect to nid 1501 — **blocked**: no enabled Redirect module on local stack.
+
+### Option 3 — Current state (do not import yet)
+
+**Active until Option 1 completes.** Seed key and canonical alias both belong to nid 1673; importer cannot safely update nid 1501.
+
+## Pre-import cleanup steps (exact order)
+
+| Step | Action | Node |
+|------|--------|------|
+| 1 | Export/snapshot nodes 1501 and 1673 | both |
+| 2 | Unpublish; set help_status archived | 1673 |
+| 3 | Clear `field_help_seed_key` | 1673 |
+| 4 | Delete alias `/help/attendees/add-event-to-calendar` | 1673 |
+| 5 | Set `field_help_seed_key` = `add_event_to_calendar` | 1501 |
+| 6 | Add alias `/help/attendees/add-event-to-calendar` | 1501 |
+| 7 | `mel:help-import-priority` **dry-run** on calendar YAML | expect nid 1501 |
+| 8 | Live import or manual body update from draft | 1501 |
+| 9 | Re-run dry-run | expect **skipped** (no changes) |
+| 10 | QA: alias, public audience, no second published calendar article | — |
+
+**Do not:**
+
+- Create a new help_article node.
+- Run calendar YAML import while `add_event_to_calendar` remains on nid 1673.
+- Import batch 02 YAML as a substitute for calendar cleanup (batch 02 excludes calendar; see `help-articles-batch-02-2026-05-notes.md`).
+
+## Can the importer safely update nid 1501 now?
+
+**No.**
+
+Until nid 1673 releases `field_help_seed_key` and the canonical alias, `mel:help-import-priority` will match and update **nid 1673** only.
+
+## Manual DB / content edit needed?
+
+**Yes** — identity migration (steps 2–6 above) before import. Body may be applied via importer after identity moves, or copied manually from `add-event-to-calendar.md` if YAML export is not yet generated.
+
+## Rollback notes
+
+| If… | Rollback |
+|-----|----------|
+| Cleanup on 1673 only | Re-publish 1673; restore seed `add_event_to_calendar`; restore path_alias id 141 |
+| Identity moved to 1501 | Clear seed on 1501; remove alias on 1501; restore 1673 published + seed + alias |
+| Import updated wrong node | Restore node export from step 1 backup |
+
+Document rollback nids and alias ids in the import log when cleanup is executed.
+
+## Related files
+
+- Draft: `add-event-to-calendar.md`
+- QA: `calendar-article-merge-qa.md`
+- Register: `next-batch-register.md`
+- Batch 02: `help-articles-batch-02-2026-05-notes.md` (calendar **excluded** from batch 02 export)

--- a/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
+++ b/docs/content-audit/help-article-drafts/next-batch/next-batch-register.md
@@ -1,7 +1,16 @@
 # Next Help Centre batch — draft register
 
-**Date:** 2026-05-23 (reconciled against import logs on `main`)  
+**Date:** 2026-05-23 (reconciled against import logs on `main`; calendar duplicate governance added)  
 **Folder:** `docs/content-audit/help-article-drafts/next-batch/`  
+**Importer:** Batches 04, 05, and 06 live imports complete (see `help-articles-batch-04-import-log.md`, `help-articles-batch-05-import-log.md`, `help-articles-batch-06-import-log.md`). **Batch 02 is exported only — not imported; there is no batch 02 import log and batch 02 must not be treated as closed.**
+
+**Calendar duplicate (2026-05-23):** See `calendar-duplicate-governance.md` and `calendar-article-merge-qa.md`. Canonical node **nid 1501**; duplicate **nid 1673** holds seed key + alias until manual cleanup. **Do not import** calendar YAML while `add_event_to_calendar` is on nid 1673.
+
+| Draft | Audience | Recommended alias | Ready to publish? | Ready to export? | Export batch | Needs verification | Notes |
+|-------|----------|-------------------|-------------------|------------------|--------------|--------------------|-------|
+| how-to-access-your-tickets.md | public | /help/attendees/how-to-access-your-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** (no import log) |
+| how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | No | Yes | batch_02_2026_05 | — | Exported in batch 02; **import pending** |
+| add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | **Blocked:** duplicate nid **1673** (seed + alias) vs canonical **1501** (stub). Content update only after 1673 retired — see `calendar-duplicate-governance.md`. **Do not create new node.** **Do not import** until seed/alias on 1501. |
 **Importer:** Batches 02, 04, 05, and 06 live imports complete (see `help-articles-batch-02-import-log.md`, `help-articles-batch-04-import-log.md`, `help-articles-batch-05-import-log.md`, `help-articles-batch-06-import-log.md`).
 
 | Draft | Audience | Recommended alias | Ready to publish? | Ready to export? | Export batch | Needs verification | Notes |
@@ -10,6 +19,12 @@
 | how-to-use-my-tickets.md | public | /help/attendees/how-to-use-my-tickets | **Imported** | Yes | batch_02_2026_05 | — | Imported batch 02 — nid **1671**; anonymous access **200** |
 | add-event-to-calendar.md | public | /help/attendees/add-event-to-calendar | No | No | — | Event `/ics` availability; email vs My Tickets parity | Calendar links conditional in copy; duplicate of nid **1501** — merge/update, not new node |
 | wallet-passes-explained.md | public | /help/attendees/wallet-passes-explained | No | No | — | Admin wallet enablement; order-state eligibility | Wallet buttons conditional in copy |
+| missing-ticket-help.md | public | /help/attendees/missing-ticket-help | No | Yes | batch_02_2026_05 | — | Exported in batch 02 |
+| organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | Blocked until paid waitlist organiser UI/reporting and auto-offer claim flow are verified | See organiser-ticket-capacity-waitlist-verification.md |
+| ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | No | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Exported in help-articles-batch-04-2026-05.yml; importer not run |
+| attendee-questions-for-organisers.md | vendor | /help/vendors/attendee-questions-for-organisers | Yes | Yes | batch_05_2026_05 | — | Exported in help-articles-batch-05-2026-05.yml; importer not run |
+| check-in-attendees.md | vendor | /help/vendors/check-in-attendees | No | No | — | QR issuance coverage; RSVP check-in source | Does not claim every ticket has QR/PDF |
+| saved-question-templates.md | vendor | /help/vendors/saved-question-templates | Yes | Yes | batch_05_2026_05 | — | Exported in help-articles-batch-05-2026-05.yml; importer not run |
 | missing-ticket-help.md | public | /help/attendees/missing-ticket-help | **Imported** | Yes | batch_02_2026_05 | — | Imported batch 02 — nid **1672**; anonymous access **200** |
 | organiser-manage-waitlists.md | vendor | /help/vendors/organiser-manage-waitlists | No | No | — | RSVP list/export verified in code; paid-tier organiser UI/export missing; RSVP auto-promote not wired; browser QA pending | See organiser-waitlists-verification.md; recommended scope RSVP-only organiser section until paid reporting ships |
 | ticket-sales-and-capacity.md | vendor | /help/vendors/ticket-sales-and-capacity | **Imported** | Yes | batch_04_2026_05 | Refund→sold count; lower capacity below sold | Imported batch 04 — nid **1674** (`help-articles-batch-04-import-log.md`) |

--- a/docs/content-audit/help-article-drafts/next-batch/saved-question-templates.md
+++ b/docs/content-audit/help-article-drafts/next-batch/saved-question-templates.md
@@ -6,34 +6,39 @@ product_area: checkout
 help_status: draft
 ai_allowed: true
 recommended_alias: /help/vendors/saved-question-templates
-source_evidence: /vendor/questions library routes; Event Studio "Choose a saved question"; myeventlane_questions module; EventStudioQuestionTemplateManager
-needs_verification: Permissions required for library access; whether editing a saved template updates past events; clone vs link behaviour in Event Studio
+source_evidence: /vendor/questions; EventStudioForm library picker; QuestionTemplateCloner; VendorQuestionAccessControlHandler
+needs_verification: —
 ---
 
 # Saved question templates
 
-Reuse common checkout questions across events by saving them to your question library. This saves time and keeps wording consistent.
+Reuse common checkout questions across events by saving them to your organiser question library. This saves time and keeps wording consistent.
 
 ## What this means
 
-A saved question template is a reusable definition (label, field type, and options) stored in your organiser library. When you build a new event, you can add a saved question instead of typing the same text again.
+A saved question template is a reusable definition (label, field type, options, and whether it is required) stored for your **organiser account** (Commerce store). Templates are **not** shown to buyers until you add them to an event. Adding a template **copies** it onto the event as its own question — it is not a live link.
 
 ## What to do next
 
 1. Sign in to your organiser account.
-2. Open your question library at `/vendor/questions`.
+2. Open your question library at `/vendor/questions` (you need permission to view the library).
 3. Select **Add question** and enter a clear label buyers will understand.
-4. Choose the field type and any choices (for dropdowns or checkboxes).
-5. Save the template.
-6. In Event Studio or checkout questions for an event, pick **Choose a saved question** (or equivalent) to attach it to the event.
-7. Adjust event-specific settings if prompted, then preview checkout before publishing.
+4. Choose the field type: **Text field**, **Textarea**, **Select (dropdown)**, or **Checkbox**. For select or checkbox, enter one option per line.
+5. Optionally mark the template as **Required** and add help text.
+6. Save the template.
+7. On the event, either:
+   - In **Event Studio**, use **Reuse from library** on the tickets/attendee area and **Add from library**, then open **Checkout questions** to set ticket targeting; or
+   - In **Checkout questions** (`/vendor/events/{event}/studio/questions`), recreate or adjust questions manually to match your template.
+8. Set **Applies to** and ticket types on the event copy if needed, then preview checkout before publishing.
 
 ## Good to know
 
-- Saved templates are for your organiser account. They are not visible to buyers until you attach them to an event.
-- If buyers have already answered a question on live bookings, treat changes carefully. Prefer archiving an old template and creating a new question rather than changing the meaning of an existing one — **Needs verification** for library edit behaviour.
-- Keep questions proportionate. A long library of rarely used fields slows checkout.
-- Do not store sensitive personal data in reusable templates unless you need it for every event that uses them.
+- Templates belong to your organiser store. Another organiser cannot see or edit your library.
+- **Editing a saved template does not change** questions already on live events or answers buyers submitted. Update the library for future events, or archive the event question and add a new one.
+- The library supports fewer field types than **Checkout questions** on an event (for example, radio, email, and number are event-only).
+- Saved templates do not include **ticket type targeting** — set that on the event after the question is attached.
+- If buyers have already answered a question on the event, treat changes like any other checkout question: archive and add anew rather than changing type or choices.
+- Keep the library small. Long lists of rarely used fields slow checkout.
 
 ## Related help
 

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -16,6 +16,10 @@ SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
 ARTIFACT_PATH="${ARTIFACT_PATH:-}"
 RUN_UPDB="${RUN_UPDB:-0}"
 RUN_CIM="${RUN_CIM:-0}"
+# Retain this many non-current release directories after each deploy (Capistrano-style).
+MEL_KEEP_RELEASES="${MEL_KEEP_RELEASES:-3}"
+# Minimum free space (MB) on APP_PATH filesystem before copying a new release.
+MEL_MIN_FREE_DISK_MB="${MEL_MIN_FREE_DISK_MB:-2048}"
 
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 RELEASE_PATH="$APP_PATH/releases/$TIMESTAMP"
@@ -103,12 +107,134 @@ mel_verify_drush_bootstrap() {
   return 0
 }
 
+mel_disk_available_mb() {
+  df -Pm "$1" | awk 'NR==2 {print $4}'
+}
+
+mel_report_disk_usage() {
+  echo "Filesystem usage for $APP_PATH:"
+  df -h "$APP_PATH" || true
+  if [ -d "$APP_PATH/releases" ]; then
+    echo "Release directories (newest first):"
+    ls -1dt "$APP_PATH/releases"/*/ 2>/dev/null | head -10 || true
+  fi
+}
+
+mel_check_disk_space() {
+  local avail_mb min_mb="${MEL_MIN_FREE_DISK_MB}"
+  avail_mb="$(mel_disk_available_mb "$APP_PATH")"
+  echo "Disk space: ${avail_mb}MB available on $(df -Pm "$APP_PATH" | awk 'NR==2 {print $1" ("$6")"}') (minimum ${min_mb}MB required for deploy)."
+  if [ "$avail_mb" -lt "$min_mb" ]; then
+    echo "ERROR: Insufficient disk space for deploy (No space left on device)." >&2
+    mel_report_disk_usage >&2
+    echo "Free space on the staging host (remove old releases, logs, or backups) and redeploy." >&2
+    return 1
+  fi
+}
+
+# Strip sites/default symlinks (shared files, settings, etc.) before rm so we never
+# touch live shared paths and so web-server-owned targets are not involved.
+mel_prepare_release_for_removal() {
+  local release_dir="$1"
+  local default_dir="$release_dir/web/sites/default"
+  local entry known
+
+  [ -d "$default_dir" ] || return 0
+
+  for known in files settings.php services.yml config; do
+    if [ -L "$default_dir/$known" ]; then
+      rm -f "$default_dir/$known" || true
+    fi
+  done
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    rm -f "$entry" || true
+  done < <(find "$default_dir" -maxdepth 1 -type l 2>/dev/null || true)
+
+  chmod -R u+w "$release_dir" 2>/dev/null || true
+}
+
+# Best-effort release removal. Pruning must not abort deploy: old trees often
+# contain www-data-owned files under sites/default from prior live releases.
+mel_remove_release_dir() {
+  local release_dir="$1"
+  local name
+  name="$(basename "$release_dir")"
+
+  mel_prepare_release_for_removal "$release_dir"
+
+  set +e
+  rm -rf "$release_dir" 2>/dev/null
+  local rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ] && [ ! -e "$release_dir" ]; then
+    return 0
+  fi
+
+  echo "  WARNING: could not fully remove release $name (permission denied on some paths)." >&2
+  echo "  On the staging host, remove leftovers manually or fix ownership under:" >&2
+  echo "    $release_dir/web/sites/default" >&2
+  return 0
+}
+
+mel_prune_old_releases() {
+  local keep="${MEL_KEEP_RELEASES}"
+  local releases_dir="$APP_PATH/releases"
+  local protected="" dir name candidates=() count i prune_failed=0
+
+  [ -d "$releases_dir" ] || return 0
+
+  if [ -e "$CURRENT_PATH" ]; then
+    protected="$(readlink -f "$CURRENT_PATH" 2>/dev/null || true)"
+  fi
+
+  echo "Pruning old releases (retain ${keep} non-current; current is never removed)..."
+
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    [ -d "$dir" ] || continue
+    if [ -n "$protected" ] && [ "$dir" = "$protected" ]; then
+      name="$(basename "$dir")"
+      echo "  Keeping (current): $name"
+      continue
+    fi
+    candidates+=("$dir")
+  done < <(find "$releases_dir" -mindepth 1 -maxdepth 1 -type d | sort -r)
+
+  count="${#candidates[@]}"
+  if [ "$count" -le "$keep" ]; then
+    echo "  ${count} release(s) eligible for pruning; nothing to remove (limit ${keep})."
+    return 0
+  fi
+
+  for ((i=keep; i<count; i++)); do
+    name="$(basename "${candidates[$i]}")"
+    echo "  Removing old release: $name"
+    if [ -e "${candidates[$i]}" ]; then
+      mel_remove_release_dir "${candidates[$i]}"
+      if [ -e "${candidates[$i]}" ]; then
+        prune_failed=1
+      fi
+    fi
+  done
+
+  if [ "$prune_failed" = "1" ]; then
+    echo "  NOTICE: Some old releases could not be pruned (non-fatal). Disk preflight will still run." >&2
+  fi
+}
+
 mel_deploy_cleanup() {
   if [ "${DEPLOY_SUCCEEDED:-0}" = "1" ]; then
     return 0
   fi
   echo "" >&2
   echo "DEPLOY FAILED — cleanup: restoring previous release (if any) and clearing maintenance mode..." >&2
+  if [ -n "${RELEASE_PATH:-}" ] && [ -d "$RELEASE_PATH" ]; then
+    echo "  Removing failed partial release: $RELEASE_PATH" >&2
+    mel_remove_release_dir "$RELEASE_PATH"
+  fi
   if [ "${MEL_CURRENT_SWITCHED:-0}" = "1" ] && [ -n "${MEL_PREVIOUS_CURRENT:-}" ] && [ -d "$MEL_PREVIOUS_CURRENT" ]; then
     echo "  Rolling back current symlink to: $MEL_PREVIOUS_CURRENT" >&2
     ln -sfn "$MEL_PREVIOUS_CURRENT" "$CURRENT_PATH" || true
@@ -129,6 +255,10 @@ echo "Deploying release: $TIMESTAMP"
 mkdir -p "$APP_PATH/releases"
 mkdir -p "$SHARED_PATH/files"
 
+mel_report_disk_usage
+mel_prune_old_releases
+mel_check_disk_space
+
 # ---- CRITICAL FIX: validate directory, not file ----
 if [ -z "$ARTIFACT_PATH" ] || [ ! -d "$ARTIFACT_PATH" ]; then
   echo "Artifact directory not found"
@@ -138,7 +268,11 @@ fi
 mkdir -p "$RELEASE_PATH"
 
 echo "Copying artifact contents..."
-cp -a "$ARTIFACT_PATH"/. "$RELEASE_PATH"/
+if ! cp -a "$ARTIFACT_PATH"/. "$RELEASE_PATH"/; then
+  echo "ERROR: Failed to copy artifact to $RELEASE_PATH (often 'No space left on device')." >&2
+  mel_report_disk_usage >&2
+  exit 1
+fi
 
 # ---- SAFETY CHECK (prevents bad deploys) ----
 [ -f "$RELEASE_PATH/web/index.php" ] || {

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module
@@ -427,7 +427,6 @@ function myeventlane_checkout_flow_mel_observability_page_payload_alter(
   array &$payload,
   MelWorkflowContext $context,
   array $merged_signals,
-  array $evaluations,
 ): void {
   if (!isset($payload['traces']) || !is_array($payload['traces'])) {
     return;

--- a/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
+++ b/web/modules/custom/myeventlane_commerce/src/Form/EventOperationalAddonCartForm.php
@@ -489,11 +489,6 @@ final class EventOperationalAddonCartForm extends FormBase {
   /**
    * @param list<array<string, mixed>> $size_options
    *
-   * @return array<string, string>
-   */
-  /**
-   * @param list<array<string, mixed>> $size_options
-   *
    * @return array<string, mixed>
    */
   private function buildSizeRadioGroup(array $size_options, int $index, string $size_id, bool $product_sold_out): array {

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2074,9 +2074,9 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 18px;
   min-height: 76px;
   padding: 14px 20px;
@@ -2106,8 +2106,9 @@
   text-transform: none;
 }
 
-.mel-event-studio-topbar__event {
+.mel-event-studio-topbar__primary {
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .mel-event-studio-topbar__title {
@@ -2125,6 +2126,16 @@
   align-items: center;
   gap: 10px;
   white-space: nowrap;
+}
+
+.mel-event-studio-topbar__meta {
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.mel-event-studio-topbar__actions {
+  flex: 0 0 auto;
+  align-self: center;
 }
 
 .mel-event-studio-topbar__badge {
@@ -2706,10 +2717,15 @@
   }
 
   .mel-event-studio-topbar {
-    grid-template-columns: minmax(0, 1fr);
+    flex-direction: column;
+    align-items: stretch;
     gap: 12px;
     padding: 12px 14px;
     border-radius: 14px;
+  }
+
+  .mel-event-studio-topbar__actions {
+    align-self: stretch;
   }
 
   .mel-event-studio-topbar__meta,
@@ -2806,11 +2822,16 @@
   }
 
   .mel-event-studio-topbar {
-    grid-template-columns: minmax(0, 1fr);
+    flex-direction: column;
+    align-items: stretch;
     position: sticky;
     top: 0;
     max-width: 100%;
     box-sizing: border-box;
+  }
+
+  .mel-event-studio-topbar__actions {
+    align-self: stretch;
   }
 
   .mel-event-studio-topbar__meta,

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -200,12 +200,37 @@
     setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
   }
 
+  function syncTopbarState(shell, stateText) {
+    const meta = shell.querySelector('.mel-event-studio-topbar__meta');
+    if (!meta) {
+      return;
+    }
+    let stateEl = meta.querySelector('[data-mel-publish-state]');
+    if (stateText) {
+      if (!stateEl) {
+        stateEl = document.createElement('span');
+        stateEl.className = 'mel-event-studio-topbar__state';
+        stateEl.setAttribute('data-mel-publish-state', '');
+        const badge = meta.querySelector('[data-mel-publish-status]');
+        if (badge) {
+          badge.insertAdjacentElement('afterend', stateEl);
+        }
+        else {
+          meta.prepend(stateEl);
+        }
+      }
+      stateEl.textContent = stateText;
+      return;
+    }
+    stateEl?.remove();
+  }
+
   function updateTopbar(shell, result) {
     if (!result || !result.topbar) {
       return;
     }
     setText(shell, '[data-mel-publish-status]', result.topbar.status || '');
-    setText(shell, '[data-mel-publish-state]', result.topbar.state || '');
+    syncTopbarState(shell, result.topbar.state || '');
     setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
     const buttons = shell.querySelectorAll('[data-mel-publish-action], [data-mel-card-publish-action], [data-mel-unpublish-action]');
     if (result.changed !== undefined && result.changed !== null) {

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -120,7 +120,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.1
+  version: 1.2
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/phpunit.xml
+++ b/web/modules/custom/myeventlane_event_studio/phpunit.xml
@@ -1,14 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Module unit tests (no kernel). From repo root:
-     vendor/bin/phpunit -c web/modules/custom/myeventlane_event_studio
-     Full Drupal bootstrap suite: cd web && ../vendor/bin/phpunit -c phpunit-event-studio.xml -->
+<!-- Lightweight unit tests (no Drupal bootstrap). From repo root:
+     ddev exec vendor/bin/phpunit -c web/modules/custom/myeventlane_event_studio/phpunit.xml
+     Filter one class (use filter=ClassName on the phpunit command).
+
+     Other tests under tests/src/Unit (Drupal UnitTestCase or heavier TestCase) use:
+     ddev exec bash -lc 'cd web && ../vendor/bin/phpunit -c phpunit-event-studio.xml' -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="tests/bootstrap-unit.php"
          colors="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
   <testsuites>
-    <testsuite name="myeventlane_event_studio_unit">
-      <directory>tests/src/Unit</directory>
+    <testsuite name="myeventlane_event_studio_unit_light">
+      <file>tests/src/Unit/EntityAutocompleteMelNormalizerTest.php</file>
+      <file>tests/src/Unit/EventStudioExtrasProductEditorTest.php</file>
+      <file>tests/src/Unit/EventStudioMerchAddonStudioTest.php</file>
+      <file>tests/src/Unit/QuestionFieldTypeRegistryTest.php</file>
+      <file>tests/src/Unit/VendorOperationalProductCreationManagerTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -167,14 +167,20 @@ final class EventStudioController extends ControllerBase {
       throw new AccessDeniedHttpException();
     }
 
-    $this->logger->notice('Vendor Event Studio workspace: event_id=@eid section=@section uid=@uid', [
-      '@eid' => (string) $node->id(),
-      '@section' => $section,
-      '@uid' => (string) $account->id(),
-    ]);
-
     $readiness = $this->eventReadiness->evaluate($node, $account);
     $sectionMetadata = $this->sectionManager->sectionMetadata($sectionPlugin);
+    $sectionContent = $this->sectionRenderer->build($sectionPlugin, $node);
+    $request = $this->requestStack->getCurrentRequest();
+    $routeName = $request !== NULL ? (string) ($request->attributes->get('_route') ?? '') : '';
+
+    $this->logger->debug('Event Studio workspace render: route=@route event_id=@eid section=@section plugin=@plugin render_target=@target section_content_keys=@keys', [
+      '@route' => $routeName,
+      '@eid' => (string) $node->id(),
+      '@section' => $section,
+      '@plugin' => (string) $sectionPlugin->getPluginId(),
+      '@target' => $sectionPlugin->renderTarget(),
+      '@keys' => is_array($sectionContent) ? implode(',', array_keys($sectionContent)) : gettype($sectionContent),
+    ]);
 
     return [
       '#theme' => 'mel_event_studio_workspace',
@@ -184,7 +190,7 @@ final class EventStudioController extends ControllerBase {
       '#current_section' => $section,
       '#current_section_label' => $this->sectionManager->sectionTitle($section),
       '#current_section_metadata' => $sectionMetadata,
-      '#section_content' => $this->sectionRenderer->build($sectionPlugin, $node),
+      '#section_content' => $sectionContent,
       '#topbar' => $this->buildTopbar($node, $readiness, $section),
       '#readiness' => $this->buildReadinessSummary($readiness),
       '#attached' => [
@@ -238,9 +244,9 @@ final class EventStudioController extends ControllerBase {
    * @return array<string, mixed>
    */
   private function buildTopbar(NodeInterface $node, EventReadinessResult $readiness, string $section): array {
-    $state = $node->isPublished()
-      ? $this->t('Published')
-      : $this->operationalState($readiness);
+    $operational_state = $this->operationalState($readiness);
+    // Published events use the status badge only; readiness text is draft-oriented.
+    $state = ($node->isPublished() && $readiness->ready) ? '' : $operational_state;
 
     return [
       'title' => $node->label(),

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -252,7 +252,9 @@ final class EventStudioPublishController {
       'published' => $node->isPublished(),
       'topbar' => [
         'status' => $node->isPublished() ? (string) $this->t('Published') : (string) $this->t('Draft'),
-        'state' => $node->isPublished() ? (string) $this->t('Published') : $this->operationalState($readiness),
+        'state' => ($node->isPublished() && $readiness->ready)
+          ? ''
+          : $this->operationalState($readiness),
         'lastSaved' => $node->getChangedTime() > 0 ? (string) $this->t('Last saved @time', [
           '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
         ]) : (string) $this->t('Not saved yet'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -234,7 +234,25 @@ final class EventStudioMelPayloadService {
 
     $field_location = $choice === 'saved' ? [] : ($mel['field_location'] ?? '');
 
-    $ticket_type = (string) ($mel['field_event_type'] ?? 'rsvp');
+    $eventNode = NULL;
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid > 0) {
+      $loaded = $entityTypeManager->getStorage('node')->load($nid);
+      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
+        $eventNode = $loaded;
+      }
+    }
+
+    $ticket_type = trim((string) ($mel['field_event_type'] ?? ''));
+    if ($ticket_type === ''
+        && $eventNode instanceof NodeInterface
+        && $eventNode->hasField('field_event_type')
+        && !$eventNode->get('field_event_type')->isEmpty()) {
+      $ticket_type = (string) $eventNode->get('field_event_type')->value;
+    }
+    if ($ticket_type === '') {
+      $ticket_type = 'rsvp';
+    }
     $capacity_raw = $mel['rsvp_capacity'] ?? '';
     $capacity = NULL;
     if ($ticket_type === 'rsvp') {
@@ -303,15 +321,6 @@ final class EventStudioMelPayloadService {
       'field_event_visibility' => trim((string) ($mel['field_event_visibility'] ?? '')),
       'event_passcode' => trim((string) ($mel['event_passcode'] ?? '')),
     ];
-
-    $eventNode = NULL;
-    $nid = (int) ($form_state->getValue('nid') ?? 0);
-    if ($nid > 0) {
-      $loaded = $entityTypeManager->getStorage('node')->load($nid);
-      if ($loaded instanceof NodeInterface && $loaded->bundle() === 'event') {
-        $eventNode = $loaded;
-      }
-    }
 
     if ($this->operationalCapabilityStudioManager !== NULL
       && (isset($mel['operational_capabilities']) || isset($mel['mel_operational_capabilities']))) {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -161,12 +161,19 @@ final class EventStudioSaveService {
     $this->applyAccessibilityTextPayload($node, $payload);
 
     if ($node->hasField('field_event_type') && isset($payload['field_event_type'])) {
-      $node->set('field_event_type', (string) $payload['field_event_type']);
+      $submitted_event_type = trim((string) $payload['field_event_type']);
+      if ($submitted_event_type !== '') {
+        $node->set('field_event_type', $submitted_event_type);
+      }
     }
 
-    $event_type = (string) ($payload['field_event_type'] ?? ($node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()
-      ? (string) $node->get('field_event_type')->value
-      : 'rsvp'));
+    $event_type = trim((string) ($payload['field_event_type'] ?? ''));
+    if ($event_type === '' && $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()) {
+      $event_type = (string) $node->get('field_event_type')->value;
+    }
+    if ($event_type === '') {
+      $event_type = 'rsvp';
+    }
 
     $ticket_errors = $this->applyTicketPayload($node, $payload, $event_type, $draft);
     if ($ticket_errors !== []) {
@@ -589,11 +596,11 @@ final class EventStudioSaveService {
     }
 
     if ($node->hasField('field_product_target')) {
-      if ($event_type === 'paid') {
+      if (in_array($event_type, ['paid', 'both'], TRUE)) {
         // Preserve field_product_target unless we successfully set a new valid product id.
         // Missing key / empty / zero from POST must NOT clear an existing link: conditional ticket UI,
         // autosave fragments, and multi-step wizard saves often omit the autocomplete while still paid.
-        // Switching booking mode away from paid clears in the branch below.
+        // Switching booking mode away from paid/both clears in the branch below.
         $has_explicit = array_key_exists('field_product_target', $payload);
         $raw_pid = $has_explicit ? $payload['field_product_target'] : NULL;
         $pid = ($raw_pid !== NULL && $raw_pid !== '' && (is_int($raw_pid) || is_numeric($raw_pid)))
@@ -621,7 +628,7 @@ final class EventStudioSaveService {
       }
     }
 
-    if (!$draft && $event_type === 'paid' && $node->hasField('field_product_target') && $node->get('field_product_target')->isEmpty()) {
+    if (!$draft && in_array($event_type, ['paid', 'both'], TRUE) && $node->hasField('field_product_target') && $node->get('field_product_target')->isEmpty()) {
       return ['Paid events need a ticket product. Link one above or open the Advanced ticket manager from Event Studio.'];
     }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -5,19 +5,21 @@
  */
 #}
 <header class="mel-event-studio-topbar" role="banner">
-  <div class="mel-event-studio-topbar__event">
+  <div class="mel-event-studio-topbar__primary">
     <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Studio'|t }}</p>
     <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
-  </div>
-  <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
-    <span class="mel-event-studio-topbar__badge" data-mel-publish-status>{{ topbar.status }}</span>
-    <span class="mel-event-studio-topbar__state" data-mel-publish-state>{{ topbar.state }}</span>
-    <span class="mel-event-studio-topbar__saved" data-mel-publish-last-saved>{{ topbar.last_saved }}</span>
-    <span class="mel-event-studio-topbar__autosave{% if topbar.restore_draft %} has-draft{% endif %}" id="mel-studio-form-state" role="status">
-      {% if topbar.restore_draft %}
-        <a href="{{ topbar.restore_url }}">{{ 'Restore draft available'|t }}</a>
+    <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
+      <span class="mel-event-studio-topbar__badge" data-mel-publish-status>{{ topbar.status }}</span>
+      {% if topbar.state %}
+        <span class="mel-event-studio-topbar__state" data-mel-publish-state>{{ topbar.state }}</span>
       {% endif %}
-    </span>
+      <span class="mel-event-studio-topbar__saved" data-mel-publish-last-saved>{{ topbar.last_saved }}</span>
+      <span class="mel-event-studio-topbar__autosave{% if topbar.restore_draft %} has-draft{% endif %}" id="mel-studio-form-state" role="status">
+        {% if topbar.restore_draft %}
+          <a href="{{ topbar.restore_url }}">{{ 'Restore draft available'|t }}</a>
+        {% endif %}
+      </span>
+    </div>
   </div>
   <div class="mel-event-studio-topbar__actions">
     {% if topbar.show_manage_event_link %}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -80,12 +80,18 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
   public function testStudioTopBarManageEventLinkPointsToVendorWorkspace(): void {
     $topbar = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-topbar.html.twig');
     $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+    $shellCss = file_get_contents(dirname(__DIR__, 3) . '/css/mel-event-studio-shell.css');
     $this->assertIsString($topbar);
     $this->assertIsString($controller);
+    $this->assertIsString($shellCss);
     $this->assertStringContainsString('show_manage_event_link', $topbar);
     $this->assertStringContainsString('Manage event', $topbar);
     $this->assertStringContainsString('manage_event_url', $topbar);
     $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $controller);
+    $this->assertStringContainsString('mel-event-studio-topbar__primary', $topbar);
+    $this->assertStringContainsString('{% if topbar.state %}', $topbar);
+    $this->assertStringContainsString('display: flex', $shellCss);
+    $this->assertStringNotContainsString('grid-template-columns: minmax(0, 1fr) auto auto', $shellCss);
   }
 
   public function testVendorEventWorkspaceRendersTodaysFocusRegion(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioProductTargetPreservationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioProductTargetPreservationTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Image\ImageFactory;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventReadinessService;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\QuestionFieldTypeRegistry;
+use Drupal\myeventlane_venue\Service\VenueManager;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
+use Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * @group myeventlane_event_studio
+ */
+final class EventStudioProductTargetPreservationTest extends UnitTestCase {
+
+  /**
+   * Partial mel without ticket fields must carry forward node product + event type.
+   */
+  public function testBuildFromFormStatePreservesProductTargetAndEventTypeFromNode(): void {
+    $event = $this->createEventNodeMock(42, 'paid', 90);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->with(42)->willReturn($event);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $form_state = $this->createMock(FormStateInterface::class);
+    $form_state->method('getValue')->willReturnMap([
+      ['mel', ['title' => 'Updated title']],
+      ['nid', 42],
+    ]);
+
+    $payload_service = new EventStudioMelPayloadService(
+      $this->createMock(EventHighlightHelper::class),
+      $this->createMock(QuestionFieldTypeRegistry::class),
+    );
+
+    $payload = $payload_service->buildFromFormState($form_state, $entity_type_manager);
+
+    $this->assertSame('paid', $payload['field_event_type']);
+    $this->assertSame(90, $payload['field_product_target']);
+  }
+
+  /**
+   * applyTicketPayload() must not clear product target for hybrid (both) events.
+   */
+  public function testApplyTicketPayloadPreservesProductTargetForBothEventType(): void {
+    $state = ['product_target_id' => 55];
+    $event = $this->createMutableEventNodeMock('both', $state);
+    $service = $this->buildSaveService();
+
+    $errors = $this->invokeApplyTicketPayload($service, $event, [
+      'field_product_target' => NULL,
+      'field_event_type' => 'both',
+    ], 'both', TRUE);
+
+    $this->assertSame([], $errors);
+    $this->assertSame(55, $state['product_target_id']);
+  }
+
+  /**
+   * Explicit valid replacement product id must still update the node reference.
+   */
+  public function testApplyTicketPayloadReplacesProductTargetWhenValidIdSubmitted(): void {
+    $state = ['product_target_id' => 55];
+    $event = $this->createMutableEventNodeMock('paid', $state);
+
+    $product = $this->createMock(\Drupal\commerce_product\Entity\ProductInterface::class);
+    $product->method('bundle')->willReturn('ticket');
+
+    $product_storage = $this->createMock(EntityStorageInterface::class);
+    $product_storage->method('load')->with(99)->willReturn($product);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->willReturnMap([
+      ['commerce_product', $product_storage],
+    ]);
+
+    $service = $this->buildSaveService($entity_type_manager);
+
+    $errors = $this->invokeApplyTicketPayload($service, $event, [
+      'field_product_target' => 99,
+      'field_event_type' => 'paid',
+    ], 'paid', TRUE);
+
+    $this->assertSame([], $errors);
+    $this->assertSame(99, $state['product_target_id']);
+  }
+
+  /**
+   * Switching away from paid-capable booking mode still clears the product target.
+   */
+  public function testApplyTicketPayloadClearsProductTargetWhenEventTypeIsRsvp(): void {
+    $state = ['product_target_id' => 55];
+    $event = $this->createMutableEventNodeMock('rsvp', $state);
+    $service = $this->buildSaveService();
+
+    $this->invokeApplyTicketPayload($service, $event, [
+      'field_product_target' => NULL,
+      'field_event_type' => 'rsvp',
+    ], 'rsvp', TRUE);
+
+    $this->assertNull($state['product_target_id']);
+  }
+
+  private function createEventNodeMock(int $nid, string $event_type, int $product_id): NodeInterface {
+    $product_field = $this->createEntityReferenceField($product_id);
+    $event_type_field = $this->createListField($event_type);
+
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('id')->willReturn($nid);
+    $event->method('bundle')->willReturn('event');
+    $event->method('hasField')->willReturnCallback(static fn (string $field): bool => in_array($field, [
+      'field_product_target',
+      'field_event_type',
+    ], TRUE));
+    $event->method('get')->willReturnCallback(static function (string $field) use ($product_field, $event_type_field): FieldItemListInterface {
+      return match ($field) {
+        'field_product_target' => $product_field,
+        'field_event_type' => $event_type_field,
+        default => throw new \InvalidArgumentException($field),
+      };
+    });
+
+    return $event;
+  }
+
+  /**
+   * @param array{product_target_id: int|null} $state
+   */
+  private function createMutableEventNodeMock(string $event_type, array &$state): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('hasField')->willReturnCallback(static fn (string $field): bool => in_array($field, [
+      'field_product_target',
+      'field_event_type',
+      'field_capacity',
+      'field_external_url',
+      'field_collect_per_ticket',
+    ], TRUE));
+    $event->method('get')->willReturnCallback(function (string $field) use (&$state, $event_type): FieldItemListInterface {
+      if ($field === 'field_product_target') {
+        return $this->createEntityReferenceField($state['product_target_id']);
+      }
+      if ($field === 'field_event_type') {
+        return $this->createListField($event_type);
+      }
+      return $this->createEmptyField();
+    });
+    $event->method('set')->willReturnCallback(function (string $field, mixed $value) use (&$state, $event): NodeInterface {
+      if ($field === 'field_product_target') {
+        if ($value === NULL || $value === []) {
+          $state['product_target_id'] = NULL;
+        }
+        elseif (is_array($value) && isset($value['target_id'])) {
+          $state['product_target_id'] = (int) $value['target_id'];
+        }
+        elseif (is_array($value) && isset($value[0]['target_id'])) {
+          $state['product_target_id'] = (int) $value[0]['target_id'];
+        }
+      }
+      return $event;
+    });
+
+    return $event;
+  }
+
+  private function createEntityReferenceField(?int $target_id): FieldItemListInterface {
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('isEmpty')->willReturn($target_id === NULL);
+    $field->target_id = $target_id;
+    return $field;
+  }
+
+  private function createListField(string $value): FieldItemListInterface {
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('isEmpty')->willReturn($value === '');
+    $field->value = $value;
+    return $field;
+  }
+
+  private function createEmptyField(): FieldItemListInterface {
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('isEmpty')->willReturn(TRUE);
+    $field->method('setValue')->willReturnSelf();
+    return $field;
+  }
+
+  private function buildSaveService(?EntityTypeManagerInterface $entity_type_manager = NULL): EventStudioSaveService {
+    $entity_type_manager ??= $this->createMock(EntityTypeManagerInterface::class);
+
+    return new EventStudioSaveService(
+      $entity_type_manager,
+      $this->createMock(VenueManager::class),
+      $this->createMock(LoggerInterface::class),
+      $this->createMock(EventHighlightHelper::class),
+      $this->createMock(PaidPublishStripeGate::class),
+      $this->createMock(VendorPublishRequirementsGate::class),
+      $this->createMock(EventReadinessService::class),
+      $this->createMock(QuestionFieldTypeRegistry::class),
+      $this->createMock(ImageFactory::class),
+      $this->createMock(TranslationInterface::class),
+      $this->createMock(\Drupal\Core\File\FileSystemInterface::class),
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $payload
+   *
+   * @return list<string>
+   */
+  private function invokeApplyTicketPayload(
+    EventStudioSaveService $service,
+    NodeInterface $node,
+    array $payload,
+    string $event_type,
+    bool $draft,
+  ): array {
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'applyTicketPayload');
+    $method->setAccessible(TRUE);
+
+    /** @var list<string> $errors */
+    $errors = $method->invoke($service, $node, $payload, $event_type, $draft);
+    return $errors;
+  }
+
+}

--- a/web/modules/custom/myeventlane_surface/myeventlane_surface.module
+++ b/web/modules/custom/myeventlane_surface/myeventlane_surface.module
@@ -31,8 +31,8 @@
  *   array $evaluations (state value strings keyed by state id).
  * - hook_mel_observability_page_payload_alter(): Final MELObservabilitySystem payload (traces,
  *   registry index, telemetry boundary reference). Parameters: array &$payload,
- *   \Drupal\myeventlane_surface\MelWorkflowContext $context, array $merged_signals,
- *   array $evaluations (state value strings keyed by state id).
+ *   \Drupal\myeventlane_surface\MelWorkflowContext $context, array $merged_signals
+ *   (state evaluations under merged_signals['state_evaluations'] when needed).
  */
 
 declare(strict_types=1);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -749,6 +749,23 @@ function _myeventlane_vendor_theme_event_studio_routes(): array {
   return [
     'myeventlane_event_studio.create',
     'myeventlane_event_studio.edit',
+    'myeventlane_event_studio.workspace',
+    'myeventlane_event_studio.workspace_information',
+    'myeventlane_event_studio.workspace_branding',
+    'myeventlane_event_studio.workspace_content',
+    'myeventlane_event_studio.workspace_tickets',
+    'myeventlane_event_studio.workspace_questions',
+    'myeventlane_event_studio.workspace_capacity',
+    'myeventlane_event_studio.workspace_extras',
+    'myeventlane_event_studio.workspace_merchandise',
+    'myeventlane_event_studio.workspace_addons',
+    'myeventlane_event_studio.workspace_add_ons',
+    'myeventlane_event_studio.workspace_promotions',
+    'myeventlane_event_studio.workspace_attendees',
+    'myeventlane_event_studio.workspace_fulfilment',
+    'myeventlane_event_studio.workspace_orders',
+    'myeventlane_event_studio.workspace_analytics',
+    'myeventlane_event_studio.workspace_settings',
   ];
 }
 
@@ -829,7 +846,7 @@ function myeventlane_vendor_theme_theme_suggestions_page_alter(array &$suggestio
     return;
   }
 
-  if (is_string($route_name) && str_starts_with($route_name, 'myeventlane_vendor')) {
+  if (is_string($route_name) && (str_starts_with($route_name, 'myeventlane_vendor') || str_starts_with($route_name, 'myeventlane_event_studio.'))) {
     $suggestions[] = 'page__vendor';
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch the staging deploy path (pruning, disk gates, smaller artifacts) and Event Studio save logic for paid/hybrid events—incorrect behaviour could break deploys or unlink ticket products; help register edits are docs-only but include conflicting duplicate tables worth fixing before merge.
> 
> **Overview**
> This PR tightens **staging deploy reliability** and fixes **Event Studio** ticket/commerce behaviour, alongside Help Centre documentation updates.
> 
> **Deploy & CI:** The reusable build **shrinks release tarballs** (excludes docs, `.github`, dev scripts, SQL, etc.) and logs artifact size. Staging workflow adds a **remote disk preflight** before upload. `remote-deploy.sh` gains **release pruning** (keep N releases), **minimum free-disk checks**, safer removal of old releases (symlink-aware), clearer copy failures, and cleanup of failed partial releases.
> 
> **Event Studio:** Saves no longer drop **`field_product_target`** when partial MEL payloads omit ticket fields—**paid and hybrid (`both`)** events keep or update the linked Commerce product; empty `field_event_type` in POST falls back to the node. Topbar layout moves to **flex** (responsive stack), hides redundant readiness text when published, and JS/Twig only show draft state when relevant. Vendor theme treats **all Event Studio workspace routes** as vendor chrome. New unit tests cover product-target preservation; PHPUnit config splits a **light** unit suite.
> 
> **Help / ops docs:** Vendor drafts for **checkout questions** and **saved templates** are aligned to verified routes and behaviour; QA/governance logs added for attendee questions and **calendar duplicate nodes** (1501 vs 1673). `next-batch-register.md` is updated with import status and calendar import blockers (note: the diff still contains **overlapping duplicate register tables** that may need editorial cleanup).
> 
> **Minor:** Observability hook drops unused `$evaluations` param; `.gitignore` covers PHPUnit result caches; duplicate docblock removed in commerce addon form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af319071225700afcead3014a1bd5f24a841789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->