### PR TITLE
Add recommended events homepage placement

### DIFF
--- a/config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml
+++ b/config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml
@@ -1,11 +1,12 @@
 uuid: e0f3144f-7ab4-48ec-9539-362ac11b15b5
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - views.view.front_recommended_events
   module:
     - system
+    - user
     - views
   theme:
     - myeventlane_theme
@@ -28,3 +29,10 @@ visibility:
     id: request_path
     negate: false
     pages: '<front>'
+  user_role:
+    id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    roles:
+      authenticated: authenticated

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -389,6 +389,7 @@
 
 // Homepage blocks must not show listing discovery chips or exposed filters.
 .mel-page--home .mel-section--latest,
+.mel-page--home .mel-section--recommended,
 .mel-page--home .mel-section--tonight,
 .mel-page--home .mel-section--discover {
   .mel-events-date-filters,
@@ -418,6 +419,7 @@
 
 .mel-page--home .mel-section--discover .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--latest .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--recommended .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--nearby .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--online .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--tonight .mel-grid.mel-grid--events,
@@ -457,6 +459,7 @@
 // Image-led discovery grids: layout only — card chrome lives in _event-card.scss.
 .mel-page--home .mel-section--discover .mel-event-grid,
 .mel-page--home .mel-section--latest .mel-event-grid,
+.mel-page--home .mel-section--recommended .mel-event-grid,
 .mel-page--home .mel-section--nearby .mel-event-grid,
 .mel-page--home .mel-section--online .mel-event-grid,
 .mel-page--home .mel-section--tonight .mel-event-grid {
@@ -465,6 +468,7 @@
 
 .mel-page--home .mel-section--discover .mel-event-card--compact,
 .mel-page--home .mel-section--latest .mel-event-card--compact,
+.mel-page--home .mel-section--recommended .mel-event-card--compact,
 .mel-page--home .mel-section--nearby .mel-event-card--compact,
 .mel-page--home .mel-section--online .mel-event-card--compact,
 .mel-page--home .mel-section--tonight .mel-event-card--compact {
@@ -478,6 +482,9 @@
 .mel-page--home .mel-section--latest .mel-event-card--standard,
 .mel-page--home .mel-section--latest .mel-event-card--hero,
 .mel-page--home .mel-section--latest .mel-event-card--featured,
+.mel-page--home .mel-section--recommended .mel-event-card--standard,
+.mel-page--home .mel-section--recommended .mel-event-card--hero,
+.mel-page--home .mel-section--recommended .mel-event-card--featured,
 .mel-page--home .mel-section--nearby .mel-event-card--standard,
 .mel-page--home .mel-section--nearby .mel-event-card--hero,
 .mel-page--home .mel-section--nearby .mel-event-card--featured,

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -41,17 +41,17 @@
       } %}
     {% endif %}
 
-    {% if page.homepage_latest %}
+    {% if page.home_recommended %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--latest mel-section--discover',
+        section_class: 'mel-section--recommended mel-section--discover',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Upcoming events'|t,
-        subtitle: 'What’s coming up across MyEventLane.'|t,
+        title: 'Recommended events'|t,
+        subtitle: 'Picked for you while you’re signed in.'|t,
         link_url: path('view.upcoming_events.page_events'),
-        link_text: 'See all'|t,
+        link_text: 'Browse marketplace'|t,
         content_wrapper_class: 'mel-section__discover-view',
-        content: page.homepage_latest
+        content: page.home_recommended
       } %}
     {% endif %}
 
@@ -80,6 +80,20 @@
         link_text: 'See all free events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_free
+      } %}
+    {% endif %}
+
+    {% if page.homepage_latest %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--latest mel-section--discover',
+        section_width_class: 'mel-section--wide',
+        container_class: 'mel-container mel-container--wide',
+        title: 'Upcoming events'|t,
+        subtitle: 'What’s coming up across MyEventLane.'|t,
+        link_url: path('view.upcoming_events.page_events'),
+        link_text: 'See all'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_latest
       } %}
     {% endif %}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Homepage layout, block visibility, and theme SCSS only; no auth or data-layer changes beyond showing content to logged-in users.
> 
> **Overview**
> Adds a **Recommended events** rail on the homepage for signed-in users, placed high on the page (after featured), and moves **Upcoming events** lower in the section order.
> 
> The `front_recommended_events` block is **enabled** in config, placed in `home_recommended`, limited to `<front>` and the **authenticated** role. `page--front.html.twig` renders `page.home_recommended` with `mel-section--recommended` copy and styling. `_front-page.scss` applies the same discovery-grid rules (hidden filters, 4-column grid, card layout) to `.mel-section--recommended` as the other homepage rails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e213fb204e4e615340551cf488f581a7356fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->