### PR TITLE
Cursor/det val stage 5e05c

### DIFF
--- a/web/scripts/homepage-real-world-validation.drush.php
+++ b/web/scripts/homepage-real-world-validation.drush.php
@@ -188,10 +188,6 @@ function mel_staging_category_tid(string $name): ?int {
  * Ensures image file exists under mel-staging-validation and returns file ID.
  */
 function mel_staging_ensure_image(string $key, string $url, string $alt, FileSystemInterface $fileSystem): ?int {
-  $fileSystem->prepareDirectory(
-    MEL_STAGING_IMAGE_DIR,
-    FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS,
-  );
   $uri = MEL_STAGING_IMAGE_DIR . '/' . $key . '.jpg';
 
   $existing = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
@@ -206,6 +202,8 @@ function mel_staging_ensure_image(string $key, string $url, string $alt, FileSys
     return NULL;
   }
 
+  // saveData() creates the destination directory; avoid prepareDirectory() which
+  // requires a by-reference variable (PHP 8.3 rejects constants/literals).
   $path = $fileSystem->saveData($data, $uri, FileSystemInterface::EXISTS_REPLACE);
   if (!is_string($path) || !file_exists($path)) {
     echo "  ⚠ Could not save image: {$key}\n";
@@ -656,8 +654,10 @@ function mel_staging_cleanup(): void {
     }
   }
 
-  if (is_dir($fileSystem->realpath(MEL_STAGING_IMAGE_DIR) ?: '')) {
-    $fileSystem->deleteRecursive(MEL_STAGING_IMAGE_DIR);
+  $imageDir = MEL_STAGING_IMAGE_DIR;
+  $realImageDir = $fileSystem->realpath($imageDir);
+  if (is_string($realImageDir) && is_dir($realImageDir)) {
+    $fileSystem->deleteRecursive($imageDir);
     echo "  ✓ Deleted staging image directory\n";
   }
 

--- a/web/scripts/homepage-real-world-validation.drush.php
+++ b/web/scripts/homepage-real-world-validation.drush.php
@@ -188,7 +188,14 @@ function mel_staging_category_tid(string $name): ?int {
  * Ensures image file exists under mel-staging-validation and returns file ID.
  */
 function mel_staging_ensure_image(string $key, string $url, string $alt, FileSystemInterface $fileSystem): ?int {
-  $uri = MEL_STAGING_IMAGE_DIR . '/' . $key . '.jpg';
+  // prepareDirectory() requires a variable (by reference); constants fail on PHP 8.3.
+  $directory = MEL_STAGING_IMAGE_DIR;
+  if (!$fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+    echo "  ⚠ Could not prepare image directory: {$directory}\n";
+    return NULL;
+  }
+
+  $uri = $directory . '/' . $key . '.jpg';
 
   $existing = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
   if ($existing !== []) {
@@ -202,8 +209,6 @@ function mel_staging_ensure_image(string $key, string $url, string $alt, FileSys
     return NULL;
   }
 
-  // saveData() creates the destination directory; avoid prepareDirectory() which
-  // requires a by-reference variable (PHP 8.3 rejects constants/literals).
   $path = $fileSystem->saveData($data, $uri, FileSystemInterface::EXISTS_REPLACE);
   if (!is_string($path) || !file_exists($path)) {
     echo "  ⚠ Could not save image: {$key}\n";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Staging/local-only Drush fixture script; changes are limited to directory handling and clearer warnings with no production or auth impact.
> 
> **Overview**
> Fixes **PHP 8.3** failures in `homepage-real-world-validation.drush.php` when creating or cleaning up staging fixture images under `public://mel-staging-validation`.
> 
> **Image seeding (`mel_staging_ensure_image`)** no longer passes the `MEL_STAGING_IMAGE_DIR` constant into `FileSystemInterface::prepareDirectory()` (by-reference). It uses a `$directory` variable, checks the return value, logs a warning, and returns `NULL` if the directory cannot be prepared.
> 
> **Cleanup (`mel_staging_cleanup`)** uses the same variable pattern for `realpath()` and `deleteRecursive()`, and only deletes when `realpath()` returns a string path that is an existing directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a4d9c568e1fac6b7d447c2a1f271b9be80d35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->