### PR TITLE
feat(messaging): add Postmark webhook endpoints for delivery and boun…

### DIFF
--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.routing.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.routing.yml
@@ -1,3 +1,21 @@
+# Postmark delivery webhook — public endpoint, secret-verified in controller.
+myeventlane_messaging.postmark_webhook_delivery:
+  path: '/webhooks/postmark/delivery'
+  defaults:
+    _controller: '\Drupal\myeventlane_messaging\Controller\PostmarkWebhookController::delivery'
+  requirements:
+    _access: 'TRUE'
+  methods: [POST]
+
+# Postmark bounce webhook — public endpoint, secret-verified in controller.
+myeventlane_messaging.postmark_webhook_bounce:
+  path: '/webhooks/postmark/bounce'
+  defaults:
+    _controller: '\Drupal\myeventlane_messaging\Controller\PostmarkWebhookController::bounce'
+  requirements:
+    _access: 'TRUE'
+  methods: [POST]
+
 # Unsubscribe endpoint for email preferences.
 myeventlane_messaging.unsubscribe:
   path: '/email/unsubscribe/{uid}/{ts}/{h}'

--- a/web/modules/custom/myeventlane_messaging/src/Controller/PostmarkWebhookController.php
+++ b/web/modules/custom/myeventlane_messaging/src/Controller/PostmarkWebhookController.php
@@ -29,10 +29,12 @@ final class PostmarkWebhookController extends ControllerBase {
    *   The preference storage.
    */
   public function __construct(
-    private readonly ConfigFactoryInterface $configFactory,
+    ConfigFactoryInterface $config_factory,
     private readonly MessageStorage $messageStorage,
     private readonly MessagePreferenceStorage $preferenceStorage,
-  ) {}
+  ) {
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * {@inheritdoc}
@@ -153,21 +155,12 @@ final class PostmarkWebhookController extends ControllerBase {
       return FALSE;
     }
 
-    // Postmark webhooks can include signature validation.
-    // For now, we'll use a simple shared secret check.
-    // In production, implement proper HMAC signature validation.
-    $authHeader = $request->headers->get('Authorization');
-    if ($authHeader && str_contains($authHeader, $secret)) {
-      return TRUE;
+    $providedSecret = $request->headers->get('X-Webhook-Secret');
+    if ($providedSecret === NULL || $providedSecret === '') {
+      return FALSE;
     }
 
-    // Also check for secret in custom header.
-    $customHeader = $request->headers->get('X-Webhook-Secret');
-    if ($customHeader && hash_equals($secret, $customHeader)) {
-      return TRUE;
-    }
-
-    return FALSE;
+    return hash_equals($secret, $providedSecret);
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/tests/src/Kernel/PostmarkWebhookControllerTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Kernel/PostmarkWebhookControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_messaging\Controller\PostmarkWebhookController;
+use Drupal\myeventlane_messaging\Service\MessagePreferenceStorage;
+use Drupal\myeventlane_messaging\Service\MessageStorage;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests Postmark webhook delivery and bounce handling.
+ *
+ * @group myeventlane_messaging
+ */
+#[RunTestsInSeparateProcesses]
+final class PostmarkWebhookControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * Webhook shared secret used in tests.
+   */
+  private const WEBHOOK_SECRET = 'test-webhook-secret';
+
+  /**
+   * Message storage under test.
+   */
+  private MessageStorage $messageStorage;
+
+  /**
+   * Webhook controller under test.
+   */
+  private PostmarkWebhookController $controller;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once dirname(__DIR__, 3) . '/myeventlane_messaging.install';
+
+    $schema = $this->container->get('database')->schema();
+    $tables = myeventlane_messaging_schema();
+
+    foreach (['myeventlane_message', 'myeventlane_message_preference'] as $table) {
+      if ($schema->tableExists($table)) {
+        $schema->dropTable($table);
+      }
+      $schema->createTable($table, $tables[$table]);
+    }
+
+    $this->container->get('config.factory')
+      ->getEditable('myeventlane_messaging.settings')
+      ->set('postmark.webhook_secret', self::WEBHOOK_SECRET)
+      ->save();
+
+    $this->messageStorage = new MessageStorage($this->container->get('database'));
+    $preferenceStorage = new MessagePreferenceStorage($this->container->get('database'));
+
+    $this->container->set('myeventlane_messaging.message_storage', $this->messageStorage);
+    $this->container->set('myeventlane_messaging.message_preference_storage', $preferenceStorage);
+
+    $this->controller = PostmarkWebhookController::create($this->container);
+  }
+
+  /**
+   * Delivery webhook updates known message status to delivered.
+   */
+  public function testDeliveryUpdatesKnownMessage(): void {
+    $id = $this->messageStorage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'delivery@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'delivery-test'),
+      'status' => 'sent',
+      'provider' => 'postmark',
+      'provider_message_id' => 'delivery-msg-id',
+    ]);
+
+    $request = $this->buildRequest(
+      ['MessageID' => 'delivery-msg-id', 'Recipient' => 'delivery@example.com'],
+      self::WEBHOOK_SECRET,
+    );
+
+    $response = $this->controller->delivery($request);
+    $this->assertSame(200, $response->getStatusCode());
+
+    $row = $this->messageStorage->load($id);
+    $this->assertNotNull($row);
+    $this->assertSame('delivered', $row->status);
+  }
+
+  /**
+   * Bounce webhook updates known message status to bounced.
+   */
+  public function testBounceUpdatesKnownMessage(): void {
+    $id = $this->messageStorage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'bounce@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'bounce-test'),
+      'status' => 'sent',
+      'provider' => 'postmark',
+      'provider_message_id' => 'bounce-msg-id',
+    ]);
+
+    $request = $this->buildRequest(
+      ['MessageID' => 'bounce-msg-id', 'Email' => 'bounce@example.com'],
+      self::WEBHOOK_SECRET,
+    );
+
+    $response = $this->controller->bounce($request);
+    $this->assertSame(200, $response->getStatusCode());
+
+    $row = $this->messageStorage->load($id);
+    $this->assertNotNull($row);
+    $this->assertSame('bounced', $row->status);
+  }
+
+  /**
+   * Missing or invalid secret returns 401.
+   */
+  public function testInvalidSecretReturns401(): void {
+    $request = $this->buildRequest(['MessageID' => 'unknown-id'], NULL);
+    $response = $this->controller->delivery($request);
+    $this->assertSame(401, $response->getStatusCode());
+
+    $request = $this->buildRequest(['MessageID' => 'unknown-id'], 'wrong-secret');
+    $response = $this->controller->delivery($request);
+    $this->assertSame(401, $response->getStatusCode());
+  }
+
+  /**
+   * Unknown MessageID returns 200 without error.
+   */
+  public function testUnknownMessageIdReturns200(): void {
+    $request = $this->buildRequest(['MessageID' => 'missing-msg-id'], self::WEBHOOK_SECRET);
+    $response = $this->controller->delivery($request);
+    $this->assertSame(200, $response->getStatusCode());
+  }
+
+  /**
+   * Builds a JSON POST request with optional webhook secret header.
+   *
+   * @param array $payload
+   *   JSON payload.
+   * @param string|null $secret
+   *   X-Webhook-Secret header value, or NULL to omit.
+   */
+  private function buildRequest(array $payload, ?string $secret): Request {
+    $headers = ['CONTENT_TYPE' => 'application/json'];
+    if ($secret !== NULL) {
+      $headers['HTTP_X_WEBHOOK_SECRET'] = $secret;
+    }
+
+    return Request::create(
+      '/webhooks/postmark/delivery',
+      'POST',
+      [],
+      [],
+      [],
+      $headers,
+      (string) json_encode($payload),
+    );
+  }
+
+}


### PR DESCRIPTION
…ce events

Implemented public endpoints for Postmark delivery and bounce webhooks, allowing for better integration with Postmark's messaging services. Updated the PostmarkWebhookController to validate incoming requests using a shared secret.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public webhook endpoints affect messaging status and bounce suppression; misconfigured secrets or Postmark header setup could block updates or leave endpoints exposed if secrets leak.
> 
> **Overview**
> Adds **public POST routes** for Postmark **delivery** and **bounce** webhooks at `/webhooks/postmark/delivery` and `/webhooks/postmark/bounce`, with access open at the route layer and verification handled in `PostmarkWebhookController`.
> 
> **Webhook auth is tightened:** incoming requests must send the configured secret only via the **`X-Webhook-Secret`** header, compared with **`hash_equals`**; **`Authorization`** and other prior acceptance paths are removed. Requests without a configured `postmark.webhook_secret` are still rejected.
> 
> The controller constructor is adjusted so **`ConfigFactoryInterface`** is injected and assigned explicitly (alongside existing message/preference storage services).
> 
> New **kernel tests** cover delivery/bounce status updates, **401** for missing/wrong secrets, and **200** for unknown `MessageID` on delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29956af4ede9d15007991103096bfe9581df1960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->