### PR TITLE
Cursor/2026 06 07 sfe2 fc4cc

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -55,6 +55,7 @@ services:
       - '@myeventlane_boost.entitlement_manager'
       - '@logger.channel.myeventlane_boost'
       - '@request_stack'
+      - '@?myeventlane_notifications.business_trigger'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\myeventlane_boost\BoostManager;
 use Drupal\myeventlane_boost\Service\BoostEntitlementManager;
+use Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -44,6 +45,7 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
     private readonly MailManagerInterface $mailManager,
     private readonly BoostManager $boostManager,
     private readonly BoostEntitlementManager $entitlementManager,
+    private readonly ?BusinessNotificationTriggerService $businessNotificationTrigger = NULL,
   ) {}
 
   /**
@@ -57,6 +59,9 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
       $container->get('plugin.manager.mail'),
       $container->get('myeventlane_boost.manager'),
       $container->get('myeventlane_boost.entitlement_manager'),
+      $container->has('myeventlane_notifications.business_trigger')
+        ? $container->get('myeventlane_notifications.business_trigger')
+        : NULL,
     );
   }
 
@@ -124,6 +129,10 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
       NULL,
       TRUE
     );
+
+    if ($this->businessNotificationTrigger !== NULL && $owner !== NULL) {
+      $this->businessNotificationTrigger->onBoostCompleted($node, (int) $owner->id());
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryReminderCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryReminderCron.php
@@ -11,6 +11,8 @@ use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService;
+use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -41,6 +43,7 @@ final class BoostExpiryReminderCron implements ContainerInjectionInterface {
     private readonly LoggerInterface $logger,
     private readonly MailManagerInterface $mailManager,
     private readonly BoostManager $boostManager,
+    private readonly ?BusinessNotificationTriggerService $businessNotificationTrigger = NULL,
   ) {}
 
   /**
@@ -53,6 +56,9 @@ final class BoostExpiryReminderCron implements ContainerInjectionInterface {
       $container->get('logger.channel.myeventlane_boost'),
       $container->get('plugin.manager.mail'),
       $container->get('myeventlane_boost.manager'),
+      $container->has('myeventlane_notifications.business_trigger')
+        ? $container->get('myeventlane_notifications.business_trigger')
+        : NULL,
     );
   }
 
@@ -109,6 +115,10 @@ final class BoostExpiryReminderCron implements ContainerInjectionInterface {
         NULL,
         TRUE
       );
+
+      if ($this->businessNotificationTrigger !== NULL) {
+        $this->businessNotificationTrigger->onBoostExpiring($node, (int) $owner->id());
+      }
 
       $count++;
     }

--- a/web/modules/custom/myeventlane_boost/src/EventSubscriber/BoostOrderSubscriber.php
+++ b/web/modules/custom/myeventlane_boost/src/EventSubscriber/BoostOrderSubscriber.php
@@ -10,6 +10,8 @@ use Drupal\commerce_cart\Event\OrderItemComparisonFieldsEvent;
 use Drupal\commerce_order\Event\OrderEvent;
 use Drupal\commerce_order\Event\OrderEvents;
 use Drupal\myeventlane_boost\Service\BoostEntitlementManager;
+use Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService;
+use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -33,6 +35,7 @@ final class BoostOrderSubscriber implements EventSubscriberInterface {
     private readonly BoostEntitlementManager $entitlementManager,
     private readonly LoggerInterface $logger,
     private readonly RequestStack $requestStack,
+    private readonly ?BusinessNotificationTriggerService $businessNotificationTrigger = NULL,
   ) {}
 
   /**
@@ -60,7 +63,17 @@ final class BoostOrderSubscriber implements EventSubscriberInterface {
 
     $this->logger->notice('ORDER_PAID for order @id', ['@id' => $order->id()]);
     foreach ($order->getItems() as $item) {
-      $this->entitlementManager->activateEntitlementFromOrderItem($order, $item);
+      $entitlement = $this->entitlementManager->activateEntitlementFromOrderItem($order, $item);
+      if ($entitlement === NULL || $this->businessNotificationTrigger === NULL) {
+        continue;
+      }
+      if (!$item->hasField('field_target_event') || $item->get('field_target_event')->isEmpty()) {
+        continue;
+      }
+      $event = $item->get('field_target_event')->entity;
+      if ($event instanceof NodeInterface) {
+        $this->businessNotificationTrigger->onBoostPurchased($event, (int) $event->getOwnerId());
+      }
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -88,12 +88,10 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   public function buildSidebarGuidance(NodeInterface $event): array {
-    $readiness = $this->eventReadiness->evaluate($event, $this->currentUser);
     $build = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-studio-sidebar-guidance']],
       'next_steps' => $this->buildNextStepsCard(),
-      'readiness' => $this->buildReadinessCard($readiness, TRUE),
     ];
 
     $support = $this->supportResolver->buildCard($event, 'sidebar');
@@ -228,11 +226,9 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildSettingsSection(NodeInterface $event): array {
-    $readiness = $this->eventReadiness->evaluate($event, $this->currentUser);
     $build = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-studio-section__form-stack']],
-      'readiness' => $this->buildReadinessCard($readiness),
       'settings' => $this->formBuilder->getForm(EventSettingsForm::class, $event),
     ];
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -178,6 +178,12 @@ final class MessagingManager {
 
     // Normalize context for storage: ensure scalar/array only for serialization.
     $storableContext = $this->normalizeContextForStorage($context);
+    if (class_exists(\Drupal\myeventlane_notifications\NotificationTaxonomy::class)) {
+      $classification = \Drupal\myeventlane_notifications\NotificationTaxonomy::emailTemplateClassification($type);
+      $storableContext['_mel_notification_context'] = $classification['context'];
+      $storableContext['_mel_notification_domain'] = $classification['domain'];
+      $storableContext['_mel_notification_priority'] = $classification['priority'];
+    }
     $storableContext['_attachments'] = $opts['attachments'] ?? [];
     $id = $this->uuid();
 

--- a/web/modules/custom/myeventlane_notifications/README.md
+++ b/web/modules/custom/myeventlane_notifications/README.md
@@ -1,0 +1,36 @@
+# MyEventLane Notifications — developer notes
+
+## Deep links (route hygiene)
+
+All **new** notifications must set:
+
+- `route_name` — Drupal route name (e.g. `myeventlane_checkout_flow.order_detail`)
+- `route_parameters` — JSON-serializable array (e.g. `['commerce_order' => 123]`)
+- `action_label` — human-readable CTA label
+
+Do **not** set `action_uri` on new notifications. Legacy notifications may still use `action_uri`; `NotificationViewBuilder::buildActionFromNotification()` prefers `route_name` and falls back to `action_uri` when the route is missing or invalid.
+
+## Classification
+
+Use `NotificationTaxonomy` for context/domain mapping:
+
+- In-app: set `context`, `domain`, and optional `action_context` on create; or rely on taxonomy defaults from `type` + `action_context`.
+- Email: `MessagingManager::queue()` stores `_mel_notification_*` keys from `NotificationTaxonomy::emailTemplateClassification()`.
+
+## Priority
+
+Allowed values: `low`, `normal`, `high`, `critical`.
+
+- `critical` — security/platform alerts; never suppressed by user preferences; surfaces like `high`.
+- `high` — refunds, capacity, boost expiring, etc.
+- `normal` / `low` — routine business and personal updates.
+
+## Trigger services
+
+| Service ID | Role |
+|---|---|
+| `myeventlane_notifications.trigger` | Order paid, RSVP, event published |
+| `myeventlane_notifications.business_trigger` | Capacity, stock, boost, followers, waitlist |
+| `myeventlane_notifications.refund_trigger` | Refund lifecycle (vendor + buyer) |
+
+Optional cross-module wiring uses `@?myeventlane_notifications.business_trigger` so modules stay bootable when notifications is disabled.

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.install
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.install
@@ -337,6 +337,28 @@ function myeventlane_notifications_update_11006(): string {
   return (string) t('Installed MEL context/domain/route notification fields and backfilled existing rows.');
 }
 
+/**
+ * Adds critical priority as an allowed mel_notification priority value.
+ */
+function myeventlane_notifications_update_11007(): string {
+  try {
+    $update_manager = \Drupal::entityDefinitionUpdateManager();
+    $notif_entity = \Drupal::entityTypeManager()->getDefinition('mel_notification');
+    $notif_fields = \Drupal\myeventlane_notifications\Entity\MelNotification::baseFieldDefinitions($notif_entity);
+    $existing = $update_manager->getFieldStorageDefinition('priority', 'mel_notification');
+    if ($existing !== NULL) {
+      $update_manager->updateFieldStorageDefinition($notif_fields['priority']);
+    }
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('myeventlane_notifications')->notice(
+      'Critical priority field storage update skipped (runtime definition applies): @message',
+      ['@message' => $e->getMessage()]
+    );
+  }
+  return (string) t('Added critical priority to MEL notifications.');
+}
+
 function _myeventlane_notifications_delivery_index_spec(array $columns, string $index_name): array {
   $definitions = [
     'recipient_uid_target_id' => [

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
@@ -17,6 +17,7 @@ use Drupal\myeventlane_notifications\NotificationPrefsFieldDefinition;
 use Drupal\myeventlane_notifications\Service\NotificationPreferenceService;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_preprocess_site_header().
@@ -127,6 +128,14 @@ function myeventlane_notifications_entity_insert(EntityInterface $entity): void 
     \Drupal::service('myeventlane_notifications.trigger')->onRsvpEntityInserted($entity);
     return;
   }
+  if ($entity->getEntityTypeId() === 'myeventlane_vendor_follow') {
+    myeventlane_notifications_on_vendor_follow_insert($entity);
+    return;
+  }
+  if ($entity->getEntityTypeId() === 'flagging') {
+    myeventlane_notifications_on_category_flag_insert($entity);
+    return;
+  }
   if ($entity instanceof NodeInterface && $entity->bundle() === 'event' && $entity->isPublished()) {
     \Drupal::service('myeventlane_notifications.trigger')->onEventPublished($entity);
   }
@@ -138,6 +147,91 @@ function myeventlane_notifications_entity_insert(EntityInterface $entity): void 
 function myeventlane_notifications_entity_update(EntityInterface $entity): void {
   if ($entity instanceof NodeInterface) {
     \Drupal::service('myeventlane_notifications.trigger')->onNodeUpdate($entity);
+    return;
+  }
+  if ($entity->getEntityTypeId() === 'event_attendee') {
+    myeventlane_notifications_on_event_attendee_update($entity);
+  }
+}
+
+/**
+ * Category follow in-app notifications (flag module flagging entity).
+ */
+function myeventlane_notifications_on_category_flag_insert(EntityInterface $flagging): void {
+  if ($flagging->getEntityTypeId() !== 'flagging') {
+    return;
+  }
+  if ((string) ($flagging->get('flag_id')->value ?? '') !== 'follow_category') {
+    return;
+  }
+  if ((string) ($flagging->get('entity_type')->value ?? '') !== 'taxonomy_term') {
+    return;
+  }
+  $termId = (int) ($flagging->get('entity_id')->value ?? 0);
+  $followerUid = (int) $flagging->getOwnerId();
+  if ($termId < 1 || $followerUid < 1) {
+    return;
+  }
+  $follower = \Drupal::entityTypeManager()->getStorage('user')->load($followerUid);
+  if ($follower instanceof UserInterface) {
+    \Drupal::service('myeventlane_notifications.business_trigger')->onCategoryFollowed($termId, $follower);
+  }
+}
+
+/**
+ * Sends organiser-follow notifications when a vendor follow row is created.
+ */
+function myeventlane_notifications_on_vendor_follow_insert(EntityInterface $follow): void {
+  if ($follow->getEntityTypeId() !== 'myeventlane_vendor_follow') {
+    return;
+  }
+  $vendorId = (int) ($follow->get('vendor_id')->target_id ?? 0);
+  $followerUid = (int) ($follow->get('user_id')->target_id ?? 0);
+  if ($vendorId < 1 || $followerUid < 1) {
+    return;
+  }
+  $vendor = \Drupal::entityTypeManager()->getStorage('myeventlane_vendor')->load($vendorId);
+  $follower = \Drupal::entityTypeManager()->getStorage('user')->load($followerUid);
+  if ($vendor instanceof \Drupal\myeventlane_vendor\Entity\Vendor && $follower instanceof UserInterface) {
+    \Drupal::service('myeventlane_notifications.business_trigger')->onOrganiserFollowed($vendor, $follower);
+  }
+}
+
+/**
+ * RSVP cancel and waitlist promotion in-app notifications.
+ */
+function myeventlane_notifications_on_event_attendee_update(EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'event_attendee') {
+    return;
+  }
+  $original = $entity->original ?? NULL;
+  if (!$original instanceof EntityInterface) {
+    return;
+  }
+  $oldStatus = (string) ($original->get('status')->value ?? '');
+  $newStatus = (string) ($entity->get('status')->value ?? '');
+  if ($oldStatus === $newStatus) {
+    return;
+  }
+
+  $eventId = (int) ($entity->get('event')->target_id ?? 0);
+  if ($eventId < 1) {
+    return;
+  }
+  $event = \Drupal::entityTypeManager()->getStorage('node')->load($eventId);
+  if (!$event instanceof NodeInterface) {
+    return;
+  }
+
+  $businessTrigger = \Drupal::service('myeventlane_notifications.business_trigger');
+  if ($newStatus === 'cancelled' && $oldStatus !== 'cancelled') {
+    $businessTrigger->onRsvpCancelled($entity, $event);
+    return;
+  }
+  if ($newStatus === 'confirmed' && $oldStatus === 'waitlist') {
+    $attendeeUid = (int) ($entity->get('uid')->target_id ?? 0);
+    $businessTrigger->onWaitlistPromotedAttendee($attendeeUid, $event);
+    $businessTrigger->onWaitlistPromotedVendor($event, (int) $entity->id());
   }
 }
 

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.services.yml
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.services.yml
@@ -50,6 +50,18 @@ services:
       - '@logger.channel.myeventlane_notifications'
       - '@string_translation'
 
+  myeventlane_notifications.business_trigger:
+    class: Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService
+    arguments:
+      - '@myeventlane_notifications.notification_manager'
+      - '@entity_type.manager'
+      - '@myeventlane_notifications.audience_resolver'
+      - '@logger.channel.myeventlane_notifications'
+      - '@string_translation'
+      - '@config.factory'
+      - '@?myeventlane_capacity.service'
+      - '@?myeventlane_commerce.operational_variation_stock_resolver'
+
   myeventlane_notifications.preference:
     class: Drupal\myeventlane_notifications\Service\NotificationPreferenceService
     arguments:
@@ -95,5 +107,6 @@ services:
     class: Drupal\myeventlane_notifications\EventSubscriber\NotificationSubscriber
     arguments:
       - '@myeventlane_notifications.trigger'
+      - '@myeventlane_notifications.business_trigger'
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/myeventlane_notifications/src/Entity/MelNotification.php
+++ b/web/modules/custom/myeventlane_notifications/src/Entity/MelNotification.php
@@ -60,6 +60,7 @@ final class MelNotification extends ContentEntityBase {
   public const PRIORITY_LOW = 'low';
   public const PRIORITY_NORMAL = 'normal';
   public const PRIORITY_HIGH = 'high';
+  public const PRIORITY_CRITICAL = 'critical';
 
   /**
    * {@inheritdoc}
@@ -156,6 +157,7 @@ final class MelNotification extends ContentEntityBase {
         self::PRIORITY_LOW => 'Low',
         self::PRIORITY_NORMAL => 'Normal',
         self::PRIORITY_HIGH => 'High',
+        self::PRIORITY_CRITICAL => 'Critical',
       ])
       ->setDisplayConfigurable('form', FALSE)
       ->setDisplayConfigurable('view', FALSE);

--- a/web/modules/custom/myeventlane_notifications/src/EventSubscriber/NotificationSubscriber.php
+++ b/web/modules/custom/myeventlane_notifications/src/EventSubscriber/NotificationSubscriber.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_notifications\EventSubscriber;
 
 use Drupal\commerce_order\Event\OrderEvent;
 use Drupal\commerce_order\Event\OrderEvents;
+use Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService;
 use Drupal\myeventlane_notifications\Service\PlatformNotificationTriggerService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -16,6 +17,7 @@ final class NotificationSubscriber implements EventSubscriberInterface {
 
   public function __construct(
     private readonly PlatformNotificationTriggerService $triggerService,
+    private readonly BusinessNotificationTriggerService $businessTriggerService,
   ) {}
 
   /**
@@ -28,7 +30,9 @@ final class NotificationSubscriber implements EventSubscriberInterface {
   }
 
   public function onOrderPaid(OrderEvent $event): void {
-    $this->triggerService->onOrderPaid($event->getOrder());
+    $order = $event->getOrder();
+    $this->triggerService->onOrderPaid($order);
+    $this->businessTriggerService->onOrderPaidCapacitySignals($order);
   }
 
 }

--- a/web/modules/custom/myeventlane_notifications/src/NotificationFilter.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationFilter.php
@@ -104,6 +104,7 @@ final class NotificationFilter {
         self::FILTER_UNREAD,
         self::FILTER_TICKETS,
         self::FILTER_ORDERS,
+        self::FILTER_EVENT_UPDATES,
         self::FILTER_REMINDERS,
       ],
       self::TAB_BUSINESS => [

--- a/web/modules/custom/myeventlane_notifications/src/NotificationTaxonomy.php
+++ b/web/modules/custom/myeventlane_notifications/src/NotificationTaxonomy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_notifications;
 
 use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\Service\NotificationPreferenceService;
 
 /**
  * Shared classification for in-app notifications and email templates.
@@ -95,7 +96,31 @@ final class NotificationTaxonomy {
         'context' => NotificationContext::BUSINESS,
         'domain' => NotificationDomain::REFUNDS,
       ],
+      'refund_requested_buyer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
+      'refund_approved_buyer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
+      'refund_rejected_buyer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
+      'refund_completed_buyer' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::ORDERS,
+      ],
       'boost_purchased' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::BOOSTS,
+      ],
+      'boost_expiring' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::BOOSTS,
+      ],
+      'boost_completed' => [
         'context' => NotificationContext::BUSINESS,
         'domain' => NotificationDomain::BOOSTS,
       ],
@@ -103,12 +128,50 @@ final class NotificationTaxonomy {
         'context' => NotificationContext::BUSINESS,
         'domain' => NotificationDomain::FOLLOWERS,
       ],
+      'category_follower_gained' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::FOLLOWERS,
+      ],
+      'capacity_reached' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::SALES,
+      ],
+      'low_stock' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::SALES,
+      ],
+      'rsvp_cancelled' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::RSVPS,
+      ],
+      'waitlist_promoted_vendor' => [
+        'context' => NotificationContext::BUSINESS,
+        'domain' => NotificationDomain::RSVPS,
+      ],
+      'waitlist_promoted_attendee' => [
+        'context' => NotificationContext::PERSONAL,
+        'domain' => NotificationDomain::RSVPS,
+      ],
       'event_approved' => [
         'context' => NotificationContext::BUSINESS,
         'domain' => NotificationDomain::EVENT_UPDATES,
       ],
       default => NULL,
     };
+  }
+
+  /**
+   * Maps myeventlane_messaging template IDs to context/domain/priority.
+   *
+   * @return array{context: string, domain: string, priority: string}
+   */
+  public static function emailTemplateClassification(string $templateId): array {
+    $base = self::fromEmailTemplate($templateId);
+    return [
+      'context' => $base['context'],
+      'domain' => $base['domain'],
+      'priority' => self::priorityForEmailTemplate($templateId),
+    ];
   }
 
   /**
@@ -180,6 +243,26 @@ final class NotificationTaxonomy {
         'context' => NotificationContext::PLATFORM,
         'domain' => NotificationDomain::PLATFORM,
       ],
+    };
+  }
+
+  /**
+   * Priority for email templates (aligned with in-app notification taxonomy).
+   */
+  public static function priorityForEmailTemplate(string $templateId): string {
+    return match ($templateId) {
+      'refund_requested_buyer',
+      'refund_approved_buyer',
+      'refund_rejected_buyer',
+      'refund_completed_buyer',
+      'refund_failed_buyer',
+      'refund_requested_vendor',
+      'refund_approved_vendor',
+      'refund_rejected_vendor',
+      'refund_completed_vendor',
+      'refund_failed_vendor' => MelNotification::PRIORITY_HIGH,
+      'boost_reminder' => MelNotification::PRIORITY_HIGH,
+      default => MelNotification::PRIORITY_NORMAL,
     };
   }
 

--- a/web/modules/custom/myeventlane_notifications/src/Service/BusinessNotificationTriggerService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/BusinessNotificationTriggerService.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_notifications\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface;
+use Drupal\myeventlane_commerce\Service\OperationalVariationStockResolver;
+use Drupal\myeventlane_notifications\Entity\MelNotification;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Business and personal lifecycle notifications (sales, RSVPs, boosts, followers).
+ */
+final class BusinessNotificationTriggerService {
+
+  public function __construct(
+    private readonly NotificationManager $notificationManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AudienceResolver $audienceResolver,
+    private readonly LoggerChannelInterface $logger,
+    private readonly TranslationInterface $translation,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly ?EventCapacityServiceInterface $capacityService = NULL,
+    private readonly ?OperationalVariationStockResolver $stockResolver = NULL,
+  ) {}
+
+  /**
+   * After a paid order, notify vendors when capacity is reached or stock is low.
+   */
+  public function onOrderPaidCapacitySignals(OrderInterface $order): void {
+    if ($this->capacityService === NULL) {
+      return;
+    }
+
+    $eventIds = $this->eventIdsFromOrder($order);
+    $nearlySoldOutPercent = (int) ($this->configFactory->get('myeventlane_automation.settings')
+      ->get('thresholds.nearly_sold_out_percent') ?? 85);
+    if ($nearlySoldOutPercent < 1 || $nearlySoldOutPercent > 99) {
+      $nearlySoldOutPercent = 85;
+    }
+
+    foreach ($eventIds as $eventId) {
+      $event = $this->entityTypeManager->getStorage('node')->load($eventId);
+      if (!$event instanceof NodeInterface || $event->bundle() !== 'event') {
+        continue;
+      }
+      $organiserUid = $this->audienceResolver->resolveEventOrganiserUid($event);
+      if ($organiserUid === NULL) {
+        continue;
+      }
+
+      if ($this->capacityService->isSoldOut($event)) {
+        $this->queueNotification(
+          [$organiserUid],
+          NotificationContext::BUSINESS,
+          NotificationDomain::SALES,
+          MelNotification::PRIORITY_HIGH,
+          75,
+          (string) $this->translation->translate('Event at capacity'),
+          (string) $this->translation->translate('@event has reached capacity.', ['@event' => $event->label()]),
+          'capacity_reached',
+          'capacity_reached:' . $eventId,
+          (string) $this->translation->translate('Manage attendees'),
+          'myeventlane_event_attendees.vendor_list',
+          ['node' => $eventId],
+        );
+        continue;
+      }
+
+      $total = $this->capacityService->getCapacityTotal($event);
+      if ($total !== NULL && $total > 0) {
+        $sold = $this->capacityService->getSoldCount($event);
+        $percentSold = (int) round(($sold / $total) * 100);
+        if ($percentSold >= $nearlySoldOutPercent) {
+          $remaining = max(0, $total - $sold);
+          $this->queueNotification(
+            [$organiserUid],
+            NotificationContext::BUSINESS,
+            NotificationDomain::SALES,
+            MelNotification::PRIORITY_HIGH,
+            65,
+            (string) $this->translation->translate('Low ticket stock'),
+            (string) $this->translation->translate('@event has @count ticket(s) remaining.', [
+              '@event' => $event->label(),
+              '@count' => (string) $remaining,
+            ]),
+            'low_stock',
+            'low_stock:' . $eventId . ':' . $remaining,
+            (string) $this->translation->translate('Manage attendees'),
+            'myeventlane_event_attendees.vendor_list',
+            ['node' => $eventId],
+          );
+        }
+      }
+
+      $this->checkOperationalProductLowStock($event, $organiserUid);
+    }
+  }
+
+  public function onBoostPurchased(NodeInterface $event, int $vendorUid): void {
+    if ($vendorUid < 1) {
+      return;
+    }
+    $this->queueNotification(
+      [$vendorUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::BOOSTS,
+      MelNotification::PRIORITY_NORMAL,
+      45,
+      (string) $this->translation->translate('Boost purchased'),
+      (string) $this->translation->translate('Your boost for @event is active.', ['@event' => $event->label()]),
+      'boost_purchased',
+      'boost_purchased:' . $event->id(),
+      (string) $this->translation->translate('View boost'),
+      'myeventlane_boost.vendor_event_boost',
+      ['event' => (int) $event->id()],
+    );
+  }
+
+  public function onBoostExpiring(NodeInterface $event, int $vendorUid): void {
+    if ($vendorUid < 1) {
+      return;
+    }
+    $this->queueNotification(
+      [$vendorUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::BOOSTS,
+      MelNotification::PRIORITY_HIGH,
+      60,
+      (string) $this->translation->translate('Boost expiring soon'),
+      (string) $this->translation->translate('The boost for @event expires in about 24 hours.', ['@event' => $event->label()]),
+      'boost_expiring',
+      'boost_expiring:' . $event->id(),
+      (string) $this->translation->translate('Extend boost'),
+      'myeventlane_boost.vendor_event_boost',
+      ['event' => (int) $event->id()],
+    );
+  }
+
+  public function onBoostCompleted(NodeInterface $event, int $vendorUid): void {
+    if ($vendorUid < 1) {
+      return;
+    }
+    $this->queueNotification(
+      [$vendorUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::BOOSTS,
+      MelNotification::PRIORITY_NORMAL,
+      40,
+      (string) $this->translation->translate('Boost completed'),
+      (string) $this->translation->translate('The boost period for @event has ended.', ['@event' => $event->label()]),
+      'boost_completed',
+      'boost_completed:' . $event->id(),
+      (string) $this->translation->translate('Boost again'),
+      'myeventlane_boost.vendor_event_boost',
+      ['event' => (int) $event->id()],
+    );
+  }
+
+  public function onOrganiserFollowed(Vendor $vendor, UserInterface $follower): void {
+    $vendorUid = (int) $vendor->getOwnerId();
+    if ($vendorUid < 1 || (int) $follower->id() === $vendorUid) {
+      return;
+    }
+    $this->queueNotification(
+      [$vendorUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::FOLLOWERS,
+      MelNotification::PRIORITY_LOW,
+      25,
+      (string) $this->translation->translate('New follower'),
+      (string) $this->translation->translate('@name is now following @vendor.', [
+        '@name' => $follower->getDisplayName(),
+        '@vendor' => $vendor->label(),
+      ]),
+      'follower_gained',
+      'follower_gained:' . $vendor->id() . ':' . $follower->id(),
+      (string) $this->translation->translate('View profile'),
+      'entity.myeventlane_vendor.canonical',
+      ['myeventlane_vendor' => (int) $vendor->id()],
+    );
+  }
+
+  /**
+   * Notifies vendors with published events in a category when it gains a follower.
+   */
+  public function onCategoryFollowed(int $termId, UserInterface $follower): int {
+    if ($termId < 1 || (int) $follower->id() < 1) {
+      return 0;
+    }
+
+    $eventIds = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->condition('status', 1)
+      ->condition('field_category', $termId)
+      ->execute();
+    if ($eventIds === []) {
+      return 0;
+    }
+
+    /** @var \Drupal\node\NodeInterface[] $events */
+    $events = $this->entityTypeManager->getStorage('node')->loadMultiple($eventIds);
+    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($termId);
+    $termLabel = $term ? $term->label() : (string) $this->translation->translate('a category');
+
+    $notified = 0;
+    $seenVendors = [];
+    foreach ($events as $event) {
+      $vendorUid = $this->audienceResolver->resolveEventOrganiserUid($event);
+      if ($vendorUid === NULL || isset($seenVendors[$vendorUid]) || $vendorUid === (int) $follower->id()) {
+        continue;
+      }
+      $seenVendors[$vendorUid] = TRUE;
+      $this->queueNotification(
+        [$vendorUid],
+        NotificationContext::BUSINESS,
+        NotificationDomain::FOLLOWERS,
+        MelNotification::PRIORITY_LOW,
+        22,
+        (string) $this->translation->translate('New category follower'),
+        (string) $this->translation->translate('@name followed @category, which includes your event @event.', [
+          '@name' => $follower->getDisplayName(),
+          '@category' => $termLabel,
+          '@event' => $event->label(),
+        ]),
+        'category_follower_gained',
+        'category_follower:' . $termId . ':' . $vendorUid . ':' . $follower->id(),
+        (string) $this->translation->translate('View event'),
+        'entity.node.canonical',
+        ['node' => (int) $event->id()],
+      );
+      $notified++;
+    }
+    return $notified;
+  }
+
+  public function onRsvpCancelled(EntityInterface $attendee, NodeInterface $event): void {
+    $organiserUid = $this->audienceResolver->resolveEventOrganiserUid($event);
+    if ($organiserUid === NULL) {
+      return;
+    }
+    $this->queueNotification(
+      [$organiserUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::RSVPS,
+      MelNotification::PRIORITY_NORMAL,
+      35,
+      (string) $this->translation->translate('RSVP cancelled'),
+      (string) $this->translation->translate('An attendee cancelled their RSVP for @event.', ['@event' => $event->label()]),
+      'rsvp_cancelled',
+      'rsvp_cancelled:' . $attendee->id(),
+      (string) $this->translation->translate('View attendees'),
+      'myeventlane_event_attendees.vendor_list',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  public function onWaitlistPromotedVendor(NodeInterface $event, int $attendeeId): void {
+    $organiserUid = $this->audienceResolver->resolveEventOrganiserUid($event);
+    if ($organiserUid === NULL) {
+      return;
+    }
+    $this->queueNotification(
+      [$organiserUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::RSVPS,
+      MelNotification::PRIORITY_NORMAL,
+      38,
+      (string) $this->translation->translate('Waitlist promoted'),
+      (string) $this->translation->translate('A waitlisted guest was promoted for @event.', ['@event' => $event->label()]),
+      'waitlist_promoted_vendor',
+      'waitlist_promoted_vendor:' . $attendeeId,
+      (string) $this->translation->translate('View attendees'),
+      'myeventlane_event_attendees.vendor_list',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  public function onWaitlistPromotedAttendee(int $attendeeUid, NodeInterface $event): void {
+    if ($attendeeUid < 1) {
+      return;
+    }
+    $this->queueNotification(
+      [$attendeeUid],
+      NotificationContext::PERSONAL,
+      NotificationDomain::RSVPS,
+      MelNotification::PRIORITY_NORMAL,
+      50,
+      (string) $this->translation->translate('You are off the waitlist'),
+      (string) $this->translation->translate('You have been confirmed for @event.', ['@event' => $event->label()]),
+      'waitlist_promoted_attendee',
+      'waitlist_promoted_attendee:' . $event->id() . ':' . $attendeeUid,
+      (string) $this->translation->translate('View event'),
+      'entity.node.canonical',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  private function checkOperationalProductLowStock(NodeInterface $event, int $organiserUid): void {
+    if ($this->stockResolver === NULL || !$event->hasField('field_event_product')) {
+      return;
+    }
+    if ($event->get('field_event_product')->isEmpty()) {
+      return;
+    }
+    $product = $event->get('field_event_product')->entity;
+    if (!$product instanceof ProductInterface) {
+      return;
+    }
+    $summary = $this->stockResolver->summarizeProductStock($product);
+    if (empty($summary['low_stock'])) {
+      return;
+    }
+    $this->queueNotification(
+      [$organiserUid],
+      NotificationContext::BUSINESS,
+      NotificationDomain::SALES,
+      MelNotification::PRIORITY_HIGH,
+      62,
+      (string) $this->translation->translate('Low add-on stock'),
+      (string) $this->translation->translate('Add-on stock is running low for @event.', ['@event' => $event->label()]),
+      'low_stock',
+      'low_stock_addon:' . $event->id(),
+      (string) $this->translation->translate('Manage extras'),
+      'myeventlane_event_studio.workspace_extras',
+      ['node' => (int) $event->id()],
+    );
+  }
+
+  /**
+   * @return list<int>
+   */
+  private function eventIdsFromOrder(OrderInterface $order): array {
+    $eventIds = [];
+    foreach ($order->getItems() as $item) {
+      if ($item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
+        $eventIds[] = (int) $item->get('field_target_event')->target_id;
+      }
+    }
+    return array_values(array_unique(array_filter($eventIds)));
+  }
+
+  /**
+   * @param list<int> $userIds
+   * @param array<string, scalar> $routeParameters
+   */
+  private function queueNotification(
+    array $userIds,
+    string $context,
+    string $domain,
+    string $priority,
+    int $priorityScore,
+    string $title,
+    string $message,
+    string $actionContext,
+    string $suppressionKey,
+    string $actionLabel,
+    string $routeName,
+    array $routeParameters,
+  ): void {
+    $userIds = array_values(array_unique(array_filter(array_map('intval', $userIds))));
+    if ($userIds === []) {
+      return;
+    }
+    try {
+      $notification = $this->notificationManager->createNotification([
+        'type' => MelNotification::TYPE_SYSTEM,
+        'title' => $title,
+        'message' => $message,
+        'audience_type' => MelNotification::AUDIENCE_USER_IDS,
+        'audience_data' => ['user_ids' => $userIds],
+        'channels' => ['toast'],
+        'status' => MelNotification::STATUS_DRAFT,
+        'priority' => $priority,
+        'priority_score' => $priorityScore,
+        'suppression_key' => $suppressionKey,
+        'context' => $context,
+        'domain' => $domain,
+        'action_label' => $actionLabel,
+        'route_name' => $routeName,
+        'route_parameters' => $routeParameters,
+        'action_context' => $actionContext,
+      ]);
+      $this->notificationManager->queueNotification($notification);
+    }
+    catch (\RuntimeException) {
+      // Suppressed duplicate.
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Failed to queue business notification (@ctx): @message', [
+        '@ctx' => $actionContext,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationDecisionEngine.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationDecisionEngine.php
@@ -73,7 +73,8 @@ final class NotificationDecisionEngine {
       return NotificationSurface::BELL_INBOX;
     }
 
-    if ((string) $notification->get('priority')->value === MelNotification::PRIORITY_HIGH) {
+    $priority = (string) $notification->get('priority')->value;
+    if ($priority === MelNotification::PRIORITY_HIGH || $priority === MelNotification::PRIORITY_CRITICAL) {
       return NotificationSurface::TOAST_INBOX;
     }
 

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationManager.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationManager.php
@@ -40,9 +40,13 @@ final class NotificationManager {
    *   Keys: type, title, message, audience_type, audience_data (array|string JSON),
    *   channels (list), status (optional), scheduled_at (optional int),
    *   priority (optional), priority_score (optional), suppression_key (optional),
-   *   group_key (optional), action_label (optional), action_uri (optional),
+   *   group_key (optional), action_label (optional), action_uri (optional legacy),
    *   action_context (optional), context (optional), domain (optional),
-   *   route_name (optional), route_parameters (optional array).
+   *   route_name (optional preferred), route_parameters (optional array).
+   *
+   * Deep-linking: always set route_name + route_parameters for new notifications.
+   * action_uri is retained for legacy rows; NotificationViewBuilder falls back to
+   * action_uri when route_name is empty or invalid. See README.md in this module.
    */
   public function createNotification(array $data): MelNotification {
     $audienceData = $data['audience_data'] ?? [];

--- a/web/modules/custom/myeventlane_notifications/src/Service/NotificationPreferenceService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/NotificationPreferenceService.php
@@ -227,6 +227,14 @@ final class NotificationPreferenceService {
    * @return array{surface: string, suppressed: bool}
    */
   public function applyPreferences(MelNotification $notification, UserInterface $user, string $engineSurface): array {
+    $priority = (string) $notification->get('priority')->value;
+    if ($priority === MelNotification::PRIORITY_CRITICAL) {
+      return [
+        'surface' => $engineSurface,
+        'suppressed' => FALSE,
+      ];
+    }
+
     $category = $this->categoryForNotification($notification);
     $prefs = $this->getPreferences($user);
     $cat = $prefs[$category] ?? self::DEFAULT_PREFS[$category] ?? [

--- a/web/modules/custom/myeventlane_notifications/src/Service/RefundNotificationTriggerService.php
+++ b/web/modules/custom/myeventlane_notifications/src/Service/RefundNotificationTriggerService.php
@@ -14,7 +14,7 @@ use Drupal\myeventlane_notifications\NotificationDomain;
 use Drupal\node\NodeInterface;
 
 /**
- * Business-context in-app notifications for refund lifecycle events.
+ * In-app notifications for refund lifecycle events (vendor and buyer).
  */
 final class RefundNotificationTriggerService {
 
@@ -45,6 +45,20 @@ final class RefundNotificationTriggerService {
       'myeventlane_refunds.vendor_refund_requests',
       ['node' => (int) $event->id()],
     );
+
+    $buyerUid = (int) ($requestRow['buyer_uid'] ?? $order->getCustomerId());
+    if ($buyerUid > 0) {
+      $this->queuePersonalRefund(
+        [$buyerUid],
+        (string) $this->translation->translate('Refund requested'),
+        (string) $this->translation->translate('Your refund request for @event is pending review.', ['@event' => $event->label()]),
+        'refund_requested_buyer',
+        'refund_request_buyer:' . $requestId,
+        (string) $this->translation->translate('View order'),
+        'myeventlane_checkout_flow.order_detail',
+        ['commerce_order' => (int) $order->id()],
+      );
+    }
   }
 
   /**
@@ -68,6 +82,20 @@ final class RefundNotificationTriggerService {
       'myeventlane_vendor.console.event_order_view',
       ['event' => (int) $event->id(), 'order' => (int) $order->id()],
     );
+
+    $buyerUid = (int) ($requestRow['buyer_uid'] ?? $order->getCustomerId());
+    if ($buyerUid > 0) {
+      $this->queuePersonalRefund(
+        [$buyerUid],
+        (string) $this->translation->translate('Refund approved'),
+        (string) $this->translation->translate('Your refund for @event was approved.', ['@event' => $event->label()]),
+        'refund_approved_buyer',
+        'refund_approved_buyer:' . $requestId,
+        (string) $this->translation->translate('View order'),
+        'myeventlane_checkout_flow.order_detail',
+        ['commerce_order' => (int) $order->id()],
+      );
+    }
   }
 
   /**
@@ -89,6 +117,20 @@ final class RefundNotificationTriggerService {
       'myeventlane_refunds.vendor_refund_requests',
       ['node' => (int) $event->id()],
     );
+
+    $buyerUid = (int) ($requestRow['buyer_uid'] ?? $order->getCustomerId());
+    if ($buyerUid > 0) {
+      $this->queuePersonalRefund(
+        [$buyerUid],
+        (string) $this->translation->translate('Refund rejected'),
+        (string) $this->translation->translate('Your refund request for @event was declined.', ['@event' => $event->label()]),
+        'refund_rejected_buyer',
+        'refund_rejected_buyer:' . $requestId,
+        (string) $this->translation->translate('View order'),
+        'myeventlane_checkout_flow.order_detail',
+        ['commerce_order' => (int) $order->id()],
+      );
+    }
   }
 
   public function onRefundCompleted(OrderInterface $order, NodeInterface $event, int $vendorUid): void {
@@ -107,6 +149,20 @@ final class RefundNotificationTriggerService {
       'myeventlane_vendor.console.event_order_view',
       ['event' => (int) $event->id(), 'order' => (int) $order->id()],
     );
+
+    $buyerUid = (int) $order->getCustomerId();
+    if ($buyerUid > 0) {
+      $this->queuePersonalRefund(
+        [$buyerUid],
+        (string) $this->translation->translate('Refund completed'),
+        (string) $this->translation->translate('Your refund for @event has been processed.', ['@event' => $event->label()]),
+        'refund_completed_buyer',
+        'refund_completed_buyer:' . $order->id() . ':' . $event->id(),
+        (string) $this->translation->translate('View order'),
+        'myeventlane_checkout_flow.order_detail',
+        ['commerce_order' => (int) $order->id()],
+      );
+    }
   }
 
   /**
@@ -115,6 +171,64 @@ final class RefundNotificationTriggerService {
    */
   private function queueBusinessRefund(
     array $userIds,
+    string $title,
+    string $message,
+    string $actionContext,
+    string $suppressionKey,
+    string $actionLabel,
+    string $routeName,
+    array $routeParameters,
+  ): void {
+    $this->queueRefund(
+      $userIds,
+      NotificationContext::BUSINESS,
+      NotificationDomain::REFUNDS,
+      $title,
+      $message,
+      $actionContext,
+      $suppressionKey,
+      $actionLabel,
+      $routeName,
+      $routeParameters,
+    );
+  }
+
+  /**
+   * @param list<int> $userIds
+   * @param array<string, scalar> $routeParameters
+   */
+  private function queuePersonalRefund(
+    array $userIds,
+    string $title,
+    string $message,
+    string $actionContext,
+    string $suppressionKey,
+    string $actionLabel,
+    string $routeName,
+    array $routeParameters,
+  ): void {
+    $this->queueRefund(
+      $userIds,
+      NotificationContext::PERSONAL,
+      NotificationDomain::ORDERS,
+      $title,
+      $message,
+      $actionContext,
+      $suppressionKey,
+      $actionLabel,
+      $routeName,
+      $routeParameters,
+    );
+  }
+
+  /**
+   * @param list<int> $userIds
+   * @param array<string, scalar> $routeParameters
+   */
+  private function queueRefund(
+    array $userIds,
+    string $context,
+    string $domain,
     string $title,
     string $message,
     string $actionContext,
@@ -139,8 +253,8 @@ final class RefundNotificationTriggerService {
         'priority' => MelNotification::PRIORITY_HIGH,
         'priority_score' => 70,
         'suppression_key' => $suppressionKey,
-        'context' => NotificationContext::BUSINESS,
-        'domain' => NotificationDomain::REFUNDS,
+        'context' => $context,
+        'domain' => $domain,
         'action_label' => $actionLabel,
         'route_name' => $routeName,
         'route_parameters' => $routeParameters,

--- a/web/modules/custom/myeventlane_notifications/tests/src/Kernel/NotificationSystemKernelTest.php
+++ b/web/modules/custom/myeventlane_notifications/tests/src/Kernel/NotificationSystemKernelTest.php
@@ -8,13 +8,18 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_notifications\Controller\NotificationController;
 use Drupal\myeventlane_notifications\Entity\MelNotification;
 use Drupal\myeventlane_notifications\Entity\MelNotificationDelivery;
+use Drupal\myeventlane_notifications\NotificationContext;
+use Drupal\myeventlane_notifications\NotificationDomain;
 use Drupal\myeventlane_notifications\NotificationFilter;
 use Drupal\myeventlane_notifications\NotificationSurface;
+use Drupal\myeventlane_notifications\NotificationTaxonomy;
 use Drupal\myeventlane_notifications\Plugin\QueueWorker\NotificationDispatchWorker;
 use Drupal\myeventlane_notifications\Service\NotificationAnalyticsService;
 use Drupal\myeventlane_notifications\Service\NotificationDecisionEngine;
 use Drupal\myeventlane_notifications\Service\NotificationPreferenceService;
+use Drupal\myeventlane_notifications\Service\NotificationUserInboxService;
 use Drupal\myeventlane_notifications\Service\NotificationViewBuilder;
+use Drupal\myeventlane_notifications\Service\RefundNotificationTriggerService;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\User;
@@ -737,6 +742,191 @@ final class NotificationSystemKernelTest extends KernelTestBase {
     $this->assertSame(1, $stats['sent']);
     $this->assertSame(0, $stats['read']);
     $this->assertSame(1, $stats['clicked']);
+  }
+
+  public function testCriticalPriorityIsAllowedValue(): void {
+    $this->installEntitySchema('mel_notification');
+    $notifStorage = $this->container->get('entity_type.manager')->getStorage('mel_notification');
+    /** @var \Drupal\myeventlane_notifications\Entity\MelNotification $notification */
+    $notification = $notifStorage->create([
+      'type' => MelNotification::TYPE_SYSTEM,
+      'title' => 'Security alert',
+      'message' => 'Account locked',
+      'audience_type' => MelNotification::AUDIENCE_ALL,
+      'audience_data' => '{}',
+      'status' => MelNotification::STATUS_DRAFT,
+      'priority' => MelNotification::PRIORITY_CRITICAL,
+      'context' => NotificationContext::PLATFORM,
+      'domain' => NotificationDomain::PLATFORM,
+    ]);
+    $notification->get('channels')->appendItem('toast');
+    $notification->save();
+    $this->assertSame(MelNotification::PRIORITY_CRITICAL, (string) $notification->get('priority')->value);
+  }
+
+  public function testCriticalPriorityIsNeverPreferenceSuppressed(): void {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('mel_notification');
+    $this->installConfig(['user']);
+
+    $user = User::create([
+      'name' => 'critical_prefs',
+      'mail' => 'critical_prefs@example.com',
+      'status' => 1,
+    ]);
+    $user->set(NotificationPreferenceService::FIELD_NAME, json_encode([
+      NotificationPreferenceService::PLATFORM_SECURITY => ['enabled' => FALSE, 'surface' => 'inbox_only'],
+    ], JSON_THROW_ON_ERROR));
+    $user->save();
+
+    $notifStorage = $this->container->get('entity_type.manager')->getStorage('mel_notification');
+    /** @var \Drupal\myeventlane_notifications\Entity\MelNotification $notification */
+    $notification = $notifStorage->create([
+      'type' => MelNotification::TYPE_SYSTEM,
+      'title' => 'Security',
+      'message' => 'Alert',
+      'audience_type' => MelNotification::AUDIENCE_ALL,
+      'audience_data' => '{}',
+      'status' => MelNotification::STATUS_DRAFT,
+      'priority' => MelNotification::PRIORITY_CRITICAL,
+      'context' => NotificationContext::PLATFORM,
+      'domain' => NotificationDomain::PLATFORM,
+    ]);
+    $notification->get('channels')->appendItem('toast');
+    $notification->save();
+
+    /** @var \Drupal\myeventlane_notifications\Service\NotificationDecisionEngine $engine */
+    $engine = $this->container->get('myeventlane_notifications.decision_engine');
+    $presentation = $engine->resolveDeliveryPresentation($notification, (int) $user->id());
+    $this->assertFalse($presentation['suppressed']);
+    $this->assertSame(NotificationSurface::TOAST_INBOX, $presentation['surface']);
+  }
+
+  public function testPersonalTabExposesEventUpdatesFilter(): void {
+    $filters = NotificationFilter::filtersForTab(NotificationFilter::TAB_PERSONAL);
+    $this->assertContains(NotificationFilter::FILTER_EVENT_UPDATES, $filters);
+    $this->assertSame(1, count(array_filter($filters, static fn(string $f): bool => $f === NotificationFilter::FILTER_EVENT_UPDATES)));
+  }
+
+  public function testViewBuilderPrefersRouteNameOverActionUri(): void {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('mel_notification');
+    $this->installConfig(['user']);
+
+    $user = User::create([
+      'name' => 'route_test',
+      'mail' => 'route_test@example.com',
+      'status' => 1,
+    ]);
+    $user->save();
+
+    $notifStorage = $this->container->get('entity_type.manager')->getStorage('mel_notification');
+    /** @var \Drupal\myeventlane_notifications\Entity\MelNotification $notification */
+    $notification = $notifStorage->create([
+      'type' => MelNotification::TYPE_SYSTEM,
+      'title' => 'Profile',
+      'message' => 'Update',
+      'audience_type' => MelNotification::AUDIENCE_ALL,
+      'audience_data' => '{}',
+      'status' => MelNotification::STATUS_DRAFT,
+      'action_label' => 'View profile',
+      'action_uri' => '/legacy-should-not-win',
+      'route_name' => 'entity.user.canonical',
+      'route_parameters' => json_encode(['user' => (int) $user->id()], JSON_THROW_ON_ERROR),
+    ]);
+    $notification->get('channels')->appendItem('toast');
+    $notification->save();
+
+    /** @var \Drupal\myeventlane_notifications\Service\NotificationViewBuilder $vb */
+    $vb = $this->container->get('myeventlane_notifications.view_builder');
+    $action = $vb->buildActionFromNotification($notification);
+    $this->assertNotNull($action);
+    $this->assertStringContainsString('/user/' . $user->id(), (string) $action['url']);
+    $this->assertStringNotContainsString('legacy-should-not-win', (string) $action['url']);
+  }
+
+  public function testBuyerRefundActionContextMapsToPersonalOrders(): void {
+    $mapped = NotificationTaxonomy::fromActionContext('refund_completed_buyer');
+    $this->assertSame(NotificationContext::PERSONAL, $mapped['context']);
+    $this->assertSame(NotificationDomain::ORDERS, $mapped['domain']);
+  }
+
+  public function testEmailTemplateClassificationIncludesPriority(): void {
+    $buyer = NotificationTaxonomy::emailTemplateClassification('refund_completed_buyer');
+    $this->assertSame(NotificationContext::PERSONAL, $buyer['context']);
+    $this->assertSame(NotificationDomain::ORDERS, $buyer['domain']);
+    $this->assertSame(MelNotification::PRIORITY_HIGH, $buyer['priority']);
+
+    $order = NotificationTaxonomy::emailTemplateClassification('order_confirmation');
+    $this->assertSame(MelNotification::PRIORITY_NORMAL, $order['priority']);
+  }
+
+  public function testBellContextFilteringScopesUnreadCounts(): void {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('mel_notification');
+    $this->installEntitySchema('mel_notification_delivery');
+    $this->installConfig(['user']);
+
+    $user = User::create([
+      'name' => 'bell_ctx',
+      'mail' => 'bell_ctx@example.com',
+      'status' => 1,
+    ]);
+    $user->save();
+
+    $notifStorage = $this->container->get('entity_type.manager')->getStorage('mel_notification');
+    $deliveryStorage = $this->container->get('entity_type.manager')->getStorage('mel_notification_delivery');
+    $now = $this->container->get('datetime.time')->getRequestTime();
+
+    foreach ([
+      [NotificationContext::PERSONAL, NotificationDomain::TICKETS, 'Personal ticket'],
+      [NotificationContext::BUSINESS, NotificationDomain::SALES, 'Business sale'],
+    ] as [$context, $domain, $title]) {
+      /** @var \Drupal\myeventlane_notifications\Entity\MelNotification $notification */
+      $notification = $notifStorage->create([
+        'type' => MelNotification::TYPE_SYSTEM,
+        'title' => $title,
+        'message' => 'M',
+        'audience_type' => MelNotification::AUDIENCE_USER_IDS,
+        'audience_data' => json_encode(['user_ids' => [(int) $user->id()]], JSON_THROW_ON_ERROR),
+        'status' => MelNotification::STATUS_SENT,
+        'context' => $context,
+        'domain' => $domain,
+      ]);
+      $notification->get('channels')->appendItem('toast');
+      $notification->save();
+
+      $deliveryStorage->create([
+        'notification_id' => $notification->id(),
+        'recipient_uid' => $user->id(),
+        'status' => MelNotificationDelivery::STATUS_SENT,
+        'delivered_at' => $now,
+        'surface' => NotificationSurface::BELL_INBOX,
+        'suppressed' => FALSE,
+      ])->save();
+    }
+
+    /** @var \Drupal\myeventlane_notifications\Service\NotificationUserInboxService $inbox */
+    $inbox = $this->container->get('myeventlane_notifications.user_inbox');
+    $this->assertSame(1, $inbox->countUnreadForContexts((int) $user->id(), [NotificationContext::PERSONAL]));
+    $this->assertSame(1, $inbox->countUnreadForContexts((int) $user->id(), [NotificationContext::BUSINESS]));
+    $this->assertSame(2, $inbox->countUnread((int) $user->id()));
+  }
+
+  public function testBoostAndFollowerActionContexts(): void {
+    $boost = NotificationTaxonomy::fromActionContext('boost_purchased');
+    $this->assertSame(NotificationContext::BUSINESS, $boost['context']);
+    $this->assertSame(NotificationDomain::BOOSTS, $boost['domain']);
+
+    $follower = NotificationTaxonomy::fromActionContext('follower_gained');
+    $this->assertSame(NotificationContext::BUSINESS, $follower['context']);
+    $this->assertSame(NotificationDomain::FOLLOWERS, $follower['domain']);
+  }
+
+  public function testRefundTriggerServiceExists(): void {
+    $this->assertTrue($this->container->has('myeventlane_notifications.refund_trigger'));
+    $service = $this->container->get('myeventlane_notifications.refund_trigger');
+    $this->assertInstanceOf(RefundNotificationTriggerService::class, $service);
   }
 
 }

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -570,22 +570,8 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
     ];
   }
   
-  // Create Event only when Event Studio create is allowed (same as shell_primary_action).
-  if ($current_user->isAuthenticated()
-    && _myeventlane_vendor_theme_named_route_accessible('myeventlane_event_studio.create', [])) {
-    try {
-      $variables['page']['quick_actions'][] = [
-        '#type' => 'link',
-        '#title' => t('+ Create Event'),
-        '#url' => \Drupal\Core\Url::fromRoute('myeventlane_event_studio.create'),
-        '#attributes' => [
-          'class' => ['mel-btn', 'mel-btn--primary', 'mel-header__action-btn'],
-        ],
-      ];
-    }
-    catch (\Throwable) {
-    }
-  }
+  // Create Event is rendered once via shell_primary_action in layout/page.html.twig.
+  // Do not duplicate in quick_actions (legacy header strip).
 
   // --- Vendor Alert Strip (STAGE A: data model, stub logic) ---
   // Exposes $page['vendor_alert'] when an alert applies. Only ONE alert at a time.
@@ -767,6 +753,19 @@ function _myeventlane_vendor_theme_event_studio_routes(): array {
     'myeventlane_event_studio.workspace_analytics',
     'myeventlane_event_studio.workspace_settings',
   ];
+}
+
+/**
+ * Whether the account is staff/support for legacy vendor workspace chrome.
+ *
+ * Mirrors VendorLegacyWizardRedirectSubscriber staff bypass: vendors are
+ * redirected to Event Studio; staff may still use workspace tabs.
+ */
+function _myeventlane_vendor_theme_is_vendor_workspace_staff(\Drupal\Core\Session\AccountInterface $account): bool {
+  if (!$account->isAuthenticated()) {
+    return FALSE;
+  }
+  return $account->hasPermission('administer nodes') || (int) $account->id() === 1;
 }
 
 /**
@@ -1279,6 +1278,7 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
         'extras_configured_panel' => NULL,
         'extras_sales_panel' => NULL,
         'manage_event_back' => NULL,
+        'show_workspace_tabs' => TRUE,
       ],
       'template' => 'mel-event/mel-event-workspace',
     ],
@@ -1609,6 +1609,16 @@ function myeventlane_vendor_theme_preprocess_mel_event_workspace(array &$variabl
         '@nid' => (string) $event->id(),
         '@message' => $e->getMessage(),
       ]);
+    }
+  }
+
+  // Vendors use Event Studio navigation; staff retain workspace tab chrome.
+  $account = \Drupal::currentUser();
+  $variables['show_workspace_tabs'] = _myeventlane_vendor_theme_is_vendor_workspace_staff($account);
+  if (!$variables['show_workspace_tabs']) {
+    $variables['tabs'] = [];
+    if (isset($variables['vendor_event_workspace_model']) && is_array($variables['vendor_event_workspace_model'])) {
+      unset($variables['vendor_event_workspace_model']['tabs']);
     }
   }
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_header.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_header.scss
@@ -57,7 +57,7 @@
     border-color: $border-color-dark;
   }
   
-  @include respond-to(lg) {
+  @include respond-to(md) {
     display: none;
   }
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_navigation.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_navigation.scss
@@ -16,7 +16,7 @@
   min-height: 100vh;
   background: $ml-vendor-bg;
 
-  @include respond-to(lg) {
+  @include respond-to(md) {
     grid-template-columns: $layout-sidebar-nav-width 1fr;
   }
 
@@ -43,7 +43,7 @@
   z-index: 40;
   overflow-y: auto;
 
-  @include respond-to(lg) {
+  @include respond-to(md) {
     position: sticky;
     top: 0;
     height: 100vh;
@@ -458,7 +458,7 @@
   font-size: 1.2rem;
   line-height: 1;
 
-  @include respond-to(lg) {
+  @include respond-to(md) {
     display: none;
   }
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard.scss
@@ -506,16 +506,17 @@
   }
 }
 
-.mel-workspace-page {
+// Legacy vendor-console workspace shell: main + right rail (vendor-console-page.html.twig).
+// Mobile-first — full-width stack below lg; sidebar rail only at desktop.
+.mel-console-page__layout--workspace {
   display: grid;
-  grid-template-columns: 320px minmax(0, 1fr);
+  grid-template-columns: 1fr;
   gap: 24px;
-  min-height: 600px;
-  background: #ffffff;
-}
+  min-width: 0;
+  width: 100%;
 
-@include respond-to(lg) {
-  .mel-workspace-page {
-    grid-template-columns: 1fr;
+  @include respond-to(lg) {
+    grid-template-columns: minmax(0, 1fr) 320px;
+    align-items: start;
   }
 }

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -82,10 +82,10 @@
           <div class="mel-vendor-dashboard__mission-actions" aria-label="{{ 'Organiser actions'|t }}">
             {% if organiser_actions is iterable and organiser_actions|length > 0 %}
               {% for action in organiser_actions %}
-                <a class="mel-btn {{ loop.first ? 'mel-btn--primary' : 'mel-btn--secondary' }}" href="{{ action.url }}">{{ action.label }}</a>
+                {% if action.key|default('') != 'create' %}
+                  <a class="mel-btn {{ loop.first ? 'mel-btn--primary' : 'mel-btn--secondary' }}" href="{{ action.url }}">{{ action.label }}</a>
+                {% endif %}
               {% endfor %}
-            {% elseif empty_state.url is defined and empty_state.url %}
-              <a class="mel-btn mel-btn--primary" href="{{ empty_state.url }}">{{ empty_state.action_label|default('Create event'|t) }}</a>
             {% endif %}
             {% if vendor.settings_url is defined and vendor.settings_url %}
               <a class="mel-btn mel-btn--ghost" href="{{ vendor.settings_url }}">{{ 'Profile & settings'|t }}</a>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -310,7 +310,7 @@
         </details>
       {% endif %}
 
-      {% if model.tabs is iterable and model.tabs is not empty %}
+      {% if show_workspace_tabs|default(true) and model.tabs is iterable and model.tabs is not empty %}
         <div class="mel-live-ops__tab-bar mel-workspace__tab-bar">
           <nav class="mel-tabs mel-tabs--horizontal mel-live-ops__tab-nav" role="tablist" aria-label="{{ 'Event sections'|t }}">
             {% include '@myeventlane_vendor_theme/components/workspace/workspace-tabs.html.twig' with { tabs: model.tabs } %}
@@ -333,7 +333,7 @@
     </div>
   {% endif %}
 
-  {% if not has_ws_model and tabs %}
+  {% if show_workspace_tabs|default(true) and not has_ws_model and tabs %}
     <div class="mel-workspace__tab-bar">
       <nav class="mel-tabs mel-tabs--horizontal" role="tablist" aria-label="{{ 'Event sections'|t }}">
         {% include '@myeventlane_vendor_theme/components/workspace/workspace-tabs.html.twig' %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
@@ -24,13 +24,7 @@
         <p class="mel-vendor-events-v2__subtitle">{{ model.subtitle }}</p>
       {% endif %}
     </div>
-    <div class="mel-vendor-events-v2__actions">
-      {% if primary.url is defined and primary.url %}
-        <a class="mel-btn mel-btn--primary mel-vendor-events-v2__cta" href="{{ primary.url }}">{{ primary.label|default('Create event'|t) }}</a>
-      {% elseif primary.label is defined and primary.label %}
-        <span class="mel-btn mel-btn--primary mel-vendor-events-v2__cta mel-btn--disabled" aria-disabled="true">{{ primary.label }}</span>
-      {% endif %}
-    </div>
+    {# Primary Create Event CTA lives in the vendor shell header (shell_primary_action). #}
   </header>
 
   <section class="mel-vendor-events-v2__summary" aria-label="{{ 'Event counts'|t }}">
@@ -230,11 +224,7 @@
       {% if empty_state.message %}
         <p class="mel-vendor-events-v2__empty-message">{{ empty_state.message }}</p>
       {% endif %}
-      {% if empty_state.url is defined and empty_state.url and empty_state.action_label %}
-        <a class="mel-btn mel-btn--primary" href="{{ empty_state.url }}">{{ empty_state.action_label }}</a>
-      {% elseif empty_state.action_label %}
-        <span class="mel-btn mel-btn--primary mel-btn--disabled" aria-disabled="true">{{ empty_state.action_label }}</span>
-      {% endif %}
+      {# Create Event CTA: use shell header primary action when the list is empty. #}
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad new notification volume on order paid, entity updates, and cron paths could surprise vendors or duplicate with email; refund buyer paths touch order/commerce flows but reuse existing queue/suppression patterns.
> 
> **Overview**
> Introduces **`BusinessNotificationTriggerService`** and registers **`myeventlane_notifications.business_trigger`**, with optional `@?` injection from boost cron/order flows so boost purchase, expiring, and completed events queue in-app toasts alongside existing email.
> 
> **Commerce and entity hooks** fan out business/personal notifications: order-paid capacity and low-stock signals, vendor/category follows, RSVP cancel, and waitlist promotion (vendor + attendee). **`RefundNotificationTriggerService`** now queues matching **buyer** personal notifications for each refund stage. **`NotificationTaxonomy`** and **`MessagingManager::queue()`** align email templates with context/domain/**priority** metadata; **`critical`** priority bypasses user preference suppression and surfaces like high.
> 
> **Product UX:** Event Studio drops sidebar/settings **readiness** cards; vendor theme hides legacy workspace tabs for non-staff, consolidates **Create Event** to the shell header, and adjusts mobile sidebar breakpoints and workspace layout CSS.
> 
> Adds module **README** (route-based deep links), update **11007** for critical priority, and expanded kernel tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4b9eb8086e29287fb2ff16ae7cc1dfe213a062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->