### PR TITLE
Complete Boost Analytics Phase 5 placement performance

### DIFF
--- a/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
@@ -137,11 +137,7 @@ final class BoostDecisionSupportService {
       $donation_revenue,
     );
 
-    $show = $has_boost_history
-      || $health['show']
-      || $insights !== []
-      || $recommendations !== []
-      || $confidence['show'];
+    $show = $health['show'] || $insights !== [] || ($confidence['show'] && !$health['show']);
 
     return [
       'show' => $show,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single conditional change in organiser-facing analytics UI gating with no data or auth impact.
> 
> **Overview**
> Tightens when the event analytics **Boost decision support** block is shown by changing the top-level `show` flag in `BoostDecisionSupportService::build()`.
> 
> **Before**, the panel could appear when the organiser had any Boost history, when health/insights/confidence/recommendations had content—**recommendations alone** or **history alone** were enough to force it on.
> 
> **After**, visibility requires **health**, **non-empty insights**, or **confidence only when health is hidden**—so recommendations no longer open the panel by themselves, and bare Boost history no longer does either. Confidence is suppressed as a sole reason when the health section is already shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fc28b6aff008e55a4d3390a49bb2f655d5cd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->