### PR TITLE
Add discovery rail attribution analytics

### DIFF
--- a/config/sync/block.block.front_featured_events.yml
+++ b/config/sync/block.block.front_featured_events.yml
@@ -1,6 +1,6 @@
 uuid: 2cc53d11-d71b-4eed-a198-bacf79ac6acb
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - views.view.front_featured_events

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -1227,6 +1227,7 @@ display:
       display_extenders: {  }
       block_description: 'Homepage: On tonight'
       block_category: MyEventLane
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/myeventlane_core/js/vendor-public.js
+++ b/web/modules/custom/myeventlane_core/js/vendor-public.js
@@ -118,6 +118,11 @@
               const payload = new FormData();
               payload.append('event_id', eventId);
 
+              const source = (link.getAttribute('data-mel-source') || '').trim();
+              if (source) {
+                payload.append('source', source);
+              }
+
               return fetch(settings.eventClickUrl, {
                 method: 'POST',
                 credentials: 'same-origin',

--- a/web/modules/custom/myeventlane_core/myeventlane_core.install
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.install
@@ -48,11 +48,18 @@ function myeventlane_core_schema(): array {
         'unsigned' => TRUE,
         'not null' => TRUE,
       ],
+      'source' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+        'description' => 'Discovery attribution source for event_click rows.',
+      ],
     ],
     'primary key' => ['id'],
     'indexes' => [
       'entity_event' => ['entity_type', 'entity_id', 'event_type'],
       'event_type_timestamp' => ['event_type', 'timestamp'],
+      'event_type_source_timestamp' => ['event_type', 'source', 'timestamp'],
       'user_id' => ['user_id'],
     ],
   ];
@@ -854,5 +861,35 @@ function myeventlane_core_update_9119(): void {
       $link->set('link', ['uri' => 'internal:/help']);
       $link->save();
     }
+  }
+}
+
+/**
+ * Adds discovery attribution source to public analytics events.
+ */
+function myeventlane_core_update_9120(): void {
+  $schema = \Drupal::database()->schema();
+  $table = 'myeventlane_public_analytics_event';
+  if (!$schema->tableExists($table)) {
+    return;
+  }
+
+  if (!$schema->fieldExists($table, 'source')) {
+    $schema->addField($table, 'source', [
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => FALSE,
+      'description' => 'Discovery attribution source for event_click rows.',
+    ]);
+  }
+
+  if (!$schema->indexExists($table, 'event_type_source_timestamp')) {
+    $module_schema = myeventlane_core_schema();
+    $schema->addIndex(
+      $table,
+      'event_type_source_timestamp',
+      ['event_type', 'source', 'timestamp'],
+      $module_schema[$table],
+    );
   }
 }

--- a/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.services.yml
@@ -19,6 +19,9 @@ services:
       - '@entity_type.manager'
       - '@logger.channel.myeventlane_core'
 
+  myeventlane_core.discovery_attribution_sources:
+    class: Drupal\myeventlane_core\Service\DiscoveryAttributionSources
+
   myeventlane_core.analytics:
     class: Drupal\myeventlane_core\Service\AnalyticsService
     arguments:
@@ -26,6 +29,7 @@ services:
       - '@current_user'
       - '@datetime.time'
       - '@logger.channel.myeventlane_core'
+      - '@myeventlane_core.discovery_attribution_sources'
 
   myeventlane_core.discovery_analytics_page_attachments:
     class: Drupal\myeventlane_core\Service\DiscoveryAnalyticsPageAttachments

--- a/web/modules/custom/myeventlane_core/src/Controller/PublicAnalyticsController.php
+++ b/web/modules/custom/myeventlane_core/src/Controller/PublicAnalyticsController.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_core\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\myeventlane_core\Service\AnalyticsService;
+use Drupal\myeventlane_core\Service\DiscoveryAttributionSources;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +21,7 @@ final class PublicAnalyticsController extends ControllerBase {
    */
   public function __construct(
     private readonly AnalyticsService $analytics,
+    private readonly DiscoveryAttributionSources $discoveryAttributionSources,
   ) {}
 
   /**
@@ -28,6 +30,7 @@ final class PublicAnalyticsController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_core.analytics'),
+      $container->get('myeventlane_core.discovery_attribution_sources'),
     );
   }
 
@@ -40,7 +43,19 @@ final class PublicAnalyticsController extends ControllerBase {
       return new JsonResponse(['status' => 'error'], 400);
     }
 
-    $tracked = $this->analytics->track('node', $event_id, AnalyticsService::EVENT_EVENT_CLICK);
+    $source = trim((string) $request->request->get('source', ''));
+    $source = $source === '' ? NULL : $source;
+    if ($source !== NULL && !$this->discoveryAttributionSources->isAllowed($source)) {
+      return new JsonResponse(['status' => 'error'], 400);
+    }
+
+    $tracked = $this->analytics->track(
+      'node',
+      $event_id,
+      AnalyticsService::EVENT_EVENT_CLICK,
+      NULL,
+      $source,
+    );
     return new JsonResponse(['status' => $tracked ? 'ok' : 'error'], $tracked ? 200 : 500);
   }
 

--- a/web/modules/custom/myeventlane_core/src/Service/AnalyticsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/AnalyticsService.php
@@ -29,6 +29,7 @@ final class AnalyticsService {
     private readonly AccountInterface $currentUser,
     private readonly TimeInterface $time,
     private readonly LoggerInterface $logger,
+    private readonly DiscoveryAttributionSources $discoveryAttributionSources,
   ) {}
 
   /**
@@ -137,10 +138,29 @@ final class AnalyticsService {
 
   /**
    * Tracks a public analytics event.
+   *
+   * @param string|null $source
+   *   Optional discovery attribution source (allowlisted values only).
    */
-  public function track(string $entity_type, int $entity_id, string $event_type, ?int $user_id = NULL): bool {
+  public function track(
+    string $entity_type,
+    int $entity_id,
+    string $event_type,
+    ?int $user_id = NULL,
+    ?string $source = NULL,
+  ): bool {
     if ($entity_type === '' || $entity_id <= 0 || $event_type === '') {
       $this->logger->error('Rejected invalid analytics event: entity_type=@type entity_id=@id event_type=@event', [
+        '@type' => $entity_type,
+        '@id' => $entity_id,
+        '@event' => $event_type,
+      ]);
+      return FALSE;
+    }
+
+    if ($source !== NULL && $source !== '' && !$this->discoveryAttributionSources->isAllowed($source)) {
+      $this->logger->error('Rejected analytics event with invalid source=@source for @type:@id (@event)', [
+        '@source' => $source,
         '@type' => $entity_type,
         '@id' => $entity_id,
         '@event' => $event_type,
@@ -157,14 +177,21 @@ final class AnalyticsService {
 
     try {
       $uid = $user_id ?? ((int) $this->currentUser->id() ?: NULL);
+      $fields = [
+        'entity_type' => $entity_type,
+        'entity_id' => $entity_id,
+        'event_type' => $event_type,
+        'user_id' => $uid,
+        'timestamp' => $this->time->getRequestTime(),
+      ];
+
+      $schema = $this->database->schema();
+      if ($source !== NULL && $source !== '' && $schema->fieldExists(self::TABLE, 'source')) {
+        $fields['source'] = $source;
+      }
+
       $this->database->insert(self::TABLE)
-        ->fields([
-          'entity_type' => $entity_type,
-          'entity_id' => $entity_id,
-          'event_type' => $event_type,
-          'user_id' => $uid,
-          'timestamp' => $this->time->getRequestTime(),
-        ])
+        ->fields($fields)
         ->execute();
       return TRUE;
     }

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoveryAnalyticsPageAttachments.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoveryAnalyticsPageAttachments.php
@@ -75,6 +75,10 @@ final class DiscoveryAnalyticsPageAttachments {
       return TRUE;
     }
 
+    if ($route_name === 'entity.node.canonical') {
+      return TRUE;
+    }
+
     foreach (self::VIEW_ROUTE_PREFIXES as $prefix) {
       if (str_starts_with($route_name, $prefix)) {
         return TRUE;

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_core\Service;
+
+/**
+ * Allowlist and resolution for public discovery click attribution sources.
+ */
+final class DiscoveryAttributionSources {
+
+  public const SOURCE_HOMEPAGE_FEATURED = 'homepage_featured';
+  public const SOURCE_HOMEPAGE_TONIGHT = 'homepage_tonight';
+  public const SOURCE_HOMEPAGE_FREE = 'homepage_free';
+  public const SOURCE_HOMEPAGE_RECOMMENDED = 'homepage_recommended';
+  public const SOURCE_HOMEPAGE_UPCOMING = 'homepage_upcoming';
+  public const SOURCE_SEARCH = 'search';
+  public const SOURCE_CATEGORY = 'category';
+  public const SOURCE_RELATED_EVENTS = 'related_events';
+  public const SOURCE_VENDOR_PROFILE = 'vendor_profile';
+
+  /**
+   * @var list<string>
+   */
+  private const ALLOWED = [
+    self::SOURCE_HOMEPAGE_FEATURED,
+    self::SOURCE_HOMEPAGE_TONIGHT,
+    self::SOURCE_HOMEPAGE_FREE,
+    self::SOURCE_HOMEPAGE_RECOMMENDED,
+    self::SOURCE_HOMEPAGE_UPCOMING,
+    self::SOURCE_SEARCH,
+    self::SOURCE_CATEGORY,
+    self::SOURCE_RELATED_EVENTS,
+    self::SOURCE_VENDOR_PROFILE,
+  ];
+
+  /**
+   * @var array<string, string>
+   */
+  private const VIEW_DISPLAY_MAP = [
+    'front_featured_events:block_featured' => self::SOURCE_HOMEPAGE_FEATURED,
+    'upcoming_events:homepage_tonight' => self::SOURCE_HOMEPAGE_TONIGHT,
+    'mel_home_events:under_20' => self::SOURCE_HOMEPAGE_FREE,
+    'front_recommended_events:block_1' => self::SOURCE_HOMEPAGE_RECOMMENDED,
+    'upcoming_events:homepage_latest' => self::SOURCE_HOMEPAGE_UPCOMING,
+    'upcoming_events:page_category' => self::SOURCE_CATEGORY,
+  ];
+
+  /**
+   * @var array<string, string>
+   */
+  private const ROUTE_MAP = [
+    'mel_search.view' => self::SOURCE_SEARCH,
+    'entity.myeventlane_vendor.canonical' => self::SOURCE_VENDOR_PROFILE,
+  ];
+
+  /**
+   * Whether a source value is allowed for storage.
+   */
+  public function isAllowed(string $source): bool {
+    return in_array($source, self::ALLOWED, TRUE);
+  }
+
+  /**
+   * Resolves attribution source for a Views display, if mapped.
+   */
+  public function forViewDisplay(string $view_id, string $display_id): ?string {
+    if ($view_id === '' || $display_id === '') {
+      return NULL;
+    }
+
+    return self::VIEW_DISPLAY_MAP[$view_id . ':' . $display_id] ?? NULL;
+  }
+
+  /**
+   * Resolves attribution source for a route, if mapped.
+   */
+  public function forRoute(?string $route_name): ?string {
+    if ($route_name === NULL || $route_name === '') {
+      return NULL;
+    }
+
+    return self::ROUTE_MAP[$route_name] ?? NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -19,6 +19,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\file\FileInterface;
+use Drupal\myeventlane_core\Service\DiscoveryAttributionSources;
 use Drupal\myeventlane_event\Form\TicketTypeFormAlter;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\Core\Render\Element;
@@ -1149,7 +1150,9 @@ function myeventlane_event_preprocess_node(array &$variables): void {
           if (!$related instanceof NodeInterface) {
             continue;
           }
-          $builds[] = $view_builder->view($related, 'compact_commerce');
+          $build = $view_builder->view($related, 'compact_commerce');
+          $build['#mel_discovery_source'] = DiscoveryAttributionSources::SOURCE_RELATED_EVENTS;
+          $builds[] = $build;
           $append_tags = Cache::mergeTags($append_tags, $related->getCacheTags());
         }
         $variables['mel_related_events'] = $builds;

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1966,12 +1966,17 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         && isset($variables['page']['home_recommended'])
         && is_array($variables['page']['home_recommended'])
         && count(Element::children($variables['page']['home_recommended'])) > 0;
+      $variables['mel_home_show_tonight'] = $homepageVisibility->viewDisplayHasResults('upcoming_events', 'homepage_tonight')
+        && isset($variables['page']['homepage_tonight'])
+        && is_array($variables['page']['homepage_tonight'])
+        && count(Element::children($variables['page']['homepage_tonight'])) > 0;
     }
     else {
       $variables['mel_home_show_featured'] = FALSE;
       $variables['mel_home_show_blog'] = FALSE;
       $variables['mel_home_show_free_rsvp'] = FALSE;
       $variables['mel_home_show_recommended'] = FALSE;
+      $variables['mel_home_show_tonight'] = FALSE;
     }
   }
 
@@ -2691,6 +2696,7 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       $event_card_view_model = \Drupal::service('myeventlane_event.event_card_view_model');
       if ($event_card_view_model->isCardViewMode($view_mode)) {
         $event_card_view_model->applyToNodeVariables($variables, $view_mode);
+        _myeventlane_theme_apply_discovery_attribution_source($variables);
       }
       if ($view_mode === 'event_card_poster') {
         $variables['mel_poster_price_pill'] = _myeventlane_theme_get_event_poster_price_pill($node);
@@ -2721,6 +2727,38 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
         $variables['#cache']['contexts'][] = 'user';
       }
     }
+  }
+}
+
+/**
+ * Sets mel_source on event card node templates for discovery attribution.
+ */
+function _myeventlane_theme_apply_discovery_attribution_source(array &$variables): void {
+  if (!\Drupal::hasService('myeventlane_core.discovery_attribution_sources')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_core\Service\DiscoveryAttributionSources $attribution_sources */
+  $attribution_sources = \Drupal::service('myeventlane_core.discovery_attribution_sources');
+
+  $source = NULL;
+  $render_source = $variables['elements']['#mel_discovery_source'] ?? NULL;
+  if (is_string($render_source) && $render_source !== '') {
+    $source = $render_source;
+  }
+  elseif (isset($variables['view']) && $variables['view'] instanceof ViewExecutable) {
+    $source = $attribution_sources->forViewDisplay(
+      $variables['view']->id(),
+      $variables['view']->current_display,
+    );
+  }
+
+  if ($source === NULL) {
+    $source = $attribution_sources->forRoute((string) (\Drupal::routeMatch()->getRouteName() ?? ''));
+  }
+
+  if ($source !== NULL && $attribution_sources->isAllowed($source)) {
+    $variables['mel_source'] = $source;
   }
 }
 
@@ -2954,6 +2992,14 @@ function myeventlane_theme_preprocess_views_view_fields(array &$variables): void
       $canonical = $event_node->toUrl('canonical');
       $variables['mel_event_card_url'] = $canonical->toString();
       $variables['mel_event_card_event_id'] = (int) $event_node->id();
+      if ($view instanceof ViewExecutable && \Drupal::hasService('myeventlane_core.discovery_attribution_sources')) {
+        /** @var \Drupal\myeventlane_core\Service\DiscoveryAttributionSources $attribution_sources */
+        $attribution_sources = \Drupal::service('myeventlane_core.discovery_attribution_sources');
+        $source = $attribution_sources->forViewDisplay($view->id(), $view->current_display);
+        if ($source !== NULL) {
+          $variables['mel_event_card_source'] = $source;
+        }
+      }
       if (!isset($variables['#cache'])) {
         $variables['#cache'] = [];
       }

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -119,7 +119,7 @@
       {{ event_flag_event_save }}
     </div>
   {% endif %}
-  <a href="{{ _url }}" class="mel-event-card__link" aria-label="{{ _title ~ ' — ' ~ _cta }}"{% if event_id is defined and event_id %} data-mel-track-event-click data-event-id="{{ event_id }}"{% endif %}>
+  <a href="{{ _url }}" class="mel-event-card__link" aria-label="{{ _title ~ ' — ' ~ _cta }}"{% if event_id is defined and event_id %} data-mel-track-event-click data-event-id="{{ event_id }}"{% if mel_source|default('') %} data-mel-source="{{ mel_source|e('html_attr') }}"{% endif %}{% endif %}>
     <div class="mel-event-card__image mel-event-card__media">
       {% if _img_render %}
         {{ _img_render }}

--- a/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/event/event-card.html.twig
@@ -29,4 +29,5 @@
   card_status_modifier: _status_mod,
   is_promoted: is_promoted|default(false),
   event_id: event_id|default(mel_event_card_event_id|default(null)),
+  mel_source: mel_source|default(mel_event_card_source|default('')),
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -54,7 +54,7 @@
       } %}
     {% endif %}
 
-    {% if page.homepage_tonight %}
+    {% if mel_home_show_tonight|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--tonight mel-section--discover',
         section_width_class: 'mel-section--wide',

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-fields.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-fields.html.twig
@@ -49,7 +49,8 @@
     ticket_type: fields.field_ticket_type.content|default('rsvp')|striptags|trim,
     ticket_label: fields.field_ticket_label.content|default('RSVP')|striptags|trim,
     accessibility: fields.field_accessibility_icons.content|default([]),
-    event_id: mel_event_card_event_id|default(null)
+    event_id: mel_event_card_event_id|default(null),
+    mel_source: mel_event_card_source|default(''),
   } only %}
 {% else %}
   {% for field in fields -%}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Requires running update 9120 before `source` is stored; invalid client `source` values are rejected with 400. Broader analytics script attachment on event canonical pages is low risk but increases tracked surfaces.
> 
> **Overview**
> Adds **discovery rail attribution** to public `event_click` analytics so clicks can be tied to where the user found the event (homepage rails, search, category, related events, vendor profile).
> 
> A new allowlisted `DiscoveryAttributionSources` service maps Views displays and routes to stable source keys; theme preprocess sets `mel_source` / `mel_event_card_source` on cards (including `related_events` on event-page recommendations), and `data-mel-source` on tracked links. Client JS forwards `source` in the click POST; the API and `AnalyticsService::track()` validate against the allowlist and persist a new optional `source` column (`myeventlane_core_update_9120` + index).
> 
> **Homepage/config tweaks:** re-enables the featured-events block, sets `block_hide_empty` on the “On tonight” view block, and gates the front-page “On tonight” section with `mel_home_show_tonight` (view has results + region content). Event canonical pages now load discovery click-tracking assets so related-event cards can fire analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0834b94ab740c350a5c7303226fb197d657cbe72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->