### PR TITLE
Launch hardening: Postmark, Honeypot and ticket monitoring fixes

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -61,6 +61,7 @@ module:
   gin_toolbar: 0
   help: 0
   history: 0
+  honeypot: 0
   image: 0
   image_widget_crop: 0
   inline_entity_form: 0

--- a/config/sync/honeypot.settings.yml
+++ b/config/sync/honeypot.settings.yml
@@ -1,0 +1,19 @@
+_core:
+  default_config_hash: 9bVDfWSa_In6VzTXmy04jJ_3ZQobihKjO9isuuUCPaw
+protect_all_forms: false
+unprotected_forms:
+  - user_login_form
+  - search_form
+  - search_block_form
+  - views_exposed_form
+  - honeypot_settings_form
+log: true
+element_name: url
+time_limit: 0
+expire: 300
+form_settings:
+  user_register_form: true
+  contact_message_feedback_form: true
+  myeventlane_rsvp_public_form: true
+  myeventlane_event_passcode_form: true
+  myeventlane_waitlist_signup_form: true

--- a/web/modules/custom/myeventlane_launch/src/EventSubscriber/LaunchOrderCompletedSubscriber.php
+++ b/web/modules/custom/myeventlane_launch/src/EventSubscriber/LaunchOrderCompletedSubscriber.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_launch\EventSubscriber;
 
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Event\OrderEvent;
+use Drupal\commerce_order\Event\OrderEvents;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifier;
 use Drupal\myeventlane_launch\Service\CheckoutIdempotencyGuard;
@@ -20,6 +22,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *
  * Does not send customer email; checkout analytics and ticket issuance checks
  * only. Order confirmation email is queued by myeventlane_messaging.
+ *
+ * Ticket issuance monitoring runs on ORDER_PAID after TicketIssuer, not on
+ * order placement (attendee roster rows are created later on place).
  */
 final class LaunchOrderCompletedSubscriber implements EventSubscriberInterface {
 
@@ -39,6 +44,7 @@ final class LaunchOrderCompletedSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       'commerce_order.place.post_transition' => ['onOrderPlace', -50],
+      OrderEvents::ORDER_PAID => ['onOrderPaid', -50],
     ];
   }
 
@@ -78,12 +84,22 @@ final class LaunchOrderCompletedSubscriber implements EventSubscriberInterface {
         'reason' => 'event_bridge_failure',
       ], $e);
     }
-
-    $this->checkTicketIssuance($entity);
   }
 
   /**
-   * Detects likely ticket issuance failures after checkout.
+   * Validates ticket issuance after payment (TicketIssuer on ORDER_PAID).
+   */
+  public function onOrderPaid(OrderEvent $event): void {
+    $order = $event->getOrder();
+    if (!$order instanceof OrderInterface) {
+      return;
+    }
+
+    $this->checkTicketIssuance($order);
+  }
+
+  /**
+   * Detects likely ticket issuance failures after ORDER_PAID.
    */
   private function checkTicketIssuance(OrderInterface $order): void {
     $orderItemIds = [];
@@ -98,21 +114,26 @@ final class LaunchOrderCompletedSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $attendeeCount = (int) $this->entityTypeManager
-      ->getStorage('event_attendee')
+    $orderId = (int) $order->id();
+    if ($orderId < 1 || !$this->entityTypeManager->hasDefinition('myeventlane_ticket')) {
+      return;
+    }
+
+    $ticketCount = (int) $this->entityTypeManager
+      ->getStorage('myeventlane_ticket')
       ->getQuery()
       ->accessCheck(FALSE)
-      ->condition('order_item', $orderItemIds, 'IN')
+      ->condition('order_id', $orderId)
       ->count()
       ->execute();
 
-    if ($attendeeCount === 0) {
+    if ($ticketCount === 0) {
       $this->monitoringService->monitorTicketIssuanceFailure([
-        'order_id' => (int) $order->id(),
+        'order_id' => $orderId,
         'order_item_ids' => $orderItemIds,
       ]);
-      $this->logger->error('Ticket issuance check failed for order {order_id}: no attendee records found.', [
-        'order_id' => (int) $order->id(),
+      $this->logger->error('Ticket issuance check failed for order {order_id}: no myeventlane_ticket records found.', [
+        'order_id' => $orderId,
       ]);
     }
   }

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-event-passcode-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-event-passcode-form.html.twig
@@ -51,6 +51,13 @@
         </div>
       </div>
     </div>
+
+    {% if element.url is defined %}
+      {{ element.url }}
+    {% endif %}
+    {% if element.honeypot_time is defined %}
+      {{ element.honeypot_time }}
+    {% endif %}
   {% else %}
     {{ children }}
   {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-rsvp-public-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--myeventlane-rsvp-public-form.html.twig
@@ -140,6 +140,13 @@
         </div>
       </div>
     </div>
+
+    {% if element.url is defined %}
+      {{ element.url }}
+    {% endif %}
+    {% if element.honeypot_time is defined %}
+      {{ element.honeypot_time }}
+    {% endif %}
   {% else %}
     {{ children }}
   {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes checkout monitoring timing and entity checks (ORDER_PAID / myeventlane_ticket), which could miss or falsely alarm if issuance order differs; Honeypot on public forms may block fast legitimate submits if misconfigured.
> 
> **Overview**
> **Launch hardening** adds **Honeypot** via config sync and protects RSVP, passcode, waitlist, registration, and contact forms while leaving login/search exposed. Custom **RSVP** and **passcode** Twig templates now output `url` and `honeypot_time` so bot traps work on layouts that do not use default `{{ children }}`.
> 
> **Ticket issuance monitoring** in `LaunchOrderCompletedSubscriber` no longer runs on order placement. It listens to **`ORDER_PAID`** (after `TicketIssuer`) and flags failures when no **`myeventlane_ticket`** rows exist for the order, instead of counting **`event_attendee`** at place time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbda6fe32218057481cde7cb075fb8319a529a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->