### PR TITLE
Fix duplicate homepage surface labels in vendor visibility reports.

### DIFF
--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -82,6 +82,11 @@ final class HomepageMerchandising {
   /**
    * @var list<int>|null
    */
+  private ?array $communitySpotlightEventIds = NULL;
+
+  /**
+   * @var list<int>|null
+   */
   private ?array $moreToDiscoverEventIds = NULL;
 
   /**
@@ -295,6 +300,21 @@ final class HomepageMerchandising {
     $fromView = $this->executeViewResultNids('front_featured_events', 'block_featured');
     $this->featuredBlockEventIds = $fromView !== [] ? $fromView : $this->getSpotlightEventIds();
     return $this->featuredBlockEventIds;
+  }
+
+  /**
+   * Community Spotlight editorial events (block_featured rows 0–2).
+   *
+   * @return list<int>
+   */
+  public function getCommunitySpotlightEventIds(): array {
+    if ($this->communitySpotlightEventIds !== NULL) {
+      return $this->communitySpotlightEventIds;
+    }
+
+    $featured = $this->getFeaturedBlockEventIds();
+    $this->communitySpotlightEventIds = array_values(array_slice($featured, 0, 3));
+    return $this->communitySpotlightEventIds;
   }
 
   /**

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageVisibilityReportService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageVisibilityReportService.php
@@ -46,7 +46,7 @@ final class HomepageVisibilityReportService {
     if (in_array($nid, $this->merchandising->getHeroEventIds(), TRUE)) {
       $surfaces[] = $this->surface('hero', (string) $this->t('Hero'));
     }
-    if (in_array($nid, $this->merchandising->getFeaturedBlockEventIds(), TRUE)) {
+    if (in_array($nid, $this->merchandising->getCommunitySpotlightEventIds(), TRUE)) {
       $surfaces[] = $this->surface('spotlight', (string) $this->t('Community Spotlight'));
     }
     if (in_array($nid, $this->merchandising->getMoreToDiscoverEventIds(), TRUE)) {


### PR DESCRIPTION
Community Spotlight reporting now uses the first three featured-block events only, matching the editorial split used for Worth checking out overflow and preventing double-counted surface labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only merchandising/reporting alignment with no auth, checkout, or data writes; wrong slice would only mislabel vendor-facing homepage placement.
> 
> **Overview**
> Vendor homepage visibility reports no longer treat every **Community Spotlight** / featured-block event as “Community Spotlight” when it also belongs in **Worth checking out**.
> 
> **HomepageMerchandising** gains **`getCommunitySpotlightEventIds()`**, returning only the first three NIDs from the featured block roster—the same editorial slice used before overflow events are assigned to **More to Discover**. **HomepageVisibilityReportService** now uses that helper for the spotlight surface instead of the full featured-block list, so events from index 3 onward are not double-labeled as both Community Spotlight and Worth checking out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9bf84c8b39b50773b0c6c5b1235256cc5e31fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->