### PR TITLE
Feature/recommended events placement

### DIFF
--- a/config/sync/field.field.node.event.field_social_proof_visibility.yml
+++ b/config/sync/field.field.node.event.field_social_proof_visibility.yml
@@ -1,0 +1,23 @@
+uuid: 9d21e728-903b-4324-9736-d6ae3da6c520
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_social_proof_visibility
+    - node.type.event
+  module:
+    - options
+id: node.event.field_social_proof_visibility
+field_name: field_social_proof_visibility
+entity_type: node
+bundle: event
+label: 'Social Proof Visibility'
+description: 'Control whether attendee activity and popularity indicators are shown on event listings and event pages.'
+required: false
+translatable: false
+default_value:
+  -
+    value: auto
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_social_proof_visibility.yml
+++ b/config/sync/field.storage.node.field_social_proof_visibility.yml
@@ -1,0 +1,30 @@
+uuid: 4a5f3cfb-1524-47b2-a1b5-86707442d1ef
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_social_proof_visibility
+field_name: field_social_proof_visibility
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: auto
+      label: Auto
+    -
+      value: show
+      label: Show
+    -
+      value: hide
+      label: Hide
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_core/src/Service/EventInterestService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventInterestService.php
@@ -19,11 +19,45 @@ final class EventInterestService {
   /**
    * Returns at most one label; priority order: high demand → selling fast → popular → just added.
    *
+   * @param 'auto'|'show'|'hide' $socialProofMode
+   *
    * @return array{label: string, type: 'high'|'urgent'|'social'|'new'}|array{}
    */
-  public function getInterestState(int $saveCount, int $viewerCount, int $createdTime): array {
+  public function getInterestState(int $saveCount, int $viewerCount, int $createdTime, string $socialProofMode = 'auto'): array {
+    if ($socialProofMode === 'hide') {
+      return [];
+    }
+
     $now = $this->time->getCurrentTime();
     $age = $now - $createdTime;
+
+    if ($socialProofMode === 'show') {
+      if ($saveCount >= 20 && $viewerCount >= 5) {
+        return [
+          'label' => '🔥 High demand',
+          'type' => 'high',
+        ];
+      }
+      if ($viewerCount > 0) {
+        return [
+          'label' => '🔥 Selling fast',
+          'type' => 'urgent',
+        ];
+      }
+      if ($saveCount > 0) {
+        return [
+          'label' => '💖 Popular',
+          'type' => 'social',
+        ];
+      }
+      if ($age < 172800) {
+        return [
+          'label' => '✨ Just added',
+          'type' => 'new',
+        ];
+      }
+      return [];
+    }
 
     if ($saveCount >= 20 && $viewerCount >= 5) {
       return [

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -131,7 +131,8 @@ final class EventCardViewModel {
       : NULL;
 
     [$cardDay, $cardMonth] = $this->startDayMonth($node);
-    [$lowStock, $attendance] = $this->capacitySignals($node, $cacheability);
+    $socialProofMode = (string) ($context['mel_social_proof_mode'] ?? 'auto');
+    [$lowStock, $attendance] = $this->capacitySignals($node, $cacheability, $socialProofMode);
 
     $badges = [];
     if ($categoryLabel) {
@@ -150,6 +151,7 @@ final class EventCardViewModel {
     }
 
     return [
+      'event_id' => (int) $node->id(),
       'title' => $node->label(),
       'url' => $url,
       'image_url' => $image['url'],
@@ -207,6 +209,7 @@ final class EventCardViewModel {
       'mel_category_label' => $variables['mel_category_label'] ?? NULL,
       'mel_category_url' => $variables['mel_category_url'] ?? NULL,
       'mel_category_slug' => $variables['mel_category_slug'] ?? 'default',
+      'mel_social_proof_mode' => $variables['mel_social_proof_mode'] ?? 'auto',
     ];
 
     $model = $this->build($node, $viewMode, $context);
@@ -248,7 +251,9 @@ final class EventCardViewModel {
     $variables['card_cta_label'] = $model['cta_label'];
     $variables['card_is_low_stock'] = $model['is_low_stock'];
     $variables['card_attendance'] = $model['attendance'];
+    $variables['mel_social_proof_mode'] = $context['mel_social_proof_mode'] ?? 'auto';
     $variables['is_promoted'] = $model['is_promoted'];
+    $variables['event_id'] = $model['event_id'];
 
     $variables['event_flag_event_save'] = $this->buildSaveFlagLink($node);
     if ($variables['event_flag_event_save']) {
@@ -450,7 +455,11 @@ final class EventCardViewModel {
   /**
    * @return array{0: bool, 1: int|null}
    */
-  private function capacitySignals(NodeInterface $node, CacheableMetadata $cacheability): array {
+  private function capacitySignals(NodeInterface $node, CacheableMetadata $cacheability, string $socialProofMode = 'auto'): array {
+    if ($socialProofMode === 'hide') {
+      return [FALSE, NULL];
+    }
+
     $lowStock = FALSE;
     $attendance = NULL;
     if (\Drupal::hasService('myeventlane_capacity.service')) {
@@ -468,7 +477,8 @@ final class EventCardViewModel {
       $readModel = \Drupal::service('myeventlane_domain_events.read_model.event_metrics');
       $metrics = $readModel->getEventMetrics((int) $node->id());
       $going = (int) ($metrics['tickets_sold'] ?? 0) + (int) ($metrics['rsvp_count'] ?? 0);
-      if ($going >= 8) {
+      $attendanceThreshold = $socialProofMode === 'show' ? 1 : 8;
+      if ($going >= $attendanceThreshold) {
         $attendance = $going;
       }
       $cacheability->addCacheTags([sprintf('event_metrics:%d', (int) $node->id())]);

--- a/web/modules/custom/myeventlane_front/myeventlane_front.info.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.info.yml
@@ -4,6 +4,7 @@ description: Front page UI blocks for MyEventLane
 core_version_requirement: ^11
 package: MyEventLane
 dependencies:
+  - myeventlane_event:myeventlane_event
   - myeventlane_analytics:myeventlane_analytics
   - myeventlane_page_visuals:myeventlane_page_visuals
   - drupal:views

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
@@ -207,7 +207,6 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
         $going = (int) ($row['going'] ?? 0);
         $event_node = $ordered_nodes[$nid] ?? NULL;
         if ($event_node instanceof NodeInterface
-          && function_exists('myeventlane_event_should_show_block_going')
           && myeventlane_event_should_show_block_going($event_node, $going)) {
           $wrapper['going'] = [
             '#type' => 'html_tag',

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\myeventlane_analytics\Service\PopularEventsService;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -204,14 +205,19 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
 
       if ($show_going) {
         $going = (int) ($row['going'] ?? 0);
-        $wrapper['going'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          '#value' => $this->t('@count going', ['@count' => $going]),
-          '#attributes' => [
-            'class' => ['mel-popular-event__going'],
-          ],
-        ];
+        $event_node = $ordered_nodes[$nid] ?? NULL;
+        if ($event_node instanceof NodeInterface
+          && function_exists('myeventlane_event_should_show_block_going')
+          && myeventlane_event_should_show_block_going($event_node, $going)) {
+          $wrapper['going'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'div',
+            '#value' => $this->t('@count going', ['@count' => $going]),
+            '#attributes' => [
+              'class' => ['mel-popular-event__going'],
+            ],
+          ];
+        }
       }
 
       $items[] = $wrapper;

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingInCategoryBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingInCategoryBlock.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\myeventlane_analytics\Service\TrendingCategoriesService;
+use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -218,14 +219,19 @@ final class TrendingInCategoryBlock extends BlockBase implements ContainerFactor
 
       if ($show_going) {
         $going = (int) ($row['going'] ?? 0);
-        $wrapper['going'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          '#value' => $this->t('@count going', ['@count' => $going]),
-          '#attributes' => [
-            'class' => ['mel-popular-event__going'],
-          ],
-        ];
+        $event_node = $ordered_nodes[$nid] ?? NULL;
+        if ($event_node instanceof NodeInterface
+          && function_exists('myeventlane_event_should_show_block_going')
+          && myeventlane_event_should_show_block_going($event_node, $going)) {
+          $wrapper['going'] = [
+            '#type' => 'html_tag',
+            '#tag' => 'div',
+            '#value' => $this->t('@count going', ['@count' => $going]),
+            '#attributes' => [
+              'class' => ['mel-popular-event__going'],
+            ],
+          ];
+        }
       }
 
       $items[] = $wrapper;

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingInCategoryBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/TrendingInCategoryBlock.php
@@ -221,7 +221,6 @@ final class TrendingInCategoryBlock extends BlockBase implements ContainerFactor
         $going = (int) ($row['going'] ?? 0);
         $event_node = $ordered_nodes[$nid] ?? NULL;
         if ($event_node instanceof NodeInterface
-          && function_exists('myeventlane_event_should_show_block_going')
           && myeventlane_event_should_show_block_going($event_node, $going)) {
           $wrapper['going'] = [
             '#type' => 'html_tag',

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -43,7 +43,7 @@
 {% set mel_eds_rsvp = mel_eds['rsvp_state']|default('unset') %}
 {% set mel_eds_has_product = (mel_eds['has_product']|default(0) == 1) or (mel_eds['has_product']|default(false) is same as(true)) %}
 {% set mel_cta_urgency = '' %}
-{% if (event_ui is not defined) or (not (event_ui.is_sold_out|default(false) == true)) %}
+{% if mel_social_proof_mode|default('auto') != 'hide' and ((event_ui is not defined) or (not (event_ui.is_sold_out|default(false) == true))) %}
   {% if mel_eds_rsvp is same as('limited') and mel_eds_cap > 0 and mel_eds_cap < 10 %}
     {% set mel_cta_urgency = 'Only @c spots left'|t({ '@c': mel_eds_cap }) %}
   {% elseif mel_eds_rsvp is same as('limited') and mel_eds_cap > 0 and mel_eds_cap < 20 %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes public marketing/urgency UI across listings, blocks, and event pages; misconfigured modes could over- or under-state demand, but behavior is field-driven with a safe default of Auto.
> 
> **Overview**
> Adds per-event control over **social proof** (attendee counts, popularity badges, scarcity copy) via a new event field **`field_social_proof_visibility`** with **Auto**, **Show**, and **Hide** (default **Auto**).
> 
> **Hide** turns off interest labels in `EventInterestService`, card attendance/low-stock signals in `EventCardViewModel`, block “X going” lines (Popular / Trending blocks gate on `myeventlane_event_should_show_block_going`), and spots-left urgency on the full event page. **Show** relaxes thresholds (e.g. interest labels and card attendance at lower counts than **Auto**). Cards also expose **`event_id`** and **`mel_social_proof_mode`** to Twig; `myeventlane_front` now depends on `myeventlane_event`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838c74ff3466a9afdb91d94438394ddd280b6b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->