### PR TITLE
Feature/boost extension cta

### DIFF
--- a/web/modules/custom/myeventlane_boost/css/boost.css
+++ b/web/modules/custom/myeventlane_boost/css/boost.css
@@ -480,3 +480,308 @@
   position: absolute;
   left: -9999px;
 }
+
+/* Boost purchase success (post-checkout) */
+.mel-boost-success {
+  padding: 24px 16px 40px;
+  font-family: 'Nunito', sans-serif;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-success__card {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 28px 24px;
+  border: 1px solid var(--mel-boost-border);
+  border-radius: var(--mel-boost-radius);
+  background: #fff;
+  box-shadow: 0 10px 28px rgba(56, 65, 99, 0.08);
+  text-align: center;
+}
+
+.mel-boost-success__icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(242, 109, 91, 0.14);
+  color: var(--mel-boost-primary);
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.mel-boost-success__title {
+  margin: 0 0 8px;
+  font-size: 1.75rem;
+  line-height: 1.25;
+  font-weight: 800;
+}
+
+.mel-boost-success__lede {
+  margin: 0 auto 20px;
+  max-width: 42ch;
+  color: var(--mel-boost-muted);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.mel-boost-success__details {
+  margin: 0 auto 24px;
+  max-width: 360px;
+  padding: 16px 18px;
+  border-radius: var(--mel-boost-radius-sm);
+  background: rgba(238, 242, 255, 0.75);
+  border: 1px solid rgba(110, 126, 242, 0.16);
+  text-align: left;
+}
+
+.mel-boost-success__detail {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: 8px 12px;
+  padding: 6px 0;
+}
+
+.mel-boost-success__detail + .mel-boost-success__detail {
+  border-top: 1px solid rgba(110, 126, 242, 0.12);
+}
+
+.mel-boost-success__detail dt {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--mel-boost-muted);
+}
+
+.mel-boost-success__detail dd {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-success__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 12px;
+}
+
+.mel-boost-success__actions .mel-btn {
+  min-height: 2.75rem;
+  min-width: 11rem;
+}
+
+.mel-boost-success__actions .mel-btn--primary {
+  background: var(--mel-boost-primary);
+  border-color: var(--mel-boost-primary);
+  color: #fff;
+}
+
+.mel-boost-success__actions .mel-btn--primary:hover,
+.mel-boost-success__actions .mel-btn--primary:focus-visible {
+  background: #e85a48;
+  border-color: #e85a48;
+}
+
+.mel-boost-success__actions .mel-btn--secondary {
+  background: #fff;
+  border: 1px solid var(--mel-boost-border);
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-success__redirect-note {
+  margin: 18px 0 0;
+  color: var(--mel-boost-muted);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 640px) {
+  .mel-boost-success__card {
+    padding: 24px 18px;
+  }
+
+  .mel-boost-success__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mel-boost-success__actions .mel-btn {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+/* Event Studio — active boost banner */
+.mel-boost-active-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 16px;
+  padding: 18px 20px;
+  border: 1px solid rgba(245, 192, 76, 0.45);
+  border-radius: var(--mel-boost-radius);
+  background: linear-gradient(135deg, #fff 0%, rgba(238, 242, 255, 0.85) 100%);
+  box-shadow: 0 4px 16px rgba(245, 192, 76, 0.1);
+  font-family: 'Nunito', sans-serif;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-active-banner__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.mel-boost-active-banner__subtitle {
+  margin: 4px 0 0;
+  font-size: 0.9375rem;
+  color: var(--mel-boost-muted);
+}
+
+.mel-boost-active-banner__remaining {
+  margin: 6px 0 0;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-active-banner__cta {
+  min-height: 44px;
+  min-width: 11rem;
+  justify-content: center;
+  border-color: var(--mel-boost-border);
+  color: var(--mel-boost-text);
+}
+
+@media (max-width: 640px) {
+  .mel-boost-active-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mel-boost-active-banner__cta {
+    width: 100%;
+  }
+}
+
+/* Phase 11C — Boost extension recommendation */
+.mel-boost-extension-card {
+  font-family: 'Nunito', sans-serif;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-extension-card--card,
+.mel-boost-extension-card--studio {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  border: 1px solid rgba(124, 131, 253, 0.35);
+  border-radius: var(--mel-boost-radius);
+  background: #e8eaff;
+}
+
+.mel-boost-extension-card--studio {
+  width: 100%;
+  margin-top: 12px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(124, 131, 253, 0.35);
+  border-radius: 0 0 var(--mel-boost-radius) var(--mel-boost-radius);
+  background: rgba(232, 234, 255, 0.65);
+}
+
+.mel-boost-active-banner--recommendation-only {
+  background: #e8eaff;
+  border-color: rgba(124, 131, 253, 0.35);
+}
+
+.mel-boost-extension-card__content {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.mel-boost-extension-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.mel-boost-extension-card__body {
+  margin: 8px 0 0;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  color: var(--mel-boost-muted);
+}
+
+.mel-boost-extension-card__cta {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 20px;
+  border-radius: var(--mel-boost-radius);
+  background: var(--mel-boost-primary);
+  border-color: var(--mel-boost-primary);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mel-boost-extension-card__cta:hover,
+.mel-boost-extension-card__cta:focus-visible {
+  background: #e55c49;
+  border-color: #e55c49;
+  color: #fff;
+  text-decoration: none;
+}
+
+.mel-boost-extension-card--compact {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  margin-top: 8px;
+  max-width: 100%;
+}
+
+.mel-boost-extension-card__compact-text {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.mel-boost-extension-card--compact .mel-boost-extension-card__cta {
+  min-height: 44px;
+  padding: 0 16px;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 640px) {
+  .mel-boost-extension-card--card,
+  .mel-boost-extension-card--studio {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mel-boost-extension-card__cta {
+    width: 100%;
+  }
+
+  .mel-boost-extension-card--compact {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/web/modules/custom/myeventlane_boost/css/boost.css
+++ b/web/modules/custom/myeventlane_boost/css/boost.css
@@ -1,47 +1,482 @@
-/* --- Tokens inlined from theme for module CSS only --- */
+/* Boost Your Event page — module library (vendor workspace + public route) */
 :root {
-  --mel-font: 'Nunito', sans-serif;
-  --c-primary:#f26d5b; --c-accent:#6e7ef2; --c-highlight:#f5c04c;
-  --c-text:#293241; --c-muted:#888; --c-navy:#2c3e50;
-  --c-bg-off:#fef5ec; --shadow:rgba(0,0,0,.06);
-  --r-pill:999px; --r-m:16px; --r-s:12px;
-  --sp-xs:4px; --sp-sm:8px; --sp-md:12px; --sp-lg:16px; --sp-xl:24px;
-  --bd:#f4f4f4;
+  --mel-boost-primary: #f26d5b;
+  --mel-boost-accent: #6e7ef2;
+  --mel-boost-highlight: #f5c04c;
+  --mel-boost-text: #293241;
+  --mel-boost-muted: #6b7280;
+  --mel-boost-border: #e8eaef;
+  --mel-boost-surface: #fef5ec;
+  --mel-boost-radius: 16px;
+  --mel-boost-radius-sm: 12px;
+}
+
+.mel-boost-page {
+  color: var(--mel-boost-text);
+  font-family: 'Nunito', sans-serif;
+}
+
+/* Action cards */
+.mel-boost-page__actions {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+@media (min-width: 768px) {
+  .mel-boost-page__actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-boost-page__action-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 1px solid var(--mel-boost-border);
+  border-radius: var(--mel-boost-radius);
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+  text-decoration: none;
+  color: inherit;
+}
+
+.mel-boost-page__action-card--boost.is-active {
+  border-color: rgba(242, 109, 91, 0.35);
+  background: linear-gradient(135deg, #fff 0%, #fff8f6 100%);
+}
+
+.mel-boost-page__action-card--edit:hover,
+.mel-boost-page__action-card--edit:focus-visible {
+  border-color: var(--mel-boost-accent);
+  box-shadow: 0 6px 20px rgba(110, 126, 242, 0.12);
+}
+
+.mel-boost-page__action-icon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: #eef0ff;
+  color: var(--mel-boost-accent);
+}
+
+.mel-boost-page__action-card--boost .mel-boost-page__action-icon {
+  background: #fdeee5;
+  color: var(--mel-boost-primary);
+}
+
+.mel-boost-page__action-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.mel-boost-page__action-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.mel-boost-page__action-text {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--mel-boost-muted);
+  line-height: 1.4;
+}
+
+.mel-boost-page__action-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.mel-boost-page__action-btn--primary {
+  background: var(--mel-boost-primary);
+  color: #fff;
+}
+
+.mel-boost-page__action-btn--secondary {
+  background: #fff;
+  border: 1px solid var(--mel-boost-border);
+  color: var(--mel-boost-text);
 }
 
 /* Hero */
-.boost-hero{display:flex;align-items:center;justify-content:space-between;gap:var(--sp-xl);margin:var(--sp-xl) 0 var(--sp-lg)}
-.boost-title{margin:0;font-family:var(--mel-font);font-size:clamp(28px,4vw,48px);font-weight:700;letter-spacing:-.01em;color:var(--c-primary)}
-.boost-kicker{margin:var(--sp-sm) 0;color:var(--c-text);font-size:clamp(16px,2.2vw,22px);font-weight:600}
-.boost-hero__art{inline-size:120px;block-size:120px;display:grid;place-items:center;border-radius:50%;background:#e5e8ff;font-size:56px;line-height:1}
+.mel-boost-page__hero {
+  display: grid;
+  gap: 20px;
+  margin-bottom: 28px;
+}
 
-/* Card */
-.boost-card{background:#fff;border:1px solid var(--bd);border-radius:var(--r-m);box-shadow:0 8px 24px var(--shadow);padding:var(--sp-lg)}
-.boost-list{display:flex;flex-direction:column;gap:var(--sp-md);margin:0 0 var(--sp-lg)}
-.boost-row{display:grid;grid-template-columns:56px 1fr auto 32px;gap:var(--sp-md);align-items:center;padding:var(--sp-md) var(--sp-lg);background:var(--c-bg-off);border:2px solid var(--bd);border-radius:var(--r-s);transition:background-color .12s ease,box-shadow .12s ease,border-color .12s ease;cursor:pointer;position:relative;z-index:1;user-select:none;-webkit-user-select:none}
-.boost-row:hover{background:#fdeee5;box-shadow:0 2px 8px var(--shadow);border-color:var(--c-primary)}
-.boost-row.is-selected{outline:3px solid rgba(110,126,242,.5);border-color:var(--c-primary);background:#fff5f3;box-shadow:0 4px 12px rgba(242,109,91,.2)}
-.boost-row__icon{inline-size:40px;block-size:40px;display:grid;place-items:center;border-radius:12px;background:#eef0ff;font-size:22px}
-.boost-row__text{display:grid;gap:2px}
-.boost-row__title{margin:0;font-weight:700;font-size:22px;color:var(--c-text)}
-.boost-row__desc{margin:0;color:var(--c-muted);font-size:14px}
-.boost-row__price{justify-self:end;font-weight:600;color:var(--c-navy);font-size:18px}
-.boost-row__radio-indicator{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;min-width:24px;min-height:24px;border-radius:50%;border:2px solid var(--c-muted);background:#fff;color:var(--c-muted);font-size:12px;transition:all .2s ease;flex-shrink:0;box-sizing:border-box;position:relative}
-.boost-row__radio-checkmark{display:none;color:#fff;font-size:16px;font-weight:700;line-height:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:1}
-.boost-row.is-selected .boost-row__radio-indicator{border-color:var(--c-primary);background:var(--c-primary);color:#fff}
-.boost-row.is-selected .boost-row__radio-checkmark{display:block}
+@media (min-width: 768px) {
+  .mel-boost-page__hero {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 32px;
+  }
+}
 
-/* Buttons (ghost + primary) */
-.button{display:inline-block;padding:10px 16px;border-radius:var(--r-pill);text-decoration:none;border:1px solid transparent;cursor:pointer}
-.button--primary{background:var(--c-primary);color:#fff}
-.button--ghost{background:#fff;border-color:var(--bd);color:var(--c-text);box-shadow:0 2px 10px var(--shadow)}
-.button--ghost:hover{background:#fff}
+.mel-boost-page__hero-title {
+  margin: 0;
+  font-size: clamp(26px, 4vw, 36px);
+  font-weight: 800;
+  line-height: 1.15;
+  color: var(--mel-boost-text);
+}
 
-/* Footer */
-.boost-footer{display:flex;justify-content:space-between;gap:var(--sp-md)}
-@media (max-width:768px){.boost-hero{flex-direction:column;align-items:flex-start}.boost-footer{flex-direction:column-reverse}}
-/* Hide Drupal radios (we use our pretty rows + JS to sync) */
-.mel-boost-radios{position:absolute;left:-9999px;top:-9999px;z-index:-1}
-/* Ensure boost rows are clickable and not blocked */
-.boost-row *{pointer-events:none}
-.boost-row{pointer-events:auto}
+.mel-boost-page__hero-subtitle {
+  margin: 10px 0 0;
+  font-size: 16px;
+  color: var(--mel-boost-muted);
+  line-height: 1.5;
+}
+
+.mel-boost-page__hero-fallback,
+.mel-boost-page__hero-perf-intro {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--mel-boost-muted);
+}
+
+.mel-boost-page__hero-perf-title {
+  margin: 12px 0 0;
+  font-weight: 600;
+  color: var(--mel-boost-text);
+}
+
+.mel-boost-page__hero-art {
+  display: none;
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .mel-boost-page__hero-art {
+    display: flex;
+  }
+}
+
+/* Benefits */
+.mel-boost-page__benefits {
+  display: grid;
+  gap: 24px;
+  margin-bottom: 32px;
+  padding: 24px;
+  border-radius: var(--mel-boost-radius);
+  background: var(--mel-boost-surface);
+  border: 1px solid var(--mel-boost-border);
+}
+
+@media (min-width: 768px) {
+  .mel-boost-page__benefits {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 32px;
+  }
+}
+
+.mel-boost-page__benefits-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.mel-boost-page__benefits-intro {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--mel-boost-muted);
+  line-height: 1.5;
+}
+
+.mel-boost-page__benefits-list,
+.mel-boost-page__audience-list {
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-boost-page__benefits-list li,
+.mel-boost-page__audience-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.mel-boost-page__benefits-list svg,
+.mel-boost-page__audience-list svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+/* Pricing section */
+.mel-boost-page__pricing-header {
+  margin-bottom: 20px;
+}
+
+.mel-boost-page__pricing-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.mel-boost-page__pricing-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--mel-boost-muted);
+}
+
+.mel-boost-page__pricing-note svg {
+  color: var(--mel-boost-accent);
+  flex-shrink: 0;
+}
+
+/* Plan cards */
+.boost-plan-grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+@media (min-width: 576px) {
+  .boost-plan-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .boost-plan-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.boost-plan-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 24px 20px 20px;
+  border: 2px solid var(--mel-boost-border);
+  border-radius: var(--mel-boost-radius);
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.boost-plan-card:hover {
+  border-color: rgba(242, 109, 91, 0.45);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.boost-plan-card.is-selected,
+.boost-plan-card--recommended.is-selected {
+  border-color: var(--mel-boost-primary);
+  box-shadow: 0 8px 24px rgba(242, 109, 91, 0.18);
+  background: linear-gradient(180deg, #fff 0%, #fff8f6 100%);
+}
+
+.boost-plan-card__badge {
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--mel-boost-primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.boost-plan-card__check {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 24px;
+  height: 24px;
+  color: var(--mel-boost-border);
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+.boost-plan-card.is-selected .boost-plan-card__check {
+  opacity: 1;
+  color: var(--mel-boost-primary);
+}
+
+.boost-plan-card__icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 12px;
+  border-radius: 12px;
+  background: #eef0ff;
+  color: var(--mel-boost-accent);
+}
+
+.boost-plan-card__days {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.boost-plan-card__subtitle {
+  margin: 6px 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--mel-boost-text);
+}
+
+.boost-plan-card__desc {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--mel-boost-muted);
+  line-height: 1.4;
+  flex: 1;
+}
+
+.boost-plan-card__price {
+  margin: 16px 0 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--mel-boost-text);
+}
+
+/* Prevent child elements from blocking card clicks */
+.boost-plan-card * {
+  pointer-events: none;
+}
+.boost-plan-card {
+  pointer-events: auto;
+}
+
+/* Hidden radios */
+.mel-boost-radios {
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  z-index: -1;
+}
+
+/* Actions */
+.boost-plan-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.boost-plan-actions__submit,
+.button--primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: min(100%, 320px);
+  padding: 14px 32px;
+  border: none;
+  border-radius: 999px;
+  background: var(--mel-boost-primary);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s ease, transform 0.15s ease;
+}
+
+.boost-plan-actions__submit:hover,
+.button--primary:hover {
+  background: #e85a48;
+}
+
+.boost-plan-trust {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.boost-plan-trust li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--mel-boost-muted);
+}
+
+.boost-plan-trust svg {
+  color: var(--mel-boost-accent);
+  flex-shrink: 0;
+}
+
+/* Stripe CTA */
+.boost-stripe-cta {
+  padding: 24px;
+  border: 1px solid var(--mel-boost-border);
+  border-radius: var(--mel-boost-radius);
+  background: #fff;
+  text-align: center;
+}
+
+.boost-stripe-cta__title {
+  margin: 0 0 8px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.boost-stripe-cta__intro,
+.boost-stripe-cta__text {
+  margin: 0 0 12px;
+  color: var(--mel-boost-muted);
+  line-height: 1.5;
+}
+
+/* Empty state */
+.myeventlane-boost-select-form .form-item--empty-message,
+.myeventlane-boost-select-form [id$="-empty"] {
+  padding: 20px;
+  border-radius: var(--mel-boost-radius-sm);
+  background: var(--mel-boost-surface);
+  color: var(--mel-boost-muted);
+  text-align: center;
+}
+
+/* Drupal form cleanup */
+.myeventlane-boost-select-form .form-actions {
+  margin: 0;
+  padding: 0;
+}
+
+.myeventlane-boost-select-form fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.myeventlane-boost-select-form legend {
+  position: absolute;
+  left: -9999px;
+}

--- a/web/modules/custom/myeventlane_boost/js/boost-purchase-success.js
+++ b/web/modules/custom/myeventlane_boost/js/boost-purchase-success.js
@@ -1,0 +1,20 @@
+(function (Drupal, drupalSettings, once) {
+  'use strict';
+
+  Drupal.behaviors.melBoostPurchaseSuccessRedirect = {
+    attach(context) {
+      const settings = drupalSettings.myeventlaneBoostPurchaseSuccess || {};
+      once('mel-boost-success-redirect', '[data-mel-boost-success-auto-redirect]', context).forEach((root) => {
+        const url = settings.redirectUrl || root.getAttribute('data-mel-boost-success-redirect-url') || '';
+        const delay = Number(settings.redirectDelayMs || root.getAttribute('data-mel-boost-success-redirect-delay') || 8000);
+        if (!url || !Number.isFinite(delay) || delay <= 0) {
+          return;
+        }
+
+        window.setTimeout(() => {
+          window.location.assign(url);
+        }, delay);
+      });
+    },
+  };
+}(Drupal, drupalSettings, once));

--- a/web/modules/custom/myeventlane_boost/js/boost-ui.js
+++ b/web/modules/custom/myeventlane_boost/js/boost-ui.js
@@ -4,16 +4,16 @@
   Drupal.behaviors.melBoostSelect = {
     attach: function (context) {
       once('melBoostForm', '.myeventlane-boost-select-form', context).forEach(function (form) {
-        const rows = Array.from(form.querySelectorAll('.boost-row'));
+        const cards = Array.from(form.querySelectorAll('.boost-plan-card'));
         const radios = Array.from(form.querySelectorAll('.mel-boost-radios input[type="radio"]'));
-        const rowContainer = form.querySelector('.boost-list');
+        const cardContainer = form.querySelector('.boost-plan-grid');
 
-        if (!rows.length || !radios.length) {
+        if (!cards.length || !radios.length) {
           return;
         }
 
-        if (rowContainer) {
-          rowContainer.setAttribute('role', 'radiogroup');
+        if (cardContainer) {
+          cardContainer.setAttribute('role', 'radiogroup');
         }
 
         const syncVisualSelection = function () {
@@ -22,13 +22,13 @@
           });
           const selectedValue = checkedRadio ? String(checkedRadio.value) : null;
 
-          rows.forEach(function (row) {
-            const rowVariationId = String(row.getAttribute('data-variation-id') || '');
-            const isSelected = selectedValue !== null && rowVariationId === selectedValue;
+          cards.forEach(function (card) {
+            const cardVariationId = String(card.getAttribute('data-variation-id') || '');
+            const isSelected = selectedValue !== null && cardVariationId === selectedValue;
 
-            row.classList.toggle('is-selected', isSelected);
-            row.setAttribute('aria-checked', isSelected ? 'true' : 'false');
-            row.setAttribute('tabindex', isSelected ? '0' : '-1');
+            card.classList.toggle('is-selected', isSelected);
+            card.setAttribute('aria-checked', isSelected ? 'true' : 'false');
+            card.setAttribute('tabindex', isSelected ? '0' : '-1');
           });
         };
 
@@ -63,21 +63,21 @@
           radio.addEventListener('change', syncVisualSelection);
         });
 
-        once('melBoostRow', '.boost-row', form).forEach(function (row) {
-          const variationId = row.getAttribute('data-variation-id');
+        once('melBoostCard', '.boost-plan-card', form).forEach(function (card) {
+          const variationId = card.getAttribute('data-variation-id');
           if (!variationId) {
             return;
           }
 
-          row.setAttribute('role', 'radio');
-          row.setAttribute('aria-checked', 'false');
-          row.setAttribute('tabindex', '-1');
+          card.setAttribute('role', 'radio');
+          card.setAttribute('aria-checked', 'false');
+          card.setAttribute('tabindex', '-1');
 
-          row.addEventListener('click', function () {
+          card.addEventListener('click', function () {
             setSelectedByVariationId(variationId);
           });
 
-          row.addEventListener('keydown', function (event) {
+          card.addEventListener('keydown', function (event) {
             if (event.key === 'Enter' || event.key === ' ') {
               event.preventDefault();
               setSelectedByVariationId(variationId);

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.libraries.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.libraries.yml
@@ -1,3 +1,21 @@
+boost_purchase_success:
+  version: 1.0
+  css:
+    component:
+      css/boost.css: {}
+  js:
+    js/boost-purchase-success.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once
+
+boost_visibility:
+  version: 1.0
+  css:
+    component:
+      css/boost.css: {}
+
 boost:
   version: 1.x
   css:

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.module
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.module
@@ -43,6 +43,20 @@ function myeventlane_boost_theme(): array {
       'template' => 'boost-event-page',
       'path' => $module_path . '/templates',
     ],
+    'boost_purchase_success' => [
+      'variables' => [
+        'event' => NULL,
+        'order' => NULL,
+        'boost_days' => 0,
+        'plan_label' => '',
+        'expiry_date' => '',
+        'workspace_url' => '',
+        'event_url' => '',
+        'analytics_url' => '',
+      ],
+      'template' => 'boost-purchase-success',
+      'path' => $module_path . '/templates',
+    ],
     'boost_performance_guide_pdf' => [
       'variables' => [
         'content' => [],

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.module
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.module
@@ -36,6 +36,8 @@ function myeventlane_boost_theme(): array {
         'form' => NULL,
         'event' => NULL,
         'boost_performance' => NULL,
+        'edit_url' => NULL,
+        'vendor_workspace' => FALSE,
         'attributes' => NULL,
       ],
       'template' => 'boost-event-page',

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.routing.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.routing.yml
@@ -124,6 +124,22 @@ myeventlane_boost.wizard.step5:
         bundle:
           - event
 
+# Post-checkout Boost purchase success (boost-only orders).
+myeventlane_boost.vendor_event_boost_success:
+  path: '/vendor/events/{event}/boost/success'
+  defaults:
+    _controller: '\Drupal\myeventlane_boost\Controller\BoostPurchaseSuccessController::success'
+    _title: 'Boost activated'
+  requirements:
+    _custom_access: 'myeventlane_boost.boost_route_access:accessVendorWorkspace'
+    event: '\d+'
+  options:
+    parameters:
+      event:
+        type: entity:node
+        bundle:
+          - event
+
 # Bridge route: add boost variation to cart (redirects to checkout flow).
 myeventlane_boost.bridge_add_to_cart:
   path: '/boost/bridge/{node}'

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -102,6 +102,25 @@ services:
     arguments:
       - '@string_translation'
 
+  # Event-scoped Boost trend intelligence (Phase 8 — daily rollup chart data only).
+  myeventlane_boost.trend_intelligence:
+    class: Drupal\myeventlane_boost\Service\BoostTrendIntelligenceService
+    arguments:
+      - '@string_translation'
+
+  # Organiser-facing Boost performance level (Phase 9 — composes decision + trend).
+  myeventlane_boost.performance_level:
+    class: Drupal\myeventlane_boost\Service\BoostPerformanceLevelService
+    arguments:
+      - '@string_translation'
+
+  # Prioritised Boost actions with CTAs (Phase 10 — reuses decision support signals).
+  myeventlane_boost.action_engine:
+    class: Drupal\myeventlane_boost\Service\BoostActionEngineService
+    arguments:
+      - '@myeventlane_boost.decision_support'
+      - '@string_translation'
+
   # Thin façade: lifecycle presentation metrics (composes BoostManager, entitlements, analytics).
   myeventlane_boost.performance:
     class: Drupal\myeventlane_boost\Service\BoostPerformanceService

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -33,6 +33,21 @@ services:
       - '@datetime.time'
       - '@logger.channel.myeventlane_boost'
 
+  myeventlane_boost.purchase_success_resolver:
+    class: Drupal\myeventlane_boost\Service\BoostPurchaseSuccessResolver
+    arguments:
+      - '@myeventlane_boost.entitlement_manager'
+
+  myeventlane_boost.checkout_redirect_subscriber:
+    class: Drupal\myeventlane_boost\EventSubscriber\BoostCheckoutRedirectSubscriber
+    arguments:
+      - '@current_route_match'
+      - '@entity_type.manager'
+      - '@myeventlane_boost.purchase_success_resolver'
+      - '@logger.channel.myeventlane_boost'
+    tags:
+      - { name: event_subscriber }
+
   # Order/checkout event subscriber for applying boosts on payment.
   myeventlane_boost.order_subscriber:
     class: Drupal\myeventlane_boost\EventSubscriber\BoostOrderSubscriber
@@ -119,6 +134,20 @@ services:
     class: Drupal\myeventlane_boost\Service\BoostActionEngineService
     arguments:
       - '@myeventlane_boost.decision_support'
+      - '@string_translation'
+
+  # Contextual Boost extension / restart recommendations (Phase 11C).
+  myeventlane_boost.extension_recommendation:
+    class: Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService
+    arguments:
+      - '@myeventlane_vendor.service.boost_status'
+      - '@myeventlane_boost.manager'
+      - '@myeventlane_boost.performance_level'
+      - '@myeventlane_boost.decision_support'
+      - '@myeventlane_boost.trend_intelligence'
+      - '@myeventlane_boost.metrics'
+      - '@myeventlane_event_state.resolver'
+      - '@datetime.time'
       - '@string_translation'
 
   # Thin façade: lifecycle presentation metrics (composes BoostManager, entitlements, analytics).

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostController.php
@@ -191,27 +191,7 @@ final class BoostController extends ControllerBase {
     $showStripeCta = !$this->currentUser()->hasPermission('administer myeventlane')
       && !$this->checkStripeConnection($this->currentUser());
 
-    if ($vendor_workspace) {
-      try {
-        $cancelUrl = Url::fromRoute('myeventlane_vendor.console.event_overview', ['event' => $node->id()]);
-        $cancelLink = Link::fromTextAndUrl($this->t('Cancel'), $cancelUrl)->toRenderable();
-      }
-      catch (\Throwable) {
-        $cancelLink = Link::fromTextAndUrl(
-          $this->t('Cancel'),
-          $node->toUrl('canonical')
-        )->toRenderable();
-      }
-    }
-    else {
-      $cancelLink = Link::fromTextAndUrl(
-        $this->t('Cancel'),
-        $node->toUrl('canonical')
-      )->toRenderable();
-    }
-    $cancelLink['#attributes']['class'][] = 'button';
-    $cancelLink['#attributes']['class'][] = 'button--ghost';
-    $cancelLink['#attributes']['class'][] = 'boost-cancel';
+    $editUrl = $this->resolveEventEditUrl($node, $vendor_workspace);
 
     $body = $showStripeCta
       ? $this->buildStripeConnectCta($node, $vendor_workspace)
@@ -222,16 +202,9 @@ final class BoostController extends ControllerBase {
       '#theme' => 'boost_event_page',
       '#boost_performance' => $boostPerformance,
       '#event' => $node,
-      '#form' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-boost-page__card']],
-        'body' => $body,
-        'footer' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['boost-footer']],
-          'left' => $cancelLink,
-        ],
-      ],
+      '#edit_url' => $editUrl?->toString(),
+      '#vendor_workspace' => $vendor_workspace,
+      '#form' => $body,
       '#attached' => [
         'library' => ['myeventlane_boost/boost'],
       ],
@@ -346,7 +319,7 @@ final class BoostController extends ControllerBase {
 
     return [
       '#type' => 'container',
-      '#attributes' => ['class' => ['boost-stripe-cta']],
+      '#attributes' => ['class' => ['boost-stripe-cta', 'mel-boost-page__stripe-cta']],
       'title' => [
         '#type' => 'html_tag',
         '#tag' => 'h2',
@@ -367,6 +340,27 @@ final class BoostController extends ControllerBase {
       ],
       'action' => $connectLink,
     ];
+  }
+
+  /**
+   * Resolves the edit-event URL for the boost page action card.
+   */
+  private function resolveEventEditUrl(NodeInterface $node, bool $vendor_workspace): ?Url {
+    if ($vendor_workspace) {
+      try {
+        return Url::fromRoute('myeventlane_vendor.console.event_editor', ['event' => $node->id()]);
+      }
+      catch (\Throwable) {
+        // Fall through to generic edit form.
+      }
+    }
+
+    try {
+      return $node->toUrl('edit-form');
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostPurchaseSuccessController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostPurchaseSuccessController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Controller;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_boost\Service\BoostPurchaseSuccessResolver;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Boost purchase success page after Commerce checkout.
+ */
+final class BoostPurchaseSuccessController extends ControllerBase {
+
+  private const REDIRECT_DELAY_MS = 8000;
+
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    private readonly BoostPurchaseSuccessResolver $purchaseSuccessResolver,
+    private readonly BoostStatusService $boostStatusService,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('myeventlane_boost.purchase_success_resolver'),
+      $container->get('myeventlane_vendor.service.boost_status'),
+    );
+  }
+
+  /**
+   * Renders the Boost purchase success experience.
+   */
+  public function success(NodeInterface $event, Request $request): array {
+    $order = $this->loadValidatedOrder($event, $request);
+    $purchase = $this->purchaseSuccessResolver->resolvePrimaryBoostPurchase($order);
+    if ($purchase === NULL) {
+      throw new NotFoundHttpException();
+    }
+
+    $account = $this->currentUser();
+    $event_id = (int) $event->id();
+    $boost = $this->boostStatusService->getVisibilityPayload($event);
+    $workspace_url = $this->safeRouteUrl('myeventlane_event_studio.workspace', ['node' => $event_id], $account);
+    $event_url = $this->safeRouteUrl('entity.node.canonical', ['node' => $event_id], $account);
+    $analytics_url = $this->safeRouteUrl('myeventlane_vendor.console.event_analytics', ['event' => $event_id], $account);
+    if ($analytics_url === '') {
+      $analytics_url = $this->safeRouteUrl('myeventlane_event_studio.workspace_analytics', ['node' => $event_id], $account);
+    }
+
+    return [
+      '#theme' => 'boost_purchase_success',
+      '#event' => $event,
+      '#order' => $order,
+      '#boost_days' => $purchase['boost_days'],
+      '#plan_label' => $purchase['plan_label'],
+      '#expiry_date' => $boost['expires'],
+      '#workspace_url' => $workspace_url,
+      '#event_url' => $event_url,
+      '#analytics_url' => $analytics_url,
+      '#attached' => [
+        'library' => ['myeventlane_boost/boost_purchase_success'],
+        'drupalSettings' => [
+          'myeventlaneBoostPurchaseSuccess' => [
+            'redirectUrl' => $workspace_url,
+            'redirectDelayMs' => self::REDIRECT_DELAY_MS,
+          ],
+        ],
+      ],
+      '#cache' => [
+        'contexts' => ['user', 'url.query_args:order'],
+        'tags' => array_merge($event->getCacheTags(), $order->getCacheTags()),
+        'max-age' => 0,
+      ],
+    ];
+  }
+
+  /**
+   * Loads and validates the order referenced by the success page query.
+   */
+  private function loadValidatedOrder(NodeInterface $event, Request $request): OrderInterface {
+    $order_id = (int) $request->query->get('order', 0);
+    if ($order_id <= 0) {
+      throw new NotFoundHttpException();
+    }
+
+    $order = $this->entityTypeManager->getStorage('commerce_order')->load($order_id);
+    if (!$order instanceof OrderInterface) {
+      throw new NotFoundHttpException();
+    }
+
+    $account = $this->currentUser();
+    $customer_id = (int) $order->getCustomerId();
+    if ($customer_id !== (int) $account->id()
+      && !$account->hasPermission('administer commerce_order')) {
+      throw new AccessDeniedHttpException();
+    }
+
+    if ($order->getState()->getId() === 'draft') {
+      throw new NotFoundHttpException();
+    }
+
+    if (!$this->purchaseSuccessResolver->isBoostOnlyOrder($order)) {
+      throw new NotFoundHttpException();
+    }
+
+    if (!$this->purchaseSuccessResolver->orderMatchesEvent($order, (int) $event->id())) {
+      throw new NotFoundHttpException();
+    }
+
+    return $order;
+  }
+
+  /**
+   * Builds a route URL string when the route exists and is accessible.
+   *
+   * @param array<string, mixed> $parameters
+   */
+  private function safeRouteUrl(string $route, array $parameters, AccountInterface $account): string {
+    try {
+      $url = Url::fromRoute($route, $parameters);
+      if (!$url->access($account)) {
+        return '';
+      }
+      return $url->toString();
+    }
+    catch (\Throwable) {
+      return '';
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/EventSubscriber/BoostCheckoutRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_boost/src/EventSubscriber/BoostCheckoutRedirectSubscriber.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\EventSubscriber;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_boost\Service\BoostPurchaseSuccessResolver;
+use Drupal\myeventlane_core\Http\MelKernelAuthRouteSilencer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects boost-only checkout completion to the vendor Boost success page.
+ *
+ * Commerce checkout does not honour destination query params; this subscriber
+ * mirrors the RSVP donation completion redirect pattern.
+ */
+final class BoostCheckoutRedirectSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly BoostPurchaseSuccessResolver $purchaseSuccessResolver,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onRequest', 29],
+    ];
+  }
+
+  /**
+   * Redirects boost-only complete step to the vendor success route.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
+      return;
+    }
+
+    if ($this->routeMatch->getRouteName() !== 'commerce_checkout.form') {
+      return;
+    }
+
+    if ($this->routeMatch->getParameter('step') !== 'complete') {
+      return;
+    }
+
+    $order = $this->getOrder();
+    if (!$order || $order->getState()->getId() === 'draft') {
+      return;
+    }
+
+    if (!$this->purchaseSuccessResolver->isBoostOnlyOrder($order)) {
+      return;
+    }
+
+    $purchase = $this->purchaseSuccessResolver->resolvePrimaryBoostPurchase($order);
+    if ($purchase === NULL || $purchase['event_id'] <= 0) {
+      $this->logger->warning('Boost-only order @order_id completed without a resolvable target event; keeping default checkout completion.', [
+        '@order_id' => $order->id(),
+      ]);
+      return;
+    }
+
+    try {
+      $url = Url::fromRoute('myeventlane_boost.vendor_event_boost_success', [
+        'event' => $purchase['event_id'],
+      ], [
+        'query' => ['order' => $order->id()],
+      ]);
+    }
+    catch (\Throwable $exception) {
+      $this->logger->error('Boost success redirect failed for order @order_id: @message', [
+        '@order_id' => $order->id(),
+        '@message' => $exception->getMessage(),
+      ]);
+      return;
+    }
+
+    $event->setResponse(new RedirectResponse($url->toString()));
+  }
+
+  private function getOrder(): ?OrderInterface {
+    $param = $this->routeMatch->getParameter('commerce_order');
+    if ($param instanceof OrderInterface) {
+      return $param;
+    }
+    $order_id = (int) $param;
+    if ($order_id <= 0) {
+      return NULL;
+    }
+    $order = $this->entityTypeManager->getStorage('commerce_order')->load($order_id);
+    return $order instanceof OrderInterface ? $order : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Form/BoostSelectForm.php
+++ b/web/modules/custom/myeventlane_boost/src/Form/BoostSelectForm.php
@@ -121,9 +121,6 @@ final class BoostSelectForm extends FormBase {
       }
     }
 
-    $form['#prefix'] = '<div class="boost-card">';
-    $form['#suffix'] = '</div>';
-
     if (empty($pids)) {
       $form['empty'] = ['#markup' => $this->t('No boost options are available right now.')];
       return $form;
@@ -193,45 +190,55 @@ final class BoostSelectForm extends FormBase {
         '@price' => $priceStr,
       ]);
 
+      $subtitle = match ($days) {
+        7 => $this->t('Immediate visibility boost'),
+        10 => $this->t('Sustain momentum'),
+        30 => $this->t('Maximise long-term reach'),
+        default => $this->t('Featured visibility for @d days', ['@d' => $days]),
+      };
+
       $desc = match ($days) {
-        7 => $this->t('Get immediate visibility boost'),
-        10 => $this->t('Sustain momentum across the week'),
-        30 => $this->t('Maximise reach for long-running events'),
+        7 => $this->t('Get featured across discovery and search'),
+        10 => $this->t('Keep momentum going through the week'),
+        30 => $this->t('Maximum exposure for longer events'),
         default => $this->t('Keep your event featured for @d days.', ['@d' => $days]),
       };
 
-      $badge = '';
-      if ($recommendedDays !== NULL && $days === $recommendedDays) {
-        $badge = '<span class="mel-boost-badge">' . $this->t('Recommended') . '</span>';
+      $isRecommended = $recommendedDays !== NULL && $days === $recommendedDays;
+      $cardClasses = ['boost-plan-card'];
+      if ($isRecommended) {
+        $cardClasses[] = 'boost-plan-card--recommended';
       }
-
-      $titleInner = '<div class="mel-boost-option-content"><strong>' . $this->t('@d days', ['@d' => $days]) . '</strong>' . $badge
-        . '<span class="mel-boost-option-desc">' . $desc . '</span></div>';
 
       $rows[$variation->id()] = [
         '#type' => 'container',
         '#attributes' => [
-          'class' => ['boost-row'],
+          'class' => $cardClasses,
           'data-variation-id' => $variation->id(),
           'data-option-days' => (string) $days,
           'role' => 'option',
           'tabindex' => '0',
         ],
-        'icon' => [
-          '#markup' => '<div class="boost-row__icon">⚡️</div>',
+        'badge' => $isRecommended ? [
+          '#markup' => '<span class="boost-plan-card__badge">' . $this->t('Recommended') . '</span>',
+        ] : [],
+        'check' => [
+          '#markup' => '<span class="boost-plan-card__check" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 20 20"><circle cx="10" cy="10" r="10" fill="currentColor"/><path d="m6 10 2.5 2.5 5.5-5.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>',
         ],
-        'text' => [
-          '#type' => 'container',
-          '#attributes' => ['class' => ['boost-row__text']],
-          'title' => [
-            '#markup' => '<div class="boost-row__title">' . $titleInner . '</div>',
-          ],
+        'icon' => [
+          '#markup' => '<div class="boost-plan-card__icon" aria-hidden="true"><svg class="icon-bolt" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M13 2 5 14h6l-1 8 8-12h-6l1-8Z" fill="currentColor"/></svg></div>',
+        ],
+        'days' => [
+          '#markup' => '<h3 class="boost-plan-card__days">' . $this->t('@d days', ['@d' => $days]) . '</h3>',
+        ],
+        'subtitle' => [
+          '#markup' => '<p class="boost-plan-card__subtitle">' . $subtitle . '</p>',
+        ],
+        'desc' => [
+          '#markup' => '<p class="boost-plan-card__desc">' . $desc . '</p>',
         ],
         'price' => [
-          '#markup' => '<div class="boost-row__price">' . $priceStr . '</div>',
-        ],
-        'radio_indicator' => [
-          '#markup' => '<div class="boost-row__radio-indicator" aria-hidden="true" role="presentation"><span class="boost-row__radio-checkmark">✓</span></div>',
+          '#markup' => '<p class="boost-plan-card__price">' . $priceStr . '</p>',
         ],
       ];
     }
@@ -267,11 +274,11 @@ final class BoostSelectForm extends FormBase {
     // Add form class for JavaScript targeting.
     $form['#attributes']['class'][] = 'myeventlane-boost-select-form';
 
-    // Styled list for visual display.
+    // Styled grid for visual display.
     $form['styled_list'] = [
       '#type' => 'container',
       '#attributes' => [
-        'class' => ['boost-list'],
+        'class' => ['boost-plan-grid'],
         'role' => 'listbox',
         'aria-label' => $this->t('Boost duration options'),
       ],
@@ -282,15 +289,19 @@ final class BoostSelectForm extends FormBase {
 
     $form['actions'] = [
       '#type' => 'actions',
-      '#attributes' => ['class' => ['boost-footer']],
+      '#attributes' => ['class' => ['boost-plan-actions']],
       'submit' => [
         '#type' => 'submit',
         '#value' => $this->t('Boost my event now'),
-        '#attributes' => ['class' => ['button', 'button--primary']],
+        '#attributes' => ['class' => ['button', 'button--primary', 'boost-plan-actions__submit']],
       ],
-      'micro' => [
+      'trust' => [
         '#type' => 'markup',
-        '#markup' => '<p class="mel-boost-micro">' . $this->t('No lock-in. Boost starts immediately.') . '</p>',
+        '#markup' => '<ul class="boost-plan-trust" aria-label="' . $this->t('Boost purchase assurances') . '">'
+          . '<li><svg class="icon-bolt" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 5 14h6l-1 8 8-12h-6l1-8Z" fill="currentColor"/></svg>' . $this->t('Instant activation') . '</li>'
+          . '<li><svg class="icon-shield" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5 2.5 3.5v4.5c0 3.5 2.3 6.2 5.5 7 3.2-.8 5.5-3.5 5.5-7V3.5L8 1.5Z" stroke="currentColor" stroke-width="1.2" fill="none"/></svg>' . $this->t('Secure payment') . '</li>'
+          . '<li><svg class="icon-chart" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><rect x="1" y="9" width="3" height="6" rx=".5" fill="currentColor"/><rect x="6" y="5" width="3" height="10" rx=".5" fill="currentColor"/><rect x="11" y="2" width="3" height="13" rx=".5" fill="currentColor"/></svg>' . $this->t('Track performance') . '</li>'
+          . '</ul>',
         '#weight' => 10,
       ],
     ];

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostActionEngineService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostActionEngineService.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Prioritised Boost action recommendations with CTAs (Phase 10).
+ *
+ * Reuses analytics signals from BoostDecisionSupportService rules without
+ * duplicating underlying metric calculations.
+ */
+final class BoostActionEngineService {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs BoostActionEngineService.
+   */
+  public function __construct(
+    private readonly BoostDecisionSupportService $decisionSupport,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds up to three prioritised actions for an event Boost panel.
+   *
+   * @param array<string, mixed> $boost_metrics
+   *   Output from BoostMetricsService::getEventBoostMetrics().
+   * @param array<string, mixed> $boost
+   *   Boost status from MetricsAggregator (expects 'active' key).
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   * @param string|null $edit_event_url
+   * @param string|null $boost_page_url
+   * @param string|null $public_event_url
+   *
+   * @return array{
+   *   show: bool,
+   *   actions: list<array{
+   *     id: string,
+   *     category: string,
+   *     title: string,
+   *     description: string,
+   *     cta_label: string,
+   *     cta_url: string,
+   *   }>,
+   * }
+   */
+  public function build(
+    array $boost_metrics,
+    array $boost,
+    bool $isTickets,
+    bool $isRsvp,
+    array $placement_performance_section,
+    ?string $edit_event_url = NULL,
+    ?string $boost_page_url = NULL,
+    ?string $public_event_url = NULL,
+  ): array {
+    $impressions = (int) ($boost_metrics['impressions'] ?? 0);
+    $clicks = (int) ($boost_metrics['clicks'] ?? 0);
+    $ctr = (float) ($boost_metrics['ctr'] ?? 0.0);
+    $spend = $this->parseFormattedAmount((string) ($boost_metrics['spend'] ?? '$0.00'));
+    $revenue = (float) ($boost_metrics['revenue_during_boost'] ?? 0.0);
+    $orders = (int) ($boost_metrics['orders_during_boost'] ?? 0);
+    $rsvps = (int) ($boost_metrics['rsvps_during_boost'] ?? 0);
+    $donation_revenue = (float) ($boost_metrics['donation_revenue_during_boost'] ?? 0.0);
+    $boost_active = !empty($boost['active']);
+    $has_boost_history = $spend > 0.0 || $impressions > 0 || $clicks > 0 || $boost_active;
+
+    if (!$has_boost_history) {
+      return $this->emptyPayload();
+    }
+
+    $roi_revenue = $this->resolveRoiRevenue($revenue, $donation_revenue, $isTickets, $isRsvp);
+    $candidates = [];
+
+    if ($spend > 0.0 && $roi_revenue > $spend * 1.5 && $boost_page_url !== NULL && $boost_page_url !== '') {
+      $candidates[] = $this->candidate(
+        'extend_boost',
+        'growth',
+        100,
+        (string) $this->t('Extend your Boost'),
+        (string) $this->t('Strong return on Boost spend — keep momentum going while performance is high.'),
+        (string) $this->t('Boost Event'),
+        $boost_page_url,
+      );
+    }
+
+    if ($impressions >= 100 && $ctr < 0.01 && $edit_event_url !== NULL && $edit_event_url !== '') {
+      $candidates[] = $this->candidate(
+        'refresh_hero_image',
+        'visibility',
+        95,
+        (string) $this->t('Refresh your event image'),
+        (string) $this->t('Visibility is solid but click-through is low — a stronger hero image can lift engagement.'),
+        (string) $this->t('Edit Event'),
+        $edit_event_url,
+      );
+    }
+
+    if ($isTickets && $clicks >= 20 && $orders < max(2, (int) floor($clicks * 0.03))
+      && $edit_event_url !== NULL && $edit_event_url !== '') {
+      $candidates[] = $this->candidate(
+        'improve_event_page',
+        'conversion',
+        90,
+        (string) $this->t('Improve your event description'),
+        (string) $this->t('People are clicking through but not buying — sharpen your event page copy.'),
+        (string) $this->t('Edit Event'),
+        $edit_event_url,
+      );
+    }
+
+    if ($isRsvp && $clicks >= 20 && $rsvps < max(3, (int) floor($clicks * 0.05))
+      && $edit_event_url !== NULL && $edit_event_url !== '') {
+      $candidates[] = $this->candidate(
+        'improve_rsvp_page',
+        'conversion',
+        88,
+        (string) $this->t('Improve your event description'),
+        (string) $this->t('Good click volume but few RSVPs during Boost — make your event page more compelling.'),
+        (string) $this->t('Edit Event'),
+        $edit_event_url,
+      );
+    }
+
+    if ($isRsvp && $rsvps >= 10 && $donation_revenue <= 0.0
+      && $edit_event_url !== NULL && $edit_event_url !== '') {
+      $candidates[] = $this->candidate(
+        'add_donation_prompt',
+        'revenue',
+        85,
+        (string) $this->t('Add a donation prompt'),
+        (string) $this->t('RSVPs are strong — invite attendees to support your event with an optional donation.'),
+        (string) $this->t('Edit Event'),
+        $edit_event_url,
+      );
+    }
+
+    $winner = $this->resolvePlacementWinnerCard($placement_performance_section);
+    if ($winner !== NULL) {
+      $winner_key = (string) ($winner['key'] ?? '');
+      $winner_label = (string) ($winner['label'] ?? '');
+      if (str_starts_with($winner_key, 'category_') && $winner_label !== ''
+        && $public_event_url !== NULL && $public_event_url !== '') {
+        $candidates[] = $this->candidate(
+          'share_category_placement',
+          'growth',
+          75,
+          (string) $this->t('Share your event'),
+          (string) $this->t('@placement is your strongest category placement — share your event link to build on that reach.', [
+            '@placement' => $winner_label,
+          ]),
+          (string) $this->t('Share Event'),
+          $public_event_url,
+        );
+      }
+      elseif ((str_starts_with($winner_key, 'homepage_') || $winner_key === 'homepage_discover')
+        && ((float) ($winner['ctr'] ?? 0.0)) >= 0.03
+        && $boost_page_url !== NULL && $boost_page_url !== '') {
+        $candidates[] = $this->candidate(
+          'extend_homepage_boost',
+          'growth',
+          72,
+          (string) $this->t('Extend your Boost'),
+          (string) $this->t('@placement is performing well — extend Boost to keep that visibility.', [
+            '@placement' => $winner_label,
+          ]),
+          (string) $this->t('Boost Event'),
+          $boost_page_url,
+        );
+      }
+    }
+
+    $weakest = $this->resolveWeakestPlacementCard($placement_performance_section);
+    if ($weakest !== NULL && $edit_event_url !== NULL && $edit_event_url !== '') {
+      $weakest_key = (string) ($weakest['key'] ?? '');
+      if ($weakest_key === 'search_results' || str_starts_with($weakest_key, 'search_')) {
+        $candidates[] = $this->candidate(
+          'improve_search_appearance',
+          'visibility',
+          65,
+          (string) $this->t('Improve how you appear in search'),
+          (string) $this->t('Search Results has your weakest click-through — review your event title and summary.'),
+          (string) $this->t('Edit Event'),
+          $edit_event_url,
+        );
+      }
+    }
+
+    if (!$boost_active && $spend <= 0.0 && $boost_page_url !== NULL && $boost_page_url !== '') {
+      $candidates[] = $this->candidate(
+        'start_boost',
+        'growth',
+        55,
+        (string) $this->t('Boost your event'),
+        (string) $this->t('Reach more potential attendees with a Boost campaign.'),
+        (string) $this->t('Boost Event'),
+        $boost_page_url,
+      );
+    }
+
+    foreach ($boost_metrics['recommendations'] ?? [] as $metrics_rec) {
+      if (!is_string($metrics_rec) || $metrics_rec === ''
+        || $edit_event_url === NULL || $edit_event_url === '') {
+        continue;
+      }
+      $candidates[] = $this->candidate(
+        'metrics_' . md5($metrics_rec),
+        'growth',
+        50,
+        (string) $this->t('Review Boost placement'),
+        $metrics_rec,
+        (string) $this->t('Edit Event'),
+        $edit_event_url,
+      );
+    }
+
+    $actions = $this->selectActions($candidates);
+
+    return [
+      'show' => $actions !== [],
+      'actions' => $actions,
+    ];
+  }
+
+  /**
+   * Selects up to three unique, non-contradictory actions.
+   *
+   * @param list<array<string, mixed>> $candidates
+   *
+   * @return list<array<string, mixed>>
+   */
+  private function selectActions(array $candidates): array {
+    usort($candidates, static fn (array $a, array $b): int => (int) ($b['priority'] ?? 0) <=> (int) ($a['priority'] ?? 0));
+
+    $selected = [];
+    $seenIds = [];
+    $seenCategories = [];
+
+    foreach ($candidates as $candidate) {
+      $id = (string) ($candidate['id'] ?? '');
+      $category = (string) ($candidate['category'] ?? '');
+      $ctaUrl = (string) ($candidate['cta_url'] ?? '');
+      if ($id === '' || $ctaUrl === '' || isset($seenIds[$id])) {
+        continue;
+      }
+
+      if ($this->contradictsExisting($candidate, $selected)) {
+        continue;
+      }
+
+      if ($category !== '' && isset($seenCategories[$category])) {
+        continue;
+      }
+
+      unset($candidate['priority']);
+      $selected[] = $candidate;
+      $seenIds[$id] = TRUE;
+      if ($category !== '') {
+        $seenCategories[$category] = TRUE;
+      }
+
+      if (count($selected) >= 3) {
+        break;
+      }
+    }
+
+    return $selected;
+  }
+
+  /**
+   * Detects contradictory action pairs.
+   *
+   * @param array<string, mixed> $candidate
+   * @param list<array<string, mixed>> $selected
+   */
+  private function contradictsExisting(array $candidate, array $selected): bool {
+    $id = (string) ($candidate['id'] ?? '');
+    foreach ($selected as $action) {
+      $existingId = (string) ($action['id'] ?? '');
+      if ($existingId === '') {
+        continue;
+      }
+
+      if (($id === 'extend_boost' || $id === 'extend_homepage_boost') && $existingId === 'start_boost') {
+        return TRUE;
+      }
+      if ($id === 'start_boost' && ($existingId === 'extend_boost' || $existingId === 'extend_homepage_boost')) {
+        return TRUE;
+      }
+
+      if (($id === 'improve_event_page' || $id === 'improve_rsvp_page')
+        && $existingId === 'improve_search_appearance') {
+        continue;
+      }
+
+      if ($id === 'extend_boost' && $existingId === 'extend_homepage_boost') {
+        return TRUE;
+      }
+      if ($id === 'extend_homepage_boost' && $existingId === 'extend_boost') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function candidate(
+    string $id,
+    string $category,
+    int $priority,
+    string $title,
+    string $description,
+    string $cta_label,
+    string $cta_url,
+  ): array {
+    return [
+      'id' => $id,
+      'category' => $category,
+      'priority' => $priority,
+      'title' => $title,
+      'description' => $description,
+      'cta_label' => $cta_label,
+      'cta_url' => $cta_url,
+    ];
+  }
+
+  /**
+   * Resolves monetary ROI basis from existing metrics.
+   */
+  private function resolveRoiRevenue(
+    float $ticket_revenue,
+    float $donation_revenue,
+    bool $isTickets,
+    bool $isRsvp,
+  ): float {
+    if ($isTickets && $ticket_revenue > 0.0) {
+      return $ticket_revenue;
+    }
+    if ($isRsvp && $donation_revenue > 0.0) {
+      return $donation_revenue;
+    }
+    if ($isTickets) {
+      return $ticket_revenue;
+    }
+    return $donation_revenue;
+  }
+
+  /**
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *
+   * @return array<string, mixed>|null
+   */
+  private function resolvePlacementWinnerCard(array $placement_performance_section): ?array {
+    return $this->decisionSupport->resolvePlacementWinnerCard($placement_performance_section);
+  }
+
+  /**
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *
+   * @return array<string, mixed>|null
+   */
+  private function resolveWeakestPlacementCard(array $placement_performance_section): ?array {
+    return $this->decisionSupport->resolveWeakestPlacementCard($placement_performance_section);
+  }
+
+  /**
+   * Parses a formatted currency string into a float.
+   */
+  private function parseFormattedAmount(string $formatted): float {
+    if ($formatted === '—' || $formatted === '') {
+      return 0.0;
+    }
+    $clean = preg_replace('/[^\d.]/', '', $formatted);
+    if ($clean === NULL || $clean === '') {
+      return 0.0;
+    }
+    return (float) $clean;
+  }
+
+  /**
+   * @return array{show: bool, actions: list<array<string, mixed>>}
+   */
+  private function emptyPayload(): array {
+    return [
+      'show' => FALSE,
+      'actions' => [],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostDecisionSupportService.php
@@ -663,7 +663,7 @@ final class BoostDecisionSupportService {
    *
    * @return array<string, mixed>|null
    */
-  private function resolvePlacementWinnerCard(array $placement_performance_section): ?array {
+  public function resolvePlacementWinnerCard(array $placement_performance_section): ?array {
     $cards = is_array($placement_performance_section['cards'] ?? NULL)
       ? $placement_performance_section['cards']
       : [];
@@ -710,7 +710,7 @@ final class BoostDecisionSupportService {
    *
    * @return array<string, mixed>|null
    */
-  private function resolveWeakestPlacementCard(array $placement_performance_section): ?array {
+  public function resolveWeakestPlacementCard(array $placement_performance_section): ?array {
     $cards = is_array($placement_performance_section['cards'] ?? NULL)
       ? $placement_performance_section['cards']
       : [];

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostExtensionRecommendationService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostExtensionRecommendationService.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_event_state\Service\EventStateResolver;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
+use Drupal\node\NodeInterface;
+
+/**
+ * Determines contextual Boost extension / restart recommendations (Phase 11C).
+ */
+final class BoostExtensionRecommendationService {
+
+  use StringTranslationTrait;
+
+  private const PRIORITY_EXPIRING_SOON = 100;
+
+  private const PRIORITY_STRONG_PERFORMANCE = 90;
+
+  private const PRIORITY_RECENTLY_EXPIRED = 80;
+
+  private const PRIORITY_UPCOMING_EVENT = 70;
+
+  private const SECONDS_PER_DAY = 86400;
+
+  public function __construct(
+    private readonly BoostStatusService $boostStatusService,
+    private readonly BoostManager $boostManager,
+    private $performanceLevelService,
+    private readonly BoostDecisionSupportService $decisionSupportService,
+    private readonly BoostTrendIntelligenceService $trendIntelligenceService,
+    private $boostMetricsService,
+    private readonly EventStateResolver $eventStateResolver,
+    private readonly TimeInterface $time,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Returns a single highest-priority recommendation, or NULL when none apply.
+   *
+   * @return array{
+   *   type: string,
+   *   title: string,
+   *   body: string,
+   *   cta_label: string,
+   *   cta_url: string,
+   *   priority: int,
+   * }|null
+   */
+  public function getRecommendation(NodeInterface $event): ?array {
+    if ($event->bundle() !== 'event') {
+      return NULL;
+    }
+
+    if ($this->isExcluded($event)) {
+      return NULL;
+    }
+
+    $now = (int) $this->time->getRequestTime();
+    $boostStatus = $this->boostManager->getBoostStatusForEvent($event, $now);
+    $visibility = $this->boostStatusService->getVisibilityPayload($event);
+    $boostActive = !empty($boostStatus['active']);
+    $endTimestamp = isset($boostStatus['end_timestamp']) ? (int) $boostStatus['end_timestamp'] : NULL;
+    $eventStart = $this->getEventStartTimestamp($event);
+    $eventFuture = $this->isEventFuture($event, $now);
+    $eventPublished = $event->isPublished();
+    $daysRemaining = $visibility['days_remaining'] ?? NULL;
+    $daysUntilStart = $this->daysUntilEventStart($eventStart, $now);
+    $daysSinceExpiry = $this->daysSinceBoostExpiry($endTimestamp, $now, $boostActive);
+
+    $candidates = [];
+
+    if ($boostActive
+      && $daysRemaining !== NULL
+      && (int) $daysRemaining <= 3
+      && $eventStart !== NULL
+      && $eventStart > $now
+      && $eventPublished) {
+      $candidates[] = $this->recommendationPayload(
+        'extend',
+        (string) $this->t('Your Boost ends soon'),
+        (string) $this->t('Keep your event visible while registrations are still open.'),
+        (string) $this->t('Extend Boost'),
+        self::PRIORITY_EXPIRING_SOON,
+        $event,
+      );
+    }
+
+    if ($boostActive && $eventFuture && $this->hasStrongPerformanceLevel($event, $boostStatus)) {
+      $candidates[] = $this->recommendationPayload(
+        'extend',
+        (string) $this->t('Your Boost is performing well'),
+        (string) $this->t('Keep the momentum going while people are discovering your event.'),
+        (string) $this->t('Extend Boost'),
+        self::PRIORITY_STRONG_PERFORMANCE,
+        $event,
+      );
+    }
+
+    if (!$boostActive
+      && $daysSinceExpiry !== NULL
+      && $daysSinceExpiry <= 7
+      && $eventFuture) {
+      $candidates[] = $this->recommendationPayload(
+        'reboost',
+        (string) $this->t('Your Boost has ended'),
+        (string) $this->t('Your event is still upcoming. Restart promotion to maintain visibility.'),
+        (string) $this->t('Re-Boost Event'),
+        self::PRIORITY_RECENTLY_EXPIRED,
+        $event,
+      );
+    }
+
+    if ($daysUntilStart !== NULL
+      && $daysUntilStart <= 14
+      && $eventFuture
+      && !$boostActive
+      && $eventPublished) {
+      $candidates[] = $this->recommendationPayload(
+        'boost',
+        (string) $this->t('Increase attendance before your event'),
+        (string) $this->t('Events often receive the most attention in the final two weeks.'),
+        (string) $this->t('Boost Event'),
+        self::PRIORITY_UPCOMING_EVENT,
+        $event,
+      );
+    }
+
+    if ($candidates === []) {
+      return NULL;
+    }
+
+    usort($candidates, static fn (array $a, array $b): int => $b['priority'] <=> $a['priority']);
+
+    return $candidates[0];
+  }
+
+  /**
+   * Global exclusions — return NULL before any rule when matched.
+   */
+  private function isExcluded(NodeInterface $event): bool {
+    if (!$event->isPublished()) {
+      return TRUE;
+    }
+
+    $state = $this->eventStateResolver->resolveState($event);
+    if (in_array($state, [EventStateResolver::STATE_ARCHIVED, EventStateResolver::STATE_CANCELLED, EventStateResolver::STATE_ENDED], TRUE)) {
+      return TRUE;
+    }
+
+    $now = (int) $this->time->getRequestTime();
+    if (!$this->isEventFuture($event, $now)) {
+      return TRUE;
+    }
+
+    $boostStatus = $this->boostManager->getBoostStatusForEvent($event, $now);
+    $endTimestamp = isset($boostStatus['end_timestamp']) ? (int) $boostStatus['end_timestamp'] : NULL;
+    if ($endTimestamp !== NULL && empty($boostStatus['active'])) {
+      $daysSinceExpiry = ($now - $endTimestamp) / self::SECONDS_PER_DAY;
+      if ($daysSinceExpiry > 7) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Uses BoostPerformanceLevelService only — no duplicate scoring.
+   *
+   * @param array<string, mixed> $boostStatus
+   */
+  private function hasStrongPerformanceLevel(NodeInterface $event, array $boostStatus): bool {
+    try {
+      $boostMetrics = $this->boostMetricsService->getEventBoostMetrics($event);
+      $boost = [
+        'active' => !empty($boostStatus['active']),
+      ];
+      $flags = $this->resolveBookingFlags($event);
+      $emptyPlacements = [
+        'show' => FALSE,
+        'cards' => [],
+      ];
+      $decisionSupport = $this->decisionSupportService->build(
+        $boostMetrics,
+        $boost,
+        $flags['tickets'],
+        $flags['rsvp'],
+        $emptyPlacements,
+      );
+      $trendIntelligence = $this->trendIntelligenceService->analyze(
+        $boostMetrics,
+        $flags['tickets'],
+        $flags['rsvp'],
+      );
+      $performanceLevel = $this->performanceLevelService->build(
+        $decisionSupport,
+        $trendIntelligence,
+      );
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+
+    if (empty($performanceLevel['show'])) {
+      return FALSE;
+    }
+
+    $level = (string) ($performanceLevel['level'] ?? '');
+    return in_array($level, ['excellent', 'good'], TRUE);
+  }
+
+  /**
+   * @return array{tickets: bool, rsvp: bool}
+   */
+  private function resolveBookingFlags(NodeInterface $event): array {
+    $eventType = '';
+    if ($event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()) {
+      $eventType = mb_strtolower(trim((string) $event->get('field_event_type')->value));
+    }
+
+    $hasProduct = $event->hasField('field_product_target')
+      && !$event->get('field_product_target')->isEmpty();
+
+    $isTickets = $hasProduct || in_array($eventType, ['paid', 'both'], TRUE);
+    $isRsvp = in_array($eventType, ['rsvp', 'both'], TRUE);
+
+    return [
+      'tickets' => $isTickets,
+      'rsvp' => $isRsvp,
+    ];
+  }
+
+  /**
+   * @return array{
+   *   type: string,
+   *   title: string,
+   *   body: string,
+   *   cta_label: string,
+   *   cta_url: string,
+   *   priority: int,
+   * }
+   */
+  private function recommendationPayload(
+    string $type,
+    string $title,
+    string $body,
+    string $ctaLabel,
+    int $priority,
+    NodeInterface $event,
+  ): array {
+    return [
+      'type' => $type,
+      'title' => $title,
+      'body' => $body,
+      'cta_label' => $ctaLabel,
+      'cta_url' => $this->buildBoostPageUrl($event),
+      'priority' => $priority,
+    ];
+  }
+
+  private function buildBoostPageUrl(NodeInterface $event): string {
+    try {
+      return Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $event->id()])->toString();
+    }
+    catch (\Throwable) {
+      return '';
+    }
+  }
+
+  private function getEventStartTimestamp(NodeInterface $event): ?int {
+    if (!$event->hasField('field_event_start') || $event->get('field_event_start')->isEmpty()) {
+      return NULL;
+    }
+    $date = $event->get('field_event_start')->date;
+    return $date ? (int) $date->getTimestamp() : NULL;
+  }
+
+  private function getEventEndTimestamp(NodeInterface $event): ?int {
+    if (!$event->hasField('field_event_end') || $event->get('field_event_end')->isEmpty()) {
+      return NULL;
+    }
+    $date = $event->get('field_event_end')->date;
+    return $date ? (int) $date->getTimestamp() : NULL;
+  }
+
+  private function isEventFuture(NodeInterface $event, int $now): bool {
+    $eventEnd = $this->getEventEndTimestamp($event);
+    if ($eventEnd !== NULL) {
+      return $eventEnd > $now;
+    }
+
+    $eventStart = $this->getEventStartTimestamp($event);
+    if ($eventStart !== NULL) {
+      return $eventStart > $now;
+    }
+
+    return TRUE;
+  }
+
+  private function daysUntilEventStart(?int $eventStart, int $now): ?int {
+    if ($eventStart === NULL || $eventStart <= $now) {
+      return NULL;
+    }
+
+    return (int) ceil(($eventStart - $now) / self::SECONDS_PER_DAY);
+  }
+
+  private function daysSinceBoostExpiry(?int $endTimestamp, int $now, bool $boostActive): ?int {
+    if ($boostActive || $endTimestamp === NULL || $endTimestamp > $now) {
+      return NULL;
+    }
+
+    return (int) ceil(($now - $endTimestamp) / self::SECONDS_PER_DAY);
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPerformanceLevelService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPerformanceLevelService.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Organiser-facing Boost performance level (Phase 9).
+ *
+ * Composes outputs from BoostDecisionSupportService and
+ * BoostTrendIntelligenceService only — no duplicate metric calculations.
+ * BoostBenchmarkService readiness adjusts internal confidence only.
+ */
+final class BoostPerformanceLevelService {
+
+  use StringTranslationTrait;
+
+  private const LEVEL_EXCELLENT = 'excellent';
+
+  private const LEVEL_GOOD = 'good';
+
+  private const LEVEL_AVERAGE = 'average';
+
+  private const LEVEL_NEEDS_ATTENTION = 'needs_attention';
+
+  /**
+   * Ordered levels for upgrade/downgrade adjustments.
+   *
+   * @var list<string>
+   */
+  private const LEVEL_ORDER = [
+    self::LEVEL_NEEDS_ATTENTION,
+    self::LEVEL_AVERAGE,
+    self::LEVEL_GOOD,
+    self::LEVEL_EXCELLENT,
+  ];
+
+  /**
+   * Constructs BoostPerformanceLevelService.
+   */
+  public function __construct(TranslationInterface $stringTranslation) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds the performance level card payload.
+   *
+   * @param array<string, mixed> $decisionSupport
+   *   Output from BoostDecisionSupportService::build().
+   * @param array<string, mixed> $trendIntelligence
+   *   Output from BoostTrendIntelligenceService::analyze().
+   * @param bool $benchmarkReady
+   *   TRUE when BoostBenchmarkService reports platform readiness.
+   *
+   * @return array<string, mixed>
+   */
+  public function build(
+    array $decisionSupport,
+    array $trendIntelligence,
+    bool $benchmarkReady = FALSE,
+  ): array {
+    $health = is_array($decisionSupport['health'] ?? NULL) ? $decisionSupport['health'] : [];
+    if (empty($health['show'])) {
+      return $this->hiddenPayload();
+    }
+
+    $confidence = is_array($decisionSupport['confidence'] ?? NULL)
+      ? $decisionSupport['confidence']
+      : [];
+    $confidenceLevel = (string) ($confidence['level'] ?? 'low');
+    if ($confidenceLevel === 'low') {
+      return $this->hiddenPayload();
+    }
+
+    $baseScore = (string) ($health['score'] ?? '');
+    $level = $this->mapHealthScoreToLevel($baseScore);
+    if ($level === NULL) {
+      return $this->hiddenPayload();
+    }
+
+    $effectiveConfidence = $this->resolveEffectiveConfidence($confidenceLevel, $benchmarkReady);
+    $level = $this->applyTrendAdjustment($level, $trendIntelligence, $effectiveConfidence);
+
+    return $this->levelPayload($level);
+  }
+
+  /**
+   * Maps decision-support health score to performance level.
+   */
+  private function mapHealthScoreToLevel(string $score): ?string {
+    return match ($score) {
+      self::LEVEL_EXCELLENT => self::LEVEL_EXCELLENT,
+      self::LEVEL_GOOD => self::LEVEL_GOOD,
+      'fair' => self::LEVEL_AVERAGE,
+      self::LEVEL_NEEDS_ATTENTION => self::LEVEL_NEEDS_ATTENTION,
+      default => NULL,
+    };
+  }
+
+  /**
+   * Strengthens confidence internally when benchmarks are ready.
+   */
+  private function resolveEffectiveConfidence(string $confidenceLevel, bool $benchmarkReady): string {
+    if ($benchmarkReady && $confidenceLevel === 'medium') {
+      return 'high';
+    }
+    return $confidenceLevel;
+  }
+
+  /**
+   * Applies one-step trend adjustment using existing trend status only.
+   *
+   * @param array<string, mixed> $trendIntelligence
+   */
+  private function applyTrendAdjustment(
+    string $level,
+    array $trendIntelligence,
+    string $effectiveConfidence,
+  ): string {
+    if (empty($trendIntelligence['show'])) {
+      return $level;
+    }
+
+    $status = (string) ($trendIntelligence['status'] ?? 'stable');
+    if ($status === 'declining') {
+      return $this->shiftLevel($level, -1);
+    }
+
+    if ($status === 'improving' && $effectiveConfidence === 'high') {
+      return $this->shiftLevel($level, 1);
+    }
+
+    return $level;
+  }
+
+  /**
+   * Shifts a level up or down within allowed bounds.
+   */
+  private function shiftLevel(string $level, int $steps): string {
+    $index = array_search($level, self::LEVEL_ORDER, TRUE);
+    if ($index === FALSE) {
+      return $level;
+    }
+
+    $newIndex = max(0, min(count(self::LEVEL_ORDER) - 1, $index + $steps));
+    return self::LEVEL_ORDER[$newIndex];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function levelPayload(string $level): array {
+    $labels = [
+      self::LEVEL_EXCELLENT => (string) $this->t('Excellent'),
+      self::LEVEL_GOOD => (string) $this->t('Good'),
+      self::LEVEL_AVERAGE => (string) $this->t('Average'),
+      self::LEVEL_NEEDS_ATTENTION => (string) $this->t('Needs Attention'),
+    ];
+    $descriptions = [
+      self::LEVEL_EXCELLENT => (string) $this->t('Your event is attracting strong attention and converting that attention into attendees.'),
+      self::LEVEL_GOOD => (string) $this->t('Your event is performing well and gaining steady engagement.'),
+      self::LEVEL_AVERAGE => (string) $this->t('Your event is receiving attention but there are opportunities to improve engagement.'),
+      self::LEVEL_NEEDS_ATTENTION => (string) $this->t('Your event would benefit from improvements to visibility or conversion.'),
+    ];
+    $badges = [
+      self::LEVEL_EXCELLENT => 'success',
+      self::LEVEL_GOOD => 'success',
+      self::LEVEL_AVERAGE => 'warning',
+      self::LEVEL_NEEDS_ATTENTION => 'danger',
+    ];
+
+    return [
+      'show' => TRUE,
+      'level' => $level,
+      'label' => $labels[$level] ?? $labels[self::LEVEL_AVERAGE],
+      'description' => $descriptions[$level] ?? $descriptions[self::LEVEL_AVERAGE],
+      'badge' => $badges[$level] ?? 'warning',
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function hiddenPayload(): array {
+    return [
+      'show' => FALSE,
+      'level' => '',
+      'label' => '',
+      'description' => '',
+      'badge' => 'muted',
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostPurchaseSuccessResolver.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostPurchaseSuccessResolver.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Resolves boost purchase summary data for checkout completion UX.
+ */
+final class BoostPurchaseSuccessResolver {
+
+  public function __construct(
+    private readonly BoostEntitlementManager $entitlementManager,
+  ) {}
+
+  /**
+   * Whether every line item in the order is a Boost purchase.
+   */
+  public function isBoostOnlyOrder(OrderInterface $order): bool {
+    $items = $order->getItems();
+    if ($items === []) {
+      return FALSE;
+    }
+
+    foreach ($items as $item) {
+      if (!$this->entitlementManager->isBoostOrderItem($item)) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Resolves the primary boost line from a completed order.
+   *
+   * @return array{
+   *     event_id: int,
+   *     event_title: string,
+   *     boost_days: int,
+   *     plan_label: string,
+   *   }|null
+   *   Purchase summary, or NULL when no boost item is present.
+   */
+  public function resolvePrimaryBoostPurchase(OrderInterface $order): ?array {
+    foreach ($order->getItems() as $item) {
+      if (!$this->entitlementManager->isBoostOrderItem($item)) {
+        continue;
+      }
+
+      $event_id = $this->resolveTargetEventId($item);
+      if ($event_id <= 0) {
+        continue;
+      }
+
+      $event_title = 'your event';
+      if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+        $event = $item->get('field_target_event')->entity;
+        if ($event instanceof NodeInterface) {
+          $event_title = $event->label();
+        }
+      }
+
+      return [
+        'event_id' => $event_id,
+        'event_title' => $event_title,
+        'boost_days' => $this->resolveBoostDays($item),
+        'plan_label' => $item->label(),
+      ];
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Whether the order's primary boost purchase targets the given event.
+   */
+  public function orderMatchesEvent(OrderInterface $order, int $event_id): bool {
+    $purchase = $this->resolvePrimaryBoostPurchase($order);
+    return $purchase !== NULL && $purchase['event_id'] === $event_id;
+  }
+
+  /**
+   * Resolves the target event ID from a boost order item.
+   */
+  public function resolveTargetEventId(OrderItemInterface $item): int {
+    if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+      return (int) $item->get('field_target_event')->target_id;
+    }
+    return 0;
+  }
+
+  /**
+   * Resolves purchased boost duration in days from line item or variation.
+   */
+  public function resolveBoostDays(OrderItemInterface $item): int {
+    $days = 0;
+    if ($item->hasField('field_boost_days_purchased') && !$item->get('field_boost_days_purchased')->isEmpty()) {
+      $days = (int) $item->get('field_boost_days_purchased')->value;
+    }
+
+    $variation = $item->getPurchasedEntity();
+    if ($days <= 0 && $variation instanceof ProductVariationInterface
+      && $variation->hasField('field_boost_days')
+      && !$variation->get('field_boost_days')->isEmpty()) {
+      $days = (int) $variation->get('field_boost_days')->value;
+    }
+
+    return max(1, $days);
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostTrendIntelligenceService.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostTrendIntelligenceService.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_boost\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Event-scoped Boost trend intelligence from daily rollup chart data.
+ *
+ * Analyses how a single boosted event is performing over time by comparing
+ * the earlier half of available daily stats with the recent half. Consumes
+ * BoostMetricsService::getEventBoostMetrics() output only — no new queries,
+ * tables, or platform benchmarks.
+ *
+ * Momentum score (0–100):
+ * - For impressions and clicks: norm = clamp((recent − earlier) / max(earlier, 1), −1, 1).
+ * - For CTR: norm = clamp((recent_ctr − earlier_ctr) / max(earlier_ctr, 0.001), −1, 1).
+ * - momentum_raw = (ctr_norm × 0.4) + (clicks_norm × 0.35) + (impressions_norm × 0.25).
+ * - momentum = round(((momentum_raw + 1) / 2) × 100). Fifty is neutral; above is upward
+ *   momentum, below is downward.
+ *
+ * Trend direction (improving / stable / declining):
+ * - Each metric votes +1 (recent > earlier), −1 (recent < earlier), or 0 (equal).
+ * - Weighted vote uses the same 40 / 35 / 25 split as momentum.
+ * - Weighted sum > 0 → improving; < 0 → declining; else stable.
+ *
+ * Confidence reuses BoostDecisionSupportService sample thresholds:
+ * - impressions < 20 → low; impressions ≥ 100 and clicks ≥ 20 → high; else medium.
+ *
+ * Revenue and RSVP during Boost are aggregate window totals only (not daily) — trend
+ * direction for those outcomes is not computed from myeventlane_boost_stats_daily.
+ */
+final class BoostTrendIntelligenceService {
+
+  use StringTranslationTrait;
+
+  /**
+   * Minimum daily data points (matches BoostMetricsService::getChartData).
+   */
+  private const MIN_DAILY_POINTS = 3;
+
+  /**
+   * Confidence thresholds — aligned with BoostDecisionSupportService::buildConfidence().
+   */
+  private const CONFIDENCE_LOW_MAX_IMPRESSIONS = 20;
+
+  private const CONFIDENCE_HIGH_MIN_IMPRESSIONS = 100;
+
+  private const CONFIDENCE_HIGH_MIN_CLICKS = 20;
+
+  /**
+   * Momentum component weights (documented in class docblock).
+   */
+  private const WEIGHT_CTR = 0.4;
+
+  private const WEIGHT_CLICKS = 0.35;
+
+  private const WEIGHT_IMPRESSIONS = 0.25;
+
+  /**
+   * Constructs BoostTrendIntelligenceService.
+   */
+  public function __construct(TranslationInterface $stringTranslation) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds trend intelligence for an event Boost analytics panel.
+   *
+   * @param array<string, mixed> $boost_metrics
+   *   Output from BoostMetricsService::getEventBoostMetrics().
+   * @param bool $isTickets
+   *   Whether ticket sales are enabled for the event.
+   * @param bool $isRsvp
+   *   Whether RSVP is enabled for the event.
+   *
+   * @return array<string, mixed>
+   *   Trend payload for Twig. Hidden (show FALSE) when insufficient_data.
+   */
+  public function analyze(array $boost_metrics, bool $isTickets, bool $isRsvp): array {
+    $impressions = (int) ($boost_metrics['impressions'] ?? 0);
+    $clicks = (int) ($boost_metrics['clicks'] ?? 0);
+    $spend = $this->parseFormattedAmount((string) ($boost_metrics['spend'] ?? '$0.00'));
+    $has_boost_history = $spend > 0.0 || $impressions > 0 || $clicks > 0;
+
+    $chart = is_array($boost_metrics['chart_data'] ?? NULL) ? $boost_metrics['chart_data'] : NULL;
+    $series = is_array($chart['impressions_vs_clicks'] ?? NULL) ? $chart['impressions_vs_clicks'] : NULL;
+
+    if ($series === NULL) {
+      return $this->insufficientPayload();
+    }
+
+    $labels = is_array($series['labels'] ?? NULL) ? $series['labels'] : [];
+    $dailyImpressions = is_array($series['impressions'] ?? NULL) ? $series['impressions'] : [];
+    $dailyClicks = is_array($series['clicks'] ?? NULL) ? $series['clicks'] : [];
+
+    if (count($labels) < self::MIN_DAILY_POINTS
+      || count($dailyImpressions) < self::MIN_DAILY_POINTS
+      || count($dailyClicks) < self::MIN_DAILY_POINTS) {
+      return $this->insufficientPayload();
+    }
+
+    $periods = $this->splitDailySeries($dailyImpressions, $dailyClicks);
+    if ($periods === NULL) {
+      return $this->insufficientPayload();
+    }
+
+    $earlier = $periods['earlier'];
+    $recent = $periods['recent'];
+    $periodImpressions = $earlier['impressions'] + $recent['impressions'];
+
+    if ($periodImpressions < self::CONFIDENCE_LOW_MAX_IMPRESSIONS) {
+      return $this->insufficientPayload();
+    }
+
+    $metricTrends = [
+      'impressions' => $this->directionForCounts($earlier['impressions'], $recent['impressions']),
+      'clicks' => $this->directionForCounts($earlier['clicks'], $recent['clicks']),
+      'ctr' => $this->directionForCtr($earlier, $recent),
+    ];
+
+    $status = $this->resolveOverallStatus($metricTrends);
+    $momentum = $this->computeMomentum($earlier, $recent);
+    $confidence = $this->buildConfidence($impressions, $clicks, $has_boost_history);
+    $summary = $this->buildSummary($status, $metricTrends, $isTickets, $isRsvp, $boost_metrics);
+
+    return [
+      'show' => TRUE,
+      'status' => $status,
+      'status_label' => $this->statusLabel($status),
+      'status_badge' => $this->statusBadge($status),
+      'confidence' => $confidence,
+      'momentum' => $momentum,
+      'momentum_label' => (string) $this->t('@score momentum', ['@score' => (string) $momentum]),
+      'summary' => $summary,
+      'metrics' => $metricTrends,
+      'has_chart' => TRUE,
+    ];
+  }
+
+  /**
+   * Splits daily impressions/clicks into earlier and recent halves.
+   *
+   * @param list<int|float|string> $dailyImpressions
+   * @param list<int|float|string> $dailyClicks
+   *
+   * @return array{
+   *   earlier: array{impressions: int, clicks: int},
+   *   recent: array{impressions: int, clicks: int},
+   * }|null
+   */
+  private function splitDailySeries(array $dailyImpressions, array $dailyClicks): ?array {
+    $count = min(count($dailyImpressions), count($dailyClicks));
+    if ($count < self::MIN_DAILY_POINTS) {
+      return NULL;
+    }
+
+    $splitAt = (int) floor($count / 2);
+    if ($splitAt < 1) {
+      return NULL;
+    }
+
+    $earlierImpressions = 0;
+    $earlierClicks = 0;
+    $recentImpressions = 0;
+    $recentClicks = 0;
+
+    for ($i = 0; $i < $count; $i++) {
+      $impression = (int) $dailyImpressions[$i];
+      $click = (int) $dailyClicks[$i];
+      if ($i < $splitAt) {
+        $earlierImpressions += $impression;
+        $earlierClicks += $click;
+      }
+      else {
+        $recentImpressions += $impression;
+        $recentClicks += $click;
+      }
+    }
+
+    return [
+      'earlier' => [
+        'impressions' => $earlierImpressions,
+        'clicks' => $earlierClicks,
+      ],
+      'recent' => [
+        'impressions' => $recentImpressions,
+        'clicks' => $recentClicks,
+      ],
+    ];
+  }
+
+  /**
+   * Vote direction for count metrics.
+   */
+  private function directionForCounts(int $earlier, int $recent): array {
+    $direction = match (TRUE) {
+      $recent > $earlier => 'improving',
+      $recent < $earlier => 'declining',
+      default => 'stable',
+    };
+
+    return [
+      'direction' => $direction,
+      'label' => $this->metricDirectionLabel('counts', $direction),
+    ];
+  }
+
+  /**
+   * Vote direction for period CTR (clicks / impressions per half).
+   *
+   * @param array{impressions: int, clicks: int} $earlier
+   * @param array{impressions: int, clicks: int} $recent
+   */
+  private function directionForCtr(array $earlier, array $recent): array {
+    $earlierCtr = $earlier['impressions'] > 0
+      ? ($earlier['clicks'] / $earlier['impressions'])
+      : 0.0;
+    $recentCtr = $recent['impressions'] > 0
+      ? ($recent['clicks'] / $recent['impressions'])
+      : 0.0;
+
+    $direction = match (TRUE) {
+      $recentCtr > $earlierCtr => 'improving',
+      $recentCtr < $earlierCtr => 'declining',
+      default => 'stable',
+    };
+
+    return [
+      'direction' => $direction,
+      'label' => $this->metricDirectionLabel('ctr', $direction),
+    ];
+  }
+
+  /**
+   * Resolves overall status from per-metric weighted votes.
+   *
+   * @param array<string, array{direction: string}> $metricTrends
+   */
+  private function resolveOverallStatus(array $metricTrends): string {
+    $weights = [
+      'ctr' => self::WEIGHT_CTR,
+      'clicks' => self::WEIGHT_CLICKS,
+      'impressions' => self::WEIGHT_IMPRESSIONS,
+    ];
+
+    $score = 0.0;
+    foreach ($weights as $key => $weight) {
+      $direction = (string) ($metricTrends[$key]['direction'] ?? 'stable');
+      $vote = match ($direction) {
+        'improving' => 1,
+        'declining' => -1,
+        default => 0,
+      };
+      $score += $vote * $weight;
+    }
+
+    return match (TRUE) {
+      $score > 0.0 => 'improving',
+      $score < 0.0 => 'declining',
+      default => 'stable',
+    };
+  }
+
+  /**
+   * Computes momentum score 0–100 from period-over-period movement.
+   *
+   * @param array{impressions: int, clicks: int} $earlier
+   * @param array{impressions: int, clicks: int} $recent
+   */
+  private function computeMomentum(array $earlier, array $recent): int {
+    $impressionsNorm = $this->normalizeDelta($recent['impressions'], $earlier['impressions']);
+    $clicksNorm = $this->normalizeDelta($recent['clicks'], $earlier['clicks']);
+
+    $earlierCtr = $earlier['impressions'] > 0
+      ? ($earlier['clicks'] / $earlier['impressions'])
+      : 0.0;
+    $recentCtr = $recent['impressions'] > 0
+      ? ($recent['clicks'] / $recent['impressions'])
+      : 0.0;
+    $ctrNorm = $this->normalizeDelta($recentCtr, $earlierCtr, 0.001);
+
+    $raw = (self::WEIGHT_CTR * $ctrNorm)
+      + (self::WEIGHT_CLICKS * $clicksNorm)
+      + (self::WEIGHT_IMPRESSIONS * $impressionsNorm);
+
+    return (int) round((($raw + 1.0) / 2.0) * 100);
+  }
+
+  /**
+   * Normalizes a delta to [−1, 1] using the earlier value as baseline.
+   */
+  private function normalizeDelta(float $recent, float $earlier, float $floor = 1.0): float {
+    $baseline = max($earlier, $floor);
+    $delta = ($recent - $earlier) / $baseline;
+    return max(-1.0, min(1.0, $delta));
+  }
+
+  /**
+   * Builds confidence metadata (thresholds match BoostDecisionSupportService).
+   *
+   * @return array{level: string, label: string, badge: string}
+   */
+  private function buildConfidence(int $impressions, int $clicks, bool $has_boost_history): array {
+    if (!$has_boost_history) {
+      return [
+        'level' => 'low',
+        'label' => (string) $this->t('Low confidence'),
+        'badge' => 'muted',
+      ];
+    }
+
+    if ($impressions < self::CONFIDENCE_LOW_MAX_IMPRESSIONS) {
+      return [
+        'level' => 'low',
+        'label' => (string) $this->t('Low confidence'),
+        'badge' => 'danger',
+      ];
+    }
+
+    if ($impressions >= self::CONFIDENCE_HIGH_MIN_IMPRESSIONS
+      && $clicks >= self::CONFIDENCE_HIGH_MIN_CLICKS) {
+      return [
+        'level' => 'high',
+        'label' => (string) $this->t('High confidence'),
+        'badge' => 'success',
+      ];
+    }
+
+    return [
+      'level' => 'medium',
+      'label' => (string) $this->t('Medium confidence'),
+      'badge' => 'warning',
+    ];
+  }
+
+  /**
+   * Builds a human-readable summary without platform comparisons.
+   */
+  private function buildSummary(
+    string $status,
+    array $metricTrends,
+    bool $isTickets,
+    bool $isRsvp,
+    array $boost_metrics,
+  ): string {
+    $lines = [];
+
+    $impressionsDirection = (string) ($metricTrends['impressions']['direction'] ?? 'stable');
+    if ($impressionsDirection === 'improving') {
+      $lines[] = (string) $this->t('Boost visibility is increasing week over week.');
+    }
+    elseif ($impressionsDirection === 'declining') {
+      $lines[] = (string) $this->t('Boost visibility has softened compared with earlier activity.');
+    }
+
+    $ctrDirection = (string) ($metricTrends['ctr']['direction'] ?? 'stable');
+    if ($ctrDirection === 'declining') {
+      $lines[] = (string) $this->t('CTR has declined compared with earlier boost activity.');
+    }
+    elseif ($ctrDirection === 'improving') {
+      $lines[] = (string) $this->t('Click-through rate is trending up in recent days.');
+    }
+
+    if ($status === 'stable' && $lines === []) {
+      $lines[] = (string) $this->t('Engagement has remained stable.');
+    }
+    elseif ($status === 'improving' && $lines === []) {
+      $lines[] = (string) $this->t('Recent boost activity is picking up momentum.');
+    }
+    elseif ($status === 'declining' && $lines === []) {
+      $lines[] = (string) $this->t('Recent boost activity is softer than earlier in the run.');
+    }
+
+    if ($isTickets && (float) ($boost_metrics['revenue_during_boost'] ?? 0.0) > 0.0) {
+      $lines[] = (string) $this->t('Ticket revenue during Boost is tracking — daily revenue trend is not available yet.');
+    }
+    elseif ($isRsvp && (int) ($boost_metrics['rsvps_during_boost'] ?? 0) > 0) {
+      $lines[] = (string) $this->t('RSVPs during Boost are tracking — daily RSVP trend is not available yet.');
+    }
+
+    return implode(' ', array_slice($lines, 0, 2));
+  }
+
+  /**
+   * Human label for overall trend status.
+   */
+  private function statusLabel(string $status): string {
+    return match ($status) {
+      'improving' => (string) $this->t('Improving'),
+      'declining' => (string) $this->t('Declining'),
+      'stable' => (string) $this->t('Stable'),
+      default => (string) $this->t('Insufficient data'),
+    };
+  }
+
+  /**
+   * Badge variant for overall trend status.
+   */
+  private function statusBadge(string $status): string {
+    return match ($status) {
+      'improving' => 'success',
+      'declining' => 'danger',
+      'stable' => 'warning',
+      default => 'muted',
+    };
+  }
+
+  /**
+   * Short label for a single metric direction.
+   */
+  private function metricDirectionLabel(string $metric, string $direction): string {
+    if ($metric === 'ctr') {
+      return match ($direction) {
+        'improving' => (string) $this->t('CTR rising'),
+        'declining' => (string) $this->t('CTR falling'),
+        default => (string) $this->t('CTR steady'),
+      };
+    }
+
+    return match ($direction) {
+      'improving' => (string) $this->t('Trending up'),
+      'declining' => (string) $this->t('Trending down'),
+      default => (string) $this->t('Holding steady'),
+    };
+  }
+
+  /**
+   * Hidden payload when daily data cannot support trend analysis.
+   *
+   * @return array<string, mixed>
+   */
+  private function insufficientPayload(): array {
+    return [
+      'show' => FALSE,
+      'status' => 'insufficient_data',
+      'status_label' => (string) $this->t('Insufficient data'),
+      'status_badge' => 'muted',
+      'confidence' => [
+        'level' => 'low',
+        'label' => '',
+        'badge' => 'muted',
+      ],
+      'momentum' => 0,
+      'momentum_label' => '',
+      'summary' => '',
+      'metrics' => [],
+      'has_chart' => FALSE,
+    ];
+  }
+
+  /**
+   * Parses a formatted currency string into a float.
+   */
+  private function parseFormattedAmount(string $formatted): float {
+    if ($formatted === '—' || $formatted === '') {
+      return 0.0;
+    }
+    $clean = preg_replace('/[^\d.]/', '', $formatted);
+    if ($clean === NULL || $clean === '') {
+      return 0.0;
+    }
+    return (float) $clean;
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/templates/boost-event-page.html.twig
+++ b/web/modules/custom/myeventlane_boost/templates/boost-event-page.html.twig
@@ -1,52 +1,154 @@
 {#
 /**
  * @file
- * Boost purchase page — layout and copy; pricing form from BoostSelectForm.
+ * Boost purchase page — matches Boost Your Event redesign.
+ *
+ * Variables:
+ * - event: The event node.
+ * - form: BoostSelectForm render array (or Stripe CTA).
+ * - boost_performance: Optional performance payload.
+ * - edit_url: URL to edit event details.
+ * - vendor_workspace: Whether rendered inside vendor event workspace.
  */
 #}
 {{ attach_library('myeventlane_boost/boost') }}
 
-{# Recommendation badge + default selection use catalog-aware logic in BoostSelectForm. #}
 <div{{ attributes }}>
-  <div class="mel-boost-hero">
-    <h1>{{ '🚀 Boost your event visibility'|t }}</h1>
-    <p>{{ 'Get more views. Sell more tickets. Reach the right audience.'|t }}</p>
-
-    {% if boost_performance and boost_performance.ui and boost_performance.ui.title %}
-      <div class="mel-boost-hero__performance">
-        <p class="mel-boost-hero__perf-title">{{ boost_performance.ui.title }}</p>
-        {% if boost_performance.ui.intro %}
-          <p class="mel-boost-hero__perf-intro">{{ boost_performance.ui.intro }}</p>
-        {% endif %}
+  {# Quick action cards #}
+  <div class="mel-boost-page__actions">
+    <article class="mel-boost-page__action-card mel-boost-page__action-card--boost is-active">
+      <div class="mel-boost-page__action-icon" aria-hidden="true">
+        <svg class="icon-rocket" width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2.5c-1.2 3.2-2.5 5.4-4.5 7.4-1.4 1.4-3.1 2.3-5 2.8l1.8 1.8 2.2-.5c1.1 1.8 2.4 3.1 4 4l-.5 2.2 1.8 1.8c.5-1.9 1.4-3.6 2.8-5 2-2 4.2-3.3 7.4-4.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+          <path d="M9.5 14.5 5 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <circle cx="14" cy="10" r="1.5" fill="currentColor"/>
+        </svg>
       </div>
-    {% else %}
-      <p class="mel-boost-hero__fallback">{{ 'Your event is live — let’s get your first bookings'|t }}</p>
+      <div class="mel-boost-page__action-body">
+        <h2 class="mel-boost-page__action-title">{{ 'Boost your event'|t }}</h2>
+        <p class="mel-boost-page__action-text">{{ 'Increase visibility and reach more attendees'|t }}</p>
+      </div>
+      <span class="mel-boost-page__action-btn mel-boost-page__action-btn--primary">{{ 'Boost event'|t }}</span>
+    </article>
+
+    {% if edit_url %}
+      <a href="{{ edit_url }}" class="mel-boost-page__action-card mel-boost-page__action-card--edit">
+        <div class="mel-boost-page__action-icon" aria-hidden="true">
+          <svg class="icon-sparkle" width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <circle cx="12" cy="12" r="3.5" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+        </div>
+        <div class="mel-boost-page__action-body">
+          <h2 class="mel-boost-page__action-title">{{ 'Expand your event details'|t }}</h2>
+          <p class="mel-boost-page__action-text">{{ 'Add photos, description, and ticket info'|t }}</p>
+        </div>
+        <span class="mel-boost-page__action-btn mel-boost-page__action-btn--secondary">{{ 'Edit details'|t }}</span>
+      </a>
     {% endif %}
   </div>
 
-  <div class="mel-boost-benefits">
-    <h3>{{ "What you'll get"|t }}</h3>
-    <p class="mel-boost-benefits__intro">{{ 'Boost helps more people discover your event across MyEventLane.'|t }}</p>
-    <ul class="mel-boost-benefits__list">
-      <li>{{ '✓ Featured placement in event discovery'|t }}</li>
-      <li>{{ '✓ Higher visibility in relevant categories'|t }}</li>
-      <li>{{ '✓ Priority placement in search results'|t }}</li>
-      <li>{{ '✓ A Boost badge that helps attendees discover promoted events'|t }}</li>
-      <li>{{ '✓ More opportunities for people to find your event'|t }}</li>
-    </ul>
-    <div class="mel-boost-audience">
-      <h4 class="mel-boost-audience__title">{{ 'Boost is especially useful for:'|t }}</h4>
-      <ul class="mel-boost-audience__list">
-        <li>{{ 'Community events'|t }}</li>
-        <li>{{ 'Fundraisers'|t }}</li>
-        <li>{{ 'Workshops'|t }}</li>
-        <li>{{ 'First-time organisers'|t }}</li>
-        <li>{{ 'Events looking to reach new audiences'|t }}</li>
+  {# Hero + benefits #}
+  <section class="mel-boost-page__hero" aria-labelledby="mel-boost-hero-title">
+    <div class="mel-boost-page__hero-content">
+      <h1 id="mel-boost-hero-title" class="mel-boost-page__hero-title">{{ 'Boost your event visibility'|t }}</h1>
+      <p class="mel-boost-page__hero-subtitle">{{ 'Get more views. Sell more tickets. Reach the right audience.'|t }}</p>
+
+      {% if boost_performance and boost_performance.ui and boost_performance.ui.title %}
+        <div class="mel-boost-page__hero-performance">
+          <p class="mel-boost-page__hero-perf-title">{{ boost_performance.ui.title }}</p>
+          {% if boost_performance.ui.intro %}
+            <p class="mel-boost-page__hero-perf-intro">{{ boost_performance.ui.intro }}</p>
+          {% endif %}
+        </div>
+      {% else %}
+        <p class="mel-boost-page__hero-fallback">{{ "Your event is live — let's get your first bookings"|t }}</p>
+      {% endif %}
+    </div>
+
+    <div class="mel-boost-page__hero-art" aria-hidden="true">
+      <svg class="icon-rocket mel-boost-page__rocket" width="200" height="160" viewBox="0 0 200 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <ellipse cx="100" cy="140" rx="70" ry="12" fill="#E8ECFF"/>
+        <path d="M88 55c-8 18-12 36-10 58l-8 18 14-6c10 8 22 12 36 12l14 6-8-18c2-22-2-40-10-58-4-8-10-14-14-14s-10 6-14 14Z" fill="#F26D5B"/>
+        <path d="M100 38c-2 6-3 12-3 18 0 8 2 16 6 24" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="100" cy="72" r="6" fill="#fff"/>
+        <path d="M72 90 58 108M128 90l14 18" stroke="#6E7EF2" stroke-width="3" stroke-linecap="round"/>
+        <rect x="30" y="100" width="8" height="24" rx="2" fill="#6E7EF2" opacity=".5"/>
+        <rect x="162" y="92" width="8" height="32" rx="2" fill="#F5C04C" opacity=".6"/>
+        <circle cx="42" cy="88" r="3" fill="#F5C04C"/>
+        <circle cx="158" cy="78" r="4" fill="#6E7EF2"/>
+        <circle cx="120" cy="48" r="2" fill="#F26D5B"/>
+      </svg>
+    </div>
+  </section>
+
+  <section class="mel-boost-page__benefits" aria-label="{{ 'Boost benefits'|t }}">
+    <div class="mel-boost-page__benefits-col">
+      <h2 class="mel-boost-page__benefits-title">{{ "What you'll get"|t }}</h2>
+      <p class="mel-boost-page__benefits-intro">{{ 'Boost helps more people discover your event across MyEventLane.'|t }}</p>
+      <ul class="mel-boost-page__benefits-list">
+        <li>
+          <svg class="icon-check" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="9" fill="#6E7EF2"/><path d="m5.5 9 2 2 5-4.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          {{ 'Featured placement in event discovery'|t }}
+        </li>
+        <li>
+          <svg class="icon-check" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="9" fill="#6E7EF2"/><path d="m5.5 9 2 2 5-4.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          {{ 'Higher visibility in relevant categories'|t }}
+        </li>
+        <li>
+          <svg class="icon-check" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="9" fill="#6E7EF2"/><path d="m5.5 9 2 2 5-4.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          {{ 'Priority placement in search results'|t }}
+        </li>
+        <li>
+          <svg class="icon-check" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="9" fill="#6E7EF2"/><path d="m5.5 9 2 2 5-4.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          {{ 'A Boost badge that helps attendees discover promoted events'|t }}
+        </li>
+        <li>
+          <svg class="icon-check" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="9" fill="#6E7EF2"/><path d="m5.5 9 2 2 5-4.5" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          {{ 'More opportunities for people to find your event'|t }}
+        </li>
       </ul>
     </div>
-  </div>
 
-  <div class="mel-boost-pricing-wrap">
-    {{ form }}
-  </div>
+    <div class="mel-boost-page__benefits-col mel-boost-page__benefits-col--audience">
+      <h2 class="mel-boost-page__benefits-title">{{ 'Boost is especially useful for:'|t }}</h2>
+      <ul class="mel-boost-page__audience-list">
+        <li>
+          <svg class="icon-person" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="5" r="3" fill="#9B8AFB"/><path d="M3 16c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#9B8AFB"/></svg>
+          {{ 'Community events'|t }}
+        </li>
+        <li>
+          <svg class="icon-person" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="5" r="3" fill="#9B8AFB"/><path d="M3 16c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#9B8AFB"/></svg>
+          {{ 'Fundraisers'|t }}
+        </li>
+        <li>
+          <svg class="icon-person" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="5" r="3" fill="#9B8AFB"/><path d="M3 16c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#9B8AFB"/></svg>
+          {{ 'Workshops'|t }}
+        </li>
+        <li>
+          <svg class="icon-person" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="5" r="3" fill="#9B8AFB"/><path d="M3 16c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#9B8AFB"/></svg>
+          {{ 'First-time organisers'|t }}
+        </li>
+        <li>
+          <svg class="icon-person" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="5" r="3" fill="#9B8AFB"/><path d="M3 16c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#9B8AFB"/></svg>
+          {{ 'Events looking to reach new audiences'|t }}
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  {# Pricing / form #}
+  <section class="mel-boost-page__pricing" aria-labelledby="mel-boost-pricing-title">
+    <div class="mel-boost-page__pricing-header">
+      <h2 id="mel-boost-pricing-title" class="mel-boost-page__pricing-title">{{ 'Choose your Boost'|t }}</h2>
+      <p class="mel-boost-page__pricing-note">
+        <svg class="icon-shield" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5 2.5 3.5v4.5c0 3.5 2.3 6.2 5.5 7 3.2-.8 5.5-3.5 5.5-7V3.5L8 1.5Z" stroke="currentColor" stroke-width="1.2" fill="none"/><path d="m5.5 8 1.8 1.8L10.5 6.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        {{ 'No lock-in. Boost starts immediately.'|t }}
+      </p>
+    </div>
+
+    <div class="mel-boost-page__form-wrap">
+      {{ form }}
+    </div>
+  </section>
 </div>

--- a/web/modules/custom/myeventlane_boost/templates/boost-purchase-success.html.twig
+++ b/web/modules/custom/myeventlane_boost/templates/boost-purchase-success.html.twig
@@ -1,0 +1,72 @@
+{#
+/**
+ * @file
+ * Boost purchase success page after Commerce checkout.
+ *
+ * Variables:
+ * - event: Target event node.
+ * - order: Completed boost-only Commerce order.
+ * - boost_days: Purchased boost duration in days.
+ * - plan_label: Purchased boost plan label.
+ * - expiry_date: Formatted boost expiry date when active.
+ * - workspace_url: Vendor Event Studio workspace URL.
+ * - event_url: Public event page URL.
+ * - analytics_url: Vendor analytics URL.
+ */
+#}
+<div
+  class="mel-boost-success"
+  data-mel-boost-success-auto-redirect
+  {% if workspace_url %}data-mel-boost-success-redirect-url="{{ workspace_url|e('html_attr') }}"{% endif %}
+  data-mel-boost-success-redirect-delay="8000"
+  role="region"
+  aria-labelledby="mel-boost-success-title"
+>
+  <article class="mel-boost-success__card">
+    <div class="mel-boost-success__icon" aria-hidden="true">🚀</div>
+    <h1 id="mel-boost-success-title" class="mel-boost-success__title">{{ 'Your event is now being promoted'|t }}</h1>
+    <p class="mel-boost-success__lede">
+      {{ 'Your Boost is active and performance tracking is collecting data.'|t }}
+    </p>
+
+    <dl class="mel-boost-success__details">
+      {% if plan_label %}
+        <div class="mel-boost-success__detail">
+          <dt>{{ 'Plan'|t }}</dt>
+          <dd>{{ plan_label }}</dd>
+        </div>
+      {% endif %}
+      <div class="mel-boost-success__detail">
+        <dt>{{ 'Duration'|t }}</dt>
+        <dd>
+          {% if boost_days == 1 %}
+            {{ '1 day'|t }}
+          {% else %}
+            {{ '@count days'|t({'@count': boost_days}) }}
+          {% endif %}
+        </dd>
+      </div>
+      {% if expiry_date %}
+        <div class="mel-boost-success__detail">
+          <dt>{{ 'Expires'|t }}</dt>
+          <dd>{{ expiry_date }}</dd>
+        </div>
+      {% endif %}
+    </dl>
+
+    <div class="mel-boost-success__actions">
+      {% if event_url %}
+        <a href="{{ event_url }}" class="mel-btn mel-btn--primary">{{ 'View Event'|t }}</a>
+      {% endif %}
+      {% if analytics_url %}
+        <a href="{{ analytics_url }}" class="mel-btn mel-btn--secondary">{{ 'View Analytics'|t }}</a>
+      {% endif %}
+    </div>
+
+    {% if workspace_url %}
+      <p class="mel-boost-success__redirect-note" aria-live="polite">
+        {{ 'Redirecting to your event workspace in 8 seconds…'|t }}
+      </p>
+    {% endif %}
+  </article>
+</div>

--- a/web/modules/custom/myeventlane_boost/tests/src/Functional/VendorEventBoostPageTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Functional/VendorEventBoostPageTest.php
@@ -106,7 +106,7 @@ final class VendorEventBoostPageTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Confirm we're on the Boost purchase page (hero + benefits copy).
-    $this->assertSession()->elementTextContains('css', '.mel-boost-hero h1', 'Boost your event visibility');
+    $this->assertSession()->elementTextContains('css', '.mel-boost-page__hero-title', 'Boost your event visibility');
     $this->assertSession()->pageTextContains("What you'll get");
     $this->assertSession()->pageTextContains('Boost helps more people discover your event across MyEventLane.');
     $this->assertSession()->pageTextContains('Boost is especially useful for:');
@@ -164,7 +164,7 @@ final class VendorEventBoostPageTest extends BrowserTestBase {
 
     $this->drupalGet('/vendor/events/' . $event->id() . '/boost');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->elementTextContains('css', '.mel-boost-hero h1', 'Boost your event visibility');
+    $this->assertSession()->elementTextContains('css', '.mel-boost-page__hero-title', 'Boost your event visibility');
     $this->assertSession()->pageTextContains('Connect Stripe to purchase Boost');
     $this->assertSession()->pageTextContains('Boost helps more people discover your event across MyEventLane.');
     $this->assertSession()->pageTextContains('Connect Stripe to continue');

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostActionEngineServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostActionEngineServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_boost\Service\BoostActionEngineService;
+use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for Boost action engine (Phase 10).
+ *
+ * @group myeventlane_boost
+ */
+final class BoostActionEngineServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  private BoostActionEngineService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    $decisionSupport = new BoostDecisionSupportService($translation);
+    $this->service = new BoostActionEngineService($decisionSupport, $translation);
+  }
+
+  /**
+   * Strong ROI prioritises extend Boost action.
+   */
+  public function testActionPrioritisationStrongRoi(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$45.00',
+        'impressions' => 500,
+        'clicks' => 80,
+        'ctr' => 0.002,
+        'revenue_during_boost' => 300.0,
+        'orders_during_boost' => 1,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      [
+        'show' => TRUE,
+        'cards' => [
+          [
+            'key' => 'category_music',
+            'label' => 'Music Category',
+            'impressions' => 200,
+            'clicks' => 30,
+            'ctr' => 0.15,
+          ],
+          [
+            'key' => 'search_results',
+            'label' => 'Search Results',
+            'impressions' => 150,
+            'clicks' => 2,
+            'ctr' => 0.013,
+          ],
+        ],
+      ],
+      '/edit',
+      '/boost',
+      'https://example.com/event',
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertLessThanOrEqual(3, count($result['actions']));
+    $this->assertSame('extend_boost', $result['actions'][0]['id']);
+    $this->assertSame('Boost Event', $result['actions'][0]['cta_label']);
+  }
+
+  /**
+   * Low CTR suggests refreshing the hero image.
+   */
+  public function testLowCtrVisibilityAction(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$20.00',
+        'impressions' => 200,
+        'clicks' => 1,
+        'ctr' => 0.005,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+      '/edit',
+      NULL,
+      NULL,
+    );
+
+    $ids = array_column($result['actions'], 'id');
+    $this->assertContains('refresh_hero_image', $ids);
+  }
+
+  /**
+   * Actions are capped at three and deduplicated by id.
+   */
+  public function testNoDuplicateActions(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$45.00',
+        'impressions' => 500,
+        'clicks' => 80,
+        'ctr' => 0.002,
+        'revenue_during_boost' => 300.0,
+        'orders_during_boost' => 1,
+      ],
+      ['active' => TRUE],
+      TRUE,
+      FALSE,
+      [
+        'show' => TRUE,
+        'cards' => [
+          [
+            'key' => 'homepage_discover',
+            'label' => 'Homepage Discover',
+            'impressions' => 200,
+            'clicks' => 30,
+            'ctr' => 0.05,
+          ],
+        ],
+      ],
+      '/edit',
+      '/boost',
+      'https://example.com/event',
+    );
+
+    $ids = array_column($result['actions'], 'id');
+    $this->assertSame(count($ids), count(array_unique($ids)));
+    $this->assertLessThanOrEqual(3, count($ids));
+  }
+
+  /**
+   * RSVP volume without donations suggests a donation prompt.
+   */
+  public function testDonationPromptForStrongRsvpVolume(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$30.00',
+        'impressions' => 250,
+        'clicks' => 60,
+        'ctr' => 0.24,
+        'rsvps_during_boost' => 15,
+        'donation_revenue_during_boost' => 0.0,
+      ],
+      ['active' => TRUE],
+      FALSE,
+      TRUE,
+      ['show' => FALSE, 'cards' => []],
+      '/edit',
+      NULL,
+      NULL,
+    );
+
+    $ids = array_column($result['actions'], 'id');
+    $this->assertContains('add_donation_prompt', $ids);
+  }
+
+  /**
+   * Hidden when there is no Boost history.
+   */
+  public function testHiddenWithoutBoostHistory(): void {
+    $result = $this->service->build(
+      [
+        'spend' => '$0.00',
+        'impressions' => 0,
+        'clicks' => 0,
+        'ctr' => 0.0,
+      ],
+      ['active' => FALSE],
+      TRUE,
+      FALSE,
+      ['show' => FALSE, 'cards' => []],
+      '/edit',
+      '/boost',
+      NULL,
+    );
+
+    $this->assertFalse($result['show']);
+    $this->assertSame([], $result['actions']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostExtensionRecommendationServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostExtensionRecommendationServiceTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
+use Drupal\myeventlane_boost\Service\BoostEntitlementManager;
+use Drupal\myeventlane_boost\Service\BoostMetricsService;
+use Drupal\myeventlane_boost\Service\BoostPerformanceLevelService;
+use Drupal\myeventlane_boost\Service\BoostTrendIntelligenceService;
+use Drupal\myeventlane_event_state\Service\EventStateResolver;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+
+/**
+ * Unit tests for Boost extension recommendations (Phase 11C).
+ *
+ * @group myeventlane_boost
+ */
+final class BoostExtensionRecommendationServiceTest extends UnitTestCase {
+
+  private const NOW = 1_700_000_000;
+
+  private BoostExtensionRecommendationService $service;
+
+  private TimeInterface $time;
+
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+
+    $this->time = $this->createMock(TimeInterface::class);
+    $this->time->method('getRequestTime')->willReturn(self::NOW);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $dateFormatter = $this->createMock(DateFormatterInterface::class);
+    $dateFormatter->method('format')->willReturn('1 Jan');
+
+    $boostManager = new BoostManager($this->entityTypeManager, $this->time, $logger);
+    $boostStatusService = new BoostStatusService(
+      $boostManager,
+      $this->entityTypeManager,
+      $dateFormatter,
+      $this->time,
+    );
+
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturn(FALSE);
+    $eventStateResolver = new EventStateResolver(
+      $this->time,
+      $this->entityTypeManager,
+      $cache,
+      NULL,
+    );
+
+    $decisionSupport = new BoostDecisionSupportService($translation);
+    $trendIntelligence = new BoostTrendIntelligenceService($translation);
+    $performanceLevel = new BoostPerformanceLevelService($translation);
+    $entitlementManager = new BoostEntitlementManager(
+      $this->entityTypeManager,
+      $this->time,
+      $logger,
+    );
+    $boostMetricsService = new BoostMetricsService(
+      $this->createMock(Connection::class),
+      $this->entityTypeManager,
+      $boostManager,
+      $entitlementManager,
+      $this->time,
+      $translation,
+    );
+
+    $this->service = new BoostExtensionRecommendationService(
+      $boostStatusService,
+      $boostManager,
+      $performanceLevel,
+      $decisionSupport,
+      $trendIntelligence,
+      $boostMetricsService,
+      $eventStateResolver,
+      $this->time,
+      $translation,
+    );
+  }
+
+  /**
+   * Rule 1 — Boost expiring soon.
+   */
+  public function testExpiringSoonRecommendation(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW + (2 * 86400),
+      eventEnd: self::NOW + (5 * 86400),
+      promoted: TRUE,
+      promoExpires: gmdate('Y-m-d\TH:i:s', self::NOW + 86400),
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+
+    $result = $this->service->getRecommendation($event);
+
+    $this->assertNotNull($result);
+    $this->assertSame('extend', $result['type']);
+    $this->assertSame(100, $result['priority']);
+    $this->assertSame('Your Boost ends soon', $result['title']);
+    $this->assertSame('Extend Boost', $result['cta_label']);
+    $this->assertIsString($result['cta_url']);
+  }
+
+  /**
+   * Rule 2 — Strong Boost performance.
+   */
+  public function testStrongPerformanceRecommendation(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW - 86400,
+      eventEnd: self::NOW + (10 * 86400),
+      eventType: 'paid',
+      hasProduct: TRUE,
+      promoted: TRUE,
+      promoExpires: gmdate('Y-m-d\TH:i:s', self::NOW + (10 * 86400)),
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+    $this->replaceMetricsStub([
+      'impressions' => 500,
+      'clicks' => 80,
+      'ctr' => 0.05,
+      'spend' => '$45.00',
+      'revenue_during_boost' => 300.0,
+      'orders_during_boost' => 5,
+    ]);
+
+    $result = $this->service->getRecommendation($event);
+
+    $this->assertNotNull($result);
+    $this->assertSame('extend', $result['type']);
+    $this->assertSame(90, $result['priority']);
+    $this->assertSame('Your Boost is performing well', $result['title']);
+  }
+
+  /**
+   * Rule 3 — Recently expired Boost.
+   */
+  public function testRecentlyExpiredRecommendation(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW + (3 * 86400),
+      eventEnd: self::NOW + (7 * 86400),
+      promoted: TRUE,
+      promoExpires: gmdate('Y-m-d\TH:i:s', self::NOW - (2 * 86400)),
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+
+    $result = $this->service->getRecommendation($event);
+
+    $this->assertNotNull($result);
+    $this->assertSame('reboost', $result['type']);
+    $this->assertSame(80, $result['priority']);
+    $this->assertSame('Your Boost has ended', $result['title']);
+    $this->assertSame('Re-Boost Event', $result['cta_label']);
+  }
+
+  /**
+   * Rule 4 — Upcoming event without Boost.
+   */
+  public function testUpcomingEventRecommendation(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW + (10 * 86400),
+      eventEnd: self::NOW + (11 * 86400),
+      promoted: FALSE,
+      promoExpires: NULL,
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+
+    $result = $this->service->getRecommendation($event);
+
+    $this->assertNotNull($result);
+    $this->assertSame('boost', $result['type']);
+    $this->assertSame(70, $result['priority']);
+    $this->assertSame('Increase attendance before your event', $result['title']);
+    $this->assertSame('Boost Event', $result['cta_label']);
+  }
+
+  /**
+   * Ended events never receive recommendations.
+   */
+  public function testEndedEventReturnsNull(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW - (10 * 86400),
+      eventEnd: self::NOW - 86400,
+      promoted: FALSE,
+      promoExpires: NULL,
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+
+    $this->assertNull($this->service->getRecommendation($event));
+  }
+
+  /**
+   * Archived events never receive recommendations.
+   */
+  public function testArchivedEventReturnsNull(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW + 86400,
+      eventEnd: self::NOW + (2 * 86400),
+      stateOverride: 'archived',
+      promoted: FALSE,
+      promoExpires: NULL,
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+
+    $this->assertNull($this->service->getRecommendation($event));
+  }
+
+  /**
+   * Highest priority rule wins when multiple match.
+   */
+  public function testPriorityOrdering(): void {
+    $event = $this->createEventNode(
+      published: TRUE,
+      eventStart: self::NOW + (2 * 86400),
+      eventEnd: self::NOW + (8 * 86400),
+      eventType: 'paid',
+      hasProduct: TRUE,
+      promoted: TRUE,
+      promoExpires: gmdate('Y-m-d\TH:i:s', self::NOW + 86400),
+    );
+    $this->entityTypeManager->method('getStorage')->willReturn($this->nodeStorageReturning($event));
+    $this->replaceMetricsStub([
+      'impressions' => 500,
+      'clicks' => 80,
+      'ctr' => 0.05,
+      'spend' => '$45.00',
+      'revenue_during_boost' => 300.0,
+      'orders_during_boost' => 5,
+    ]);
+
+    $result = $this->service->getRecommendation($event);
+
+    $this->assertNotNull($result);
+    $this->assertSame(100, $result['priority']);
+    $this->assertSame('Your Boost ends soon', $result['title']);
+  }
+
+  /**
+   * Builds a mock event node with optional field values.
+   */
+  private function createEventNode(
+    bool $published = TRUE,
+    ?int $eventStart = NULL,
+    ?int $eventEnd = NULL,
+    string $eventType = '',
+    bool $hasProduct = FALSE,
+    string $stateOverride = '',
+    bool $promoted = FALSE,
+    ?string $promoExpires = NULL,
+  ): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('id')->willReturn(42);
+    $event->method('bundle')->willReturn('event');
+    $event->method('isPublished')->willReturn($published);
+
+    $event->method('hasField')->willReturnCallback(static function (string $field): bool {
+      return in_array($field, [
+        'field_event_start',
+        'field_event_end',
+        'field_event_type',
+        'field_product_target',
+        'field_event_state_override',
+        'field_promoted',
+        'field_promo_expires',
+      ], TRUE);
+    });
+
+    $event->method('get')->willReturnCallback(function (string $field) use (
+      $eventType,
+      $hasProduct,
+      $eventStart,
+      $eventEnd,
+      $stateOverride,
+      $promoted,
+      $promoExpires,
+    ) {
+      return match ($field) {
+        'field_event_type' => $this->fieldList($eventType),
+        'field_product_target' => $this->fieldList($hasProduct ? '1' : ''),
+        'field_event_start' => $this->dateFieldList($eventStart),
+        'field_event_end' => $this->dateFieldList($eventEnd),
+        'field_event_state_override' => $this->fieldList($stateOverride),
+        'field_promoted' => $this->fieldList($promoted ? '1' : '0'),
+        'field_promo_expires' => $this->fieldList($promoExpires ?? ''),
+        default => $this->fieldList(''),
+      };
+    });
+
+    return $event;
+  }
+
+  /**
+   * @param array<string, mixed> $metrics
+   */
+  private function replaceMetricsStub(array $metrics): void {
+    $stub = new class($metrics) {
+      public function __construct(private readonly array $metrics) {}
+
+      public function getEventBoostMetrics(NodeInterface $event): array {
+        return $this->metrics;
+      }
+    };
+
+    $property = new ReflectionProperty(BoostExtensionRecommendationService::class, 'boostMetricsService');
+    $property->setAccessible(TRUE);
+    $property->setValue($this->service, $stub);
+  }
+
+  private function nodeStorageReturning(NodeInterface $event): object {
+    return new class($event) {
+      public function __construct(private readonly NodeInterface $event) {}
+
+      public function load($id): NodeInterface {
+        return $this->event;
+      }
+    };
+  }
+
+  private function fieldList(?string $value): object {
+    $value = $value ?? '';
+    return new class($value) {
+      public function __construct(public mixed $value) {}
+
+      public function isEmpty(): bool {
+        return $this->value === '' || $this->value === NULL;
+      }
+    };
+  }
+
+  private function dateFieldList(?int $timestamp): object {
+    if ($timestamp === NULL) {
+      return new class {
+        public function isEmpty(): bool {
+          return TRUE;
+        }
+      };
+    }
+
+    $date = new class($timestamp) {
+      public function __construct(private readonly int $timestamp) {}
+
+      public function getTimestamp(): int {
+        return $this->timestamp;
+      }
+    };
+
+    return new class($date) {
+      public function __construct(public object $date) {}
+
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostPerformanceLevelServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostPerformanceLevelServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_boost\Service\BoostActionEngineService;
+use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\myeventlane_boost\Service\BoostPerformanceLevelService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for Boost performance level (Phase 9).
+ *
+ * @group myeventlane_boost
+ */
+final class BoostPerformanceLevelServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  private BoostPerformanceLevelService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    $this->service = new BoostPerformanceLevelService($translation);
+  }
+
+  /**
+   * Excellent level maps from decision-support health score.
+   */
+  public function testExcellentLevel(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'excellent',
+        ],
+        'confidence' => [
+          'level' => 'high',
+        ],
+      ],
+      ['show' => FALSE],
+      FALSE,
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertSame('excellent', $result['level']);
+    $this->assertSame('Excellent', $result['label']);
+    $this->assertStringContainsString('strong attention', (string) $result['description']);
+  }
+
+  /**
+   * Good level maps from decision-support health score.
+   */
+  public function testGoodLevel(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'good',
+        ],
+        'confidence' => [
+          'level' => 'medium',
+        ],
+      ],
+      ['show' => FALSE],
+      FALSE,
+    );
+
+    $this->assertSame('good', $result['level']);
+    $this->assertSame('Good', $result['label']);
+    $this->assertStringContainsString('performing well', (string) $result['description']);
+  }
+
+  /**
+   * Fair health score maps to Average performance level.
+   */
+  public function testAverageLevelFromFairHealth(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'fair',
+        ],
+        'confidence' => [
+          'level' => 'medium',
+        ],
+      ],
+      ['show' => FALSE],
+      FALSE,
+    );
+
+    $this->assertSame('average', $result['level']);
+    $this->assertSame('Average', $result['label']);
+    $this->assertStringContainsString('opportunities to improve', (string) $result['description']);
+  }
+
+  /**
+   * Needs attention level maps from decision-support health score.
+   */
+  public function testNeedsAttentionLevel(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'needs_attention',
+        ],
+        'confidence' => [
+          'level' => 'medium',
+        ],
+      ],
+      ['show' => FALSE],
+      FALSE,
+    );
+
+    $this->assertSame('needs_attention', $result['level']);
+    $this->assertSame('Needs Attention', $result['label']);
+    $this->assertStringContainsString('visibility or conversion', (string) $result['description']);
+  }
+
+  /**
+   * Hidden when confidence is low.
+   */
+  public function testHiddenWhenConfidenceLow(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'good',
+        ],
+        'confidence' => [
+          'level' => 'low',
+        ],
+      ],
+      ['show' => FALSE],
+      FALSE,
+    );
+
+    $this->assertFalse($result['show']);
+  }
+
+  /**
+   * Declining trend downgrades performance level one step.
+   */
+  public function testDecliningTrendDowngradesLevel(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'excellent',
+        ],
+        'confidence' => [
+          'level' => 'high',
+        ],
+      ],
+      [
+        'show' => TRUE,
+        'status' => 'declining',
+      ],
+      FALSE,
+    );
+
+    $this->assertSame('good', $result['level']);
+  }
+
+  /**
+   * Benchmark readiness strengthens confidence for trend upgrades.
+   */
+  public function testBenchmarkReadyUpgradesWithImprovingTrend(): void {
+    $result = $this->service->build(
+      [
+        'health' => [
+          'show' => TRUE,
+          'score' => 'fair',
+        ],
+        'confidence' => [
+          'level' => 'medium',
+        ],
+      ],
+      [
+        'show' => TRUE,
+        'status' => 'improving',
+      ],
+      TRUE,
+    );
+
+    $this->assertSame('good', $result['level']);
+  }
+
+}
+

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostTrendIntelligenceServiceTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostTrendIntelligenceServiceTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_boost\Service\BoostTrendIntelligenceService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for Boost trend intelligence rules.
+ *
+ * @group myeventlane_boost
+ */
+final class BoostTrendIntelligenceServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  private BoostTrendIntelligenceService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation
+      ->method('translateString')
+      ->willReturnCallback(static fn (TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    $this->service = new BoostTrendIntelligenceService($translation);
+  }
+
+  /**
+   * Recent half outperforms earlier half → improving.
+   */
+  public function testImprovingTrend(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [10, 10, 10, 30, 30, 30],
+        clicks: [1, 1, 1, 4, 4, 4],
+        totalImpressions: 240,
+        totalClicks: 30,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertSame('improving', $result['status']);
+    $this->assertGreaterThan(50, $result['momentum']);
+    $this->assertSame('improving', $result['metrics']['impressions']['direction']);
+    $this->assertSame('improving', $result['metrics']['clicks']['direction']);
+    $this->assertSame('improving', $result['metrics']['ctr']['direction']);
+    $this->assertStringContainsString('visibility is increasing', (string) $result['summary']);
+  }
+
+  /**
+   * Equal halves → stable.
+   */
+  public function testStableTrend(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [20, 20, 20, 20, 20, 20],
+        clicks: [2, 2, 2, 2, 2, 2],
+        totalImpressions: 240,
+        totalClicks: 24,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertSame('stable', $result['status']);
+    $this->assertSame(50, $result['momentum']);
+    $this->assertStringContainsString('remained stable', (string) $result['summary']);
+  }
+
+  /**
+   * Recent half underperforms earlier half → declining.
+   */
+  public function testDecliningTrend(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [40, 40, 40, 10, 10, 10],
+        clicks: [5, 5, 5, 1, 1, 1],
+        totalImpressions: 240,
+        totalClicks: 33,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertSame('declining', $result['status']);
+    $this->assertLessThan(50, $result['momentum']);
+    $this->assertSame('declining', $result['metrics']['impressions']['direction']);
+    $this->assertStringContainsString('CTR has declined', (string) $result['summary']);
+  }
+
+  /**
+   * Missing chart data hides the section.
+   */
+  public function testInsufficientDataWithoutChart(): void {
+    $result = $this->service->analyze(
+      [
+        'spend' => '$10.00',
+        'impressions' => 15,
+        'clicks' => 2,
+        'ctr' => 0.133,
+        'chart_data' => NULL,
+      ],
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertFalse($result['show']);
+    $this->assertSame('insufficient_data', $result['status']);
+  }
+
+  /**
+   * Fewer than three daily points hides the section.
+   */
+  public function testInsufficientDataWithTooFewDailyPoints(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [10, 10],
+        clicks: [1, 1],
+        totalImpressions: 20,
+        totalClicks: 2,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertFalse($result['show']);
+    $this->assertSame('insufficient_data', $result['status']);
+  }
+
+  /**
+   * Low impression volume across periods hides the section.
+   */
+  public function testInsufficientDataWithLowImpressionVolume(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [2, 2, 2, 3, 3, 3],
+        clicks: [0, 0, 1, 0, 0, 1],
+        totalImpressions: 15,
+        totalClicks: 2,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertFalse($result['show']);
+    $this->assertSame('insufficient_data', $result['status']);
+  }
+
+  /**
+   * High sample size yields high confidence.
+   */
+  public function testHighConfidenceWithStrongSample(): void {
+    $result = $this->service->analyze(
+      $this->metricsWithChart(
+        impressions: [20, 20, 20, 25, 25, 25],
+        clicks: [4, 4, 4, 5, 5, 5],
+        totalImpressions: 150,
+        totalClicks: 27,
+      ),
+      TRUE,
+      FALSE,
+    );
+
+    $this->assertTrue($result['show']);
+    $this->assertSame('high', $result['confidence']['level']);
+  }
+
+  /**
+   * Builds chart_data fixture aligned with BoostMetricsService shape.
+   *
+   * @param list<int> $impressions
+   * @param list<int> $clicks
+   *
+   * @return array<string, mixed>
+   */
+  private function metricsWithChart(
+    array $impressions,
+    array $clicks,
+    int $totalImpressions,
+    int $totalClicks,
+  ): array {
+    $labels = [];
+    foreach (range(1, count($impressions)) as $day) {
+      $labels[] = sprintf('2026-01-%02d', $day);
+    }
+
+    $ctr = $totalImpressions > 0 ? ($totalClicks / $totalImpressions) : 0.0;
+
+    return [
+      'spend' => '$25.00',
+      'impressions' => $totalImpressions,
+      'clicks' => $totalClicks,
+      'ctr' => $ctr,
+      'chart_data' => [
+        'impressions_vs_clicks' => [
+          'labels' => $labels,
+          'impressions' => $impressions,
+          'clicks' => $clicks,
+        ],
+        'ctr_by_placement' => [
+          'labels' => ['homepage_discover'],
+          'data' => [round($ctr * 100, 2)],
+        ],
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2683,53 +2683,66 @@
   line-height: 1.45;
 }
 
-.mel-event-studio-publish-feedback__growth {
+.mel-publish-boost-cta {
   margin: 0 0 0.85rem;
-  padding-bottom: 0.85rem;
-  border-bottom: 1px solid rgba(56, 65, 99, 0.12);
+  padding: 1rem 1.15rem;
+  border-radius: 16px;
+  border: 1px solid rgba(139, 92, 246, 0.18);
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(56, 65, 99, 0.06);
 }
 
-.mel-event-studio-publish-feedback__growth-title {
-  margin: 0 0 0.35rem;
-  font-weight: 650;
-  color: #384163;
-  font-size: 1rem;
+.mel-event-studio-publish-feedback__success .mel-publish-boost-cta {
+  margin-top: 0.35rem;
+}
+
+.mel-publish-boost-cta__title {
+  margin: 0 0 0.4rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
   line-height: 1.35;
+  color: #384163;
 }
 
-.mel-event-studio-publish-feedback__growth-body {
+.mel-publish-boost-cta__copy {
   margin: 0 0 0.75rem;
   color: #475569;
   font-size: 0.9375rem;
   line-height: 1.45;
 }
 
-.mel-event-studio-publish-feedback__actions {
+.mel-publish-boost-cta__features {
+  margin: 0 0 0.85rem;
+  padding: 0.75rem 0.85rem;
+  list-style: none;
+  border-radius: 12px;
+  background: rgba(238, 242, 255, 0.75);
+  border: 1px solid rgba(139, 92, 246, 0.12);
+}
+
+.mel-publish-boost-cta__features li {
+  position: relative;
+  margin: 0;
+  padding: 0.2rem 0 0.2rem 1.35rem;
+  color: #384163;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.mel-publish-boost-cta__features li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  top: 0.2rem;
+  font-weight: 700;
+  color: #7c3aed;
+}
+
+.mel-publish-boost-cta__actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.65rem 0.85rem;
-}
-
-.mel-event-studio-publish-feedback__grow {
-  min-height: 2.75rem;
-}
-
-.mel-event-studio-publish-feedback__boost-link {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.75rem;
-  padding: 0.35rem 0.15rem;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: #e06c5c;
-  text-decoration: underline;
-  text-underline-offset: 0.15em;
-}
-
-.mel-event-studio-publish-feedback__boost-link:hover,
-.mel-event-studio-publish-feedback__boost-link:focus-visible {
-  color: #c85a4b;
 }
 
 .mel-event-studio-publish-feedback__row {
@@ -2750,12 +2763,12 @@
     align-items: stretch;
   }
 
-  .mel-event-studio-publish-feedback__actions {
+  .mel-publish-boost-cta__actions {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .mel-event-studio-publish-feedback__grow,
+  .mel-publish-boost-cta__actions .mel-btn,
   .mel-event-studio-publish-feedback__row .mel-btn {
     justify-content: center;
     text-align: center;

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio.css
@@ -1142,24 +1142,10 @@ textarea.mel-input--body {
   max-width: 36rem;
 }
 
-.mel-publish-celebrate__growth {
+.mel-publish-celebrate .mel-publish-boost-cta {
   margin-bottom: 0.85rem;
-  padding-bottom: 0.85rem;
-  border-bottom: 1px solid rgba(56, 65, 99, 0.12);
-}
-
-.mel-publish-celebrate__growth-title {
-  margin: 0 0 0.35rem;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-}
-
-.mel-publish-celebrate__growth-lede {
-  margin: 0 0 0.75rem;
-  color: var(--mel-studio-muted);
-  font-size: 0.9375rem;
-  line-height: 1.45;
-  max-width: 36rem;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .mel-publish-celebrate__actions {
@@ -1173,32 +1159,6 @@ textarea.mel-input--body {
   align-items: center;
   gap: 0.5rem 0.65rem;
   margin-top: 0.65rem;
-}
-
-.mel-publish-celebrate__row--grow-primary {
-  margin-top: 0;
-}
-
-.mel-publish-celebrate__row--grow-links {
-  margin-top: 0.5rem;
-  gap: 0.75rem 1rem;
-}
-
-.mel-publish-celebrate__growth-link {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.75rem;
-  padding: 0.35rem 0.15rem;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: var(--mel-studio-accent, #e06c5c);
-  text-decoration: underline;
-  text-underline-offset: 0.15em;
-}
-
-.mel-publish-celebrate__growth-link:hover,
-.mel-publish-celebrate__growth-link:focus-visible {
-  color: var(--mel-studio-accent-strong, #c85a4b);
 }
 
 .mel-publish-celebrate__row--view {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -352,37 +352,25 @@
 
     setText('[data-mel-publish-success-title]', handoff.title);
     setText('[data-mel-publish-success-message]', handoff.message);
-    setText('[data-mel-publish-success-growth-title]', handoff.growth_title);
-    setText('[data-mel-publish-success-growth-body]', handoff.growth_body);
 
-    const growthBlock = successPanel.querySelector('[data-mel-publish-success-growth]');
-    const growLink = successPanel.querySelector('[data-mel-publish-success-grow]');
+    const boostCard = successPanel.querySelector('[data-mel-publish-success-boost-card]');
     const boostLink = successPanel.querySelector('[data-mel-publish-success-boost]');
     const viewRow = successPanel.querySelector('[data-mel-publish-success-view-row]');
     const viewLink = successPanel.querySelector('[data-mel-publish-success-view]');
     const socialRow = successPanel.querySelector('[data-mel-publish-success-social]');
 
-    if (growthBlock) {
-      growthBlock.hidden = false;
-    }
-    if (growLink) {
-      if (handoff.grow_url) {
-        growLink.href = handoff.grow_url;
-        growLink.hidden = false;
-      }
-      else {
-        growLink.hidden = true;
-        growLink.removeAttribute('href');
-      }
-    }
-    if (boostLink) {
+    if (boostCard) {
       if (handoff.boost_url) {
-        boostLink.href = handoff.boost_url;
-        boostLink.hidden = false;
+        boostCard.hidden = false;
+        if (boostLink) {
+          boostLink.href = handoff.boost_url;
+        }
       }
       else {
-        boostLink.hidden = true;
-        boostLink.removeAttribute('href');
+        boostCard.hidden = true;
+        if (boostLink) {
+          boostLink.removeAttribute('href');
+        }
       }
     }
     if (viewLink && viewRow) {
@@ -443,8 +431,21 @@
     }
   }
 
+  function bindPublishBoostDismiss(context) {
+    once('mel-publish-boost-dismiss', '[data-mel-publish-boost-dismiss]', context).forEach((button) => {
+      button.addEventListener('click', () => {
+        const card = button.closest('[data-mel-publish-success-boost-card], [data-mel-publish-boost-cta]');
+        if (card) {
+          card.hidden = true;
+        }
+      });
+    });
+  }
+
   Drupal.behaviors.melEventStudioShellAutosave = {
     attach(context) {
+      bindPublishBoostDismiss(context);
+
       once('mel-event-studio-mobile-priority', '[data-mel-studio-shell]', context).forEach((shell) => {
         applyMobilePriorities(shell);
         const handoff = studioSettings().publishHandoff;

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio.js
@@ -5220,6 +5220,15 @@
 
   Drupal.behaviors.melEventStudioCelebrateShare = {
     attach: function (context) {
+      once('mel-publish-boost-dismiss-builder', '[data-mel-publish-boost-dismiss]', context).forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var card = btn.closest('[data-mel-publish-boost-cta]');
+          if (card) {
+            card.hidden = true;
+          }
+        });
+      });
+
       once('mel-event-studio-celebrate-copy', '[data-mel-celebrate-copy]', context).forEach(function (btn) {
         btn.addEventListener('click', function (e) {
           e.preventDefault();

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.22
+  version: 1.23
   css:
     theme:
       css/mel-event-studio.css: {}
@@ -150,7 +150,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.4
+  version: 1.5
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -51,6 +51,8 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'section_content' => NULL,
         'topbar' => [],
         'readiness' => [],
+        'boost' => NULL,
+        'boost_extension_recommendation' => NULL,
         'publish_handoff' => NULL,
       ],
       'template' => 'mel-event-studio-workspace',

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -15,6 +15,7 @@ services:
       - '@myeventlane_event_studio.empty_state_builder'
       - '@myeventlane_core.domain_detector'
       - '@myeventlane_event_studio.preprocess'
+      - '@myeventlane_vendor.service.boost_status'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -19,10 +19,13 @@ use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
 use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
+use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -48,6 +51,8 @@ final class EventStudioController extends ControllerBase {
     private readonly EventStudioEmptyStateBuilder $emptyStateBuilder,
     private readonly DomainDetector $domainDetector,
     private readonly EventStudioPreprocess $eventStudioPreprocess,
+    private readonly BoostStatusService $boostStatusService,
+    private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
   }
@@ -67,6 +72,8 @@ final class EventStudioController extends ControllerBase {
       $container->get('myeventlane_event_studio.empty_state_builder'),
       $container->get('myeventlane_core.domain_detector'),
       $container->get('myeventlane_event_studio.preprocess'),
+      $container->get('myeventlane_vendor.service.boost_status'),
+      $container->get('myeventlane_boost.extension_recommendation'),
     );
   }
 
@@ -209,6 +216,13 @@ final class EventStudioController extends ControllerBase {
       $publish_handoff = $this->eventStudioPreprocess->buildPublishSuccessHandoff($node);
     }
 
+    $boost = $this->buildBoostWorkspacePayload($node, $account);
+    $boost_extension_recommendation = $this->boostExtensionRecommendation?->getRecommendation($node);
+    $attached_libraries = ['myeventlane_event_studio/mel_event_studio_shell_only'];
+    if ($boost !== NULL || $boost_extension_recommendation !== NULL) {
+      $attached_libraries[] = 'myeventlane_boost/boost_visibility';
+    }
+
     $this->logger->debug('Event Studio workspace render: route=@route event_id=@eid section=@section plugin=@plugin render_target=@target section_content_keys=@keys', [
       '@route' => $routeName,
       '@eid' => (string) $node->id(),
@@ -229,9 +243,11 @@ final class EventStudioController extends ControllerBase {
       '#section_content' => $sectionContent,
       '#topbar' => $this->buildTopbar($node, $readiness, $section),
       '#readiness' => $this->buildReadinessSummary($readiness),
+      '#boost' => $boost,
+      '#boost_extension_recommendation' => $boost_extension_recommendation,
       '#publish_handoff' => $publish_handoff,
       '#attached' => [
-        'library' => ['myeventlane_event_studio/mel_event_studio_shell_only'],
+        'library' => $attached_libraries,
         'drupalSettings' => [
           'myeventlaneEventStudio' => [
             'autosaveUrl' => Url::fromRoute('myeventlane_event_studio.autosave')->toString(),
@@ -362,6 +378,47 @@ final class EventStudioController extends ControllerBase {
       return (string) $this->t('Needs Attention');
     }
     return (string) $this->t('Ready');
+  }
+
+  /**
+   * Builds boost visibility payload for the workspace shell when active.
+   *
+   * @return array<string, mixed>|null
+   *   Boost card data, or NULL when boost is not active.
+   */
+  private function buildBoostWorkspacePayload(NodeInterface $node, AccountInterface $account): ?array {
+    $visibility = $this->boostStatusService->getVisibilityPayload($node);
+    if (empty($visibility['active'])) {
+      return NULL;
+    }
+
+    $analyticsUrl = $this->safeRouteUrl('myeventlane_event_studio.workspace_analytics', ['node' => $node->id()], $account);
+    if ($analyticsUrl === '') {
+      $analyticsUrl = $this->safeRouteUrl('myeventlane_vendor.console.event_analytics', ['event' => $node->id()], $account);
+    }
+
+    return [
+      'active' => TRUE,
+      'days_remaining' => $visibility['days_remaining'],
+      'expires' => $visibility['expires'],
+      'analytics_url' => $analyticsUrl,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $parameters
+   */
+  private function safeRouteUrl(string $routeName, array $parameters, AccountInterface $account): string {
+    try {
+      $url = Url::fromRoute($routeName, $parameters);
+      if (!$url->access($account)) {
+        return '';
+      }
+      return $url->toString();
+    }
+    catch (\Throwable) {
+      return '';
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -168,9 +168,7 @@ final class EventStudioPreprocess {
     $variables['mel_publish_celebrate_share'] = [];
     $variables['mel_publish_celebrate_calendar_url'] = NULL;
     $variables['mel_publish_celebrate_node_id'] = NULL;
-    $variables['mel_publish_celebrate_grow_url'] = NULL;
     $variables['mel_publish_celebrate_boost_url'] = NULL;
-    $variables['mel_publish_celebrate_promote_url'] = NULL;
 
     $celebrate_requested = FALSE;
     if ($request !== NULL && (string) $request->query->get('mel_celebrate') === '1') {
@@ -190,9 +188,7 @@ final class EventStudioPreprocess {
         $variables['mel_publish_celebrate_share'] = $handoff['share'];
         $variables['mel_publish_celebrate_calendar_url'] = $handoff['calendar_url'];
         $variables['mel_publish_celebrate_node_id'] = (int) $node->id();
-        $variables['mel_publish_celebrate_promote_url'] = $handoff['promote_url'];
         $variables['mel_publish_celebrate_boost_url'] = $handoff['boost_url'];
-        $variables['mel_publish_celebrate_grow_url'] = $handoff['grow_url'];
       }
     }
 
@@ -226,9 +222,7 @@ final class EventStudioPreprocess {
       'text' => $snippet,
     ]);
 
-    $promote_url = $this->celebrateRouteUrl('myeventlane_vendor.console.event_promotion', ['event' => $event_id]);
     $boost_url = $this->celebrateRouteUrl('myeventlane_boost.vendor_event_boost', ['event' => $event_id]);
-    $grow_url = $boost_url ?? $promote_url;
 
     $calendar_url = NULL;
     if ($node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()) {
@@ -247,11 +241,7 @@ final class EventStudioPreprocess {
     return [
       'title' => (string) $this->t('🎉 Your event is now live'),
       'message' => (string) $this->t('Published successfully'),
-      'growth_title' => (string) $this->t('Ready for more attendees?'),
-      'growth_body' => (string) $this->t('Boost or feature your event to reach more people on MyEventLane.'),
-      'grow_url' => $grow_url,
-      'boost_url' => ($boost_url !== NULL && $boost_url !== $grow_url) ? $boost_url : NULL,
-      'promote_url' => $promote_url,
+      'boost_url' => $boost_url,
       'view_url' => $canonical_absolute,
       'share' => [
         'facebook' => 'https://www.facebook.com/sharer/sharer.php?' . UrlHelper::buildQuery(['u' => $canonical_absolute]),

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -17,6 +17,42 @@
     topbar: topbar
   }, with_context = false) }}
 
+  {% if boost is not null and boost.active %}
+    <section class="mel-boost-active-banner" aria-labelledby="mel-boost-active-title">
+      <div class="mel-boost-active-banner__content">
+        <h2 id="mel-boost-active-title" class="mel-boost-active-banner__title">{{ '🚀 Boost Active'|t }}</h2>
+        <p class="mel-boost-active-banner__subtitle">{{ 'Featured across MyEventLane'|t }}</p>
+        {% if boost.days_remaining is not null %}
+          <p class="mel-boost-active-banner__remaining">
+            {% if boost.days_remaining == 1 %}
+              {{ '1 day remaining'|t }}
+            {% else %}
+              {{ '@count days remaining'|t({'@count': boost.days_remaining}) }}
+            {% endif %}
+          </p>
+        {% elseif boost.expires %}
+          <p class="mel-boost-active-banner__remaining">{{ 'Featured until @date'|t({'@date': boost.expires}) }}</p>
+        {% endif %}
+      </div>
+      {% if boost.analytics_url %}
+        <a class="mel-btn mel-btn--secondary mel-boost-active-banner__cta" href="{{ boost.analytics_url }}">{{ 'View Performance'|t }}</a>
+      {% endif %}
+      {% if boost_extension_recommendation %}
+        {% include '@myeventlane_vendor_theme/components/mel-boost-extension-card.html.twig' with {
+          recommendation: boost_extension_recommendation,
+          variant: 'studio',
+        } only %}
+      {% endif %}
+    </section>
+  {% elseif boost_extension_recommendation %}
+    <section class="mel-boost-active-banner mel-boost-active-banner--recommendation-only" aria-labelledby="mel-boost-extension-studio-title">
+      {% include '@myeventlane_vendor_theme/components/mel-boost-extension-card.html.twig' with {
+        recommendation: boost_extension_recommendation,
+        variant: 'studio',
+      } only %}
+    </section>
+  {% endif %}
+
   <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip>
     <div class="mel-event-studio-readiness-strip__summary">
       <strong data-mel-readiness-title>{{ readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t }}</strong>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -39,12 +39,17 @@
     <div class="mel-event-studio-publish-feedback__success" data-mel-publish-success hidden>
       <h2 class="mel-event-studio-publish-feedback__title" data-mel-publish-success-title></h2>
       <p class="mel-event-studio-publish-feedback__status" data-mel-publish-success-message></p>
-      <div class="mel-event-studio-publish-feedback__growth" data-mel-publish-success-growth hidden>
-        <p class="mel-event-studio-publish-feedback__growth-title" data-mel-publish-success-growth-title></p>
-        <p class="mel-event-studio-publish-feedback__growth-body" data-mel-publish-success-growth-body></p>
-        <div class="mel-event-studio-publish-feedback__actions">
-          <a class="mel-btn mel-btn--primary mel-event-studio-publish-feedback__grow" href="#" data-mel-publish-success-grow hidden>{{ 'Grow My Event'|t }}</a>
-          <a class="mel-event-studio-publish-feedback__boost-link" href="#" data-mel-publish-success-boost hidden>{{ 'Boost Event'|t }}</a>
+      <div class="mel-publish-boost-cta" data-mel-publish-success-boost-card hidden role="region" aria-labelledby="mel-publish-success-boost-title">
+        <h3 id="mel-publish-success-boost-title" class="mel-publish-boost-cta__title">{{ 'Boost your event visibility'|t }}</h3>
+        <p class="mel-publish-boost-cta__copy">{{ 'Your event is live. Help more people discover it across MyEventLane.'|t }}</p>
+        <ul class="mel-publish-boost-cta__features" aria-label="{{ 'Boost benefits'|t }}">
+          <li>{{ 'Featured discovery placement'|t }}</li>
+          <li>{{ 'Better category visibility'|t }}</li>
+          <li>{{ 'Higher search visibility'|t }}</li>
+        </ul>
+        <div class="mel-publish-boost-cta__actions">
+          <a class="mel-btn mel-btn--primary" href="#" data-mel-publish-success-boost>{{ 'Boost my event'|t }}</a>
+          <button type="button" class="mel-btn mel-btn--ghost" data-mel-publish-boost-dismiss>{{ 'Maybe later'|t }}</button>
         </div>
       </div>
       <div class="mel-event-studio-publish-feedback__row" data-mel-publish-success-view-row hidden>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -50,27 +50,10 @@
             <p class="mel-publish-celebrate__lede">{{ 'Nice work — your event is published and ready for attendees.'|t }}</p>
           </div>
           <div class="mel-publish-celebrate__actions">
-            {% if mel_publish_celebrate_grow_url %}
-              <section class="mel-publish-celebrate__growth" aria-labelledby="mel-publish-celebrate-growth-title">
-                <h3 id="mel-publish-celebrate-growth-title" class="mel-publish-celebrate__growth-title">{{ 'Ready for more attendees?'|t }}</h3>
-                <p class="mel-publish-celebrate__growth-lede">{{ 'Your event is now live. Promote it to reach more people and increase bookings.'|t }}</p>
-                <div class="mel-publish-celebrate__row mel-publish-celebrate__row--grow-primary">
-                  <a class="mel-btn mel-btn--primary" href="{{ mel_publish_celebrate_grow_url }}">{{ 'Grow My Event'|t }}</a>
-                </div>
-                {% set show_boost_secondary = mel_publish_celebrate_boost_url and mel_publish_celebrate_boost_url != mel_publish_celebrate_grow_url %}
-                {% set show_promote_secondary = mel_publish_celebrate_promote_url and mel_publish_celebrate_promote_url != mel_publish_celebrate_grow_url %}
-                {% if show_boost_secondary or show_promote_secondary %}
-                  <div class="mel-publish-celebrate__row mel-publish-celebrate__row--grow-links" role="list" aria-label="{{ 'Growth options'|t }}">
-                    {% if show_boost_secondary %}
-                      <a class="mel-publish-celebrate__growth-link" href="{{ mel_publish_celebrate_boost_url }}" role="listitem">{{ 'Boost Event'|t }}</a>
-                    {% endif %}
-                    {% if show_promote_secondary %}
-                      <a class="mel-publish-celebrate__growth-link" href="{{ mel_publish_celebrate_promote_url }}" role="listitem">{{ 'Promote Event'|t }}</a>
-                    {% endif %}
-                  </div>
-                {% endif %}
-              </section>
-            {% endif %}
+            {{ include('@myeventlane_event_studio/mel-publish-boost-cta.html.twig', {
+              boost_url: mel_publish_celebrate_boost_url,
+              dismiss_button: true
+            }, with_context = false) }}
             <div class="mel-publish-celebrate__row mel-publish-celebrate__row--split mel-publish-celebrate__row--view">
               <a class="mel-btn mel-btn--secondary" href="{{ mel_publish_celebrate_share_url_absolute }}" target="_blank" rel="noopener noreferrer">{{ 'View event'|t }}</a>
               <button

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-publish-boost-cta.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-publish-boost-cta.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Publish-success Boost conversion CTA (Phase 11A).
+ *
+ * Variables:
+ * - boost_url: Vendor Boost purchase URL (card hidden when empty).
+ * - dismiss_button: When TRUE, "Maybe later" dismisses via JS (default TRUE).
+ */
+#}
+{% if boost_url %}
+  <article
+    class="mel-publish-boost-cta"
+    data-mel-publish-boost-cta
+    role="region"
+    aria-labelledby="mel-publish-boost-cta-title"
+  >
+    <h3 id="mel-publish-boost-cta-title" class="mel-publish-boost-cta__title">{{ 'Boost your event visibility'|t }}</h3>
+    <p class="mel-publish-boost-cta__copy">{{ 'Your event is live. Help more people discover it across MyEventLane.'|t }}</p>
+    <ul class="mel-publish-boost-cta__features" aria-label="{{ 'Boost benefits'|t }}">
+      <li>{{ 'Featured discovery placement'|t }}</li>
+      <li>{{ 'Better category visibility'|t }}</li>
+      <li>{{ 'Higher search visibility'|t }}</li>
+    </ul>
+    <div class="mel-publish-boost-cta__actions">
+      <a class="mel-btn mel-btn--primary" href="{{ boost_url }}" data-mel-publish-boost-primary>{{ 'Boost my event'|t }}</a>
+      {% if dismiss_button|default(true) %}
+        <button type="button" class="mel-btn mel-btn--ghost" data-mel-publish-boost-dismiss>{{ 'Maybe later'|t }}</button>
+      {% endif %}
+    </div>
+  </article>
+{% endif %}

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -193,6 +193,8 @@ services:
     arguments:
       - '@myeventlane_boost.manager'
       - '@entity_type.manager'
+      - '@date.formatter'
+      - '@datetime.time'
 
   myeventlane_vendor.service.metrics_aggregator:
     class: Drupal\myeventlane_vendor\Service\MetricsAggregator
@@ -255,6 +257,8 @@ services:
       - '@logger.factory'
       - '@myeventlane_vendor.vendor_event_removal'
       - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_vendor.service.boost_status'
+      - '@myeventlane_boost.extension_recommendation'
 
   myeventlane_vendor.dashboard_view_model_builder:
     class: Drupal\myeventlane_vendor\Service\VendorDashboardViewModelBuilder
@@ -277,6 +281,7 @@ services:
       - '@myeventlane_vendor.vendor_event_removal'
       - '@myeventlane_surface.state_readiness_helper'
       - '@myeventlane_surface.data_presentation_manager'
+      - '@myeventlane_vendor.service.boost_status'
       - '@myeventlane_core.domain_detector'
 
   myeventlane_vendor.service.event_tabs:
@@ -460,6 +465,7 @@ services:
       - '@?myeventlane_boost.performance_level'
       - '@?myeventlane_boost.action_engine'
       - '@?myeventlane_boost.benchmark'
+      - '@?myeventlane_boost.extension_recommendation'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -456,6 +456,10 @@ services:
       - '@myeventlane_event_studio.commerce_sales_summary_builder'
       - '@myeventlane_commerce.event_operational_extras_sales_summary_builder'
       - '@?myeventlane_boost.decision_support'
+      - '@?myeventlane_boost.trend_intelligence'
+      - '@?myeventlane_boost.performance_level'
+      - '@?myeventlane_boost.action_engine'
+      - '@?myeventlane_boost.benchmark'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -21,6 +21,7 @@ use Drupal\node\NodeInterface;
 use Drupal\myeventlane_boost\Service\BoostActionEngineService;
 use Drupal\myeventlane_boost\Service\BoostBenchmarkService;
 use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
 use Drupal\myeventlane_boost\Service\BoostPerformanceLevelService;
 use Drupal\myeventlane_boost\Service\BoostTrendIntelligenceService;
 use Drupal\myeventlane_core\Service\DomainDetector;
@@ -58,6 +59,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     private readonly ?BoostPerformanceLevelService $boostPerformanceLevel = NULL,
     private readonly ?BoostActionEngineService $boostActionEngine = NULL,
     private readonly ?BoostBenchmarkService $boostBenchmark = NULL,
+    private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
   }
@@ -373,6 +375,8 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
 
     $has_boost_metrics = $boost_performance_section['show_metrics'];
 
+    $boost_extension_recommendation = $this->boostExtensionRecommendation?->getRecommendation($event);
+
     return $this->buildVendorPage('mel_event_workspace', [
       'event' => $event,
       'tabs' => $tabs,
@@ -407,6 +411,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#boost_performance_section' => $boost_performance_section,
         '#boost_decision_support' => $boost_decision_support,
         '#boost_performance_level' => $boost_performance_level,
+        '#boost_extension_recommendation' => $boost_extension_recommendation,
         '#boost_action_engine' => $boost_action_engine,
         '#boost_trend_intelligence' => $boost_trend_intelligence,
         '#placement_performance_section' => $placement_performance_section,
@@ -425,6 +430,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       '#attached' => [
         'library' => [
           'myeventlane_vendor_theme/analytics',
+          'myeventlane_boost/boost_visibility',
         ],
         'drupalSettings' => [
           'vendorCharts' => $chart_data,

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAnalyticsController.php
@@ -18,7 +18,11 @@ use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
 use Drupal\myeventlane_event_studio\Service\EventStudioCommerceSalesSummaryBuilder;
 use Drupal\myeventlane_pro\Service\ProActiveResolver;
 use Drupal\node\NodeInterface;
+use Drupal\myeventlane_boost\Service\BoostActionEngineService;
+use Drupal\myeventlane_boost\Service\BoostBenchmarkService;
 use Drupal\myeventlane_boost\Service\BoostDecisionSupportService;
+use Drupal\myeventlane_boost\Service\BoostPerformanceLevelService;
+use Drupal\myeventlane_boost\Service\BoostTrendIntelligenceService;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_vendor\Service\MetricsAggregator;
 use Drupal\myeventlane_vendor\Service\VendorEventTabsService;
@@ -50,6 +54,10 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     private readonly ?EventStudioCommerceSalesSummaryBuilder $commerceSalesSummaryBuilder = NULL,
     private readonly ?EventOperationalExtrasSalesSummaryBuilder $extrasSalesSummaryBuilder = NULL,
     private readonly ?BoostDecisionSupportService $boostDecisionSupport = NULL,
+    private readonly ?BoostTrendIntelligenceService $boostTrendIntelligence = NULL,
+    private readonly ?BoostPerformanceLevelService $boostPerformanceLevel = NULL,
+    private readonly ?BoostActionEngineService $boostActionEngine = NULL,
+    private readonly ?BoostBenchmarkService $boostBenchmark = NULL,
   ) {
     parent::__construct($domain_detector, $current_user, $messenger);
   }
@@ -297,6 +305,38 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       $boost_page_url,
     );
 
+    $boost_trend_intelligence = $this->buildBoostTrendIntelligenceSection(
+      $boost_metrics,
+      $is_tickets_enabled,
+      $is_rsvp_enabled,
+    );
+
+    $benchmark_ready = $this->isBoostBenchmarkReady();
+
+    $boost_performance_level = $this->buildBoostPerformanceLevelSection(
+      $boost_decision_support,
+      $boost_trend_intelligence,
+      $benchmark_ready,
+    );
+
+    $boost_action_engine = $this->buildBoostActionEngineSection(
+      $boost_metrics,
+      $boost,
+      $is_tickets_enabled,
+      $is_rsvp_enabled,
+      $placement_performance_section,
+      $edit_event_url,
+      $boost_page_url,
+      $public_event_url,
+    );
+
+    if ($boost_trend_intelligence['show'] && $boost_trend_intelligence['has_chart']) {
+      $miniChart = $this->buildBoostTrendMiniChart($boost_metrics['chart_data'] ?? NULL);
+      if ($miniChart !== NULL) {
+        $chart_data['boost-trend-ctr'] = $miniChart;
+      }
+    }
+
     if ($placement_performance_section['show'] && $placement_performance_section['cards'] !== []) {
       $chart_data['boost-placement-impressions'] = [
         'type' => 'bar',
@@ -329,7 +369,6 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
       $capacity_pct,
       $public_event_url,
       $ticketRows,
-      $boost_decision_support,
     );
 
     $has_boost_metrics = $boost_performance_section['show_metrics'];
@@ -367,6 +406,9 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#recommendations' => $recommendations,
         '#boost_performance_section' => $boost_performance_section,
         '#boost_decision_support' => $boost_decision_support,
+        '#boost_performance_level' => $boost_performance_level,
+        '#boost_action_engine' => $boost_action_engine,
+        '#boost_trend_intelligence' => $boost_trend_intelligence,
         '#placement_performance_section' => $placement_performance_section,
         '#has_all_sales_trend_chart' => isset($chart_data['event-sales']) && array_sum(array_column($sales_series, 'amount')) > 0,
         '#has_ticket_mix_chart' => isset($chart_data['event-ticket-mix']),
@@ -375,6 +417,7 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
         '#has_revenue_breakdown_chart' => isset($chart_data['event-revenue-breakdown']),
         '#has_boost_metrics' => $has_boost_metrics,
         '#has_boost_trend_chart' => isset($chart_data['boost-impressions-clicks']),
+        '#has_boost_trend_mini_chart' => isset($chart_data['boost-trend-ctr']),
         '#has_placement_impressions_chart' => isset($chart_data['boost-placement-impressions']),
         '#is_tickets_enabled' => $is_tickets_enabled,
         '#is_rsvp_enabled' => $is_rsvp_enabled,
@@ -1422,6 +1465,178 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
   }
 
   /**
+   * Boost trend intelligence section (Phase 8).
+   *
+   * @param array<string, mixed> $boost_metrics
+   *
+   * @return array<string, mixed>
+   */
+  private function buildBoostTrendIntelligenceSection(
+    array $boost_metrics,
+    bool $isTickets,
+    bool $isRsvp,
+  ): array {
+    if (!$this->boostTrendIntelligence) {
+      return [
+        'show' => FALSE,
+        'status' => 'insufficient_data',
+        'status_label' => '',
+        'status_badge' => 'muted',
+        'confidence' => ['level' => 'low', 'label' => '', 'badge' => 'muted'],
+        'momentum' => 0,
+        'momentum_label' => '',
+        'summary' => '',
+        'metrics' => [],
+        'has_chart' => FALSE,
+      ];
+    }
+
+    return $this->boostTrendIntelligence->analyze($boost_metrics, $isTickets, $isRsvp);
+  }
+
+  /**
+   * Performance level card (Phase 9).
+   *
+   * @param array<string, mixed> $decisionSupport
+   * @param array<string, mixed> $trendIntelligence
+   *
+   * @return array<string, mixed>
+   */
+  private function buildBoostPerformanceLevelSection(
+    array $decisionSupport,
+    array $trendIntelligence,
+    bool $benchmarkReady,
+  ): array {
+    if (!$this->boostPerformanceLevel) {
+      return [
+        'show' => FALSE,
+        'level' => '',
+        'label' => '',
+        'description' => '',
+        'badge' => 'muted',
+      ];
+    }
+
+    return $this->boostPerformanceLevel->build($decisionSupport, $trendIntelligence, $benchmarkReady);
+  }
+
+  /**
+   * Prioritised Boost actions with CTAs (Phase 10).
+   *
+   * @param array<string, mixed> $boost_metrics
+   * @param array<string, mixed> $boost
+   * @param array{
+   *   show: bool,
+   *   cards: list<array<string, mixed>>,
+   * } $placement_performance_section
+   *
+   * @return array<string, mixed>
+   */
+  private function buildBoostActionEngineSection(
+    array $boost_metrics,
+    array $boost,
+    bool $isTickets,
+    bool $isRsvp,
+    array $placement_performance_section,
+    ?string $edit_event_url,
+    ?string $boost_page_url,
+    ?string $public_event_url,
+  ): array {
+    if (!$this->boostActionEngine) {
+      return [
+        'show' => FALSE,
+        'actions' => [],
+      ];
+    }
+
+    return $this->boostActionEngine->build(
+      $boost_metrics,
+      $boost,
+      $isTickets,
+      $isRsvp,
+      $placement_performance_section,
+      $edit_event_url,
+      $boost_page_url,
+      $public_event_url,
+    );
+  }
+
+  /**
+   * Whether platform Boost benchmarks are ready (internal gate only).
+   */
+  private function isBoostBenchmarkReady(): bool {
+    if (!$this->boostBenchmark) {
+      return FALSE;
+    }
+
+    try {
+      $benchmark = $this->boostBenchmark->getGlobalBenchmark();
+      return !empty($benchmark['ready']);
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_vendor')->warning('Boost benchmark readiness check failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
+  }
+
+  /**
+   * Compact daily CTR line chart for trend intelligence (existing Chart.js infra).
+   *
+   * @param array<string, mixed>|null $chartData
+   *
+   * @return array<string, mixed>|null
+   */
+  private function buildBoostTrendMiniChart(?array $chartData): ?array {
+    if (!is_array($chartData)) {
+      return NULL;
+    }
+
+    $series = is_array($chartData['impressions_vs_clicks'] ?? NULL)
+      ? $chartData['impressions_vs_clicks']
+      : NULL;
+    if ($series === NULL) {
+      return NULL;
+    }
+
+    $labels = is_array($series['labels'] ?? NULL) ? $series['labels'] : [];
+    $impressions = is_array($series['impressions'] ?? NULL) ? $series['impressions'] : [];
+    $clicks = is_array($series['clicks'] ?? NULL) ? $series['clicks'] : [];
+    if (count($labels) < 3 || count($impressions) < 3 || count($clicks) < 3) {
+      return NULL;
+    }
+
+    $ctrData = [];
+    $count = min(count($labels), count($impressions), count($clicks));
+    for ($i = 0; $i < $count; $i++) {
+      $impression = (int) $impressions[$i];
+      $click = (int) $clicks[$i];
+      $ctrData[] = $impression > 0 ? round(100.0 * $click / $impression, 2) : 0.0;
+    }
+
+    return [
+      'type' => 'line',
+      'labels' => array_slice($labels, 0, $count),
+      'datasets' => [
+        [
+          'label' => (string) $this->t('CTR %'),
+          'data' => $ctrData,
+          'borderColor' => '#10b981',
+          'backgroundColor' => 'rgba(16, 185, 129, 0.12)',
+        ],
+      ],
+      'options' => [
+        'plugins' => [
+          'legend' => [
+            'display' => FALSE,
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
    * Boost decision support section (Stage 3).
    *
    * @param array<string, mixed> $boost_metrics
@@ -1464,13 +1679,11 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
   /**
    * Rules-based next-step recommendations (max 3).
    *
-   * Boost-specific recommendations come from BoostDecisionSupportService.
-   * Operational fallbacks fill remaining slots when fewer than three Boost recs exist.
+   * Operational fallbacks fill remaining slots (Boost actions use Action Engine).
    *
    * @param array<string, mixed> $overview
    * @param array<string, mixed> $commerce
    * @param array<string, mixed> $boost
-   * @param array<string, mixed> $boost_decision_support
    *
    * @return list<string>
    */
@@ -1484,11 +1697,8 @@ final class VendorEventAnalyticsController extends VendorConsoleBaseController {
     ?float $capacity_pct,
     ?string $public_event_url,
     array $ticketRows,
-    array $boost_decision_support = [],
   ): array {
-    $recs = is_array($boost_decision_support['recommendations'] ?? NULL)
-      ? $boost_decision_support['recommendations']
-      : [];
+    $recs = [];
 
     if (count($recs) < 3 && $isTickets) {
       $best_ticket = $this->findBestSellingTicketFromTiers($ticketRows);

--- a/web/modules/custom/myeventlane_vendor/src/Service/BoostStatusService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/BoostStatusService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_boost\BoostManager;
 use Drupal\node\NodeInterface;
@@ -19,6 +21,8 @@ final class BoostStatusService {
   public function __construct(
     private readonly BoostManager $boostManager,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly DateFormatterInterface $dateFormatter,
+    private readonly TimeInterface $time,
   ) {}
 
   /**
@@ -64,33 +68,7 @@ final class BoostStatusService {
         ];
       }
 
-      // Check if event is published (required for boost).
-      $isPublished = $event->isPublished();
-      if (!$isPublished) {
-        return [
-          'eligible' => FALSE,
-          'active' => FALSE,
-          'reason' => 'unpublished',
-          'types' => [],
-          'expires' => NULL,
-        ];
-      }
-
-      // Use canonical API to get boost status.
-      $boostStatus = $this->boostManager->getBoostStatusForEvent($event);
-
-      // Event is eligible if published.
-      // Additional eligibility checks (e.g., Stripe connection) should be
-      // handled at the route access level.
-      return [
-        'eligible' => TRUE,
-        'active' => $boostStatus['active'],
-        'reason' => NULL,
-        'types' => $this->getAvailableBoostTypes(),
-        'expires' => $boostStatus['end_timestamp']
-          ? date('Y-m-d\TH:i:s', $boostStatus['end_timestamp'])
-          : NULL,
-      ];
+      return $this->getBoostStatusesForEvent($event);
     }
     catch (\Exception $e) {
       // Return safe defaults on error.
@@ -101,6 +79,80 @@ final class BoostStatusService {
         'types' => [],
         'expires' => NULL,
       ];
+    }
+  }
+
+  /**
+   * Gets boost statuses for a loaded event node (avoids redundant entity load).
+   *
+   * @return array{
+   *   eligible: bool,
+   *   active: bool,
+   *   reason: string|null,
+   *   types: list<string>,
+   *   expires: string|null,
+   * }
+   */
+  public function getBoostStatusesForEvent(NodeInterface $event): array {
+    if ($event->bundle() !== 'event') {
+      return [
+        'eligible' => FALSE,
+        'active' => FALSE,
+        'reason' => 'invalid_event',
+        'types' => [],
+        'expires' => NULL,
+      ];
+    }
+
+    // Check if event is published (required for boost).
+    $isPublished = $event->isPublished();
+    if (!$isPublished) {
+      return [
+        'eligible' => FALSE,
+        'active' => FALSE,
+        'reason' => 'unpublished',
+        'types' => [],
+        'expires' => NULL,
+      ];
+    }
+
+    // Use canonical API to get boost status.
+    $boostStatus = $this->boostManager->getBoostStatusForEvent($event);
+
+    // Event is eligible if published.
+    // Additional eligibility checks (e.g., Stripe connection) should be
+    // handled at the route access level.
+    return [
+      'eligible' => TRUE,
+      'active' => $boostStatus['active'],
+      'reason' => NULL,
+      'types' => $this->getAvailableBoostTypes(),
+      'expires' => $boostStatus['end_timestamp']
+        ? date('Y-m-d\TH:i:s', $boostStatus['end_timestamp'])
+        : NULL,
+    ];
+  }
+
+  /**
+   * Builds vendor-facing boost visibility payload for Twig / view models.
+   *
+   * @return array{
+   *   active: bool,
+   *   expires: string|null,
+   *   days_remaining: int|null,
+   * }
+   */
+  public function getVisibilityPayload(NodeInterface $event): array {
+    if ($event->bundle() !== 'event') {
+      return $this->emptyVisibilityPayload();
+    }
+
+    try {
+      $boostStatus = $this->boostManager->getBoostStatusForEvent($event);
+      return $this->formatVisibilityPayload($boostStatus);
+    }
+    catch (\Exception) {
+      return $this->emptyVisibilityPayload();
     }
   }
 
@@ -116,6 +168,49 @@ final class BoostStatusService {
       'featured',
       'homepage',
       'category',
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $boostStatus
+   *
+   * @return array{
+   *   active: bool,
+   *   expires: string|null,
+   *   days_remaining: int|null,
+   * }
+   */
+  private function formatVisibilityPayload(array $boostStatus): array {
+    $active = !empty($boostStatus['active']);
+    $endTimestamp = $boostStatus['end_timestamp'] ?? NULL;
+
+    if (!$active || $endTimestamp === NULL) {
+      return $this->emptyVisibilityPayload();
+    }
+
+    $now = (int) $this->time->getRequestTime();
+    $secondsRemaining = max(0, (int) $endTimestamp - $now);
+    $daysRemaining = max(1, (int) ceil($secondsRemaining / 86400));
+
+    return [
+      'active' => TRUE,
+      'expires' => $this->dateFormatter->format((int) $endTimestamp, 'custom', 'j M'),
+      'days_remaining' => $daysRemaining,
+    ];
+  }
+
+  /**
+   * @return array{
+   *   active: bool,
+   *   expires: string|null,
+   *   days_remaining: int|null,
+   * }
+   */
+  private function emptyVisibilityPayload(): array {
+    return [
+      'active' => FALSE,
+      'expires' => NULL,
+      'days_remaining' => NULL,
     ];
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -56,6 +56,7 @@ final class VendorDashboardViewModelBuilder {
     private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly MelReadinessHelper $readinessHelper,
     private readonly MelDataPresentationManager $dataPresentationManager,
+    private readonly BoostStatusService $boostStatusService,
     private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $string_translation;
@@ -579,9 +580,7 @@ final class VendorDashboardViewModelBuilder {
 
     $presentation = $this->presentationAlerts->buildChipSummary($node, $hasProduct, $eventType);
     $presentationIssues = is_array($presentation['items'] ?? NULL) ? $presentation['items'] : [];
-    $isPromoted = $node->hasField('field_promoted')
-      && !$node->get('field_promoted')->isEmpty()
-      && (bool) $node->get('field_promoted')->value;
+    $boost = $this->boostStatusService->getVisibilityPayload($node);
 
     $capacity = (int) ($domain['capacity'] ?? 0);
     $capacityLabel = $capacity > 0
@@ -639,7 +638,8 @@ final class VendorDashboardViewModelBuilder {
       'presentation_issues' => $presentationIssues,
       'attention_reasons' => $this->buildAttentionReasons($status, $eventType, $startTs, $endTs, $presentationIssues),
       'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
-      'is_promoted' => $isPromoted,
+      'boost' => $boost,
+      'is_promoted' => !empty($boost['active']),
       'removal' => $this->vendorEventRemovalService->buildRemovalUiPayload($node, $account),
       'links' => [
         'manage' => $this->safeUrlFromRoute('myeventlane_vendor.console.event_workspace', ['event' => $nid]),
@@ -1118,6 +1118,7 @@ final class VendorDashboardViewModelBuilder {
         'booking_state_label' => (string) ($event['booking_state_label'] ?? ''),
         'metric_label' => (string) ($event['metric_label'] ?? ''),
         'reasons' => array_values($reasons),
+        'boost' => is_array($event['boost'] ?? NULL) ? $event['boost'] : ['active' => FALSE],
         'links' => is_array($event['links'] ?? NULL) ? $event['links'] : [],
       ];
       if (count($rows) >= 6) {
@@ -1149,6 +1150,7 @@ final class VendorDashboardViewModelBuilder {
         'status_label' => (string) ($event['status_label'] ?? ''),
         'booking_state_label' => (string) ($event['booking_state_label'] ?? ''),
         'metric_label' => (string) ($event['metric_label'] ?? ''),
+        'boost' => is_array($event['boost'] ?? NULL) ? $event['boost'] : ['active' => FALSE],
         'links' => is_array($event['links'] ?? NULL) ? $event['links'] : [],
       ];
       if (count($rows) >= 4) {

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
@@ -14,6 +14,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\Component\Datetime\TimeInterface;
@@ -47,6 +48,8 @@ final class VendorEventIndexViewModelBuilder {
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly MelReadinessHelper $readinessHelper,
+    private readonly BoostStatusService $boostStatusService,
+    private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
@@ -270,9 +273,8 @@ final class VendorEventIndexViewModelBuilder {
 
     $attentionLabel = $this->buildAttentionLabel($status, $eventType, $titleEmpty, $missingDate, $presentationItems);
 
-    $isBoosted = $node->hasField('field_promoted')
-      && !$node->get('field_promoted')->isEmpty()
-      && (bool) $node->get('field_promoted')->value;
+    $boost = $this->boostStatusService->getVisibilityPayload($node);
+    $boostExtensionRecommendation = $this->boostExtensionRecommendation?->getRecommendation($node);
 
     return [
       'nid' => $nid,
@@ -291,6 +293,8 @@ final class VendorEventIndexViewModelBuilder {
       'presentation_issues' => $presentationItems,
       'image' => $this->vendorEventRemovalService->buildEventThumbnailData($node),
       'removal' => $this->vendorEventRemovalService->buildRemovalUiPayload($node, $account),
+      'boost' => $boost,
+      'boost_extension_recommendation' => $boostExtensionRecommendation,
       'links' => [
         'manage' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_workspace', ['event' => $nid], $account),
         'edit' => $this->routeUrlIfAccessible('myeventlane_event_studio.edit', ['node' => $nid], $account),
@@ -300,7 +304,6 @@ final class VendorEventIndexViewModelBuilder {
         'attendees' => $this->routeUrlIfAccessible('myeventlane_event_attendees.vendor_list', ['node' => $nid], $account),
         'analytics' => $this->routeUrlIfAccessible('myeventlane_vendor.console.event_analytics', ['event' => $nid], $account),
       ],
-      '_is_boosted' => $isBoosted,
       '_changed' => $node->getChangedTime(),
       '_start_ts' => $startTs,
     ];
@@ -482,7 +485,7 @@ final class VendorEventIndexViewModelBuilder {
       'needs_attention' => !empty($row['needs_attention']),
       'rsvp' => in_array(($row['event_type'] ?? ''), ['rsvp', 'both'], TRUE),
       'paid' => in_array(($row['event_type'] ?? ''), ['paid', 'both'], TRUE),
-      'boosted' => $boostFieldExists && !empty($row['_is_boosted']),
+      'boosted' => !empty($row['boost']['active']),
       default => FALSE,
     };
   }
@@ -520,7 +523,7 @@ final class VendorEventIndexViewModelBuilder {
    * @return array<string, mixed>
    */
   private function stripInternalsRow(array $row): array {
-    unset($row['_is_boosted'], $row['_changed'], $row['_start_ts']);
+    unset($row['_changed'], $row['_start_ts']);
     return $row;
   }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_boost.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_boost.scss
@@ -1,131 +1,16 @@
 // ==========================================================================
-// Boost purchase page (module: boost-event-page.html.twig + BoostSelectForm)
+// Boost purchase page — workspace overrides (base styles in module boost.css)
 // ==========================================================================
 
 @use '../tokens/colors';
-@use '../tokens/radii';
-@use '../tokens/typography';
+@use '../tokens/breakpoints';
 
-.mel-boost-hero {
-  margin-bottom: 24px;
-
-  h1 {
-    font-size: 28px;
-    font-weight: 700;
-  }
-
-  p {
-    color: colors.$mel-color-text-muted;
-  }
+.mel-boost-page {
+  max-width: 100%;
 }
 
-.mel-boost-hero__performance {
-  margin-top: 12px;
+// Vendor workspace content area: ensure full-width layout.
+.mel-workspace__content .mel-boost-page {
+  width: 100%;
+  min-width: 0;
 }
-
-.mel-boost-hero__perf-title {
-  font-weight: 600;
-  color: colors.$mel-color-text;
-  margin: 0 0 4px;
-}
-
-.mel-boost-hero__perf-intro {
-  margin: 0;
-  color: colors.$mel-color-text-muted;
-}
-
-.mel-boost-hero__fallback {
-  margin-top: 8px;
-  color: colors.$mel-color-text-muted;
-}
-
-.mel-boost-benefits {
-  background: colors.$mel-color-surface-alt;
-  padding: 16px;
-  border-radius: radii.$mel-radius-md;
-  margin-bottom: 20px;
-
-  h3 {
-    margin: 0;
-    font-size: typography.mel-font-size(lg);
-    font-weight: 600;
-  }
-
-  &__intro {
-    margin: 8px 0 0;
-    color: colors.$mel-color-text-muted;
-    line-height: 1.5;
-  }
-
-  &__list {
-    margin-top: 8px;
-    padding-left: 1.25rem;
-
-    li {
-      margin-bottom: 6px;
-      color: colors.$mel-color-text;
-    }
-  }
-}
-
-.mel-boost-audience {
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 1px solid colors.$mel-color-border;
-
-  &__title {
-    margin: 0;
-    font-size: typography.mel-font-size(base);
-    font-weight: 600;
-    color: colors.$mel-color-text;
-  }
-
-  &__list {
-    margin: 8px 0 0;
-    padding-left: 1.25rem;
-
-    li {
-      margin-bottom: 4px;
-      color: colors.$mel-color-text-muted;
-    }
-  }
-}
-
-.mel-boost-pricing-wrap {
-  margin-top: 0;
-}
-
-.mel-boost-badge {
-  background: colors.$mel-color-accent;
-  color: colors.$mel-color-text-inverse;
-  padding: 4px 10px;
-  border-radius: radii.$mel-radius-pill;
-  font-size: 12px;
-  margin-left: 8px;
-  white-space: nowrap;
-  vertical-align: middle;
-}
-
-.mel-boost-option-content {
-  .mel-boost-option-desc {
-    display: block;
-    font-size: 13px;
-    color: colors.$mel-color-text-muted;
-    margin-top: 4px;
-  }
-}
-
-.mel-boost-micro {
-  font-size: 12px;
-  color: colors.$mel-color-text-muted;
-  margin-top: 8px;
-  margin-bottom: 0;
-}
-
-// Stack primary action + micro copy (cancel stays in page footer row).
-.myeventlane-boost-select-form .boost-footer {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0;
-}
-

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1372,6 +1372,7 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'boost_performance_section' => [],
         'boost_decision_support' => [],
         'boost_performance_level' => [],
+        'boost_extension_recommendation' => NULL,
         'boost_action_engine' => [],
         'boost_trend_intelligence' => [],
         'placement_performance_section' => [],

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_boost-extension-card.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_boost-extension-card.scss
@@ -1,0 +1,131 @@
+/**
+ * @file
+ * Boost extension / restart recommendation card (Phase 11C).
+ */
+
+@use '../tokens/colors' as c;
+@use '../tokens/radii' as r;
+@use '../tokens/spacing' as sp;
+
+$mel-coral: #f26d5b;
+$mel-coral-hover: #e55c49;
+$mel-lavender-soft: #e8eaff;
+$mel-lavender-border: rgba(124, 131, 253, 0.35);
+
+.mel-boost-extension-card {
+  font-family: 'Nunito', sans-serif;
+  color: c.$ml-vendor-text-dark;
+}
+
+.mel-boost-extension-card--card,
+.mel-boost-extension-card--studio {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: sp.$spacing-4;
+  padding: sp.$spacing-4 sp.$spacing-5;
+  border: 1px solid $mel-lavender-border;
+  border-radius: 16px;
+  background: $mel-lavender-soft;
+}
+
+.mel-boost-extension-card--studio {
+  width: 100%;
+  margin-top: sp.$spacing-3;
+  padding-top: sp.$spacing-4;
+  border-top: 1px solid $mel-lavender-border;
+  border-radius: 0 0 16px 16px;
+  background: rgba(232, 234, 255, 0.65);
+}
+
+.mel-boost-active-banner--recommendation-only {
+  background: $mel-lavender-soft;
+  border-color: $mel-lavender-border;
+}
+
+.mel-boost-extension-card--card {
+  margin-bottom: sp.$spacing-5;
+}
+
+.mel-boost-extension-card__content {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.mel-boost-extension-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.mel-boost-extension-card__body {
+  margin: sp.$spacing-2 0 0;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  color: c.$ml-vendor-slate;
+}
+
+.mel-boost-extension-card__cta {
+  min-height: 44px;
+  min-width: 44px;
+  padding-inline: sp.$spacing-5;
+  border-radius: 16px;
+  background: $mel-coral;
+  border-color: $mel-coral;
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover,
+  &:focus-visible {
+    background: $mel-coral-hover;
+    border-color: $mel-coral-hover;
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.mel-boost-extension-card--compact {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: sp.$spacing-2 sp.$spacing-3;
+  margin-top: sp.$spacing-2;
+  max-width: 100%;
+}
+
+.mel-boost-extension-card__compact-text {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: c.$ml-vendor-text-dark;
+}
+
+.mel-boost-extension-card--compact .mel-boost-extension-card__cta {
+  min-height: 44px;
+  padding: 0 sp.$spacing-4;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 640px) {
+  .mel-boost-extension-card--card,
+  .mel-boost-extension-card--studio {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mel-boost-extension-card__cta {
+    width: 100%;
+  }
+
+  .mel-boost-extension-card--compact {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -70,6 +70,7 @@
   @include meta.load-css('components/auth');
   @include meta.load-css('components/vendor-order-view');
   @include meta.load-css('components/boost-metrics');
+  @include meta.load-css('components/boost-extension-card');
   @include meta.load-css('components/mel-event-settings');
   @include meta.load-css('components/mel-event-overview');
   @include meta.load-css('components/insights');

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -14,6 +14,8 @@
 @use '../tokens/shadows' as *;
 @use '../tokens/typography' as *;
 
+$mel-dash-lavender: #7c83fd;
+
 .mel-vendor-dashboard {
   .mel-live-ops__split {
     margin-top: 0;
@@ -272,6 +274,62 @@
     border-radius: $radius-lg;
     background: $bg-primary;
     scroll-snap-align: start;
+  }
+
+  &__attention-card--boosted,
+  &__upcoming-card--boosted,
+  &__event-row--boosted {
+    border-color: rgba(245, 192, 76, 0.55);
+    box-shadow:
+      0 0 0 1px rgba(245, 192, 76, 0.18),
+      0 4px 16px rgba(245, 192, 76, 0.1);
+  }
+
+  &__boost-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 0 $spacing-2;
+    border-radius: 999px;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-bold;
+    border: 1px solid rgba(245, 192, 76, 0.65);
+    background: rgba(245, 192, 76, 0.22);
+    color: $text-primary;
+  }
+
+  &__boost-badge--inline {
+    min-height: 24px;
+    padding: 0 $spacing-2;
+  }
+
+  &__boost-expiry {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-normal;
+  }
+
+  &__boost-performance {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-bold;
+    color: $mel-dash-lavender;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:hover {
+      color: $ml-vendor-navy;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $mel-dash-lavender;
+      outline-offset: 2px;
+      border-radius: $radius-sm;
+    }
   }
 
   &__upcoming-title {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_vendor-events.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_vendor-events.scss
@@ -229,6 +229,55 @@ $mel-focus: #7c83fd;
   gap: sp.$spacing-3;
 }
 
+.mel-vendor-events-v2__card--boosted {
+  border-color: rgba(245, 192, 76, 0.55);
+  box-shadow:
+    0 0 0 1px rgba(245, 192, 76, 0.2),
+    0 4px 18px rgba(245, 192, 76, 0.12);
+}
+
+.mel-vendor-events-v2__boost-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 sp.$spacing-3;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  border: 1px solid rgba(245, 192, 76, 0.65);
+  background: rgba(245, 192, 76, 0.22);
+  color: c.$ml-vendor-text-dark;
+}
+
+.mel-vendor-events-v2__boost-meta {
+  margin: calc(-1 * sp.$spacing-2) 0 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: c.$ml-vendor-slate;
+  line-height: 1.4;
+}
+
+.mel-vendor-events-v2__boost-performance {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: $mel-lavender-strong;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+
+  &:hover {
+    color: c.$ml-vendor-navy;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $mel-focus;
+    outline-offset: 2px;
+    border-radius: r.$radius-sm;
+  }
+}
+
 .mel-vendor-events-v2__card-top {
   display: flex;
   gap: sp.$spacing-4;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-boost-extension-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-boost-extension-card.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Contextual Boost extension / restart recommendation (Phase 11C).
+ *
+ * Variables:
+ * - recommendation: payload from BoostExtensionRecommendationService
+ * - variant: compact|card|studio (default card)
+ * - boost: optional visibility payload for compact expiry copy
+ */
+#}
+{% set rec = recommendation|default(null) %}
+{% if rec and rec.cta_url|default('') %}
+  {% set variant = variant|default('card') %}
+  {% set boost = boost|default({}) %}
+  {% if variant == 'compact' %}
+    <div class="mel-boost-extension-card mel-boost-extension-card--compact">
+      <p class="mel-boost-extension-card__compact-text">
+        {% if rec.type == 'extend' and boost.days_remaining is not null %}
+          {{ '🚀 Boost ends in @count days'|t({'@count': boost.days_remaining}) }}
+        {% else %}
+          {{ rec.title }}
+        {% endif %}
+      </p>
+      <a
+        class="mel-btn mel-btn--primary mel-boost-extension-card__cta"
+        href="{{ rec.cta_url }}"
+        aria-label="{{ rec.cta_label }} — {{ rec.title }}"
+      >{{ rec.cta_label }}</a>
+    </div>
+  {% elseif variant == 'studio' %}
+    <div class="mel-boost-extension-card mel-boost-extension-card--studio">
+      <div class="mel-boost-extension-card__content">
+        <h3 class="mel-boost-extension-card__title">{{ rec.title }}</h3>
+        {% if rec.body %}
+          <p class="mel-boost-extension-card__body">{{ rec.body }}</p>
+        {% endif %}
+      </div>
+      <a
+        class="mel-btn mel-btn--primary mel-boost-extension-card__cta"
+        href="{{ rec.cta_url }}"
+        aria-label="{{ rec.cta_label }} — {{ rec.title }}"
+      >{{ rec.cta_label }}</a>
+    </div>
+  {% else %}
+    <article class="mel-boost-extension-card mel-boost-extension-card--card" aria-labelledby="mel-boost-extension-title">
+      <div class="mel-boost-extension-card__content">
+        <h2 id="mel-boost-extension-title" class="mel-boost-extension-card__title">{{ rec.title }}</h2>
+        {% if rec.body %}
+          <p class="mel-boost-extension-card__body">{{ rec.body }}</p>
+        {% endif %}
+      </div>
+      <a
+        class="mel-btn mel-btn--primary mel-boost-extension-card__cta"
+        href="{{ rec.cta_url }}"
+        aria-label="{{ rec.cta_label }} — {{ rec.title }}"
+      >{{ rec.cta_label }}</a>
+    </article>
+  {% endif %}
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-dashboard-event-boost.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-dashboard-event-boost.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Boost expiry and performance link for vendor dashboard event cards.
+ *
+ * Variables:
+ * - boost: { active, expires, days_remaining }
+ * - links: optional link bag with analytics URL.
+ */
+#}
+{% set boost = boost|default({}) %}
+{% set links = links|default({}) %}
+{% if boost.active %}
+  {% if boost.expires or boost.days_remaining is not null %}
+    <p class="mel-vendor-dashboard__boost-expiry">
+      {% if boost.expires %}
+        {{ 'Featured until @date'|t({'@date': boost.expires}) }}
+      {% elseif boost.days_remaining == 1 %}
+        {{ '1 day remaining'|t }}
+      {% else %}
+        {{ '@count days remaining'|t({'@count': boost.days_remaining}) }}
+      {% endif %}
+    </p>
+  {% endif %}
+  {% if links.analytics is defined and links.analytics %}
+    <a class="mel-vendor-dashboard__boost-performance" href="{{ links.analytics }}">{{ 'View Boost Performance →'|t }}</a>
+  {% endif %}
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -162,9 +162,10 @@
       <div class="mel-vendor-dashboard__attention-row" role="list">
         {% for ev in attention_events %}
           {% set links = ev.links|default({}) %}
+          {% set boost = ev.boost|default({}) %}
           {% set status = ev.status|default('') %}
           {% set status_chip = status == 'draft' ? 'warn' : 'lavender' %}
-          <article class="mel-vendor-dashboard__attention-card" role="listitem">
+          <article class="mel-vendor-dashboard__attention-card{% if boost.active %} mel-vendor-dashboard__attention-card--boosted{% endif %}" role="listitem">
             <div>
               <h3 class="mel-vendor-dashboard__upcoming-title">{{ ev.title|default('Untitled event'|t) }}</h3>
               {% if ev.date_label is defined and ev.date_label %}
@@ -175,10 +176,17 @@
               {% if ev.status_label is defined and ev.status_label %}
                 <span class="mel-live-ops__chip mel-live-ops__chip--{{ status_chip }}">{{ ev.status_label }}</span>
               {% endif %}
+              {% if boost.active %}
+                <span class="mel-vendor-dashboard__boost-badge mel-vendor-dashboard__boost-badge--inline">{{ '🚀 Boosted'|t }}</span>
+              {% endif %}
               {% for reason in ev.reasons|default([]) %}
                 <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ reason }}</span>
               {% endfor %}
             </div>
+            {% include '@myeventlane_vendor_theme/components/mel-dashboard-event-boost.html.twig' with {
+              boost: boost,
+              links: links,
+            } only %}
             {% if ev.booking_state_label is defined and ev.booking_state_label %}
               <p class="mel-vendor-dashboard__upcoming-meta">{{ ev.booking_state_label }}</p>
             {% endif %}
@@ -232,9 +240,10 @@
       <div class="mel-vendor-dashboard__upcoming-row" role="list">
         {% for ev in upcoming_events %}
           {% set links = ev.links|default({}) %}
+          {% set boost = ev.boost|default({}) %}
           {% set status = ev.status|default('upcoming') %}
           {% set status_chip = status == 'draft' ? 'warn' : 'lavender' %}
-          <article class="mel-vendor-dashboard__upcoming-card" role="listitem">
+          <article class="mel-vendor-dashboard__upcoming-card{% if boost.active %} mel-vendor-dashboard__upcoming-card--boosted{% endif %}" role="listitem">
             <div>
               <h3 class="mel-vendor-dashboard__upcoming-title">{{ ev.title|default('Untitled event'|t) }}</h3>
               {% if ev.date_label is defined and ev.date_label %}
@@ -245,10 +254,17 @@
               {% if ev.status_label is defined and ev.status_label %}
                 <span class="mel-live-ops__chip mel-live-ops__chip--{{ status_chip }}">{{ ev.status_label }}</span>
               {% endif %}
+              {% if boost.active %}
+                <span class="mel-vendor-dashboard__boost-badge mel-vendor-dashboard__boost-badge--inline">{{ '🚀 Boosted'|t }}</span>
+              {% endif %}
               {% if ev.booking_state_label is defined and ev.booking_state_label %}
                 <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ ev.booking_state_label }}</span>
               {% endif %}
             </div>
+            {% include '@myeventlane_vendor_theme/components/mel-dashboard-event-boost.html.twig' with {
+              boost: boost,
+              links: links,
+            } only %}
             {% if ev.metric_label is defined and ev.metric_label %}
               <p class="mel-vendor-dashboard__upcoming-meta">{{ ev.metric_label }}</p>
             {% endif %}
@@ -341,9 +357,10 @@
           <div class="mel-vendor-dashboard__event-grid">
             {% for ev in model_events|slice(0, 6) %}
               {% set links = ev.links|default({}) %}
+              {% set boost = ev.boost|default({}) %}
               {% set et = ev.event_type|default('unknown') %}
               {% set type_label = et == 'paid' ? 'Paid tickets'|t : (et == 'rsvp' ? 'RSVP'|t : (et == 'both' ? 'Tickets & RSVP'|t : 'Setup needed'|t)) %}
-              <article class="mel-live-ops__attendee-row mel-vendor-dashboard__event-row">
+              <article class="mel-live-ops__attendee-row mel-vendor-dashboard__event-row{% if boost.active %} mel-vendor-dashboard__event-row--boosted{% endif %}">
                 <div class="mel-live-ops__attendee-meta">
                   <div class="mel-live-ops__attendee-ident">
                     {% set img = ev.image|default({}) %}
@@ -368,8 +385,15 @@
                         {% if ev.status_label is defined and ev.status_label %}
                           <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ ev.status_label }}</span>
                         {% endif %}
+                        {% if boost.active %}
+                          <span class="mel-vendor-dashboard__boost-badge mel-vendor-dashboard__boost-badge--inline">{{ '🚀 Boosted'|t }}</span>
+                        {% endif %}
                         <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ type_label }}</span>
                       </div>
+                      {% include '@myeventlane_vendor_theme/components/mel-dashboard-event-boost.html.twig' with {
+                        boost: boost,
+                        links: links,
+                      } only %}
                       {% if ev.metric_label is defined and ev.metric_label %}
                         <p class="mel-live-ops__attendee-ticket">{{ ev.metric_label }}</p>
                       {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -258,6 +258,12 @@
       <h2 id="mel-analytics-boost-title" class="mel-live-ops__panel-title">{{ 'Boost performance'|t }}</h2>
       <p class="mel-live-ops__panel-intro">{{ boost_perf.intro|default('Boost puts your event in front of more people.'|t) }}</p>
     </div>
+    {% if boost_extension_recommendation %}
+      {% include '@myeventlane_vendor_theme/components/mel-boost-extension-card.html.twig' with {
+        recommendation: boost_extension_recommendation,
+        variant: 'card',
+      } only %}
+    {% endif %}
     {% include '@myeventlane_vendor_theme/components/mel-boost-performance-level.html.twig' with {
       boost_performance_level: boost_level,
     } only %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
@@ -104,8 +104,10 @@
     <div class="mel-vendor-events-v2__grid">
       {% for ev in events %}
         {% set links = ev.links|default({}) %}
+        {% set boost = ev.boost|default({}) %}
+        {% set boost_extension_recommendation = ev.boost_extension_recommendation|default(null) %}
         {% set sev = ev.status_severity|default('neutral') %}
-        <article class="mel-vendor-events-v2__card">
+        <article class="mel-vendor-events-v2__card{% if boost.active %} mel-vendor-events-v2__card--boosted{% endif %}">
           <div class="mel-vendor-events-v2__card-top">
             {% set img = ev.image|default({}) %}
             {% set img_url = img.url|default('') %}
@@ -123,6 +125,9 @@
             <div class="mel-vendor-events-v2__card-body">
               <div class="mel-vendor-events-v2__card-header">
                 <span class="mel-vendor-events-v2__status mel-vendor-events-v2__status--{{ sev|e('html_attr') }}">{{ ev.status_label|default('') }}</span>
+                {% if boost.active %}
+                  <span class="mel-vendor-events-v2__boost-badge">{{ '🚀 Boosted'|t }}</span>
+                {% endif %}
                 {% if ev.needs_attention and ev.attention_label %}
                   <span class="mel-vendor-events-v2__attention">{{ ev.attention_label }}</span>
                 {% endif %}
@@ -140,6 +145,26 @@
                 </div>
               {% endif %}
               <h2 class="mel-vendor-events-v2__card-title">{{ ev.title|default('') }}</h2>
+              {% if boost.active %}
+                <p class="mel-vendor-events-v2__boost-meta">
+                  {% if boost.expires %}
+                    {{ 'Featured until @date'|t({'@date': boost.expires}) }}
+                  {% elseif boost.days_remaining is not null %}
+                    {% if boost.days_remaining == 1 %}
+                      {{ '1 day remaining'|t }}
+                    {% else %}
+                      {{ '@count days remaining'|t({'@count': boost.days_remaining}) }}
+                    {% endif %}
+                  {% endif %}
+                </p>
+              {% endif %}
+              {% if boost_extension_recommendation %}
+                {% include '@myeventlane_vendor_theme/components/mel-boost-extension-card.html.twig' with {
+                  recommendation: boost_extension_recommendation,
+                  variant: 'compact',
+                  boost: boost,
+                } only %}
+              {% endif %}
               <div class="mel-vendor-events-v2__meta">
                 {% if ev.date_label %}
                   <span class="mel-vendor-events-v2__meta-line">{{ ev.date_label }}</span>
@@ -159,6 +184,9 @@
                   <span class="mel-vendor-events-v2__metric">{{ ev.capacity_label }}</span>
                 {% endif %}
               </div>
+              {% if boost.active and links.analytics is defined and links.analytics %}
+                <a class="mel-vendor-events-v2__boost-performance" href="{{ links.analytics }}">{{ 'View Boost Performance →'|t }}</a>
+              {% endif %}
             </div>
           </div>
           <div class="mel-vendor-events-v2__card-actions">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Commerce checkout completion redirects and order-gated success URLs (customer-facing purchase path), plus broad UI/analytics wiring across vendor and Event Studio surfaces; core entitlement logic is mostly reused and covered by new unit tests.
> 
> **Overview**
> This PR **redesigns the vendor Boost purchase experience** (plan **grid cards**, new page layout with action cards and benefits, updated copy/trust cues) and **retargets the select-form JS** from `.boost-row` to `.boost-plan-card`. The boost page controller now passes **edit URL** and renders the form body directly instead of a card/footer with Cancel.
> 
> **Boost-only Commerce checkout** is redirected from the standard complete step to a new **`/vendor/events/{event}/boost/success?order=`** page via `BoostCheckoutRedirectSubscriber` and `BoostPurchaseSuccessResolver`, with a success theme, optional auto-redirect to Event Studio, and order/customer validation.
> 
> **Organiser-facing Boost intelligence** adds trend, performance level, prioritised action, and **extension/restart recommendation** services; vendor **event analytics** exposes these (plus a mini CTR chart) and **general recommendations no longer duplicate Boost decision-support recs**. **Event Studio workspace** shows an active Boost banner, extension CTAs, and publish-celebrate handoff is simplified to a dismissible **Boost CTA** (dropping separate grow/promote links).
> 
> Shared **`boost.css`** expands styling for success, active banner, and extension cards; new Drupal libraries attach visibility/success assets where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55447285dfba0d63095f39db493ebda31721e8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->