### PR TITLE
Polish vendor dashboard experience

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -74,6 +74,69 @@ $mel-dash-lavender: #7c83fd;
       linear-gradient(135deg, $bg-primary 0%, rgba($ml-slate-50, 0.72) 100%);
   }
 
+  &__mission-hero {
+    .mel-vendor-dashboard__metric-board.mel-live-ops__metric-board {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: $spacing-2;
+      margin-top: $spacing-4;
+
+      @include respond-to(md) {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: $spacing-3;
+      }
+
+      @include respond-to(lg) {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+      }
+    }
+
+    .mel-vendor-dashboard__metric-card.mel-live-ops__stat-card {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+      gap: $spacing-1;
+      min-width: 0;
+      min-height: 2.75rem;
+      padding: $spacing-3;
+      border: 1px solid rgba($ml-vendor-navy, 0.08);
+      border-radius: $radius-lg;
+      background: rgba($bg-primary, 0.94);
+      box-shadow: $shadow-xs;
+    }
+
+    .mel-live-ops__stat-value {
+      margin: 0;
+      color: $text-primary;
+      font-size: clamp(1.125rem, 2.5vw, 1.375rem);
+      font-weight: $font-weight-bold;
+      line-height: $line-height-tight;
+    }
+
+    .mel-live-ops__stat-label {
+      margin: 0;
+      color: $text-secondary;
+      font-size: $font-size-xs;
+      font-weight: $font-weight-semibold;
+      letter-spacing: 0.03em;
+      line-height: 1.25;
+      text-transform: uppercase;
+    }
+
+    .mel-live-ops__stat-card--total .mel-live-ops__stat-value {
+      color: $primary;
+    }
+
+    .mel-live-ops__stat-card--ready .mel-live-ops__stat-value {
+      color: $mel-ws-purple;
+    }
+
+    .mel-live-ops__stat-card--capacity .mel-live-ops__stat-value {
+      color: $ml-color-accent;
+    }
+  }
+
   &__mission-hero-layout {
     @include respond-to(md) {
       grid-template-columns: minmax(0, 1fr) minmax(14rem, 0.36fr);
@@ -398,10 +461,16 @@ $mel-dash-lavender: #7c83fd;
     }
   }
 
+  &__events-scope {
+    grid-column: 1 / -1;
+    min-width: 0;
+  }
+
   &__event-grid {
     display: grid;
     grid-template-columns: 1fr;
     gap: $spacing-4;
+    min-width: 0;
 
     @include respond-to(md) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -410,40 +479,76 @@ $mel-dash-lavender: #7c83fd;
     @include respond-to(xl) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
-  }
 
-  &__event-row.mel-live-ops__attendee-row {
-    margin-bottom: 0;
-  }
-
-  &__event-row .mel-live-ops__attendee-ident {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    gap: $spacing-3;
-    min-width: 0;
-  }
-
-  &__event-row .mel-live-ops__attendee-side {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-2;
-    align-items: center;
-    justify-content: flex-start;
-    width: 100%;
-
-    @include respond-to(md) {
-      width: auto;
-      justify-content: flex-end;
+    .mel-vendor-dashboard__event-row.mel-live-ops__attendee-row {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-3;
+      margin-bottom: 0;
+      min-width: 0;
+      // Shared live-ops attendee rows switch to two columns at md+; that collides
+      // with the dashboard event card grid and causes overlapping actions.
+      grid-template-columns: none;
+      align-items: stretch;
     }
-  }
 
-  &__event-row .mel-live-ops__hero-cta {
-    width: 100%;
-    justify-content: center;
+    .mel-vendor-dashboard__event-row .mel-live-ops__attendee-meta {
+      min-width: 0;
+    }
 
-    @include respond-to(md) {
-      width: auto;
+    .mel-vendor-dashboard__event-row .mel-live-ops__attendee-ident {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: $spacing-3;
+      min-width: 0;
+
+      > div:last-child {
+        flex: 1;
+        min-width: 0;
+      }
+    }
+
+    .mel-vendor-dashboard__event-row .mel-live-ops__attendee-name {
+      word-break: break-word;
+    }
+
+    .mel-vendor-dashboard__event-row .mel-live-ops__chip-row {
+      flex-wrap: wrap;
+    }
+
+    .mel-vendor-dashboard__event-row .mel-live-ops__attendee-side {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: flex-start;
+      gap: $spacing-2;
+      width: 100%;
+      padding-top: $spacing-2;
+      border-top: 1px solid rgba($ml-vendor-navy, 0.08);
+      text-align: left;
+
+      .mel-btn,
+      .mel-event-card-remove-open {
+        min-height: 2.75rem;
+        flex: 1 1 calc(50% - #{$spacing-2});
+
+        @include respond-to(sm) {
+          flex: 0 1 auto;
+        }
+      }
+
+      .mel-live-ops__hero-cta {
+        width: 100%;
+        justify-content: center;
+        flex: 1 1 100%;
+
+        @include respond-to(sm) {
+          width: auto;
+          flex: 0 1 auto;
+        }
+      }
     }
   }
 
@@ -497,6 +602,800 @@ $mel-dash-lavender: #7c83fd;
     border: 1px solid rgba($ml-vendor-navy, 0.08);
     border-radius: $radius-lg;
     background: $bg-primary;
+  }
+
+  &__section-head--compact {
+    margin-bottom: $spacing-2;
+  }
+
+  &__attention-strip--compact,
+  &__upcoming-strip--compact,
+  &__activity-stream--compact {
+    padding: $spacing-3;
+  }
+
+  &__compact-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    overflow: hidden;
+  }
+
+  &__compact-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-2 $spacing-3;
+    min-height: 2.75rem;
+    padding: $spacing-2 $spacing-3;
+    border-bottom: 1px solid rgba($ml-vendor-navy, 0.06);
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  &__compact-row-main {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    flex: 1 1 12rem;
+  }
+
+  &__compact-row-title {
+    color: $text-primary;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-tight;
+  }
+
+  &__compact-row-meta {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__compact-row-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    white-space: nowrap;
+  }
+
+  &__compact-table-wrap {
+    overflow-x: auto;
+  }
+
+  &__compact-table-event {
+    font-weight: $font-weight-semibold;
+    text-align: left;
+  }
+
+  &__compact-table-action {
+    white-space: nowrap;
+  }
+
+  &__compact-feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__compact-feed-item {
+    display: flex;
+    align-items: center;
+    gap: $spacing-2;
+    min-height: 2.75rem;
+    padding: $spacing-1 0;
+    border-bottom: 1px solid rgba($ml-vendor-navy, 0.06);
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  &__compact-feed-icon {
+    flex: 0 0 auto;
+    width: 1rem;
+    color: $success;
+    font-weight: $font-weight-bold;
+    text-align: center;
+  }
+
+  &__compact-feed-link,
+  &__compact-feed-text {
+    min-width: 0;
+    color: $text-primary;
+  }
+
+  &__compact-feed-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    font-weight: $font-weight-semibold;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:focus-visible {
+      outline: 2px solid rgba($primary, 0.35);
+      outline-offset: 2px;
+      border-radius: $radius-sm;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Visual hierarchy — metric board, momentum card, action queue, cards, timeline
+  // ---------------------------------------------------------------------------
+
+  &__momentum-card {
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-color-accent, 0.22);
+    border-left: 4px solid $ml-color-accent;
+    border-radius: $radius-workspace-card;
+    background: linear-gradient(135deg, rgba($ml-accent-coral-light, 0.45) 0%, rgba($bg-primary, 0.98) 100%);
+    box-shadow: $shadow-xs;
+  }
+
+  &__momentum-title {
+    margin: $spacing-1 0 0;
+    color: $text-primary;
+    font-size: $font-size-lg;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__momentum-message {
+    margin: $spacing-2 0 0;
+    color: $text-secondary;
+    font-size: $font-size-base;
+    line-height: $line-height-normal;
+  }
+
+  &__momentum-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    margin-top: $spacing-2;
+    color: $text-primary;
+    font-weight: $font-weight-semibold;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:focus-visible {
+      outline: 2px solid rgba($primary, 0.35);
+      outline-offset: 2px;
+      border-radius: $radius-sm;
+    }
+  }
+
+  &__action-queue {
+    border-left: 4px solid rgba($primary, 0.55);
+  }
+
+  &__action-queue-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: $spacing-2;
+  }
+
+  &__action-queue-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-2 $spacing-3;
+    min-height: 2.75rem;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: rgba($ml-slate-50, 0.55);
+  }
+
+  &__action-queue-item--primary {
+    border-color: rgba($warning, 0.28);
+    background: linear-gradient(135deg, rgba($warning-light, 0.28) 0%, rgba($bg-primary, 0.96) 100%);
+    box-shadow: $shadow-xs;
+  }
+
+  &__action-queue-body {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    flex: 1 1 12rem;
+  }
+
+  &__action-queue-title {
+    color: $text-primary;
+    font-size: $font-size-base;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__action-queue-problem {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__action-queue-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    white-space: nowrap;
+    font-weight: $font-weight-semibold;
+  }
+
+  &__summary-cards {
+    display: grid;
+    gap: $spacing-3;
+    grid-template-columns: 1fr;
+
+    @include respond-to(sm) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @include respond-to(lg) {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      overflow: visible;
+    }
+  }
+
+  &__summary-card {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    min-height: 2.75rem;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-lg;
+    background: $ml-vendor-bg;
+    box-shadow: $shadow-xs;
+  }
+
+  &__summary-card-title {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__summary-card-date {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__summary-card-status {
+    margin: 0;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+
+    &--draft {
+      color: $text-muted;
+      background: rgba($ml-vendor-navy, 0.04);
+      border-radius: $radius-sm;
+      display: inline-flex;
+      align-items: center;
+      min-height: 1.75rem;
+      padding: 0 $spacing-2;
+      width: fit-content;
+    }
+
+    &--upcoming {
+      color: $mel-ws-purple;
+    }
+
+    &--boosted {
+      color: $ml-color-accent;
+      background: rgba($ml-color-accent, 0.12);
+      border-radius: $radius-sm;
+      display: inline-flex;
+      align-items: center;
+      min-height: 1.75rem;
+      padding: 0 $spacing-2;
+      width: fit-content;
+    }
+  }
+
+  &__summary-card-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    margin-top: $spacing-1;
+    font-weight: $font-weight-semibold;
+  }
+
+  &__timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 $spacing-1;
+    border-left: 2px solid rgba($ml-vendor-navy, 0.1);
+  }
+
+  &__timeline-item {
+    position: relative;
+    display: flex;
+    gap: $spacing-3;
+    min-height: 2.75rem;
+    padding: $spacing-2 0 $spacing-2 $spacing-3;
+  }
+
+  &__timeline-marker {
+    position: absolute;
+    left: calc(-1 * #{$spacing-1} - 0.4375rem);
+    top: $spacing-3;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.125rem;
+    height: 1.125rem;
+    border-radius: 50%;
+    background: $bg-primary;
+    border: 2px solid rgba($info, 0.35);
+    color: $info;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+  }
+
+  &__timeline-item--success &__timeline-marker {
+    border-color: rgba($success, 0.45);
+    color: $success;
+  }
+
+  &__timeline-item--warn &__timeline-marker {
+    border-color: rgba($warning, 0.45);
+    color: $warning;
+  }
+
+  &__timeline-content {
+    min-width: 0;
+    flex: 1 1 auto;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__timeline-link,
+  &__timeline-text {
+    color: $text-primary;
+  }
+
+  &__timeline-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    font-weight: $font-weight-semibold;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:focus-visible {
+      outline: 2px solid rgba($primary, 0.35);
+      outline-offset: 2px;
+      border-radius: $radius-sm;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Homepage visibility productisation (collapsed Homepage performance panel)
+  // ---------------------------------------------------------------------------
+
+  &__homepage-visibility {
+    display: grid;
+    gap: $spacing-4;
+  }
+
+  &__visibility-heading {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-xl;
+    line-height: $line-height-tight;
+  }
+
+  &__visibility-intro {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-base;
+    line-height: $line-height-normal;
+  }
+
+  &__visibility-summary-card {
+    padding: $spacing-4;
+    border: 1px solid rgba($success, 0.22);
+    border-radius: $radius-workspace-card;
+    background: linear-gradient(135deg, rgba($success-light, 0.35) 0%, rgba($bg-primary, 0.98) 100%);
+    box-shadow: $shadow-xs;
+  }
+
+  &__visibility-signals {
+    display: grid;
+    gap: $spacing-3;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__visibility-signal {
+    display: flex;
+    align-items: flex-start;
+    gap: $spacing-3;
+    min-height: 2.75rem;
+    padding: $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: rgba($bg-primary, 0.92);
+  }
+
+  &__visibility-signal-icon {
+    flex: 0 0 auto;
+    font-size: 1.125rem;
+    line-height: 1.2;
+  }
+
+  &__visibility-signal-copy {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+  }
+
+  &__visibility-signal-label {
+    color: $text-secondary;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  &__visibility-signal-value {
+    color: $text-primary;
+    font-size: $font-size-lg;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__visibility-signal--boost.is-active {
+    border-color: rgba($ml-color-accent, 0.28);
+    background: linear-gradient(135deg, rgba($ml-accent-coral-light, 0.45) 0%, rgba($bg-primary, 0.96) 100%);
+
+    .mel-vendor-dashboard__visibility-signal-value {
+      color: $ml-color-accent;
+    }
+  }
+
+  &__visibility-rec {
+    padding: $spacing-4;
+    border: 1px solid rgba($mel-ws-purple, 0.16);
+    border-left: 4px solid $mel-ws-purple;
+    border-radius: $radius-lg;
+    background: rgba($mel-ws-purple-tint, 0.35);
+  }
+
+  &__visibility-rec-title {
+    margin: $spacing-1 0 0;
+    color: $text-primary;
+    font-size: $font-size-lg;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__visibility-rec-message {
+    margin: $spacing-2 0 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__visibility-rec-action {
+    margin-top: $spacing-3;
+    min-height: 2.75rem;
+  }
+
+  &__details--visibility-placements {
+    margin-top: 0;
+  }
+
+  &__details-grid--single {
+    @include respond-to(lg) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__visibility-breakdown {
+    display: grid;
+    gap: $spacing-2;
+    margin: 0;
+
+    @include respond-to(sm) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__visibility-breakdown-item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: $spacing-2;
+    min-height: 2.75rem;
+    padding: $spacing-2 $spacing-3;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-md;
+    background: rgba($ml-vendor-bg, 0.85);
+
+    dt {
+      margin: 0;
+      color: $text-secondary;
+      font-size: $font-size-sm;
+      font-weight: $font-weight-semibold;
+    }
+
+    dd {
+      margin: 0;
+      color: $text-primary;
+      font-size: $font-size-sm;
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  &__visibility-breakdown-item--clicks dd {
+    color: $primary;
+  }
+
+  &__visibility-events {
+    display: grid;
+    gap: $spacing-3;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__visibility-event-card {
+    display: grid;
+    gap: $spacing-3;
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-workspace-card;
+    background: $ml-vendor-bg;
+    box-shadow: $shadow-xs;
+  }
+
+  &__visibility-event-card.is-boosted {
+    border-color: rgba($ml-color-accent, 0.24);
+  }
+
+  &__visibility-event-card.is-ready {
+    background: linear-gradient(135deg, rgba($success-light, 0.22) 0%, rgba($bg-primary, 0.98) 100%);
+  }
+
+  &__visibility-event-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: $spacing-2;
+  }
+
+  &__visibility-event-title {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-base;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__visibility-event-boost {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    padding: 0 $spacing-2;
+    border-radius: $radius-sm;
+    background: rgba($ml-vendor-navy, 0.06);
+    color: $text-muted;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+
+    &.is-active {
+      background: rgba($ml-color-accent, 0.14);
+      color: $ml-color-accent;
+    }
+  }
+
+  &__visibility-event-meta {
+    display: grid;
+    gap: $spacing-2;
+    margin: 0;
+  }
+
+  &__visibility-event-field {
+    dt {
+      margin: 0 0 $spacing-1;
+      color: $text-secondary;
+      font-size: $font-size-xs;
+      font-weight: $font-weight-semibold;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    dd {
+      margin: 0;
+      color: $text-primary;
+      font-size: $font-size-sm;
+      line-height: $line-height-normal;
+    }
+  }
+
+  &__visibility-click-list {
+    margin: $spacing-2 0 0;
+    padding-left: $spacing-4;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+  }
+
+  &__visibility-event-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    font-weight: $font-weight-semibold;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Analytics productisation — insight, grouped summary, top events
+  // ---------------------------------------------------------------------------
+
+  &__analytics-insight {
+    padding: $spacing-4;
+    border: 1px solid rgba($mel-ws-purple, 0.16);
+    border-left: 4px solid $mel-ws-purple;
+    border-radius: $radius-lg;
+    background: rgba($mel-ws-purple-tint, 0.35);
+  }
+
+  &__analytics-insight-title {
+    margin: $spacing-1 0 0;
+    color: $text-primary;
+    font-size: $font-size-lg;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__analytics-insight-message {
+    margin: $spacing-2 0 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__analytics-insight-action {
+    margin-top: $spacing-3;
+    min-height: 2.75rem;
+  }
+
+  &__analytics-summary {
+    gap: $spacing-4;
+  }
+
+  &__analytics-group {
+    display: grid;
+    gap: $spacing-3;
+  }
+
+  &__analytics-group-title {
+    margin: 0;
+    color: $mel-ws-purple;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  &__analytics-card {
+    padding: $spacing-4;
+    box-shadow: $shadow-xs;
+  }
+
+  &__analytics-top-events {
+    display: grid;
+    gap: $spacing-3;
+
+    @include respond-to(md) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  &__analytics-top-event {
+    display: grid;
+    gap: $spacing-2;
+    padding: $spacing-4;
+    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border-radius: $radius-lg;
+    background: $ml-vendor-bg;
+    box-shadow: $shadow-xs;
+  }
+
+  &__analytics-top-event-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: $spacing-2;
+  }
+
+  &__analytics-top-event-title {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-base;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+  }
+
+  &__analytics-top-event-boost {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    padding: 0 $spacing-2;
+    border-radius: $radius-sm;
+    background: rgba($ml-color-accent, 0.12);
+    color: $ml-color-accent;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    text-transform: uppercase;
+  }
+
+  &__analytics-top-event-meta {
+    display: grid;
+    gap: $spacing-1;
+    margin: 0;
+
+    div {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: $spacing-2;
+      min-height: 1.75rem;
+    }
+
+    dt {
+      margin: 0;
+      color: $text-secondary;
+      font-size: $font-size-xs;
+      font-weight: $font-weight-semibold;
+      text-transform: uppercase;
+    }
+
+    dd {
+      margin: 0;
+      color: $text-primary;
+      font-size: $font-size-sm;
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  &__analytics-top-event-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    margin-top: $spacing-1;
+    font-weight: $font-weight-semibold;
+  }
+
+  &__details--event-analytics-table {
+    margin-top: $spacing-2;
   }
 }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_mel-dashboard.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_mel-dashboard.scss
@@ -179,6 +179,14 @@
   tbody tr:last-child td {
     border-bottom: none;
   }
+
+  &.mel-table--compact {
+    thead th,
+    tbody td,
+    tbody th {
+      padding: $spacing-2 $spacing-3;
+    }
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -1,12 +1,17 @@
 {#
 /**
  * @file
- * Organiser mission control dashboard.
+ * Organiser mission control dashboard — action-first layout.
+ *
+ * Visible: priority action, mission hero, events to fix, upcoming events,
+ * recent signals. Reporting surfaces live in collapsed <details> panels.
  */
 #}
 {% set model = vendor_dashboard_view_model|default({}) %}
 {% set vendor = model.vendor|default({}) %}
 {% set readiness = model.readiness|default({}) %}
+{% set homepage_readiness = homepage_readiness|default(null) %}
+{% set homepage_visibility = model.homepage_visibility|default(null) %}
 {% set readiness_items = readiness.items|default([]) %}
 {% set organiser_overview = model.organiser_overview|default([]) %}
 {% set organiser_actions = model.organiser_actions|default([]) %}
@@ -61,18 +66,40 @@
             {% if events_empty %}
               {{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}
             {% else %}
-              {{ model.hero_shell_hint|default('Bookings, events, and payouts are summarised across your organiser account.'|t) }}
+              {{ 'Manage events, track attendees, and grow your audience.'|t }}
             {% endif %}
           </p>
 
-          {% if organiser_overview is iterable and organiser_overview|length > 0 %}
-            <div class="mel-vendor-dashboard__mission-summary" role="list" aria-label="{{ 'Organiser account summary'|t }}">
-              {% for item in organiser_overview|slice(0, 4) %}
-                {% set overview_sev = item.severity|default('neutral') %}
-                {% set overview_chip = overview_sev == 'success' ? 'success' : (overview_sev == 'warning' or overview_sev == 'error' ? 'warn' : 'calm') %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--{{ overview_chip }}" role="listitem">
-                  {{ item.value|default('0') }} {{ item.label|default('') }}
-                </span>
+          {% if not events_empty and (organiser_overview is iterable and organiser_overview|length > 0 or kpis is iterable and kpis|length > 0) %}
+            {% set snapshot_defs = [
+              { key: 'live_events', label: 'Live events'|t, pool: 'overview' },
+              { key: 'upcoming_events', label: 'Upcoming'|t, pool: 'overview' },
+              { key: 'bookings', label: 'Bookings'|t, pool: 'overview' },
+              { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis' },
+              { key: 'revenue', label: 'Revenue'|t, pool: 'kpis' },
+            ] %}
+            {% set snapshot_modifiers = ['total', 'in', 'ready', 'capacity', 'remain'] %}
+            <div class="mel-vendor-dashboard__metric-board mel-live-ops__metric-board" role="list" aria-label="{{ 'Business snapshot'|t }}">
+              {% for def in snapshot_defs %}
+                {% set metric_value = '0' %}
+                {% if def.pool == 'overview' %}
+                  {% for item in organiser_overview %}
+                    {% if item.key|default('') == def.key %}
+                      {% set metric_value = item.value|default('0') %}
+                    {% endif %}
+                  {% endfor %}
+                {% else %}
+                  {% for item in kpis %}
+                    {% if item.key|default('') == def.key %}
+                      {% set metric_value = item.value|default('0') %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+                {% set stat_mod = snapshot_modifiers[loop.index0 % snapshot_modifiers|length] %}
+                <article class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }} mel-vendor-dashboard__metric-card" role="listitem">
+                  <span class="mel-live-ops__stat-value">{{ metric_value }}</span>
+                  <span class="mel-live-ops__stat-label">{{ def.label }}</span>
+                </article>
               {% endfor %}
             </div>
           {% endif %}
@@ -96,189 +123,103 @@
     </div>
   </section>
 
-  {% include '@myeventlane_vendor_theme/components/mel-vendor-analytics-overview.html.twig' with {
-    analytics_cards: analytics_cards|default([]),
-  } only %}
-
-  {% include '@myeventlane_vendor_theme/components/mel-vendor-event-performance.html.twig' with {
-    event_performance: event_performance|default([]),
-    empty_state: empty_state,
-  } only %}
-
-  {% if organiser_overview is iterable and organiser_overview|length > 0 %}
-    <section class="mel-vendor-dashboard__overview-strip" aria-labelledby="mel-dash-overview-title">
-      <div class="mel-vendor-dashboard__section-head">
-        <div>
-          <p class="mel-live-ops__eyebrow">{{ 'Mission control'|t }}</p>
-          <h2 id="mel-dash-overview-title" class="mel-live-ops__panel-title">{{ 'Organiser overview'|t }}</h2>
-        </div>
-        {% if model_events is iterable and model_events|length > 0 %}
-          <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ 'Across your events'|t }}</span>
+  {% set visibility_summary = homepage_visibility.summary|default(null) %}
+  {% set tickets_sold_row = kpis|filter(row => row.key|default('') == 'tickets_sold')|first|default({}) %}
+  {% set rsvps_row = kpis|filter(row => row.key|default('') == 'rsvps')|first|default({}) %}
+  {% set bookings_row = organiser_overview|filter(row => row.key|default('') == 'bookings')|first|default({}) %}
+  {% set tickets_sold_value = tickets_sold_row.value|default('0') %}
+  {% set rsvps_value = rsvps_row.value|default('0') %}
+  {% set bookings_value = bookings_row.value|default('0') %}
+  {% set activity_win = activity_items|filter(item => item.type|default('') == 'success' and 'Stripe payouts' not in item.message|default(''))|first|default(null) %}
+  {% set has_readiness_signal = visibility_summary and visibility_summary.promotion_ready_label|default('')|trim != '' %}
+  {% set has_boost_signal = visibility_summary and visibility_summary.boost_active|default(false) %}
+  {% if activity_win or tickets_sold_value != '0' or rsvps_value != '0' or bookings_value != '0' or has_readiness_signal or has_boost_signal %}
+    <section class="mel-vendor-dashboard__momentum-card" aria-labelledby="mel-dash-momentum-title">
+      <p class="mel-live-ops__eyebrow">{{ 'Momentum'|t }}</p>
+      {% if activity_win %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'Community activity'|t }}</h2>
+        {% if activity_win.url is defined and activity_win.url %}
+          <a class="mel-vendor-dashboard__momentum-message mel-vendor-dashboard__momentum-link" href="{{ activity_win.url }}">{{ activity_win.message|default('') }}</a>
+        {% else %}
+          <p class="mel-vendor-dashboard__momentum-message">{{ activity_win.message|default('') }}</p>
         {% endif %}
-      </div>
-      <div class="mel-vendor-dashboard__overview-items" role="list">
-        {% for item in organiser_overview|slice(0, 6) %}
-          {% set overview_sev = item.severity|default('neutral') %}
-          {% set overview_chip = overview_sev == 'success' ? 'success' : (overview_sev == 'warning' or overview_sev == 'error' ? 'warn' : 'calm') %}
-          <article class="mel-vendor-dashboard__overview-item mel-vendor-dashboard__overview-item--{{ overview_chip }}" role="listitem">
-            <span class="mel-vendor-dashboard__overview-label">{{ item.label|default('') }}</span>
-            <strong class="mel-vendor-dashboard__overview-value">{{ item.value|default('0') }}</strong>
-            {% if item.context is defined and item.context %}
-              <span class="mel-vendor-dashboard__overview-context">{{ item.context }}</span>
-            {% endif %}
-          </article>
-        {% endfor %}
-      </div>
+      {% elseif tickets_sold_value != '0' %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'Ticket sales'|t }}</h2>
+        <p class="mel-vendor-dashboard__momentum-message">{{ '@count tickets sold so far across your events.'|t({'@count': tickets_sold_value}) }}</p>
+      {% elseif rsvps_value != '0' %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'RSVPs'|t }}</h2>
+        <p class="mel-vendor-dashboard__momentum-message">{{ '@count RSVPs received across your events.'|t({'@count': rsvps_value}) }}</p>
+      {% elseif bookings_value != '0' %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'Bookings'|t }}</h2>
+        <p class="mel-vendor-dashboard__momentum-message">{{ '@count bookings across your live events.'|t({'@count': bookings_value}) }}</p>
+      {% elseif has_readiness_signal %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'Homepage readiness'|t }}</h2>
+        <p class="mel-vendor-dashboard__momentum-message">{{ visibility_summary.promotion_ready_label }}</p>
+      {% elseif has_boost_signal %}
+        <h2 id="mel-dash-momentum-title" class="mel-vendor-dashboard__momentum-title">{{ 'Homepage boost'|t }}</h2>
+        <p class="mel-vendor-dashboard__momentum-message">{{ visibility_summary.boost_label|default('Boost is active on the homepage.'|t) }}</p>
+      {% endif %}
     </section>
   {% endif %}
-
-  <section class="mel-live-ops__metrics mel-vendor-dashboard__metric-strip" aria-labelledby="mel-dash-kpis-title">
-    <h2 id="mel-dash-kpis-title" class="mel-live-ops__panel-title">{{ 'Quick metrics'|t }}</h2>
-    <p class="mel-live-ops__panel-intro">
-      {{ 'Lightweight organiser signals across bookings, events, attendees, and payouts.'|t }}
-    </p>
-    {% if metric_rows is iterable and metric_rows|length > 0 %}
-      <div class="mel-live-ops__metric-board mel-vendor-dashboard__metric-board" role="list">
-        {% for metric in metric_rows|slice(0, 5) %}
-          {% set stat_mod = kpi_board_modifiers[loop.index0 % kpi_board_modifiers|length] %}
-          {% set metric_inner %}
-            <span class="mel-live-ops__stat-label">{{ metric.label|default('') }}</span>
-            <span class="mel-live-ops__stat-value">{{ metric.value|default('-') }}</span>
-            {% if metric.context is defined and metric.context %}
-              <span class="mel-live-ops__stat-note">{{ metric.context }}</span>
-            {% endif %}
-          {% endset %}
-          {% if metric.url is defined and metric.url %}
-            <a class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem" href="{{ metric.url }}">{{ metric_inner }}</a>
-          {% else %}
-            <article class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }}" role="listitem">{{ metric_inner }}</article>
-          {% endif %}
-        {% endfor %}
-      </div>
-    {% endif %}
-  </section>
 
   {% if attention_events is iterable and attention_events|length > 0 %}
-    <section class="mel-vendor-dashboard__attention-strip" aria-labelledby="mel-dash-attention-title">
-      <div class="mel-vendor-dashboard__section-head">
-        <div>
-          <p class="mel-live-ops__eyebrow">{{ 'Needs your attention'|t }}</p>
-          <h2 id="mel-dash-attention-title" class="mel-live-ops__panel-title">{{ 'Events to fix or finish'|t }}</h2>
-          <p class="mel-live-ops__muted mel-vendor-dashboard__attention-lede">{{ 'Drafts, missing ticket or RSVP setup, upcoming dates, and check-in readiness — without exposing attendee details here.'|t }}</p>
-        </div>
-        <span class="mel-live-ops__chip mel-live-ops__chip--warn">{{ attention_events|length }} {{ 'to review'|t }}</span>
+    <section class="mel-vendor-dashboard__attention-strip mel-vendor-dashboard__attention-strip--compact mel-vendor-dashboard__action-queue" aria-labelledby="mel-dash-attention-title">
+      <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
+        <p class="mel-live-ops__eyebrow">{{ 'Action queue'|t }}</p>
+        <h2 id="mel-dash-attention-title" class="mel-live-ops__panel-title">{{ 'Events to fix or finish'|t }}</h2>
       </div>
-      <div class="mel-vendor-dashboard__attention-row" role="list">
-        {% for ev in attention_events %}
+      <ol class="mel-vendor-dashboard__action-queue-list" role="list">
+        {% for ev in attention_events|slice(0, 3) %}
           {% set links = ev.links|default({}) %}
-          {% set boost = ev.boost|default({}) %}
-          {% set status = ev.status|default('') %}
-          {% set status_chip = status == 'draft' ? 'warn' : 'lavender' %}
-          <article class="mel-vendor-dashboard__attention-card{% if boost.active %} mel-vendor-dashboard__attention-card--boosted{% endif %}" role="listitem">
-            <div>
-              <h3 class="mel-vendor-dashboard__upcoming-title">{{ ev.title|default('Untitled event'|t) }}</h3>
-              {% if ev.date_label is defined and ev.date_label %}
-                <p class="mel-vendor-dashboard__upcoming-date">{{ ev.date_label }}</p>
-              {% endif %}
+          {% set problem = ev.reasons|default([])|first|default('') %}
+          {% if problem == '' and ev.booking_state_label is defined and ev.booking_state_label %}
+            {% set problem = ev.booking_state_label %}
+          {% endif %}
+          {% if problem == '' %}
+            {% set problem = 'Needs review'|t %}
+          {% endif %}
+          <li class="mel-vendor-dashboard__action-queue-item{% if loop.first %} mel-vendor-dashboard__action-queue-item--primary{% endif %}" role="listitem">
+            <div class="mel-vendor-dashboard__action-queue-body">
+              <span class="mel-vendor-dashboard__action-queue-title">{{ ev.title|default('Untitled event'|t) }}</span>
+              <span class="mel-vendor-dashboard__action-queue-problem">{{ problem }}</span>
             </div>
-            <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Attention reasons'|t }}">
-              {% if ev.status_label is defined and ev.status_label %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--{{ status_chip }}">{{ ev.status_label }}</span>
-              {% endif %}
-              {% if boost.active %}
-                <span class="mel-vendor-dashboard__boost-badge mel-vendor-dashboard__boost-badge--inline">{{ '🚀 Boosted'|t }}</span>
-              {% endif %}
-              {% for reason in ev.reasons|default([]) %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ reason }}</span>
-              {% endfor %}
-            </div>
-            {% include '@myeventlane_vendor_theme/components/mel-dashboard-event-boost.html.twig' with {
-              boost: boost,
-              links: links,
-            } only %}
-            {% if ev.booking_state_label is defined and ev.booking_state_label %}
-              <p class="mel-vendor-dashboard__upcoming-meta">{{ ev.booking_state_label }}</p>
-            {% endif %}
             {% if links.manage is defined and links.manage %}
-              <a class="mel-live-ops__readiness-link" href="{{ links.manage }}">{{ 'Open workspace'|t }}</a>
+              <a class="mel-live-ops__readiness-link mel-vendor-dashboard__action-queue-link" href="{{ links.manage }}">{{ 'Open workspace'|t }} →</a>
             {% endif %}
-          </article>
+          </li>
         {% endfor %}
-      </div>
+      </ol>
     </section>
   {% endif %}
 
-  <section class="mel-vendor-dashboard__activity-stream" aria-labelledby="mel-dash-activity-title">
-    <div class="mel-vendor-dashboard__section-head">
-      <div>
-        <p class="mel-live-ops__eyebrow">{{ 'Operational activity'|t }}</p>
-        <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent signals'|t }}</h2>
-      </div>
-      <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ 'Sparse updates'|t }}</span>
-    </div>
-    {% if activity_items is iterable and activity_items|length > 0 %}
-      <div class="mel-vendor-dashboard__activity-list" role="list">
-        {% for item in activity_items|slice(0, 4) %}
-          {% set row_type = item.type|default('info') %}
-          {% set row_chip = row_type == 'success' ? 'success' : (row_type == 'warning' or row_type == 'error' ? 'warn' : 'info') %}
-          <article class="mel-vendor-dashboard__activity-item" role="listitem">
-            <span class="mel-live-ops__chip mel-live-ops__chip--{{ row_chip }}">{{ row_type == 'success' ? ('Signal'|t) : ('Update'|t) }}</span>
-            <p class="mel-vendor-dashboard__activity-message">{{ item.message|default('') }}</p>
-            {% if item.url is defined and item.url %}
-              <a class="mel-live-ops__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}</a>
-            {% endif %}
-          </article>
-        {% endfor %}
-      </div>
-    {% else %}
-      <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
-    {% endif %}
-  </section>
-
   {% if upcoming_events is iterable and upcoming_events|length > 0 %}
-    <section class="mel-vendor-dashboard__upcoming-strip" aria-labelledby="mel-dash-upcoming-title">
-      <div class="mel-vendor-dashboard__section-head">
+    <section class="mel-vendor-dashboard__upcoming-strip mel-vendor-dashboard__upcoming-strip--compact" aria-labelledby="mel-dash-upcoming-title">
+      <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
         <div>
-          <p class="mel-live-ops__eyebrow">{{ 'Upcoming events'|t }}</p>
-          <h2 id="mel-dash-upcoming-title" class="mel-live-ops__panel-title">{{ 'Next in view'|t }}</h2>
+          <p class="mel-live-ops__eyebrow">{{ 'Next up'|t }}</p>
+          <h2 id="mel-dash-upcoming-title" class="mel-live-ops__panel-title">{{ 'Upcoming events'|t }}</h2>
         </div>
         {% if empty_state.url is defined and empty_state.url %}
           <a class="mel-live-ops__readiness-link" href="{{ empty_state.url }}">{{ 'View all events'|t }}</a>
         {% endif %}
       </div>
-      <div class="mel-vendor-dashboard__upcoming-row" role="list">
-        {% for ev in upcoming_events %}
+      <div class="mel-vendor-dashboard__summary-cards" role="list">
+        {% for ev in upcoming_events|slice(0, 4) %}
           {% set links = ev.links|default({}) %}
           {% set boost = ev.boost|default({}) %}
-          {% set status = ev.status|default('upcoming') %}
-          {% set status_chip = status == 'draft' ? 'warn' : 'lavender' %}
-          <article class="mel-vendor-dashboard__upcoming-card{% if boost.active %} mel-vendor-dashboard__upcoming-card--boosted{% endif %}" role="listitem">
-            <div>
-              <h3 class="mel-vendor-dashboard__upcoming-title">{{ ev.title|default('Untitled event'|t) }}</h3>
-              {% if ev.date_label is defined and ev.date_label %}
-                <p class="mel-vendor-dashboard__upcoming-date">{{ ev.date_label }}</p>
-              {% endif %}
-            </div>
-            <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact" role="group" aria-label="{{ 'Event state'|t }}">
-              {% if ev.status_label is defined and ev.status_label %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--{{ status_chip }}">{{ ev.status_label }}</span>
-              {% endif %}
-              {% if boost.active %}
-                <span class="mel-vendor-dashboard__boost-badge mel-vendor-dashboard__boost-badge--inline">{{ '🚀 Boosted'|t }}</span>
-              {% endif %}
-              {% if ev.booking_state_label is defined and ev.booking_state_label %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--calm">{{ ev.booking_state_label }}</span>
-              {% endif %}
-            </div>
-            {% include '@myeventlane_vendor_theme/components/mel-dashboard-event-boost.html.twig' with {
-              boost: boost,
-              links: links,
-            } only %}
-            {% if ev.metric_label is defined and ev.metric_label %}
-              <p class="mel-vendor-dashboard__upcoming-meta">{{ ev.metric_label }}</p>
+          {% set event_status = ev.status|default('') %}
+          {% set status_mod = boost.active ? 'boosted' : (event_status == 'draft' ? 'draft' : 'upcoming') %}
+          {% set status_text = boost.active ? ('Boosted'|t) : (ev.status_label|default('')) %}
+          <article class="mel-vendor-dashboard__summary-card" role="listitem">
+            <h3 class="mel-vendor-dashboard__summary-card-title">{{ ev.title|default('Untitled event'|t) }}</h3>
+            {% if ev.date_label is defined and ev.date_label %}
+              <p class="mel-vendor-dashboard__summary-card-date">{{ ev.date_label }}</p>
+            {% endif %}
+            {% if status_text %}
+              <p class="mel-vendor-dashboard__summary-card-status mel-vendor-dashboard__summary-card-status--{{ status_mod }}">{{ status_text }}</p>
             {% endif %}
             {% if links.manage is defined and links.manage %}
-              <a class="mel-live-ops__readiness-link" href="{{ links.manage }}">{{ 'Open event'|t }}</a>
+              <a class="mel-live-ops__readiness-link mel-vendor-dashboard__summary-card-action" href="{{ links.manage }}">{{ 'Open'|t }} →</a>
             {% endif %}
           </article>
         {% endfor %}
@@ -286,9 +227,290 @@
     </section>
   {% endif %}
 
-  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--setup">
-    <summary>{{ 'Account setup and recommendations'|t }}</summary>
+  <section class="mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact" aria-labelledby="mel-dash-activity-title">
+    <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
+      <p class="mel-live-ops__eyebrow">{{ 'Operational activity'|t }}</p>
+      <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent signals'|t }}</h2>
+    </div>
+    {% if activity_items is iterable and activity_items|length > 0 %}
+      <ol class="mel-vendor-dashboard__timeline" role="list">
+        {% for item in activity_items|slice(0, 5) %}
+          {% set row_type = item.type|default('info') %}
+          {% set feed_icon = row_type == 'success' ? '✓' : '•' %}
+          <li class="mel-vendor-dashboard__timeline-item mel-vendor-dashboard__timeline-item--{{ row_type == 'success' ? 'success' : (row_type == 'warning' ? 'warn' : 'info') }}" role="listitem">
+            <span class="mel-vendor-dashboard__timeline-marker" aria-hidden="true">{{ feed_icon }}</span>
+            <div class="mel-vendor-dashboard__timeline-content">
+              {% if item.url is defined and item.url %}
+                <a class="mel-vendor-dashboard__timeline-link" href="{{ item.url }}">{{ item.message|default('') }}</a>
+              {% else %}
+                <span class="mel-vendor-dashboard__timeline-text">{{ item.message|default('') }}</span>
+              {% endif %}
+            </div>
+          </li>
+        {% endfor %}
+      </ol>
+    {% else %}
+      <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
+    {% endif %}
+  </section>
+
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--homepage-performance mel-vendor-dashboard__details--events">
+    <summary>{{ 'Homepage performance'|t }}</summary>
     <div class="mel-vendor-dashboard__details-grid">
+      {% if homepage_readiness %}
+        <section class="mel-vendor-dashboard__homepage-readiness" aria-label="{{ 'Homepage readiness summary'|t }}">
+          {{ homepage_readiness }}
+        </section>
+      {% endif %}
+
+      {% if homepage_visibility %}
+        <section class="mel-vendor-dashboard__homepage-visibility" aria-labelledby="mel-homepage-visibility-title" role="region">
+          <h2 id="mel-homepage-visibility-title" class="mel-vendor-dashboard__visibility-heading">{{ homepage_visibility.heading|default('Homepage Visibility'|t) }}</h2>
+          {% if homepage_visibility.intro|default('') %}
+            <p class="mel-vendor-dashboard__visibility-intro">{{ homepage_visibility.intro }}</p>
+          {% endif %}
+          {% set visibility_summary = homepage_visibility.summary|default(null) %}
+          {% if visibility_summary %}
+            <div class="mel-vendor-dashboard__visibility-summary-card" role="region" aria-label="{{ 'Homepage visibility summary'|t }}">
+              <ul class="mel-vendor-dashboard__visibility-signals" role="list">
+                {% if visibility_summary.promotion_ready_label|default('')|trim != '' %}
+                  <li class="mel-vendor-dashboard__visibility-signal mel-vendor-dashboard__visibility-signal--ready" role="listitem">
+                    <span class="mel-vendor-dashboard__visibility-signal-icon" aria-hidden="true">✓</span>
+                    <span class="mel-vendor-dashboard__visibility-signal-copy">
+                      <span class="mel-vendor-dashboard__visibility-signal-label">{{ 'Homepage promotion ready'|t }}</span>
+                      <strong class="mel-vendor-dashboard__visibility-signal-value">{{ visibility_summary.promotion_ready_label }}</strong>
+                    </span>
+                  </li>
+                {% endif %}
+                {% if visibility_summary.boost_label|default('')|trim != '' %}
+                  <li class="mel-vendor-dashboard__visibility-signal mel-vendor-dashboard__visibility-signal--boost{% if visibility_summary.boost_active|default(false) %} is-active{% endif %}" role="listitem">
+                    <span class="mel-vendor-dashboard__visibility-signal-icon" aria-hidden="true">🚀</span>
+                    <span class="mel-vendor-dashboard__visibility-signal-copy">
+                      <span class="mel-vendor-dashboard__visibility-signal-label">{{ 'Boost'|t }}</span>
+                      <strong class="mel-vendor-dashboard__visibility-signal-value">{{ visibility_summary.boost_label }}</strong>
+                    </span>
+                  </li>
+                {% endif %}
+                {% if visibility_summary.homepage_impressions_label|default('')|trim != '' %}
+                  <li class="mel-vendor-dashboard__visibility-signal mel-vendor-dashboard__visibility-signal--impressions" role="listitem">
+                    <span class="mel-vendor-dashboard__visibility-signal-icon" aria-hidden="true">👀</span>
+                    <span class="mel-vendor-dashboard__visibility-signal-copy">
+                      <span class="mel-vendor-dashboard__visibility-signal-label">{{ 'Homepage impressions'|t }}</span>
+                      <strong class="mel-vendor-dashboard__visibility-signal-value">{{ visibility_summary.homepage_impressions_label }}</strong>
+                    </span>
+                  </li>
+                {% endif %}
+                {% if visibility_summary.homepage_clicks_label|default('')|trim != '' %}
+                  <li class="mel-vendor-dashboard__visibility-signal mel-vendor-dashboard__visibility-signal--clicks" role="listitem">
+                    <span class="mel-vendor-dashboard__visibility-signal-icon" aria-hidden="true">🎯</span>
+                    <span class="mel-vendor-dashboard__visibility-signal-copy">
+                      <span class="mel-vendor-dashboard__visibility-signal-label">{{ 'Homepage clicks'|t }}</span>
+                      <strong class="mel-vendor-dashboard__visibility-signal-value">{{ visibility_summary.homepage_clicks_label }}</strong>
+                    </span>
+                  </li>
+                {% endif %}
+              </ul>
+            </div>
+
+            {% set visibility_impressions = visibility_summary.homepage_impressions|default(0) %}
+            {% set visibility_clicks = visibility_summary.homepage_clicks|default(0) %}
+            {% set not_ready_row = homepage_visibility.rows|default([])|filter(row => not row.readiness_ready|default(false))|first|default(null) %}
+            {% if not visibility_summary.boost_active|default(false) %}
+              <aside class="mel-vendor-dashboard__visibility-rec" aria-labelledby="mel-homepage-visibility-rec-title">
+                <p class="mel-live-ops__eyebrow">{{ 'Recommended next step'|t }}</p>
+                <h3 id="mel-homepage-visibility-rec-title" class="mel-vendor-dashboard__visibility-rec-title">{{ 'Turn on Boost to reach more people'|t }}</h3>
+                <p class="mel-vendor-dashboard__visibility-rec-message">{{ 'Boost helps your events appear in more homepage spots while promotion is active.'|t }}</p>
+                <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__visibility-rec-action" href="{{ path('myeventlane_vendor.console.boost') }}">{{ 'Promote an event'|t }}</a>
+              </aside>
+            {% elseif not visibility_summary.promotion_ready|default(false) and not_ready_row and not_ready_row.event_id|default(0) %}
+              <aside class="mel-vendor-dashboard__visibility-rec" aria-labelledby="mel-homepage-visibility-rec-title">
+                <p class="mel-live-ops__eyebrow">{{ 'Recommended next step'|t }}</p>
+                <h3 id="mel-homepage-visibility-rec-title" class="mel-vendor-dashboard__visibility-rec-title">{{ 'Finish homepage readiness'|t }}</h3>
+                <p class="mel-vendor-dashboard__visibility-rec-message">{{ '@event still needs a few homepage-ready details before it can shine on discovery.'|t({'@event': not_ready_row.event_title|default('This event')}) }}</p>
+                <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__visibility-rec-action" href="{{ path('myeventlane_event_studio.workspace', {'node': not_ready_row.event_id|default(0)}) }}">{{ 'Open event workspace'|t }}</a>
+              </aside>
+            {% elseif visibility_impressions > 0 and visibility_clicks == 0 %}
+              <aside class="mel-vendor-dashboard__visibility-rec" aria-labelledby="mel-homepage-visibility-rec-title">
+                <p class="mel-live-ops__eyebrow">{{ 'Recommended next step'|t }}</p>
+                <h3 id="mel-homepage-visibility-rec-title" class="mel-vendor-dashboard__visibility-rec-title">{{ 'Turn views into clicks'|t }}</h3>
+                <p class="mel-vendor-dashboard__visibility-rec-message">{{ 'Your events are being seen on the homepage. Try a stronger image or clearer title to invite more clicks.'|t }}</p>
+                {% set visible_row = homepage_visibility.rows|default([])|filter(row => row.homepage_visible|default(false))|first|default(not_ready_row) %}
+                {% if visible_row and visible_row.event_id|default(0) %}
+                  <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__visibility-rec-action" href="{{ path('myeventlane_event_studio.workspace', {'node': visible_row.event_id}) }}">{{ 'Improve event presentation'|t }}</a>
+                {% endif %}
+              </aside>
+            {% endif %}
+
+            {% if visibility_summary.surfaces|default([])|length > 0 or visibility_summary.surface_clicks|default([])|length > 0 %}
+              <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--visibility-placements">
+                <summary>{{ 'View placement breakdown'|t }}</summary>
+                <div class="mel-vendor-dashboard__details-grid mel-vendor-dashboard__details-grid--single">
+                  <dl class="mel-vendor-dashboard__visibility-breakdown">
+                    {% for surface in visibility_summary.surfaces|default([]) %}
+                      <div class="mel-vendor-dashboard__visibility-breakdown-item">
+                        <dt>{{ surface.label|default('') }}</dt>
+                        <dd>{{ surface.count|default(0) }}</dd>
+                      </div>
+                    {% endfor %}
+                    {% for surface in visibility_summary.surface_clicks|default([]) %}
+                      <div class="mel-vendor-dashboard__visibility-breakdown-item mel-vendor-dashboard__visibility-breakdown-item--clicks">
+                        <dt>{{ surface.label|default('') }}</dt>
+                        <dd>{{ surface.clicks|default(0) }} {{ 'clicks'|t }}</dd>
+                      </div>
+                    {% endfor %}
+                  </dl>
+                </div>
+              </details>
+            {% endif %}
+          {% endif %}
+
+          {% if homepage_visibility.rows|default([])|length > 0 %}
+            <div class="mel-vendor-dashboard__visibility-events" role="list" aria-label="{{ 'Event homepage performance'|t }}">
+              {% for row in homepage_visibility.rows %}
+                <article class="mel-vendor-dashboard__visibility-event-card{% if row.boost_active|default(false) %} is-boosted{% endif %}{% if row.readiness_ready|default(false) %} is-ready{% endif %}" role="listitem">
+                  <header class="mel-vendor-dashboard__visibility-event-head">
+                    <h3 class="mel-vendor-dashboard__visibility-event-title">{{ row.event_title|default('') }}</h3>
+                    <span class="mel-vendor-dashboard__visibility-event-boost{% if row.boost_active|default(false) %} is-active{% endif %}">{{ row.boost_label|default('') }}</span>
+                  </header>
+                  <dl class="mel-vendor-dashboard__visibility-event-meta">
+                    <div class="mel-vendor-dashboard__visibility-event-field">
+                      <dt>{{ 'Where appearing'|t }}</dt>
+                      <dd>
+                        {% if row.surface_labels|default([])|length > 0 %}
+                          {{ row.surface_labels|join(', ') }}
+                        {% else %}
+                          {{ 'Not on homepage'|t }}
+                        {% endif %}
+                        {% if row.surface_click_labels|default([])|length > 0 %}
+                          <ul class="mel-vendor-dashboard__visibility-click-list">
+                            {% for click_label in row.surface_click_labels %}
+                              <li>{{ click_label }}</li>
+                            {% endfor %}
+                          </ul>
+                        {% endif %}
+                      </dd>
+                    </div>
+                    <div class="mel-vendor-dashboard__visibility-event-field">
+                      <dt>{{ 'Homepage ready'|t }}</dt>
+                      <dd>{{ row.readiness_label|default('') }}</dd>
+                    </div>
+                    <div class="mel-vendor-dashboard__visibility-event-field">
+                      <dt>{{ 'Engagement'|t }}</dt>
+                      <dd>
+                        {% if row.engagement_label|default('') %}
+                          {{ row.engagement_label }}
+                        {% else %}
+                          {{ '—'|t }}
+                        {% endif %}
+                      </dd>
+                    </div>
+                  </dl>
+                  {% if row.event_id|default(0) %}
+                    <a class="mel-live-ops__readiness-link mel-vendor-dashboard__visibility-event-action" href="{{ path('myeventlane_event_studio.workspace', {'node': row.event_id}) }}">{{ 'Open event workspace'|t }} →</a>
+                  {% endif %}
+                </article>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </section>
+      {% endif %}
+
+      {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
+        <div class="mel-vendor-dashboard__boost-slot mel-vendor-dashboard__boost-slot--below-events">
+          {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
+            event: {
+              title: mel_top_boost_opportunity.title,
+              image: mel_top_boost_opportunity.image|default(null),
+            },
+            performance: mel_top_boost_opportunity.performance,
+          } only %}
+        </div>
+      {% endif %}
+    </div>
+  </details>
+
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--analytics mel-vendor-dashboard__details--events">
+    <summary>{{ 'Analytics'|t }}</summary>
+    <div class="mel-vendor-dashboard__details-grid mel-vendor-dashboard__details-grid--single">
+      {% set analytics_data = analytics|default({}) %}
+      {% set duplicate_analytics_keys = ['revenue', 'tickets_sold', 'rsvps', 'upcoming_events'] %}
+      {% set audience_keys = ['profile_views', 'total_event_views', 'followers'] %}
+      {% set conversion_keys = ['follow_conversion', 'avg_ticket_conversion', 'boost_ctr', 'boost_views', 'boost_clicks'] %}
+      {% set sales_keys = ['orders'] %}
+      {% set performance_rows = event_performance|default([]) %}
+      {% set ranked_performance_rows = performance_rows|sort((a, b) => b.views|default(0) <=> a.views|default(0)) %}
+      {% set top_performance_rows = ranked_performance_rows|slice(0, 3) %}
+      {% set top_event_row = ranked_performance_rows|filter(row => row.views|default(0) > 0 or row.tickets_sold|default(0) > 0)|first|default(null) %}
+      {% set boost_views_count = analytics_data.boost_views|default(0) %}
+      {% set boost_clicks_count = analytics_data.boost_clicks|default(0) %}
+      {% set profile_views_count = analytics_data.profile_views|default(0) %}
+
+      {% if boost_views_count > 0 and boost_clicks_count == 0 %}
+        <aside class="mel-vendor-dashboard__analytics-insight" aria-labelledby="mel-dash-analytics-insight-title">
+          <p class="mel-live-ops__eyebrow">{{ 'Insight'|t }}</p>
+          <h3 id="mel-dash-analytics-insight-title" class="mel-vendor-dashboard__analytics-insight-title">{{ 'Turn boost views into clicks'|t }}</h3>
+          <p class="mel-vendor-dashboard__analytics-insight-message">{{ 'Your events are being seen but not clicked.'|t }}</p>
+          {% if top_event_row and top_event_row.event_id|default(0) %}
+            <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_event_studio.workspace', {'node': top_event_row.event_id}) }}">{{ 'Improve event presentation'|t }}</a>
+          {% endif %}
+        </aside>
+      {% elseif top_event_row %}
+        <aside class="mel-vendor-dashboard__analytics-insight" aria-labelledby="mel-dash-analytics-insight-title">
+          <p class="mel-live-ops__eyebrow">{{ 'Insight'|t }}</p>
+          <h3 id="mel-dash-analytics-insight-title" class="mel-vendor-dashboard__analytics-insight-title">{{ 'Top performing event'|t }}</h3>
+          <p class="mel-vendor-dashboard__analytics-insight-message">{{ '@event is outperforming your other events.'|t({'@event': top_event_row.title|default('This event')}) }}</p>
+          {% if top_event_row.event_id|default(0) %}
+            <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_event_studio.workspace_analytics', {'node': top_event_row.event_id}) }}">{{ 'View event analytics'|t }}</a>
+          {% endif %}
+        </aside>
+      {% elseif profile_views_count > 0 %}
+        <aside class="mel-vendor-dashboard__analytics-insight" aria-labelledby="mel-dash-analytics-insight-title">
+          <p class="mel-live-ops__eyebrow">{{ 'Insight'|t }}</p>
+          <h3 id="mel-dash-analytics-insight-title" class="mel-vendor-dashboard__analytics-insight-title">{{ 'Profile discovery'|t }}</h3>
+          <p class="mel-vendor-dashboard__analytics-insight-message">{{ 'More people are discovering your organiser profile.'|t }}</p>
+          <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_vendor.console.boost') }}">{{ 'Promote another event'|t }}</a>
+        </aside>
+      {% endif %}
+
+      {% include '@myeventlane_vendor_theme/components/mel-vendor-analytics-overview.html.twig' with {
+        analytics_cards: analytics_cards|default([]),
+        duplicate_keys: duplicate_analytics_keys,
+        audience_keys: audience_keys,
+        conversion_keys: conversion_keys,
+        sales_keys: sales_keys,
+      } only %}
+
+      {% include '@myeventlane_vendor_theme/components/mel-vendor-event-performance.html.twig' with {
+        event_performance: performance_rows,
+        top_events: top_performance_rows,
+        empty_state: empty_state,
+      } only %}
+    </div>
+  </details>
+
+  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--account">
+    <summary>{{ 'Account & settings'|t }}</summary>
+    <div class="mel-vendor-dashboard__details-grid">
+      {% if launch_pro_status is defined and launch_pro_status %}
+        <div class="mel-vendor-dashboard__micro-surface">{{ launch_pro_status }}</div>
+      {% elseif is_pro|default(false) %}
+        <div class="mel-vendor-dashboard__micro-surface">
+          <span class="mel-live-ops__chip mel-live-ops__chip--success">{{ 'PRO PLAN active'|t }}</span>
+          <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ path('myeventlane_pro.manage') }}">{{ 'Manage'|t }}</a>
+        </div>
+      {% elseif show_pro_prompt|default(false) %}
+        <div class="mel-vendor-dashboard__micro-surface">
+          <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ 'FREE PLAN'|t }}</span>
+          <a class="mel-live-ops__chip mel-live-ops__chip--live" href="{{ pro_upgrade_url|default(path('myeventlane_pro.overview')) }}">{{ 'Upgrade to Pro'|t }}</a>
+        </div>
+      {% endif %}
+
+      {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
+        <div class="mel-vendor-dashboard__billing-strip mel-vendor-dashboard__billing-strip--below-events">{{ mel_contribution_billing_strip }}</div>
+      {% endif %}
+
+      {% include '@myeventlane_vendor_theme/includes/dashboard-mel-support-strip.html.twig' %}
+
       {% if onboarding_panel is defined and onboarding_panel %}
         <div class="mel-vendor-dashboard__onboarding">{{ onboarding_panel }}</div>
       {% endif %}
@@ -350,12 +572,38 @@
           </div>
         </section>
       {% endif %}
-    </div>
-  </details>
 
-  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--events">
-    <summary>{{ 'All events and secondary guidance'|t }}</summary>
-    <div class="mel-vendor-dashboard__details-grid">
+      {% if growth_cards is defined and growth_cards|length > 0 %}
+        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-growth-title">
+          <div class="mel-live-ops__timeline-head">
+            <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Promotion guidance'|t }}</h2>
+            <p class="mel-live-ops__panel-intro">{{ 'Suggestions remain secondary to organiser mission control.'|t }}</p>
+          </div>
+          <ul class="mel-vendor-dashboard__growth-feed" role="list">
+            {% for card in growth_cards %}
+              <li>
+                <article class="mel-growth-card {{ card.card_class|default('') }}" role="listitem" data-insight-key="{{ card.key }}"{% if card.event_id is defined and card.event_id %} data-event-id="{{ card.event_id }}"{% endif %}>
+                  <div class="mel-growth-card__body">
+                    <h3 class="mel-growth-card__title">{{ card.title }}</h3>
+                    <p class="mel-growth-card__message">{{ card.message }}</p>
+                    <div class="mel-growth-card__actions">
+                      {% if card.cta_track_url %}
+                        <a href="{{ card.cta_track_url }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                      {% elseif card.cta_route %}
+                        <a href="{{ path(card.cta_route, card.cta_params|default({})) }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                      {% endif %}
+                    </div>
+                  </div>
+                  {% if card.dismissible %}
+                    <button type="button" class="mel-growth-card__dismiss" data-mel-growth-dismiss aria-label="{{ 'Dismiss suggestion'|t }}">{{ 'Dismiss'|t }}</button>
+                  {% endif %}
+                </article>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+
       <section class="mel-vendor-dashboard__events-scope" aria-labelledby="mel-dash-events-title">
         <div class="mel-live-ops__timeline-head">
           <h2 id="mel-dash-events-title" class="mel-live-ops__panel-title">{{ 'Your events'|t }}</h2>
@@ -462,69 +710,6 @@
           </div>
         </section>
       {% endif %}
-
-      {% if growth_cards is defined and growth_cards|length > 0 %}
-        <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-growth-title">
-          <div class="mel-live-ops__timeline-head">
-            <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Promotion guidance'|t }}</h2>
-            <p class="mel-live-ops__panel-intro">{{ 'Suggestions remain secondary to organiser mission control.'|t }}</p>
-          </div>
-          <ul class="mel-vendor-dashboard__growth-feed" role="list">
-            {% for card in growth_cards %}
-              <li>
-                <article class="mel-growth-card {{ card.card_class|default('') }}" role="listitem" data-insight-key="{{ card.key }}"{% if card.event_id is defined and card.event_id %} data-event-id="{{ card.event_id }}"{% endif %}>
-                  <div class="mel-growth-card__body">
-                    <h3 class="mel-growth-card__title">{{ card.title }}</h3>
-                    <p class="mel-growth-card__message">{{ card.message }}</p>
-                    <div class="mel-growth-card__actions">
-                      {% if card.cta_track_url %}
-                        <a href="{{ card.cta_track_url }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
-                      {% elseif card.cta_route %}
-                        <a href="{{ path(card.cta_route, card.cta_params|default({})) }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
-                      {% endif %}
-                    </div>
-                  </div>
-                  {% if card.dismissible %}
-                    <button type="button" class="mel-growth-card__dismiss" data-mel-growth-dismiss aria-label="{{ 'Dismiss suggestion'|t }}">{{ 'Dismiss'|t }}</button>
-                  {% endif %}
-                </article>
-              </li>
-            {% endfor %}
-          </ul>
-        </section>
-      {% endif %}
     </div>
   </details>
-
-  <footer class="mel-vendor-dashboard__footer-surfaces" aria-label="{{ 'Secondary dashboard surfaces'|t }}">
-    {% if launch_pro_status is defined and launch_pro_status %}
-      <div class="mel-vendor-dashboard__micro-surface">{{ launch_pro_status }}</div>
-    {% elseif is_pro|default(false) %}
-      <div class="mel-vendor-dashboard__micro-surface">
-        <span class="mel-live-ops__chip mel-live-ops__chip--success">{{ 'PRO PLAN active'|t }}</span>
-        <a class="mel-live-ops__chip mel-live-ops__chip--lavender" href="{{ path('myeventlane_pro.manage') }}">{{ 'Manage'|t }}</a>
-      </div>
-    {% elseif show_pro_prompt|default(false) %}
-      <div class="mel-vendor-dashboard__micro-surface">
-        <span class="mel-live-ops__chip mel-live-ops__chip--lavender">{{ 'FREE PLAN'|t }}</span>
-        <a class="mel-live-ops__chip mel-live-ops__chip--live" href="{{ pro_upgrade_url|default(path('myeventlane_pro.overview')) }}">{{ 'Upgrade to Pro'|t }}</a>
-      </div>
-    {% endif %}
-
-    {% if mel_contribution_billing_strip is defined and mel_contribution_billing_strip %}
-      <div class="mel-vendor-dashboard__billing-strip mel-vendor-dashboard__billing-strip--below-events">{{ mel_contribution_billing_strip }}</div>
-    {% endif %}
-
-    {% if mel_top_boost_opportunity is defined and mel_top_boost_opportunity %}
-      <div class="mel-vendor-dashboard__boost-slot mel-vendor-dashboard__boost-slot--below-events">
-        {% include '@myeventlane_vendor_theme/components/mel-top-boost-opportunity.html.twig' with {
-          event: {
-            title: mel_top_boost_opportunity.title,
-            image: mel_top_boost_opportunity.image|default(null),
-          },
-          performance: mel_top_boost_opportunity.performance,
-        } only %}
-      </div>
-    {% endif %}
-  </footer>
 </section>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/footer-dashboard-light.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/footer-dashboard-light.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Lightweight dashboard footer — store status and account links only.
+ */
+#}
+{% set footer_context = footer_context|default({
+  store_name: null,
+  payout_balance: '$0.00',
+  environment: 'Production',
+  vendor_console_urls: {}
+}) %}
+<footer class="mel-footer mel-footer--dashboard" role="contentinfo">
+  <div class="mel-footer-dashboard">
+    <div class="mel-footer-dashboard__status">
+      {% if footer_context.store_name %}
+        <strong class="mel-footer-dashboard__store">{{ footer_context.store_name }}</strong>
+      {% endif %}
+      {% if footer_context.environment %}
+        <span class="mel-badge mel-badge--env">{{ footer_context.environment }}</span>
+      {% endif %}
+      <span class="mel-footer-dashboard__balance">{{ 'Payout balance'|t }}: {{ footer_context.payout_balance|default('$0.00') }}</span>
+    </div>
+    <nav class="mel-footer-dashboard__links" aria-label="{{ 'Account links'|t }}">
+      <a class="mel-footer-dashboard__link" href="/user">{{ 'Profile'|t }}</a>
+      {% if footer_context.vendor_console_urls.settings|default('') %}
+        <a class="mel-footer-dashboard__link" href="{{ footer_context.vendor_console_urls.settings }}">{{ 'Settings'|t }}</a>
+      {% endif %}
+      <a class="mel-footer-dashboard__link" href="/user/logout">{{ 'Log out'|t }}</a>
+    </nav>
+  </div>
+</footer>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -73,9 +73,14 @@
         <div class="mel-shell-layout mel-shell-layout--with-utility">
           <div class="mel-shell-layout__main">
             {% if is_dashboard_route %}
-              <section class="mel-dashboard-page mel-dashboard-page--governed">
+              <section class="mel-dashboard-page mel-dashboard-page--governed mel-vendor-dashboard">
                 {% if mel_surface|default('') == 'vendor' %}
-                  {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+                  <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--governance">
+                    <summary>{{ 'Console guidance and readiness'|t }}</summary>
+                    <div class="mel-vendor-dashboard__details-grid">
+                      {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+                    </div>
+                  </details>
                 {% endif %}
                 {{ page.content }}
               </section>
@@ -91,9 +96,14 @@
         </div>
       {% else %}
         {% if is_dashboard_route %}
-          <section class="mel-dashboard-page mel-dashboard-page--governed">
+          <section class="mel-dashboard-page mel-dashboard-page--governed mel-vendor-dashboard">
             {% if mel_surface|default('') == 'vendor' %}
-              {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+              <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--governance">
+                <summary>{{ 'Console guidance and readiness'|t }}</summary>
+                <div class="mel-vendor-dashboard__details-grid">
+                  {% include '@myeventlane_vendor_theme/includes/mel-vendor-dashboard-governance-stack.html.twig' %}
+                </div>
+              </details>
             {% endif %}
             {{ page.content }}
           </section>
@@ -108,11 +118,13 @@
     <div data-mel-support-root class="mel-vendor-shell__support-mount" aria-live="polite"></div>
 
     {% if is_dashboard_route %}
-      {% include '@myeventlane_vendor_theme/includes/dashboard-mel-support-strip.html.twig' %}
+      <div class="mel-vendor-shell__footer mel-vendor-shell__footer--dashboard">
+        {% include '@myeventlane_vendor_theme/includes/footer-dashboard-light.html.twig' %}
+      </div>
+    {% else %}
+      <div class="mel-vendor-shell__footer">
+        {% include '@myeventlane_vendor_theme/includes/footer-internal.html.twig' %}
+      </div>
     {% endif %}
-
-    <div class="mel-vendor-shell__footer">
-      {% include '@myeventlane_vendor_theme/includes/footer-internal.html.twig' %}
-    </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large Twig/SCSS surface on a primary vendor route; key metrics and CTAs moved behind `<details>`, which can affect discoverability and needs regression on responsive event cards and analytics includes.
> 
> **Overview**
> Restructures the **organiser mission control** dashboard so day-to-day work stays above the fold and reporting moves into **collapsed `<details>`** sections.
> 
> The default view now emphasizes priority action, hero **business snapshot** metrics (replacing chip overview and a separate quick-metrics strip), a **Momentum** highlight, a compact **action queue** for events needing attention, **summary cards** for upcoming events, and a **timeline** for recent signals. **Homepage performance** (readiness, visibility signals, recommendations, per-event cards, boost opportunity) and **Analytics** (conditional insights, grouped overview includes, top events) are no longer inline on first load.
> 
> **Account & settings** absorbs Pro/billing, support strip, onboarding, readiness, secondary actions, promotion guidance, and the full event grid. **Page shell** changes tuck console governance into a collapsible panel on dashboard routes, swap the dashboard footer for a **light footer** (store/payout/links), and remove the old dashboard support-strip placement from the shell.
> 
> **SCSS** adds styling for the new hierarchy (momentum, action queue, summary cards, timeline, homepage visibility, analytics productisation), hero metric board layout, **event grid** attendee-row overrides to fix overlapping actions, plus **`mel-table--compact`**. Analytics component includes pass new grouping/filter keys and top-event rows (requires matching component updates if not in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58bcddf5c1fa78c454635845c74fde0a5a236ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->