### PR TITLE
Fix/bugbot boost admin publish cache

### DIFF
--- a/config/sync/search_api.index.mel_content.yml
+++ b/config/sync/search_api.index.mel_content.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.storage.node.field_category
     - field.storage.node.field_event_end
     - field.storage.node.field_event_start
+    - field.storage.node.field_promoted
     - field.storage.node.field_audience
     - field.storage.node.field_help_article_type
     - field.storage.node.field_help_keywords
@@ -100,6 +101,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_help_topic
+  field_promoted:
+    label: Promoted
+    datasource_id: 'entity:node'
+    property_path: field_promoted
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_promoted
   field_venue_address:
     label: 'Venue address'
     datasource_id: 'entity:node'

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -110,6 +110,19 @@ display:
             format: full_html
           tokenize: false
       sorts:
+        field_promoted_value:
+          id: field_promoted_value
+          table: node__field_promoted
+          field: field_promoted_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_event_start_value:
           id: field_event_start_value
           table: node__field_event_start

--- a/docs/event-studio-section-contracts.md
+++ b/docs/event-studio-section-contracts.md
@@ -64,12 +64,17 @@ Each section plugin must define:
 | `capacity` | `myeventlane_event_studio.workspace_capacity` | ticket | active |
 | `merchandise` | `myeventlane_event_studio.workspace_merchandise` | commerce product | deferred |
 | `addons` | `myeventlane_event_studio.workspace_addons` | commerce product | deferred |
-| `promotions` | `myeventlane_event_studio.workspace_promotions` | event | active |
+| `messaging` | `myeventlane_event_studio.workspace_messaging` | event | active |
 | `attendees` | `myeventlane_event_studio.workspace_attendees` | operations | readonly |
 | `fulfilment` | `myeventlane_event_studio.workspace_fulfilment` | fulfilment | deferred |
 | `orders` | `myeventlane_event_studio.workspace_orders` | commerce | readonly |
 | `analytics` | `myeventlane_event_studio.workspace_analytics` | analytics | readonly |
 | `settings` | `myeventlane_event_studio.workspace_settings` | event | active |
+
+> The `messaging` section was previously named `promotions`. The legacy path
+> `/vendor/events/{node}/studio/promotions` (route
+> `myeventlane_event_studio.workspace_promotions`) now issues a redirect to
+> `/vendor/events/{node}/studio/messaging` so existing bookmarks keep working.
 
 ## Rendering Rules
 

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.install
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.install
@@ -387,3 +387,23 @@ function myeventlane_boost_update_10006(): void {
     ->condition('source', '')
     ->execute();
 }
+
+/**
+ * Creates missing canonical aggregate table myeventlane_boost_stats.
+ *
+ * Upgraded environments received Phase 2 tables via update_10001() but never
+ * got myeventlane_boost_stats because hook_schema() only runs on install.
+ * BoostImpressionTracker and BoostClickTracker write here; BoostMetricsService
+ * reads aggregated impressions/clicks from this table.
+ */
+function myeventlane_boost_update_10007(): string {
+  $schema = \Drupal::database()->schema();
+  if ($schema->tableExists('myeventlane_boost_stats')) {
+    return 'myeventlane_boost_stats already exists.';
+  }
+
+  $full = myeventlane_boost_schema();
+  $schema->createTable('myeventlane_boost_stats', $full['myeventlane_boost_stats']);
+
+  return 'Created myeventlane_boost_stats table.';
+}

--- a/web/modules/custom/myeventlane_boost/src/Form/BoostPurchaseForm.php
+++ b/web/modules/custom/myeventlane_boost/src/Form/BoostPurchaseForm.php
@@ -223,7 +223,9 @@ final class BoostPurchaseForm extends FormBase {
     $nid = (int) $form_state->getValue('event_id');
     $uid = (int) $this->currentUser()->id();
 
-    if (!$this->stripeChecker->isConnected($this->currentUser())) {
+    $account = $this->currentUser();
+    if (!$account->hasPermission('administer myeventlane')
+      && !$this->stripeChecker->isConnected($account)) {
       $this->messenger()->addWarning($this->t('Connect Stripe to continue boosting this event.'));
       if ($nid > 0) {
         $form_state->setRedirect('myeventlane_boost.boost_page', ['node' => $nid]);

--- a/web/modules/custom/myeventlane_boost/src/Form/BoostSelectForm.php
+++ b/web/modules/custom/myeventlane_boost/src/Form/BoostSelectForm.php
@@ -380,7 +380,8 @@ final class BoostSelectForm extends FormBase {
       $this->logger->notice('Boost form submission started');
 
       $account = $this->currentUser();
-      if (!$this->stripeChecker->isConnected($account)) {
+      if (!$account->hasPermission('administer myeventlane')
+        && !$this->stripeChecker->isConnected($account)) {
         $this->messenger()->addWarning($this->t('Connect Stripe to continue boosting this event.'));
         $nid = (int) $form_state->getValue('event_nid');
         if ($nid > 0) {

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -341,7 +341,7 @@ function _myeventlane_event_studio_workspace_route_names(): array {
     'myeventlane_event_studio.workspace_merchandise',
     'myeventlane_event_studio.workspace_addons',
     'myeventlane_event_studio.workspace_add_ons',
-    'myeventlane_event_studio.workspace_promotions',
+    'myeventlane_event_studio.workspace_messaging',
     'myeventlane_event_studio.workspace_attendees',
     'myeventlane_event_studio.workspace_fulfilment',
     'myeventlane_event_studio.workspace_orders',

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -169,12 +169,25 @@ myeventlane_event_studio.workspace_add_ons:
       node:
         type: entity:node
 
-myeventlane_event_studio.workspace_promotions:
-  path: '/vendor/events/{node}/studio/promotions'
+myeventlane_event_studio.workspace_messaging:
+  path: '/vendor/events/{node}/studio/messaging'
   defaults:
     _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
     _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
-    section: 'promotions'
+    section: 'messaging'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+# Legacy alias: preserves bookmarked /studio/promotions URLs (renamed to messaging).
+myeventlane_event_studio.workspace_promotions:
+  path: '/vendor/events/{node}/studio/promotions'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::redirectToMessagingWorkspace'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -239,7 +239,7 @@ final class EventStudioController extends ControllerBase {
       ],
       '#cache' => [
         'tags' => $node->getCacheTags(),
-        'contexts' => ['route', 'user', 'user.permissions'],
+        'contexts' => ['route', 'user', 'user.permissions', 'url.query_args:mel_celebrate'],
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -151,6 +151,26 @@ final class EventStudioController extends ControllerBase {
   }
 
   /**
+   * Preserves bookmarked promotions URLs while routing to the renamed Messaging section.
+   */
+  public function redirectToMessagingWorkspace(NodeInterface $node): RedirectResponse {
+    if ($node->bundle() !== 'event') {
+      throw new NotFoundHttpException();
+    }
+    $account = $this->currentUser();
+    if (!$account->hasPermission('administer nodes')
+      && !$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
+      throw new AccessDeniedHttpException();
+    }
+    $request = $this->requestStack->getCurrentRequest();
+    $options = [];
+    if ($request !== NULL && $request->query->count() > 0) {
+      $options['query'] = $request->query->all();
+    }
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace_messaging', ['node' => $node->id()], $options)->toString());
+  }
+
+  /**
    * Builds the canonical operational Event Studio shell.
    *
    * @return array<string, mixed>

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -233,7 +233,7 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       'myeventlane_event_attendees.waitlist_manage',
       'myeventlane_vendor.console.event_rsvps' => 'myeventlane_event_studio.workspace_attendees',
       'myeventlane_vendor.manage_event.promote',
-      'myeventlane_vendor.console.event_promotion' => 'myeventlane_event_studio.workspace_promotions',
+      'myeventlane_vendor.console.event_promotion' => 'myeventlane_event_studio.workspace_messaging',
       'myeventlane_vendor.console.event_orders',
       'myeventlane_vendor.console.event_order_view' => 'myeventlane_event_studio.workspace_orders',
       'myeventlane_vendor.console.event_analytics' => 'myeventlane_event_studio.workspace_analytics',

--- a/web/modules/custom/myeventlane_event_studio/src/Form/MessagingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/MessagingForm.php
@@ -8,16 +8,16 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
- * Isolated Event Studio form for promotion section convergence.
+ * Isolated Event Studio form for the messaging section (formerly "promotions").
  */
-final class EventPromotionForm extends EventStudioBaseForm {
+final class MessagingForm extends EventStudioBaseForm {
 
   public function getFormId(): string {
-    return 'myeventlane_event_studio_promotion_form';
+    return 'myeventlane_event_studio_messaging_form';
   }
 
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.workspace_promotions';
+    return 'myeventlane_event_studio.workspace_messaging';
   }
 
   protected function getPreviousRouteName(): ?string {
@@ -25,7 +25,7 @@ final class EventPromotionForm extends EventStudioBaseForm {
   }
 
   protected function getCurrentStepId(): string {
-    return 'promotions';
+    return 'messaging';
   }
 
   protected function getContinueButtonLabel() {
@@ -34,7 +34,7 @@ final class EventPromotionForm extends EventStudioBaseForm {
 
   protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
     $this->messenger()->addStatus($this->t('Saved.'));
-    $form_state->setRedirect('myeventlane_event_studio.workspace_promotions', ['node' => $saved->id()]);
+    $form_state->setRedirect('myeventlane_event_studio.workspace_messaging', ['node' => $saved->id()]);
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MessagingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MessagingSection.php
@@ -7,21 +7,21 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Promotions section metadata.
+ * Messaging section metadata (formerly "promotions").
  */
 #[EventStudioSection(
-  id: 'promotions',
+  id: 'messaging',
   title: 'Visibility & updates',
   group: 'Manage Event',
-  routeName: 'myeventlane_event_studio.workspace_promotions',
+  routeName: 'myeventlane_event_studio.workspace_messaging',
   section_state: 'active',
   weight: 40,
   icon: 'promotions',
-  renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventPromotionForm',
+  renderTarget: 'form:Drupal\myeventlane_event_studio\Form\MessagingForm',
   writable: TRUE,
   readiness_participant: FALSE,
   empty_state_type: 'none',
   mobile_priority: 40,
   operationalArea: 'event',
 )]
-final class PromotionsSection extends EventStudioSectionBase {}
+final class MessagingSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMessagingRenameTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMessagingRenameTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the promotions -> messaging section rename (MEL-UX-042).
+ *
+ * Keeps the canonical messaging route, the legacy redirect, the section
+ * plugin id, and the form wiring aligned so the rename cannot silently drift.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioMessagingRenameTest extends TestCase {
+
+  private function moduleDir(): string {
+    return dirname(__DIR__, 3);
+  }
+
+  /**
+   * The canonical messaging route and the legacy promotions redirect coexist.
+   */
+  public function testRoutingDefinesMessagingRouteAndLegacyRedirect(): void {
+    $routing = file_get_contents($this->moduleDir() . '/myeventlane_event_studio.routing.yml');
+    $this->assertIsString($routing);
+
+    // Canonical route renamed to messaging.
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_messaging:', $routing);
+    $this->assertStringContainsString("path: '/vendor/events/{node}/studio/messaging'", $routing);
+    $this->assertStringContainsString("section: 'messaging'", $routing);
+
+    // Legacy promotions path is preserved as a redirect, not the live workspace.
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_promotions:', $routing);
+    $this->assertStringContainsString("path: '/vendor/events/{node}/studio/promotions'", $routing);
+    $this->assertStringContainsString('EventStudioController::redirectToMessagingWorkspace', $routing);
+
+    // The old live wiring must be gone.
+    $this->assertStringNotContainsString("section: 'promotions'", $routing);
+    $this->assertStringNotContainsString("path: '/vendor/events/{node}/studio/promotions'\n  defaults:\n    _controller: '\\Drupal\\myeventlane_event_studio\\Controller\\EventStudioController::workspace'", $routing);
+  }
+
+  /**
+   * The redirect controller target exists and points at the messaging route.
+   */
+  public function testRedirectControllerTargetsMessaging(): void {
+    $controller = file_get_contents($this->moduleDir() . '/src/Controller/EventStudioController.php');
+    $this->assertIsString($controller);
+    $this->assertStringContainsString('public function redirectToMessagingWorkspace(', $controller);
+    $this->assertStringContainsString("Url::fromRoute('myeventlane_event_studio.workspace_messaging'", $controller);
+  }
+
+  /**
+   * The section plugin is renamed to messaging and wired to the new route/form.
+   */
+  public function testMessagingSectionPluginContract(): void {
+    $section = $this->moduleDir() . '/src/Plugin/EventStudioSection/MessagingSection.php';
+    $this->assertFileExists($section);
+    $this->assertFileDoesNotExist($this->moduleDir() . '/src/Plugin/EventStudioSection/PromotionsSection.php');
+
+    $contents = file_get_contents($section);
+    $this->assertIsString($contents);
+    $this->assertStringContainsString('final class MessagingSection', $contents);
+    $this->assertStringContainsString("id: 'messaging'", $contents);
+    $this->assertStringContainsString("routeName: 'myeventlane_event_studio.workspace_messaging'", $contents);
+    $this->assertStringContainsString('form:Drupal\myeventlane_event_studio\Form\MessagingForm', $contents);
+  }
+
+  /**
+   * The section form is renamed and redirects back to the messaging route.
+   */
+  public function testMessagingFormWiring(): void {
+    $form = $this->moduleDir() . '/src/Form/MessagingForm.php';
+    $this->assertFileExists($form);
+    $this->assertFileDoesNotExist($this->moduleDir() . '/src/Form/EventPromotionForm.php');
+
+    $contents = file_get_contents($form);
+    $this->assertIsString($contents);
+    $this->assertStringContainsString('final class MessagingForm', $contents);
+    $this->assertStringContainsString("return 'myeventlane_event_studio.workspace_messaging';", $contents);
+    $this->assertStringContainsString("return 'messaging';", $contents);
+  }
+
+}

--- a/web/modules/custom/myeventlane_search/config/install/search_api.index.mel_content.yml
+++ b/web/modules/custom/myeventlane_search/config/install/search_api.index.mel_content.yml
@@ -71,6 +71,11 @@ field_settings:
     type: date
     datasource_id: 'entity:node'
     property_path: field_event_end
+  field_promoted:
+    label: Promoted
+    type: boolean
+    datasource_id: 'entity:node'
+    property_path: field_promoted
   rendered_item:
     label: 'Rendered item'
     type: text
@@ -118,6 +123,7 @@ dependencies:
     - field.field.node.event.field_category
     - field.field.node.event.field_event_end
     - field.field.node.event.field_event_start
+    - field.field.node.event.field_promoted
     - field.field.node.event.field_venue_address
     - field.field.node.event.field_venue_name
     - field.field.node.page.body

--- a/web/modules/custom/myeventlane_search/myeventlane_search.module
+++ b/web/modules/custom/myeventlane_search/myeventlane_search.module
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_search_api_query_alter().
+ *
+ * Applies promoted-event tie-breaking for tagged event discovery queries.
+ */
+function myeventlane_search_search_api_query_alter(\Drupal\search_api\Query\QueryInterface $query): void {
+  if (!$query->hasTag('myeventlane_event_discovery')) {
+    return;
+  }
+
+  $index = $query->getIndex();
+  if ($index->id() !== 'mel_content' || !array_key_exists('field_promoted', $index->getFields())) {
+    return;
+  }
+
+  $query->sort('search_api_relevance', \Drupal\search_api\Query\QueryInterface::SORT_DESC);
+  $query->sort('field_promoted', \Drupal\search_api\Query\QueryInterface::SORT_DESC);
+}
+
+/**
  * Implements hook_theme().
  */
 function myeventlane_search_theme($existing, $type, $theme, $path): array {

--- a/web/modules/custom/myeventlane_search/src/Controller/SearchAutocompleteController.php
+++ b/web/modules/custom/myeventlane_search/src/Controller/SearchAutocompleteController.php
@@ -109,6 +109,7 @@ final class SearchAutocompleteController extends ControllerBase {
    */
   private function fetchEvents(IndexInterface $index, string $keys, int $now): array {
     $query = $index->query();
+    $query->addTag('myeventlane_event_discovery');
     $query->setFulltextFields(self::EVENT_FULLTEXT_FIELDS);
     $query->keys($keys);
     $query->addCondition('type', 'event');
@@ -149,6 +150,7 @@ final class SearchAutocompleteController extends ControllerBase {
    */
   private function fetchVenues(IndexInterface $index, string $keys, int $now): array {
     $query = $index->query();
+    $query->addTag('myeventlane_event_discovery');
     $query->setFulltextFields(self::VENUE_FULLTEXT_FIELDS);
     $query->keys($keys);
     $query->addCondition('type', 'event');

--- a/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
+++ b/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
@@ -160,6 +160,7 @@ final class SearchController extends ControllerBase {
   private function runContentQuery(IndexInterface $index, string $keys): array {
     $now = (int) $this->time->getRequestTime();
     $query = $index->query();
+    $query->addTag('myeventlane_event_discovery');
     $query->setFulltextFields(self::CONTENT_MAIN_FULLTEXT_FIELDS);
     $query->keys($keys);
     $or = $query->createConditionGroup('OR');
@@ -207,6 +208,7 @@ final class SearchController extends ControllerBase {
   private function buildVenueItems(IndexInterface $index, string $keys): array {
     $now = (int) $this->time->getRequestTime();
     $query = $index->query();
+    $query->addTag('myeventlane_event_discovery');
     $query->setFulltextFields(self::CONTENT_VENUE_FULLTEXT_FIELDS);
     $query->keys($keys);
     $query->addCondition('type', 'event');

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -760,7 +760,7 @@ function _myeventlane_vendor_theme_event_studio_routes(): array {
     'myeventlane_event_studio.workspace_merchandise',
     'myeventlane_event_studio.workspace_addons',
     'myeventlane_event_studio.workspace_add_ons',
-    'myeventlane_event_studio.workspace_promotions',
+    'myeventlane_event_studio.workspace_messaging',
     'myeventlane_event_studio.workspace_attendees',
     'myeventlane_event_studio.workspace_fulfilment',
     'myeventlane_event_studio.workspace_orders',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes public event ordering and search tie-breaks; adds a DB update for boost metrics. Admin Stripe bypass is permission-scoped but affects commerce checkout paths.
> 
> **Overview**
> This PR ties **promoted** events into public discovery and fixes a few Boost / Event Studio operational gaps.
> 
> **Discovery:** `field_promoted` is added to the `mel_content` Search API index, and tagged event-discovery queries sort by relevance then promoted (DESC). The **Upcoming Events** view now sorts promoted first, then start time. Search/autocomplete controllers tag queries with `myeventlane_event_discovery` so the alter hook applies consistently.
> 
> **Event Studio:** The former **promotions** workspace is renamed to **messaging** (`/studio/messaging`, section id `messaging`, `MessagingForm` / `MessagingSection`). Old `/studio/promotions` URLs redirect via `redirectToMessagingWorkspace`; legacy vendor routes and docs are updated. Workspace render cache adds `url.query_args:mel_celebrate` so publish-celebration handoff varies correctly. A unit test guards the rename wiring.
> 
> **Boost:** `myeventlane_boost_update_10007()` creates `myeventlane_boost_stats` on upgraded sites that missed it at install. **Boost purchase/select** forms skip the Stripe-connected check when the user has `administer myeventlane`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f3186000804f940dc5038dc66eb8ea48e567bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->