### PR TITLE
Cursor/ief stable bbcd4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "drupal/gin_toolbar": "^3.0",
     "drupal/honeypot": "^2.2",
     "drupal/image_widget_crop": "^3.0",
-    "drupal/inline_entity_form": "^3.0@rc",
+    "drupal/inline_entity_form": "^3.0",
     "drupal/klaro": "^3.0",
     "drupal/mailsystem": "^4.5",
     "drupal/menu_link_attributes": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3dd71aed32a9c1cd35a5ba6498512c7",
+    "content-hash": "cc73f96f6706fcf95f3fd14a498cd7b8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4103,17 +4103,17 @@
         },
         {
             "name": "drupal/inline_entity_form",
-            "version": "3.0.0-rc21",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "3.0.0-rc21"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0-rc21.zip",
-                "reference": "3.0.0-rc21",
-                "shasum": "bbfb99be0ee35ad197556b2aa02f6e181e34ff1f"
+                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "43417cf232df36d6a621151dffa569b77dfd9725"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9 || ^10 || ^11",
@@ -4126,11 +4126,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0-rc21",
-                    "datestamp": "1746459780",
+                    "version": "3.0.0",
+                    "datestamp": "1780695753",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -17509,8 +17509,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "drupal/commerce_recurring": 5,
-        "drupal/conditional_fields": 15,
-        "drupal/inline_entity_form": 5
+        "drupal/conditional_fields": 15
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPlacementResolver.php
@@ -120,6 +120,10 @@ final class BoostPlacementResolver {
       return 'category_unknown';
     }
 
+    if (str_starts_with($routeName, 'view.frontpage.')) {
+      return 'homepage_discover';
+    }
+
     if (str_starts_with($routeName, 'view.front_') || str_contains($routeName, 'homepage')) {
       return 'homepage_discover';
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency promotion to a stable release with security coverage; the placement change is a narrow routing fix for boost analytics attribution.
> 
> **Overview**
> **Promotes `drupal/inline_entity_form` from `^3.0@rc` to stable `^3.0`**, updating `composer.lock` to **3.0.0** (replacing **3.0.0-rc21**), dropping the RC stability flag, and bringing the module under Drupal’s **security advisory policy**.
> 
> **Maps Drupal Views frontpage routes** (`view.frontpage.*`) to the **`homepage_discover`** boost placement in `BoostPlacementResolver`, so homepage traffic (e.g. `/home` via `view.frontpage.page_1`) is no longer attributed to the generic **`listing`** fallback—aligning with existing stats remediation documented in `myeventlane_boost_update_10008`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25953857f2440e3ff3b77dba42021b790708cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->