### PR TITLE
Add client-side Boost impression tracking

### DIFF
--- a/web/modules/custom/myeventlane_boost/js/boost-impression.js
+++ b/web/modules/custom/myeventlane_boost/js/boost-impression.js
@@ -1,0 +1,86 @@
+(function (Drupal, once, drupalSettings) {
+  const sentKeys = window.__melBoostImpressionKeys = window.__melBoostImpressionKeys || new Set();
+
+  const dedupeKey = (orderItemId, placement) => `${orderItemId}|${placement}`;
+
+  const sendImpression = (orderItemId, eventId, placement) => {
+    const key = dedupeKey(orderItemId, placement);
+    if (sentKeys.has(key)) {
+      return;
+    }
+    sentKeys.add(key);
+
+    const impressionUrl = drupalSettings.melBoostImpression?.impressionUrl;
+    if (!impressionUrl) {
+      return;
+    }
+
+    const payload = JSON.stringify({
+      order_item_id: orderItemId,
+      event_id: eventId,
+      placement,
+    });
+
+    if (typeof navigator.sendBeacon === 'function') {
+      navigator.sendBeacon(
+        impressionUrl,
+        new Blob([payload], { type: 'application/json' }),
+      );
+      return;
+    }
+
+    fetch(impressionUrl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {});
+  };
+
+  Drupal.behaviors.melBoostImpression = {
+    attach(context) {
+      once('mel-boost-impression', '[data-mel-boost-impression]', context).forEach((element) => {
+        const orderItemId = Number.parseInt(element.getAttribute('data-boost-order-item-id') || '', 10);
+        const eventId = Number.parseInt(element.getAttribute('data-boost-event-id') || '', 10);
+        const placement = (element.getAttribute('data-boost-placement') || '').trim();
+        if (!Number.isFinite(orderItemId) || orderItemId <= 0) {
+          return;
+        }
+        if (!Number.isFinite(eventId) || eventId <= 0) {
+          return;
+        }
+        if (!placement) {
+          return;
+        }
+
+        const key = dedupeKey(orderItemId, placement);
+        if (sentKeys.has(key)) {
+          return;
+        }
+
+        if ('IntersectionObserver' in window) {
+          const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+              if (!entry.isIntersecting) {
+                return;
+              }
+              sendImpression(orderItemId, eventId, placement);
+              observer.disconnect();
+            });
+          }, {
+            threshold: 0.25,
+            rootMargin: '0px',
+          });
+          observer.observe(element);
+          return;
+        }
+
+        sendImpression(orderItemId, eventId, placement);
+      });
+    },
+  };
+})(Drupal, once, drupalSettings);

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.libraries.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.libraries.yml
@@ -8,3 +8,12 @@ boost:
   dependencies:
     - core/drupal
     - core/once
+
+impression:
+  version: 1.x
+  js:
+    js/boost-impression.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.module
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.module
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\Core\Template\Attribute;
+use Drupal\Core\Url;
 use Drupal\myeventlane_boost\Cron\BoostExpiryCron;
 use Drupal\myeventlane_boost\Cron\BoostExpiryReminderCron;
 
@@ -146,6 +147,17 @@ function myeventlane_boost_mail(string $key, array &$message, array $params): vo
 
   // Set HTML content type for all boost emails.
   $message['headers']['Content-Type'] = 'text/html; charset=UTF-8';
+}
+
+/**
+ * Implements hook_page_attachments().
+ *
+ * Exposes the impression beacon endpoint to client-side tracking behaviour.
+ */
+function myeventlane_boost_page_attachments(array &$attachments): void {
+  $attachments['#attached']['drupalSettings']['melBoostImpression'] = [
+    'impressionUrl' => Url::fromRoute('myeventlane_boost.impression')->toString(),
+  ];
 }
 
 /**

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.routing.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.routing.yml
@@ -149,6 +149,15 @@ myeventlane_boost.performance_guide_pdf:
   options:
     _maintenance_access: FALSE
 
+# Client-side Boost card impression beacon.
+myeventlane_boost.impression:
+  path: '/mel/boost/impression'
+  defaults:
+    _controller: '\Drupal\myeventlane_boost\Controller\BoostImpressionController::record'
+  requirements:
+    _permission: 'access content'
+  methods: [POST]
+
 # Admin settings page.
 myeventlane_boost.settings:
   path: '/admin/config/myeventlane/boost'

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -109,6 +109,21 @@ services:
       - '@datetime.time'
       - '@logger.channel.myeventlane_boost'
 
+  myeventlane_boost.placement_resolver:
+    class: Drupal\myeventlane_boost\Service\BoostPlacementResolver
+    arguments:
+      - '@current_route_match'
+      - '@?myeventlane_core.event_category_url'
+
+  myeventlane_boost.impression_attribution:
+    class: Drupal\myeventlane_boost\Service\BoostImpressionAttributionService
+    arguments:
+      - '@myeventlane_boost.entitlement_manager'
+      - '@myeventlane_boost.placement_resolver'
+      - '@myeventlane_boost.impression_tracker'
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_boost'
+
   # Boost click tracker.
   myeventlane_boost.click_tracker:
     class: Drupal\myeventlane_boost\Service\BoostClickTracker

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostImpressionController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostImpressionController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_boost\Service\BoostImpressionAttributionService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Receives client-side Boost impression beacons.
+ */
+final class BoostImpressionController extends ControllerBase {
+
+  /**
+   * Constructs a BoostImpressionController.
+   */
+  public function __construct(
+    private readonly BoostImpressionAttributionService $attributionService,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('myeventlane_boost.impression_attribution'),
+    );
+  }
+
+  /**
+   * Records a validated Boost card impression.
+   */
+  public function record(Request $request): Response {
+    $payload = $this->decodePayload($request);
+    if ($payload === NULL) {
+      return new JsonResponse(['status' => 'error', 'message' => 'invalid_payload'], 400);
+    }
+
+    $orderItemId = (int) ($payload['order_item_id'] ?? 0);
+    $eventId = (int) ($payload['event_id'] ?? 0);
+    $placement = trim((string) ($payload['placement'] ?? ''));
+
+    $recorded = $this->attributionService->recordValidatedImpression($orderItemId, $eventId, $placement);
+    if (!$recorded) {
+      return new JsonResponse(['status' => 'error', 'message' => 'not_recorded'], 400);
+    }
+
+    return new JsonResponse(['status' => 'ok']);
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   *   Decoded JSON payload or NULL when malformed.
+   */
+  private function decodePayload(Request $request): ?array {
+    $contentType = (string) $request->headers->get('Content-Type', '');
+    if (str_contains($contentType, 'application/json')) {
+      $raw = $request->getContent();
+      if ($raw === '') {
+        return NULL;
+      }
+      try {
+        $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+      }
+      catch (\JsonException) {
+        return NULL;
+      }
+      return is_array($decoded) ? $decoded : NULL;
+    }
+
+    $orderItemId = $request->request->get('order_item_id');
+    $eventId = $request->request->get('event_id');
+    $placement = $request->request->get('placement');
+    if ($orderItemId === NULL && $eventId === NULL && $placement === NULL) {
+      return NULL;
+    }
+
+    return [
+      'order_item_id' => $orderItemId,
+      'event_id' => $eventId,
+      'placement' => $placement,
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostEntitlementManager.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostEntitlementManager.php
@@ -241,6 +241,75 @@ final class BoostEntitlementManager {
   }
 
   /**
+   * Returns the primary active entitlement for an event.
+   *
+   * When multiple entitlements overlap, returns the active row with the latest
+   * end timestamp (aligned with getActiveEndTimestampForEvent()).
+   */
+  public function getPrimaryActiveEntitlementForEvent(int $eventNid): ?BoostEntitlementInterface {
+    if ($eventNid <= 0) {
+      return NULL;
+    }
+
+    $now = $this->time->getRequestTime();
+    $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('event', $eventNid)
+      ->condition('status', BoostEntitlementInterface::STATUS_ACTIVE)
+      ->condition('starts', $now, '<=')
+      ->condition('ends', $now, '>')
+      ->sort('ends', 'DESC')
+      ->range(0, 1)
+      ->execute();
+
+    if (empty($ids)) {
+      return NULL;
+    }
+
+    $entity = $storage->load(reset($ids));
+    return $entity instanceof BoostEntitlementInterface ? $entity : NULL;
+  }
+
+  /**
+   * Loads a non-revoked entitlement by source order item ID.
+   */
+  public function getEntitlementByOrderItemId(int $orderItemId): ?BoostEntitlementInterface {
+    if ($orderItemId <= 0) {
+      return NULL;
+    }
+
+    $ids = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('order_item_id', $orderItemId)
+      ->condition('status', BoostEntitlementInterface::STATUS_REVOKED, '<>')
+      ->range(0, 1)
+      ->execute();
+
+    if (empty($ids)) {
+      return NULL;
+    }
+
+    $entity = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement')->load(reset($ids));
+    return $entity instanceof BoostEntitlementInterface ? $entity : NULL;
+  }
+
+  /**
+   * Checks whether an entitlement is active for the current request time.
+   */
+  public function isEntitlementCurrentlyActive(BoostEntitlementInterface $entitlement): bool {
+    if ((string) $entitlement->get('status')->value !== BoostEntitlementInterface::STATUS_ACTIVE) {
+      return FALSE;
+    }
+
+    $now = $this->time->getRequestTime();
+    $starts = (int) ($entitlement->get('starts')->value ?? 0);
+    $ends = (int) ($entitlement->get('ends')->value ?? 0);
+    return $starts <= $now && $ends > $now;
+  }
+
+  /**
    * Returns the latest active end timestamp for an event.
    */
   public function getActiveEndTimestampForEvent(int $eventNid): ?int {

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds cache-safe Boost impression metadata and validates beacon payloads.
+ */
+final class BoostImpressionAttributionService {
+
+  /**
+   * Constructs a BoostImpressionAttributionService.
+   */
+  public function __construct(
+    private readonly BoostEntitlementManager $entitlementManager,
+    private readonly BoostPlacementResolver $placementResolver,
+    private readonly BoostImpressionTracker $impressionTracker,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Builds impression metadata for a boosted event card render.
+   *
+   * @return array{order_item_id: int, event_id: int, placement: string}|null
+   *   Metadata for client-side beacons, or NULL when not attributable.
+   */
+  public function buildCardMetadata(NodeInterface $event): ?array {
+    if ($event->bundle() !== 'event' || !$event->isPublished()) {
+      return NULL;
+    }
+
+    $entitlement = $this->entitlementManager->getPrimaryActiveEntitlementForEvent((int) $event->id());
+    if (!$entitlement instanceof BoostEntitlementInterface) {
+      return NULL;
+    }
+
+    $orderItemId = (int) ($entitlement->get('order_item_id')->value ?? 0);
+    if ($orderItemId <= 0) {
+      return NULL;
+    }
+
+    $placement = $this->placementResolver->resolveCurrentPlacement();
+    if (!$this->placementResolver->isValidPlacement($placement)) {
+      return NULL;
+    }
+
+    return [
+      'order_item_id' => $orderItemId,
+      'event_id' => (int) $event->id(),
+      'placement' => $placement,
+    ];
+  }
+
+  /**
+   * Validates a beacon payload and records the impression via the tracker.
+   */
+  public function recordValidatedImpression(int $orderItemId, int $eventId, string $placement): bool {
+    if ($orderItemId <= 0 || $eventId <= 0 || !$this->placementResolver->isValidPlacement($placement)) {
+      $this->logger->warning('Rejected Boost impression beacon: invalid payload shape.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+        'placement' => $placement,
+      ]);
+      return FALSE;
+    }
+
+    if (!$this->validateActiveEntitlement($orderItemId, $eventId)) {
+      return FALSE;
+    }
+
+    return $this->impressionTracker->recordImpression($orderItemId, $eventId, $placement);
+  }
+
+  /**
+   * Ensures the order item maps to an active entitlement for the event.
+   */
+  private function validateActiveEntitlement(int $orderItemId, int $eventId): bool {
+    $entitlement = $this->entitlementManager->getEntitlementByOrderItemId($orderItemId);
+    if (!$entitlement instanceof BoostEntitlementInterface) {
+      $this->logger->warning('Rejected Boost impression beacon: entitlement not found.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+      ]);
+      return FALSE;
+    }
+
+    $entitlementEventId = (int) ($entitlement->get('event')->target_id ?? 0);
+    if ($entitlementEventId !== $eventId) {
+      $this->logger->warning('Rejected Boost impression beacon: entitlement event mismatch.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+        'entitlement_event_id' => $entitlementEventId,
+      ]);
+      return FALSE;
+    }
+
+    if ((string) $entitlement->get('status')->value !== BoostEntitlementInterface::STATUS_ACTIVE) {
+      $this->logger->warning('Rejected Boost impression beacon: entitlement not active.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+        'status' => (string) $entitlement->get('status')->value,
+      ]);
+      return FALSE;
+    }
+
+    if (!$this->entitlementManager->isEntitlementCurrentlyActive($entitlement)) {
+      $this->logger->warning('Rejected Boost impression beacon: entitlement outside active window.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+      ]);
+      return FALSE;
+    }
+
+    $orderItem = $this->entityTypeManager->getStorage('commerce_order_item')->load($orderItemId);
+    if (!$orderItem || $orderItem->bundle() !== 'boost') {
+      $this->logger->warning('Rejected Boost impression beacon: invalid boost order item.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+      ]);
+      return FALSE;
+    }
+
+    if (!$orderItem->hasField('field_target_event')) {
+      return FALSE;
+    }
+
+    $targetEventId = (int) ($orderItem->get('field_target_event')->target_id ?? 0);
+    if ($targetEventId !== $eventId) {
+      $this->logger->warning('Rejected Boost impression beacon: order item target mismatch.', [
+        'order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+        'target_event_id' => $targetEventId,
+      ]);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionTracker.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionTracker.php
@@ -64,7 +64,9 @@ final class BoostImpressionTracker {
           'placement' => $placement,
         ])
         ->insertFields([
+          'boost_order_item_id' => $boost_order_item_id,
           'event_id' => $event_id,
+          'placement' => $placement,
           'impressions' => 1,
           'created' => $now,
           'changed' => $now,

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\myeventlane_core\Service\EventCategoryUrlService;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Resolves Boost placement keys from the current request route.
+ *
+ * Placement keys align with myeventlane_boost_stats (e.g. homepage_discover,
+ * category_music, search_results).
+ */
+final class BoostPlacementResolver {
+
+  /**
+   * Constructs a BoostPlacementResolver.
+   */
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly ?EventCategoryUrlService $categoryUrlService,
+  ) {}
+
+  /**
+   * Resolves the placement identifier for the current page request.
+   */
+  public function resolveCurrentPlacement(): string {
+    $routeName = (string) ($this->routeMatch->getRouteName() ?? '');
+
+    if ($routeName === '<front>') {
+      return 'homepage_discover';
+    }
+
+    if ($routeName === 'mel_search.view') {
+      return 'search_results';
+    }
+
+    if ($routeName === 'view.upcoming_events.page_category') {
+      $argument = $this->routeMatch->getParameter('arg_0');
+      if ($this->categoryUrlService !== NULL && ($argument !== NULL && $argument !== '')) {
+        $term = $this->categoryUrlService->resolveTerm($argument);
+        if ($term instanceof TermInterface) {
+          return 'category_' . $this->sanitizePlacementSegment($this->categoryUrlService->getSlug($term));
+        }
+      }
+      if (is_string($argument) && $argument !== '') {
+        return 'category_' . $this->sanitizePlacementSegment($argument);
+      }
+      return 'category_unknown';
+    }
+
+    if (str_starts_with($routeName, 'view.front_') || str_contains($routeName, 'homepage')) {
+      return 'homepage_discover';
+    }
+
+    if (str_starts_with($routeName, 'view.upcoming_events.')) {
+      $suffix = substr($routeName, strlen('view.upcoming_events.'));
+      $suffix = $this->sanitizePlacementSegment($suffix !== '' ? $suffix : 'listing');
+      return 'listing_' . $suffix;
+    }
+
+    return 'listing';
+  }
+
+  /**
+   * Validates a placement key format.
+   */
+  public function isValidPlacement(string $placement): bool {
+    return $placement !== '' && (bool) preg_match('/^[a-z][a-z0-9_]{0,63}$/', $placement);
+  }
+
+  /**
+   * Normalizes a route or slug segment for placement keys.
+   */
+  private function sanitizePlacementSegment(string $value): string {
+    $normalized = strtolower(trim($value));
+    $normalized = preg_replace('/[^a-z0-9_]+/', '_', $normalized) ?? '';
+    $normalized = trim($normalized, '_');
+    return $normalized !== '' ? $normalized : 'unknown';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -16,6 +16,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\myeventlane_event\Form\TicketTypeFormAlter;
@@ -887,6 +888,17 @@ function myeventlane_event_entity_view_alter(array &$build, EntityInterface $ent
       '@message' => $e->getMessage(),
     ]);
   }
+
+  if ($entity->isPublished()) {
+    try {
+      myeventlane_event_attach_boost_impression_to_build($build, $entity, $display->getMode());
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_event')->error('Boost impression metadata: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
 }
 
 /**
@@ -1229,6 +1241,15 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     $bookingAvailability
   );
 
+  try {
+    myeventlane_event_apply_boost_impression_metadata($variables, $node, $view_mode);
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_event')->error('Boost impression card metadata: @message', [
+      '@message' => $e->getMessage(),
+    ]);
+  }
+
   // Hide obvious placeholder strings on public event teasers and summaries.
   $public_visibility_modes = [
     'full',
@@ -1490,6 +1511,97 @@ function myeventlane_event_finalize_event_ui(
     $out['image_badge_type'] = 'apricot';
   }
   return $out;
+}
+
+/**
+ * Attaches cache-safe Boost impression metadata to an event card build.
+ */
+function myeventlane_event_attach_boost_impression_to_build(
+  array &$build,
+  NodeInterface $node,
+  string $viewMode,
+): void {
+  if (!in_array($viewMode, myeventlane_event_get_event_card_view_modes(), TRUE)) {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_boost.impression_attribution')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution */
+  $attribution = \Drupal::service('myeventlane_boost.impression_attribution');
+  $metadata = $attribution->buildCardMetadata($node);
+  if (!is_array($metadata)) {
+    return;
+  }
+
+  $build['#boost_impression'] = $metadata;
+  $build['#attached']['library'][] = 'myeventlane_boost/impression';
+  if (!isset($build['#cache'])) {
+    $build['#cache'] = [];
+  }
+  if (!is_array($build['#cache'])) {
+    $build['#cache'] = [];
+  }
+  $contexts = $build['#cache']['contexts'] ?? [];
+  if (!is_array($contexts)) {
+    $contexts = [];
+  }
+  $build['#cache']['contexts'] = array_values(array_unique(array_merge(
+    $contexts,
+    ['route.name', 'url.path'],
+  )));
+}
+
+/**
+ * Applies Boost impression tracking attributes to node preprocess variables.
+ */
+function myeventlane_event_apply_boost_impression_metadata(
+  array &$variables,
+  NodeInterface $node,
+  string $viewMode,
+): void {
+  if (!in_array($viewMode, myeventlane_event_get_event_card_view_modes(), TRUE)) {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_boost.impression_attribution')) {
+    return;
+  }
+
+  $elements = is_array($variables['elements'] ?? NULL) ? $variables['elements'] : [];
+  $metadata = $elements['#boost_impression'] ?? NULL;
+  if (!is_array($metadata)) {
+    /** @var \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution */
+    $attribution = \Drupal::service('myeventlane_boost.impression_attribution');
+    $metadata = $attribution->buildCardMetadata($node);
+  }
+  if (!is_array($metadata)) {
+    return;
+  }
+
+  $variables['mel_boost_impression'] = $metadata;
+  if (!isset($variables['attributes']) || !$variables['attributes'] instanceof Attribute) {
+    $variables['attributes'] = new Attribute();
+  }
+  $variables['attributes']->setAttribute('data-mel-boost-impression', '1');
+  $variables['attributes']->setAttribute('data-boost-order-item-id', (string) $metadata['order_item_id']);
+  $variables['attributes']->setAttribute('data-boost-event-id', (string) $metadata['event_id']);
+  $variables['attributes']->setAttribute('data-boost-placement', $metadata['placement']);
+  $variables['event_id'] = $metadata['event_id'];
+
+  if (!isset($variables['#attached'])) {
+    $variables['#attached'] = [];
+  }
+  $variables['#attached']['library'][] = 'myeventlane_boost/impression';
+
+  if (!isset($variables['#cache'])) {
+    $variables['#cache'] = [];
+  }
+  $contexts = (array) ($variables['#cache']['contexts'] ?? []);
+  $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
+    $contexts,
+    ['route.name', 'url.path'],
+  )));
 }
 
 /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -64,7 +64,6 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       throw new AccessDeniedHttpException('Pro subscription is required.');
     }
     $tabs = $this->eventTabsService->getTabs($event, 'analytics');
-    $charts = $this->metricsAggregator->getEventCharts($event);
     $overview = $this->metricsAggregator->getEventOverview($event);
 
     $ticketRows = array_values(array_filter(
@@ -73,6 +72,8 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     ));
     $ticket_tier_rollup = $this->ticketTierAnalytics->buildEventTierRollup($event, $ticketRows);
     $ticket_tier_rollup['tier_row_count'] = count($ticketRows);
+
+    $charts = $this->metricsAggregator->getEventCharts($event);
 
     $chart_data = [
       'event-sales' => [
@@ -100,6 +101,44 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         ],
       ],
     ];
+
+    $ticket_mix_labels = [];
+    $ticket_mix_sold = [];
+    foreach ($overview['tickets'] ?? [] as $ticket) {
+      if (!is_array($ticket)) {
+        continue;
+      }
+      $sold = (int) ($ticket['sold'] ?? 0);
+      if ($sold <= 0) {
+        continue;
+      }
+      $label = trim((string) ($ticket['label'] ?? ''));
+      if ($label === '') {
+        continue;
+      }
+      $ticket_mix_labels[] = $label;
+      $ticket_mix_sold[] = $sold;
+    }
+    if ($ticket_mix_labels !== []) {
+      $chart_data['event-ticket-mix'] = [
+        'type' => 'doughnut',
+        'labels' => $ticket_mix_labels,
+        'datasets' => [
+          [
+            'label' => (string) $this->t('Tickets sold'),
+            'data' => $ticket_mix_sold,
+            'backgroundColor' => [
+              '#6C7EF2',
+              '#F26D5B',
+              '#5CC98B',
+              '#FFD46F',
+              '#8b5cf6',
+              '#06b6d4',
+            ],
+          ],
+        ],
+      ];
+    }
 
     $boost_page_url = NULL;
     try {
@@ -157,6 +196,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#export_pdf_url' => $export_pdf_url,
         '#export_excel_url' => $export_excel_url,
         '#commerce_analytics' => $commerce_analytics,
+        '#has_ticket_mix_chart' => isset($chart_data['event-ticket-mix']),
       ],
       '#attached' => [
         'library' => [

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
@@ -44,11 +44,11 @@ mel_event_card_remove:
     - core/drupal
     - core/once
 
-# Chart.js library (CDN)
+# Chart.js is bundled in dist/main.js via dynamic import (src/js/main.js).
 chartjs:
-  version: 4.4.1
-  js:
-    https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js: { type: external, minified: true }
+  version: 1.x
+  dependencies:
+    - myeventlane_vendor_theme/global-styling
 
 # Event form with tabs and validation
 event-form:
@@ -62,7 +62,7 @@ event-form:
 analytics:
   dependencies:
     - myeventlane_vendor_theme/global-styling
-    - myeventlane_vendor_theme/chartjs
+    - core/drupalSettings
 
 # Event overview (Mission Control) — charts + layout tokens
 event_overview:

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1362,6 +1362,8 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'edit_event_url' => NULL,
         'export_pdf_url' => NULL,
         'export_excel_url' => NULL,
+        'commerce_analytics' => [],
+        'has_ticket_mix_chart' => FALSE,
       ],
       'template' => 'event/analytics',
     ],

--- a/web/themes/custom/myeventlane_vendor_theme/package-lock.json
+++ b/web/themes/custom/myeventlane_vendor_theme/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "myeventlane-vendor-theme",
       "version": "2.0.0",
+      "dependencies": {
+        "chart.js": "^4.4.4"
+      },
       "devDependencies": {
         "autoprefixer": "^10.4.22",
         "eslint": "^8.54.0",
@@ -280,6 +283,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -1297,6 +1306,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/web/themes/custom/myeventlane_vendor_theme/package.json
+++ b/web/themes/custom/myeventlane_vendor_theme/package.json
@@ -13,6 +13,9 @@
     "lint:js": "eslint 'src/js/**/*.js'",
     "lint": "npm run lint:scss && npm run lint:js"
   },
+  "dependencies": {
+    "chart.js": "^4.4.4"
+  },
   "devDependencies": {
     "autoprefixer": "^10.4.22",
     "eslint": "^8.54.0",

--- a/web/themes/custom/myeventlane_vendor_theme/src/js/main.js
+++ b/web/themes/custom/myeventlane_vendor_theme/src/js/main.js
@@ -177,20 +177,58 @@ import './vendor-alert';
   };
 
   /**
+   * Lazy-load Chart.js from the local npm bundle (no CDN).
+   *
+   * @return {Promise<typeof import('chart.js').Chart>}
+   */
+  const loadChartJs = (() => {
+    /** @type {Promise<any>|null} */
+    let pending = null;
+    return () => {
+      if (typeof Chart !== 'undefined') {
+        return Promise.resolve(Chart);
+      }
+      if (!pending) {
+        pending = import('chart.js/auto').then((module) => {
+          const chart = module.default ?? module.Chart;
+          window.Chart = chart;
+          return chart;
+        });
+      }
+      return pending;
+    };
+  })();
+
+  /**
    * Dashboard charts initialization (Chart.js).
    */
   Drupal.behaviors.melDashboardCharts = {
     attach: function (context) {
-      const chartContainers = once('mel-chart', '[data-chart-id]', context);
-      if (!chartContainers || chartContainers.length === 0) {
+      const chartTargets = once('mel-chart', '[data-chart-id]', context);
+      if (!chartTargets || chartTargets.length === 0) {
         return;
       }
 
-      // Check if Chart.js is loaded (only when charts exist on the page).
-      if (typeof Chart === 'undefined') {
-        console.warn('Chart.js not loaded (charts will not render).');
-        return;
-      }
+      loadChartJs().then((ChartLib) => {
+        if (!ChartLib) {
+          console.warn('Chart.js not loaded (charts will not render).');
+          return;
+        }
+
+        initCharts(chartTargets, ChartLib);
+      }).catch((error) => {
+        console.error('Chart.js failed to load.', error);
+      });
+    }
+  };
+
+  /**
+   * Initializes Chart.js instances for vendor chart targets.
+   *
+   * @param {HTMLElement[]} chartTargets
+   * @param {any} ChartLib
+   */
+  function initCharts(chartTargets, ChartLib) {
 
       // Chart color palette from design tokens
       const colors = {
@@ -231,12 +269,20 @@ import './vendor-alert';
         }
       };
 
-      chartContainers.forEach((container) => {
+      chartTargets.forEach((container) => {
         const chartId = container.dataset.chartId;
-        const canvas = container.querySelector('canvas');
+        if (!chartId) {
+          return;
+        }
+
+        const canvas = container instanceof HTMLCanvasElement
+          ? container
+          : container.querySelector('canvas');
         const chartData = drupalSettings?.vendorCharts?.[chartId];
 
-        if (!canvas || !chartData) return;
+        if (!canvas || !chartData) {
+          return;
+        }
 
         // Merge options
         const options = { ...defaultOptions, ...chartData.options };
@@ -249,7 +295,7 @@ import './vendor-alert';
         }
 
         // Create chart
-        new Chart(canvas, {
+        new ChartLib(canvas, {
           type: chartData.type || 'line',
           data: {
             labels: chartData.labels || [],
@@ -265,8 +311,7 @@ import './vendor-alert';
           options
         });
       });
-    }
-  };
+  }
 
   /**
    * Accessible tooltips (ARIA-describedby, role=tooltip).

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics.scss
@@ -29,6 +29,82 @@
   margin-top: 0;
 }
 
+.mel-chart-card {
+  padding: $mel-spacing-lg;
+}
+
+.mel-chart-card__title {
+  margin: 0 0 $mel-spacing-md;
+  font-size: $font-size-section-title;
+  font-weight: $font-weight-semibold;
+}
+
+.mel-chart-card__canvas--tall {
+  position: relative;
+  min-height: 220px;
+  height: 220px;
+}
+
+.mel-chart-card__canvas--donut {
+  position: relative;
+  min-height: 240px;
+  height: 240px;
+  max-width: 320px;
+  margin: 0 auto $mel-spacing-lg;
+}
+
+.mel-analytics__ticket-mix-chart {
+  margin-bottom: $mel-spacing-lg;
+}
+
+.mel-analytics__capacity-card {
+  margin-top: $mel-spacing-lg;
+  padding: $mel-spacing-lg;
+  border-radius: $radius-card;
+  border: 1px solid $border-color-light;
+  background: $bg-secondary;
+}
+
+.mel-analytics__capacity-title {
+  margin: 0 0 $mel-spacing-sm;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mel-analytics__capacity-value {
+  margin: 0;
+  font-size: $font-size-2xl;
+  font-weight: $font-weight-bold;
+  font-variant-numeric: tabular-nums;
+  color: $text-primary;
+  line-height: $line-height-tight;
+}
+
+.mel-analytics__capacity-bar {
+  margin-top: $mel-spacing-md;
+  height: 12px;
+  border-radius: $radius-full;
+  background: $bg-tertiary;
+  overflow: hidden;
+}
+
+.mel-analytics__capacity-bar-fill {
+  height: 100%;
+  border-radius: $radius-full;
+  background: $primary;
+  min-width: 0;
+  transition: width 0.3s ease;
+}
+
+.mel-analytics__capacity-meta {
+  margin: $mel-spacing-sm 0 0;
+  font-size: $font-size-sm;
+  color: $text-secondary;
+}
+
 // ============================================================================
 // ANALYTICS HEADER
 // ============================================================================

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -44,6 +44,9 @@
 {% set boost_metrics = overview.boost_metrics|default({}) %}
 {% set has_sales_chart = charts.sales|default([])|length > 0 %}
 {% set has_rsvp_chart = charts.rsvps|default([])|length > 0 %}
+{% set has_ticket_mix_chart = has_ticket_mix_chart|default(false) %}
+{% set capacity_total = ticket_tier_rollup.total_remaining is not null ? (ticket_tier_rollup.total_sold|default(0) + ticket_tier_rollup.total_remaining) : 0 %}
+{% set capacity_pct = capacity_total > 0 ? ((ticket_tier_rollup.total_sold|default(0) / capacity_total) * 100)|round(1) : null %}
 {% set att_total = attendees.total|default(0) %}
 {% set att_in = attendees.checked_in|default(0) %}
 {% set check_pct = att_total > 0 ? ((att_in / att_total) * 100)|round(1) : 0 %}
@@ -126,6 +129,24 @@
         {% if ticket_tier_rollup.conversion_note %}
           <p class="mel-text--muted mel-analytics__conversion-note">{{ ticket_tier_rollup.conversion_note }}</p>
         {% endif %}
+        {% if capacity_pct is not null %}
+          <div class="mel-analytics__capacity-card" role="group" aria-labelledby="mel-analytics-capacity-title">
+            <h3 id="mel-analytics-capacity-title" class="mel-analytics__capacity-title">{{ 'Capacity sold'|t }}</h3>
+            <p class="mel-analytics__capacity-value">{{ capacity_pct }}%</p>
+            <div class="mel-analytics__capacity-bar" aria-hidden="true">
+              <div class="mel-analytics__capacity-bar-fill" style="width: {{ capacity_pct > 100 ? 100 : capacity_pct }}%;"></div>
+            </div>
+            <p class="mel-analytics__capacity-meta">
+              {{ ticket_tier_rollup.total_sold|default(0) }} {{ 'sold'|t }} · {{ ticket_tier_rollup.total_remaining }} {{ 'remaining'|t }}
+            </p>
+          </div>
+        {% elseif ticket_tier_rollup.tier_row_count|default(0) > 0 %}
+          <div class="mel-analytics__capacity-card mel-analytics__capacity-card--unlimited" role="group" aria-labelledby="mel-analytics-capacity-unlimited-title">
+            <h3 id="mel-analytics-capacity-unlimited-title" class="mel-analytics__capacity-title">{{ 'Capacity sold'|t }}</h3>
+            <p class="mel-analytics__capacity-value">{{ ticket_tier_rollup.total_sold|default(0) }}</p>
+            <p class="mel-analytics__capacity-meta">{{ 'Sold so far — capacity is unlimited or mixed across tiers.'|t }}</p>
+          </div>
+        {% endif %}
     </section>
   {% endif %}
 
@@ -133,8 +154,8 @@
     <div class="mel-chart-card">
       <h3 class="mel-chart-card__title">{{ 'Sales over time'|t }}</h3>
       {% if has_sales_chart %}
-        <div class="mel-chart-card__canvas" data-mel-chart>
-          <canvas data-chart-id="event-sales" height="200"></canvas>
+        <div class="mel-chart-card__canvas mel-chart-card__canvas--tall" data-chart-id="event-sales" role="img" aria-label="{{ 'Sales over time chart'|t }}">
+          <canvas height="200"></canvas>
         </div>
       {% else %}
         <div class="mel-empty-state mel-empty-state--chart">
@@ -146,8 +167,8 @@
     <div class="mel-chart-card">
       <h3 class="mel-chart-card__title">{{ 'RSVPs over time'|t }}</h3>
       {% if has_rsvp_chart %}
-        <div class="mel-chart-card__canvas" data-mel-chart>
-          <canvas data-chart-id="event-rsvps" height="200"></canvas>
+        <div class="mel-chart-card__canvas mel-chart-card__canvas--tall" data-chart-id="event-rsvps" role="img" aria-label="{{ 'RSVPs over time chart'|t }}">
+          <canvas height="200"></canvas>
         </div>
       {% else %}
         <div class="mel-empty-state mel-empty-state--chart">
@@ -165,6 +186,13 @@
     </div>
     <div class="mel-card__body">
       {% if overview.tickets|length > 0 %}
+        {% if has_ticket_mix_chart %}
+          <div class="mel-analytics__ticket-mix-chart">
+            <div class="mel-chart-card__canvas mel-chart-card__canvas--donut" data-chart-id="event-ticket-mix" role="img" aria-label="{{ 'Ticket mix chart'|t }}">
+              <canvas height="220"></canvas>
+            </div>
+          </div>
+        {% endif %}
         {% for ticket in overview.tickets %}
           {% set sold = ticket.sold|default(0) %}
           {% set avail = ticket.available %}


### PR DESCRIPTION
- Introduced `boost-impression.js` to handle impression tracking via Intersection Observer and send beacons to the server.
- Updated `myeventlane_boost.libraries.yml` to include the new JavaScript library.
- Implemented `myeventlane_boost_page_attachments()` to expose the impression URL to client-side settings.
- Added a new route for the impression endpoint in `myeventlane_boost.routing.yml`.
- Created `BoostImpressionController` to process incoming impression requests.
- Enhanced service definitions in `myeventlane_boost.services.yml` for impression attribution handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public POST endpoint and entitlement validation affect Boost billing metrics; incorrect validation could under-count or accept bad beacons, while vendor chart changes are mostly presentation.
> 
> **Overview**
> Adds **client-side Boost impression tracking** so boosted event cards count views when they enter the viewport, with server-side validation before stats are updated.
> 
> Event card renders now attach cache-aware metadata (order item, event, placement from the current route) and `data-*` attributes plus the new `myeventlane_boost/impression` library. **`boost-impression.js`** dedupes by order item + placement, uses **IntersectionObserver** (25% visible) when available, and POSTs JSON via **`sendBeacon`** or **`fetch`** to **`POST /mel/boost/impression`**. Global **`drupalSettings.melBoostImpression.impressionUrl`** comes from **`hook_page_attachments`**. New **`BoostImpressionAttributionService`** and **`BoostPlacementResolver`** validate entitlements, boost order items, and placement keys; **`BoostEntitlementManager`** gains helpers to resolve the primary active entitlement and check the active window. **`BoostImpressionTracker`** merge insert fields are corrected for upserts.
> 
> **Vendor event analytics** (same PR): Chart.js moves from CDN to an npm bundle with lazy **`import('chart.js/auto')`** in the vendor theme; the analytics page adds an optional **ticket-mix doughnut**, **capacity sold** progress UI, and **`data-chart-id`** on chart containers for the updated chart initializer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd122b9e6f2d7527db880997892c202fa5e79e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->