### PR TITLE
Cursor/social proof mode f010d

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -298,6 +298,11 @@ hidden:
   field_cancelled_at: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_geo: true
   field_event_highlights: true
@@ -334,6 +339,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_venue: true
   field_venue_address: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -64,6 +64,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -107,6 +112,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue_address: true

--- a/web/modules/custom/myeventlane_core/js/vendor-public.js
+++ b/web/modules/custom/myeventlane_core/js/vendor-public.js
@@ -101,24 +101,35 @@
         link.addEventListener('click', () => {
           const settings = drupalSettings.melPublicAnalytics || {};
           const eventId = link.getAttribute('data-event-id');
-          const eventClickToken = settings.csrfToken || csrfToken;
-          if (!settings.eventClickUrl || !eventId || !eventClickToken) {
+          if (!settings.eventClickUrl || !eventId) {
             return;
           }
 
-          const payload = new FormData();
-          payload.append('event_id', eventId);
+          const tokenPromise = settings.csrfToken
+            ? Promise.resolve(settings.csrfToken)
+            : getCsrfToken();
 
-          fetch(settings.eventClickUrl, {
-            method: 'POST',
-            credentials: 'same-origin',
-            body: payload,
-            keepalive: true,
-            headers: {
-              'X-CSRF-Token': eventClickToken,
-              'X-Requested-With': 'XMLHttpRequest',
-            },
-          }).catch((error) => console.error(error));
+          tokenPromise
+            .then((eventClickToken) => {
+              if (!eventClickToken) {
+                return;
+              }
+
+              const payload = new FormData();
+              payload.append('event_id', eventId);
+
+              return fetch(settings.eventClickUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: payload,
+                keepalive: true,
+                headers: {
+                  'X-CSRF-Token': eventClickToken,
+                  'X-Requested-With': 'XMLHttpRequest',
+                },
+              });
+            })
+            .catch((error) => console.error(error));
         });
       });
     },

--- a/web/modules/custom/myeventlane_core/myeventlane_core.module
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.module
@@ -303,3 +303,12 @@ function myeventlane_core_metatags_alter(array &$metatags): void {
     $metatags['canonical_url'] = $categoryUrl->getCategoryUrlString($term);
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function myeventlane_core_page_attachments(array &$attachments): void {
+  /** @var \Drupal\myeventlane_core\Service\DiscoveryAnalyticsPageAttachments $discovery_analytics */
+  $discovery_analytics = \Drupal::service('myeventlane_core.discovery_analytics_page_attachments');
+  $discovery_analytics->attachIfNeeded($attachments);
+}

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -27,6 +27,12 @@ services:
       - '@datetime.time'
       - '@logger.channel.myeventlane_core'
 
+  myeventlane_core.discovery_analytics_page_attachments:
+    class: Drupal\myeventlane_core\Service\DiscoveryAnalyticsPageAttachments
+    arguments:
+      - '@current_route_match'
+      - '@path.matcher'
+
   myeventlane_core.event_viewer_count:
     class: Drupal\myeventlane_core\Service\EventViewerCountService
     arguments: ['@state', '@datetime.time']

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoveryAnalyticsPageAttachments.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoveryAnalyticsPageAttachments.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+
+/**
+ * Attaches public event-click analytics to discovery listing surfaces.
+ *
+ * Reuses the existing vendor_public library and melPublicAnalytics settings.
+ * CSRF tokens are fetched client-side so anonymous page cache stays safe.
+ */
+final class DiscoveryAnalyticsPageAttachments {
+
+  /**
+   * View routes that render public event discovery cards.
+   *
+   * @var list<string>
+   */
+  private const VIEW_ROUTE_PREFIXES = [
+    'view.upcoming_events.',
+    'view.front_featured_events.',
+    'view.front_recommended_events.',
+    'view.featured_events.',
+    'view.mel_home_events.',
+    'view.front_discover_events.',
+  ];
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly PathMatcherInterface $pathMatcher,
+  ) {}
+
+  /**
+   * Merges analytics library and drupalSettings when on a discovery surface.
+   *
+   * @param array<string, mixed> $attachments
+   *   Page attachments render array (altered by reference).
+   */
+  public function attachIfNeeded(array &$attachments): void {
+    if (!$this->isDiscoverySurface()) {
+      return;
+    }
+
+    $this->ensureLibrary($attachments);
+
+    $existing = $attachments['#attached']['drupalSettings']['melPublicAnalytics'] ?? NULL;
+    if (is_array($existing) && !empty($existing['eventClickUrl'])) {
+      return;
+    }
+
+    $attachments['#attached']['drupalSettings']['melPublicAnalytics'] = [
+      'eventClickUrl' => Url::fromRoute('myeventlane_core.analytics_event_click')->toString(),
+    ];
+  }
+
+  /**
+   * Whether the current route is a public event discovery surface.
+   */
+  private function isDiscoverySurface(): bool {
+    if ($this->pathMatcher->isFrontPage()) {
+      return TRUE;
+    }
+
+    $route_name = (string) ($this->routeMatch->getRouteName() ?? '');
+    if ($route_name === '') {
+      return FALSE;
+    }
+
+    if ($route_name === 'mel_search.view') {
+      return TRUE;
+    }
+
+    foreach (self::VIEW_ROUTE_PREFIXES as $prefix) {
+      if (str_starts_with($route_name, $prefix)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * @param array<string, mixed> $attachments
+   */
+  private function ensureLibrary(array &$attachments): void {
+    $libraries = $attachments['#attached']['library'] ?? [];
+    if (!is_array($libraries)) {
+      $libraries = [];
+    }
+    if (!in_array('myeventlane_core/vendor_public', $libraries, TRUE)) {
+      $attachments['#attached']['library'][] = 'myeventlane_core/vendor_public';
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -916,6 +916,8 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     return;
   }
 
+  $variables['mel_social_proof_mode'] = myeventlane_event_get_social_proof_mode($node);
+
   $elements = is_array($variables['elements'] ?? NULL) ? $variables['elements'] : [];
   $recommendation_context = $elements['#recommendation_context'] ?? NULL;
   $variables['recommendation_context'] = is_array($recommendation_context)
@@ -1058,7 +1060,8 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     $variables['mel_event_gallery'] = $variables['mel_event_media']['gallery'];
   }
 
-  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_save_count')) {
+  $social_proof_mode = (string) ($variables['mel_social_proof_mode'] ?? 'auto');
+  if ($view_mode === 'full' && $social_proof_mode !== 'hide' && \Drupal::hasService('myeventlane_core.event_save_count')) {
     /** @var \Drupal\myeventlane_core\Service\EventSaveCountService $save_count_service */
     $save_count_service = \Drupal::service('myeventlane_core.event_save_count');
     $count = $save_count_service->getSaveCount((int) $node->id());
@@ -1080,7 +1083,7 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       $variables['event_save_count'] = NULL;
     }
   }
-  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_viewer_count')) {
+  if ($view_mode === 'full' && $social_proof_mode !== 'hide' && \Drupal::hasService('myeventlane_core.event_viewer_count')) {
     $variables['event_viewer_count_total'] = 0;
     $variables['event_viewer_count'] = NULL;
     try {
@@ -1089,7 +1092,8 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       $nid = (int) $node->id();
       $viewer_count = $viewer_service->recordViewAndGetCount($nid);
       $variables['event_viewer_count_total'] = $viewer_count;
-      if ($viewer_count > 1) {
+      $viewer_threshold = $social_proof_mode === 'show' ? 0 : 1;
+      if ($viewer_count > $viewer_threshold) {
         $variables['event_viewer_count'] = [
           '#markup' => \Drupal::translation()->formatPlural(
             $viewer_count,
@@ -1112,13 +1116,14 @@ function myeventlane_event_preprocess_node(array &$variables): void {
       ]);
     }
   }
-  if ($view_mode === 'full' && \Drupal::hasService('myeventlane_core.event_interest')) {
+  if ($view_mode === 'full' && $social_proof_mode !== 'hide' && \Drupal::hasService('myeventlane_core.event_interest')) {
     /** @var \Drupal\myeventlane_core\Service\EventInterestService $interest_service */
     $interest_service = \Drupal::service('myeventlane_core.event_interest');
     $variables['event_interest'] = $interest_service->getInterestState(
       (int) ($variables['event_save_count_total'] ?? 0),
       (int) ($variables['event_viewer_count_total'] ?? 0),
-      (int) $node->getCreatedTime()
+      (int) $node->getCreatedTime(),
+      $social_proof_mode
     );
   }
   $variables['mel_related_events'] = NULL;
@@ -1387,6 +1392,30 @@ function myeventlane_event_preprocess_myeventlane_vendor_dashboard(array &$varia
 }
 
 /**
+ * Resolves organiser social-proof visibility for an event node.
+ *
+ * @return 'auto'|'show'|'hide'
+ */
+function myeventlane_event_get_social_proof_mode(NodeInterface $node): string {
+  if (!$node->hasField('field_social_proof_visibility') || $node->get('field_social_proof_visibility')->isEmpty()) {
+    return 'auto';
+  }
+  $mode = (string) $node->get('field_social_proof_visibility')->value;
+  return in_array($mode, ['auto', 'show', 'hide'], TRUE) ? $mode : 'auto';
+}
+
+/**
+ * Whether a block-level "@count going" label should render for an event.
+ */
+function myeventlane_event_should_show_block_going(NodeInterface $node, int $going): bool {
+  return match (myeventlane_event_get_social_proof_mode($node)) {
+    'hide' => FALSE,
+    'show' => $going > 0,
+    default => TRUE,
+  };
+}
+
+/**
  * Map event_domain_state + CTA to semantic UI (Twig: labels and types only).
  */
 function myeventlane_event_finalize_event_ui(
@@ -1443,6 +1472,10 @@ function myeventlane_event_finalize_event_ui(
       && $capacity < 20
     ) {
       $out['capacity_hint'] = (string) t('Limited spots remaining');
+    }
+    if (myeventlane_event_get_social_proof_mode($node) === 'hide') {
+      $out['capacity_hint'] = NULL;
+      $out['is_limited'] = FALSE;
     }
     return $out;
   }
@@ -1510,6 +1543,12 @@ function myeventlane_event_finalize_event_ui(
     $out['image_badge_label'] = (string) t('Featured');
     $out['image_badge_type'] = 'apricot';
   }
+
+  if (myeventlane_event_get_social_proof_mode($node) === 'hide') {
+    $out['capacity_hint'] = NULL;
+    $out['is_limited'] = FALSE;
+  }
+
   return $out;
 }
 

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -181,12 +181,24 @@ services:
     tags:
       - { name: event_subscriber }
 
-  myeventlane_event.event_view_tracking_subscriber:
-    class: Drupal\myeventlane_event\EventSubscriber\EventViewTrackingSubscriber
+  myeventlane_event.event_page_view_tracker:
+    class: Drupal\myeventlane_event\Service\EventPageViewTracker
     arguments:
       - '@myeventlane_core.analytics'
       - '@myeventlane_event.public_visibility'
       - '@current_user'
+
+  myeventlane_event.event_view_tracking_middleware:
+    class: Drupal\myeventlane_event\StackMiddleware\EventViewTrackingMiddleware
+    arguments:
+      - '@myeventlane_event.event_page_view_tracker'
+    tags:
+      - { name: http_middleware, priority: 210 }
+
+  myeventlane_event.event_view_tracking_subscriber:
+    class: Drupal\myeventlane_event\EventSubscriber\EventViewTrackingSubscriber
+    arguments:
+      - '@myeventlane_event.event_page_view_tracker'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventViewTrackingSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventViewTrackingSubscriber.php
@@ -4,26 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event\EventSubscriber;
 
-use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\myeventlane_core\Http\MelKernelAuthRouteSilencer;
-use Drupal\myeventlane_core\Service\AnalyticsService;
-use Drupal\myeventlane_event\Service\PublicEventVisibility;
-use Drupal\node\NodeInterface;
+use Drupal\myeventlane_event\Service\EventPageViewTracker;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Records event page views on canonical event routes.
  *
- * Runs after the passcode gate subscriber so redirects are not counted.
+ * Runs on CONTROLLER (after routing and param conversion) so the event node is
+ * available on the request. REQUEST-phase listeners run before Drupal routing.
  */
 final class EventViewTrackingSubscriber implements EventSubscriberInterface {
 
   public function __construct(
-    private readonly AnalyticsService $analytics,
-    private readonly PublicEventVisibility $publicVisibility,
-    private readonly AccountProxyInterface $currentUser,
+    private readonly EventPageViewTracker $eventPageViewTracker,
   ) {}
 
   /**
@@ -31,37 +26,19 @@ final class EventViewTrackingSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
-      KernelEvents::REQUEST => ['onKernelRequest', 20],
+      KernelEvents::CONTROLLER => ['onKernelController', 0],
     ];
   }
 
   /**
-   * Tracks a view when the event full page is actually served.
+   * Tracks a view when the event full page controller is about to run.
    */
-  public function onKernelRequest(RequestEvent $event): void {
-    if (!$event->isMainRequest() || $event->hasResponse()) {
+  public function onKernelController(ControllerEvent $event): void {
+    if (!$event->isMainRequest()) {
       return;
     }
 
-    $request = $event->getRequest();
-    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
-      return;
-    }
-
-    if ((string) $request->attributes->get('_route', '') !== 'entity.node.canonical') {
-      return;
-    }
-
-    $node = $request->attributes->get('node');
-    if (!$node instanceof NodeInterface || $node->bundle() !== 'event' || !$node->isPublished()) {
-      return;
-    }
-
-    if (!$this->publicVisibility->isDirectlyViewable($node, $this->currentUser, $request)) {
-      return;
-    }
-
-    $this->analytics->track('node', (int) $node->id(), AnalyticsService::EVENT_EVENT_VIEW);
+    $this->eventPageViewTracker->trackFromKernelRequest($event->getRequest());
   }
 
 }

--- a/web/modules/custom/myeventlane_event/src/Service/EventPageViewTracker.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventPageViewTracker.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_core\Http\MelKernelAuthRouteSilencer;
+use Drupal\myeventlane_core\Service\AnalyticsService;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Records canonical event page views for vendor analytics.
+ */
+final class EventPageViewTracker {
+
+  /**
+   * Page cache header set by Drupal core on internal page cache hits.
+   */
+  private const PAGE_CACHE_HEADER = 'X-Drupal-Cache';
+
+  public function __construct(
+    private readonly AnalyticsService $analytics,
+    private readonly PublicEventVisibility $publicVisibility,
+    private readonly AccountProxyInterface $currentUser,
+  ) {}
+
+  /**
+   * Tracks a view during the kernel request phase (after routing).
+   */
+  public function trackFromKernelRequest(Request $request, ?Response $response = NULL): void {
+    $this->trackIfViewableEventPage($request, $response);
+  }
+
+  /**
+   * Tracks a view when internal page cache serves a stored response.
+   */
+  public function trackFromPageCacheHit(Request $request, Response $response): void {
+    if ($response->headers->get(self::PAGE_CACHE_HEADER) !== 'HIT') {
+      return;
+    }
+
+    $this->trackIfViewableEventPage($request, $response);
+  }
+
+  /**
+   * Tracks a view when the canonical event page is actually delivered.
+   */
+  private function trackIfViewableEventPage(Request $request, ?Response $response = NULL): void {
+    if (MelKernelAuthRouteSilencer::shouldBypassAuthAccountRoutes($request)) {
+      return;
+    }
+
+    if ($response !== NULL) {
+      if ($response->isRedirection() || $response->getStatusCode() >= 400) {
+        return;
+      }
+    }
+
+    $node = $this->resolveEventNode($request);
+    if (!$node instanceof NodeInterface || !$node->isPublished()) {
+      return;
+    }
+
+    if (!$this->publicVisibility->isDirectlyViewable($node, $this->currentUser, $request)) {
+      return;
+    }
+
+    $this->analytics->track('node', (int) $node->id(), AnalyticsService::EVENT_EVENT_VIEW);
+  }
+
+  /**
+   * Resolves the event node from routed request attributes only.
+   *
+   * Routing must have completed; never call the router here — that can
+   * initialise router.request_context before the request stack is ready.
+   */
+  private function resolveEventNode(Request $request): ?NodeInterface {
+    if ((string) $request->attributes->get('_route', '') !== 'entity.node.canonical') {
+      return NULL;
+    }
+
+    $node = $request->attributes->get('node');
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      return NULL;
+    }
+
+    return $node;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/StackMiddleware/EventViewTrackingMiddleware.php
+++ b/web/modules/custom/myeventlane_event/src/StackMiddleware/EventViewTrackingMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\StackMiddleware;
+
+use Drupal\myeventlane_event\Service\EventPageViewTracker;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Records event views when internal page cache serves a stored response.
+ *
+ * Dynamic page cache hits are handled by EventViewTrackingSubscriber after
+ * routing; this middleware covers internal page cache hits that bypass the
+ * kernel request subscribers entirely.
+ */
+final class EventViewTrackingMiddleware implements HttpKernelInterface {
+
+  public function __construct(
+    private readonly HttpKernelInterface $httpKernel,
+    private readonly EventPageViewTracker $eventPageViewTracker,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE): Response {
+    $response = $this->httpKernel->handle($request, $type, $catch);
+
+    if ($type === self::MAIN_REQUEST) {
+      $this->eventPageViewTracker->trackFromPageCacheHit($request, $response);
+    }
+
+    return $response;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -369,6 +369,7 @@ final class EventStudioAutosaveController {
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? $params['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? $params['field_category'] ?? ''),
       'field_tags' => $this->extractMultipleEntityIds($mel['field_tags'] ?? $params['field_tags'] ?? ''),
+      'field_social_proof_visibility' => trim((string) ($mel['field_social_proof_visibility'] ?? $params['field_social_proof_visibility'] ?? 'auto')),
       'field_accessibility' => $this->extractMultipleEntityIds($mel['field_accessibility'] ?? $params['field_accessibility'] ?? ''),
       'field_accessibility_contact' => trim((string) ($mel['field_accessibility_contact'] ?? $params['field_accessibility_contact'] ?? '')),
       'field_accessibility_directions' => trim((string) ($mel['field_accessibility_directions'] ?? $params['field_accessibility_directions'] ?? '')),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioDescriptionForm.php
@@ -121,6 +121,19 @@ class EventStudioDescriptionForm extends EventStudioBaseForm {
       '#prefix' => '<section class="mel-es-field-group mel-es-field-group--visibility" aria-labelledby="mel-es-content-visibility-title"><header class="mel-es-field-group__header"><h3 class="mel-es-field-group__title" id="mel-es-content-visibility-title">' . $this->t('Visibility') . '</h3><p class="mel-es-field-group__hint">' . $this->t('Tune discovery tags and ticket sales timing without changing checkout logic.') . '</p></header><div class="mel-es-field-group__body">',
     ];
 
+    $form['mel']['field_social_proof_visibility'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Social Proof Visibility'),
+      '#description' => $this->t('Control whether attendee activity and popularity indicators are shown on event listings and event pages.'),
+      '#options' => $this->listStringFieldOptions('field_social_proof_visibility') ?: [
+        'auto' => $this->t('Auto'),
+        'show' => $this->t('Show'),
+        'hide' => $this->t('Hide'),
+      ],
+      '#default_value' => $melDefaults['field_social_proof_visibility'] ?? 'auto',
+      '#attributes' => ['class' => ['mel-input']],
+    ];
+
     $form['mel']['field_sales_start'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Ticket sales start'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelDefaultsProvider.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelDefaultsProvider.php
@@ -208,6 +208,11 @@ final class EventStudioMelDefaultsProvider {
       $field_refund_policy_default = (string) $event->get('field_refund_policy')->value;
     }
 
+    $field_social_proof_visibility_default = 'auto';
+    if ($event->hasField('field_social_proof_visibility') && !$event->get('field_social_proof_visibility')->isEmpty()) {
+      $field_social_proof_visibility_default = (string) $event->get('field_social_proof_visibility')->value;
+    }
+
     $field_accessibility_default = [];
     if ($event->hasField('field_accessibility') && !$event->get('field_accessibility')->isEmpty()) {
       $field_accessibility_default = $event->get('field_accessibility')->referencedEntities();
@@ -646,6 +651,16 @@ final class EventStudioMelDefaultsProvider {
       '#target_type' => 'taxonomy_term',
       '#tags' => TRUE,
       '#default_value' => $tags_default,
+    ];
+
+    $mel['field_social_proof_visibility'] = [
+      '#type' => 'select',
+      '#options' => $this->listStringFieldOptions('field_social_proof_visibility') ?: [
+        'auto' => 'Auto',
+        'show' => 'Show',
+        'hide' => 'Hide',
+      ],
+      '#default_value' => $field_social_proof_visibility_default,
     ];
 
     $mel['field_accessibility'] = [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -283,6 +283,7 @@ final class EventStudioMelPayloadService {
       'field_contact_phone' => trim((string) ($mel['field_contact_phone'] ?? '')),
       'field_category' => $this->extractMultipleEntityIds($mel['field_category'] ?? ''),
       'field_tags' => $this->extractMultipleEntityIds($mel['field_tags'] ?? ''),
+      'field_social_proof_visibility' => trim((string) ($mel['field_social_proof_visibility'] ?? 'auto')),
       'field_accessibility' => $this->extractMultipleEntityIds($mel['field_accessibility'] ?? ''),
       'field_accessibility_contact' => trim((string) ($mel['field_accessibility_contact'] ?? '')),
       'field_accessibility_directions' => trim((string) ($mel['field_accessibility_directions'] ?? '')),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -890,6 +890,22 @@ final class EventStudioSaveService {
         $node->set('field_refund_policy', in_array($v, $allowed, TRUE) ? $v : NULL);
       }
     }
+
+    if ($node->hasField('field_social_proof_visibility') && array_key_exists('field_social_proof_visibility', $payload)) {
+      $v = trim((string) $payload['field_social_proof_visibility']);
+      $allowed = $this->listStringValueKeys($node->getFieldDefinition('field_social_proof_visibility'));
+      if ($allowed === []) {
+        $this->logger->warning('Studio save: field_social_proof_visibility allowed values missing; skipping set (nid @nid).', [
+          '@nid' => (string) ($node->id() ?? 'new'),
+        ]);
+      }
+      else {
+        if ($v === '' || !in_array($v, $allowed, TRUE)) {
+          $v = in_array('auto', $allowed, TRUE) ? 'auto' : (string) reset($allowed);
+        }
+        $node->set('field_social_proof_visibility', $v);
+      }
+    }
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1962,11 +1962,16 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         && isset($variables['page']['homepage_free'])
         && is_array($variables['page']['homepage_free'])
         && count(Element::children($variables['page']['homepage_free'])) > 0;
+      $variables['mel_home_show_recommended'] = $homepageVisibility->viewDisplayHasResults('front_recommended_events', 'block_1')
+        && isset($variables['page']['home_recommended'])
+        && is_array($variables['page']['home_recommended'])
+        && count(Element::children($variables['page']['home_recommended'])) > 0;
     }
     else {
       $variables['mel_home_show_featured'] = FALSE;
       $variables['mel_home_show_blog'] = FALSE;
       $variables['mel_home_show_free_rsvp'] = FALSE;
+      $variables['mel_home_show_recommended'] = FALSE;
     }
   }
 
@@ -2586,7 +2591,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       $variables['directory'] = $base_path . $theme_path;
     }
 
-    // Event Intelligence Layer: one calm label per event (placeholder tier; replace with metrics later).
+    // Event Intelligence Layer: placeholder chip (node-id derived); suppressed in show/hide modes.
     $variables['mel_signal'] = NULL;
     $mel_state = (string) ($variables['mel_event_state'] ?? '');
     $event_ui_signal = is_array($variables['event_ui'] ?? NULL) ? $variables['event_ui'] : [];
@@ -2594,7 +2599,8 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
     $signal_hide = ($mel_state === 'cancelled')
       || ($mel_state === 'sold_out')
       || $signal_sold_out;
-    if (!$signal_hide) {
+    $social_proof_mode = (string) ($variables['mel_social_proof_mode'] ?? 'auto');
+    if (!$signal_hide && $social_proof_mode === 'auto') {
       $mel_signals = [
         (string) t('Popular'),
         (string) t('Trending'),
@@ -2694,7 +2700,8 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
     if ($view_mode === 'full' && $node?->bundle() === 'event') {
       _myeventlane_theme_apply_event_page_style_theme_variables($variables, $node);
       $variables['mel_event_selling_fast'] = FALSE;
-      if (\Drupal::hasService('myeventlane_capacity.service')) {
+      $social_proof_mode = (string) ($variables['mel_social_proof_mode'] ?? 'auto');
+      if ($social_proof_mode !== 'hide' && \Drupal::hasService('myeventlane_capacity.service')) {
         $capacity = \Drupal::service('myeventlane_capacity.service');
         $total_cap = $capacity->getCapacityTotal($node);
         $remaining = $capacity->getRemaining($node);
@@ -2946,6 +2953,7 @@ function myeventlane_theme_preprocess_views_view_fields(array &$variables): void
     if ($event_node instanceof NodeInterface && $event_node->access('view')) {
       $canonical = $event_node->toUrl('canonical');
       $variables['mel_event_card_url'] = $canonical->toString();
+      $variables['mel_event_card_event_id'] = (int) $event_node->id();
       if (!isset($variables['#cache'])) {
         $variables['#cache'] = [];
       }
@@ -4636,7 +4644,10 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
     }
   }
 
-  if (\Drupal::hasService('myeventlane_capacity.service')) {
+  $booking_social_proof_mode = function_exists('myeventlane_event_get_social_proof_mode')
+    ? myeventlane_event_get_social_proof_mode($event)
+    : 'auto';
+  if ($booking_social_proof_mode !== 'hide' && \Drupal::hasService('myeventlane_capacity.service')) {
     try {
       /** @var \Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface $capacity */
       $capacity = \Drupal::service('myeventlane_capacity.service');
@@ -4660,6 +4671,7 @@ function myeventlane_theme_preprocess_myeventlane_event_book(array &$variables):
       ]);
     }
   }
+  $variables['mel_social_proof_mode'] = $booking_social_proof_mode;
 
   $categoryText = '';
   if ($event->hasField('field_category') && !$event->get('field_category')->isEmpty()) {

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -383,6 +383,7 @@
 // Discovery - dense marketplace grid across homepage rails.
 // ---------------------------------------------------------------------------
 
+.mel-page--home .mel-section--recommended,
 .mel-page--home .mel-section--latest {
   padding-top: clamp(1rem, 2.6vw, 1.9rem);
 }

--- a/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
@@ -24,4 +24,5 @@
   card_status_primary: _status_primary,
   card_status_modifier: _status_mod,
   is_promoted: is_promoted|default(false),
+  event_id: event_id|default(mel_event_card_event_id|default(null)),
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -41,7 +41,7 @@
       } %}
     {% endif %}
 
-    {% if page.home_recommended %}
+    {% if mel_home_show_recommended|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--recommended mel-section--discover',
         section_width_class: 'mel-section--wide',

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-fields.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-fields.html.twig
@@ -48,7 +48,8 @@
     category_slug: fields.field_category_slug.content|default('')|striptags|trim,
     ticket_type: fields.field_ticket_type.content|default('rsvp')|striptags|trim,
     ticket_label: fields.field_ticket_label.content|default('RSVP')|striptags|trim,
-    accessibility: fields.field_accessibility_icons.content|default([])
+    accessibility: fields.field_accessibility_icons.content|default([]),
+    event_id: mel_event_card_event_id|default(null)
   } only %}
 {% else %}
   {% for field in fields -%}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Analytics and view-count paths run on more requests (middleware + discovery attachments); social proof changes affect public UX broadly but are gated by a new optional field defaulting to auto.
> 
> **Overview**
> Adds organiser control over **social proof** on events via `field_social_proof_visibility` (**auto** / **show** / **hide**), wired through Event Studio (description step, defaults, autosave, save) and hidden on core node form/view displays. **Hide** turns off save/viewer counts, interest labels, capacity hints, selling-fast, booking signals, and placeholder `mel_signal` chips; **show** relaxes viewer-count display thresholds.
> 
> **Discovery analytics** now attaches `vendor_public` and `melPublicAnalytics.eventClickUrl` on homepage, search, and listing view routes (`DiscoveryAnalyticsPageAttachments` + `hook_page_attachments`). Event cards pass `event_id` into Twig; click tracking fetches CSRF client-side when not pre-attached so cached pages stay safe.
> 
> **Event page view tracking** is refactored into `EventPageViewTracker`, invoked from a `CONTROLLER` subscriber (post-routing) and **HTTP middleware** for internal page cache `HIT`s so views are still counted when the kernel subscribers are skipped.
> 
> Homepage **recommended** rail only renders when the view has results (`mel_home_show_recommended`); donation-related fields are added to entity display hidden lists alongside social proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8def962a75c63169312d47748d4539ffc0b6b110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->