### PR TITLE
fix(messaging): persist provider IDs and honor Postmark message stream

### DIFF
--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderInterface.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderInterface.php
@@ -26,4 +26,11 @@ interface DeliveryProviderInterface {
    */
   public function id(): string;
 
+  /**
+   * Provider-assigned message ID from the last successful send(), if any.
+   *
+   * Used to correlate delivery webhooks (e.g. Postmark MessageID).
+   */
+  public function getLastProviderMessageId(): ?string;
+
 }

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DrupalMailProvider.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DrupalMailProvider.php
@@ -95,4 +95,11 @@ final class DrupalMailProvider implements DeliveryProviderInterface {
     return FALSE;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getLastProviderMessageId(): ?string {
+    return NULL;
+  }
+
 }

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
@@ -67,12 +67,17 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
       return FALSE;
     }
 
+    $messageStream = $config->get('postmark.message_stream');
+    if (!is_string($messageStream) || $messageStream === '') {
+      $messageStream = 'outbound';
+    }
+
     $payload = [
       'From' => !empty($fromName) ? "{$fromName} <{$fromEmail}>" : $fromEmail,
       'To' => $to,
       'Subject' => $subject,
       'HtmlBody' => $htmlBody,
-      'MessageStream' => 'outbound',
+      'MessageStream' => $messageStream,
     ];
 
     if (!empty($replyTo)) {
@@ -147,12 +152,9 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
   private ?string $lastMessageId = NULL;
 
   /**
-   * Gets the last provider message ID.
-   *
-   * @return string|null
-   *   Provider message ID from last send() call.
+   * {@inheritdoc}
    */
-  public function getLastMessageId(): ?string {
+  public function getLastProviderMessageId(): ?string {
     return $this->lastMessageId;
   }
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -459,10 +459,16 @@ final class MessagingManager {
 
     $this->messageStorage->incrementAttempts($messageId);
     if ($sent) {
-      $this->messageStorage->update($messageId, [
+      $updates = [
         'status' => 'sent',
         'sent' => (int) time(),
-      ]);
+        'provider' => $provider->id(),
+      ];
+      $providerMessageId = $provider->getLastProviderMessageId();
+      if ($providerMessageId !== NULL && $providerMessageId !== '') {
+        $updates['provider_message_id'] = $providerMessageId;
+      }
+      $this->messageStorage->update($messageId, $updates);
       $this->logger->info('Sent message @type to @to. message_id=@id', [
         '@type' => $type,
         '@to' => $to,


### PR DESCRIPTION
Store provider and provider_message_id when the queue send path marks a message sent so Postmark webhooks can match delivery and bounce events. Read postmark.message_stream from config instead of hardcoding outbound.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the transactional email send path and stored message metadata used for webhook correlation; misconfiguration of message stream could misroute sends in Postmark.
> 
> **Overview**
> When the queue send path marks a message **sent**, it now also writes **`provider`** and, when available, **`provider_message_id`** so Postmark (and other) delivery webhooks can match bounces and delivery events to stored rows.
> 
> Delivery providers expose a shared **`getLastProviderMessageId()`** on the interface (Postmark renames from **`getLastMessageId()`**; Drupal mail always returns `NULL`). Postmark API sends use **`postmark.message_stream`** from site config, falling back to **`outbound`** instead of a hardcoded stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f063499075e1ad12fb62798167999808fd6549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->