### PR TITLE
Fix/bugbot hero framing and cloudflared tunnel

### DIFF
--- a/.ddev/share-providers/cloudflared.sh
+++ b/.ddev/share-providers/cloudflared.sh
@@ -73,10 +73,11 @@ fi
 # Using --protocol http2 for better compatibility
 if [[ -n "$TUNNEL_NAME" ]]; then
   echo "Using named tunnel: $TUNNEL_NAME" >&2
+  echo "Local origin for ingress must be configured in ~/.cloudflared/config.yml (e.g. service: $DDEV_LOCAL_URL)." >&2
   echo >&2
-  echo "Running command: cloudflared --url $DDEV_LOCAL_URL --protocol http2${ARGS:+ $ARGS} tunnel run $TUNNEL_NAME" >&2
+  echo "Running command: cloudflared --protocol http2 tunnel run $TUNNEL_NAME${ARGS:+ $ARGS}" >&2
   echo >&2
-  cloudflared --url "$DDEV_LOCAL_URL" --protocol http2 $ARGS tunnel run "$TUNNEL_NAME" 2>&1
+  cloudflared --protocol http2 tunnel run "$TUNNEL_NAME" $ARGS 2>&1
 else
   echo >&2
   echo "Running command: cloudflared tunnel --url $DDEV_LOCAL_URL --protocol http2 $ARGS" >&2

--- a/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
@@ -186,7 +186,9 @@
     if (source && source.getAttribute("src")) {
       return source.src;
     }
-    return fromSettings || "";
+    // Do not fall back to drupalSettings when FIDs differ — that URL is stale
+    // until branding is saved after a cover image change.
+    return "";
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted fixes to a dev share script and client-side preview logic with no auth or production data path changes.
> 
> **Overview**
> Fixes two unrelated issues: **DDEV cloudflared named tunnels** and **Event Studio hero framing preview** after a cover image change.
> 
> For **named** Cloudflare tunnels, the share script no longer passes `--url $DDEV_LOCAL_URL` to `cloudflared tunnel run` (that flag is for quick tunnels). It now runs `cloudflared --protocol http2 tunnel run $TUNNEL_NAME` and tells developers to point ingress at DDEV in `~/.cloudflared/config.yml`. Quick tunnel behavior is unchanged.
> 
> In **branding hero tools**, `resolveFramingImageSrc` stops using the saved `drupalSettings` hero URL when the form’s active file ID does not match the saved `fileId`. After uploading or swapping a cover before **Save branding**, the framing preview uses the widget preview image or hides instead of showing the previous cover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648b1b6cebf58fa099607ff951937e0f9deaf8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->