### PR TITLE
Fix FinanceReadModel gross/refund mismatch and fulfillment orders.

### DIFF
--- a/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
+++ b/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
@@ -19,6 +19,13 @@ final class FinanceReadModel {
   private const PROJECTION_TTL = 300;
   private const FALLBACK_TTL = 60;
 
+  /**
+   * Order states counted as paid for vendor line-item revenue.
+   *
+   * Aligns with BoostMetricsService and MetricsAggregator donation analytics.
+   */
+  private const PAID_ORDER_STATES = ['completed', 'fulfillment'];
+
   public function __construct(
     private readonly Connection $database,
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -270,16 +277,46 @@ final class FinanceReadModel {
     $organiserDonationRevenue = $this->sumOrganiserDonationRevenueForEvent($eventId);
     $grossRevenue = round($ticketRevenue + $organiserDonationRevenue, 2);
 
-    $refundTotal = (float) ($finance['refund_total'] ?? 0.0);
+    // Use event-scoped refunds so multi-event orders do not over-subtract.
+    $refundTotal = $this->sumEventScopedRefundTotal($eventId);
     $melFee = (float) ($finance['mel_fee'] ?? 0.0);
     $stripeFee = (float) ($finance['stripe_fee'] ?? 0.0);
     $netRevenue = round(max(0.0, $grossRevenue - $refundTotal - $melFee - $stripeFee), 2);
 
     $finance['gross_revenue'] = $grossRevenue;
     $finance['net_revenue'] = $netRevenue;
+    $finance['refund_total'] = $refundTotal;
     $finance['organiser_donation_revenue'] = round($organiserDonationRevenue, 2);
 
     return $finance;
+  }
+
+  /**
+   * Sums completed refunds attributed to a single event.
+   *
+   * @param int $eventId
+   *   Event node ID.
+   *
+   * @return float
+   *   Refund total in major currency units.
+   */
+  private function sumEventScopedRefundTotal(int $eventId): float {
+    if (
+      $eventId <= 0
+      || !$this->database->schema()->tableExists('myeventlane_refund_log')
+    ) {
+      return 0.0;
+    }
+
+    $query = $this->database->select('myeventlane_refund_log', 'r');
+    $query->addExpression('COALESCE(SUM(r.amount_cents), 0)', 'sum_cents');
+    $query->condition('r.event_id', $eventId);
+    $query->condition('r.status', 'completed');
+    $query->condition('r.amount_cents', 0, '>');
+
+    $sumCents = (int) $query->execute()->fetchField();
+
+    return round($sumCents / 100, 2);
   }
 
   /**
@@ -300,7 +337,7 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', 'completed');
+    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $excludedTypes, 'NOT IN');
 
@@ -326,7 +363,7 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', 'completed');
+    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $organiserTypes, 'IN');
 


### PR DESCRIPTION
When aligning vendor gross to per-event line items, use event-scoped refunds from myeventlane_refund_log instead of whole-order payment refunds so multi-event orders do not depress net revenue. Include fulfillment orders in paid line-item sums to match Boost and donation analytics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendor-facing revenue and net calculations; incorrect refund or order-state logic could misstate payouts, but scope is limited to this read model’s SQL aggregation path.
> 
> **Overview**
> **`FinanceReadModel`** vendor-aligned gross/net now subtracts **per-event** completed refunds from `myeventlane_refund_log` instead of the projection’s whole-order `refund_total`, so multi-event carts no longer over-reduce net for a single event. The returned payload’s **`refund_total`** is updated to match that event-scoped sum.
> 
> Ticket and organiser-donation line revenue queries now treat orders in **`completed`** and **`fulfillment`** as paid via a shared **`PAID_ORDER_STATES`** constant, aligned with Boost and donation analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109a675aaf2ccbd60e40b2dfff727fa6b5b6ce11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->