### PR TITLE
fix(surface): isolate workflow and state alter failures

### DIFF
--- a/web/modules/custom/myeventlane_surface/myeventlane_surface.services.yml
+++ b/web/modules/custom/myeventlane_surface/myeventlane_surface.services.yml
@@ -212,6 +212,7 @@ services:
       - '@module_handler'
       - '@myeventlane_onboarding.manager'
       - '@path.matcher'
+      - '@logger.channel.myeventlane_surface'
 
   myeventlane_surface.workflow_progress_helper:
     class: Drupal\myeventlane_surface\MelWorkflowProgressHelper
@@ -424,6 +425,7 @@ services:
     arguments:
       - '@myeventlane_surface.workflow_resolver'
       - '@module_handler'
+      - '@logger.channel.myeventlane_surface'
 
   myeventlane_surface.state_lifecycle_helper:
     class: Drupal\myeventlane_surface\MelLifecycleHelper

--- a/web/modules/custom/myeventlane_surface/src/MelStateResolver.php
+++ b/web/modules/custom/myeventlane_surface/src/MelStateResolver.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_surface;
 use Drupal\myeventlane_core\MelStateEvaluation;
 
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 
 /**
  * Merges workflow signals with domain facts and evaluates interpretation contracts.
@@ -20,6 +21,7 @@ final class MelStateResolver {
   public function __construct(
     private readonly MelWorkflowResolver $workflowResolver,
     private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly LoggerChannelInterface $logger,
   ) {}
 
   /**
@@ -36,7 +38,14 @@ final class MelStateResolver {
    */
   public function mergeDomainSignals(MelWorkflowContext $context): array {
     $facts = [];
-    $this->moduleHandler->alter('mel_state_domain_facts', $facts, $context);
+    try {
+      $this->moduleHandler->alter('mel_state_domain_facts', $facts, $context);
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('mel_state_domain_facts alter failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
 
     $merged = array_merge($context->signals, $facts);
     return $this->applyInterpretationAliases($merged);

--- a/web/modules/custom/myeventlane_surface/src/MelWorkflowResolver.php
+++ b/web/modules/custom/myeventlane_surface/src/MelWorkflowResolver.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_surface;
 use Drupal\myeventlane_core\MelSurfaceId;
 
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -30,6 +31,7 @@ final class MelWorkflowResolver {
     private readonly ModuleHandlerInterface $moduleHandler,
     private readonly OnboardingManager $onboardingManager,
     private readonly PathMatcherInterface $pathMatcher,
+    private readonly LoggerChannelInterface $logger,
   ) {}
 
   /**
@@ -50,7 +52,14 @@ final class MelWorkflowResolver {
       'route_name' => $route_name,
       'path' => $path,
     ];
-    $this->moduleHandler->alter('mel_workflow_signals', $signals, $this->currentUser, $workflow_context);
+    try {
+      $this->moduleHandler->alter('mel_workflow_signals', $signals, $this->currentUser, $workflow_context);
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('mel_workflow_signals alter failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
 
     return new MelWorkflowContext(
       surface: $surface,

--- a/web/modules/custom/myeventlane_surface/tests/modules/mel_surface_alter_contract_test/mel_surface_alter_contract_test.module
+++ b/web/modules/custom/myeventlane_surface/tests/modules/mel_surface_alter_contract_test/mel_surface_alter_contract_test.module
@@ -18,10 +18,27 @@ function mel_surface_alter_contract_test_mel_workflow_signals_alter(
   AccountInterface $account,
   array &$workflow_context,
 ): void {
+  if (\Drupal::state()->get('mel_surface_alter_contract_test.throw_workflow_alter')) {
+    \Drupal::state()->set('mel_surface_alter_contract_test.workflow_alter_reached', TRUE);
+    throw new \RuntimeException('mel_surface_alter_contract_test forced workflow alter failure');
+  }
   \Drupal::state()->set(
     'mel_surface_alter_contract_test.workflow_context',
     $workflow_context,
   );
+}
+
+/**
+ * Implements hook_mel_state_domain_facts_alter().
+ */
+function mel_surface_alter_contract_test_mel_state_domain_facts_alter(
+  array &$facts,
+  MelWorkflowContext $context,
+): void {
+  if (\Drupal::state()->get('mel_surface_alter_contract_test.throw_state_domain_facts_alter')) {
+    \Drupal::state()->set('mel_surface_alter_contract_test.state_alter_reached', TRUE);
+    throw new \RuntimeException('mel_surface_alter_contract_test forced state domain facts alter failure');
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_surface/tests/src/Kernel/MelSurfaceAlterContractKernelTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Kernel/MelSurfaceAlterContractKernelTest.php
@@ -38,12 +38,48 @@ final class MelSurfaceAlterContractKernelTest extends MelSurfaceGovernanceKernel
   protected function setUp(): void {
     parent::setUp();
     \Drupal::state()->deleteMultiple([
+      'mel_surface_alter_contract_test.throw_workflow_alter',
+      'mel_surface_alter_contract_test.throw_state_domain_facts_alter',
+      'mel_surface_alter_contract_test.workflow_alter_reached',
+      'mel_surface_alter_contract_test.state_alter_reached',
       'mel_surface_alter_contract_test.workflow_context',
       'mel_surface_alter_contract_test.observability_merged_keys',
       'mel_surface_alter_contract_test.observability_state_evaluations',
       'mel_surface_alter_contract_test.operational_policy_merged_keys',
       'mel_surface_alter_contract_test.operational_policy_state_evaluations',
     ]);
+  }
+
+  public function testWorkflowAlterFailureDoesNotBreakBuildContext(): void {
+    \Drupal::state()->set('mel_surface_alter_contract_test.throw_workflow_alter', TRUE);
+    $this->loginAnonymous();
+    $this->pushRouteRequest('/checkout/review', 'commerce_checkout.review', new Route('/checkout/review'));
+
+    $context = $this->container->get('myeventlane_surface.workflow_resolver')->buildContext();
+
+    $this->assertTrue((bool) \Drupal::state()->get('mel_surface_alter_contract_test.workflow_alter_reached'));
+    $this->assertSame('commerce_checkout.review', $context->routeName);
+    $this->assertSame('/checkout/review', $context->path);
+    $this->assertIsArray($context->signals);
+    $this->assertArrayHasKey('route.checkout_sensitive', $context->signals);
+
+    $this->popRequest();
+  }
+
+  public function testStateDomainFactsAlterFailureDoesNotBreakMergeDomainSignals(): void {
+    \Drupal::state()->set('mel_surface_alter_contract_test.throw_state_domain_facts_alter', TRUE);
+    $this->loginAnonymous();
+    $this->pushRouteRequest('/checkout/review', 'commerce_checkout.review', new Route('/checkout/review'));
+
+    $workflow_resolver = $this->container->get('myeventlane_surface.workflow_resolver');
+    $context = $workflow_resolver->buildContext();
+    $merged = $this->container->get('myeventlane_surface.state_resolver')->mergeDomainSignals($context);
+
+    $this->assertTrue((bool) \Drupal::state()->get('mel_surface_alter_contract_test.state_alter_reached'));
+    $this->assertIsArray($merged);
+    $this->assertArrayHasKey('route.checkout_sensitive', $merged);
+
+    $this->popRequest();
   }
 
   public function testWorkflowSignalsAlterDeliversRouteAndPathContextBag(): void {


### PR DESCRIPTION
- **docs(help): verify attendee question drafts**
- **docs(help): export attendee questions help batch**
- **docs(help): log attendee questions help import**
- **docs(help): record calendar duplicate governance**
- **fix(tests): pass OperationalVariationStockResolver in kernel helpers**
- **fix(deploy): prevent drush deploy exit 255 on low CLI memory**
- **feat(event-studio): enhance event extras layout and summary features**
- **Add guidelines for framing Cursor prompts in MEL documentation**
- **refactor(styles): update event layout classes and media queries**
- **Update SCSS for event layout: change class reference from .mel-event-full__primary to .mel-event-full__main for improved grid ownership.**
- **fix: resolve Bugbot regressions across runtime, seed, layout, and deploy**
- **refactor(EventStudioMelPayloadService): improve normalization of hero image data**
- **refactor(EventStudioMelPayloadService): improve normalization of hero image data**
- **Update PHPUnit result cache with new test execution times for EventStudioExtrasProductEditorTest**
- **Update PHPUnit result cache and enhance sidebar link styles in SCSS. Adjusted link colors and focus states for better accessibility and visual consistency.**
- **fix(commerce): remove stale PHPDoc on buildSizeRadioGroup**
- **chore: ignore and untrack module-level PHPUnit result cache**
- **fix(event-studio): scope lightweight phpunit.xml to bootstrap-safe tests**
- **Update .gitignore to streamline PHPUnit result cache entry by removing the specific path prefix, enhancing clarity and consistency in ignored files.**
- **Refactor topbar layout and functionality: change from grid to flexbox for better alignment, update state handling in JavaScript, and adjust CSS classes for improved responsiveness. Increment library version to 1.2.**
- **fix(deploy): prevent staging failures from disk exhaustion**
- **refactor(event-studio): enhance workspace logging and section content handling**
- **Refactor EventStudioController logging and improve section content handling. Removed unused methods from EventStudioMelPayloadService and streamlined event type retrieval logic.**
- **feat(event-studio): add methods for normalizing and building hero image fields from MEL fragments**
- **fix(event-studio): address issues with hero image normalization and legacy data handling**
- **refactor(event-studio): streamline hero image processing and legacy data handling**
- **fix(studio): align paid publish blocker with stripe gate**
- **fix(stripe): support standard accounts in manage flow**
- **refactor(myeventlane): remove unused evaluations parameter from observability page payload alter function**
- **Enhance deployment workflows and documentation**
- **fix(surface): align alter hook contracts**
- **fix(surface): workflow alter context bag and api contracts**
- **fix(surface): isolate workflow and state alter failures**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive error handling around existing alter hooks with no change to signal semantics on success paths; covered by contract kernel tests.
> 
> **Overview**
> **MelWorkflowResolver** and **MelStateResolver** now wrap `hook_mel_workflow_signals_alter` and `hook_mel_state_domain_facts_alter` in **try/catch** blocks. Failures are logged as warnings on `logger.channel.myeventlane_surface` instead of aborting request handling, so a broken contrib alter cannot break checkout or surface context building.
> 
> Service definitions inject the surface logger into both resolvers. The alter contract test module can **force exceptions** from those hooks, and new kernel tests assert `buildContext()` and `mergeDomainSignals()` still return usable signals (e.g. `route.checkout_sensitive`) after a forced alter failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c615c3d411cf6c21f90e0c9d51c8377fa78ee51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->