### PR TITLE
Add donation fields to event form and enhance messaging settings

### DIFF
--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -112,6 +112,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true

--- a/config/sync/field.field.commerce_order_item.rsvp_donation.field_rsvp_submission.yml
+++ b/config/sync/field.field.commerce_order_item.rsvp_donation.field_rsvp_submission.yml
@@ -1,3 +1,4 @@
+uuid: d8433aec-c2ee-4886-9410-e7eee0bf48b3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/myeventlane_messaging.settings.yml
+++ b/config/sync/myeventlane_messaging.settings.yml
@@ -6,3 +6,9 @@ event_reminder_hours: 24
 cart_abandoned_enabled: true
 cart_abandoned_hours: 2
 batch_size: 50
+max_messages_per_run: 200
+delivery_provider: drupal_mail
+postmark:
+  server_token: ''
+  webhook_secret: ''
+  message_stream: outbound

--- a/web/modules/custom/myeventlane_messaging/config/schema/myeventlane_messaging.schema.yml
+++ b/web/modules/custom/myeventlane_messaging/config/schema/myeventlane_messaging.schema.yml
@@ -31,6 +31,22 @@ myeventlane_messaging.settings:
     max_messages_per_run:
       type: integer
       label: 'Max messages per cron run'
+    delivery_provider:
+      type: string
+      label: 'Delivery provider (drupal_mail or postmark)'
+    postmark:
+      type: mapping
+      label: 'Postmark settings'
+      mapping:
+        server_token:
+          type: string
+          label: 'Server token (set via MEL_POSTMARK_SERVER_TOKEN in production)'
+        webhook_secret:
+          type: string
+          label: 'Webhook secret (set via MEL_POSTMARK_WEBHOOK_SECRET in production)'
+        message_stream:
+          type: string
+          label: 'Postmark message stream'
 
 # Template configs: myeventlane_messaging.template.*
 myeventlane_messaging.template.*:

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -44,6 +44,7 @@ services:
       - '@myeventlane_messaging.delivery.drupal_mail'
       - '@myeventlane_messaging.delivery.postmark'
       - '@config.factory'
+      - '@logger.channel.myeventlane_messaging'
 
   myeventlane_messaging.vendor_brand_resolver:
     class: Drupal\myeventlane_messaging\Service\VendorBrandResolver

--- a/web/modules/custom/myeventlane_messaging/src/Form/MessagingSettingsForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/MessagingSettingsForm.php
@@ -32,6 +32,56 @@ final class MessagingSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('myeventlane_messaging.settings');
 
+    $form['delivery'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Delivery provider'),
+      '#open' => TRUE,
+    ];
+
+    $form['delivery']['delivery_provider'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Email delivery provider'),
+      '#description' => $this->t('Select the provider used to send email. Postmark requires server credentials configured via environment variables.'),
+      '#options' => [
+        'drupal_mail' => $this->t('Drupal Mail'),
+        'postmark' => $this->t('Postmark'),
+      ],
+      '#default_value' => $config->get('delivery_provider') ?? 'drupal_mail',
+      '#required' => TRUE,
+    ];
+
+    $form['delivery']['postmark'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Postmark settings'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="delivery_provider"]' => ['value' => 'postmark'],
+        ],
+      ],
+    ];
+
+    $form['delivery']['postmark']['postmark_message_stream'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Message stream'),
+      '#description' => $this->t('Postmark message stream identifier (default: outbound).'),
+      '#default_value' => $config->get('postmark.message_stream') ?? 'outbound',
+      '#maxlength' => 64,
+      '#required' => TRUE,
+    ];
+
+    $form['delivery']['postmark']['postmark_server_token_status'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Server token'),
+      '#markup' => $this->secretStatusMarkup('MEL_POSTMARK_SERVER_TOKEN', (string) ($config->get('postmark.server_token') ?? '')),
+    ];
+
+    $form['delivery']['postmark']['postmark_webhook_secret_status'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Webhook secret'),
+      '#markup' => $this->secretStatusMarkup('MEL_POSTMARK_WEBHOOK_SECRET', (string) ($config->get('postmark.webhook_secret') ?? '')),
+    ];
+
     $form['sender'] = [
       '#type' => 'details',
       '#title' => $this->t('Sender settings'),
@@ -149,9 +199,46 @@ final class MessagingSettingsForm extends ConfigFormBase {
       ->set('cart_abandoned_hours', $form_state->getValue('cart_abandoned_hours'))
       ->set('batch_size', $form_state->getValue('batch_size'))
       ->set('max_messages_per_run', $form_state->getValue('max_messages_per_run'))
+      ->set('delivery_provider', $form_state->getValue('delivery_provider'))
+      ->set('postmark.message_stream', $form_state->getValue('postmark_message_stream'))
       ->save();
 
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Builds status markup for an env-backed secret field.
+   *
+   * @param string $envName
+   *   Environment variable name (e.g. MEL_POSTMARK_SERVER_TOKEN).
+   * @param string $effectiveValue
+   *   Effective config value after settings.php overrides.
+   */
+  private function secretStatusMarkup(string $envName, string $effectiveValue): string {
+    if ($this->getEnvValue($envName) !== '') {
+      return (string) $this->t('Configured via environment variable (@env).', ['@env' => $envName]);
+    }
+    if ($effectiveValue !== '') {
+      return (string) $this->t('Configured.');
+    }
+    return (string) $this->t('Not configured. Set @env in the web PHP process environment.', ['@env' => $envName]);
+  }
+
+  /**
+   * Reads a non-empty environment variable value.
+   */
+  private function getEnvValue(string $name): string {
+    $value = getenv($name);
+    if (is_string($value) && $value !== '') {
+      return $value;
+    }
+    if (isset($_ENV[$name]) && is_string($_ENV[$name]) && $_ENV[$name] !== '') {
+      return $_ENV[$name];
+    }
+    if (isset($_SERVER[$name]) && is_string($_SERVER[$name]) && $_SERVER[$name] !== '') {
+      return $_SERVER[$name];
+    }
+    return '';
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_messaging\Service\Delivery;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Resolves and returns the delivery provider for sending messages.
@@ -19,21 +20,24 @@ final class DeliveryProviderManager {
    * @param \Drupal\myeventlane_messaging\Service\Delivery\DrupalMailProvider $drupalMailProvider
    *   The default Drupal mail provider.
    * @param \Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider $postmarkProvider
-   *   The Postmark delivery provider (registered; selection deferred to later phase).
+   *   The Postmark delivery provider (registered; transport activation deferred).
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory (for future vendor provider selection).
+   *   The config factory for site delivery provider selection.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Logger channel for unknown provider warnings.
    */
   public function __construct(
     private readonly DrupalMailProvider $drupalMailProvider,
     private readonly PostmarkDeliveryProvider $postmarkProvider,
     private readonly ConfigFactoryInterface $configFactory,
+    private readonly LoggerInterface $logger,
   ) {}
 
   /**
    * Returns the delivery provider to use.
    *
    * @param string|null $providerId
-   *   Provider id (e.g. 'drupal_mail'). NULL to use default.
+   *   Provider id (e.g. 'drupal_mail'). NULL to use configured default.
    * @param mixed $context
    *   Optional context (e.g. event_id) for vendor-specific provider choice.
    *
@@ -41,12 +45,32 @@ final class DeliveryProviderManager {
    *   The provider instance.
    */
   public function getProvider(?string $providerId = NULL, $context = NULL): DeliveryProviderInterface {
-    $id = $providerId ?? 'drupal_mail';
-    // Stub: future Postmark/SendGrid/SES would be selected by id or context.
+    $id = $providerId ?? $this->getConfiguredProviderId();
+    return $this->resolveProviderById($id);
+  }
+
+  /**
+   * Reads delivery_provider from site messaging settings.
+   */
+  private function getConfiguredProviderId(): string {
+    $config = $this->configFactory->get('myeventlane_messaging.settings');
+    $id = $config->get('delivery_provider');
+    return is_string($id) && $id !== '' ? $id : 'drupal_mail';
+  }
+
+  /**
+   * Maps a provider id to a registered provider instance.
+   */
+  private function resolveProviderById(string $id): DeliveryProviderInterface {
     if ($id === 'drupal_mail') {
       return $this->drupalMailProvider;
     }
-    // Default to Drupal mail for any unknown or stub id.
+    if ($id === 'postmark') {
+      return $this->postmarkProvider;
+    }
+    $this->logger->warning('Unknown delivery provider "@id"; falling back to drupal_mail.', [
+      '@id' => $id,
+    ]);
     return $this->drupalMailProvider;
   }
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
@@ -26,7 +26,7 @@ final class MessageStorage {
    *
    * @param array $row
    *   Keys: template, channel, recipient, langcode, context (array), context_hash,
-   *   scheduled_for, status, attempts, created, sent.
+   *   scheduled_for, status, attempts, created, sent, provider, provider_message_id.
    *
    * @return string
    *   The message UUID.
@@ -53,6 +53,8 @@ final class MessageStorage {
         'attempts' => (int) ($row['attempts'] ?? 0),
         'created' => (int) ($row['created'] ?? 0),
         'sent' => (int) ($row['sent'] ?? 0),
+        'provider' => $row['provider'] ?? '',
+        'provider_message_id' => $row['provider_message_id'] ?? '',
       ])
       ->execute();
 
@@ -118,6 +120,32 @@ final class MessageStorage {
   }
 
   /**
+   * Finds a message by provider-assigned message ID.
+   *
+   * @param string $messageId
+   *   Provider message identifier (e.g. Postmark MessageID).
+   *
+   * @return object|null
+   *   StdClass with all columns; context as unserialized array. NULL if not found.
+   */
+  public function findByProviderMessageId(string $messageId): ?object {
+    if ($messageId === '') {
+      return NULL;
+    }
+    $r = $this->connection->select('myeventlane_message', 'm')
+      ->fields('m')
+      ->condition('m.provider_message_id', $messageId)
+      ->execute()
+      ->fetchObject();
+
+    if (!$r) {
+      return NULL;
+    }
+    $r->context = $r->context ? unserialize($r->context, ['allowed_classes' => FALSE]) : [];
+    return $r;
+  }
+
+  /**
    * Sent order_confirmation rows for a commerce order (recipient + serialized order_id).
    *
    * @return object[]
@@ -152,13 +180,13 @@ final class MessageStorage {
    * @param string $id
    *   Message UUID.
    * @param array $updates
-   *   Keys: status, attempts, sent.
+   *   Keys: status, attempts, sent, provider, provider_message_id.
    *
    * @return int
    *   Number of rows updated.
    */
   public function update(string $id, array $updates): int {
-    $allowed = ['status', 'attempts', 'sent'];
+    $allowed = ['status', 'attempts', 'sent', 'provider', 'provider_message_id'];
     $fields = array_intersect_key($updates, array_flip($allowed));
     if (empty($fields)) {
       return 0;

--- a/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_messaging\Service\MessageStorage;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests MessageStorage provider tracking (create, update, lookup).
+ *
+ * @group myeventlane_messaging
+ */
+#[RunTestsInSeparateProcesses]
+final class MessageStorageTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * Message storage under test.
+   */
+  private MessageStorage $storage;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once dirname(__DIR__, 3) . '/myeventlane_messaging.install';
+
+    $schema = $this->container->get('database')->schema();
+    $tables = myeventlane_messaging_schema();
+    if ($schema->tableExists('myeventlane_message')) {
+      $schema->dropTable('myeventlane_message');
+    }
+    $schema->createTable('myeventlane_message', $tables['myeventlane_message']);
+
+    $this->storage = new MessageStorage($this->container->get('database'));
+  }
+
+  /**
+   * create() persists provider and provider_message_id.
+   */
+  public function testCreatePersistsProviderFields(): void {
+    $id = $this->storage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'test@example.com',
+      'context' => ['key' => 'value'],
+      'context_hash' => hash('sha256', 'create-test'),
+      'status' => 'sent',
+      'provider' => 'postmark',
+      'provider_message_id' => 'create-test-id',
+    ]);
+
+    $row = $this->storage->load($id);
+    $this->assertNotNull($row);
+    $this->assertSame('postmark', $row->provider);
+    $this->assertSame('create-test-id', $row->provider_message_id);
+    $this->assertSame(['key' => 'value'], $row->context);
+  }
+
+  /**
+   * update() can set provider and provider_message_id.
+   */
+  public function testUpdateProviderFields(): void {
+    $id = $this->storage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'test@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'update-test'),
+      'status' => 'queued',
+    ]);
+
+    $updated = $this->storage->update($id, [
+      'status' => 'sent',
+      'provider' => 'postmark',
+      'provider_message_id' => 'update-test-id',
+    ]);
+    $this->assertSame(1, $updated);
+
+    $row = $this->storage->load($id);
+    $this->assertNotNull($row);
+    $this->assertSame('sent', $row->status);
+    $this->assertSame('postmark', $row->provider);
+    $this->assertSame('update-test-id', $row->provider_message_id);
+  }
+
+  /**
+   * findByProviderMessageId() returns a hydrated row.
+   */
+  public function testFindByProviderMessageId(): void {
+    $this->storage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'lookup@example.com',
+      'context' => ['lookup' => TRUE],
+      'context_hash' => hash('sha256', 'lookup-test'),
+      'status' => 'sent',
+      'provider' => 'postmark',
+      'provider_message_id' => 'lookup-test-id',
+    ]);
+
+    $row = $this->storage->findByProviderMessageId('lookup-test-id');
+    $this->assertNotNull($row);
+    $this->assertSame('lookup@example.com', $row->recipient);
+    $this->assertSame('postmark', $row->provider);
+    $this->assertSame(['lookup' => TRUE], $row->context);
+  }
+
+  /**
+   * findByProviderMessageId() returns NULL when not found.
+   */
+  public function testFindByProviderMessageIdNotFound(): void {
+    $this->assertNull($this->storage->findByProviderMessageId('missing-id'));
+    $this->assertNull($this->storage->findByProviderMessageId(''));
+  }
+
+}

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/DeliveryProviderManagerTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/DeliveryProviderManagerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Http\ClientFactory;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager;
+use Drupal\myeventlane_messaging\Service\Delivery\DrupalMailProvider;
+use Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager
+ *
+ * @group myeventlane_messaging
+ */
+final class DeliveryProviderManagerTest extends UnitTestCase {
+
+  /**
+   * @covers ::getProvider
+   */
+  public function testConfiguredDrupalMailReturnsDrupalMailProvider(): void {
+    $manager = $this->manager('drupal_mail');
+    $this->assertSame('drupal_mail', $manager->getProvider()->id());
+  }
+
+  /**
+   * @covers ::getProvider
+   */
+  public function testConfiguredPostmarkReturnsPostmarkProvider(): void {
+    $manager = $this->manager('postmark');
+    $this->assertSame('postmark', $manager->getProvider()->id());
+  }
+
+  /**
+   * @covers ::getProvider
+   */
+  public function testExplicitProviderOverridesConfig(): void {
+    $manager = $this->manager('drupal_mail');
+    $this->assertSame('postmark', $manager->getProvider('postmark')->id());
+  }
+
+  /**
+   * @covers ::getProvider
+   */
+  public function testUnknownProviderFallsBackToDrupalMail(): void {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        'Unknown delivery provider "@id"; falling back to drupal_mail.',
+        ['@id' => 'invalid-provider'],
+      );
+
+    $manager = $this->manager('drupal_mail', $logger);
+    $this->assertSame('drupal_mail', $manager->getProvider('invalid-provider')->id());
+  }
+
+  /**
+   * @covers ::getProvider
+   */
+  public function testUnknownConfiguredProviderFallsBackToDrupalMail(): void {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        'Unknown delivery provider "@id"; falling back to drupal_mail.',
+        ['@id' => 'invalid-provider'],
+      );
+
+    $manager = $this->manager('invalid-provider', $logger);
+    $this->assertSame('drupal_mail', $manager->getProvider()->id());
+  }
+
+  private function manager(string $deliveryProvider, ?LoggerInterface $logger = NULL): DeliveryProviderManager {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(static function (string $key) use ($deliveryProvider) {
+      return $key === 'delivery_provider' ? $deliveryProvider : NULL;
+    });
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('myeventlane_messaging.settings')->willReturn($config);
+
+    $channelLogger = $logger ?? $this->createMock(LoggerInterface::class);
+    $mailManager = $this->createMock(MailManagerInterface::class);
+    $drupalMail = new DrupalMailProvider($mailManager, $channelLogger);
+    $httpFactory = $this->createMock(ClientFactory::class);
+    $postmark = new PostmarkDeliveryProvider($httpFactory, $factory, $channelLogger);
+
+    return new DeliveryProviderManager($drupalMail, $postmark, $factory, $channelLogger);
+  }
+
+}

--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -180,3 +180,29 @@ $mel_stripe_webhook = $melGetEnv('MEL_STRIPE_WEBHOOK_SECRET');
 if ($mel_stripe_webhook !== '') {
   $config['commerce_payment.commerce_payment_gateway.stripe_pe_recurring']['configuration']['webhook_signing_secret'] = $mel_stripe_webhook;
 }
+
+// ---------------------------------------------------------------------------
+// Postmark (MyEventLane Messaging): secrets from the environment.
+//
+// PostmarkDeliveryProvider reads postmark.server_token; PostmarkWebhookController
+// reads postmark.webhook_secret. Do not commit tokens in config/sync; set env vars
+// on the host (same pattern as Stripe above).
+//
+//   MEL_POSTMARK_SERVER_TOKEN   — Postmark Server API token
+//   MEL_POSTMARK_WEBHOOK_SECRET — Postmark webhook signing secret
+//
+// DDEV: set these in a gitignored .ddev/config.local.yaml, for example
+//   web_environment:
+//     - MEL_POSTMARK_SERVER_TOKEN=…
+//     - MEL_POSTMARK_WEBHOOK_SECRET=…
+// then ddev restart.
+// ---------------------------------------------------------------------------
+$mel_postmark_server_token = $melGetEnv('MEL_POSTMARK_SERVER_TOKEN');
+if ($mel_postmark_server_token !== '') {
+  $config['myeventlane_messaging.settings']['postmark']['server_token'] = $mel_postmark_server_token;
+}
+
+$mel_postmark_webhook_secret = $melGetEnv('MEL_POSTMARK_WEBHOOK_SECRET');
+if ($mel_postmark_webhook_secret !== '') {
+  $config['myeventlane_messaging.settings']['postmark']['webhook_secret'] = $mel_postmark_webhook_secret;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Switching the site-wide delivery provider affects all outbound messaging; misconfigured Postmark env vars could block or misroute email until fallback behavior is understood.
> 
> **Overview**
> This PR wires **site-selectable email delivery** (Drupal Mail vs Postmark) into MyEventLane messaging and adds **provider-level message tracking** for webhook correlation.
> 
> **Messaging:** Synced settings add `delivery_provider`, Postmark placeholders (`server_token`, `webhook_secret`, `message_stream`), and `max_messages_per_run`. The admin settings form gains a delivery section (provider radios, editable message stream, read-only env status for secrets). `DeliveryProviderManager` now reads `delivery_provider` from config, returns `PostmarkDeliveryProvider` when selected, and logs plus falls back to Drupal Mail for unknown IDs. `MessageStorage` persists and updates `provider` / `provider_message_id` and adds `findByProviderMessageId()`. Postmark tokens are injected from `MEL_POSTMARK_*` env vars in `settings.mel_shared_session.php` (Stripe-style). Kernel and unit tests cover storage and provider resolution.
> 
> **Config housekeeping:** The event **studio_branding** form display hides donation-related fields. The `rsvp_donation` order item `field_rsvp_submission` config gets a stable **uuid**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b4825c72ce857c50e441e2749e37b3c47a644b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->