### PR TITLE
fix(studio): hide legacy wizard nav on workspace routes

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioBaseForm.php
@@ -222,11 +222,13 @@ abstract class EventStudioBaseForm extends FormBase {
       '#default_value' => (string) (int) $node->getRevisionId(),
     ];
 
-    $form['wizard_nav'] = [
-      '#theme' => 'mel_event_studio_wizard_nav',
-      '#node' => $node,
-      '#current_step' => $this->getCurrentStepId(),
-    ];
+    if (!_myeventlane_event_studio_is_workspace_route()) {
+      $form['wizard_nav'] = [
+        '#theme' => 'mel_event_studio_wizard_nav',
+        '#node' => $node,
+        '#current_step' => $this->getCurrentStepId(),
+      ];
+    }
 
     $melDefaults = $this->wizardMelBaseline->getBaselineMel($node);
     $draft = $this->autosaveService->getDraft($node, $this->getCurrentStepId());

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
@@ -30,6 +30,23 @@ final class EventStudioWorkspaceLibraryAttachmentTest extends TestCase {
     $this->assertStringContainsString("'myeventlane_event_studio.workspace_add_ons'", $module);
   }
 
+  public function testBaseFormSkipsWizardNavOnWorkspaceRoutes(): void {
+    $baseForm = file_get_contents($this->moduleRoot . '/src/Form/EventStudioBaseForm.php');
+    $this->assertIsString($baseForm);
+    $this->assertStringContainsString('_myeventlane_event_studio_is_workspace_route()', $baseForm);
+    $this->assertMatchesRegularExpression(
+      '/if\s*\(!_myeventlane_event_studio_is_workspace_route\(\)\)\s*\{[\s\S]*mel_event_studio_wizard_nav/s',
+      $baseForm,
+    );
+  }
+
+  public function testCheckoutQuestionsFormDoesNotRenderWizardNav(): void {
+    $form = file_get_contents($this->moduleRoot . '/src/Form/EventCheckoutQuestionsForm.php');
+    $this->assertIsString($form);
+    $this->assertStringNotContainsString('mel_event_studio_wizard_nav', $form);
+    $this->assertStringNotContainsString('EventStudioBaseForm', $form);
+  }
+
   public function testBaseFormSkipsLegacyBundleOnWorkspaceRoutes(): void {
     $baseForm = file_get_contents($this->moduleRoot . '/src/Form/EventStudioBaseForm.php');
     $this->assertIsString($baseForm);


### PR DESCRIPTION
## Summary

- Skip `mel_event_studio_wizard_nav` on workspace section forms when `_myeventlane_event_studio_is_workspace_route()` is true.
- Workspace already uses the shell sidebar; this removes duplicate navigation confirmed in browser audit.
- Legacy wizard step routes (`edit_basic`, etc.) are unchanged.

Stacks on #504 (`fix/event-studio-baseline-extraction`).

## Test plan

- [x] `ddev drush cr`
- [x] `ddev drush config:status` — no drift
- [x] `composer validate`
- [x] `npm run mel:lint` / `npm run mel:build`
- [x] PHPUnit `EventStudioWorkspaceLibraryAttachmentTest` — 9/9
- [x] Playwright: information, branding, content, tickets, settings — sidebar present, wizard nav absent, publish visible
- [x] Autosave still succeeds on information after change
- [x] Legacy `/vendor/events/{node}/edit/basic` still renders wizard nav


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation change on workspace routes; legacy wizard behavior and save/autosave paths are untouched.
> 
> **Overview**
> **Event Studio workspace** section forms no longer render the legacy **`mel_event_studio_wizard_nav`** block from `EventStudioBaseForm` when the current route is a workspace section (`_myeventlane_event_studio_is_workspace_route()`). The workspace shell already provides sidebar navigation, so this removes duplicate step UI on those routes.
> 
> **Legacy wizard** step URLs (e.g. `edit_basic`) are unchanged and still get the wizard nav. Unit tests in `EventStudioWorkspaceLibraryAttachmentTest` lock in the guarded `wizard_nav` wiring and that checkout-questions forms do not reference the wizard nav theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1ed902006d2b9031699e3b0b9b8ebad235d0ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->