### PR TITLE
Feature/boost benchmark foundations

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.install
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.install
@@ -536,3 +536,95 @@ function myeventlane_boost_update_10008(): string {
     '@daily_renamed' => $daily_renamed,
   ]);
 }
+
+/**
+ * Re-run listing aggregate migration for rows missed by created-only window.
+ *
+ * Update 10008 only selected listing rows with created >= bug window. Rows opened
+ * earlier via BoostClickTracker but receiving misattributed homepage impressions
+ * during the window were skipped. This hook uses stats_log occurred_at to find
+ * those boost_order_item_id values and migrate any remaining listing rows.
+ */
+function myeventlane_boost_update_10009(): string {
+  $database = \Drupal::database();
+  $schema = $database->schema();
+
+  if (!$schema->tableExists('myeventlane_boost_stats')) {
+    return 'Skipped Boost listing placement follow-up: myeventlane_boost_stats missing.';
+  }
+
+  $window_start = 1780650187;
+
+  $listing_boost_item_ids = [];
+  if ($schema->tableExists('myeventlane_boost_stats_log')) {
+    $listing_boost_item_ids = $database->select('myeventlane_boost_stats_log', 'l')
+      ->fields('l', ['boost_order_item_id'])
+      ->condition('placement', 'listing')
+      ->condition('occurred_at', $window_start, '>=')
+      ->distinct()
+      ->execute()
+      ->fetchCol();
+    $listing_boost_item_ids = array_values(array_filter(
+      array_map('intval', $listing_boost_item_ids),
+      static fn (int $id): bool => $id > 0,
+    ));
+  }
+
+  $listing_query = $database->select('myeventlane_boost_stats', 's')
+    ->fields('s')
+    ->condition('placement', 'listing');
+
+  if ($listing_boost_item_ids !== []) {
+    $or = $listing_query->orConditionGroup()
+      ->condition('created', $window_start, '>=')
+      ->condition('boost_order_item_id', $listing_boost_item_ids, 'IN');
+    $listing_query->condition($or);
+  }
+  else {
+    $listing_query->condition('created', $window_start, '>=');
+  }
+
+  $listing_rows = $listing_query->execute()->fetchAll();
+
+  $stats_merged = 0;
+  $stats_renamed = 0;
+
+  foreach ($listing_rows as $listing_row) {
+    $homepage_row = $database->select('myeventlane_boost_stats', 'h')
+      ->fields('h')
+      ->condition('boost_order_item_id', $listing_row->boost_order_item_id)
+      ->condition('placement', 'homepage_discover')
+      ->range(0, 1)
+      ->execute()
+      ->fetchObject();
+
+    if ($homepage_row) {
+      $database->update('myeventlane_boost_stats')
+        ->fields([
+          'impressions' => (int) $homepage_row->impressions + (int) $listing_row->impressions,
+          'clicks' => (int) $homepage_row->clicks + (int) $listing_row->clicks,
+          'created' => min((int) $homepage_row->created, (int) $listing_row->created),
+          'changed' => max((int) $homepage_row->changed, (int) $listing_row->changed),
+        ])
+        ->condition('id', $homepage_row->id)
+        ->execute();
+
+      $database->delete('myeventlane_boost_stats')
+        ->condition('id', $listing_row->id)
+        ->execute();
+      $stats_merged++;
+    }
+    else {
+      $database->update('myeventlane_boost_stats')
+        ->fields(['placement' => 'homepage_discover'])
+        ->condition('id', $listing_row->id)
+        ->execute();
+      $stats_renamed++;
+    }
+  }
+
+  return (string) t('Boost listing placement follow-up: @stats_merged aggregate rows merged, @stats_renamed renamed.', [
+    '@stats_merged' => $stats_merged,
+    '@stats_renamed' => $stats_renamed,
+  ]);
+}

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -88,6 +88,14 @@ services:
       - '@datetime.time'
       - '@string_translation'
 
+  # Platform-wide Boost benchmarks (Phase 7A — internal only).
+  myeventlane_boost.benchmark:
+    class: Drupal\myeventlane_boost\Service\BoostBenchmarkService
+    arguments:
+      - '@database'
+      - '@cache.default'
+      - '@myeventlane_boost.placement_resolver'
+
   # Boost analytics decision support (Stage 3 — no new queries).
   myeventlane_boost.decision_support:
     class: Drupal\myeventlane_boost\Service\BoostDecisionSupportService

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostBenchmarkService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostBenchmarkService.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
+
+/**
+ * Platform-wide Boost benchmarks for future cohort comparisons.
+ *
+ * Phase 7A foundations only — not exposed to organisers. Aggregates
+ * impressions, clicks, CTR, and distinct boosted events from existing
+ * boost stats storage. Readiness is gated on platform-wide volume.
+ */
+final class BoostBenchmarkService {
+
+  private const CACHE_TTL = 43200;
+
+  private const CACHE_KEY_GLOBAL = 'mel:boost_benchmark:global';
+
+  private const CACHE_KEY_EVENT_TYPE_PREFIX = 'mel:boost_benchmark:event_type:';
+
+  private const CACHE_KEY_PLACEMENT_PREFIX = 'mel:boost_benchmark:placement:';
+
+  private const READINESS_MIN_IMPRESSIONS = 500;
+
+  private const READINESS_MIN_CLICKS = 50;
+
+  private const READINESS_MIN_EVENTS = 25;
+
+  /**
+   * Allowed field_event_type values for event-type benchmarks.
+   */
+  private const EVENT_TYPES = ['rsvp', 'paid', 'both', 'external'];
+
+  /**
+   * Constructs a BoostBenchmarkService.
+   */
+  public function __construct(
+    private readonly Connection $database,
+    private readonly CacheBackendInterface $cache,
+    private readonly BoostPlacementResolver $placementResolver,
+  ) {}
+
+  /**
+   * Returns the platform-wide Boost benchmark.
+   *
+   * @return array
+   *   Benchmark payload with readiness, impressions, clicks, ctr, and
+   *   distinct_boosted_events keys.
+   */
+  public function getGlobalBenchmark(): array {
+    return $this->getCached(self::CACHE_KEY_GLOBAL, fn (): array => $this->loadStatsAggregate());
+  }
+
+  /**
+   * Returns a Boost benchmark scoped to an event type.
+   *
+   * @param string $eventType
+   *   Field event type value (rsvp, paid, both, external).
+   *
+   * @return array
+   *   Benchmark payload with readiness, impressions, clicks, ctr, and
+   *   distinct_boosted_events keys.
+   */
+  public function getEventTypeBenchmark(string $eventType): array {
+    $eventType = strtolower(trim($eventType));
+    if (!in_array($eventType, self::EVENT_TYPES, TRUE)) {
+      return $this->buildResponse([
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ]);
+    }
+
+    $cacheKey = self::CACHE_KEY_EVENT_TYPE_PREFIX . $eventType;
+    return $this->getCached($cacheKey, fn (): array => $this->loadStatsAggregateForEventType($eventType));
+  }
+
+  /**
+   * Returns a Boost benchmark scoped to a placement key.
+   *
+   * @param string $placement
+   *   Placement identifier from boost stats (e.g. homepage_discover).
+   *
+   * @return array
+   *   Benchmark payload with readiness, impressions, clicks, ctr, and
+   *   distinct_boosted_events keys.
+   */
+  public function getPlacementBenchmark(string $placement): array {
+    $placement = strtolower(trim($placement));
+    if (!$this->placementResolver->isValidPlacement($placement)) {
+      return $this->buildResponse([
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ]);
+    }
+
+    $cacheKey = self::CACHE_KEY_PLACEMENT_PREFIX . $placement;
+    return $this->getCached($cacheKey, fn (): array => $this->loadStatsAggregateForPlacement($placement));
+  }
+
+  /**
+   * Loads cached benchmark data or computes and stores it.
+   *
+   * @param string $cacheKey
+   *   Cache identifier.
+   * @param callable $loader
+   *   Raw aggregate loader returning impressions, clicks, and event count.
+   *
+   * @return array
+   *   Benchmark payload.
+   */
+  private function getCached(string $cacheKey, callable $loader): array {
+    $cached = $this->cache->get($cacheKey);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $cached->data;
+    }
+
+    $payload = $this->buildResponse($loader());
+    $this->cache->set($cacheKey, $payload, time() + self::CACHE_TTL);
+    return $payload;
+  }
+
+  /**
+   * Builds a benchmark response with readiness metadata.
+   *
+   * @param array $raw
+   *   Raw aggregate values for the requested slice.
+   *
+   * @return array
+   *   Benchmark payload.
+   */
+  private function buildResponse(array $raw): array {
+    $impressions = max(0, (int) ($raw['impressions'] ?? 0));
+    $clicks = max(0, (int) ($raw['clicks'] ?? 0));
+    $distinctEvents = max(0, (int) ($raw['distinct_boosted_events'] ?? 0));
+
+    $platform = $this->getPlatformTotals();
+    $payload = [
+      'impressions' => $impressions,
+      'clicks' => $clicks,
+      'ctr' => $this->computeCtr($impressions, $clicks),
+      'distinct_boosted_events' => $distinctEvents,
+    ];
+
+    if ($platform['impressions'] < self::READINESS_MIN_IMPRESSIONS
+      || $platform['clicks'] < self::READINESS_MIN_CLICKS
+      || $platform['distinct_boosted_events'] < self::READINESS_MIN_EVENTS) {
+      return $payload + [
+        'ready' => FALSE,
+        'reason' => 'insufficient_data',
+      ];
+    }
+
+    return $payload + ['ready' => TRUE];
+  }
+
+  /**
+   * Returns platform-wide totals used for readiness gating.
+   *
+   * @return array
+   *   Platform aggregate totals keyed by impressions, clicks, and
+   *   distinct_boosted_events.
+   */
+  private function getPlatformTotals(): array {
+    $cached = $this->cache->get(self::CACHE_KEY_GLOBAL);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return [
+        'impressions' => (int) ($cached->data['impressions'] ?? 0),
+        'clicks' => (int) ($cached->data['clicks'] ?? 0),
+        'distinct_boosted_events' => (int) ($cached->data['distinct_boosted_events'] ?? 0),
+      ];
+    }
+
+    return $this->loadStatsAggregate();
+  }
+
+  /**
+   * Loads platform-wide aggregates from myeventlane_boost_stats.
+   *
+   * @return array
+   *   Aggregate totals keyed by impressions, clicks, and
+   *   distinct_boosted_events.
+   */
+  private function loadStatsAggregate(): array {
+    if (!$this->database->schema()->tableExists('myeventlane_boost_stats')) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    try {
+      $query = $this->database->select('myeventlane_boost_stats', 's');
+      $query->addExpression('COALESCE(SUM(s.impressions), 0)', 'impressions');
+      $query->addExpression('COALESCE(SUM(s.clicks), 0)', 'clicks');
+      $query->addExpression('COUNT(DISTINCT s.event_id)', 'distinct_boosted_events');
+      $row = $query->execute()->fetchAssoc();
+    }
+    catch (\Exception) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    return [
+      'impressions' => (int) ($row['impressions'] ?? 0),
+      'clicks' => (int) ($row['clicks'] ?? 0),
+      'distinct_boosted_events' => (int) ($row['distinct_boosted_events'] ?? 0),
+    ];
+  }
+
+  /**
+   * Loads aggregates for a single event type via node field join.
+   *
+   * @return array
+   *   Aggregate totals keyed by impressions, clicks, and
+   *   distinct_boosted_events.
+   */
+  private function loadStatsAggregateForEventType(string $eventType): array {
+    if (!$this->database->schema()->tableExists('myeventlane_boost_stats')
+      || !$this->database->schema()->tableExists('node__field_event_type')) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    try {
+      $query = $this->database->select('myeventlane_boost_stats', 's');
+      $query->innerJoin(
+        'node__field_event_type',
+        'et',
+        'et.entity_id = s.event_id AND et.deleted = 0',
+      );
+      $query->condition('et.field_event_type_value', $eventType);
+      $query->addExpression('COALESCE(SUM(s.impressions), 0)', 'impressions');
+      $query->addExpression('COALESCE(SUM(s.clicks), 0)', 'clicks');
+      $query->addExpression('COUNT(DISTINCT s.event_id)', 'distinct_boosted_events');
+      $row = $query->execute()->fetchAssoc();
+    }
+    catch (\Exception) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    return [
+      'impressions' => (int) ($row['impressions'] ?? 0),
+      'clicks' => (int) ($row['clicks'] ?? 0),
+      'distinct_boosted_events' => (int) ($row['distinct_boosted_events'] ?? 0),
+    ];
+  }
+
+  /**
+   * Loads aggregates for a single placement from myeventlane_boost_stats.
+   *
+   * @return array
+   *   Aggregate totals keyed by impressions, clicks, and
+   *   distinct_boosted_events.
+   */
+  private function loadStatsAggregateForPlacement(string $placement): array {
+    if (!$this->database->schema()->tableExists('myeventlane_boost_stats')) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    try {
+      $query = $this->database->select('myeventlane_boost_stats', 's');
+      $query->condition('s.placement', $placement);
+      $query->addExpression('COALESCE(SUM(s.impressions), 0)', 'impressions');
+      $query->addExpression('COALESCE(SUM(s.clicks), 0)', 'clicks');
+      $query->addExpression('COUNT(DISTINCT s.event_id)', 'distinct_boosted_events');
+      $row = $query->execute()->fetchAssoc();
+    }
+    catch (\Exception) {
+      return [
+        'impressions' => 0,
+        'clicks' => 0,
+        'distinct_boosted_events' => 0,
+      ];
+    }
+
+    return [
+      'impressions' => (int) ($row['impressions'] ?? 0),
+      'clicks' => (int) ($row['clicks'] ?? 0),
+      'distinct_boosted_events' => (int) ($row['distinct_boosted_events'] ?? 0),
+    ];
+  }
+
+  /**
+   * Computes click-through rate.
+   *
+   * Uses the same ratio semantics as BoostMetricsService.
+   */
+  private function computeCtr(int $impressions, int $clicks): float {
+    return $impressions > 0 ? ($clicks / $impressions) : 0.0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
@@ -68,6 +68,7 @@ final class BoostDecisionSupportService {
       $impressions,
       $spend,
       $revenue,
+      $donation_revenue,
       $orders,
       $rsvps,
       $isTickets,
@@ -181,6 +182,16 @@ final class BoostDecisionSupportService {
 
     $roi_revenue = $this->resolveRoiRevenue($revenue, $donation_revenue, $isTickets, $isRsvp);
     $candidates = [];
+
+    foreach ($boost_metrics['recommendations'] ?? [] as $metrics_rec) {
+      if (!is_string($metrics_rec) || $metrics_rec === '') {
+        continue;
+      }
+      $candidates[] = [
+        'priority' => 78,
+        'text' => $metrics_rec,
+      ];
+    }
 
     if ($spend > 0.0 && $roi_revenue > $spend * 1.5) {
       $candidates[] = [
@@ -340,6 +351,7 @@ final class BoostDecisionSupportService {
     int $impressions,
     float $spend,
     float $revenue,
+    float $donation_revenue,
     int $orders,
     int $rsvps,
     bool $isTickets,
@@ -359,7 +371,8 @@ final class BoostDecisionSupportService {
 
     $ctr_pct = $ctr * 100.0;
     $has_conversions = ($isTickets && $orders > 0) || ($isRsvp && $rsvps > 0);
-    $revenue_beats_spend = $spend > 0.0 && $revenue > $spend;
+    $roi_revenue = $this->resolveRoiRevenue($revenue, $donation_revenue, $isTickets, $isRsvp);
+    $revenue_beats_spend = $spend > 0.0 && $roi_revenue > $spend;
     $winner = $this->resolvePlacementWinnerCard($placement_performance_section);
 
     if ($impressions >= 20 && $ctr_pct < 1.0 && !$has_conversions) {
@@ -399,7 +412,7 @@ final class BoostDecisionSupportService {
     if ($revenue_beats_spend) {
       $points += 3;
     }
-    elseif ($revenue > 0.0) {
+    elseif ($roi_revenue > 0.0) {
       $points += 1;
     }
 

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostBenchmarkServiceKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostBenchmarkServiceKernelTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Kernel;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_boost\Service\BoostBenchmarkService;
+use Drupal\myeventlane_boost\Service\BoostPlacementResolver;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Kernel tests for platform Boost benchmark aggregation.
+ *
+ * @group myeventlane_boost
+ */
+final class BoostBenchmarkServiceKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * The service under test.
+   */
+  private BoostBenchmarkService $benchmarkService;
+
+  /**
+   * The test database connection.
+   */
+  private Connection $database;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once dirname(__DIR__, 3) . '/myeventlane_boost.install';
+    $schema = myeventlane_boost_schema();
+    $this->database = $this->container->get('database');
+    $this->database->schema()->createTable(
+      'myeventlane_boost_stats',
+      $schema['myeventlane_boost_stats'],
+    );
+    $this->installEventTypeFieldTable();
+
+    $placementResolver = new BoostPlacementResolver(
+      $this->createMock(RouteMatchInterface::class),
+      NULL,
+      $this->createMock(RouterInterface::class),
+      new RequestStack(),
+    );
+
+    $this->benchmarkService = new BoostBenchmarkService(
+      $this->database,
+      $this->container->get('cache.default'),
+      $placementResolver,
+    );
+  }
+
+  /**
+   * Benchmarks are not ready when platform totals are below thresholds.
+   */
+  public function testReadinessFalseWhenInsufficientData(): void {
+    $this->insertStatsRow(1, 101, 'homepage_discover', 100, 10);
+    $this->insertStatsRow(2, 102, 'homepage_discover', 50, 5);
+
+    $result = $this->benchmarkService->getGlobalBenchmark();
+
+    $this->assertFalse($result['ready']);
+    $this->assertSame('insufficient_data', $result['reason']);
+    $this->assertSame(150, $result['impressions']);
+    $this->assertSame(15, $result['clicks']);
+    $this->assertSame(2, $result['distinct_boosted_events']);
+  }
+
+  /**
+   * Benchmarks become ready once platform thresholds are met.
+   */
+  public function testReadinessTrueWhenThresholdsMet(): void {
+    $now = time();
+    for ($i = 1; $i <= 25; $i++) {
+      $this->database->insert('myeventlane_boost_stats')
+        ->fields([
+          'boost_order_item_id' => $i,
+          'event_id' => 1000 + $i,
+          'placement' => 'homepage_discover',
+          'impressions' => 20,
+          'clicks' => 2,
+          'created' => $now,
+          'changed' => $now,
+        ])
+        ->execute();
+    }
+
+    $result = $this->benchmarkService->getGlobalBenchmark();
+
+    $this->assertTrue($result['ready']);
+    $this->assertArrayNotHasKey('reason', $result);
+    $this->assertSame(500, $result['impressions']);
+    $this->assertSame(50, $result['clicks']);
+    $this->assertSame(25, $result['distinct_boosted_events']);
+  }
+
+  /**
+   * CTR is computed as clicks divided by impressions.
+   */
+  public function testCtrCalculation(): void {
+    $this->insertStatsRow(1, 201, 'homepage_discover', 200, 25);
+
+    $result = $this->benchmarkService->getGlobalBenchmark();
+
+    $this->assertSame(0.125, $result['ctr']);
+  }
+
+  /**
+   * Placement benchmarks filter stats rows by placement key.
+   */
+  public function testPlacementBenchmark(): void {
+    $this->insertStatsRow(1, 301, 'homepage_discover', 120, 12);
+    $this->insertStatsRow(2, 302, 'search_results', 80, 8);
+
+    $result = $this->benchmarkService->getPlacementBenchmark('search_results');
+
+    $this->assertFalse($result['ready']);
+    $this->assertSame('insufficient_data', $result['reason']);
+    $this->assertSame(80, $result['impressions']);
+    $this->assertSame(8, $result['clicks']);
+    $this->assertSame(0.1, $result['ctr']);
+    $this->assertSame(1, $result['distinct_boosted_events']);
+  }
+
+  /**
+   * Event type benchmarks join boost stats to field_event_type.
+   */
+  public function testEventTypeBenchmark(): void {
+    $this->insertStatsRow(1, 401, 'homepage_discover', 150, 15);
+    $this->insertStatsRow(2, 402, 'homepage_discover', 50, 5);
+    $this->insertEventType(401, 'paid');
+    $this->insertEventType(402, 'rsvp');
+
+    $result = $this->benchmarkService->getEventTypeBenchmark('paid');
+
+    $this->assertFalse($result['ready']);
+    $this->assertSame('insufficient_data', $result['reason']);
+    $this->assertSame(150, $result['impressions']);
+    $this->assertSame(15, $result['clicks']);
+    $this->assertSame(0.1, $result['ctr']);
+    $this->assertSame(1, $result['distinct_boosted_events']);
+  }
+
+  /**
+   * Benchmark responses are cached for twelve hours.
+   */
+  public function testBenchmarkUsesCache(): void {
+    $cache = $this->container->get('cache.default');
+    assert($cache instanceof CacheBackendInterface);
+
+    $this->insertStatsRow(1, 501, 'homepage_discover', 10, 1);
+    $this->benchmarkService->getGlobalBenchmark();
+
+    $this->database->delete('myeventlane_boost_stats')->execute();
+    $cached = $this->benchmarkService->getGlobalBenchmark();
+
+    $this->assertSame(10, $cached['impressions']);
+    $this->assertSame(1, $cached['clicks']);
+    $this->assertNotFalse($cache->get('mel:boost_benchmark:global'));
+  }
+
+  /**
+   * Creates the minimal node field table used for event type joins.
+   */
+  private function installEventTypeFieldTable(): void {
+    $schema = $this->database->schema();
+    if ($schema->tableExists('node__field_event_type')) {
+      return;
+    }
+
+    $schema->createTable('node__field_event_type', [
+      'description' => 'Test event type field table.',
+      'fields' => [
+        'bundle' => [
+          'type' => 'varchar',
+          'length' => 128,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'deleted' => [
+          'type' => 'int',
+          'size' => 'tiny',
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+        'entity_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'revision_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'langcode' => [
+          'type' => 'varchar',
+          'length' => 32,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'delta' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'field_event_type_value' => [
+          'type' => 'varchar',
+          'length' => 255,
+          'not null' => FALSE,
+        ],
+      ],
+      'primary key' => ['entity_id', 'deleted', 'delta', 'langcode'],
+    ]);
+  }
+
+  /**
+   * Inserts a boost stats row.
+   */
+  private function insertStatsRow(
+    int $orderItemId,
+    int $eventId,
+    string $placement,
+    int $impressions,
+    int $clicks,
+  ): void {
+    $now = time();
+    $this->database->insert('myeventlane_boost_stats')
+      ->fields([
+        'boost_order_item_id' => $orderItemId,
+        'event_id' => $eventId,
+        'placement' => $placement,
+        'impressions' => $impressions,
+        'clicks' => $clicks,
+        'created' => $now,
+        'changed' => $now,
+      ])
+      ->execute();
+  }
+
+  /**
+   * Inserts an event type field value for benchmark joins.
+   */
+  private function insertEventType(int $eventId, string $eventType): void {
+    $this->database->insert('node__field_event_type')
+      ->fields([
+        'bundle' => 'event',
+        'deleted' => 0,
+        'entity_id' => $eventId,
+        'revision_id' => $eventId,
+        'langcode' => 'en',
+        'delta' => 0,
+        'field_event_type_value' => $eventType,
+      ])
+      ->execute();
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDecisionSupportServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDecisionSupportServiceTest.php
@@ -217,6 +217,52 @@ final class BoostDecisionSupportServiceTest extends UnitTestCase {
   }
 
   /**
+   * RSVP health uses donation revenue when ticket revenue is absent.
+   */
+  public function testRsvpHealthUsesDonationRevenue(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$40.00',
+        'impressions' => 250,
+        'clicks' => 45,
+        'ctr' => 0.18,
+        'revenue_during_boost' => 0.0,
+        'rsvps_during_boost' => 12,
+        'donation_revenue_during_boost' => 120.0,
+        'donation_revenue_during_boost_formatted' => '$120.00',
+      ],
+      ['active' => TRUE],
+      FALSE,
+      TRUE,
+      ['show' => FALSE, 'cards' => []],
+    );
+
+    $this->assertSame('excellent', $result['health']['score']);
+  }
+
+  /**
+   * BoostMetricsService placement recommendations are merged into decision support.
+   */
+  public function testMetricsRecommendationsMerged(): void {
+    $recs = $this->service->buildRecommendations(
+      [
+        'spend' => '$10.00',
+        'impressions' => 80,
+        'clicks' => 10,
+        'ctr' => 0.125,
+        'recommendations' => ['Category placements outperformed homepage for this event.'],
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+      NULL,
+    );
+
+    $this->assertContains('Category placements outperformed homepage for this event.', $recs);
+  }
+
+  /**
    * Placement winner is hidden when data is insufficient.
    */
   public function testPlacementWinnerHiddenWithInsufficientData(): void {

--- a/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
+++ b/web/modules/custom/myeventlane_domain_events/src/ProjectionReadModel/FinanceReadModel.php
@@ -277,8 +277,10 @@ final class FinanceReadModel {
     $organiserDonationRevenue = $this->sumOrganiserDonationRevenueForEvent($eventId);
     $grossRevenue = round($ticketRevenue + $organiserDonationRevenue, 2);
 
-    // Use event-scoped refunds so multi-event orders do not over-subtract.
-    $refundTotal = $this->sumEventScopedRefundTotal($eventId);
+    // Prefer event-scoped refunds when logged; otherwise keep projection/payment fallback.
+    $loggedRefunds = $this->sumEventScopedRefundTotal($eventId);
+    $fallbackRefunds = (float) ($finance['refund_total'] ?? 0.0);
+    $refundTotal = $loggedRefunds > 0.0 ? $loggedRefunds : $fallbackRefunds;
     $melFee = (float) ($finance['mel_fee'] ?? 0.0);
     $stripeFee = (float) ($finance['stripe_fee'] ?? 0.0);
     $netRevenue = round(max(0.0, $grossRevenue - $refundTotal - $melFee - $stripeFee), 2);

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -1511,10 +1511,6 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       }
     }
 
-    if (count($recs) < 3 && empty($boost['active']) && $boost_page_url !== NULL) {
-      $recs[] = (string) $this->t('Consider boosting your event to increase visibility.');
-    }
-
     if (count($recs) < 3 && $isTickets && $this->countTicketsSoldFromTiers($ticketRows) === 0 && $public_event_url !== NULL) {
       $recs[] = (string) $this->t('Share your public event link to start driving ticket sales.');
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Update hook 10009 mutates production boost stats rows; FinanceReadModel refund selection changes net revenue when refund log is empty vs non-empty.
> 
> **Overview**
> Adds **Phase 7A** internal **BoostBenchmarkService** (registered as `myeventlane_boost.benchmark`) that aggregates impressions, clicks, CTR, and distinct boosted events from `myeventlane_boost_stats`, with 12-hour cache and a **readiness** gate on platform volume. Benchmarks can be sliced **globally**, by **event type** (`field_event_type`), or by **placement** (validated via `BoostPlacementResolver`).
> 
> **Boost decision support** now treats **donation revenue** like ticket revenue for RSVP health and ROI scoring, and **folds in** string recommendations from `BoostMetricsService` into the organiser recommendation list. **Vendor event analytics** drops the generic “consider boosting” tip from its recommendation builder (Boost-specific copy remains elsewhere).
> 
> **Database update `10009`** extends the listing → `homepage_discover` stats migration: it still targets the bug window but also includes listing aggregate rows whose `boost_order_item_id` appears in `myeventlane_boost_stats_log` during that window, so older rows that received misattributed homepage traffic are not skipped.
> 
> **FinanceReadModel** changes refund handling when aligning vendor line-item revenue: **event-scoped refund log totals** are used when they are &gt; 0; otherwise **projection/payment fallback** `refund_total` is kept.
> 
> Kernel/unit tests cover benchmark aggregation, caching, readiness, and the decision-support donation/metrics-recommendation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0083856620df7b99ef39373ed7b679a44b63b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->