### PR TITLE
Add event view tracking and conversion analytics

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Service/AnalyticsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/AnalyticsService.php
@@ -17,6 +17,7 @@ final class AnalyticsService {
   public const EVENT_VENDOR_PAGE_VIEW = 'vendor_page_view';
   public const EVENT_FOLLOW_CLICK = 'follow_click';
   public const EVENT_EVENT_CLICK = 'event_click';
+  public const EVENT_EVENT_VIEW = 'event_view';
 
   private const TABLE = 'myeventlane_public_analytics_event';
 
@@ -69,6 +70,68 @@ final class AnalyticsService {
         '@message' => $e->getMessage(),
       ]);
       return 0;
+    }
+  }
+
+  /**
+   * Counts analytics events for many entities in one query.
+   *
+   * @param list<int> $entity_ids
+   *   Entity IDs to count (invalid IDs are ignored).
+   *
+   * @return array<int, int>
+   *   Map of entity_id => count (missing IDs are omitted).
+   */
+  public function countEventsByEntityIds(
+    string $entity_type,
+    array $entity_ids,
+    string $event_type,
+    ?int $start_ts = NULL,
+    ?int $end_ts = NULL,
+  ): array {
+    if ($entity_type === '' || $event_type === '') {
+      return [];
+    }
+
+    $entity_ids = array_values(array_unique(array_filter(
+      array_map(static fn(mixed $id): int => (int) $id, $entity_ids),
+      static fn(int $id): bool => $id > 0,
+    )));
+    if ($entity_ids === []) {
+      return [];
+    }
+
+    if (!$this->database->schema()->tableExists(self::TABLE)) {
+      return [];
+    }
+
+    try {
+      $query = $this->database->select(self::TABLE, 'a');
+      $query->addField('a', 'entity_id', 'entity_id');
+      $query->addExpression('COUNT(*)', 'cnt');
+      $query->condition('entity_type', $entity_type);
+      $query->condition('entity_id', $entity_ids, 'IN');
+      $query->condition('event_type', $event_type);
+      if ($start_ts !== NULL) {
+        $query->condition('timestamp', $start_ts, '>=');
+      }
+      if ($end_ts !== NULL) {
+        $query->condition('timestamp', $end_ts, '<=');
+      }
+      $query->groupBy('entity_id');
+
+      $counts = [];
+      foreach ($query->execute() as $row) {
+        $counts[(int) $row->entity_id] = (int) $row->cnt;
+      }
+      return $counts;
+    }
+    catch (\Exception $e) {
+      $this->logger->warning('Failed to batch-count analytics events (@event): @message', [
+        '@event' => $event_type,
+        '@message' => $e->getMessage(),
+      ]);
+      return [];
     }
   }
 

--- a/web/modules/custom/myeventlane_core/src/Service/VendorFollowService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/VendorFollowService.php
@@ -102,6 +102,30 @@ final class VendorFollowService {
   }
 
   /**
+   * Counts followers gained for a vendor within an inclusive time range.
+   *
+   * @param int $start_ts
+   *   Inclusive start timestamp (follow entity created time).
+   * @param int $end_ts
+   *   Inclusive end timestamp (follow entity created time).
+   */
+  public function countFollowersInRange(Vendor $vendor, int $start_ts, int $end_ts): int {
+    if ($start_ts > $end_ts) {
+      return 0;
+    }
+
+    $query = $this->entityTypeManager
+      ->getStorage('myeventlane_vendor_follow')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('vendor_id', (int) $vendor->id())
+      ->condition('created', $start_ts, '>=')
+      ->condition('created', $end_ts, '<=');
+
+    return (int) $query->count()->execute();
+  }
+
+  /**
    * Loads follow entity IDs for a user/vendor pair.
    *
    * @return int[]

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -181,6 +181,15 @@ services:
     tags:
       - { name: event_subscriber }
 
+  myeventlane_event.event_view_tracking_subscriber:
+    class: Drupal\myeventlane_event\EventSubscriber\EventViewTrackingSubscriber
+    arguments:
+      - '@myeventlane_core.analytics'
+      - '@myeventlane_event.public_visibility'
+      - '@current_user'
+    tags:
+      - { name: event_subscriber }
+
   myeventlane_event.access.event_book:
     class: Drupal\myeventlane_event\Access\EventBookAccessCheck
     arguments:

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventViewTrackingSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventViewTrackingSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\EventSubscriber;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_core\Http\MelKernelAuthRouteSilencer;
+use Drupal\myeventlane_core\Service\AnalyticsService;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Records event page views on canonical event routes.
+ *
+ * Runs after the passcode gate subscriber so redirects are not counted.
+ */
+final class EventViewTrackingSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly AnalyticsService $analytics,
+    private readonly PublicEventVisibility $publicVisibility,
+    private readonly AccountProxyInterface $currentUser,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onKernelRequest', 20],
+    ];
+  }
+
+  /**
+   * Tracks a view when the event full page is actually served.
+   */
+  public function onKernelRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest() || $event->hasResponse()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
+      return;
+    }
+
+    if ((string) $request->attributes->get('_route', '') !== 'entity.node.canonical') {
+      return;
+    }
+
+    $node = $request->attributes->get('node');
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event' || !$node->isPublished()) {
+      return;
+    }
+
+    if (!$this->publicVisibility->isDirectlyViewable($node, $this->currentUser, $request)) {
+      return;
+    }
+
+    $this->analytics->track('node', (int) $node->id(), AnalyticsService::EVENT_EVENT_VIEW);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -734,6 +734,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     $revenueFormatted = $this->formatCurrencyCents((int) ($metrics['revenue_net_cents'] ?? 0), $currency);
     $followConversion = (float) ($metrics['follow_conversion'] ?? 0.0);
     $boostCtr = (float) ($metrics['boost_ctr'] ?? 0.0);
+    $totalEventViews = (int) ($metrics['total_event_views'] ?? 0);
+    $avgTicketConversion = (float) ($metrics['avg_ticket_conversion'] ?? 0.0);
 
     $analytics = [
       'profile_views' => (int) ($metrics['profile_views'] ?? 0),
@@ -746,9 +748,12 @@ final class VendorDashboardController extends VendorConsoleBaseController {
       'boost_views' => (int) ($metrics['boost_views'] ?? 0),
       'boost_clicks' => (int) ($metrics['boost_clicks'] ?? 0),
       'boost_ctr' => $boostCtr,
+      'total_event_views' => $totalEventViews,
+      'avg_ticket_conversion' => $avgTicketConversion,
     ];
 
     $last30Days = (string) $this->t('Last 30 days');
+    $allTime = (string) $this->t('All time');
     $completedOrders = (string) $this->t('Completed');
     $paidTickets = (string) $this->t('Paid tickets');
     $confirmedRsvps = (string) $this->t('Confirmed');
@@ -775,6 +780,20 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'value' => number_format($followConversion, 1) . '%',
         'sub' => $last30Days,
         'aria_label' => (string) $this->t('Follow conversion'),
+      ],
+      [
+        'key' => 'total_event_views',
+        'label' => (string) $this->t('Total Event Views'),
+        'value' => number_format($totalEventViews),
+        'sub' => $allTime,
+        'aria_label' => (string) $this->t('Total event views'),
+      ],
+      [
+        'key' => 'avg_ticket_conversion',
+        'label' => (string) $this->t('Avg Ticket Conversion'),
+        'value' => number_format($avgTicketConversion, 1) . '%',
+        'sub' => $allTime,
+        'aria_label' => (string) $this->t('Average ticket conversion'),
       ],
       [
         'key' => 'revenue',

--- a/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
@@ -126,9 +126,10 @@ final class MetricsAggregator {
    *   Linked commerce store.
    *
    * @return array<string, int|float|string>
-   *   Keys: profile_views, followers, follow_conversion, revenue_net_cents,
+   *   Keys: profile_views, followers (all time), follow_conversion (last 30
+   *   days: new follows / profile views), revenue_net_cents,
    *   orders_count, tickets_sold, rsvps_confirmed, currency, boost_views,
-   *   boost_clicks, boost_ctr.
+   *   boost_clicks, boost_ctr, total_event_views, avg_ticket_conversion.
    */
   public function getVendorAnalyticsOverview(int $userId, Vendor $vendor, StoreInterface $store): array {
     $range = $this->vendorKpiService->getDefaultRangeLast30Days();
@@ -145,8 +146,9 @@ final class MetricsAggregator {
     );
 
     $followers = $this->vendorFollowService->countFollowers($vendor);
+    $newFollowers = $this->vendorFollowService->countFollowersInRange($vendor, $start, $end);
     $followConversion = $profileViews > 0
-      ? round($followers / $profileViews * 100, 1)
+      ? round($newFollowers / $profileViews * 100, 1)
       : 0.0;
 
     $kpi = $this->vendorKpiService->getKpisForStore($store, $start, $end, 'AUD');
@@ -155,6 +157,38 @@ final class MetricsAggregator {
       ? $this->userVendorMembershipQuery->getManagedEventNodeIds($userId, TRUE)
       : [];
     $boostRollup = $this->boostMetricsService->getVendorBoostRollup($publishedEventIds);
+
+    $managedEventIds = $userId > 0
+      ? $this->userVendorMembershipQuery->getManagedEventNodeIds($userId, FALSE)
+      : [];
+    $eventViewCounts = $this->analyticsService->countEventsByEntityIds(
+      'node',
+      $managedEventIds,
+      AnalyticsService::EVENT_EVENT_VIEW,
+    );
+    $totalEventViews = array_sum($eventViewCounts);
+
+    $ticketConversionRates = [];
+    foreach ($managedEventIds as $managedEventId) {
+      $managedEventId = (int) $managedEventId;
+      $views = $eventViewCounts[$managedEventId] ?? 0;
+      if ($views <= 0) {
+        continue;
+      }
+
+      try {
+        $salesSummary = $this->ticketSalesService->getSalesSummaryForEventId($managedEventId);
+      }
+      catch (\Throwable) {
+        $salesSummary = [];
+      }
+
+      $ticketsSold = (int) ($salesSummary['tickets_sold'] ?? 0);
+      $ticketConversionRates[] = round($ticketsSold / $views * 100, 1);
+    }
+    $avgTicketConversion = $ticketConversionRates !== []
+      ? round(array_sum($ticketConversionRates) / count($ticketConversionRates), 1)
+      : 0.0;
 
     return [
       'profile_views' => $profileViews,
@@ -168,6 +202,8 @@ final class MetricsAggregator {
       'boost_views' => (int) ($boostRollup['impressions'] ?? 0),
       'boost_clicks' => (int) ($boostRollup['clicks'] ?? 0),
       'boost_ctr' => (float) ($boostRollup['ctr_percent'] ?? 0.0),
+      'total_event_views' => $totalEventViews,
+      'avg_ticket_conversion' => $avgTicketConversion,
     ];
   }
 
@@ -178,7 +214,8 @@ final class MetricsAggregator {
    *   Vendor account user ID.
    *
    * @return list<array<string, int|string>>
-   *   Rows with event_id, title, url, rsvps, tickets_sold, revenue, boost_ctr.
+   *   Rows with event_id, title, url, views, rsvps, tickets_sold, revenue,
+   *   rsvp_conv, ticket_conv, boost_ctr.
    */
   public function getEventPerformanceRows(int $userId): array {
     if ($userId <= 0) {
@@ -192,6 +229,11 @@ final class MetricsAggregator {
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($eventIds);
     $boostCtrMap = $this->boostMetricsService->getEventBoostCtrByEventIds($eventIds);
+    $viewCounts = $this->analyticsService->countEventsByEntityIds(
+      'node',
+      $eventIds,
+      AnalyticsService::EVENT_EVENT_VIEW,
+    );
 
     $rows = [];
     foreach ($eventIds as $eventId) {
@@ -215,15 +257,20 @@ final class MetricsAggregator {
         $rsvps = 0;
       }
 
+      $views = $viewCounts[$eventId] ?? 0;
+      $ticketsSold = (int) ($salesSummary['tickets_sold'] ?? 0);
       $boost = $boostCtrMap[$eventId] ?? ['ctr_display' => '—'];
 
       $rows[] = [
         'event_id' => $eventId,
         'title' => (string) $node->getTitle(),
         'url' => $this->eventPerformanceUrl($eventId),
+        'views' => $views,
         'rsvps' => $rsvps,
-        'tickets_sold' => (int) ($salesSummary['tickets_sold'] ?? 0),
+        'tickets_sold' => $ticketsSold,
         'revenue' => (string) ($salesSummary['net'] ?? '$0.00'),
+        'rsvp_conv' => $this->formatConversionPercent($rsvps, $views),
+        'ticket_conv' => $this->formatConversionPercent($ticketsSold, $views),
         'boost_ctr' => (string) ($boost['ctr_display'] ?? '—'),
         '_sort_changed' => (int) $node->getChangedTime(),
       ];
@@ -236,6 +283,17 @@ final class MetricsAggregator {
     unset($row);
 
     return $rows;
+  }
+
+  /**
+   * Formats a conversion rate for dashboard display.
+   */
+  private function formatConversionPercent(int $numerator, int $denominator): string {
+    if ($denominator <= 0) {
+      return '—';
+    }
+
+    return number_format(round($numerator / $denominator * 100, 1), 1) . '%';
   }
 
   /**

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-vendor-event-performance.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-vendor-event-performance.scss
@@ -56,6 +56,11 @@ $font-family-main: $font-family-sans;
     background: $gray-50;
   }
 
+  .mel-vendor-event-performance__numeric {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
   tbody tr:last-child {
     th,
     td {

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-event-performance.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-event-performance.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Vendor dashboard event performance table (Stage 2).
+ * Vendor dashboard event performance table (Stage 2 + Stage 3 conversion).
  *
  * No calculations in Twig — all values pre-formatted in PHP.
  */
@@ -16,9 +16,12 @@
         <thead>
           <tr>
             <th scope="col">{{ 'Event'|t }}</th>
+            <th scope="col">{{ 'Views'|t }}</th>
             <th scope="col">{{ 'RSVPs'|t }}</th>
             <th scope="col">{{ 'Tickets Sold'|t }}</th>
             <th scope="col">{{ 'Revenue (All Time)'|t }}</th>
+            <th scope="col">{{ 'RSVP Conv %'|t }}</th>
+            <th scope="col">{{ 'Ticket Conv %'|t }}</th>
             <th scope="col">{{ 'Boost CTR'|t }}</th>
           </tr>
         </thead>
@@ -32,10 +35,13 @@
                   {{ row.title }}
                 {% endif %}
               </th>
-              <td>{{ row.rsvps|default(0) }}</td>
-              <td>{{ row.tickets_sold|default(0) }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.views|default(0) }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.rsvps|default(0) }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.tickets_sold|default(0) }}</td>
               <td>{{ row.revenue|default('$0.00') }}</td>
-              <td>{{ row.boost_ctr|default('—') }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.rsvp_conv|default('—') }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.ticket_conv|default('—') }}</td>
+              <td class="mel-vendor-event-performance__numeric">{{ row.boost_ctr|default('—') }}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -54,6 +60,10 @@
           </h3>
           <dl class="mel-vendor-event-performance__card-metrics">
             <div class="mel-vendor-event-performance__card-metric">
+              <dt>{{ 'Views'|t }}</dt>
+              <dd>{{ row.views|default(0) }}</dd>
+            </div>
+            <div class="mel-vendor-event-performance__card-metric">
               <dt>{{ 'RSVPs'|t }}</dt>
               <dd>{{ row.rsvps|default(0) }}</dd>
             </div>
@@ -64,6 +74,14 @@
             <div class="mel-vendor-event-performance__card-metric">
               <dt>{{ 'Revenue (All Time)'|t }}</dt>
               <dd>{{ row.revenue|default('$0.00') }}</dd>
+            </div>
+            <div class="mel-vendor-event-performance__card-metric">
+              <dt>{{ 'RSVP Conv %'|t }}</dt>
+              <dd>{{ row.rsvp_conv|default('—') }}</dd>
+            </div>
+            <div class="mel-vendor-event-performance__card-metric">
+              <dt>{{ 'Ticket Conv %'|t }}</dt>
+              <dd>{{ row.ticket_conv|default('—') }}</dd>
             </div>
             <div class="mel-vendor-event-performance__card-metric">
               <dt>{{ 'Boost CTR'|t }}</dt>


### PR DESCRIPTION
- Track event_view analytics on canonical event pages
- Add batch event view aggregation
- Add RSVP and ticket conversion metrics
- Add total event views KPI
- Add average ticket conversion KPI
- Extend vendor event performance reporting
- Reuse MEL analytics infrastructure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Request-time analytics writes on every qualifying event page view and dashboard aggregation adds batch queries; follow conversion semantics change for existing KPIs.
> 
> **Overview**
> Adds **`event_view`** public analytics and wires vendor dashboards to view-based conversion metrics.
> 
> A new **`EventViewTrackingSubscriber`** records `event_view` on published event canonical routes when the page is directly viewable (after the passcode gate, so redirects are not counted). **`AnalyticsService`** gains `EVENT_EVENT_VIEW` and **`countEventsByEntityIds`** for batched per-node counts; **`VendorFollowService`** adds **`countFollowersInRange`** so **follow conversion** uses new follows in the last 30 days over profile views instead of total followers.
> 
> **`MetricsAggregator`** rolls up total event views and average ticket conversion (all-time views vs tickets sold per managed event), and extends event performance rows with views, RSVP %, and ticket % conversions. **`VendorDashboardController`** surfaces two new KPI cards; the event performance Twig/SCSS adds columns and tabular numeric styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766679d179616e995db0e99a3427f851022aca82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->