### PR TITLE
Fix Bugbot findings in Boost impression tracking.

### DIFF
--- a/web/modules/custom/myeventlane_boost/js/boost-impression.js
+++ b/web/modules/custom/myeventlane_boost/js/boost-impression.js
@@ -8,12 +8,13 @@
     if (sentKeys.has(key)) {
       return;
     }
-    sentKeys.add(key);
 
     const impressionUrl = drupalSettings.melBoostImpression?.impressionUrl;
     if (!impressionUrl) {
       return;
     }
+
+    sentKeys.add(key);
 
     const payload = JSON.stringify({
       order_item_id: orderItemId,

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.module
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.module
@@ -11,6 +11,7 @@ use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\myeventlane_boost\Cron\BoostExpiryCron;
 use Drupal\myeventlane_boost\Cron\BoostExpiryReminderCron;
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 
 /**
  * Implements hook_theme().
@@ -176,4 +177,51 @@ function myeventlane_boost_cron(): void {
 
   // Nightly rollup: log -> daily aggregates (Phase 2).
   \Drupal::service('myeventlane_boost.daily_rollup')->run();
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function myeventlane_boost_entity_insert(\Drupal\Core\Entity\EntityInterface $entity): void {
+  myeventlane_boost_invalidate_event_impression_cache($entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function myeventlane_boost_entity_update(\Drupal\Core\Entity\EntityInterface $entity): void {
+  myeventlane_boost_invalidate_event_impression_cache($entity);
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function myeventlane_boost_entity_delete(\Drupal\Core\Entity\EntityInterface $entity): void {
+  myeventlane_boost_invalidate_event_impression_cache($entity);
+}
+
+/**
+ * Invalidates Boost impression cache tags when entitlements change.
+ */
+function myeventlane_boost_invalidate_event_impression_cache(\Drupal\Core\Entity\EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'myeventlane_boost_entitlement') {
+    return;
+  }
+  if (!$entity instanceof BoostEntitlementInterface) {
+    return;
+  }
+
+  $eventId = (int) ($entity->get('event')->target_id ?? 0);
+  if ($eventId <= 0) {
+    return;
+  }
+
+  $tags = [
+    \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService::EVENT_CACHE_TAG_PREFIX . $eventId,
+  ];
+  if (!$entity->isNew()) {
+    $tags[] = 'myeventlane_boost_entitlement:' . $entity->id();
+  }
+
+  \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
 }

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -114,6 +114,8 @@ services:
     arguments:
       - '@current_route_match'
       - '@?myeventlane_core.event_category_url'
+      - '@router'
+      - '@request_stack'
 
   myeventlane_boost.impression_attribution:
     class: Drupal\myeventlane_boost\Service\BoostImpressionAttributionService
@@ -122,6 +124,8 @@ services:
       - '@myeventlane_boost.placement_resolver'
       - '@myeventlane_boost.impression_tracker'
       - '@entity_type.manager'
+      - '@cache.default'
+      - '@request_stack'
       - '@logger.channel.myeventlane_boost'
 
   # Boost click tracker.

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostImpressionController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostImpressionController.php
@@ -45,7 +45,7 @@ final class BoostImpressionController extends ControllerBase {
     $eventId = (int) ($payload['event_id'] ?? 0);
     $placement = trim((string) ($payload['placement'] ?? ''));
 
-    $recorded = $this->attributionService->recordValidatedImpression($orderItemId, $eventId, $placement);
+    $recorded = $this->attributionService->recordValidatedImpression($orderItemId, $eventId, $placement, $request);
     if (!$recorded) {
       return new JsonResponse(['status' => 'error', 'message' => 'not_recorded'], 400);
     }

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
@@ -4,15 +4,28 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_boost\Service;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Builds cache-safe Boost impression metadata and validates beacon payloads.
  */
 final class BoostImpressionAttributionService {
+
+  /**
+   * Cache tag prefix for event-scoped Boost card renders.
+   */
+  public const EVENT_CACHE_TAG_PREFIX = 'myeventlane_boost_event:';
+
+  /**
+   * Dedupe window for repeated impression beacons from the same client.
+   */
+  private const IMPRESSION_DEDUPE_TTL = 86400;
 
   /**
    * Constructs a BoostImpressionAttributionService.
@@ -22,6 +35,8 @@ final class BoostImpressionAttributionService {
     private readonly BoostPlacementResolver $placementResolver,
     private readonly BoostImpressionTracker $impressionTracker,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+    private readonly RequestStack $requestStack,
     private readonly LoggerInterface $logger,
   ) {}
 
@@ -59,9 +74,31 @@ final class BoostImpressionAttributionService {
   }
 
   /**
+   * Cache tags for event card renders that may include Boost impressions.
+   *
+   * @return list<string>
+   *   Tags that must invalidate when Boost entitlements for the event change.
+   */
+  public function buildCardCacheTags(NodeInterface $event): array {
+    if ($event->bundle() !== 'event') {
+      return [];
+    }
+
+    $eventId = (int) $event->id();
+    $tags = [self::EVENT_CACHE_TAG_PREFIX . $eventId];
+
+    $entitlement = $this->entitlementManager->getPrimaryActiveEntitlementForEvent($eventId);
+    if ($entitlement instanceof BoostEntitlementInterface) {
+      $tags[] = 'myeventlane_boost_entitlement:' . $entitlement->id();
+    }
+
+    return $tags;
+  }
+
+  /**
    * Validates a beacon payload and records the impression via the tracker.
    */
-  public function recordValidatedImpression(int $orderItemId, int $eventId, string $placement): bool {
+  public function recordValidatedImpression(int $orderItemId, int $eventId, string $placement, ?Request $request = NULL): bool {
     if ($orderItemId <= 0 || $eventId <= 0 || !$this->placementResolver->isValidPlacement($placement)) {
       $this->logger->warning('Rejected Boost impression beacon: invalid payload shape.', [
         'order_item_id' => $orderItemId,
@@ -71,11 +108,89 @@ final class BoostImpressionAttributionService {
       return FALSE;
     }
 
+    $request = $request ?? $this->requestStack->getCurrentRequest();
+    if (!$request instanceof Request || !$this->validatePostedPlacement($placement, $request)) {
+      return FALSE;
+    }
+
     if (!$this->validateActiveEntitlement($orderItemId, $eventId)) {
       return FALSE;
     }
 
-    return $this->impressionTracker->recordImpression($orderItemId, $eventId, $placement);
+    if ($this->isDuplicateImpression($orderItemId, $placement, $request)) {
+      return TRUE;
+    }
+
+    if (!$this->impressionTracker->recordImpression($orderItemId, $eventId, $placement)) {
+      return FALSE;
+    }
+
+    $this->rememberImpression($orderItemId, $placement, $request);
+    return TRUE;
+  }
+
+  /**
+   * Ensures the posted placement matches the page that sent the beacon.
+   */
+  private function validatePostedPlacement(string $postedPlacement, Request $request): bool {
+    $referer = $request->headers->get('Referer');
+    if (!is_string($referer) || $referer === '') {
+      $this->logger->warning('Rejected Boost impression beacon: missing Referer header.');
+      return FALSE;
+    }
+
+    $resolvedPlacement = $this->placementResolver->resolvePlacementFromReferer($referer);
+    if ($resolvedPlacement === NULL) {
+      $this->logger->warning('Rejected Boost impression beacon: could not resolve Referer placement.', [
+        'referer' => $referer,
+        'placement' => $postedPlacement,
+      ]);
+      return FALSE;
+    }
+
+    if ($resolvedPlacement !== $postedPlacement) {
+      $this->logger->warning('Rejected Boost impression beacon: placement mismatch.', [
+        'posted_placement' => $postedPlacement,
+        'resolved_placement' => $resolvedPlacement,
+        'referer' => $referer,
+      ]);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Checks whether this client already recorded the impression recently.
+   */
+  private function isDuplicateImpression(int $orderItemId, string $placement, Request $request): bool {
+    return (bool) $this->cache->get($this->buildImpressionCacheId($orderItemId, $placement, $request));
+  }
+
+  /**
+   * Stores a short-lived dedupe marker after a successful impression record.
+   */
+  private function rememberImpression(int $orderItemId, string $placement, Request $request): void {
+    $this->cache->set(
+      $this->buildImpressionCacheId($orderItemId, $placement, $request),
+      TRUE,
+      time() + self::IMPRESSION_DEDUPE_TTL,
+    );
+  }
+
+  private function buildImpressionCacheId(int $orderItemId, string $placement, Request $request): string {
+    return 'myeventlane_boost:impression:' . $orderItemId . ':' . $placement . ':' . $this->buildClientFingerprint($request);
+  }
+
+  private function buildClientFingerprint(Request $request): string {
+    if ($request->hasSession()) {
+      $session = $request->getSession();
+      if ($session->isStarted()) {
+        return 'session:' . $session->getId();
+      }
+    }
+
+    return 'anon:' . hash('sha256', ($request->getClientIp() ?? '') . '|' . ($request->headers->get('User-Agent') ?? ''));
   }
 
   /**

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
@@ -7,6 +7,11 @@ namespace Drupal\myeventlane_boost\Service;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\myeventlane_core\Service\EventCategoryUrlService;
 use Drupal\taxonomy\TermInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Resolves Boost placement keys from the current request route.
@@ -22,14 +27,64 @@ final class BoostPlacementResolver {
   public function __construct(
     private readonly RouteMatchInterface $routeMatch,
     private readonly ?EventCategoryUrlService $categoryUrlService,
+    private readonly RouterInterface $router,
+    private readonly RequestStack $requestStack,
   ) {}
 
   /**
    * Resolves the placement identifier for the current page request.
    */
   public function resolveCurrentPlacement(): string {
-    $routeName = (string) ($this->routeMatch->getRouteName() ?? '');
+    return $this->resolvePlacementFromRoute(
+      (string) ($this->routeMatch->getRouteName() ?? ''),
+      $this->extractRouteParameters($this->routeMatch),
+    );
+  }
 
+  /**
+   * Resolves placement from the page that initiated an impression beacon.
+   */
+  public function resolvePlacementFromReferer(string $referer): ?string {
+    $refererPath = parse_url($referer, PHP_URL_PATH);
+    if (!is_string($refererPath) || $refererPath === '') {
+      return NULL;
+    }
+
+    $currentRequest = $this->requestStack->getCurrentRequest();
+    if ($currentRequest === NULL) {
+      return NULL;
+    }
+
+    $basePath = $currentRequest->getBasePath();
+    if ($basePath !== '' && str_starts_with($refererPath, $basePath)) {
+      $refererPath = substr($refererPath, strlen($basePath)) ?: '/';
+    }
+
+    try {
+      $matchRequest = Request::create($refererPath);
+      $matchRequest->headers->set('HOST', $currentRequest->getHost());
+      $attributes = $this->router->matchRequest($matchRequest);
+    }
+    catch (ResourceNotFoundException | MethodNotAllowedException) {
+      return NULL;
+    }
+
+    $routeName = (string) ($attributes['_route'] ?? '');
+    unset(
+      $attributes['_route'],
+      $attributes['_controller'],
+      $attributes['_title'],
+      $attributes['_form'],
+      $attributes['_access_checks'],
+    );
+
+    return $this->resolvePlacementFromRoute($routeName, $attributes);
+  }
+
+  /**
+   * Resolves a placement key from a route name and its parameters.
+   */
+  public function resolvePlacementFromRoute(string $routeName, array $parameters = []): string {
     if ($routeName === '<front>') {
       return 'homepage_discover';
     }
@@ -39,7 +94,7 @@ final class BoostPlacementResolver {
     }
 
     if ($routeName === 'view.upcoming_events.page_category') {
-      $argument = $this->routeMatch->getParameter('arg_0');
+      $argument = $parameters['arg_0'] ?? NULL;
       if ($this->categoryUrlService !== NULL && ($argument !== NULL && $argument !== '')) {
         $term = $this->categoryUrlService->resolveTerm($argument);
         if ($term instanceof TermInterface) {
@@ -63,6 +118,18 @@ final class BoostPlacementResolver {
     }
 
     return 'listing';
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   Raw route parameters keyed for placement resolution.
+   */
+  private function extractRouteParameters(RouteMatchInterface $routeMatch): array {
+    $parameters = [];
+    foreach ($routeMatch->getParameters()->keys() as $name) {
+      $parameters[$name] = $routeMatch->getRawParameter($name);
+    }
+    return $parameters;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1530,6 +1530,8 @@ function myeventlane_event_attach_boost_impression_to_build(
 
   /** @var \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution */
   $attribution = \Drupal::service('myeventlane_boost.impression_attribution');
+  myeventlane_event_merge_boost_impression_cache($build, $node, $attribution);
+
   $metadata = $attribution->buildCardMetadata($node);
   if (!is_array($metadata)) {
     return;
@@ -1568,11 +1570,13 @@ function myeventlane_event_apply_boost_impression_metadata(
     return;
   }
 
+  /** @var \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution */
+  $attribution = \Drupal::service('myeventlane_boost.impression_attribution');
+  myeventlane_event_merge_boost_impression_cache($variables, $node, $attribution);
+
   $elements = is_array($variables['elements'] ?? NULL) ? $variables['elements'] : [];
   $metadata = $elements['#boost_impression'] ?? NULL;
   if (!is_array($metadata)) {
-    /** @var \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution */
-    $attribution = \Drupal::service('myeventlane_boost.impression_attribution');
     $metadata = $attribution->buildCardMetadata($node);
   }
   if (!is_array($metadata)) {
@@ -1602,6 +1606,33 @@ function myeventlane_event_apply_boost_impression_metadata(
     $contexts,
     ['route.name', 'url.path'],
   )));
+}
+
+/**
+ * Merges Boost entitlement cache tags into a render array.
+ */
+function myeventlane_event_merge_boost_impression_cache(
+  array &$build,
+  NodeInterface $node,
+  \Drupal\myeventlane_boost\Service\BoostImpressionAttributionService $attribution,
+): void {
+  $tags = $attribution->buildCardCacheTags($node);
+  if ($tags === []) {
+    return;
+  }
+
+  if (!isset($build['#cache'])) {
+    $build['#cache'] = [];
+  }
+  if (!is_array($build['#cache'])) {
+    $build['#cache'] = [];
+  }
+
+  $existingTags = $build['#cache']['tags'] ?? [];
+  if (!is_array($existingTags)) {
+    $existingTags = [];
+  }
+  $build['#cache']['tags'] = array_values(array_unique(array_merge($existingTags, $tags)));
 }
 
 /**


### PR DESCRIPTION
Validate beacon placement against the Referer page route, add entitlement cache tags so card renders invalidate when boosts change, dedupe repeated POSTs server-side, and only mark client impressions sent after the URL exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics validation and render-cache tags for boosted listings; legitimate beacons without Referer or with privacy-stripped headers may fail to record.
> 
> **Overview**
> Tightens **Boost impression tracking** so beacons are harder to spoof and cached event cards refresh when entitlements change.
> 
> **Server validation:** Impression POSTs must include a **Referer**; placement in the payload is checked against the route resolved from that URL (`resolvePlacementFromReferer` via the router). **24-hour dedupe** uses cache keyed by order item, placement, and a session or IP+UA fingerprint; duplicates return success without double-counting.
> 
> **Render cache:** Event card builds merge **Boost cache tags** (`myeventlane_boost_event:{id}` and entitlement tags). **Entity hooks** on boost entitlements invalidate those tags on insert/update/delete.
> 
> **Client:** `boost-impression.js` only marks an impression as sent **after** `impressionUrl` is present, so missing config does not block retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4494d9c27dc909b5b96d27d0318065cebdf9b787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->