### PR TITLE
Cursor/boost decision 2a3e7

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -88,6 +88,12 @@ services:
       - '@datetime.time'
       - '@string_translation'
 
+  # Boost analytics decision support (Stage 3 — no new queries).
+  myeventlane_boost.decision_support:
+    class: Drupal\myeventlane_boost\Service\BoostDecisionSupportService
+    arguments:
+      - '@string_translation'
+
   # Thin façade: lifecycle presentation metrics (composes BoostManager, entitlements, analytics).
   myeventlane_boost.performance:
     class: Drupal\myeventlane_boost\Service\BoostPerformanceService

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
@@ -1,0 +1,744 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Transforms Boost metrics into organiser-facing decision support.
+ *
+ * Consumes output from BoostMetricsService only — no new queries or calculations
+ * of underlying metrics.
+ */
+final class BoostDecisionSupportService {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs BoostDecisionSupportService.
+   */
+  public function __construct(TranslationInterface $stringTranslation) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds decision support for the event analytics Boost panel.
+   *
+   * @param array<string, mixed> $boost_metrics
+   *   Output from BoostMetricsService::getEventBoostMetrics().
+   * @param array<string, mixed> $boost
+   *   Boost status from MetricsAggregator (expects 'active' key).
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *   Pre-built placement cards from the analytics controller.
+   * @param string|null $boost_page_url
+   *   URL to the Boost purchase page, if available.
+   *
+   * @return array<string, mixed>
+   *   Decision support payload for Twig.
+   */
+  public function build(
+    array $boost_metrics,
+    array $boost,
+    bool $isTickets,
+    bool $isRsvp,
+    array $placement_performance_section,
+    ?string $boost_page_url = NULL,
+  ): array {
+    $impressions = (int) ($boost_metrics['impressions'] ?? 0);
+    $clicks = (int) ($boost_metrics['clicks'] ?? 0);
+    $ctr = (float) ($boost_metrics['ctr'] ?? 0.0);
+    $spend = $this->parseFormattedAmount((string) ($boost_metrics['spend'] ?? '$0.00'));
+    $revenue = (float) ($boost_metrics['revenue_during_boost'] ?? 0.0);
+    $orders = (int) ($boost_metrics['orders_during_boost'] ?? 0);
+    $tickets = (int) ($boost_metrics['tickets_during_boost'] ?? 0);
+    $rsvps = (int) ($boost_metrics['rsvps_during_boost'] ?? 0);
+    $donation_revenue = (float) ($boost_metrics['donation_revenue_during_boost'] ?? 0.0);
+    $boost_active = !empty($boost['active']);
+    $has_boost_history = $spend > 0.0 || $impressions > 0 || $clicks > 0 || $boost_active;
+
+    $confidence = $this->buildConfidence($impressions, $clicks, $has_boost_history);
+    $health = $this->buildHealthScore(
+      $ctr,
+      $impressions,
+      $spend,
+      $revenue,
+      $orders,
+      $rsvps,
+      $isTickets,
+      $isRsvp,
+      $has_boost_history,
+      $placement_performance_section,
+    );
+    $placement_winner = $this->buildPlacementWinner(
+      $placement_performance_section,
+      $tickets,
+      $orders,
+      $rsvps,
+      $isTickets,
+      $isRsvp,
+    );
+    $conversion_insights = $this->buildConversionInsights(
+      $clicks,
+      $orders,
+      $rsvps,
+      $isTickets,
+      $isRsvp,
+    );
+    $roi_insight = $this->buildRoiInsight(
+      $spend,
+      $revenue,
+      $donation_revenue,
+      $isTickets,
+      $isRsvp,
+      (string) ($boost_metrics['sales_during_boost'] ?? '$0.00'),
+      (string) ($boost_metrics['donation_revenue_during_boost_formatted'] ?? '$0.00'),
+    );
+
+    $insights = [];
+    if ($placement_winner['show']) {
+      $insights[] = [
+        'type' => 'placement',
+        'title' => (string) $this->t('Best placement'),
+        'body' => $placement_winner['label'],
+        'detail' => $placement_winner['reason'],
+      ];
+    }
+    foreach ($conversion_insights as $insight) {
+      $insights[] = $insight;
+    }
+    if ($roi_insight['show']) {
+      $insights[] = [
+        'type' => 'roi',
+        'title' => (string) $this->t('Return on Boost'),
+        'lines' => $roi_insight['lines'],
+      ];
+    }
+
+    $recommendations = $this->buildRecommendations(
+      $boost_metrics,
+      $boost,
+      $isTickets,
+      $isRsvp,
+      $placement_performance_section,
+      $boost_page_url,
+      $ctr,
+      $impressions,
+      $clicks,
+      $spend,
+      $revenue,
+      $orders,
+      $rsvps,
+      $donation_revenue,
+    );
+
+    $show = $has_boost_history
+      || $health['show']
+      || $insights !== []
+      || $recommendations !== []
+      || $confidence['show'];
+
+    return [
+      'show' => $show,
+      'confidence' => $confidence,
+      'health' => $health,
+      'insights' => $insights,
+      'recommendations' => $recommendations,
+    ];
+  }
+
+  /**
+   * Builds prioritised Boost recommendations (max 3, no duplicates).
+   *
+   * @return list<string>
+   */
+  public function buildRecommendations(
+    array $boost_metrics,
+    array $boost,
+    bool $isTickets,
+    bool $isRsvp,
+    array $placement_performance_section,
+    ?string $boost_page_url,
+    ?float $ctr = NULL,
+    ?int $impressions = NULL,
+    ?int $clicks = NULL,
+    ?float $spend = NULL,
+    ?float $revenue = NULL,
+    ?int $orders = NULL,
+    ?int $rsvps = NULL,
+    ?float $donation_revenue = NULL,
+  ): array {
+    $ctr = $ctr ?? (float) ($boost_metrics['ctr'] ?? 0.0);
+    $impressions = $impressions ?? (int) ($boost_metrics['impressions'] ?? 0);
+    $clicks = $clicks ?? (int) ($boost_metrics['clicks'] ?? 0);
+    $spend = $spend ?? $this->parseFormattedAmount((string) ($boost_metrics['spend'] ?? '$0.00'));
+    $revenue = $revenue ?? (float) ($boost_metrics['revenue_during_boost'] ?? 0.0);
+    $orders = $orders ?? (int) ($boost_metrics['orders_during_boost'] ?? 0);
+    $rsvps = $rsvps ?? (int) ($boost_metrics['rsvps_during_boost'] ?? 0);
+    $donation_revenue = $donation_revenue ?? (float) ($boost_metrics['donation_revenue_during_boost'] ?? 0.0);
+    $boost_active = !empty($boost['active']);
+
+    $roi_revenue = $this->resolveRoiRevenue($revenue, $donation_revenue, $isTickets, $isRsvp);
+    $candidates = [];
+
+    if ($spend > 0.0 && $roi_revenue > $spend * 1.5) {
+      $candidates[] = [
+        'priority' => 100,
+        'text' => (string) $this->t('Strong return on Boost spend — consider extending Boost.'),
+      ];
+    }
+
+    if ($impressions >= 100 && $ctr < 0.01) {
+      $candidates[] = [
+        'priority' => 95,
+        'text' => (string) $this->t('Improve your event hero image to lift click-through rate.'),
+      ];
+    }
+
+    if ($isTickets && $clicks >= 20 && $orders < max(2, (int) floor($clicks * 0.03))) {
+      $candidates[] = [
+        'priority' => 90,
+        'text' => (string) $this->t('Improve your event description to convert more visitors.'),
+      ];
+      $candidates[] = [
+        'priority' => 85,
+        'text' => (string) $this->t('Review ticket pricing — clicks are strong but sales are lagging.'),
+      ];
+    }
+
+    if ($isRsvp && $clicks >= 20 && $rsvps < max(3, (int) floor($clicks * 0.05))) {
+      $candidates[] = [
+        'priority' => 90,
+        'text' => (string) $this->t('Improve your event description to convert more visitors.'),
+      ];
+      $candidates[] = [
+        'priority' => 82,
+        'text' => (string) $this->t('Good click volume but few RSVPs during Boost — sharpen your event page copy.'),
+      ];
+    }
+
+    $winner = $this->resolvePlacementWinnerCard($placement_performance_section);
+    if ($winner !== NULL) {
+      $winner_key = (string) ($winner['key'] ?? '');
+      $winner_label = (string) ($winner['label'] ?? '');
+      if (str_starts_with($winner_key, 'category_') && $winner_label !== '') {
+        $candidates[] = [
+          'priority' => 75,
+          'text' => (string) $this->t('Promote through @placement — it is your strongest category placement.', [
+            '@placement' => $winner_label,
+          ]),
+        ];
+      }
+      elseif ((str_starts_with($winner_key, 'homepage_') || $winner_key === 'homepage_discover')
+        && ($winner['ctr'] ?? 0.0) >= 0.03) {
+        $candidates[] = [
+          'priority' => 72,
+          'text' => (string) $this->t('@placement is performing well — consider extending Boost.', [
+            '@placement' => $winner_label,
+          ]),
+        ];
+      }
+    }
+
+    $weakest = $this->resolveWeakestPlacementCard($placement_performance_section);
+    if ($weakest !== NULL) {
+      $weakest_key = (string) ($weakest['key'] ?? '');
+      $weakest_label = (string) ($weakest['label'] ?? '');
+      if ($weakest_key === 'search_results') {
+        $candidates[] = [
+          'priority' => 65,
+          'text' => (string) $this->t('Search Results has your weakest CTR — improve your event title and keywords.'),
+        ];
+      }
+      elseif (str_starts_with($weakest_key, 'search_') && $weakest_label !== '') {
+        $candidates[] = [
+          'priority' => 63,
+          'text' => (string) $this->t('@placement has your weakest CTR — review how your event appears in search.', [
+            '@placement' => $weakest_label,
+          ]),
+        ];
+      }
+    }
+
+    if (!$boost_active && $spend <= 0.0 && $boost_page_url !== NULL && $boost_page_url !== '') {
+      $candidates[] = [
+        'priority' => 55,
+        'text' => (string) $this->t('Consider Boost to reach more potential attendees.'),
+      ];
+    }
+
+    usort($candidates, static fn (array $a, array $b): int => $b['priority'] <=> $a['priority']);
+
+    $unique = [];
+    $seen = [];
+    foreach ($candidates as $candidate) {
+      $text = (string) ($candidate['text'] ?? '');
+      if ($text === '' || isset($seen[$text])) {
+        continue;
+      }
+      $seen[$text] = TRUE;
+      $unique[] = $text;
+      if (count($unique) >= 3) {
+        break;
+      }
+    }
+
+    return $unique;
+  }
+
+  /**
+   * @return array{show: bool, level: string, label: string, badge: string}
+   */
+  private function buildConfidence(int $impressions, int $clicks, bool $has_boost_history): array {
+    if (!$has_boost_history) {
+      return [
+        'show' => FALSE,
+        'level' => 'low',
+        'label' => '',
+        'badge' => 'muted',
+      ];
+    }
+
+    if ($impressions < 20) {
+      return [
+        'show' => TRUE,
+        'level' => 'low',
+        'label' => (string) $this->t('Low confidence'),
+        'badge' => 'danger',
+      ];
+    }
+
+    if ($impressions >= 100 && $clicks >= 20) {
+      return [
+        'show' => TRUE,
+        'level' => 'high',
+        'label' => (string) $this->t('High confidence'),
+        'badge' => 'success',
+      ];
+    }
+
+    return [
+      'show' => TRUE,
+      'level' => 'medium',
+      'label' => (string) $this->t('Medium confidence'),
+      'badge' => 'warning',
+    ];
+  }
+
+  /**
+   * @return array{
+   *   show: bool,
+   *   score: string,
+   *   label: string,
+   *   explanation: string,
+   *   badge: string,
+   * }
+   */
+  private function buildHealthScore(
+    float $ctr,
+    int $impressions,
+    float $spend,
+    float $revenue,
+    int $orders,
+    int $rsvps,
+    bool $isTickets,
+    bool $isRsvp,
+    bool $has_boost_history,
+    array $placement_performance_section,
+  ): array {
+    if (!$has_boost_history) {
+      return [
+        'show' => FALSE,
+        'score' => '',
+        'label' => '',
+        'explanation' => '',
+        'badge' => 'muted',
+      ];
+    }
+
+    $ctr_pct = $ctr * 100.0;
+    $has_conversions = ($isTickets && $orders > 0) || ($isRsvp && $rsvps > 0);
+    $revenue_beats_spend = $spend > 0.0 && $revenue > $spend;
+    $winner = $this->resolvePlacementWinnerCard($placement_performance_section);
+
+    if ($impressions >= 20 && $ctr_pct < 1.0 && !$has_conversions) {
+      return $this->healthResult(
+        'needs_attention',
+        $this->buildHealthExplanation('needs_attention', $ctr_pct, $winner),
+      );
+    }
+
+    if ($ctr_pct >= 5.0 && $revenue_beats_spend) {
+      return $this->healthResult(
+        'excellent',
+        $this->buildHealthExplanation('excellent', $ctr_pct, $winner),
+      );
+    }
+
+    $points = 0;
+    if ($ctr_pct >= 5.0) {
+      $points += 3;
+    }
+    elseif ($ctr_pct >= 2.0) {
+      $points += 2;
+    }
+    elseif ($ctr_pct >= 1.0) {
+      $points += 1;
+    }
+
+    if ($has_conversions) {
+      if (($isTickets && $orders >= 5) || ($isRsvp && $rsvps >= 10)) {
+        $points += 3;
+      }
+      else {
+        $points += 2;
+      }
+    }
+
+    if ($revenue_beats_spend) {
+      $points += 3;
+    }
+    elseif ($revenue > 0.0) {
+      $points += 1;
+    }
+
+    $best_ctr = (float) ($winner['ctr'] ?? 0.0);
+    if ($best_ctr >= 0.05) {
+      $points += 2;
+    }
+    elseif ($best_ctr >= 0.02) {
+      $points += 1;
+    }
+
+    $score = match (TRUE) {
+      $points >= 8 => 'excellent',
+      $points >= 5 => 'good',
+      $points >= 3 => 'fair',
+      default => 'needs_attention',
+    };
+
+    return $this->healthResult($score, $this->buildHealthExplanation($score, $ctr_pct, $winner));
+  }
+
+  /**
+   * @return array{
+   *   show: bool,
+   *   score: string,
+   *   label: string,
+   *   explanation: string,
+   *   badge: string,
+   * }
+   */
+  private function healthResult(string $score, string $explanation): array {
+    $labels = [
+      'excellent' => (string) $this->t('Excellent'),
+      'good' => (string) $this->t('Good'),
+      'fair' => (string) $this->t('Fair'),
+      'needs_attention' => (string) $this->t('Needs attention'),
+    ];
+    $badges = [
+      'excellent' => 'success',
+      'good' => 'success',
+      'fair' => 'warning',
+      'needs_attention' => 'danger',
+    ];
+
+    return [
+      'show' => TRUE,
+      'score' => $score,
+      'label' => $labels[$score] ?? $labels['fair'],
+      'explanation' => $explanation,
+      'badge' => $badges[$score] ?? 'warning',
+    ];
+  }
+
+  /**
+   * @param array<string, mixed>|null $winner
+   */
+  private function buildHealthExplanation(string $score, float $ctr_pct, ?array $winner): string {
+    $winner_label = (string) ($winner['label'] ?? '');
+    $winner_ctr = isset($winner['ctr']) ? number_format((float) $winner['ctr'] * 100, 1) . '%' : '';
+
+    return match ($score) {
+      'excellent' => $winner_label !== '' && $winner_ctr !== ''
+        ? (string) $this->t('Your Boost is performing better than average. @placement is generating the strongest engagement at @ctr CTR.', [
+          '@placement' => $winner_label,
+          '@ctr' => $winner_ctr,
+        ])
+        : (string) $this->t('Your Boost is performing better than average with @ctr click-through rate.', [
+          '@ctr' => number_format($ctr_pct, 1) . '%',
+        ]),
+      'good' => $winner_label !== ''
+        ? (string) $this->t('Boost is delivering solid results. @placement is your top placement so far.', [
+          '@placement' => $winner_label,
+        ])
+        : (string) $this->t('Boost is delivering solid reach and engagement.'),
+      'fair' => (string) $this->t('Boost is building visibility — watch conversions over the next few days.'),
+      default => $winner_label !== ''
+        ? (string) $this->t('Engagement is below average. Review how your event appears on @placement first.', [
+          '@placement' => $winner_label,
+        ])
+        : (string) $this->t('Engagement is below average — review your hero image and event page copy.'),
+    };
+  }
+
+  /**
+   * @return array{show: bool, label: string, reason: string}
+   */
+  private function buildPlacementWinner(
+    array $placement_performance_section,
+    int $tickets,
+    int $orders,
+    int $rsvps,
+    bool $isTickets,
+    bool $isRsvp,
+  ): array {
+    $winner = $this->resolvePlacementWinnerCard($placement_performance_section);
+    if ($winner === NULL) {
+      return [
+        'show' => FALSE,
+        'label' => '',
+        'reason' => '',
+      ];
+    }
+
+    $ctr_display = number_format((float) ($winner['ctr'] ?? 0.0) * 100, 1) . '%';
+    $clicks = (int) ($winner['clicks'] ?? 0);
+    $reason_parts = [(string) $this->t('@ctr CTR', ['@ctr' => $ctr_display])];
+
+    if ($clicks > 0) {
+      $reason_parts[] = (string) $this->t('@count clicks', ['@count' => (string) $clicks]);
+    }
+
+    if ($isTickets && $tickets > 0) {
+      $reason_parts[] = (string) $this->t('@count ticket sales during Boost', ['@count' => (string) $tickets]);
+    }
+    elseif ($isTickets && $orders > 0) {
+      $reason_parts[] = (string) $this->t('@count orders during Boost', ['@count' => (string) $orders]);
+    }
+    elseif ($isRsvp && $rsvps > 0) {
+      $reason_parts[] = (string) $this->t('@count RSVPs during Boost', ['@count' => (string) $rsvps]);
+    }
+
+    return [
+      'show' => TRUE,
+      'label' => (string) ($winner['label'] ?? ''),
+      'reason' => implode(' · ', $reason_parts),
+    ];
+  }
+
+  /**
+   * @return list<array{type: string, title: string, body: string}>
+   */
+  private function buildConversionInsights(
+    int $clicks,
+    int $orders,
+    int $rsvps,
+    bool $isTickets,
+    bool $isRsvp,
+  ): array {
+    if ($clicks <= 0) {
+      return [];
+    }
+
+    $insights = [];
+    if ($isTickets) {
+      $pct = (int) round(($orders / $clicks) * 100);
+      $insights[] = [
+        'type' => 'conversion',
+        'title' => (string) $this->t('Ticket conversion'),
+        'body' => (string) $this->t('@pct% of visitors who clicked your event purchased a ticket.', [
+          '@pct' => (string) $pct,
+        ]),
+      ];
+    }
+    if ($isRsvp) {
+      $pct = (int) round(($rsvps / $clicks) * 100);
+      $insights[] = [
+        'type' => 'conversion',
+        'title' => (string) $this->t('RSVP conversion'),
+        'body' => (string) $this->t('@pct% of visitors who clicked your event completed an RSVP.', [
+          '@pct' => (string) $pct,
+        ]),
+      ];
+    }
+
+    return $insights;
+  }
+
+  /**
+   * @return array{show: bool, lines: list<string>}
+   */
+  private function buildRoiInsight(
+    float $spend,
+    float $revenue,
+    float $donation_revenue,
+    bool $isTickets,
+    bool $isRsvp,
+    string $sales_formatted,
+    string $donation_formatted,
+  ): array {
+    if ($spend <= 0.0) {
+      return [
+        'show' => FALSE,
+        'lines' => [],
+      ];
+    }
+
+    $roi_revenue = $this->resolveRoiRevenue($revenue, $donation_revenue, $isTickets, $isRsvp);
+    $spend_formatted = '$' . number_format($spend, 2, '.', ',');
+
+    if ($roi_revenue <= 0.0) {
+      return [
+        'show' => TRUE,
+        'lines' => [
+          (string) $this->t('Boost generated visibility but has not yet recovered its cost.'),
+        ],
+      ];
+    }
+
+    $revenue_display = $isTickets && $revenue > 0.0
+      ? $sales_formatted
+      : ($donation_revenue > 0.0 ? $donation_formatted : $sales_formatted);
+
+    $lines = [
+      (string) $this->t('Boost generated @revenue revenue from @spend spend.', [
+        '@revenue' => $revenue_display,
+        '@spend' => $spend_formatted,
+      ]),
+    ];
+
+    if ($roi_revenue > $spend) {
+      $lines[] = (string) $this->t('Every $1 spent returned $@ratio.', [
+        '@ratio' => number_format($roi_revenue / $spend, 2),
+      ]);
+    }
+
+    return [
+      'show' => TRUE,
+      'lines' => $lines,
+    ];
+  }
+
+  /**
+   * Resolves monetary ROI basis from existing metrics.
+   */
+  private function resolveRoiRevenue(
+    float $ticket_revenue,
+    float $donation_revenue,
+    bool $isTickets,
+    bool $isRsvp,
+  ): float {
+    if ($isTickets && $ticket_revenue > 0.0) {
+      return $ticket_revenue;
+    }
+    if ($isRsvp && $donation_revenue > 0.0) {
+      return $donation_revenue;
+    }
+    if ($isTickets) {
+      return $ticket_revenue;
+    }
+    return $donation_revenue;
+  }
+
+  /**
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *
+   * @return array<string, mixed>|null
+   */
+  private function resolvePlacementWinnerCard(array $placement_performance_section): ?array {
+    $cards = is_array($placement_performance_section['cards'] ?? NULL)
+      ? $placement_performance_section['cards']
+      : [];
+    if ($cards === []) {
+      return NULL;
+    }
+
+    $eligible = array_values(array_filter(
+      $cards,
+      static fn (array $card): bool => (int) ($card['impressions'] ?? 0) >= 10,
+    ));
+    if ($eligible === []) {
+      return NULL;
+    }
+
+    if (count($eligible) < 2) {
+      $only = $eligible[0];
+      if ((int) ($only['impressions'] ?? 0) < 20) {
+        return NULL;
+      }
+    }
+
+    $max_clicks = max(array_map(static fn (array $card): int => (int) ($card['clicks'] ?? 0), $eligible));
+    usort($eligible, static function (array $a, array $b) use ($max_clicks): int {
+      $score_a = ((float) ($a['ctr'] ?? 0.0) * 0.6)
+        + (($max_clicks > 0 ? (int) ($a['clicks'] ?? 0) / $max_clicks : 0.0) * 0.4);
+      $score_b = ((float) ($b['ctr'] ?? 0.0) * 0.6)
+        + (($max_clicks > 0 ? (int) ($b['clicks'] ?? 0) / $max_clicks : 0.0) * 0.4);
+      $cmp = $score_b <=> $score_a;
+      if ($cmp !== 0) {
+        return $cmp;
+      }
+      return (int) ($b['clicks'] ?? 0) <=> (int) ($a['clicks'] ?? 0);
+    });
+
+    return $eligible[0];
+  }
+
+  /**
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *
+   * @return array<string, mixed>|null
+   */
+  private function resolveWeakestPlacementCard(array $placement_performance_section): ?array {
+    $cards = is_array($placement_performance_section['cards'] ?? NULL)
+      ? $placement_performance_section['cards']
+      : [];
+    if (count($cards) < 2) {
+      return NULL;
+    }
+
+    $eligible = array_values(array_filter(
+      $cards,
+      static fn (array $card): bool => (int) ($card['impressions'] ?? 0) >= 10,
+    ));
+    if (count($eligible) < 2) {
+      return NULL;
+    }
+
+    usort($eligible, static fn (array $a, array $b): int => (float) ($a['ctr'] ?? 0.0) <=> (float) ($b['ctr'] ?? 0.0));
+    $weakest = $eligible[0];
+    $strongest = $eligible[count($eligible) - 1];
+    if (($weakest['key'] ?? '') === ($strongest['key'] ?? '')) {
+      return NULL;
+    }
+
+    return $weakest;
+  }
+
+  /**
+   * Parses a formatted currency string into a float.
+   */
+  private function parseFormattedAmount(string $formatted): float {
+    if ($formatted === '—' || $formatted === '') {
+      return 0.0;
+    }
+    $clean = preg_replace('/[^\d.]/', '', $formatted);
+    if ($clean === NULL || $clean === '') {
+      return 0.0;
+    }
+    return (float) $clean;
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDecisionSupportServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDecisionSupportServiceTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for Boost decision support rules.
+ *
+ * @group myeventlane_boost
+ */
+final class BoostDecisionSupportServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  private BoostDecisionSupportService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    $this->service = new BoostDecisionSupportService($translation);
+  }
+
+  /**
+   * Excellent health when CTR and revenue exceed thresholds.
+   */
+  public function testExcellentHealthScore(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$45.00',
+        'impressions' => 500,
+        'clicks' => 60,
+        'ctr' => 0.12,
+        'revenue_during_boost' => 280.0,
+        'orders_during_boost' => 8,
+        'tickets_during_boost' => 8,
+        'sales_during_boost' => '$280.00',
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      [
+        'show' => TRUE,
+        'cards' => [
+          [
+            'key' => 'homepage_discover',
+            'label' => 'Homepage Discover',
+            'impressions' => 300,
+            'clicks' => 40,
+            'ctr' => 0.133,
+          ],
+        ],
+      ],
+    );
+
+    $this->assertTrue($result['health']['show']);
+    $this->assertSame('excellent', $result['health']['score']);
+    $this->assertSame('high', $result['confidence']['level']);
+  }
+
+  /**
+   * Needs attention when CTR is very low and there are no conversions.
+   */
+  public function testNeedsAttentionHealthScore(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$30.00',
+        'impressions' => 200,
+        'clicks' => 1,
+        'ctr' => 0.005,
+        'revenue_during_boost' => 0.0,
+        'orders_during_boost' => 0,
+        'tickets_during_boost' => 0,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+    );
+
+    $this->assertSame('needs_attention', $result['health']['score']);
+    $this->assertSame('medium', $result['confidence']['level']);
+  }
+
+  /**
+   * Conversion insight is shown when clicks exist.
+   */
+  public function testConversionInsightForPaidEvent(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$20.00',
+        'impressions' => 120,
+        'clicks' => 50,
+        'ctr' => 0.416,
+        'revenue_during_boost' => 100.0,
+        'orders_during_boost' => 9,
+        'tickets_during_boost' => 9,
+        'sales_during_boost' => '$100.00',
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+    );
+
+    $conversion = array_values(array_filter(
+      $result['insights'],
+      static fn (array $insight): bool => ($insight['type'] ?? '') === 'conversion',
+    ));
+    $this->assertCount(1, $conversion);
+    $this->assertStringContainsString('18%', (string) $conversion[0]['body']);
+  }
+
+  /**
+   * ROI insight uses plain language without exposing formulas.
+   */
+  public function testRoiInsightStrongReturn(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$45.00',
+        'impressions' => 400,
+        'clicks' => 30,
+        'ctr' => 0.075,
+        'revenue_during_boost' => 280.0,
+        'orders_during_boost' => 6,
+        'sales_during_boost' => '$280.00',
+      ],
+      ['active' => FALSE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+    );
+
+    $roi = array_values(array_filter(
+      $result['insights'],
+      static fn (array $insight): bool => ($insight['type'] ?? '') === 'roi',
+    ));
+    $this->assertCount(1, $roi);
+    $this->assertStringContainsString('$280.00', (string) $roi[0]['lines'][0]);
+    $this->assertStringContainsString('6.22', (string) $roi[0]['lines'][1]);
+  }
+
+  /**
+   * Recommendations are prioritised and capped at three.
+   */
+  public function testRecommendationsPrioritisedAndUnique(): void {
+    $recs = $this->service->buildRecommendations(
+      [
+        'spend' => '$45.00',
+        'impressions' => 500,
+        'clicks' => 80,
+        'ctr' => 0.002,
+        'revenue_during_boost' => 300.0,
+        'orders_during_boost' => 1,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      [
+        'show' => TRUE,
+        'cards' => [
+          [
+            'key' => 'category_music',
+            'label' => 'Music Category',
+            'impressions' => 200,
+            'clicks' => 30,
+            'ctr' => 0.15,
+          ],
+          [
+            'key' => 'search_results',
+            'label' => 'Search Results',
+            'impressions' => 150,
+            'clicks' => 2,
+            'ctr' => 0.013,
+          ],
+        ],
+      ],
+      '/boost',
+    );
+
+    $this->assertLessThanOrEqual(3, count($recs));
+    $this->assertSame(count($recs), count(array_unique($recs)));
+    $this->assertStringContainsString('extending Boost', (string) $recs[0]);
+  }
+
+  /**
+   * No Boost scenario suggests considering Boost.
+   */
+  public function testNoBoostRecommendation(): void {
+    $recs = $this->service->buildRecommendations(
+      [
+        'spend' => '$0.00',
+        'impressions' => 0,
+        'clicks' => 0,
+        'ctr' => 0.0,
+      ],
+      ['active' => FALSE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+      '/boost',
+    );
+
+    $this->assertContains('Consider Boost to reach more potential attendees.', $recs);
+  }
+
+  /**
+   * Placement winner is hidden when data is insufficient.
+   */
+  public function testPlacementWinnerHiddenWithInsufficientData(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$10.00',
+        'impressions' => 15,
+        'clicks' => 2,
+        'ctr' => 0.133,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      [
+        'show' => TRUE,
+        'cards' => [
+          [
+            'key' => 'homepage_discover',
+            'label' => 'Homepage Discover',
+            'impressions' => 15,
+            'clicks' => 2,
+            'ctr' => 0.133,
+          ],
+        ],
+      ],
+    );
+
+    $placement = array_values(array_filter(
+      $result['insights'],
+      static fn (array $insight): bool => ($insight['type'] ?? '') === 'placement',
+    ));
+    $this->assertCount(0, $placement);
+    $this->assertSame('low', $result['confidence']['level']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
+++ b/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
@@ -19,6 +19,13 @@ final class FinanceReadModel {
   private const PROJECTION_TTL = 300;
   private const FALLBACK_TTL = 60;
 
+  /**
+   * Order states counted as paid for vendor line-item revenue.
+   *
+   * Aligns with BoostMetricsService and MetricsAggregator donation analytics.
+   */
+  private const PAID_ORDER_STATES = ['completed', 'fulfillment'];
+
   public function __construct(
     private readonly Connection $database,
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -300,7 +307,7 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', 'completed');
+    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $excludedTypes, 'NOT IN');
 
@@ -326,7 +333,7 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', 'completed');
+    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $organiserTypes, 'IN');
 

--- a/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
+++ b/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
@@ -20,11 +20,11 @@ final class FinanceReadModel {
   private const FALLBACK_TTL = 60;
 
   /**
-   * Order states counted as paid for vendor line-item revenue.
+   * Order states counted as paid for organiser donation line-item revenue.
    *
    * Aligns with BoostMetricsService and MetricsAggregator donation analytics.
    */
-  private const PAID_ORDER_STATES = ['completed', 'fulfillment'];
+  private const ORGANISER_DONATION_ORDER_STATES = ['completed', 'fulfillment'];
 
   public function __construct(
     private readonly Connection $database,
@@ -307,7 +307,8 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
+    // Ticket revenue follows vendor-commerce-sales-monitoring: completed only.
+    $query->condition('o.state', 'completed');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $excludedTypes, 'NOT IN');
 
@@ -333,7 +334,7 @@ final class FinanceReadModel {
     $query->join('commerce_order', 'o', 'o.order_id = oi.order_id');
     $query->join('commerce_order_item__field_target_event', 'lnk', 'lnk.entity_id = oi.order_item_id');
     $query->addExpression('COALESCE(SUM(oi.unit_price__number * oi.quantity), 0)', 'revenue');
-    $query->condition('o.state', self::PAID_ORDER_STATES, 'IN');
+    $query->condition('o.state', self::ORGANISER_DONATION_ORDER_STATES, 'IN');
     $query->condition('lnk.field_target_event_target_id', $eventId);
     $query->condition('oi.type', $organiserTypes, 'IN');
 

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -455,6 +455,7 @@ services:
       - '@?myeventlane_pro.active_resolver'
       - '@myeventlane_event_studio.commerce_sales_summary_builder'
       - '@myeventlane_commerce.event_operational_extras_sales_summary_builder'
+      - '@?myeventlane_boost.decision_support'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -18,6 +18,7 @@ use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
 use Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
 use Drupal\node\NodeInterface;
+use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_vendor\Service\MetricsAggregator;
 use Drupal\myeventlane_vendor\Service\VendorEventTabsService;
@@ -48,6 +49,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     private readonly ?ProActiveResolver $proActiveResolver = NULL,
     private readonly ?EventStudioCommerceSalesSummaryBuilder $commerceSalesSummaryBuilder = NULL,
     private readonly ?EventOperationalExtrasSalesSummaryBuilder $extrasSalesSummaryBuilder = NULL,
+    private readonly ?BoostDecisionSupportService $boostDecisionSupport = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
   }
@@ -285,6 +287,16 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     );
 
     $placement_performance_section = $this->buildPlacementPerformanceSection($boost_metrics);
+
+    $boost_decision_support = $this->buildBoostDecisionSupportSection(
+      $boost_metrics,
+      $boost,
+      $is_tickets_enabled,
+      $is_rsvp_enabled,
+      $placement_performance_section,
+      $boost_page_url,
+    );
+
     if ($placement_performance_section['show'] && $placement_performance_section['cards'] !== []) {
       $chart_data['boost-placement-impressions'] = [
         'type' => 'bar',
@@ -317,7 +329,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       $capacity_pct,
       $public_event_url,
       $ticketRows,
-      $placement_performance_section,
+      $boost_decision_support,
     );
 
     $has_boost_metrics = $boost_performance_section['show_metrics'];
@@ -354,6 +366,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#rsvp_health_section' => $rsvp_health_section,
         '#recommendations' => $recommendations,
         '#boost_performance_section' => $boost_performance_section,
+        '#boost_decision_support' => $boost_decision_support,
         '#placement_performance_section' => $placement_performance_section,
         '#has_all_sales_trend_chart' => isset($chart_data['event-sales']) && array_sum(array_column($sales_series, 'amount')) > 0,
         '#has_ticket_mix_chart' => isset($chart_data['event-ticket-mix']),
@@ -1409,83 +1422,55 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
   }
 
   /**
-   * Placement-specific recommendations from sorted placement cards.
+   * Boost decision support section (Stage 3).
    *
-   * @param array{
-   *   show: bool,
-   *   cards: list<array{
-   *     key: string,
-   *     label: string,
-   *     impressions: int,
-   *     clicks: int,
-   *     ctr: float,
-   *   }>,
-   * } $placement_performance_section
-   *
-   * @return list<string>
-   */
-  private function buildPlacementRecommendations(array $placement_performance_section): array {
-    $cards = is_array($placement_performance_section['cards'] ?? NULL)
-      ? $placement_performance_section['cards']
-      : [];
-    if (count($cards) < 2) {
-      return [];
-    }
-
-    $eligible = array_values(array_filter(
-      $cards,
-      static fn (array $card): bool => (int) ($card['impressions'] ?? 0) >= 10,
-    ));
-    if (count($eligible) < 2) {
-      return [];
-    }
-
-    usort($eligible, static fn (array $a, array $b): int => $b['ctr'] <=> $a['ctr']);
-    $strongest = $eligible[0];
-    $weakest = $eligible[count($eligible) - 1];
-    if (($strongest['key'] ?? '') === ($weakest['key'] ?? '')) {
-      return [];
-    }
-
-    $recs = [];
-    $strongest_key = (string) ($strongest['key'] ?? '');
-    $weakest_key = (string) ($weakest['key'] ?? '');
-    $strongest_label = (string) ($strongest['label'] ?? '');
-
-    if (str_starts_with($strongest_key, 'homepage_') || $strongest_key === 'homepage_discover') {
-      $recs[] = (string) $this->t('@placement has your strongest CTR — consider extending Boost.', [
-        '@placement' => $strongest_label,
-      ]);
-    }
-    elseif (str_starts_with($strongest_key, 'category_')) {
-      $recs[] = (string) $this->t('@placement is your strongest placement — promote within that audience.', [
-        '@placement' => $strongest_label,
-      ]);
-    }
-
-    if ($weakest_key === 'search_results') {
-      $recs[] = (string) $this->t('Search Results has your weakest CTR — try improving your event keywords and title.');
-    }
-    elseif (str_starts_with($weakest_key, 'search_')) {
-      $weakest_label = (string) ($weakest['label'] ?? '');
-      $recs[] = (string) $this->t('@placement has your weakest CTR — review how your event appears in search.', [
-        '@placement' => $weakest_label,
-      ]);
-    }
-
-    return $recs;
-  }
-
-  /**
-   * Rules-based next-step recommendations (max 3, no new services).
-   *
-   * @param array<string, mixed> $overview
-   * @param array<string, mixed> $commerce
+   * @param array<string, mixed> $boost_metrics
    * @param array<string, mixed> $boost
    * @param array{
    *   show: bool,
    *   cards: list<array<string, mixed>>,
    * } $placement_performance_section
+   *
+   * @return array<string, mixed>
+   */
+  private function buildBoostDecisionSupportSection(
+    array $boost_metrics,
+    array $boost,
+    bool $isTickets,
+    bool $isRsvp,
+    array $placement_performance_section,
+    ?string $boost_page_url,
+  ): array {
+    if (!$this->boostDecisionSupport) {
+      return [
+        'show' => FALSE,
+        'confidence' => ['show' => FALSE, 'level' => 'low', 'label' => '', 'badge' => 'muted'],
+        'health' => ['show' => FALSE, 'score' => '', 'label' => '', 'explanation' => '', 'badge' => 'muted'],
+        'insights' => [],
+        'recommendations' => [],
+      ];
+    }
+
+    return $this->boostDecisionSupport->build(
+      $boost_metrics,
+      $boost,
+      $isTickets,
+      $isRsvp,
+      $placement_performance_section,
+      $boost_page_url,
+    );
+  }
+
+  /**
+   * Rules-based next-step recommendations (max 3).
+   *
+   * Boost-specific recommendations come from BoostDecisionSupportService.
+   * Operational fallbacks fill remaining slots when fewer than three Boost recs exist.
+   *
+   * @param array<string, mixed> $overview
+   * @param array<string, mixed> $commerce
+   * @param array<string, mixed> $boost
+   * @param array<string, mixed> $boost_decision_support
    *
    * @return list<string>
    */
@@ -1499,51 +1484,11 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     ?float $capacity_pct,
     ?string $public_event_url,
     array $ticketRows,
-    array $placement_performance_section = [],
+    array $boost_decision_support = [],
   ): array {
-    $recs = [];
-    $boost_metrics = is_array($overview['boost_metrics'] ?? NULL) ? $overview['boost_metrics'] : [];
-
-    foreach ($boost_metrics['recommendations'] ?? [] as $rec) {
-      if (!is_string($rec) || $rec === '') {
-        continue;
-      }
-      $recs[] = $rec;
-    }
-
-    if (count($recs) < 3) {
-      foreach ($this->buildPlacementRecommendations($placement_performance_section) as $rec) {
-        if (count($recs) >= 3) {
-          break;
-        }
-        $recs[] = $rec;
-      }
-    }
-
-    if (count($recs) < 3 && !empty($boost['active'])) {
-      $ctr = (float) ($boost_metrics['ctr'] ?? 0);
-      $impressions = (int) ($boost_metrics['impressions'] ?? 0);
-      $clicks = (int) ($boost_metrics['clicks'] ?? 0);
-      $rsvps_during_boost = (int) ($boost_metrics['rsvps_during_boost'] ?? 0);
-      $orders_during_boost = (int) ($boost_metrics['orders_during_boost'] ?? 0);
-      $donation_revenue = (float) ($boost_metrics['donation_revenue_during_boost'] ?? 0.0);
-
-      if ($impressions >= 100 && $ctr < 0.01) {
-        $recs[] = (string) $this->t('Strong Boost reach but low CTR — consider updating your event hero image.');
-      }
-
-      if ($isRsvp && $clicks >= 20 && $rsvps_during_boost < max(3, (int) floor($clicks * 0.05))) {
-        $recs[] = (string) $this->t('Good click volume but few RSVPs during Boost — try improving your event page copy.');
-      }
-
-      if ($isRsvp && $rsvps_during_boost >= 10 && $donation_revenue <= 0.0) {
-        $recs[] = (string) $this->t('RSVPs are strong but donations are low — consider adding a donation prompt on your event page.');
-      }
-
-      if ($isTickets && $clicks >= 20 && $orders_during_boost < max(2, (int) floor($clicks * 0.03))) {
-        $recs[] = (string) $this->t('Good click volume but few orders during Boost — review your ticket pricing and tiers.');
-      }
-    }
+    $recs = is_array($boost_decision_support['recommendations'] ?? NULL)
+      ? $boost_decision_support['recommendations']
+      : [];
 
     if (count($recs) < 3 && $isTickets) {
       $best_ticket = $this->findBestSellingTicketFromTiers($ticketRows);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1370,6 +1370,7 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'rsvp_health_section' => [],
         'recommendations' => [],
         'boost_performance_section' => [],
+        'boost_decision_support' => [],
         'placement_performance_section' => [],
         'has_all_sales_trend_chart' => FALSE,
         'has_ticket_mix_chart' => FALSE,

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics.scss
@@ -205,6 +205,110 @@
   margin-top: 0;
 }
 
+// Stage 3 — Boost decision support (health + insight cards)
+.mel-analytics__boost-decision {
+  display: flex;
+  flex-direction: column;
+  gap: $mel-spacing-sm;
+  margin-top: $mel-spacing-md;
+}
+
+.mel-analytics__boost-decision-head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $mel-spacing-sm;
+}
+
+.mel-analytics__boost-insights-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $mel-spacing-sm;
+
+  @include respond-to(md) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-analytics__boost-card {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+  min-height: 44px;
+  padding: $mel-spacing-md;
+  border-radius: $radius-card;
+  border: 1px solid $border-color-light;
+  background: $bg-primary;
+  box-shadow: $shadow-xs;
+}
+
+.mel-analytics__boost-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $mel-spacing-sm;
+}
+
+.mel-analytics__boost-card-kicker {
+  margin: 0;
+  font-size: $font-size-xs;
+  font-weight: $font-weight-semibold;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mel-analytics__boost-card-score {
+  margin: 0;
+  font-size: $font-size-lg;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
+  line-height: $line-height-tight;
+}
+
+.mel-analytics__boost-card-copy {
+  margin: 0;
+  font-size: $font-size-sm;
+  color: $text-secondary;
+  line-height: 1.45;
+}
+
+.mel-analytics__boost-card--health {
+  border-left: 4px solid $primary;
+}
+
+.mel-analytics__boost-card--excellent,
+.mel-analytics__boost-card--good {
+  border-left-color: #10b981;
+}
+
+.mel-analytics__boost-card--fair {
+  border-left-color: #f59e0b;
+}
+
+.mel-analytics__boost-card--needs_attention {
+  border-left-color: #ef4444;
+}
+
+.mel-analytics__boost-card--insight {
+  border-left: 4px solid #6366f1;
+}
+
+.mel-analytics__boost-card--roi {
+  border-left-color: #2563eb;
+}
+
+.mel-analytics__boost-card--placement {
+  border-left-color: $primary;
+}
+
+.mel-analytics__boost-card--conversion {
+  border-left-color: #10b981;
+}
+
+.mel-analytics__action-card {
+  min-height: 44px;
+}
+
 .mel-analytics__boost-groups {
   display: grid;
   grid-template-columns: 1fr;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-boost-decision-support.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-boost-decision-support.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Boost decision support — health, insights, and confidence (Stage 3).
+ *
+ * Variables:
+ * - boost_decision: output of BoostDecisionSupportService::build()
+ */
+#}
+{% if boost_decision.show|default(false) %}
+  <div class="mel-analytics__boost-decision" role="region" aria-label="{{ 'Boost insights'|t }}">
+    {% if boost_decision.health.show|default(false) or boost_decision.confidence.show|default(false) %}
+      <div class="mel-analytics__boost-decision-head">
+        {% if boost_decision.health.show|default(false) %}
+          <article class="mel-analytics__boost-card mel-analytics__boost-card--health mel-analytics__boost-card--{{ boost_decision.health.score|default('fair') }}">
+            <div class="mel-analytics__boost-card-top">
+              <h3 class="mel-analytics__boost-card-kicker">{{ 'Boost health'|t }}</h3>
+              {% if boost_decision.confidence.show|default(false) %}
+                <span class="mel-badge mel-badge--{{ boost_decision.confidence.badge|default('muted') }}">{{ boost_decision.confidence.label }}</span>
+              {% endif %}
+            </div>
+            <p class="mel-analytics__boost-card-score">{{ boost_decision.health.label }}</p>
+            {% if boost_decision.health.explanation|default('') is not empty %}
+              <p class="mel-analytics__boost-card-copy">{{ boost_decision.health.explanation }}</p>
+            {% endif %}
+          </article>
+        {% elseif boost_decision.confidence.show|default(false) %}
+          <div class="mel-analytics__boost-card mel-analytics__boost-card--confidence">
+            <span class="mel-badge mel-badge--{{ boost_decision.confidence.badge|default('muted') }}">{{ boost_decision.confidence.label }}</span>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    {% if boost_decision.insights|default([])|length > 0 %}
+      <div class="mel-analytics__boost-insights-grid">
+        {% for insight in boost_decision.insights %}
+          <article class="mel-analytics__boost-card mel-analytics__boost-card--insight mel-analytics__boost-card--{{ insight.type|default('insight') }}">
+            {% if insight.title|default('') is not empty %}
+              <h3 class="mel-analytics__boost-card-kicker">{{ insight.title }}</h3>
+            {% endif %}
+            {% if insight.body|default('') is not empty %}
+              <p class="mel-analytics__boost-card-score">{{ insight.body }}</p>
+            {% endif %}
+            {% if insight.detail|default('') is not empty %}
+              <p class="mel-analytics__boost-card-copy">{{ insight.detail }}</p>
+            {% endif %}
+            {% if insight.lines|default([])|length > 0 %}
+              {% for line in insight.lines %}
+                <p class="mel-analytics__boost-card-copy">{{ line }}</p>
+              {% endfor %}
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -249,11 +249,15 @@
 
   {# Boost — marketing performance (never mixed with revenue) #}
   {% set boost_perf = boost_performance_section|default({}) %}
+  {% set boost_decision = boost_decision_support|default({}) %}
   <section class="mel-analytics__business mel-analytics__business--boost mel-live-ops__panel mel-analytics__boost-panel" aria-labelledby="mel-analytics-boost-title">
     <div class="mel-live-ops__timeline-head">
       <h2 id="mel-analytics-boost-title" class="mel-live-ops__panel-title">{{ 'Boost performance'|t }}</h2>
       <p class="mel-live-ops__panel-intro">{{ boost_perf.intro|default('Boost puts your event in front of more people.'|t) }}</p>
     </div>
+    {% include '@myeventlane_vendor_theme/components/mel-boost-decision-support.html.twig' with {
+      boost_decision: boost_decision,
+    } only %}
     {% if boost_perf.show_metrics|default(false) %}
       <div class="mel-analytics__boost-groups">
         {% if boost_perf.reach.show|default(false) and boost_perf.reach.kpis|default([])|length > 0 %}
@@ -372,11 +376,11 @@
 
   {# Recommendations — what to do next (max 3) #}
   {% if next_steps|length > 0 %}
-    <section class="mel-analytics__recommendations" aria-labelledby="mel-analytics-recs-title">
+    <section class="mel-analytics__recommendations mel-analytics__recommendations--actions" aria-labelledby="mel-analytics-recs-title">
       <h2 id="mel-analytics-recs-title" class="mel-live-ops__panel-title">{{ 'What to do next'|t }}</h2>
       <ul class="mel-analytics__recommendations-list">
         {% for step in next_steps %}
-          <li class="mel-analytics__recommendations-item">{{ step }}</li>
+          <li class="mel-analytics__recommendations-item mel-analytics__action-card">{{ step }}</li>
         {% endfor %}
       </ul>
     </section>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-layer rules on existing metrics only; optional service injection keeps vendor analytics working if boost is absent. Recommendation wording may shift vs prior controller rules—worth a quick UX pass.
> 
> **Overview**
> Adds **Stage 3 Boost decision support** on vendor event analytics: a new `BoostDecisionSupportService` turns existing Boost metrics and placement cards into health scores, confidence badges, insights (best placement, conversion, ROI), and up to three prioritised recommendations—without new database queries.
> 
> **Vendor analytics wiring:** `VendorEventAnalyticsController` injects the optional boost service, builds a `boost_decision_support` payload, passes it to Twig, and **moves Boost/placement recommendation logic** out of the controller (removed `buildPlacementRecommendations` and inline Boost rules). **What to do next** now starts from the service’s recommendations and only fills remaining slots with ticket/merchandise/capacity fallbacks.
> 
> **UI:** New `mel-boost-decision-support.html.twig` renders cards inside the Boost performance panel; `_analytics.scss` styles health/insight cards and action-style recommendation items.
> 
> **Tests:** Unit tests cover health tiers, conversion/ROI copy, recommendation caps, and insufficient placement data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c898837787d2ae003d7b841254f93bbe4882a536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->