### PR TITLE
Enhance Notification System with Context and Domain Support

### DIFF
--- a/web/modules/custom/myeventlane_messaging/config/schema/myeventlane_messaging.schema.yml
+++ b/web/modules/custom/myeventlane_messaging/config/schema/myeventlane_messaging.schema.yml
@@ -53,6 +53,12 @@ myeventlane_messaging.template.*:
   type: config_object
   label: 'Messaging template'
   mapping:
+    notification_context:
+      type: string
+      label: 'Notification context (personal, business, platform) — optional override; defaults from NotificationTaxonomy'
+    notification_domain:
+      type: string
+      label: 'Notification domain (tickets, orders, sales, etc.) — optional override'
     enabled:
       type: boolean
       label: 'Template enabled'

--- a/web/modules/custom/myeventlane_notifications/css/mel-notifications-ui.css
+++ b/web/modules/custom/myeventlane_notifications/css/mel-notifications-ui.css
@@ -407,6 +407,88 @@
   background: rgba(41, 50, 65, 0.25);
 }
 
+.mel-notif-inbox__accent--ticket,
+.mel-notif-inbox__accent--order {
+  background: #f26d5b;
+}
+.mel-notif-inbox__accent--sale {
+  background: #6b5ce6;
+}
+.mel-notif-inbox__accent--refund {
+  background: #c45c8a;
+}
+.mel-notif-inbox__accent--rsvp {
+  background: #3d9a82;
+}
+.mel-notif-inbox__accent--follower {
+  background: #5b8def;
+}
+.mel-notif-inbox__accent--event-update {
+  background: #6b5ce6;
+}
+.mel-notif-inbox__accent--boost {
+  background: #f0ad4e;
+}
+.mel-notif-inbox__accent--reminder {
+  background: #3d9a82;
+}
+
+.mel-notif-inbox__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+}
+
+.mel-notif-inbox__tab {
+  display: inline-flex;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: rgba(41, 50, 65, 0.75);
+  background: rgba(41, 50, 65, 0.05);
+}
+
+.mel-notif-inbox__tab.is-active,
+.mel-notif-inbox__tab[aria-current='page'] {
+  background: #6b5ce6;
+  color: #fff;
+}
+
+.mel-notif-inbox__row-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.mel-notif-inbox__badge {
+  display: inline-flex;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  letter-spacing: 0.02em;
+  background: rgba(41, 50, 65, 0.08);
+  color: rgba(41, 50, 65, 0.8);
+}
+
+.mel-notif-bell__row-badge {
+  display: inline-block;
+  margin-bottom: 0.2rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  background: rgba(41, 50, 65, 0.08);
+  color: rgba(41, 50, 65, 0.75);
+}
+
 .mel-notif-inbox__row-title {
   font-weight: 600;
   font-size: 1rem;

--- a/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
+++ b/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
@@ -42,15 +42,36 @@
     return id > 0 && getSessionSeenIds().indexOf(id) !== -1;
   }
 
-  function accentForType(type) {
-    if (type === 'ticket') {
+  function accentForDomain(domain, type) {
+    if (domain === 'tickets') {
       return '#f26d5b';
     }
-    if (type === 'event') {
+    if (domain === 'orders') {
+      return '#e8a54b';
+    }
+    if (domain === 'sales') {
       return '#6b5ce6';
     }
-    if (type === 'reminder') {
+    if (domain === 'refunds') {
+      return '#c45c8a';
+    }
+    if (domain === 'rsvps') {
       return '#3d9a82';
+    }
+    if (domain === 'followers') {
+      return '#5b8def';
+    }
+    if (domain === 'event_updates') {
+      return '#6b5ce6';
+    }
+    if (domain === 'boosts') {
+      return '#f0ad4e';
+    }
+    if (domain === 'reminders') {
+      return '#3d9a82';
+    }
+    if (type === 'ticket') {
+      return '#f26d5b';
     }
     return '#293241';
   }
@@ -117,7 +138,7 @@
     var el = document.createElement('div');
     el.className = 'mel-notification-toast';
     el.dataset.deliveryId = String(item.id);
-    el.style.borderLeft = '4px solid ' + accentForType(item.type);
+    el.style.borderLeft = '4px solid ' + accentForDomain(item.domain || '', item.type);
 
     var title = document.createElement('div');
     title.style.fontWeight = '600';
@@ -178,7 +199,7 @@
       .catch(function () {});
   }
 
-  function updateBadge(badge, count) {
+  function updateBadge(badge, count, data) {
     if (!badge) {
       return;
     }
@@ -191,8 +212,21 @@
     badge.textContent = n > 99 ? '99+' : String(n);
     if (n < 1) {
       badge.classList.add('mel-notif-bell__badge--empty');
+      badge.setAttribute('aria-hidden', 'true');
     } else {
       badge.classList.remove('mel-notif-bell__badge--empty');
+      badge.removeAttribute('aria-hidden');
+    }
+    if (data && typeof Drupal !== 'undefined' && Drupal.t) {
+      var label = Drupal.t('@count unread notifications', { '@count': n });
+      if (data.personal !== undefined && data.business !== undefined) {
+        label = Drupal.t('@count unread (@personal personal, @platform platform)', {
+          '@count': n,
+          '@personal': data.personal || 0,
+          '@platform': data.platform || 0,
+        });
+      }
+      badge.setAttribute('aria-label', label);
     }
   }
 
@@ -215,6 +249,15 @@
       btn.type = 'button';
       btn.className = 'mel-notif-bell__row' + (row.is_unread ? ' is-unread' : '');
       btn.setAttribute('role', 'menuitem');
+      if (row.domain) {
+        btn.style.borderLeft = '3px solid ' + accentForDomain(row.domain, row.type);
+      }
+      if (row.badge) {
+        var badgeEl = document.createElement('span');
+        badgeEl.className = 'mel-notif-bell__row-badge mel-notif-bell__row-badge--' + row.badge;
+        badgeEl.textContent = (row.domain || '').replace(/_/g, ' ');
+        btn.appendChild(badgeEl);
+      }
       var t = document.createElement('div');
       t.className = 'mel-notif-bell__row-title';
       t.textContent = row.title || '';
@@ -329,7 +372,7 @@
           return r.json();
         })
         .then(function (data) {
-          updateBadge(badge, data.unread);
+          updateBadge(badge, data.unread, data);
         })
         .catch(function () {});
     }

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.install
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.install
@@ -264,6 +264,79 @@ function myeventlane_notifications_update_11005(): string {
  * @param string $index_name
  *   Index name (must match the $name argument to addIndex()).
  */
+/**
+ * Context-aware notification fields and backfill for existing rows.
+ */
+function myeventlane_notifications_update_11006(): string {
+  try {
+    $update_manager = \Drupal::entityDefinitionUpdateManager();
+    $notif_entity = \Drupal::entityTypeManager()->getDefinition('mel_notification');
+    $notif_fields = \Drupal\myeventlane_notifications\Entity\MelNotification::baseFieldDefinitions($notif_entity);
+
+    foreach (['context', 'domain', 'route_name', 'route_parameters'] as $field_name) {
+      if ($update_manager->getFieldStorageDefinition($field_name, 'mel_notification') === NULL) {
+        $update_manager->installFieldStorageDefinition(
+          $field_name,
+          'mel_notification',
+          'myeventlane_notifications',
+          $notif_fields[$field_name]
+        );
+      }
+    }
+
+    $storage = \Drupal::entityTypeManager()->getStorage('mel_notification');
+    $ids = $storage->getQuery()->accessCheck(FALSE)->execute();
+    if ($ids !== []) {
+      /** @var \Drupal\myeventlane_notifications\Entity\MelNotification[] $entities */
+      $entities = $storage->loadMultiple($ids);
+      foreach ($entities as $entity) {
+        $needsSave = FALSE;
+        if (trim((string) $entity->get('context')->value) === '') {
+          $legacy = \Drupal\myeventlane_notifications\NotificationTaxonomy::fromLegacyType(
+            (string) $entity->get('type')->value,
+            (string) $entity->get('action_context')->value
+          );
+          $entity->set('context', $legacy['context']);
+          $entity->set('domain', $legacy['domain']);
+          $needsSave = TRUE;
+        }
+        if ($needsSave) {
+          $entity->save();
+        }
+      }
+    }
+
+    if ($schema = \Drupal::database()->schema()) {
+      $table = 'mel_notification';
+      if ($schema->tableExists($table) && $schema->fieldExists($table, 'context') &&
+        !$schema->indexExists($table, 'mel_notif_context')) {
+        $schema->addIndex($table, 'mel_notif_context', ['context'], [
+          'fields' => [
+            'context' => ['type' => 'varchar', 'length' => 255, 'not null' => TRUE],
+          ],
+          'indexes' => ['mel_notif_context' => ['context']],
+        ]);
+      }
+      if ($schema->tableExists($table) && $schema->fieldExists($table, 'domain') &&
+        !$schema->indexExists($table, 'mel_notif_domain')) {
+        $schema->addIndex($table, 'mel_notif_domain', ['domain'], [
+          'fields' => [
+            'domain' => ['type' => 'varchar', 'length' => 255, 'not null' => TRUE],
+          ],
+          'indexes' => ['mel_notif_domain' => ['domain']],
+        ]);
+      }
+    }
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_notifications')->error('Context-aware notification schema update failed: @message', [
+      '@message' => $e->getMessage(),
+    ]);
+    return (string) t('MEL context-aware notification field update failed (see log).');
+  }
+  return (string) t('Installed MEL context/domain/route notification fields and backfilled existing rows.');
+}
+
 function _myeventlane_notifications_delivery_index_spec(array $columns, string $index_name): array {
   $definitions = [
     'recipient_uid_target_id' => [

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\myeventlane_notifications\NotificationContext;
 use Drupal\myeventlane_notifications\NotificationPrefsFieldDefinition;
 use Drupal\myeventlane_notifications\Service\NotificationPreferenceService;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
@@ -26,7 +27,7 @@ function myeventlane_notifications_preprocess_site_header(array &$variables): vo
   if (\Drupal::theme()->getActiveTheme()->getName() !== 'myeventlane_theme') {
     return;
   }
-  $variables['notification_bell'] = \Drupal::service('myeventlane_notifications.bell_presenter')->build();
+  $variables['notification_bell'] = \Drupal::service('myeventlane_notifications.bell_presenter')->build(NotificationContext::PERSONAL);
 }
 
 /**
@@ -38,7 +39,7 @@ function myeventlane_notifications_preprocess_page(array &$variables): void {
   if (\Drupal::theme()->getActiveTheme()->getName() !== 'myeventlane_vendor_theme') {
     return;
   }
-  $variables['page']['mel_notification_bell'] = \Drupal::service('myeventlane_notifications.bell_presenter')->build();
+  $variables['page']['mel_notification_bell'] = \Drupal::service('myeventlane_notifications.bell_presenter')->build(NotificationContext::BUSINESS);
 }
 
 /**
@@ -48,6 +49,7 @@ function myeventlane_notifications_theme(array $existing, string $type, string $
   return [
     'mel_notification_bell' => [
       'variables' => [
+        'bell_context' => 'personal',
         'inbox_url' => NULL,
         'settings_url' => NULL,
       ],
@@ -55,7 +57,9 @@ function myeventlane_notifications_theme(array $existing, string $type, string $
     ],
     'mel_notification_inbox' => [
       'variables' => [
+        'tab' => 'all',
         'filter' => 'all',
+        'tab_links' => [],
         'filter_links' => [],
         'groups' => [],
         'empty' => FALSE,
@@ -204,16 +208,21 @@ function myeventlane_notifications_page_attachments(array &$attachments): void {
   $readTemplate = Url::fromRoute('myeventlane_notifications.mark_read', ['delivery' => $placeholder], ['absolute' => TRUE])->toString();
   $readTemplate = str_replace((string) $placeholder, '__DELIVERY__', $readTemplate);
 
+  $bellContext = $theme === 'myeventlane_vendor_theme'
+    ? NotificationContext::BUSINESS
+    : NotificationContext::PERSONAL;
   $library = $theme === 'myeventlane_vendor_theme'
     ? 'myeventlane_vendor_theme/mel_notifications'
     : 'myeventlane_theme/mel_notifications';
   $attachments['#attached']['library'][] = $library;
+  $query = ['bell_context' => $bellContext];
   $attachments['#attached']['drupalSettings']['myeventlaneNotifications'] = [
     'pollSeconds' => 25,
-    'pollUrl' => Url::fromRoute('myeventlane_notifications.unread', [], ['absolute' => TRUE])->toString(),
-    'countUrl' => Url::fromRoute('myeventlane_notifications.unread_count', [], ['absolute' => TRUE])->toString(),
-    'previewUrl' => Url::fromRoute('myeventlane_notifications.preview', [], ['absolute' => TRUE])->toString(),
-    'readAllUrl' => Url::fromRoute('myeventlane_notifications.mark_all_read', [], ['absolute' => TRUE])->toString(),
+    'bellContext' => $bellContext,
+    'pollUrl' => Url::fromRoute('myeventlane_notifications.unread', [], ['absolute' => TRUE, 'query' => $query])->toString(),
+    'countUrl' => Url::fromRoute('myeventlane_notifications.unread_count', [], ['absolute' => TRUE, 'query' => $query])->toString(),
+    'previewUrl' => Url::fromRoute('myeventlane_notifications.preview', [], ['absolute' => TRUE, 'query' => $query])->toString(),
+    'readAllUrl' => Url::fromRoute('myeventlane_notifications.mark_all_read', [], ['absolute' => TRUE, 'query' => $query])->toString(),
     'inboxUrl' => Url::fromRoute('myeventlane_notifications.inbox', [], ['absolute' => TRUE])->toString(),
     'readUrlTemplate' => $readTemplate,
   ];

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.services.yml
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.services.yml
@@ -40,6 +40,15 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@url_generator'
+      - '@router.route_provider'
+
+  myeventlane_notifications.refund_trigger:
+    class: Drupal\myeventlane_notifications\Service\RefundNotificationTriggerService
+    arguments:
+      - '@myeventlane_notifications.notification_manager'
+      - '@entity_type.manager'
+      - '@logger.channel.myeventlane_notifications'
+      - '@string_translation'
 
   myeventlane_notifications.preference:
     class: Drupal\myeventlane_notifications\Service\NotificationPreferenceService

--- a/web/modules/custom/myeventlane_notifications/src/Controller/NotificationController.php
+++ b/web/modules/custom/myeventlane_notifications/src/Controller/NotificationController.php
@@ -8,11 +8,14 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationFilter;
 use Drupal\myeventlane_notifications\Service\NotificationUserInboxService;
 use Drupal\myeventlane_notifications\Service\NotificationViewBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -42,13 +45,16 @@ final class NotificationController extends ControllerBase {
   /**
    * Returns unread in-app deliveries for the current user (toast polling).
    */
-  public function unread(): CacheableJsonResponse {
+  public function unread(Request $request): CacheableJsonResponse {
     $uid = (int) $this->currentUser()->id();
     if ($uid < 1) {
       throw new AccessDeniedHttpException();
     }
 
-    $ids = $this->userInbox->getUnreadDeliveryIds($uid, self::UNREAD_HARD_LIMIT);
+    $bellContext = $this->bellContextFromRequest($request);
+    $contexts = $this->contextsForBell($bellContext);
+
+    $ids = $this->userInbox->getUnreadDeliveryIds($uid, self::UNREAD_HARD_LIMIT, $contexts);
     $rows = $this->viewBuilder->buildRowsForDeliveries($ids, $uid);
     $payload = [];
     foreach ($rows as $row) {
@@ -59,6 +65,8 @@ final class NotificationController extends ControllerBase {
         'message' => (string) $row['message'],
         'message_preview' => (string) $row['message_preview'],
         'type' => (string) $row['type'],
+        'context' => (string) $row['context'],
+        'domain' => (string) $row['domain'],
         'created' => (int) $row['created'],
         'priority_score' => (int) $row['priority_score'],
         'toast_eligible' => (bool) $row['toast_eligible'],
@@ -78,13 +86,24 @@ final class NotificationController extends ControllerBase {
   /**
    * JSON unread count for the bell badge.
    */
-  public function unreadCount(): CacheableJsonResponse {
+  public function unreadCount(Request $request): CacheableJsonResponse {
     $uid = (int) $this->currentUser()->id();
     if ($uid < 1) {
       throw new AccessDeniedHttpException();
     }
-    $count = $this->userInbox->countUnread($uid);
-    $response = new CacheableJsonResponse(['unread' => $count]);
+
+    $bellContext = $this->bellContextFromRequest($request);
+    $contexts = $this->contextsForBell($bellContext);
+    $breakdown = $this->userInbox->countUnreadBreakdown($uid);
+    $count = $this->userInbox->countUnreadForContexts($uid, $contexts);
+
+    $response = new CacheableJsonResponse([
+      'unread' => $count,
+      'personal' => $breakdown['personal'],
+      'business' => $breakdown['business'],
+      'platform' => $breakdown['platform'],
+      'bell_context' => $bellContext,
+    ]);
     $response->addCacheableDependency($this->currentUser());
     $response->getCacheableMetadata()->setCacheContexts(['user']);
     $response->getCacheableMetadata()->setCacheMaxAge(0);
@@ -94,14 +113,17 @@ final class NotificationController extends ControllerBase {
   /**
    * Bell dropdown preview (recent unread first).
    */
-  public function preview(): CacheableJsonResponse {
+  public function preview(Request $request): CacheableJsonResponse {
     $uid = (int) $this->currentUser()->id();
     if ($uid < 1) {
       throw new AccessDeniedHttpException();
     }
-    $ids = $this->userInbox->getUnreadDeliveryIds($uid, NotificationUserInboxService::BELL_PREVIEW_LIMIT);
+
+    $bellContext = $this->bellContextFromRequest($request);
+    $contexts = $this->contextsForBell($bellContext);
+    $ids = $this->userInbox->getUnreadDeliveryIds($uid, NotificationUserInboxService::BELL_PREVIEW_LIMIT, $contexts);
     $rows = $this->viewBuilder->buildRowsForDeliveries($ids, $uid);
-    $response = new CacheableJsonResponse(['items' => $rows]);
+    $response = new CacheableJsonResponse(['items' => $rows, 'bell_context' => $bellContext]);
     $response->addCacheableDependency($this->currentUser());
     $response->getCacheableMetadata()->setCacheContexts(['user']);
     $response->getCacheableMetadata()->setCacheMaxAge(0);
@@ -172,13 +194,33 @@ final class NotificationController extends ControllerBase {
   /**
    * Marks all deliveries read for the current user.
    */
-  public function markAllRead(): JsonResponse {
+  public function markAllRead(Request $request): JsonResponse {
     $uid = (int) $this->currentUser()->id();
     if ($uid < 1) {
       throw new AccessDeniedHttpException();
     }
-    $updated = $this->userInbox->markAllRead($uid);
+
+    $bellContext = $this->bellContextFromRequest($request);
+    $contexts = $this->contextsForBell($bellContext);
+    $updated = $this->userInbox->markAllRead($uid, $contexts);
     return new JsonResponse(['status' => 'ok', 'updated' => $updated]);
+  }
+
+  private function bellContextFromRequest(Request $request): string {
+    $raw = (string) $request->query->get('bell_context', NotificationContext::PERSONAL);
+    if (!in_array($raw, [NotificationContext::PERSONAL, NotificationContext::BUSINESS], TRUE)) {
+      return NotificationContext::PERSONAL;
+    }
+    return $raw;
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function contextsForBell(string $bellContext): array {
+    return $bellContext === NotificationContext::BUSINESS
+      ? NotificationContext::vendorBellContexts()
+      : NotificationContext::publicBellContexts();
   }
 
 }

--- a/web/modules/custom/myeventlane_notifications/src/Controller/UserInboxController.php
+++ b/web/modules/custom/myeventlane_notifications/src/Controller/UserInboxController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_notifications\Form\MarkAllReadForm;
 use Drupal\myeventlane_notifications\Form\MarkDeliveryReadForm;
+use Drupal\myeventlane_notifications\NotificationContext;
 use Drupal\myeventlane_notifications\NotificationFilter;
 use Drupal\myeventlane_notifications\Service\NotificationUserInboxService;
 use Drupal\myeventlane_notifications\Service\NotificationViewBuilder;
@@ -44,13 +45,18 @@ final class UserInboxController extends ControllerBase {
       throw new AccessDeniedHttpException();
     }
 
-    $filter = (string) $request->query->get('filter', NotificationFilter::ALL);
-    if (!in_array($filter, NotificationFilter::allowed(), TRUE)) {
-      $filter = NotificationFilter::ALL;
+    $tab = (string) $request->query->get('tab', NotificationFilter::TAB_ALL);
+    if (!in_array($tab, NotificationFilter::allowedTabs(), TRUE)) {
+      $tab = NotificationFilter::TAB_ALL;
+    }
+
+    $filter = (string) $request->query->get('filter', NotificationFilter::FILTER_ALL);
+    if (!in_array($filter, NotificationFilter::allowedFilters(), TRUE)) {
+      $filter = NotificationFilter::FILTER_ALL;
     }
 
     $page = max(0, (int) $request->query->get('page', 0));
-    $ids = $this->userInbox->getInboxDeliveryIds($uid, $filter, $page);
+    $ids = $this->userInbox->getInboxDeliveryIds($uid, $tab, $filter, $page);
     $rows = $this->viewBuilder->buildRowsForDeliveries($ids, $uid);
     $rows = $this->viewBuilder->applyGroupSummaries($rows);
     $groups = $this->viewBuilder->groupRowsByDate($rows);
@@ -65,7 +71,7 @@ final class UserInboxController extends ControllerBase {
       foreach ($group['items'] as $row) {
         $items[] = [
           'row' => $row,
-          'mark_read_form' => $this->formBuilder()->getForm(MarkDeliveryReadForm::class, (int) $row['delivery_id'], $filter),
+          'mark_read_form' => $this->formBuilder()->getForm(MarkDeliveryReadForm::class, (int) $row['delivery_id'], $tab, $filter),
         ];
       }
       $groups_out[] = [
@@ -74,19 +80,31 @@ final class UserInboxController extends ControllerBase {
       ];
     }
 
+    $tab_links = [];
+    foreach (NotificationFilter::allowedTabs() as $key) {
+      $tab_links[] = [
+        'id' => $key,
+        'label' => $this->tabLabel($key),
+        'url' => Url::fromRoute('myeventlane_notifications.inbox', [], ['query' => ['tab' => $key, 'filter' => NotificationFilter::FILTER_ALL]])->toString(),
+        'active' => $key === $tab,
+      ];
+    }
+
     $filter_links = [];
-    foreach (NotificationFilter::allowed() as $key) {
+    foreach (NotificationFilter::filtersForTab($tab) as $key) {
       $filter_links[] = [
         'id' => $key,
         'label' => $this->filterLabel($key),
-        'url' => Url::fromRoute('myeventlane_notifications.inbox', [], ['query' => ['filter' => $key]])->toString(),
+        'url' => Url::fromRoute('myeventlane_notifications.inbox', [], ['query' => ['tab' => $tab, 'filter' => $key]])->toString(),
         'active' => $key === $filter,
       ];
     }
 
     $build = [
       '#theme' => 'mel_notification_inbox',
+      '#tab' => $tab,
       '#filter' => $filter,
+      '#tab_links' => $tab_links,
       '#filter_links' => $filter_links,
       '#groups' => $groups_out,
       '#empty' => $rows === [],
@@ -106,20 +124,38 @@ final class UserInboxController extends ControllerBase {
     ];
 
     if ($rows !== []) {
-      $build['#mark_all_form'] = $this->formBuilder()->getForm(MarkAllReadForm::class, $filter);
+      $build['#mark_all_form'] = $this->formBuilder()->getForm(MarkAllReadForm::class, $tab, $filter);
     }
 
     return $build;
   }
 
+  private function tabLabel(string $key): string {
+    return match ($key) {
+      NotificationFilter::TAB_ALL => (string) $this->t('All'),
+      NotificationFilter::TAB_PERSONAL => (string) $this->t('Personal'),
+      NotificationFilter::TAB_BUSINESS => (string) $this->t('Business'),
+      NotificationFilter::TAB_PLATFORM => (string) $this->t('Platform'),
+      default => $key,
+    };
+  }
+
   private function filterLabel(string $key): string {
     return match ($key) {
-      NotificationFilter::ALL => (string) $this->t('All'),
-      NotificationFilter::UNREAD => (string) $this->t('Unread'),
-      NotificationFilter::TICKETS => (string) $this->t('Tickets'),
-      NotificationFilter::EVENTS => (string) $this->t('Events'),
-      NotificationFilter::REMINDERS => (string) $this->t('Reminders'),
-      NotificationFilter::PLATFORM => (string) $this->t('Platform'),
+      NotificationFilter::FILTER_ALL => (string) $this->t('All'),
+      NotificationFilter::FILTER_UNREAD => (string) $this->t('Unread'),
+      NotificationFilter::FILTER_TICKETS => (string) $this->t('Tickets'),
+      NotificationFilter::FILTER_ORDERS => (string) $this->t('Orders'),
+      NotificationFilter::FILTER_REMINDERS => (string) $this->t('Reminders'),
+      NotificationFilter::FILTER_SALES => (string) $this->t('Sales'),
+      NotificationFilter::FILTER_REFUNDS => (string) $this->t('Refunds'),
+      NotificationFilter::FILTER_RSVPS => (string) $this->t('RSVPs'),
+      NotificationFilter::FILTER_FOLLOWERS => (string) $this->t('Followers'),
+      NotificationFilter::FILTER_EVENT_UPDATES => (string) $this->t('Event updates'),
+      NotificationFilter::FILTER_BOOSTS => (string) $this->t('Boosts'),
+      NotificationFilter::FILTER_SYSTEM => (string) $this->t('System'),
+      NotificationFilter::LEGACY_EVENTS => (string) $this->t('Events'),
+      NotificationFilter::LEGACY_PLATFORM => (string) $this->t('Platform'),
       default => $key,
     };
   }

--- a/web/modules/custom/myeventlane_notifications/src/Entity/MelNotification.php
+++ b/web/modules/custom/myeventlane_notifications/src/Entity/MelNotification.php
@@ -8,6 +8,8 @@ use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
 
 /**
  * Defines a platform notification (broadcast or targeted template).
@@ -197,6 +199,47 @@ final class MelNotification extends ContentEntityBase {
       ->setLabel(new TranslatableMarkup('Action context'))
       ->setDescription(new TranslatableMarkup('Optional machine token for analytics/routing (not shown in UI).'))
       ->setSetting('max_length', 128)
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $context_values = [];
+    foreach (NotificationContext::allowed() as $key) {
+      $context_values[$key] = $key;
+    }
+
+    $fields['context'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Context'))
+      ->setDescription(new TranslatableMarkup('personal, business, or platform audience surface.'))
+      ->setRequired(TRUE)
+      ->setDefaultValue(NotificationContext::PERSONAL)
+      ->setSetting('allowed_values', $context_values)
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $domain_values = [];
+    foreach (NotificationDomain::allowed() as $key) {
+      $domain_values[$key] = $key;
+    }
+
+    $fields['domain'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Domain'))
+      ->setDescription(new TranslatableMarkup('What happened (tickets, sales, refunds, etc.).'))
+      ->setRequired(TRUE)
+      ->setDefaultValue(NotificationDomain::PLATFORM)
+      ->setSetting('allowed_values', $domain_values)
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $fields['route_name'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Route name'))
+      ->setDescription(new TranslatableMarkup('Drupal route for deep-linking (preferred over action_uri).'))
+      ->setSetting('max_length', 255)
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    $fields['route_parameters'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(new TranslatableMarkup('Route parameters (JSON)'))
+      ->setDescription(new TranslatableMarkup('JSON object of route parameters for route_name.'))
       ->setDisplayConfigurable('form', FALSE)
       ->setDisplayConfigurable('view', FALSE);
 

--- a/web/modules/custom/myeventlane_notifications/src/Form/MarkAllReadForm.php
+++ b/web/modules/custom/myeventlane_notifications/src/Form/MarkAllReadForm.php
@@ -36,10 +36,17 @@ final class MarkAllReadForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, string $filter = NotificationFilter::ALL): array {
-    if (!in_array($filter, NotificationFilter::allowed(), TRUE)) {
-      $filter = NotificationFilter::ALL;
+  public function buildForm(array $form, FormStateInterface $form_state, string $tab = NotificationFilter::TAB_ALL, string $filter = NotificationFilter::FILTER_ALL): array {
+    if (!in_array($tab, NotificationFilter::allowedTabs(), TRUE)) {
+      $tab = NotificationFilter::TAB_ALL;
     }
+    if (!in_array($filter, NotificationFilter::allowedFilters(), TRUE)) {
+      $filter = NotificationFilter::FILTER_ALL;
+    }
+    $form['tab'] = [
+      '#type' => 'hidden',
+      '#value' => $tab,
+    ];
     $form['filter'] = [
       '#type' => 'hidden',
       '#value' => $filter,
@@ -58,14 +65,19 @@ final class MarkAllReadForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $uid = (int) $this->currentUser()->id();
+    $tab = (string) $form_state->getValue('tab');
     $filter = (string) $form_state->getValue('filter');
-    if (!in_array($filter, NotificationFilter::allowed(), TRUE)) {
-      $filter = NotificationFilter::ALL;
+    if (!in_array($tab, NotificationFilter::allowedTabs(), TRUE)) {
+      $tab = NotificationFilter::TAB_ALL;
+    }
+    if (!in_array($filter, NotificationFilter::allowedFilters(), TRUE)) {
+      $filter = NotificationFilter::FILTER_ALL;
     }
     if ($uid > 0) {
-      $this->userInbox->markAllRead($uid);
+      $contexts = NotificationFilter::contextsForTab($tab);
+      $this->userInbox->markAllRead($uid, $contexts);
     }
-    $form_state->setRedirect('myeventlane_notifications.inbox', [], ['query' => ['filter' => $filter]]);
+    $form_state->setRedirect('myeventlane_notifications.inbox', [], ['query' => ['tab' => $tab, 'filter' => $filter]]);
   }
 
 }

--- a/web/modules/custom/myeventlane_notifications/src/Form/MarkDeliveryReadForm.php
+++ b/web/modules/custom/myeventlane_notifications/src/Form/MarkDeliveryReadForm.php
@@ -37,13 +37,20 @@ final class MarkDeliveryReadForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, int $delivery_id = 0, string $filter = NotificationFilter::ALL): array {
-    if (!in_array($filter, NotificationFilter::allowed(), TRUE)) {
-      $filter = NotificationFilter::ALL;
+  public function buildForm(array $form, FormStateInterface $form_state, int $delivery_id = 0, string $tab = NotificationFilter::TAB_ALL, string $filter = NotificationFilter::FILTER_ALL): array {
+    if (!in_array($tab, NotificationFilter::allowedTabs(), TRUE)) {
+      $tab = NotificationFilter::TAB_ALL;
+    }
+    if (!in_array($filter, NotificationFilter::allowedFilters(), TRUE)) {
+      $filter = NotificationFilter::FILTER_ALL;
     }
     $form['delivery_id'] = [
       '#type' => 'hidden',
       '#value' => $delivery_id,
+    ];
+    $form['tab'] = [
+      '#type' => 'hidden',
+      '#value' => $tab,
     ];
     $form['filter'] = [
       '#type' => 'hidden',
@@ -64,14 +71,18 @@ final class MarkDeliveryReadForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $uid = (int) $this->currentUser()->id();
     $deliveryId = (int) $form_state->getValue('delivery_id');
+    $tab = (string) $form_state->getValue('tab');
     $filter = (string) $form_state->getValue('filter');
-    if (!in_array($filter, NotificationFilter::allowed(), TRUE)) {
-      $filter = NotificationFilter::ALL;
+    if (!in_array($tab, NotificationFilter::allowedTabs(), TRUE)) {
+      $tab = NotificationFilter::TAB_ALL;
+    }
+    if (!in_array($filter, NotificationFilter::allowedFilters(), TRUE)) {
+      $filter = NotificationFilter::FILTER_ALL;
     }
     if ($uid > 0 && $deliveryId > 0) {
       $this->userInbox->markReadOne($uid, $deliveryId);
     }
-    $form_state->setRedirect('myeventlane_notifications.inbox', [], ['query' => ['filter' => $filter]]);
+    $form_state->setRedirect('myeventlane_notifications.inbox', [], ['query' => ['tab' => $tab, 'filter' => $filter]]);
   }
 
 }

--- a/web/modules/custom/myeventlane_notifications/src/Form/NotificationPreferencesForm.php
+++ b/web/modules/custom/myeventlane_notifications/src/Form/NotificationPreferencesForm.php
@@ -53,55 +53,75 @@ final class NotificationPreferencesForm extends FormBase {
     $form['intro'] = [
       '#type' => 'markup',
       '#markup' => '<p class="mel-notif-prefs__intro">' . $this->t(
-        'Choose what we surface in the header bell, toasts, and your inbox. Ticket confirmations always remain available in your inbox even if you turn off ticket alerts.'
+        'Choose what we surface in the header bell, toasts, and your inbox. Preferences are grouped by personal, business, and platform context.'
       ) . '</p>',
     ];
 
-    $categories = [
-      NotificationPreferenceService::CATEGORY_TICKETS => $this->t('Tickets'),
-      NotificationPreferenceService::CATEGORY_EVENTS => $this->t('Events'),
-      NotificationPreferenceService::CATEGORY_REMINDERS => $this->t('Reminders'),
-      NotificationPreferenceService::CATEGORY_PLATFORM => $this->t('Platform'),
-      NotificationPreferenceService::CATEGORY_PROMO => $this->t('Promotions'),
+    $sections = [
+      'personal' => [
+        '#title' => $this->t('Personal'),
+        'categories' => [
+          NotificationPreferenceService::PERSONAL_TICKET_PURCHASES => $this->t('Ticket purchases'),
+          NotificationPreferenceService::PERSONAL_ORDER_UPDATES => $this->t('Order updates'),
+          NotificationPreferenceService::PERSONAL_EVENT_REMINDERS => $this->t('Event reminders'),
+        ],
+      ],
+      'business' => [
+        '#title' => $this->t('Business'),
+        'categories' => [
+          NotificationPreferenceService::BUSINESS_SALES => $this->t('Sales'),
+          NotificationPreferenceService::BUSINESS_REFUNDS => $this->t('Refunds'),
+          NotificationPreferenceService::BUSINESS_RSVPS => $this->t('RSVPs'),
+          NotificationPreferenceService::BUSINESS_FOLLOWERS => $this->t('Followers'),
+          NotificationPreferenceService::BUSINESS_EVENT_UPDATES => $this->t('Event updates'),
+          NotificationPreferenceService::BUSINESS_BOOSTS => $this->t('Boost activity'),
+        ],
+      ],
+      'platform' => [
+        '#title' => $this->t('Platform'),
+        'categories' => [
+          NotificationPreferenceService::PLATFORM_SECURITY => $this->t('Security'),
+          NotificationPreferenceService::PLATFORM_ACCOUNT => $this->t('Account'),
+          NotificationPreferenceService::PLATFORM_SYSTEM => $this->t('System alerts'),
+        ],
+      ],
     ];
 
-    // #tree is required so each category gets distinct #parents (e.g.
-    // category → tickets → surface). Without it, Drupal flattens #parents to
-    // ['surface'] / ['enabled'] for every section, merging all radios into one
-    // group and colliding checkbox values so preferences cannot save correctly.
     $form['category'] = [
       '#type' => 'container',
       '#tree' => TRUE,
     ];
 
-    foreach ($categories as $key => $label) {
-      $form['category'][$key] = [
-        '#type' => 'fieldset',
-        '#title' => $label,
-        '#attributes' => ['class' => ['mel-notif-prefs__fieldset']],
+    foreach ($sections as $sectionKey => $section) {
+      $form['category'][$sectionKey] = [
+        '#type' => 'details',
+        '#title' => $section['#title'],
+        '#open' => TRUE,
+        '#attributes' => ['class' => ['mel-notif-prefs__section']],
       ];
-      $form['category'][$key]['enabled'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Enable notifications in this category'),
-        '#default_value' => !empty($prefs[$key]['enabled']),
-      ];
-      $form['category'][$key]['surface'] = [
-        '#type' => 'radios',
-        '#title' => $this->t('How they appear when enabled'),
-        '#options' => $surface_options,
-        '#default_value' => $prefs[$key]['surface'] ?? NotificationSurface::INBOX_ONLY,
-        '#states' => [
-          'visible' => [
-            ':input[name="category[' . $key . '][enabled]"]' => ['checked' => TRUE],
+      foreach ($section['categories'] as $key => $label) {
+        $form['category'][$sectionKey][$key] = [
+          '#type' => 'fieldset',
+          '#title' => $label,
+          '#attributes' => ['class' => ['mel-notif-prefs__fieldset']],
+        ];
+        $form['category'][$sectionKey][$key]['enabled'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Enable notifications in this category'),
+          '#default_value' => !empty($prefs[$key]['enabled']),
+        ];
+        $form['category'][$sectionKey][$key]['surface'] = [
+          '#type' => 'radios',
+          '#title' => $this->t('How they appear when enabled'),
+          '#options' => $surface_options,
+          '#default_value' => $prefs[$key]['surface'] ?? NotificationSurface::INBOX_ONLY,
+          '#states' => [
+            'visible' => [
+              ':input[name="category[' . $sectionKey . '][' . $key . '][enabled]"]' => ['checked' => TRUE],
+            ],
           ],
-        ],
-      ];
-      $form['category'][$key]['help'] = [
-        '#type' => 'markup',
-        '#markup' => '<p class="description">' . $this->t(
-          'Toast appears briefly on screen. Bell shows a badge and dropdown preview. Inbox keeps everything on the notifications page.'
-        ) . '</p>',
-      ];
+        ];
+      }
     }
 
     $form['actions'] = ['#type' => 'actions'];
@@ -130,9 +150,22 @@ final class NotificationPreferencesForm extends FormBase {
     }
 
     $out = [];
+    $categoryValues = $form_state->getValue('category');
+    if (!is_array($categoryValues)) {
+      $categoryValues = [];
+    }
     foreach (NotificationPreferenceService::categoryKeys() as $key) {
-      $enabled = (bool) $form_state->getValue(['category', $key, 'enabled']);
-      $surface = (string) $form_state->getValue(['category', $key, 'surface']);
+      $enabled = TRUE;
+      $surface = NotificationSurface::INBOX_ONLY;
+      foreach (['personal', 'business', 'platform'] as $section) {
+        if (!isset($categoryValues[$section][$key]) || !is_array($categoryValues[$section][$key])) {
+          continue;
+        }
+        $entry = $categoryValues[$section][$key];
+        $enabled = (bool) ($entry['enabled'] ?? TRUE);
+        $surface = (string) ($entry['surface'] ?? NotificationSurface::INBOX_ONLY);
+        break;
+      }
       if (!in_array($surface, NotificationSurface::allowed(), TRUE)) {
         $surface = NotificationSurface::INBOX_ONLY;
       }

--- a/web/modules/custom/myeventlane_notifications/src/NotificationContext.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationContext.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_notifications;
+
+/**
+ * Notification audience context (not Drupal user role).
+ *
+ * Controls which bell/inbox surface shows a delivery.
+ */
+final class NotificationContext {
+
+  public const PERSONAL = 'personal';
+
+  public const BUSINESS = 'business';
+
+  public const PLATFORM = 'platform';
+
+  /**
+   * @return list<string>
+   */
+  public static function allowed(): array {
+    return [
+      self::PERSONAL,
+      self::BUSINESS,
+      self::PLATFORM,
+    ];
+  }
+
+  /**
+   * Contexts visible on the public-site bell (personal + platform).
+   *
+   * @return list<string>
+   */
+  public static function publicBellContexts(): array {
+    return [self::PERSONAL, self::PLATFORM];
+  }
+
+  /**
+   * Contexts visible on the vendor-dashboard bell (business + platform).
+   *
+   * @return list<string>
+   */
+  public static function vendorBellContexts(): array {
+    return [self::BUSINESS, self::PLATFORM];
+  }
+
+}

--- a/web/modules/custom/myeventlane_notifications/src/NotificationDomain.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationDomain.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_notifications;
+
+/**
+ * Notification domain (what happened).
+ */
+final class NotificationDomain {
+
+  public const TICKETS = 'tickets';
+
+  public const ORDERS = 'orders';
+
+  public const SALES = 'sales';
+
+  public const REFUNDS = 'refunds';
+
+  public const RSVPS = 'rsvps';
+
+  public const FOLLOWERS = 'followers';
+
+  public const EVENT_UPDATES = 'event_updates';
+
+  public const BOOSTS = 'boosts';
+
+  public const REMINDERS = 'reminders';
+
+  public const PLATFORM = 'platform';
+
+  /**
+   * @return list<string>
+   */
+  public static function allowed(): array {
+    return [
+      self::TICKETS,
+      self::ORDERS,
+      self::SALES,
+      self::REFUNDS,
+      self::RSVPS,
+      self::FOLLOWERS,
+      self::EVENT_UPDATES,
+      self::BOOSTS,
+      self::REMINDERS,
+      self::PLATFORM,
+    ];
+  }
+
+  /**
+   * Domains available under a context tab in the inbox.
+   *
+   * @return list<string>
+   */
+  public static function forContext(string $context): array {
+    return match ($context) {
+      NotificationContext::PERSONAL => [
+        self::TICKETS,
+        self::ORDERS,
+        self::REMINDERS,
+      ],
+      NotificationContext::BUSINESS => [
+        self::SALES,
+        self::REFUNDS,
+        self::RSVPS,
+        self::FOLLOWERS,
+        self::EVENT_UPDATES,
+        self::BOOSTS,
+      ],
+      NotificationContext::PLATFORM => [
+        self::PLATFORM,
+      ],
+      default => self::allowed(),
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_notifications/src/NotificationFilter.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationFilter.php
@@ -5,34 +5,172 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_notifications;
 
 /**
- * Inbox filter keys (query ?filter=).
+ * Inbox tab and filter keys (query ?tab= and ?filter=).
  */
 final class NotificationFilter {
 
-  public const ALL = 'all';
+  public const TAB_ALL = 'all';
 
-  public const UNREAD = 'unread';
+  public const TAB_PERSONAL = 'personal';
 
-  public const TICKETS = 'tickets';
+  public const TAB_BUSINESS = 'business';
 
-  public const EVENTS = 'events';
+  public const TAB_PLATFORM = 'platform';
 
-  public const REMINDERS = 'reminders';
+  public const FILTER_ALL = 'all';
 
-  public const PLATFORM = 'platform';
+  public const FILTER_UNREAD = 'unread';
+
+  // Personal domain filters.
+  public const FILTER_TICKETS = 'tickets';
+
+  public const FILTER_ORDERS = 'orders';
+
+  public const FILTER_REMINDERS = 'reminders';
+
+  // Business domain filters.
+  public const FILTER_SALES = 'sales';
+
+  public const FILTER_REFUNDS = 'refunds';
+
+  public const FILTER_RSVPS = 'rsvps';
+
+  public const FILTER_FOLLOWERS = 'followers';
+
+  public const FILTER_EVENT_UPDATES = 'event_updates';
+
+  public const FILTER_BOOSTS = 'boosts';
+
+  // Platform domain filter.
+  public const FILTER_SYSTEM = 'system';
+
+  // Legacy keys (backwards compatible query strings).
+  public const LEGACY_EVENTS = 'events';
+
+  public const LEGACY_PLATFORM = 'platform';
 
   /**
    * @return list<string>
    */
-  public static function allowed(): array {
+  public static function allowedTabs(): array {
     return [
-      self::ALL,
-      self::UNREAD,
-      self::TICKETS,
-      self::EVENTS,
-      self::REMINDERS,
-      self::PLATFORM,
+      self::TAB_ALL,
+      self::TAB_PERSONAL,
+      self::TAB_BUSINESS,
+      self::TAB_PLATFORM,
     ];
+  }
+
+  /**
+   * @return list<string>
+   */
+  public static function allowedFilters(): array {
+    return [
+      self::FILTER_ALL,
+      self::FILTER_UNREAD,
+      self::FILTER_TICKETS,
+      self::FILTER_ORDERS,
+      self::FILTER_REMINDERS,
+      self::FILTER_SALES,
+      self::FILTER_REFUNDS,
+      self::FILTER_RSVPS,
+      self::FILTER_FOLLOWERS,
+      self::FILTER_EVENT_UPDATES,
+      self::FILTER_BOOSTS,
+      self::FILTER_SYSTEM,
+      self::LEGACY_EVENTS,
+      self::LEGACY_PLATFORM,
+    ];
+  }
+
+  /**
+   * @deprecated Use allowedTabs() and allowedFilters().
+   *
+   * @return list<string>
+   */
+  public static function allowed(): array {
+    return self::allowedFilters();
+  }
+
+  /**
+   * Domain filters shown for a context tab.
+   *
+   * @return list<string>
+   */
+  public static function filtersForTab(string $tab): array {
+    return match ($tab) {
+      self::TAB_PERSONAL => [
+        self::FILTER_ALL,
+        self::FILTER_UNREAD,
+        self::FILTER_TICKETS,
+        self::FILTER_ORDERS,
+        self::FILTER_REMINDERS,
+      ],
+      self::TAB_BUSINESS => [
+        self::FILTER_ALL,
+        self::FILTER_UNREAD,
+        self::FILTER_SALES,
+        self::FILTER_REFUNDS,
+        self::FILTER_RSVPS,
+        self::FILTER_FOLLOWERS,
+        self::FILTER_EVENT_UPDATES,
+        self::FILTER_BOOSTS,
+      ],
+      self::TAB_PLATFORM => [
+        self::FILTER_ALL,
+        self::FILTER_UNREAD,
+        self::FILTER_SYSTEM,
+      ],
+      default => [
+        self::FILTER_ALL,
+        self::FILTER_UNREAD,
+        self::FILTER_TICKETS,
+        self::FILTER_ORDERS,
+        self::FILTER_REMINDERS,
+        self::FILTER_SALES,
+        self::FILTER_REFUNDS,
+        self::FILTER_RSVPS,
+        self::FILTER_FOLLOWERS,
+        self::FILTER_EVENT_UPDATES,
+        self::FILTER_BOOSTS,
+        self::FILTER_SYSTEM,
+      ],
+    };
+  }
+
+  /**
+   * Maps a filter key to notification domain(s).
+   *
+   * @return list<string>|null
+   */
+  public static function domainsForFilter(string $filter): ?array {
+    return match ($filter) {
+      self::FILTER_TICKETS => [NotificationDomain::TICKETS],
+      self::FILTER_ORDERS => [NotificationDomain::ORDERS],
+      self::FILTER_REMINDERS => [NotificationDomain::REMINDERS],
+      self::FILTER_SALES => [NotificationDomain::SALES],
+      self::FILTER_REFUNDS => [NotificationDomain::REFUNDS],
+      self::FILTER_RSVPS => [NotificationDomain::RSVPS],
+      self::FILTER_FOLLOWERS => [NotificationDomain::FOLLOWERS],
+      self::FILTER_EVENT_UPDATES, self::LEGACY_EVENTS => [NotificationDomain::EVENT_UPDATES],
+      self::FILTER_BOOSTS => [NotificationDomain::BOOSTS],
+      self::FILTER_SYSTEM, self::LEGACY_PLATFORM => [NotificationDomain::PLATFORM],
+      default => NULL,
+    };
+  }
+
+  /**
+   * Maps a tab key to notification context(s).
+   *
+   * @return list<string>|null
+   */
+  public static function contextsForTab(string $tab): ?array {
+    return match ($tab) {
+      self::TAB_PERSONAL => [NotificationContext::PERSONAL],
+      self::TAB_BUSINESS => [NotificationContext::BUSINESS],
+      self::TAB_PLATFORM => [NotificationContext::PLATFORM],
+      default => NULL,
+    };
   }
 
 }

--- a/web/modules/custom/myeventlane_notifications/src/NotificationTaxonomy.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationTaxonomy.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_notifications;
+
+use Drupal\myeventlane_notifications\Entity\MelNotification;
+
+/**
+ * Shared classification for in-app notifications and email templates.
+ */
+final class NotificationTaxonomy {
+
+  /**
+   * Maps legacy mel_notification.type (+ optional action_context) to context/domain.
+   *
+   * @return array{context: string, domain: string}
+   */
+  public static function fromLegacyType(string $type, string $actionContext = ''): array {
+    $actionContext = trim($actionContext);
+
+    if ($actionContext !== '') {
+      $fromAction = self::fromActionContext($actionContext);
+      if ($fromAction !== NULL) {
+        return $fromAction;
+      }
+    }
+
+    return match ($type) {
+      MelNotification::TYPE_TICKET => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::TICKETS,
+      ],
+      MelNotification::TYPE_REMINDER => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::REMINDERS,
+      ],
+      MelNotification::TYPE_EVENT => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::EVENT_UPDATES,
+      ],
+      MelNotification::TYPE_PROMO => [
+        'context' => NotificationContext::PLATFORM,
+        'domain' => NotificationDomain::PLATFORM,
+      ],
+      MelNotification::TYPE_SYSTEM => [
+        'context' => NotificationContext::PLATFORM,
+        'domain' => NotificationDomain::PLATFORM,
+      ],
+      default => [
+        'context' => NotificationContext::PLATFORM,
+        'domain' => NotificationDomain::PLATFORM,
+      ],
+    };
+  }
+
+  /**
+   * @return array{context: string, domain: string}|null
+   */
+  public static function fromActionContext(string $actionContext): ?array {
+    return match ($actionContext) {
+      'checkout_ticket_confirm' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::TICKETS,
+      ],
+      'rsvp_attendee_confirm' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::EVENT_UPDATES,
+      ],
+      'event_published_follower' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::EVENT_UPDATES,
+      ],
+      'rsvp_vendor_alert' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::RSVPS,
+      ],
+      'vendor_sale' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::SALES,
+      ],
+      'refund_requested' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+      ],
+      'refund_approved' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+      ],
+      'refund_rejected' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+      ],
+      'refund_completed' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+      ],
+      'boost_purchased' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::BOOSTS,
+      ],
+      'follower_gained' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::FOLLOWERS,
+      ],
+      'event_approved' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::EVENT_UPDATES,
+      ],
+      default => NULL,
+    };
+  }
+
+  /**
+   * Maps myeventlane_messaging template IDs to context/domain.
+   *
+   * @return array{context: string, domain: string}
+   */
+  public static function fromEmailTemplate(string $templateId): array {
+    return match ($templateId) {
+      'order_confirmation',
+      'order_receipt',
+      'order_invoice',
+      'assign_tickets_buyer',
+      'ticket_tier_waitlist_offer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::TICKETS,
+      ],
+      'cart_abandoned' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
+      'event_reminder',
+      'event_reminder_24h',
+      'event_reminder_7d' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::REMINDERS,
+      ],
+      'rsvp_confirmation' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::RSVPS,
+      ],
+      'rsvp_vendor_copy' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::RSVPS,
+      ],
+      'vendor_event_update',
+      'vendor_event_important_change',
+      'vendor_event_cancellation' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::EVENT_UPDATES,
+      ],
+      'boost_confirmation',
+      'boost_reminder' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::BOOSTS,
+      ],
+      'refund_requested_vendor',
+      'refund_approved_vendor',
+      'refund_rejected_vendor',
+      'refund_completed_vendor',
+      'refund_failed_vendor' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+      ],
+      'refund_requested_buyer',
+      'refund_approved_buyer',
+      'refund_rejected_buyer',
+      'refund_completed_buyer',
+      'refund_failed_buyer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
+      'refund_completed_admin',
+      'refund_failed_admin' => [
+        'context' => NotificationContext::PLATFORM,
+        'domain' => NotificationDomain::PLATFORM,
+      ],
+      default => [
+        'context' => NotificationContext::PLATFORM,
+        'domain' => NotificationDomain::PLATFORM,
+      ],
+    };
+  }
+
+  /**
+   * Preference category key for a context/domain pair.
+   */
+  public static function preferenceKey(string $context, string $domain): string {
+    if ($context === NotificationContext::PLATFORM) {
+      return NotificationPreferenceService::PLATFORM_SECURITY;
+    }
+    if ($context === NotificationContext::BUSINESS) {
+      return match ($domain) {
+        NotificationDomain::SALES => NotificationPreferenceService::BUSINESS_SALES,
+        NotificationDomain::REFUNDS => NotificationPreferenceService::BUSINESS_REFUNDS,
+        NotificationDomain::RSVPS => NotificationPreferenceService::BUSINESS_RSVPS,
+        NotificationDomain::FOLLOWERS => NotificationPreferenceService::BUSINESS_FOLLOWERS,
+        NotificationDomain::EVENT_UPDATES => NotificationPreferenceService::BUSINESS_EVENT_UPDATES,
+        NotificationDomain::BOOSTS => NotificationPreferenceService::BUSINESS_BOOSTS,
+        default => NotificationPreferenceService::BUSINESS_SALES,
+      };
+    }
+    return match ($domain) {
+      NotificationDomain::TICKETS => NotificationPreferenceService::PERSONAL_TICKET_PURCHASES,
+      NotificationDomain::ORDERS => NotificationPreferenceService::PERSONAL_ORDER_UPDATES,
+      NotificationDomain::REMINDERS => NotificationPreferenceService::PERSONAL_EVENT_REMINDERS,
+      default => NotificationPreferenceService::PERSONAL_ORDER_UPDATES,
+    };
+  }
+
+  /**
+   * Migrates legacy preference JSON keys to the new structure.
+   *
+   * @param array<string, mixed> $decoded
+   *
+   * @return array<string, array{enabled: bool, surface: string}>
+   */
+  public static function migrateLegacyPreferences(array $decoded): array {
+    $map = [
+      'tickets' => NotificationPreferenceService::PERSONAL_TICKET_PURCHASES,
+      'events' => NotificationPreferenceService::BUSINESS_EVENT_UPDATES,
+      'reminders' => NotificationPreferenceService::PERSONAL_EVENT_REMINDERS,
+      'platform' => NotificationPreferenceService::PLATFORM_SYSTEM,
+      'promo' => NotificationPreferenceService::PLATFORM_SYSTEM,
+    ];
+    $out = [];
+    foreach ($map as $legacy => $modern) {
+      if (!isset($decoded[$legacy]) || !is_array($decoded[$legacy])) {
+        continue;
+      }
+      $entry = $decoded[$legacy];
+      if (!isset($out[$modern])) {
+        $out[$modern] = [
+          'enabled' => (bool) ($entry['enabled'] ?? TRUE),
+          'surface' => (string) ($entry['surface'] ?? NotificationSurface::BELL_INBOX),
+        ];
+        continue;
+      }
+      $out[$modern]['enabled'] = $out[$modern]['enabled'] || (bool) ($entry['enabled'] ?? TRUE);
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationBellPresenter.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationBellPresenter.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_notifications\Service;
 
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_notifications\NotificationContext;
 
 /**
  * Builds the header notification bell render array without the Block plugin API.
@@ -21,17 +22,25 @@ final class NotificationBellPresenter {
   ) {}
 
   /**
+   * @param string $bellContext
+   *   Primary bell context: personal (public site) or business (vendor dashboard).
+   *
    * @return array<string, mixed>
    *   Empty when the user must not see the bell.
    */
-  public function build(): array {
+  public function build(string $bellContext = NotificationContext::PERSONAL): array {
     $account = $this->currentUser->getAccount();
     if (!$account->isAuthenticated() || !$account->hasPermission('access myeventlane notifications')) {
       return [];
     }
 
+    if (!in_array($bellContext, [NotificationContext::PERSONAL, NotificationContext::BUSINESS], TRUE)) {
+      $bellContext = NotificationContext::PERSONAL;
+    }
+
     return [
       '#theme' => 'mel_notification_bell',
+      '#bell_context' => $bellContext,
       '#inbox_url' => $this->urlGenerator->generateFromRoute('myeventlane_notifications.inbox'),
       '#settings_url' => $this->urlGenerator->generateFromRoute('myeventlane_notifications.preferences'),
       '#attached' => [

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationManager.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationManager.php
@@ -12,6 +12,9 @@ use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
+use Drupal\myeventlane_notifications\NotificationTaxonomy;
 use Drupal\myeventlane_notifications\Plugin\QueueWorker\NotificationDispatchWorker;
 
 /**
@@ -38,7 +41,8 @@ final class NotificationManager {
    *   channels (list), status (optional), scheduled_at (optional int),
    *   priority (optional), priority_score (optional), suppression_key (optional),
    *   group_key (optional), action_label (optional), action_uri (optional),
-   *   action_context (optional).
+   *   action_context (optional), context (optional), domain (optional),
+   *   route_name (optional), route_parameters (optional array).
    */
   public function createNotification(array $data): MelNotification {
     $audienceData = $data['audience_data'] ?? [];
@@ -65,19 +69,40 @@ final class NotificationManager {
       }
     }
 
+    $type = (string) ($data['type'] ?? MelNotification::TYPE_SYSTEM);
+    $actionContext = trim((string) ($data['action_context'] ?? ''));
+    $legacy = NotificationTaxonomy::fromLegacyType($type, $actionContext);
+
+    $context = trim((string) ($data['context'] ?? $legacy['context']));
+    $domain = trim((string) ($data['domain'] ?? $legacy['domain']));
+    if (!in_array($context, NotificationContext::allowed(), TRUE)) {
+      throw new \InvalidArgumentException('Invalid notification context.');
+    }
+    if (!in_array($domain, NotificationDomain::allowed(), TRUE)) {
+      throw new \InvalidArgumentException('Invalid notification domain.');
+    }
+
+    $routeName = trim((string) ($data['route_name'] ?? ''));
+    $routeParameters = $data['route_parameters'] ?? [];
+    if (!is_array($routeParameters)) {
+      throw new \InvalidArgumentException('route_parameters must be an array.');
+    }
+    $routeParametersJson = $routeParameters === []
+      ? ''
+      : json_encode($routeParameters, JSON_THROW_ON_ERROR);
+
     $actionLabel = trim((string) ($data['action_label'] ?? ''));
     $actionUri = $this->normalizeActionUri($data['action_uri'] ?? '');
-    $actionContext = trim((string) ($data['action_context'] ?? ''));
-    if ($actionLabel !== '' && $actionUri === '') {
-      throw new \InvalidArgumentException('action_label requires a valid action_uri.');
+    if ($actionLabel !== '' && $actionUri === '' && $routeName === '') {
+      throw new \InvalidArgumentException('action_label requires action_uri or route_name.');
     }
-    if ($actionUri !== '' && $actionLabel === '') {
-      throw new \InvalidArgumentException('action_uri requires action_label.');
+    if (($actionUri !== '' || $routeName !== '') && $actionLabel === '') {
+      throw new \InvalidArgumentException('action_uri or route_name requires action_label.');
     }
 
     /** @var \Drupal\myeventlane_notifications\Entity\MelNotification $entity */
     $entity = $this->entityTypeManager->getStorage('mel_notification')->create([
-      'type' => $data['type'],
+      'type' => $type,
       'title' => $data['title'],
       'message' => $data['message'],
       'audience_type' => $data['audience_type'],
@@ -91,6 +116,10 @@ final class NotificationManager {
       'action_label' => $actionLabel,
       'action_uri' => $actionUri,
       'action_context' => $actionContext,
+      'context' => $context,
+      'domain' => $domain,
+      'route_name' => $routeName,
+      'route_parameters' => $routeParametersJson,
     ]);
     foreach ($channels as $channel) {
       $entity->get('channels')->appendItem($channel);

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationPreferenceService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationPreferenceService.php
@@ -6,7 +6,10 @@ namespace Drupal\myeventlane_notifications\Service;
 
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
 use Drupal\myeventlane_notifications\NotificationSurface;
+use Drupal\myeventlane_notifications\NotificationTaxonomy;
 use Drupal\user\UserInterface;
 
 /**
@@ -16,6 +19,34 @@ final class NotificationPreferenceService {
 
   public const FIELD_NAME = 'mel_notification_prefs';
 
+  // Personal.
+  public const PERSONAL_TICKET_PURCHASES = 'personal_ticket_purchases';
+
+  public const PERSONAL_ORDER_UPDATES = 'personal_order_updates';
+
+  public const PERSONAL_EVENT_REMINDERS = 'personal_event_reminders';
+
+  // Business.
+  public const BUSINESS_SALES = 'business_sales';
+
+  public const BUSINESS_REFUNDS = 'business_refunds';
+
+  public const BUSINESS_RSVPS = 'business_rsvps';
+
+  public const BUSINESS_FOLLOWERS = 'business_followers';
+
+  public const BUSINESS_EVENT_UPDATES = 'business_event_updates';
+
+  public const BUSINESS_BOOSTS = 'business_boosts';
+
+  // Platform.
+  public const PLATFORM_SECURITY = 'platform_security';
+
+  public const PLATFORM_ACCOUNT = 'platform_account';
+
+  public const PLATFORM_SYSTEM = 'platform_system';
+
+  // Legacy keys (read-only migration).
   public const CATEGORY_TICKETS = 'tickets';
 
   public const CATEGORY_EVENTS = 'events';
@@ -31,11 +62,18 @@ final class NotificationPreferenceService {
    */
   public static function categoryKeys(): array {
     return [
-      self::CATEGORY_TICKETS,
-      self::CATEGORY_EVENTS,
-      self::CATEGORY_REMINDERS,
-      self::CATEGORY_PLATFORM,
-      self::CATEGORY_PROMO,
+      self::PERSONAL_TICKET_PURCHASES,
+      self::PERSONAL_ORDER_UPDATES,
+      self::PERSONAL_EVENT_REMINDERS,
+      self::BUSINESS_SALES,
+      self::BUSINESS_REFUNDS,
+      self::BUSINESS_RSVPS,
+      self::BUSINESS_FOLLOWERS,
+      self::BUSINESS_EVENT_UPDATES,
+      self::BUSINESS_BOOSTS,
+      self::PLATFORM_SECURITY,
+      self::PLATFORM_ACCOUNT,
+      self::PLATFORM_SYSTEM,
     ];
   }
 
@@ -43,24 +81,52 @@ final class NotificationPreferenceService {
    * @var array<string, array{enabled: bool, surface: string}>
    */
   private const DEFAULT_PREFS = [
-    self::CATEGORY_TICKETS => [
+    self::PERSONAL_TICKET_PURCHASES => [
       'enabled' => TRUE,
       'surface' => NotificationSurface::TOAST_INBOX,
     ],
-    self::CATEGORY_EVENTS => [
+    self::PERSONAL_ORDER_UPDATES => [
       'enabled' => TRUE,
       'surface' => NotificationSurface::BELL_INBOX,
     ],
-    self::CATEGORY_REMINDERS => [
+    self::PERSONAL_EVENT_REMINDERS => [
       'enabled' => TRUE,
       'surface' => NotificationSurface::INBOX_ONLY,
     ],
-    self::CATEGORY_PLATFORM => [
+    self::BUSINESS_SALES => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::TOAST_INBOX,
+    ],
+    self::BUSINESS_REFUNDS => [
       'enabled' => TRUE,
       'surface' => NotificationSurface::BELL_INBOX,
     ],
-    self::CATEGORY_PROMO => [
-      'enabled' => FALSE,
+    self::BUSINESS_RSVPS => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::BUSINESS_FOLLOWERS => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::BUSINESS_EVENT_UPDATES => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::BUSINESS_BOOSTS => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::PLATFORM_SECURITY => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::PLATFORM_ACCOUNT => [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ],
+    self::PLATFORM_SYSTEM => [
+      'enabled' => TRUE,
       'surface' => NotificationSurface::INBOX_ONLY,
     ],
   ];
@@ -94,6 +160,14 @@ final class NotificationPreferenceService {
     if (!is_array($decoded)) {
       return $merged;
     }
+
+    $migrated = NotificationTaxonomy::migrateLegacyPreferences($decoded);
+    foreach ($migrated as $key => $entry) {
+      if (isset($merged[$key])) {
+        $merged[$key] = array_merge($merged[$key], $entry);
+      }
+    }
+
     foreach ($merged as $key => $default) {
       if (!isset($decoded[$key]) || !is_array($decoded[$key])) {
         continue;
@@ -130,34 +204,46 @@ final class NotificationPreferenceService {
   }
 
   /**
-   * Maps mel_notification.type to preference category key.
+   * Maps mel_notification context/domain to preference category key.
+   */
+  public function categoryForNotification(MelNotification $notification): string {
+    $context = (string) $notification->get('context')->value;
+    $domain = (string) $notification->get('domain')->value;
+    if ($context === '' || $domain === '') {
+      return $this->categoryForNotificationType((string) $notification->get('type')->value);
+    }
+    return NotificationTaxonomy::preferenceKey($context, $domain);
+  }
+
+  /**
+   * Maps legacy mel_notification.type to preference category key.
    */
   public function categoryForNotificationType(string $type): string {
-    return match ($type) {
-      MelNotification::TYPE_TICKET => self::CATEGORY_TICKETS,
-      MelNotification::TYPE_EVENT => self::CATEGORY_EVENTS,
-      MelNotification::TYPE_REMINDER => self::CATEGORY_REMINDERS,
-      MelNotification::TYPE_PROMO => self::CATEGORY_PROMO,
-      MelNotification::TYPE_SYSTEM => self::CATEGORY_PLATFORM,
-      default => self::CATEGORY_PLATFORM,
-    };
+    $legacy = NotificationTaxonomy::fromLegacyType($type);
+    return NotificationTaxonomy::preferenceKey($legacy['context'], $legacy['domain']);
   }
 
   /**
    * @return array{surface: string, suppressed: bool}
    */
   public function applyPreferences(MelNotification $notification, UserInterface $user, string $engineSurface): array {
-    $type = (string) $notification->get('type')->value;
-    $category = $this->categoryForNotificationType($type);
+    $category = $this->categoryForNotification($notification);
     $prefs = $this->getPreferences($user);
-    $cat = $prefs[$category] ?? self::DEFAULT_PREFS[$category];
+    $cat = $prefs[$category] ?? self::DEFAULT_PREFS[$category] ?? [
+      'enabled' => TRUE,
+      'surface' => NotificationSurface::BELL_INBOX,
+    ];
     $enabled = (bool) ($cat['enabled'] ?? TRUE);
     $userSurface = isset($cat['surface']) && is_string($cat['surface']) && in_array($cat['surface'], NotificationSurface::allowed(), TRUE)
       ? (string) $cat['surface']
       : NULL;
 
+    $domain = (string) $notification->get('domain')->value;
+    $isTicket = $domain === NotificationDomain::TICKETS
+      || (string) $notification->get('type')->value === MelNotification::TYPE_TICKET;
+
     if (!$enabled) {
-      if ($type === MelNotification::TYPE_TICKET) {
+      if ($isTicket) {
         return [
           'surface' => NotificationSurface::INBOX_ONLY,
           'suppressed' => FALSE,

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationUserInboxService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationUserInboxService.php
@@ -6,8 +6,8 @@ namespace Drupal\myeventlane_notifications\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\myeventlane_notifications\Entity\MelNotification;
 use Drupal\myeventlane_notifications\Entity\MelNotificationDelivery;
+use Drupal\myeventlane_notifications\NotificationContext;
 use Drupal\myeventlane_notifications\NotificationFilter;
 
 /**
@@ -26,8 +26,24 @@ final class NotificationUserInboxService {
     private readonly TimeInterface $time,
   ) {}
 
+  /**
+   * Total unread across all contexts.
+   */
   public function countUnread(int $uid): int {
-    if ($uid < 1) {
+    return $this->countUnreadForContexts($uid, NotificationContext::allowed());
+  }
+
+  /**
+   * Unread count for specific contexts (bell surfaces).
+   *
+   * @param list<string> $contexts
+   */
+  public function countUnreadForContexts(int $uid, array $contexts): int {
+    if ($uid < 1 || $contexts === []) {
+      return 0;
+    }
+    $notificationIds = $this->notificationIdsForContexts($contexts);
+    if ($notificationIds === []) {
       return 0;
     }
     $storage = $this->entityTypeManager->getStorage('mel_notification_delivery');
@@ -35,6 +51,7 @@ final class NotificationUserInboxService {
       ->accessCheck(FALSE)
       ->condition('recipient_uid', $uid)
       ->condition('suppressed', 0)
+      ->condition('notification_id', $notificationIds, 'IN')
       ->condition('status', [
         MelNotificationDelivery::STATUS_SENT,
         MelNotificationDelivery::STATUS_PENDING,
@@ -44,15 +61,34 @@ final class NotificationUserInboxService {
   }
 
   /**
+   * Breakdown of unread counts by context.
+   *
+   * @return array{personal: int, business: int, platform: int, unread: int}
+   */
+  public function countUnreadBreakdown(int $uid): array {
+    $personal = $this->countUnreadForContexts($uid, [NotificationContext::PERSONAL]);
+    $business = $this->countUnreadForContexts($uid, [NotificationContext::BUSINESS]);
+    $platform = $this->countUnreadForContexts($uid, [NotificationContext::PLATFORM]);
+    return [
+      'personal' => $personal,
+      'business' => $business,
+      'platform' => $platform,
+      'unread' => $personal + $business + $platform,
+    ];
+  }
+
+  /**
+   * @param list<string> $contexts
+   *
    * @return list<int>
    */
-  public function getUnreadDeliveryIds(int $uid, int $limit = self::BELL_PREVIEW_LIMIT): array {
+  public function getUnreadDeliveryIds(int $uid, int $limit = self::BELL_PREVIEW_LIMIT, array $contexts = []): array {
     if ($uid < 1) {
       return [];
     }
     $limit = max(1, min(50, $limit));
     $storage = $this->entityTypeManager->getStorage('mel_notification_delivery');
-    $ids = $storage->getQuery()
+    $query = $storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('recipient_uid', $uid)
       ->condition('suppressed', 0)
@@ -62,15 +98,24 @@ final class NotificationUserInboxService {
       ], 'IN')
       ->sort('delivered_at', 'DESC')
       ->sort('id', 'DESC')
-      ->range(0, $limit)
-      ->execute();
+      ->range(0, $limit);
+
+    if ($contexts !== []) {
+      $notificationIds = $this->notificationIdsForContexts($contexts);
+      if ($notificationIds === []) {
+        return [];
+      }
+      $query->condition('notification_id', $notificationIds, 'IN');
+    }
+
+    $ids = $query->execute();
     return array_values(array_map('intval', $ids));
   }
 
   /**
    * @return list<int>
    */
-  public function getInboxDeliveryIds(int $uid, string $filter, int $page): array {
+  public function getInboxDeliveryIds(int $uid, string $tab, string $filter, int $page): array {
     if ($uid < 1) {
       return [];
     }
@@ -89,67 +134,85 @@ final class NotificationUserInboxService {
       ->sort('id', 'DESC')
       ->range($offset, self::INBOX_PAGE_SIZE);
 
-    if ($filter === NotificationFilter::UNREAD) {
+    if ($filter === NotificationFilter::FILTER_UNREAD) {
       $query->condition('status', [
         MelNotificationDelivery::STATUS_SENT,
         MelNotificationDelivery::STATUS_PENDING,
       ], 'IN');
     }
 
-    $notificationTypeFilter = $this->notificationTypesForFilter($filter);
-    if ($notificationTypeFilter !== NULL) {
-      $nids = $this->entityTypeManager->getStorage('mel_notification')->getQuery()
-        ->accessCheck(FALSE)
-        ->condition('type', $notificationTypeFilter, 'IN')
-        ->execute();
-      $nids = array_values(array_map('intval', $nids));
-      if ($nids === []) {
-        return [];
-      }
-      $query->condition('notification_id', $nids, 'IN');
+    $contexts = NotificationFilter::contextsForTab($tab);
+    $domains = NotificationFilter::domainsForFilter($filter);
+    $notificationIds = $this->notificationIdsForScope($contexts, $domains);
+    if ($notificationIds === []) {
+      return [];
     }
+    $query->condition('notification_id', $notificationIds, 'IN');
 
     $ids = $query->execute();
     return array_values(array_map('intval', $ids));
   }
 
   /**
-   * @return list<int>|null
-   *   Notification type machine names, or NULL when filter does not restrict type.
+   * @param list<string>|null $contexts
+   * @param list<string>|null $domains
+   *
+   * @return list<int>
    */
-  private function notificationTypesForFilter(string $filter): ?array {
-    return match ($filter) {
-      NotificationFilter::TICKETS => [MelNotification::TYPE_TICKET],
-      NotificationFilter::EVENTS => [MelNotification::TYPE_EVENT],
-      NotificationFilter::REMINDERS => [MelNotification::TYPE_REMINDER],
-      NotificationFilter::PLATFORM => [
-        MelNotification::TYPE_SYSTEM,
-        MelNotification::TYPE_PROMO,
-      ],
-      default => NULL,
-    };
+  private function notificationIdsForScope(?array $contexts, ?array $domains): array {
+    $notifQuery = $this->entityTypeManager->getStorage('mel_notification')->getQuery()
+      ->accessCheck(FALSE);
+    if ($contexts !== NULL) {
+      $notifQuery->condition('context', $contexts, 'IN');
+    }
+    if ($domains !== NULL) {
+      $notifQuery->condition('domain', $domains, 'IN');
+    }
+    $ids = $notifQuery->execute();
+    return array_values(array_map('intval', $ids));
+  }
+
+  /**
+   * @param list<string> $contexts
+   *
+   * @return list<int>
+   */
+  private function notificationIdsForContexts(array $contexts): array {
+    return $this->notificationIdsForScope($contexts, NULL);
   }
 
   /**
    * Marks every unread delivery for the user as read.
    *
+   * @param list<string>|null $contexts
+   *   When set, only deliveries in these contexts are marked read.
+   *
    * @return int
    *   Number of rows updated.
    */
-  public function markAllRead(int $uid): int {
+  public function markAllRead(int $uid, ?array $contexts = NULL): int {
     if ($uid < 1) {
       return 0;
     }
     $storage = $this->entityTypeManager->getStorage('mel_notification_delivery');
-    $ids = $storage->getQuery()
+    $query = $storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('recipient_uid', $uid)
       ->condition('suppressed', 0)
       ->condition('status', [
         MelNotificationDelivery::STATUS_SENT,
         MelNotificationDelivery::STATUS_PENDING,
-      ], 'IN')
-      ->execute();
+      ], 'IN');
+
+    if ($contexts !== NULL && $contexts !== []) {
+      $notificationIds = $this->notificationIdsForContexts($contexts);
+      if ($notificationIds === []) {
+        return 0;
+      }
+      $query->condition('notification_id', $notificationIds, 'IN');
+    }
+
+    $ids = $query->execute();
     $ids = array_values(array_map('intval', $ids));
     if ($ids === []) {
       return 0;
@@ -198,4 +261,3 @@ final class NotificationUserInboxService {
   }
 
 }
-

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationViewBuilder.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationViewBuilder.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_notifications\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
 use Drupal\myeventlane_notifications\Entity\MelNotificationDelivery;
+use Drupal\myeventlane_notifications\NotificationDomain;
 use Drupal\myeventlane_notifications\NotificationSurface;
 
 /**
@@ -21,6 +23,7 @@ final class NotificationViewBuilder {
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly UrlGeneratorInterface $urlGenerator,
+    private readonly RouteProviderInterface $routeProvider,
   ) {}
 
   public function messagePreview(string $message): string {
@@ -50,8 +53,30 @@ final class NotificationViewBuilder {
    */
   public function buildActionFromNotification(MelNotification $notification): ?array {
     $label = trim((string) $notification->get('action_label')->value);
+    if ($label === '') {
+      return NULL;
+    }
+
+    $routeName = trim((string) $notification->get('route_name')->value);
+    if ($routeName !== '') {
+      $params = $this->decodeRouteParameters($notification);
+      try {
+        if (!$this->routeProvider->getRouteByName($routeName)) {
+          return NULL;
+        }
+        $url = Url::fromRoute($routeName, $params);
+        return [
+          'label' => $label,
+          'url' => $url->setAbsolute()->toString(),
+        ];
+      }
+      catch (\Throwable) {
+        // Fall through to action_uri.
+      }
+    }
+
     $uri = trim((string) $notification->get('action_uri')->value);
-    if ($label === '' || $uri === '') {
+    if ($uri === '') {
       return NULL;
     }
     if (!str_starts_with($uri, '/') || str_starts_with($uri, '//')) {
@@ -66,6 +91,32 @@ final class NotificationViewBuilder {
     }
     catch (\Throwable) {
       return NULL;
+    }
+  }
+
+  /**
+   * @return array<string, scalar>
+   */
+  private function decodeRouteParameters(MelNotification $notification): array {
+    $raw = trim((string) $notification->get('route_parameters')->value);
+    if ($raw === '') {
+      return [];
+    }
+    try {
+      $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+      if (!is_array($decoded)) {
+        return [];
+      }
+      $out = [];
+      foreach ($decoded as $key => $value) {
+        if (is_string($key) && (is_string($value) || is_int($value))) {
+          $out[$key] = $value;
+        }
+      }
+      return $out;
+    }
+    catch (\Throwable) {
+      return [];
     }
   }
 
@@ -142,6 +193,8 @@ final class NotificationViewBuilder {
     $action = $this->buildTrackedActionForDelivery($delivery, $notification);
     $delivered = (int) ($delivery->get('delivered_at')->value ?? 0);
     $groupKey = trim((string) $notification->get('group_key')->value);
+    $domain = (string) $notification->get('domain')->value;
+    $context = (string) $notification->get('context')->value;
 
     return [
       'delivery_id' => (int) $delivery->id(),
@@ -150,7 +203,10 @@ final class NotificationViewBuilder {
       'message' => $message,
       'message_preview' => $this->messagePreview($message),
       'type' => (string) $notification->get('type')->value,
-      'icon' => $this->iconForType((string) $notification->get('type')->value),
+      'context' => $context,
+      'domain' => $domain,
+      'icon' => $this->iconForDomain($domain, (string) $notification->get('type')->value),
+      'badge' => $this->badgeForDomain($domain),
       'created' => (int) $notification->get('created')->value,
       'delivered_at' => $delivered,
       'priority_score' => (int) $notification->get('priority_score')->value,
@@ -217,15 +273,17 @@ final class NotificationViewBuilder {
       }
       else {
         $first = $buffer[0];
-        $type = (string) ($first['type'] ?? '');
         $count = count($buffer);
         $out[] = [
           'delivery_id' => (int) ($first['delivery_id'] ?? 0),
           'notification_id' => (int) ($first['notification_id'] ?? 0),
           'title' => (string) ($first['title'] ?? ''),
           'message_preview' => '',
-          'type' => $type,
+          'type' => (string) ($first['type'] ?? ''),
+          'context' => (string) ($first['context'] ?? ''),
+          'domain' => (string) ($first['domain'] ?? ''),
           'icon' => $first['icon'] ?? 'bell',
+          'badge' => $first['badge'] ?? 'bell',
           'created' => (int) ($first['created'] ?? 0),
           'delivered_at' => (int) ($first['delivered_at'] ?? 0),
           'priority_score' => (int) ($first['priority_score'] ?? 0),
@@ -269,6 +327,26 @@ final class NotificationViewBuilder {
     $flush();
 
     return $out;
+  }
+
+  public function iconForDomain(string $domain, string $legacyType = ''): string {
+    return match ($domain) {
+      NotificationDomain::TICKETS => 'ticket',
+      NotificationDomain::ORDERS => 'order',
+      NotificationDomain::SALES => 'sale',
+      NotificationDomain::REFUNDS => 'refund',
+      NotificationDomain::RSVPS => 'rsvp',
+      NotificationDomain::FOLLOWERS => 'follower',
+      NotificationDomain::EVENT_UPDATES => 'event-update',
+      NotificationDomain::BOOSTS => 'boost',
+      NotificationDomain::REMINDERS => 'reminder',
+      NotificationDomain::PLATFORM => 'platform',
+      default => $this->iconForType($legacyType),
+    };
+  }
+
+  public function badgeForDomain(string $domain): string {
+    return $this->iconForDomain($domain);
   }
 
   public function iconForType(string $type): string {

--- a/web/modules/custom/myeventlane_notifications/src/Service/PlatformNotificationTriggerService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/PlatformNotificationTriggerService.php
@@ -10,8 +10,9 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\Core\Url;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
 use Drupal\node\NodeInterface;
 
 /**
@@ -48,13 +49,19 @@ final class PlatformNotificationTriggerService {
     }
 
     $titles = [];
+    $organiserUids = [];
     foreach ($eventIds as $eventId) {
       $node = $this->entityTypeManager->getStorage('node')->load($eventId);
       if ($node instanceof NodeInterface) {
         $titles[] = $node->label();
+        $organiserUid = $this->audienceResolver->resolveEventOrganiserUid($node);
+        if ($organiserUid !== NULL) {
+          $organiserUids[] = $organiserUid;
+        }
       }
     }
     $label = $titles !== [] ? implode(', ', $titles) : $this->shortOrderLabel($order);
+    $primaryEventId = $eventIds[0];
 
     try {
       $notification = $this->notificationManager->createNotification([
@@ -70,8 +77,10 @@ final class PlatformNotificationTriggerService {
         'suppression_key' => 'order_paid:' . $order->id(),
         'group_key' => 'ticket_order:' . $order->id(),
         'action_label' => (string) $this->translation->translate('View tickets'),
-        'action_uri' => '/my-tickets',
+        'route_name' => 'myeventlane_checkout_flow.my_tickets',
         'action_context' => 'checkout_ticket_confirm',
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::TICKETS,
       ]);
       $this->notificationManager->queueNotification($notification);
     }
@@ -83,6 +92,45 @@ final class PlatformNotificationTriggerService {
         '@order' => $order->id(),
         '@message' => $e->getMessage(),
       ]);
+    }
+
+    $organiserUids = array_values(array_unique(array_filter($organiserUids)));
+    foreach ($organiserUids as $organiserUid) {
+      if ($organiserUid === $customerId) {
+        continue;
+      }
+      try {
+        $sale = $this->notificationManager->createNotification([
+          'type' => MelNotification::TYPE_EVENT,
+          'title' => (string) $this->translation->translate('New order received'),
+          'message' => (string) $this->translation->translate('You received a new ticket order for @events.', ['@events' => $label]),
+          'audience_type' => MelNotification::AUDIENCE_USER_IDS,
+          'audience_data' => ['user_ids' => [$organiserUid]],
+          'channels' => ['toast'],
+          'status' => MelNotification::STATUS_DRAFT,
+          'priority' => MelNotification::PRIORITY_NORMAL,
+          'priority_score' => 60,
+          'suppression_key' => 'vendor_sale:' . $order->id() . ':' . $organiserUid,
+          'action_label' => (string) $this->translation->translate('View order'),
+          'route_name' => 'myeventlane_vendor.console.event_order_view',
+          'route_parameters' => [
+            'event' => $primaryEventId,
+            'order' => (int) $order->id(),
+          ],
+          'action_context' => 'vendor_sale',
+          'context' => NotificationContext::BUSINESS,
+          'domain' => NotificationDomain::SALES,
+        ]);
+        $this->notificationManager->queueNotification($sale);
+      }
+      catch (\RuntimeException $e) {
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('Failed to queue vendor sale notification for order @order: @message', [
+          '@order' => $order->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
     }
   }
 
@@ -110,13 +158,6 @@ final class PlatformNotificationTriggerService {
       return;
     }
 
-    $eventPath = '/node/' . $nid;
-    try {
-      $eventPath = Url::fromRoute('entity.node.canonical', ['node' => $nid], ['absolute' => FALSE])->toString();
-    }
-    catch (\Throwable) {
-    }
-
     try {
       $notification = $this->notificationManager->createNotification([
         'type' => MelNotification::TYPE_EVENT,
@@ -131,8 +172,11 @@ final class PlatformNotificationTriggerService {
         'suppression_key' => 'event_published:' . $nid,
         'group_key' => 'category_event_digest',
         'action_label' => (string) $this->translation->translate('See event'),
-        'action_uri' => $eventPath,
+        'route_name' => 'entity.node.canonical',
+        'route_parameters' => ['node' => $nid],
         'action_context' => 'event_published_follower',
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::EVENT_UPDATES,
       ]);
       $this->notificationManager->queueNotification($notification);
       $this->state->set($stateKey, 1);
@@ -164,13 +208,6 @@ final class PlatformNotificationTriggerService {
 
     $attendeeUid = (int) $submission->get('user_id')->target_id;
 
-    $eventPath = '/node/' . $eventId;
-    try {
-      $eventPath = Url::fromRoute('entity.node.canonical', ['node' => $eventId], ['absolute' => FALSE])->toString();
-    }
-    catch (\Throwable) {
-    }
-
     if ($attendeeUid > 0) {
       try {
         $confirm = $this->notificationManager->createNotification([
@@ -184,8 +221,11 @@ final class PlatformNotificationTriggerService {
           'priority_score' => 55,
           'suppression_key' => 'rsvp_confirm:' . $submission->id(),
           'action_label' => (string) $this->translation->translate('View event'),
-          'action_uri' => $eventPath,
+          'route_name' => 'entity.node.canonical',
+          'route_parameters' => ['node' => $eventId],
           'action_context' => 'rsvp_attendee_confirm',
+          'context' => NotificationContext::PERSONAL,
+          'domain' => NotificationDomain::RSVPS,
         ]);
         $this->notificationManager->queueNotification($confirm);
       }
@@ -216,9 +256,12 @@ final class PlatformNotificationTriggerService {
         'priority' => MelNotification::PRIORITY_NORMAL,
         'priority_score' => 35,
         'suppression_key' => 'rsvp_vendor:' . $submission->id(),
-        'action_label' => (string) $this->translation->translate('Review event'),
-        'action_uri' => $eventPath,
+        'action_label' => (string) $this->translation->translate('View attendees'),
+        'route_name' => 'myeventlane_event_attendees.vendor_list',
+        'route_parameters' => ['node' => $eventId],
         'action_context' => 'rsvp_vendor_alert',
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::RSVPS,
       ]);
       $this->notificationManager->queueNotification($vendorNote);
     }

--- a/web/modules/custom/myeventlane_notifications/src/Service/RefundNotificationTriggerService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/RefundNotificationTriggerService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_notifications\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
+use Drupal\node\NodeInterface;
+
+/**
+ * Business-context in-app notifications for refund lifecycle events.
+ */
+final class RefundNotificationTriggerService {
+
+  public function __construct(
+    private readonly NotificationManager $notificationManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerChannelInterface $logger,
+    private readonly TranslationInterface $translation,
+  ) {}
+
+  /**
+   * @param array<string, mixed> $requestRow
+   *   Refund request row from RefundRequestStorage.
+   */
+  public function onRefundRequested(array $requestRow, OrderInterface $order, NodeInterface $event): void {
+    $vendorUid = (int) ($requestRow['vendor_uid'] ?? $event->getOwnerId());
+    if ($vendorUid < 1) {
+      return;
+    }
+    $requestId = (int) ($requestRow['id'] ?? 0);
+    $this->queueBusinessRefund(
+      [$vendorUid],
+      (string) $this->translation->translate('Refund requested'),
+      (string) $this->translation->translate('A buyer requested a refund for @event.', ['@event' => $event->label()]),
+      'refund_requested',
+      'refund_request:' . $requestId,
+      (string) $this->translation->translate('Review request'),
+      'myeventlane_refunds.vendor_refund_requests',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $requestRow
+   */
+  public function onRefundApproved(array $requestRow, OrderInterface $order, NodeInterface $event): void {
+    $vendorUid = (int) ($requestRow['vendor_uid'] ?? $event->getOwnerId());
+    if ($vendorUid < 1) {
+      return;
+    }
+    $requestId = (int) ($requestRow['id'] ?? 0);
+    $this->queueBusinessRefund(
+      [$vendorUid],
+      (string) $this->translation->translate('Refund approved'),
+      (string) $this->translation->translate('You approved a refund for order @order.', [
+        '@order' => $order->getOrderNumber() ?: (string) $order->id(),
+      ]),
+      'refund_approved',
+      'refund_approved:' . $requestId,
+      (string) $this->translation->translate('View order'),
+      'myeventlane_vendor.console.event_order_view',
+      ['event' => (int) $event->id(), 'order' => (int) $order->id()],
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $requestRow
+   */
+  public function onRefundRejected(array $requestRow, OrderInterface $order, NodeInterface $event): void {
+    $vendorUid = (int) ($requestRow['vendor_uid'] ?? $event->getOwnerId());
+    if ($vendorUid < 1) {
+      return;
+    }
+    $requestId = (int) ($requestRow['id'] ?? 0);
+    $this->queueBusinessRefund(
+      [$vendorUid],
+      (string) $this->translation->translate('Refund rejected'),
+      (string) $this->translation->translate('You declined a refund request for @event.', ['@event' => $event->label()]),
+      'refund_rejected',
+      'refund_rejected:' . $requestId,
+      (string) $this->translation->translate('View requests'),
+      'myeventlane_refunds.vendor_refund_requests',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  public function onRefundCompleted(OrderInterface $order, NodeInterface $event, int $vendorUid): void {
+    if ($vendorUid < 1) {
+      return;
+    }
+    $this->queueBusinessRefund(
+      [$vendorUid],
+      (string) $this->translation->translate('Refund completed'),
+      (string) $this->translation->translate('A refund for order @order has been processed.', [
+        '@order' => $order->getOrderNumber() ?: (string) $order->id(),
+      ]),
+      'refund_completed',
+      'refund_completed:' . $order->id() . ':' . $event->id(),
+      (string) $this->translation->translate('View order'),
+      'myeventlane_vendor.console.event_order_view',
+      ['event' => (int) $event->id(), 'order' => (int) $order->id()],
+    );
+  }
+
+  /**
+   * @param list<int> $userIds
+   * @param array<string, scalar> $routeParameters
+   */
+  private function queueBusinessRefund(
+    array $userIds,
+    string $title,
+    string $message,
+    string $actionContext,
+    string $suppressionKey,
+    string $actionLabel,
+    string $routeName,
+    array $routeParameters,
+  ): void {
+    $userIds = array_values(array_unique(array_filter(array_map('intval', $userIds))));
+    if ($userIds === []) {
+      return;
+    }
+    try {
+      $notification = $this->notificationManager->createNotification([
+        'type' => MelNotification::TYPE_SYSTEM,
+        'title' => $title,
+        'message' => $message,
+        'audience_type' => MelNotification::AUDIENCE_USER_IDS,
+        'audience_data' => ['user_ids' => $userIds],
+        'channels' => ['toast'],
+        'status' => MelNotification::STATUS_DRAFT,
+        'priority' => MelNotification::PRIORITY_HIGH,
+        'priority_score' => 70,
+        'suppression_key' => $suppressionKey,
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::REFUNDS,
+        'action_label' => $actionLabel,
+        'route_name' => $routeName,
+        'route_parameters' => $routeParameters,
+        'action_context' => $actionContext,
+      ]);
+      $this->notificationManager->queueNotification($notification);
+    }
+    catch (\RuntimeException) {
+      // Suppressed duplicate.
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Failed to queue refund notification (@ctx): @message', [
+        '@ctx' => $actionContext,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_notifications/templates/mel-notification-bell.html.twig
+++ b/web/modules/custom/myeventlane_notifications/templates/mel-notification-bell.html.twig
@@ -4,7 +4,7 @@
  * Notification bell shell; list + badge updated via mel-notifications-ui.js.
  */
 #}
-<div class="mel-notif-bell" data-mel-notif-bell>
+<div class="mel-notif-bell" data-mel-notif-bell data-mel-bell-context="{{ bell_context }}">
   <button type="button"
           class="mel-notif-bell__trigger"
           data-mel-notif-bell-trigger
@@ -18,7 +18,10 @@
         <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
       </svg>
     </span>
-    <span class="mel-notif-bell__badge mel-notif-bell__badge--empty" data-mel-notif-bell-badge aria-hidden="true">0</span>
+    <span class="mel-notif-bell__badge mel-notif-bell__badge--empty"
+          data-mel-notif-bell-badge
+          aria-live="polite"
+          aria-label="{{ 'Unread notifications'|t }}">0</span>
   </button>
 
   <div class="mel-notif-bell__panel"

--- a/web/modules/custom/myeventlane_notifications/templates/mel-notification-inbox.html.twig
+++ b/web/modules/custom/myeventlane_notifications/templates/mel-notification-inbox.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Full notifications inbox (filters, grouped list, empty state).
+ * Full notifications inbox (tabs, filters, grouped list, empty state).
  */
 #}
 <div class="mel-notif-inbox mel-container">
@@ -9,7 +9,7 @@
     <div class="mel-notif-inbox__header-row">
       <div>
         <h1 class="mel-notif-inbox__title">{{ 'Notifications'|t }}</h1>
-        <p class="mel-notif-inbox__lede">{{ 'Tickets, events, reminders, and platform updates in one calm place.'|t }}</p>
+        <p class="mel-notif-inbox__lede">{{ 'Personal tickets, business sales, and platform updates — organised by context.'|t }}</p>
       </div>
       {% if settings_url %}
         <a href="{{ settings_url }}" class="mel-notif-inbox__settings">{{ 'Notification settings'|t }}</a>
@@ -17,11 +17,21 @@
     </div>
   </header>
 
+  <nav class="mel-notif-inbox__tabs" aria-label="{{ 'Notification context'|t }}">
+    {% for link in tab_links %}
+      <a href="{{ link.url }}"
+         class="mel-notif-inbox__tab{% if link.active %} is-active{% endif %}"
+         {% if link.active %}aria-current="page"{% endif %}>
+        {{ link.label }}
+      </a>
+    {% endfor %}
+  </nav>
+
   <nav class="mel-notif-inbox__filters" aria-label="{{ 'Filter notifications'|t }}">
     {% for link in filter_links %}
       <a href="{{ link.url }}"
          class="mel-notif-inbox__chip{% if link.active %} is-active{% endif %}"
-         {% if link.active %}aria-current="page"{% endif %}>
+         {% if link.active %}aria-current="true"{% endif %}>
         {{ link.label }}
       </a>
     {% endfor %}
@@ -58,9 +68,12 @@
             {% for item in group.items %}
               {% set row = item.row %}
               <li class="mel-notif-inbox__item{% if row.is_unread %} is-unread{% endif %}">
-                <div class="mel-notif-inbox__accent mel-notif-inbox__accent--{{ row.icon }}" aria-hidden="true"></div>
+                <div class="mel-notif-inbox__accent mel-notif-inbox__accent--{{ row.badge }}" aria-hidden="true"></div>
                 <div class="mel-notif-inbox__body">
-                  <div class="mel-notif-inbox__row-title">{{ row.title }}</div>
+                  <div class="mel-notif-inbox__row-head">
+                    <span class="mel-notif-inbox__badge mel-notif-inbox__badge--{{ row.badge }}" aria-label="{{ row.domain|replace({'_': ' '})|capitalize }}">{{ row.domain|replace({'_': ' '}) }}</span>
+                    <div class="mel-notif-inbox__row-title">{{ row.title }}</div>
+                  </div>
                   {% if row.is_group_summary %}
                     <div class="mel-notif-inbox__preview">{{ row.group_summary_label }}</div>
                   {% else %}
@@ -85,7 +98,7 @@
     {% if pager_info.has_more %}
       {% set next_page = pager_info.page + 1 %}
       <nav class="mel-notif-inbox__pager" aria-label="{{ 'Pagination'|t }}">
-        <a href="{{ path('myeventlane_notifications.inbox', {}, {'query': {'filter': filter, 'page': next_page}}) }}" class="mel-notif-inbox__pager-link">
+        <a href="{{ path('myeventlane_notifications.inbox', {}, {'query': {'tab': tab, 'filter': filter, 'page': next_page}}) }}" class="mel-notif-inbox__pager-link">
           {{ 'Older'|t }}
         </a>
       </nav>

--- a/web/modules/custom/myeventlane_notifications/tests/src/Kernel/NotificationSystemKernelTest.php
+++ b/web/modules/custom/myeventlane_notifications/tests/src/Kernel/NotificationSystemKernelTest.php
@@ -413,7 +413,7 @@ final class NotificationSystemKernelTest extends KernelTestBase {
 
     /** @var \Drupal\myeventlane_notifications\Service\NotificationUserInboxService $inbox */
     $inbox = $this->container->get('myeventlane_notifications.user_inbox');
-    $ids = $inbox->getInboxDeliveryIds((int) $user->id(), NotificationFilter::TICKETS, 0);
+    $ids = $inbox->getInboxDeliveryIds((int) $user->id(), NotificationFilter::TAB_ALL, NotificationFilter::FILTER_TICKETS, 0);
     $this->assertCount(1, $ids);
   }
 
@@ -615,7 +615,7 @@ final class NotificationSystemKernelTest extends KernelTestBase {
 
     /** @var \Drupal\myeventlane_notifications\Service\NotificationUserInboxService $inbox */
     $inbox = $this->container->get('myeventlane_notifications.user_inbox');
-    $ids = $inbox->getInboxDeliveryIds((int) $user->id(), NotificationFilter::ALL, 0);
+    $ids = $inbox->getInboxDeliveryIds((int) $user->id(), NotificationFilter::TAB_ALL, NotificationFilter::FILTER_ALL, 0);
     $this->assertSame([], $ids);
     $this->assertSame(0, $inbox->countUnread((int) $user->id()));
   }

--- a/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
+++ b/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
@@ -61,3 +61,4 @@ services:
       - '@lock'
       - '@module_handler'
       - '@myeventlane_core.domain_detector'
+      - '@?myeventlane_notifications.refund_trigger'

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
@@ -22,6 +22,7 @@ use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\Service\StripeService;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
+use Drupal\myeventlane_notifications\Service\RefundNotificationTriggerService;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 
@@ -67,6 +68,8 @@ final class RefundProcessor {
    *   The module handler.
    * @param \Drupal\myeventlane_core\Service\DomainDetector $domainDetector
    *   The domain detector (for public-domain customer links).
+   * @param \Drupal\myeventlane_notifications\Service\RefundNotificationTriggerService|null $refundNotificationTrigger
+   *   Optional in-app refund notifications (when myeventlane_notifications is enabled).
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -85,6 +88,7 @@ final class RefundProcessor {
     private readonly LockBackendInterface $lock,
     private readonly ModuleHandlerInterface $moduleHandler,
     private readonly DomainDetector $domainDetector,
+    private readonly ?RefundNotificationTriggerService $refundNotificationTrigger = NULL,
   ) {}
 
   /**
@@ -180,6 +184,11 @@ final class RefundProcessor {
       }
     }
 
+    $requestRow = $this->refundRequestStorage->load($requestId);
+    if ($requestRow !== NULL) {
+      $this->refundNotificationTrigger?->onRefundRequested($requestRow, $order, $event);
+    }
+
     return $requestId;
   }
 
@@ -256,6 +265,8 @@ final class RefundProcessor {
       }
     }
 
+    $this->refundNotificationTrigger?->onRefundApproved($req, $order, $event);
+
     return $logId;
   }
 
@@ -310,6 +321,8 @@ final class RefundProcessor {
         $this->messagingManager->sendMessage($id);
       }
     }
+
+    $this->refundNotificationTrigger?->onRefundRejected($req, $order, $event);
   }
 
   /**
@@ -1217,6 +1230,9 @@ final class RefundProcessor {
     if ($refundRequestId) {
       $this->refundRequestStorage->update((int) $refundRequestId, ['status' => RefundRequestStorage::STATUS_COMPLETED]);
     }
+
+    $vendorUid = (int) ($log['vendor_uid'] ?? $event->getOwnerId());
+    $this->refundNotificationTrigger?->onRefundCompleted($order, $event, $vendorUid);
   }
 
   /**


### PR DESCRIPTION
- Added 'context' and 'domain' fields to MelNotification entity for better categorization of notifications.
- Updated NotificationFilter to include new tab and filter constants for personal, business, and platform contexts.
- Refactored NotificationPreferenceService to accommodate new notification categories and preferences.
- Enhanced NotificationManager and NotificationUserInboxService to handle context-specific notifications.
- Improved NotificationViewBuilder to display context and domain information in notifications.
- Updated NotificationController to support context-aware unread counts and delivery management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires running update 11006 and touches order/refund notification paths plus user preference JSON shape; bell scoping changes what counts as unread on each surface.
> 
> **Overview**
> Introduces **context** (personal, business, platform) and **domain** (tickets, sales, refunds, etc.) on `mel_notification`, with `NotificationTaxonomy` for legacy backfill, email template schema overrides, and preference migration. Update **11006** installs fields, backfills rows, and adds DB indexes.
> 
> **Bell and inbox** are context-aware: public theme uses personal+platform unread; vendor console uses business+platform. JSON endpoints accept `bell_context`; mark-all-read scopes to the active bell. The inbox gains **All / Personal / Business / Platform** tabs and richer domain filters; UI shows domain badges and accent colors.
> 
> **Preferences** are regrouped into personal, business, and platform categories with new keys; suppression still respects ticket inbox visibility.
> 
> **Triggers** set explicit context/domain, prefer `route_name`/`route_parameters` over raw paths, add **vendor sale** on paid orders, and add **RefundNotificationTriggerService** hooked from `RefundProcessor` (optional service). Messaging template config documents optional context/domain overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967e947b2b3988aa7fd267434a529f7e22b5c99b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->