### PR TITLE
Register Postmark delivery provider service

### DIFF
--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -31,10 +31,18 @@ services:
       - '@plugin.manager.mail'
       - '@logger.channel.myeventlane_messaging'
 
+  myeventlane_messaging.delivery.postmark:
+    class: Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider
+    arguments:
+      - '@http_client_factory'
+      - '@config.factory'
+      - '@logger.channel.myeventlane_messaging'
+
   myeventlane_messaging.delivery_provider_manager:
     class: Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager
     arguments:
       - '@myeventlane_messaging.delivery.drupal_mail'
+      - '@myeventlane_messaging.delivery.postmark'
       - '@config.factory'
 
   myeventlane_messaging.vendor_brand_resolver:

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderManager.php
@@ -18,11 +18,14 @@ final class DeliveryProviderManager {
    *
    * @param \Drupal\myeventlane_messaging\Service\Delivery\DrupalMailProvider $drupalMailProvider
    *   The default Drupal mail provider.
+   * @param \Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider $postmarkProvider
+   *   The Postmark delivery provider (registered; selection deferred to later phase).
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory (for future vendor provider selection).
    */
   public function __construct(
     private readonly DrupalMailProvider $drupalMailProvider,
+    private readonly PostmarkDeliveryProvider $postmarkProvider,
     private readonly ConfigFactoryInterface $configFactory,
   ) {}
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
@@ -45,6 +45,8 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
    * {@inheritdoc}
    */
   public function send(array $params): bool {
+    $this->lastMessageId = NULL;
+
     $config = $this->configFactory->get('myeventlane_messaging.settings');
     $serverToken = $config->get('postmark.server_token');
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small DI and constructor wiring plus a defensive reset in Postmark send; no change to which provider is selected for outbound email yet.
> 
> **Overview**
> **Wires Postmark into the messaging module’s delivery layer** without changing which provider sends mail at runtime.
> 
> A new `myeventlane_messaging.delivery.postmark` service is defined and **injected into** `DeliveryProviderManager` alongside the existing Drupal mail provider. `getProvider()` still resolves only `drupal_mail` (unknown ids fall back the same way); comments note Postmark selection is deferred to a later phase.
> 
> **Postmark `send()`** now **clears** `lastMessageId` at the start of each call so a failed or skipped send does not leave a stale provider message ID for downstream correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac152938d05c92a602b7a60bacd8f37319ad1596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->