### PR TITLE
Improve homepage discovery conversion UX

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -222,6 +222,72 @@
   }
 }
 
+// Calendar date badge — day/month from EventCardViewModel (card_day / card_month).
+.mel-event-card__date-badge {
+  position: absolute;
+  top: mel.$mel-ds-space-sm;
+  left: mel.$mel-ds-space-sm;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: mel.$mel-ds-space-xs mel.$mel-ds-space-sm;
+  border-radius: mel.$mel-ds-radius-sm;
+  background: color-mix(in srgb, #fff 94%, mel.$mel-ds-color-bg 6%);
+  color: mel.$mel-ds-color-text;
+  text-align: center;
+  line-height: 1.1;
+  box-shadow: 0 2px 10px rgba(36, 48, 58, 0.14);
+  pointer-events: none;
+
+  @supports (backdrop-filter: blur(1px)) {
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+}
+
+.mel-event-card__date-badge-day {
+  display: block;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.mel-event-card__date-badge-month {
+  display: block;
+  margin-top: 1px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, mel.$mel-ds-color-text 72%, mel.$mel-ds-color-muted 28%);
+}
+
+.mel-event-card:has(.mel-event-card__date-badge) .mel-event-card__image-badge,
+.mel-event-card:has(.mel-event-card__date-badge) .mel-event-card__badge {
+  top: mel.$mel-ds-space-sm;
+  left: auto;
+  right: mel.$mel-ds-space-sm;
+}
+
+.mel-event-card--hero:has(.mel-event-card__date-badge) .mel-event-card__date-badge,
+.mel-event-card--featured:has(.mel-event-card__date-badge) .mel-event-card__date-badge {
+  top: mel.$mel-ds-space-md;
+  right: mel.$mel-ds-space-md;
+  left: auto;
+}
+
+// Elevated price / RSVP label — fixed slot directly under title (non-hero cards).
+.mel-event-card__price-slot {
+  margin: 0 0 mel.$mel-ds-space-xs;
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
 // Outrank .mel-pill--on-image / .mel-pill (listing + hero) without.
 .mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--highlight,
 .mel-event-card__media .mel-pill--on-image.mel-event-card__state-pill--highlight,
@@ -993,6 +1059,28 @@
   .mel-event-card__image-badge,
   .mel-event-card__overlay {
     display: none;
+  }
+
+  .mel-event-card__date-badge {
+    top: 8px;
+    left: 8px;
+    min-width: 40px;
+    min-height: 40px;
+    padding: 4px 6px;
+    border-radius: mel.$mel-ds-radius-sm;
+  }
+
+  .mel-event-card__date-badge-day {
+    font-size: 13px;
+  }
+
+  .mel-event-card__date-badge-month {
+    font-size: 10px;
+  }
+
+  .mel-event-card__price-slot {
+    margin-bottom: 2px;
+    font-size: 13px;
   }
 
   .mel-event-card__body,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -226,10 +226,6 @@
 
 .mel-home-hero__art {
   min-width: 0;
-
-  @include breakpoints.mel-break(lg, max) {
-    order: -1;
-  }
 }
 
 .mel-home-hero__art--hide-mobile {

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -68,6 +68,15 @@
   {% set _category = { 'label': category, 'url': null } %}
 {% endif %}
 
+{% set _date_day = card_day|default(date_day|default(''))|striptags|trim %}
+{% set _date_month = card_month|default(date_month|default(''))|striptags|trim %}
+{% set _has_date_badge = _date_day != '' and _date_month != '' %}
+
+{% set _price_label = card_price_label|default('')|striptags|trim %}
+{% if _price_label == '' %}
+  {% set _price_label = _status_primary|default('')|striptags|trim %}
+{% endif %}
+
 {% set _state_badge_type = 'highlight' %}
 {# Image pill: event_ui only — is_sold_out > image_badge (boost/Featured from myeventlane_event_finalize_event_ui) > category. #}
 {% set _image_badge_label = null %}
@@ -124,6 +133,13 @@
         />
       {% else %}
         <div class="mel-event-card__placeholder" aria-hidden="true"></div>
+      {% endif %}
+
+      {% if _has_date_badge %}
+        <div class="mel-event-card__date-badge" aria-hidden="true">
+          <span class="mel-event-card__date-badge-day">{{ _date_day }}</span>
+          <span class="mel-event-card__date-badge-month">{{ _date_month }}</span>
+        </div>
       {% endif %}
 
       {% if _variant not in ['compact', 'list'] %}
@@ -192,6 +208,10 @@
       {% else %}
         <h3 class="mel-event-card__title">{{ _title }}</h3>
 
+        {% if _price_label %}
+          <p class="mel-event-card__price mel-event-card__price-slot mel-event-card__status mel-event-card__status--{{ _status_mod }}">{{ _price_label }}</p>
+        {% endif %}
+
         {% if _time %}
           <p class="mel-event-card__when mel-event-card__date">
             <span class="mel-event-card__meta-text">{{ _time }}</span>
@@ -208,14 +228,9 @@
           {% endif %}
         </div>
 
-        {% if _status_primary or _status_secondary %}
+        {% if _status_secondary %}
           <div class="mel-event-card__status-row mel-event-card__meta">
-            {% if _status_primary %}
-              <p class="mel-event-card__status mel-event-card__status--{{ _status_mod }}">{{ _status_primary }}</p>
-            {% endif %}
-            {% if _status_secondary %}
-              <p class="mel-event-card__status-secondary">{{ _status_secondary }}</p>
-            {% endif %}
+            <p class="mel-event-card__status-secondary">{{ _status_secondary }}</p>
           </div>
         {% endif %}
         {% if _category and _category.label %}

--- a/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
@@ -9,6 +9,7 @@
 {% set _status_primary = _tt == 'rsvp' ? 'Free RSVP'|t : (_tt == 'external' ? 'External ticketing'|t : (_tt == 'paid' or _tt == 'both' ? 'Paid tickets'|t : '')) %}
 {% set _status_mod = _tt == 'external' ? 'external' : (_tt == 'rsvp' ? 'free' : 'default') %}
 {% set _tl = ticket_label|default('')|striptags|trim %}
+{% set _price_from_view = _tl %}
 {% include '@myeventlane_theme/components/event-card/mel-event-card.html.twig' with {
   variant: 'standard',
   card_title: title|default(''),
@@ -17,11 +18,14 @@
   card_image_alt: title|default(''),
   card_time_range: date_full|default(''),
   card_location: location|default(''),
+  card_day: date_day|default(''),
+  card_month: date_month|default(''),
   card_category: (category is defined and category) ? { label: category, url: null } : null,
   category_slug: category_slug|default(''),
   card_type: _tt,
   card_cta_label: _tl ? _tl : _cta_fallback,
-  card_status_primary: _status_primary,
+  card_price_label: _price_from_view,
+  card_status_primary: _price_from_view != '' ? _price_from_view : _status_primary,
   card_status_modifier: _status_mod,
   is_promoted: is_promoted|default(false),
   event_id: event_id|default(mel_event_card_event_id|default(null)),

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -26,21 +26,6 @@
 
   <div class="mel-page mel-page--home">
 
-    {% if mel_home_show_featured|default(false) %}
-      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--featured',
-        section_width_class: 'mel-section--wide',
-        container_class: 'mel-container mel-container--wide',
-        header_extra_class: 'mel-section__header--featured',
-        title: 'Featured events'|t,
-        subtitle: 'The can’t-miss pick at the top of the lane.'|t,
-        link_url: path('view.upcoming_events.page_events'),
-        link_text: 'Browse marketplace'|t,
-        link_class: 'mel-link',
-        content: page.homepage_featured
-      } %}
-    {% endif %}
-
     {% if mel_home_show_recommended|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--recommended mel-section--discover',
@@ -52,20 +37,6 @@
         link_text: 'Browse marketplace'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.home_recommended
-      } %}
-    {% endif %}
-
-    {% if page.homepage_tonight %}
-      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--tonight mel-section--discover',
-        section_width_class: 'mel-section--wide',
-        container_class: 'mel-container mel-container--wide',
-        title: 'On tonight'|t,
-        subtitle: 'Last-minute plans and events already warming up.'|t,
-        link_url: path('view.upcoming_events.page_today'),
-        link_text: 'See today'|t,
-        content_wrapper_class: 'mel-section__discover-view',
-        content: page.homepage_tonight
       } %}
     {% endif %}
 
@@ -83,15 +54,29 @@
       } %}
     {% endif %}
 
+    {% if page.homepage_tonight %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--tonight mel-section--discover',
+        section_width_class: 'mel-section--wide',
+        container_class: 'mel-container mel-container--wide',
+        title: 'On tonight'|t,
+        subtitle: 'Last-minute plans and events already warming up.'|t,
+        link_url: path('view.upcoming_events.page_today'),
+        link_text: 'See today'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_tonight
+      } %}
+    {% endif %}
+
     {% if page.homepage_latest %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--latest mel-section--discover',
         section_width_class: 'mel-section--wide',
         container_class: 'mel-container mel-container--wide',
-        title: 'Upcoming events'|t,
-        subtitle: 'What’s coming up across MyEventLane.'|t,
+        title: 'Browse all upcoming events'|t,
+        subtitle: 'See everything coming up — filters and search live on the events page.'|t,
         link_url: path('view.upcoming_events.page_events'),
-        link_text: 'See all'|t,
+        link_text: 'Browse all events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_latest
       } %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Theme-only Twig/SCSS changes to cards and homepage section order; no auth or backend logic in this diff.
> 
> **Overview**
> **Event cards** gain a calendar **date badge** on the image (`card_day` / `card_month`) and move **price/RSVP copy** into a dedicated slot under the title via `card_price_label`, with image state pills shifted to the top-right when a date badge is present. The Views bridge passes `date_day`/`date_month` and prefers `ticket_label` for that price line instead of showing primary status at the bottom.
> 
> **Homepage discovery** drops the separate **Featured events** rail, leads with **Recommended**, moves **Free & RSVP** up (before Tonight), and retitles the latest block to **Browse all upcoming events** with clearer CTAs toward the marketplace.
> 
> **Home hero** removes the large-breakpoint rule that forced hero art above content on smaller viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9db386f17f0cd03bc46b019129933a8f01922c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->