### PR TITLE
Fix/homepage merchandising bugbot

### DIFF
--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
@@ -91,7 +91,7 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
     }
 
     $featured_events = NULL;
-    if ($this->featuredEventsRenderBuilder->hasResults()) {
+    if ($this->featuredEventsRenderBuilder->hasHeroResults()) {
       $featured_events = $this->featuredEventsRenderBuilder->buildHeroRotator();
     }
 

--- a/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
@@ -24,10 +24,17 @@ final class FeaturedEventsRenderBuilder {
   ) {}
 
   /**
-   * Whether the featured events View display has at least one row.
+   * Whether the spotlight featured events display has at least one row.
    */
   public function hasResults(): bool {
     return $this->displayHasResults(self::DISPLAY_ID);
+  }
+
+  /**
+   * Whether the hero rotator display has at least one row.
+   */
+  public function hasHeroResults(): bool {
+    return $this->displayHasResults(self::HERO_DISPLAY_ID);
   }
 
   /**

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -36,6 +36,7 @@ final class HomepageMerchandising {
       'homepage_latest',
     ],
     'mel_home_events' => [
+      'embed_discover',
       'under_20',
     ],
     'front_recommended_events' => [
@@ -52,6 +53,11 @@ final class HomepageMerchandising {
    * @var list<int>|null
    */
   private ?array $spotlightEventIds = NULL;
+
+  /**
+   * @var list<int>|null
+   */
+  private ?array $discoverEventIds = NULL;
 
   /**
    * @var list<int>|null
@@ -108,21 +114,29 @@ final class HomepageMerchandising {
 
     return match ($viewId . ':' . $displayId) {
       'front_featured_events:block_featured' => $hero,
-      'upcoming_events:homepage_tonight' => array_values(array_unique([...$hero, ...$spotlight])),
+      'mel_home_events:embed_discover' => array_values(array_unique([...$hero, ...$spotlight])),
+      'upcoming_events:homepage_tonight' => array_values(array_unique([
+        ...$hero,
+        ...$spotlight,
+        ...$this->getDiscoverEventIds(),
+      ])),
       'mel_home_events:under_20' => array_values(array_unique([
         ...$hero,
         ...$spotlight,
+        ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
       ])),
       'upcoming_events:homepage_latest' => array_values(array_unique([
         ...$hero,
         ...$spotlight,
+        ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
         ...$this->getFreeRsvpEventIds(),
       ])),
       'front_recommended_events:block_1' => array_values(array_unique([
         ...$hero,
         ...$spotlight,
+        ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
         ...$this->getFreeRsvpEventIds(),
         ...$this->getLatestEventIds(),
@@ -201,6 +215,18 @@ final class HomepageMerchandising {
     }
     $this->spotlightEventIds = $promoted;
     return $this->spotlightEventIds;
+  }
+
+  /**
+   * @return list<int>
+   */
+  public function getDiscoverEventIds(): array {
+    if ($this->discoverEventIds !== NULL) {
+      return $this->discoverEventIds;
+    }
+
+    $this->discoverEventIds = $this->executeViewResultNids('mel_home_events', 'embed_discover');
+    return $this->discoverEventIds;
   }
 
   /**

--- a/web/modules/custom/myeventlane_views/myeventlane_views.module
+++ b/web/modules/custom/myeventlane_views/myeventlane_views.module
@@ -49,9 +49,12 @@ function myeventlane_views_views_query_alter(ViewExecutable $view, QueryPluginBa
 
   $timezone = new \DateTimeZone(date_default_timezone_get());
   $now = new \DateTimeImmutable('now', $timezone);
-  $tomorrow = $now->setTime(0, 0, 0)->modify('+1 day');
+  $today = $now->setTime(0, 0, 0);
+  $tomorrow = $today->modify('+1 day');
 
-  $min = $now->format('Y-m-d\TH:i:s');
+  // Include in-progress events that started earlier today (end >= now is set in
+  // Views config). Lower bound is start of today, not current time.
+  $min = $today->format('Y-m-d\TH:i:s');
   $max = $tomorrow->format('Y-m-d\TH:i:s');
 
   $query->addWhere(1, $field_alias, $min, '>=');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which events appear on multiple homepage rails and alters tonight’s date filter; wrong cascade logic could hide events or show duplicates, but scope is front-page Views merchandising only.
> 
> **Overview**
> Fixes homepage merchandising so the **hero rotator**, **discover rail**, and lower rails use the right View displays and dedupe order.
> 
> **Hero vs spotlight:** `HomeHeroBlock` now gates the carousel with **`hasHeroResults()`** (`block_hero`) instead of the spotlight **`hasResults()`** (`block_featured`), so the hero only shows when the hero display has rows.
> 
> **Discover in the cascade:** **`embed_discover`** is part of merchandising. Discover excludes hero + spotlight; **Tonight**, **under $20**, **Latest**, and **Recommended** also exclude discover event IDs via **`getDiscoverEventIds()`**. Spotlight (**`block_featured`**) keeps excluding only the hero (not discover).
> 
> **Tonight window:** The **`homepage_tonight`** query alter uses **start of today** as the lower bound on **`field_event_start`** (not “now”), so same-day events that already started but are still in progress can appear when end ≥ now is enforced in Views config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937b3a4c05371ab0dca08719dec192f4d50d1d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->