### PR TITLE
fix(booking): update ticket availability resolution to include custom…

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
+++ b/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
@@ -491,7 +491,8 @@ final class BookingFlowResolver {
     }
 
     try {
-      $variations = $this->ticketAvailability->filterPurchasableVariations($event, $product);
+      $context = $this->ticketAvailability->buildDefaultCustomerAccessContext($event);
+      $variations = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context);
     }
     catch (\Throwable $e) {
       $this->logger->error('Could not resolve paid booking availability for event @event_id: @message', [


### PR DESCRIPTION
…er access context

Modified the resolvePaidAvailability method to incorporate a customer access context when filtering purchasable variations, enhancing the accuracy of booking availability resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when events show as available vs sold out/not started on public surfaces; behavior should be more consistent but may differ from the old session-aware filter for users with grants or waitlist claims.
> 
> **Overview**
> **Paid booking availability** in `BookingFlowResolver::resolvePaidAvailability` now builds a **default customer access context** and passes it into `filterPurchasableVariations`, matching how customer-facing tier display already filters purchasable variations.
> 
> Previously the call relied on the service’s implicit context (public/session-aware access), which could disagree with what anonymous visitors see on CTAs and listing availability states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a379cdc118e1bbcd291486de74f1990422cab16d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->