### PR TITLE
Prevent Stripe iframe mobile overflow

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/base/_base.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_base.scss
@@ -32,6 +32,9 @@ html,
 body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   color: var(--mel-navy);
+  // Stripe.js injects a hidden anti-fraud iframe (~432px wide) as a direct child of
+  // body; clip prevents that third-party element from widening the page on mobile.
+  overflow-x: clip;
 }
 
 body {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single global CSS property with a documented third-party workaround; no payment or auth logic changes.
> 
> **Overview**
> Adds **`overflow-x: clip`** on the shared `html, body` rule in `_base.scss` so a Stripe.js anti-fraud iframe (~432px wide, injected as a direct child of `body`) no longer forces horizontal scroll on narrow viewports.
> 
> An inline comment documents the Stripe iframe cause so future layout changes don’t remove the guard accidentally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe483da10fe8766ff7d4fab3c1fbb83512ee1ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->