### PR TITLE
fix(booking): use public access context for paid availability CTAs

### DIFF
--- a/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
+++ b/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
@@ -491,7 +491,7 @@ final class BookingFlowResolver {
     }
 
     try {
-      $context = $this->ticketAvailability->buildDefaultCustomerAccessContext($event);
+      $context = $this->ticketAvailability->buildPublicAccessContext($event);
       $variations = $this->ticketAvailability->filterPurchasableVariations($event, $product, $context);
     }
     catch (\Throwable $e) {


### PR DESCRIPTION
resolvePaidAvailability incorrectly called buildDefaultCustomerAccessContext, which omits session tier grants, waitlist claims, and group eligibility. That made sold-out CTAs appear while TicketSelectionForm still offered tickets.

Align with the ticket selection form by filtering with buildPublicAccessContext.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method context swap in booking flow resolution; reduces false sold-out states with no auth or payment logic changes.
> 
> **Overview**
> **Paid event CTAs and availability** now use the same ticket access context as public booking instead of the anonymous “default customer” preview context.
> 
> In `BookingFlowResolver::resolvePaidAvailability`, `filterPurchasableVariations` is fed **`buildPublicAccessContext`** rather than **`buildDefaultCustomerAccessContext`**. That includes session tier grants, waitlist claim IDs, and group eligibility, so **`getPrimaryCta`** / **`getAvailabilityState`** no longer report **sold out** when **`TicketSelectionForm`** would still list purchasable tiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f027d920acc6664b3f35a4bdca11e3c0dc654d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->