### PR TITLE
Fix/boost impression chip ajax dedupe race

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -125,6 +125,7 @@ services:
       - '@myeventlane_boost.impression_tracker'
       - '@entity_type.manager'
       - '@cache.default'
+      - '@lock'
       - '@request_stack'
       - '@logger.channel.myeventlane_boost'
 

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostImpressionAttributionService.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_boost\Service;
 
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -28,6 +29,11 @@ final class BoostImpressionAttributionService {
   private const IMPRESSION_DEDUPE_TTL = 86400;
 
   /**
+   * Lock timeout while claiming an impression dedupe slot.
+   */
+  private const IMPRESSION_LOCK_TIMEOUT = 5.0;
+
+  /**
    * Constructs a BoostImpressionAttributionService.
    */
   public function __construct(
@@ -36,6 +42,7 @@ final class BoostImpressionAttributionService {
     private readonly BoostImpressionTracker $impressionTracker,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly CacheBackendInterface $cache,
+    private readonly LockBackendInterface $lock,
     private readonly RequestStack $requestStack,
     private readonly LoggerInterface $logger,
   ) {}
@@ -117,16 +124,26 @@ final class BoostImpressionAttributionService {
       return FALSE;
     }
 
-    if ($this->isDuplicateImpression($orderItemId, $placement, $request)) {
+    $lockName = $this->buildImpressionDedupeKey($orderItemId, $placement, $request);
+    if (!$this->lock->acquire($lockName, self::IMPRESSION_LOCK_TIMEOUT)) {
       return TRUE;
     }
 
-    if (!$this->impressionTracker->recordImpression($orderItemId, $eventId, $placement)) {
-      return FALSE;
-    }
+    try {
+      if ($this->isDuplicateImpression($orderItemId, $placement, $request)) {
+        return TRUE;
+      }
 
-    $this->rememberImpression($orderItemId, $placement, $request);
-    return TRUE;
+      if (!$this->impressionTracker->recordImpression($orderItemId, $eventId, $placement)) {
+        return FALSE;
+      }
+
+      $this->rememberImpression($orderItemId, $placement, $request);
+      return TRUE;
+    }
+    finally {
+      $this->lock->release($lockName);
+    }
   }
 
   /**
@@ -178,8 +195,12 @@ final class BoostImpressionAttributionService {
     );
   }
 
-  private function buildImpressionCacheId(int $orderItemId, string $placement, Request $request): string {
+  private function buildImpressionDedupeKey(int $orderItemId, string $placement, Request $request): string {
     return 'myeventlane_boost:impression:' . $orderItemId . ':' . $placement . ':' . $this->buildClientFingerprint($request);
+  }
+
+  private function buildImpressionCacheId(int $orderItemId, string $placement, Request $request): string {
+    return $this->buildImpressionDedupeKey($orderItemId, $placement, $request);
   }
 
   private function buildClientFingerprint(Request $request): string {

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
@@ -35,8 +35,21 @@ final class BoostPlacementResolver {
    * Resolves the placement identifier for the current page request.
    */
   public function resolveCurrentPlacement(): string {
+    $routeName = (string) ($this->routeMatch->getRouteName() ?? '');
+
+    // Chip AJAX renders cards on the filter route; attribute to the category page.
+    if ($routeName === 'myeventlane_core.event_filter') {
+      $request = $this->requestStack->getCurrentRequest();
+      if ($request instanceof Request) {
+        $chipPlacement = $this->resolvePlacementFromChipFilterRequest($request);
+        if ($chipPlacement !== NULL && $this->isValidPlacement($chipPlacement)) {
+          return $chipPlacement;
+        }
+      }
+    }
+
     return $this->resolvePlacementFromRoute(
-      (string) ($this->routeMatch->getRouteName() ?? ''),
+      $routeName,
       $this->extractRouteParameters($this->routeMatch),
     );
   }
@@ -118,6 +131,35 @@ final class BoostPlacementResolver {
     }
 
     return 'listing';
+  }
+
+  /**
+   * Resolves placement for category chip AJAX card renders.
+   *
+   * Cards are built on myeventlane_core.event_filter, but beacons validate against
+   * the browser Referer (the category listing page). Prefer Referer, then the
+   * category query param sent by mel-chips.js.
+   */
+  private function resolvePlacementFromChipFilterRequest(Request $request): ?string {
+    $referer = $request->headers->get('Referer');
+    if (is_string($referer) && $referer !== '') {
+      $fromReferer = $this->resolvePlacementFromReferer($referer);
+      if ($fromReferer !== NULL && $this->isValidPlacement($fromReferer)) {
+        return $fromReferer;
+      }
+    }
+
+    $category = $request->query->get('category');
+    if ($category === NULL || $category === '' || $this->categoryUrlService === NULL) {
+      return NULL;
+    }
+
+    $term = $this->categoryUrlService->resolveTerm($category);
+    if (!$term instanceof TermInterface) {
+      return NULL;
+    }
+
+    return 'category_' . $this->sanitizePlacementSegment($this->categoryUrlService->getSlug($term));
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how Boost impressions are counted and attributed; incorrect lock or placement logic could skew analytics but does not touch auth or payments.
> 
> **Overview**
> Fixes **Boost impression** handling for category chip AJAX and concurrent beacons.
> 
> **Impression dedupe:** `recordValidatedImpression` now acquires a per-client dedupe **lock** (via `@lock`) before the cache check and DB write, so parallel beacons cannot double-count. Failed lock acquisition is treated like a duplicate and returns success without recording again.
> 
> **Chip filter placement:** On route `myeventlane_core.event_filter`, card metadata no longer falls through to a generic listing key. Placement is resolved from the **Referer** (category page) or the **`category` query param**, matching what beacon validation expects so chip-filter renders attribute to the correct `category_*` placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cdd10f16da4c692916addd0a216d75e9a4ffdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->