### PR TITLE
Complete Event Studio launch hardening and state consistency validation

### DIFF
--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.info.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 lifecycle: stable
 
 dependencies:
+  - myeventlane_event_studio:myeventlane_event_studio
   - myeventlane_vendor:myeventlane_vendor
   - myeventlane_analytics:myeventlane_analytics
   - myeventlane_core:myeventlane_core

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostController.php
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_boost\Form\BoostSelectForm;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
+use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_vendor\Service\VendorEventTabsService;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,6 +42,7 @@ final class BoostController extends ControllerBase {
     FormBuilderInterface $formBuilder,
     private readonly VendorEventTabsService $eventTabsService,
     private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
+    private readonly EventReadinessFacade $readinessFacade,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->formBuilder = $formBuilder;
@@ -55,6 +57,7 @@ final class BoostController extends ControllerBase {
       $container->get('form_builder'),
       $container->get('myeventlane_vendor.service.event_tabs'),
       $container->get('myeventlane_event.featured_readiness_render'),
+      $container->get('myeventlane_event_studio.readiness_facade'),
     );
   }
 
@@ -208,11 +211,7 @@ final class BoostController extends ControllerBase {
       '#edit_url' => $editUrl?->toString(),
       '#vendor_workspace' => $vendor_workspace,
       '#form' => $body,
-      '#homepage_readiness' => $this->homepageReadinessRender->buildChecklistCard(
-        $node,
-        TRUE,
-        TRUE,
-      ),
+      '#homepage_readiness' => $this->buildHomepageReadinessCard($node),
       '#attached' => [
         'library' => ['myeventlane_boost/boost'],
       ],
@@ -426,6 +425,21 @@ final class BoostController extends ControllerBase {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Homepage promotion readiness card via the shared readiness facade.
+   *
+   * @return array<string, mixed>
+   */
+  private function buildHomepageReadinessCard(NodeInterface $node): array {
+    $bundle = $this->readinessFacade->evaluate($node, $this->currentUser());
+    return $this->homepageReadinessRender->buildChecklistCardFromPresentation(
+      $node,
+      is_array($bundle['promotion'] ?? NULL) ? $bundle['promotion'] : [],
+      TRUE,
+      TRUE,
+    );
   }
 
 }

--- a/web/modules/custom/myeventlane_boost/src/Controller/BoostPurchaseSuccessController.php
+++ b/web/modules/custom/myeventlane_boost/src/Controller/BoostPurchaseSuccessController.php
@@ -12,6 +12,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_boost\Service\BoostPurchaseSuccessResolver;
 use Drupal\myeventlane_event\Service\BoostedEventQualityGate;
 use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
+use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,6 +33,7 @@ final class BoostPurchaseSuccessController extends ControllerBase {
     private readonly BoostStatusService $boostStatusService,
     private readonly BoostedEventQualityGate $qualityGate,
     private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
+    private readonly EventReadinessFacade $readinessFacade,
   ) {
     $this->entityTypeManager = $entityTypeManager;
   }
@@ -46,6 +48,7 @@ final class BoostPurchaseSuccessController extends ControllerBase {
       $container->get('myeventlane_vendor.service.boost_status'),
       $container->get('myeventlane_event.boosted_quality_gate'),
       $container->get('myeventlane_event.featured_readiness_render'),
+      $container->get('myeventlane_event_studio.readiness_facade'),
     );
   }
 
@@ -90,11 +93,7 @@ final class BoostPurchaseSuccessController extends ControllerBase {
       '#workspace_url' => $workspace_url,
       '#event_url' => $event_url,
       '#analytics_url' => $analytics_url,
-      '#homepage_readiness' => $this->homepageReadinessRender->buildChecklistCard(
-        $event,
-        TRUE,
-        TRUE,
-      ),
+      '#homepage_readiness' => $this->buildHomepageReadinessCard($event, $account),
       '#attached' => [
         'library' => ['myeventlane_boost/boost_purchase_success'],
         'drupalSettings' => [
@@ -164,6 +163,21 @@ final class BoostPurchaseSuccessController extends ControllerBase {
     catch (\Throwable) {
       return '';
     }
+  }
+
+  /**
+   * Homepage promotion readiness card via the shared readiness facade.
+   *
+   * @return array<string, mixed>
+   */
+  private function buildHomepageReadinessCard(NodeInterface $event, AccountInterface $account): array {
+    $bundle = $this->readinessFacade->evaluate($event, $account);
+    return $this->homepageReadinessRender->buildChecklistCardFromPresentation(
+      $event,
+      is_array($bundle['promotion'] ?? NULL) ? $bundle['promotion'] : [],
+      TRUE,
+      TRUE,
+    );
   }
 
 }

--- a/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDisplayReadinessConsolidationTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Unit/BoostDisplayReadinessConsolidationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Contract tests for boost display readiness facade consolidation.
+ *
+ * @group myeventlane_boost
+ */
+final class BoostDisplayReadinessConsolidationTest extends UnitTestCase {
+
+  public function testBoostControllersUseReadinessFacadeForHomepageCard(): void {
+    $boost = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/BoostController.php');
+    $success = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/BoostPurchaseSuccessController.php');
+    $info = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_boost.info.yml');
+
+    $this->assertIsString($boost);
+    $this->assertIsString($success);
+    $this->assertIsString($info);
+    $this->assertStringContainsString('EventReadinessFacade', $boost);
+    $this->assertStringContainsString('buildChecklistCardFromPresentation', $boost);
+    $this->assertStringNotContainsString('buildChecklistCard(', $boost);
+    $this->assertStringContainsString('EventReadinessFacade', $success);
+    $this->assertStringContainsString('buildChecklistCardFromPresentation', $success);
+    $this->assertStringNotContainsString('buildChecklistCard(', $success);
+    $this->assertStringContainsString('myeventlane_event_studio:myeventlane_event_studio', $info);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/css/mel-homepage-readiness.css
+++ b/web/modules/custom/myeventlane_event/css/mel-homepage-readiness.css
@@ -10,6 +10,21 @@
   padding: 0.875rem 1rem;
 }
 
+.mel-homepage-readiness--summary-only {
+  padding: 0.75rem 1rem;
+}
+
+.mel-homepage-readiness--summary-only .mel-homepage-readiness__title {
+  margin-bottom: 0.25rem;
+  font-size: 0.9375rem;
+}
+
+.mel-homepage-readiness--summary-only .mel-homepage-readiness__intro,
+.mel-homepage-readiness--summary-only .mel-homepage-readiness__status {
+  margin-bottom: 0;
+  font-size: 0.875rem;
+}
+
 .mel-homepage-readiness.is-ready {
   border-color: #bbf7d0;
   background: #f0fdf4;

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -100,6 +100,8 @@ function myeventlane_event_theme($existing, $type, $theme, $path) {
         'presentation' => [],
         'compact' => TRUE,
         'show_spotlight_notice' => FALSE,
+        'summary_only' => FALSE,
+        'hide_published_item' => FALSE,
       ],
       'template' => 'mel-homepage-readiness-checklist',
     ],

--- a/web/modules/custom/myeventlane_event/src/Service/FeaturedEventReadinessRenderBuilder.php
+++ b/web/modules/custom/myeventlane_event/src/Service/FeaturedEventReadinessRenderBuilder.php
@@ -28,13 +28,37 @@ final class FeaturedEventReadinessRenderBuilder {
    * @return array<string, mixed>
    */
   public function buildChecklistCard(NodeInterface $event, bool $compact = TRUE, bool $show_spotlight_notice = FALSE): array {
-    $presentation = $this->readinessService->getPresentation($event);
+    return $this->buildChecklistCardFromPresentation(
+      $event,
+      $this->readinessService->getPresentation($event),
+      $compact,
+      $show_spotlight_notice,
+    );
+  }
 
+  /**
+   * Checklist card from an existing presentation payload (avoids duplicate evaluation).
+   *
+   * @param array<string, mixed> $presentation
+   *   Payload from FeaturedEventReadinessService::getPresentation().
+   *
+   * @return array<string, mixed>
+   */
+  public function buildChecklistCardFromPresentation(
+    NodeInterface $event,
+    array $presentation,
+    bool $compact = TRUE,
+    bool $show_spotlight_notice = FALSE,
+    bool $summary_only = FALSE,
+    bool $hide_published_item = FALSE,
+  ): array {
     return [
       '#theme' => 'mel_homepage_readiness_checklist',
       '#presentation' => $presentation,
       '#compact' => $compact,
       '#show_spotlight_notice' => $show_spotlight_notice,
+      '#summary_only' => $summary_only,
+      '#hide_published_item' => $hide_published_item,
       '#cache' => [
         'tags' => $event->getCacheTags(),
         'contexts' => ['languages:language_interface'],
@@ -68,17 +92,26 @@ final class FeaturedEventReadinessRenderBuilder {
       }
     }
 
+    return $this->buildDashboardSummaryFromCounts(count($boosted_events), $ready, $needs_attention);
+  }
+
+  /**
+   * Dashboard summary from precomputed promotion readiness counts.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildDashboardSummaryFromCounts(int $total_boosted, int $ready_count, int $needs_attention_count): array {
     return [
       '#theme' => 'mel_homepage_readiness_dashboard_summary',
       '#heading' => (string) $this->t('Homepage Readiness'),
-      '#total_boosted' => count($boosted_events),
-      '#ready_count' => $ready,
-      '#needs_attention_count' => $needs_attention,
-      '#status_label' => $needs_attention === 0
-        ? (string) $this->t('All boosted events are homepage ready')
-        : (string) $this->t('@ready ready, @attention need attention', [
-          '@ready' => $ready,
-          '@attention' => $needs_attention,
+      '#total_boosted' => $total_boosted,
+      '#ready_count' => $ready_count,
+      '#needs_attention_count' => $needs_attention_count,
+      '#status_label' => $needs_attention_count === 0
+        ? (string) $this->t('All boosted events are ready for homepage promotion')
+        : (string) $this->t('@ready ready for promotion, @attention need attention', [
+          '@ready' => $ready_count,
+          '@attention' => $needs_attention_count,
         ]),
       '#cache' => [
         'max-age' => 0,

--- a/web/modules/custom/myeventlane_event/templates/mel-homepage-readiness-checklist.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-homepage-readiness-checklist.html.twig
@@ -7,13 +7,15 @@
  * - presentation: Payload from FeaturedEventReadinessService::getPresentation().
  * - compact: Whether to use compact spacing.
  * - show_spotlight_notice: Show Community Spotlight eligibility note.
+ * - summary_only: Status headline only; hide checklist rows.
+ * - hide_published_item: Omit the published row when publish state is shown elsewhere.
  */
 #}
 {% set presentation = presentation|default({}) %}
 {% set items = presentation.items|default([]) %}
 {% set ready = presentation.ready|default(false) %}
 <section
-  class="mel-homepage-readiness{% if compact %} mel-homepage-readiness--compact{% endif %}{% if ready %} is-ready{% else %} needs-attention{% endif %}"
+  class="mel-homepage-readiness{% if compact %} mel-homepage-readiness--compact{% endif %}{% if summary_only %} mel-homepage-readiness--summary-only{% endif %}{% if ready %} is-ready{% else %} needs-attention{% endif %}"
   aria-labelledby="mel-homepage-readiness-title"
   role="region"
 >
@@ -26,16 +28,20 @@
   <p class="mel-homepage-readiness__status">
     <strong>{{ presentation.status_label|default('') }}</strong>
   </p>
-  <ul class="mel-homepage-readiness__list" aria-label="{{ 'Homepage readiness checklist'|t }}">
-    {% for item in items %}
-      <li class="mel-homepage-readiness__item{% if item.complete %} is-complete{% else %} is-incomplete{% endif %}">
-        <span class="mel-homepage-readiness__mark" aria-hidden="true">{% if item.complete %}✓{% else %}✗{% endif %}</span>
-        <span class="mel-homepage-readiness__label">
-          {{ item.complete ? item.label : item.label_incomplete }}
-        </span>
-      </li>
-    {% endfor %}
-  </ul>
+  {% if not summary_only %}
+    <ul class="mel-homepage-readiness__list" aria-label="{{ 'Homepage readiness checklist'|t }}">
+      {% for item in items %}
+        {% if not (hide_published_item|default(false) and item.item_key|default('') == 'published') %}
+          <li class="mel-homepage-readiness__item{% if item.complete %} is-complete{% else %} is-incomplete{% endif %}">
+            <span class="mel-homepage-readiness__mark" aria-hidden="true">{% if item.complete %}✓{% else %}✗{% endif %}</span>
+            <span class="mel-homepage-readiness__label">
+              {{ item.complete ? item.label : item.label_incomplete }}
+            </span>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  {% endif %}
   {% if show_spotlight_notice and not ready %}
     <p class="mel-homepage-readiness__notice">{{ presentation.spotlight_notice|default('') }}</p>
   {% endif %}

--- a/web/modules/custom/myeventlane_event/templates/mel-homepage-readiness-dashboard-summary.html.twig
+++ b/web/modules/custom/myeventlane_event/templates/mel-homepage-readiness-dashboard-summary.html.twig
@@ -18,7 +18,7 @@
       <dd>{{ total_boosted|default(0) }}</dd>
     </div>
     <div class="mel-homepage-readiness__stat">
-      <dt>{{ 'Ready'|t }}</dt>
+      <dt>{{ 'Ready for promotion'|t }}</dt>
       <dd>{{ ready_count|default(0) }}</dd>
     </div>
     <div class="mel-homepage-readiness__stat">

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2186,6 +2186,117 @@
   min-height: 44px;
 }
 
+.mel-event-studio-topbar__status-action {
+  font-weight: 700;
+  opacity: 0.88;
+  pointer-events: none;
+}
+
+.mel-event-studio--workspace > .mel-event-studio-readiness-strip,
+.mel-event-studio--workspace > .mel-event-studio-homepage-readiness,
+.mel-event-studio--workspace > .mel-boost-active-banner,
+.mel-event-studio--workspace > .mel-event-studio-event-health {
+  margin-bottom: 16px;
+}
+
+.mel-event-studio-event-health {
+  padding: 12px 16px;
+  border: 1px solid #e8e8ef;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.mel-event-studio-event-health__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.mel-event-studio-event-health__title {
+  margin: 0;
+  font-family: 'Nunito', system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 750;
+  line-height: 1.3;
+  color: #0f172a;
+}
+
+.mel-event-studio-event-health__updated {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: #64748b;
+}
+
+.mel-event-studio-event-health__list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.mel-event-studio-event-health__item {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+.mel-event-studio-event-health__item--ready {
+  background: #f0fdf4;
+}
+
+.mel-event-studio-event-health__item--attention {
+  background: #fff7f7;
+}
+
+.mel-event-studio-event-health__item--active {
+  background: #faf5ff;
+}
+
+.mel-event-studio-event-health__label {
+  margin: 0 0 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.mel-event-studio-event-health__value {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: #0f172a;
+}
+
+.mel-event-studio-event-health__detail {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.mel-event-studio-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 4px 0 0;
+}
+
+.mel-event-studio-overview .item-list__title {
+  margin: 0 0 8px;
+  color: #0f172a;
+  font-size: 0.95rem;
+  font-weight: 750;
+}
+
 .mel-event-studio-topbar__manage-event {
   white-space: nowrap;
 }
@@ -2334,6 +2445,12 @@
 
 .mel-event-studio-sidebar__link.is-active {
   box-shadow: inset 4px 0 0 #f26d5b, 0 8px 18px rgba(242, 109, 91, 0.1);
+  font-weight: 750;
+}
+
+.mel-event-studio-sidebar__link:focus-visible {
+  outline: 2px solid #f26d5b;
+  outline-offset: 2px;
 }
 
 .mel-event-studio-sidebar__guidance,
@@ -2854,6 +2971,10 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 10px;
+  }
+
+  .mel-event-studio-event-health__list {
+    grid-template-columns: 1fr;
   }
 
   .mel-event-studio-workspace {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -202,18 +202,74 @@
     if (!readiness) {
       return;
     }
+    const published = shell.dataset.melPublished === '1' || !!studioSettings().published;
+    const hasBlockers = (readiness.errors || []).length > 0 || (readiness.warnings || []).length > 0;
+    const showStrip = readiness.show_publish_strip !== undefined
+      ? !!readiness.show_publish_strip
+      : (!published || !readiness.ready || hasBlockers);
     const strip = shell.querySelector('[data-mel-readiness-strip]');
     if (!strip) {
       return;
     }
+    strip.hidden = !showStrip;
+    if (!showStrip) {
+      return;
+    }
     strip.classList.toggle('is-ready', !!readiness.ready);
     strip.classList.toggle('needs-attention', !readiness.ready);
-    setText(strip, '[data-mel-readiness-title]', readiness.ready ? Drupal.t('Ready to publish') : Drupal.t('Needs attention'));
+    const title = readiness.strip_title
+      || (readiness.ready
+        ? (published ? Drupal.t('Published and ready') : Drupal.t('Ready to publish'))
+        : Drupal.t('Needs attention'));
+    setText(strip, '[data-mel-readiness-title]', title);
     setText(strip, '[data-mel-readiness-state]', readiness.state || '');
     setText(strip, '[data-mel-readiness-errors-count]', Drupal.formatPlural((readiness.errors || []).length, '1 blocker', '@count blocker(s)'));
     setText(strip, '[data-mel-readiness-warnings-count]', Drupal.formatPlural((readiness.warnings || []).length, '1 warning', '@count warning(s)'));
     setText(strip, '[data-mel-readiness-recommendations-count]', Drupal.formatPlural((readiness.recommendations || []).length, '1 idea', '@count idea(s)'));
     setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
+  }
+
+  function syncHomepageReadinessVisibility(shell, showHomepageReadiness) {
+    const wrapper = shell.querySelector('.mel-event-studio-homepage-readiness');
+    if (!wrapper) {
+      return;
+    }
+    wrapper.hidden = showHomepageReadiness === false;
+  }
+
+  function updateEventHealth(shell, health) {
+    if (!health || !Array.isArray(health.items)) {
+      return;
+    }
+    const panel = shell.querySelector('[data-mel-event-health]');
+    if (!panel) {
+      return;
+    }
+    if (health.last_updated) {
+      setText(panel, '[data-mel-event-health-updated]', health.last_updated);
+    }
+    health.items.forEach((item) => {
+      if (!item || !item.key) {
+        return;
+      }
+      setText(panel, `[data-mel-event-health-value="${item.key}"]`, item.value || '');
+      const detailEl = panel.querySelector(`[data-mel-event-health-detail="${item.key}"]`);
+      if (detailEl) {
+        if (item.detail) {
+          detailEl.textContent = item.detail;
+          detailEl.hidden = false;
+        }
+        else {
+          detailEl.textContent = '';
+          detailEl.hidden = true;
+        }
+      }
+      const row = panel.querySelector(`[data-mel-event-health-row="${item.key}"]`);
+      if (row && item.tone) {
+        row.className = `mel-event-studio-event-health__item mel-event-studio-event-health__item--${item.tone}`;
+        row.setAttribute('data-mel-event-health-row', item.key);
+      }
+    });
   }
 
   function syncTopbarState(shell, stateText) {
@@ -245,6 +301,10 @@
     if (!result || !result.topbar) {
       return;
     }
+    if (result.published !== undefined) {
+      studioSettings().published = !!result.published;
+      shell.dataset.melPublished = result.published ? '1' : '0';
+    }
     setText(shell, '[data-mel-publish-status]', result.topbar.status || '');
     syncTopbarState(shell, result.topbar.state || '');
     setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
@@ -266,6 +326,12 @@
     const button = shell.querySelector('[data-mel-publish-action]');
     if (button) {
       setPublishButtonState(button, result.published ? 'published' : 'idle');
+    }
+    if (result.event_health) {
+      updateEventHealth(shell, result.event_health);
+    }
+    if (result.readiness && result.readiness.show_homepage_readiness !== undefined) {
+      syncHomepageReadinessVisibility(shell, result.readiness.show_homepage_readiness);
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -50,6 +50,7 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'current_section_metadata' => [],
         'section_content' => NULL,
         'topbar' => [],
+        'event_health' => [],
         'readiness' => [],
         'homepage_readiness' => NULL,
         'boost' => NULL,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -8,7 +8,7 @@ services:
       - '@request_stack'
       - '@myeventlane_vendor.event_access_checker'
       - '@date.formatter'
-      - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.readiness_facade'
       - '@myeventlane_event_studio.autosave'
       - '@plugin.manager.myeventlane_event_studio_section'
       - '@myeventlane_event_studio.section_renderer'
@@ -17,8 +17,16 @@ services:
       - '@myeventlane_event_studio.preprocess'
       - '@myeventlane_vendor.service.boost_status'
       - '@myeventlane_event.featured_readiness_render'
+      - '@myeventlane_event_studio.workspace_presentation'
+      - '@myeventlane_boost.extension_recommendation'
     tags:
       - { name: controller.service_arguments }
+
+  myeventlane_event_studio.workspace_presentation:
+    class: Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation
+    arguments:
+      - '@date.formatter'
+      - '@string_translation'
 
   myeventlane_event_studio.preprocess:
     class: Drupal\myeventlane_event_studio\EventStudioPreprocess
@@ -385,6 +393,15 @@ services:
       - '@myeventlane_event_studio.event_style_access'
       - '@entity_type.manager'
 
+  myeventlane_event_studio.publish_eligibility:
+    class: Drupal\myeventlane_event_studio\Service\PublishEligibilityEvaluator
+    arguments:
+      - '@myeventlane_vendor.publish_requirements_gate'
+      - '@myeventlane_vendor.paid_publish_stripe_gate'
+      - '@myeventlane_event_studio.readiness'
+      - '@logger.channel.myeventlane_event_studio'
+      - '@string_translation'
+
   myeventlane_event_studio.save:
     class: Drupal\myeventlane_event_studio\Service\EventStudioSaveService
     arguments:
@@ -392,9 +409,7 @@ services:
       - '@myeventlane_venue.manager'
       - '@logger.channel.myeventlane_event_studio'
       - '@myeventlane_event_studio.highlight_helper'
-      - '@myeventlane_vendor.paid_publish_stripe_gate'
-      - '@myeventlane_vendor.publish_requirements_gate'
-      - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.publish_eligibility'
       - '@myeventlane_event_studio.question_field_type_registry'
       - '@image.factory'
       - '@string_translation'
@@ -475,6 +490,9 @@ services:
     arguments:
       - '@myeventlane_event_studio.save'
       - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.readiness_facade'
+      - '@myeventlane_event_studio.workspace_presentation'
+      - '@myeventlane_vendor.service.boost_status'
       - '@myeventlane_event_studio.autosave'
       - '@plugin.manager.myeventlane_event_studio_section'
       - '@myeventlane_vendor.event_access_checker'

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -17,7 +17,8 @@ use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
-use Drupal\myeventlane_event_studio\Service\EventReadinessService;
+use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
 use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
 use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
@@ -45,7 +46,7 @@ final class EventStudioController extends ControllerBase {
     private readonly RequestStack $requestStack,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
     private readonly DateFormatterInterface $dateFormatter,
-    private readonly EventReadinessService $eventReadiness,
+    private readonly EventReadinessFacade $readinessFacade,
     private readonly EventStudioAutosaveService $autosaveService,
     private readonly EventStudioSectionManager $sectionManager,
     private readonly EventStudioSectionRenderer $sectionRenderer,
@@ -54,6 +55,7 @@ final class EventStudioController extends ControllerBase {
     private readonly EventStudioPreprocess $eventStudioPreprocess,
     private readonly BoostStatusService $boostStatusService,
     private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
+    private readonly EventStudioWorkspacePresentation $workspacePresentation,
     private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
@@ -67,7 +69,7 @@ final class EventStudioController extends ControllerBase {
       $container->get('request_stack'),
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('date.formatter'),
-      $container->get('myeventlane_event_studio.readiness'),
+      $container->get('myeventlane_event_studio.readiness_facade'),
       $container->get('myeventlane_event_studio.autosave'),
       $container->get('plugin.manager.myeventlane_event_studio_section'),
       $container->get('myeventlane_event_studio.section_renderer'),
@@ -76,6 +78,7 @@ final class EventStudioController extends ControllerBase {
       $container->get('myeventlane_event_studio.preprocess'),
       $container->get('myeventlane_vendor.service.boost_status'),
       $container->get('myeventlane_event.featured_readiness_render'),
+      $container->get('myeventlane_event_studio.workspace_presentation'),
       $container->get('myeventlane_boost.extension_recommendation'),
     );
   }
@@ -206,7 +209,8 @@ final class EventStudioController extends ControllerBase {
       throw new AccessDeniedHttpException();
     }
 
-    $readiness = $this->eventReadiness->evaluate($node, $account);
+    $readiness_bundle = $this->readinessFacade->evaluate($node, $account);
+    $readiness = $readiness_bundle['publish'];
     $sectionMetadata = $this->sectionManager->sectionMetadata($sectionPlugin);
     $sectionContent = $this->buildWorkspaceSectionContent($sectionPlugin, $node);
     $request = $this->requestStack->getCurrentRequest();
@@ -235,6 +239,9 @@ final class EventStudioController extends ControllerBase {
       '@keys' => is_array($sectionContent) ? implode(',', array_keys($sectionContent)) : gettype($sectionContent),
     ]);
 
+    $readiness_summary = $this->workspacePresentation->buildReadinessSummary($readiness_bundle, $node);
+    $event_health = $this->workspacePresentation->buildEventHealth($readiness_bundle, $node, $boost);
+
     return [
       '#theme' => 'mel_event_studio_workspace',
       '#node' => $node,
@@ -245,8 +252,9 @@ final class EventStudioController extends ControllerBase {
       '#current_section_metadata' => $sectionMetadata,
       '#section_content' => $sectionContent,
       '#topbar' => $this->buildTopbar($node, $readiness, $section),
-      '#readiness' => $this->buildReadinessSummary($readiness),
-      '#homepage_readiness' => $this->homepageReadinessRender->buildChecklistCard($node, TRUE, TRUE),
+      '#event_health' => $event_health,
+      '#readiness' => $readiness_summary,
+      '#homepage_readiness' => $this->buildHomepageReadinessCard($node, $readiness_bundle, $section),
       '#boost' => $boost,
       '#boost_extension_recommendation' => $boost_extension_recommendation,
       '#publish_handoff' => $publish_handoff,
@@ -334,7 +342,7 @@ final class EventStudioController extends ControllerBase {
    * @return array<string, mixed>
    */
   private function buildTopbar(NodeInterface $node, EventReadinessResult $readiness, string $section): array {
-    $operational_state = $this->operationalState($readiness);
+    $operational_state = $this->workspacePresentation->operationalState($readiness);
     // Published events use the status badge only; readiness text is draft-oriented.
     $state = ($node->isPublished() && $readiness->ready) ? '' : $operational_state;
 
@@ -342,9 +350,7 @@ final class EventStudioController extends ControllerBase {
       'title' => $node->label(),
       'status' => $node->isPublished() ? $this->t('Published') : $this->t('Draft'),
       'state' => $state,
-      'last_saved' => $node->getChangedTime() > 0 ? $this->t('Last saved @time', [
-        '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
-      ]) : $this->t('Not saved yet'),
+      'show_last_saved' => FALSE,
       'restore_draft' => $this->autosaveService->hasDraft($node, $section),
       'restore_url' => Url::fromRoute($this->sectionManager->sectionRouteName($section), [
         'node' => $node->id(),
@@ -363,25 +369,24 @@ final class EventStudioController extends ControllerBase {
     ];
   }
 
-  /**
-   * @return array{ready: bool, errors: list<string>, warnings: list<string>, completed: list<string>, recommendations: list<string>, state: string}
-   */
-  private function buildReadinessSummary(EventReadinessResult $result): array {
-    return [
-      'ready' => $result->ready,
-      'errors' => $result->errors,
-      'warnings' => $result->warnings,
-      'completed' => $result->completed,
-      'recommendations' => $result->recommendations,
-      'state' => $this->operationalState($result),
-    ];
-  }
-
-  private function operationalState(EventReadinessResult $result): string {
-    if (!$result->ready) {
-      return (string) $this->t('Needs Attention');
+  private function buildHomepageReadinessCard(NodeInterface $node, array $readiness_bundle, string $section): ?array {
+    $promotion_ready = (bool) ($readiness_bundle['promotion_ready'] ?? FALSE);
+    $published = $node->isPublished();
+    if (!$this->workspacePresentation->shouldShowHomepageReadinessCard($promotion_ready, $published)) {
+      return NULL;
     }
-    return (string) $this->t('Ready');
+    if ($section !== 'overview' && $promotion_ready) {
+      return NULL;
+    }
+
+    return $this->homepageReadinessRender->buildChecklistCardFromPresentation(
+      $node,
+      is_array($readiness_bundle['promotion'] ?? NULL) ? $readiness_bundle['promotion'] : [],
+      TRUE,
+      !$promotion_ready,
+      FALSE,
+      $published,
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceRefreshController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioGovernanceRefreshController.php
@@ -77,15 +77,30 @@ final class EventStudioGovernanceRefreshController {
       }
     }
 
-    $delta_bundle = $this->governanceBuilder->buildDeltaPayload($node, $baseline);
-    $response = new JsonResponse([
-      'ok' => TRUE,
-      'governance_enabled' => $delta_bundle['governance_enabled'],
-      'unchanged' => $delta_bundle['unchanged'],
-      'delta' => $delta_bundle['delta'],
-    ]);
-    $response->headers->set('Cache-Control', 'private, no-store');
-    return $response;
+    try {
+      $delta_bundle = $this->governanceBuilder->buildDeltaPayload($node, $baseline);
+      $response = new JsonResponse([
+        'ok' => TRUE,
+        'governance_enabled' => $delta_bundle['governance_enabled'],
+        'unchanged' => $delta_bundle['unchanged'],
+        'delta' => $delta_bundle['delta'],
+      ]);
+      $response->headers->set('Cache-Control', 'private, no-store');
+      return $response;
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio governance refresh failed nid=@nid uid=@uid: @message', [
+        '@nid' => (string) $node->id(),
+        '@uid' => (string) $account->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $response = new JsonResponse([
+        'ok' => FALSE,
+        'message' => 'Governance refresh failed. Try again shortly.',
+      ], 500);
+      $response->headers->set('Cache-Control', 'private, no-store');
+      return $response;
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -12,9 +12,12 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\EventStudioPreprocess;
 use Drupal\myeventlane_event_studio\EventStudioSectionManager;
+use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -33,6 +36,9 @@ final class EventStudioPublishController {
   public function __construct(
     private readonly EventStudioSaveService $saveService,
     private readonly EventReadinessService $eventReadiness,
+    private readonly EventReadinessFacade $readinessFacade,
+    private readonly EventStudioWorkspacePresentation $workspacePresentation,
+    private readonly BoostStatusService $boostStatusService,
     private readonly EventStudioAutosaveService $autosaveService,
     private readonly EventStudioSectionManager $sectionManager,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
@@ -110,19 +116,6 @@ final class EventStudioPublishController {
 
     if (!$publishing) {
       return $this->setPublishedState($node, FALSE);
-    }
-
-    $readiness = $this->eventReadiness->evaluate($node, $account);
-    if (!$readiness->ready) {
-      return $this->readinessResponse(
-        FALSE,
-        422,
-        $node,
-        $readiness,
-        (string) $this->t('Cannot publish yet'),
-        'cannot_publish',
-        $readiness->errors,
-      );
     }
 
     return $this->setPublishedState($node, TRUE);
@@ -246,6 +239,14 @@ final class EventStudioPublishController {
     array $messages,
     ?string $restoreSection = NULL,
   ): JsonResponse {
+    $readiness_bundle = $this->readinessFacade->evaluate($node, $this->currentUser);
+    $publish_result = $readiness_bundle['publish'];
+    $boost = $this->buildBoostHealthPayload($node);
+    $ajax_readiness = $this->workspacePresentation->buildAjaxReadinessPayloadFromBundle(
+      $readiness_bundle,
+      $node,
+    );
+
     $payload = [
       'ok' => $ok,
       'state' => $state,
@@ -254,21 +255,15 @@ final class EventStudioPublishController {
       'published' => $node->isPublished(),
       'topbar' => [
         'status' => $node->isPublished() ? (string) $this->t('Published') : (string) $this->t('Draft'),
-        'state' => ($node->isPublished() && $readiness->ready)
+        'state' => ($node->isPublished() && $publish_result->ready)
           ? ''
-          : $this->operationalState($readiness),
+          : $this->workspacePresentation->operationalState($publish_result),
         'lastSaved' => $node->getChangedTime() > 0 ? (string) $this->t('Last saved @time', [
           '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
         ]) : (string) $this->t('Not saved yet'),
       ],
-      'readiness' => [
-        'ready' => $readiness->ready,
-        'errors' => $readiness->errors,
-        'warnings' => $readiness->warnings,
-        'completed' => $readiness->completed,
-        'recommendations' => $readiness->recommendations,
-        'state' => $this->operationalState($readiness),
-      ],
+      'readiness' => $ajax_readiness,
+      'event_health' => $this->workspacePresentation->buildEventHealth($readiness_bundle, $node, $boost),
       'changed' => $node->getChangedTime(),
       'revisionId' => (int) $node->getRevisionId(),
     ];
@@ -292,11 +287,19 @@ final class EventStudioPublishController {
     return new JsonResponse($payload, $status);
   }
 
-  private function operationalState(EventReadinessResult $result): string {
-    if (!$result->ready) {
-      return (string) $this->t('Needs Attention');
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildBoostHealthPayload(NodeInterface $node): ?array {
+    $visibility = $this->boostStatusService->getVisibilityPayload($node);
+    if (empty($visibility['active'])) {
+      return NULL;
     }
-    return (string) $this->t('Ready');
+    return [
+      'active' => TRUE,
+      'days_remaining' => $visibility['days_remaining'],
+      'expires' => $visibility['expires'],
+    ];
   }
 
   private function blockedHeading(bool $publishing): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -132,9 +132,12 @@ final class EventBrandingForm extends EventStudioBaseForm {
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
     $this->ensureInjectedServices();
+    $nid = (int) ($form_state->getValue('nid') ?? 0);
+    if ($nid > 0) {
+      $this->saveService->prepareBrandingHeroFormStateForValidation($form_state);
+    }
     parent::validateForm($form, $form_state);
 
-    $nid = (int) ($form_state->getValue('nid') ?? 0);
     if ($nid < 1) {
       return;
     }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -28,8 +28,6 @@ use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager;
 use Drupal\myeventlane_venue\Entity\Venue;
 use Drupal\myeventlane_venue\Service\VenueManager;
-use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
-use Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Psr\Log\LoggerInterface;
@@ -61,9 +59,7 @@ final class EventStudioSaveService {
     private readonly VenueManager $venueManager,
     private readonly LoggerInterface $logger,
     private readonly EventHighlightHelper $eventHighlightHelper,
-    private readonly PaidPublishStripeGate $paidPublishStripeGate,
-    private readonly VendorPublishRequirementsGate $publishRequirementsGate,
-    private readonly EventReadinessService $eventReadiness,
+    private readonly PublishEligibilityEvaluator $publishEligibilityEvaluator,
     private readonly QuestionFieldTypeRegistry $fieldTypeRegistry,
     private readonly ImageFactory $imageFactory,
     private readonly TranslationInterface $stringTranslation,
@@ -87,12 +83,6 @@ final class EventStudioSaveService {
   public function save(array $payload, ?NodeInterface $node, AccountInterface $account, bool $draft = FALSE): array {
     $payload = $this->resolvePayloadTitle($payload, $node);
 
-    $effectiveEventType = isset($payload['field_event_type'])
-      ? (string) $payload['field_event_type']
-      : ($node instanceof NodeInterface && $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()
-        ? (string) $node->get('field_event_type')->value
-        : 'rsvp');
-
     $willPublish = FALSE;
     if (!$draft) {
       if ($node === NULL) {
@@ -100,23 +90,6 @@ final class EventStudioSaveService {
       }
       else {
         $willPublish = (bool) ($payload['status'] ?? TRUE);
-      }
-    }
-
-    if (!$draft && $willPublish) {
-      $denials = $this->publishRequirementsGate->getLivePublishDenialReasons($account);
-      if ($denials !== []) {
-        return ['node' => NULL, 'errors' => $denials];
-      }
-    }
-
-    if (!$draft && $willPublish && in_array($effectiveEventType, ['paid', 'both'], TRUE)) {
-      $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed(
-        $account,
-        $node instanceof NodeInterface ? (int) $node->id() : NULL,
-      );
-      if ($stripeMsg !== NULL) {
-        return ['node' => NULL, 'errors' => [$stripeMsg]];
       }
     }
 
@@ -302,9 +275,9 @@ final class EventStudioSaveService {
     }
 
     if (!$draft && $willPublish) {
-      $readiness = $this->eventReadiness->evaluate($node, $account);
-      if (!$readiness->ready) {
-        return ['node' => NULL, 'errors' => $readiness->errors];
+      $eligibility = $this->publishEligibilityEvaluator->evaluate($node, $account);
+      if (!$eligibility['allowed']) {
+        return ['node' => NULL, 'errors' => $eligibility['messages']];
       }
     }
 
@@ -503,22 +476,9 @@ final class EventStudioSaveService {
       throw new \InvalidArgumentException('Expected event node.');
     }
     if ($published) {
-      $denials = $this->publishRequirementsGate->getLivePublishDenialReasons($account);
-      if ($denials !== []) {
-        throw new \InvalidArgumentException(implode(' ', $denials));
-      }
-      $eventType = $node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()
-        ? (string) $node->get('field_event_type')->value
-        : 'rsvp';
-      if (in_array($eventType, ['paid', 'both'], TRUE)) {
-        $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed($account, (int) $node->id());
-        if ($stripeMsg !== NULL) {
-          throw new \InvalidArgumentException($stripeMsg);
-        }
-      }
-      $readiness = $this->eventReadiness->evaluate($node, $account);
-      if (!$readiness->ready) {
-        throw new \InvalidArgumentException(implode(' ', $readiness->errors));
+      $eligibility = $this->publishEligibilityEvaluator->evaluate($node, $account);
+      if (!$eligibility['allowed']) {
+        throw new \InvalidArgumentException(implode(' ', $eligibility['messages']));
       }
     }
     $node->setPublished($published);
@@ -1294,6 +1254,16 @@ final class EventStudioSaveService {
   }
 
   /**
+   * Syncs branding hero widget input before form validation.
+   *
+   * image_widget_crop AJAX can leave crop_applied only in user input; element
+   * validators read form_state values and would falsely reject an applied crop.
+   */
+  public function prepareBrandingHeroFormStateForValidation(FormStateInterface $form_state): void {
+    $this->syncBrandingHeroSubmittedValues($form_state);
+  }
+
+  /**
    * Copies hero widget values from raw user input when Form API values are stale.
    *
    * image_widget_crop AJAX handlers can leave fids / crop / focal point in user input
@@ -1436,7 +1406,8 @@ final class EventStudioSaveService {
     $delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($field_fragment);
     return array_key_exists('fids', $delta)
       || array_key_exists('focal_point', $delta)
-      || array_key_exists('image_crop', $delta);
+      || array_key_exists('image_crop', $delta)
+      || $this->brandingHeroCropAppliedFromDelta($delta) === 1;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -106,53 +106,26 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildOverviewSection(NodeInterface $event): array {
-    $build = [
+    return [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-event-studio-overview']],
-      'hero' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-overview__hero']],
-        'kicker' => [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $this->t('Your event workspace'),
-          '#attributes' => ['class' => ['mel-event-studio-overview__kicker']],
-        ],
-        'title' => [
-          '#type' => 'html_tag',
-          '#tag' => 'h3',
-          '#value' => $this->t('Your event workspace is ready'),
-          '#attributes' => ['class' => ['mel-event-studio-overview__title']],
-        ],
-        'summary' => [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $this->t('Work through one section at a time. MEL keeps the practical setup organised so you can focus on building an event people will want to attend.'),
-          '#attributes' => ['class' => ['mel-event-studio-overview__summary']],
-        ],
+      'intro' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Use the sections below to finish setup. Readiness and boost status stay above so you always know what needs attention next.'),
+        '#attributes' => ['class' => ['mel-event-studio-overview__summary']],
       ],
-      'orientation' => [
-        '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-overview__orientation']],
-        'title' => [
-          '#type' => 'html_tag',
-          '#tag' => 'h4',
-          '#value' => $this->t('What lives here'),
-          '#attributes' => ['class' => ['mel-event-studio-overview__subtitle']],
+      'actions' => [
+        '#theme' => 'item_list',
+        '#title' => $this->t('Suggested next steps'),
+        '#items' => [
+          $this->t('Start with Event information for the public details guests see first.'),
+          $this->t('Confirm RSVP or ticket setup before sharing the page.'),
+          $this->t('Review Branding and Content when you are ready to promote the event.'),
         ],
-        'items' => [
-          '#theme' => 'item_list',
-          '#items' => [
-            $this->t('Start with the public event details guests will see first.'),
-            $this->t('Add tickets, questions, and settings only when they help your event run smoothly.'),
-            $this->t('Readiness checks and suggestions stay beside the work so you always know the next step.'),
-          ],
-          '#attributes' => ['class' => ['mel-event-studio-overview__list']],
-        ],
+        '#attributes' => ['class' => ['mel-event-studio-overview__list']],
       ],
     ];
-
-    return $build;
   }
 
   /**
@@ -173,7 +146,7 @@ final class EventStudioSectionRenderer {
         '#items' => [
           $this->t('Check event information and public copy first.'),
           $this->t('Confirm RSVP or ticket setup before sharing the page.'),
-          $this->t('Use Settings to review readiness and publish from Studio.'),
+          $this->t('Use the readiness strip above when you are ready to publish.'),
         ],
         '#attributes' => ['class' => ['mel-event-studio-next-steps__list']],
       ],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\node\NodeInterface;
+
+/**
+ * Display-only workspace readiness and event health presentation.
+ *
+ * Does not evaluate readiness; consumes existing facade/controller outputs.
+ */
+final class EventStudioWorkspacePresentation {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly DateFormatterInterface $dateFormatter,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * @param array{
+   *   publish: EventReadinessResult,
+   *   promotion: array<string, mixed>,
+   *   publish_required: list<string>,
+   *   promotion_required: list<string>,
+   *   recommended: list<string>,
+   *   publish_ready: bool,
+   *   promotion_ready: bool,
+   * } $readiness_bundle
+   *
+   * @return array<string, mixed>
+   */
+  public function buildReadinessSummary(array $readiness_bundle, NodeInterface $node): array {
+    $result = $readiness_bundle['publish'];
+    $published = $node->isPublished();
+    $has_blockers = $result->errors !== [] || $result->warnings !== [];
+
+    return [
+      'ready' => $result->ready,
+      'errors' => $result->errors,
+      'warnings' => $result->warnings,
+      'completed' => $result->completed,
+      'recommendations' => $readiness_bundle['recommended'],
+      'state' => $this->operationalState($result),
+      'promotion_ready' => (bool) ($readiness_bundle['promotion_ready'] ?? FALSE),
+      'published' => $published,
+      'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
+      'strip_title' => $this->readinessStripTitle($result, $published),
+    ];
+  }
+
+  /**
+   * @param array{
+   *   publish: EventReadinessResult,
+   *   promotion: array<string, mixed>,
+   *   promotion_ready: bool,
+   * } $readiness_bundle
+   * @param array<string, mixed>|null $boost
+   *
+   * @return array<string, mixed>
+   */
+  public function buildEventHealth(array $readiness_bundle, NodeInterface $node, ?array $boost): array {
+    $result = $readiness_bundle['publish'];
+    $published = $node->isPublished();
+    $promotion_ready = (bool) ($readiness_bundle['promotion_ready'] ?? FALSE);
+    $promotion = is_array($readiness_bundle['promotion'] ?? NULL) ? $readiness_bundle['promotion'] : [];
+
+    $boost_active = is_array($boost) && !empty($boost['active']);
+    $boost_detail = '';
+    if ($boost_active) {
+      if (isset($boost['days_remaining']) && $boost['days_remaining'] !== NULL) {
+        $days = (int) $boost['days_remaining'];
+        $boost_detail = $days === 1
+          ? (string) $this->t('1 day remaining')
+          : (string) $this->t('@count days remaining', ['@count' => $days]);
+      }
+      elseif (!empty($boost['expires'])) {
+        $boost_detail = (string) $this->t('Featured until @date', ['@date' => (string) $boost['expires']]);
+      }
+    }
+
+    return [
+      'heading' => (string) $this->t('Event health'),
+      'last_updated' => $this->formatLastUpdated($node),
+      'items' => [
+        [
+          'key' => 'publish',
+          'label' => (string) $this->t('Publish'),
+          'value' => $published ? (string) $this->t('Published') : (string) $this->t('Draft'),
+          'detail' => $result->ready
+            ? (string) $this->t('Ready')
+            : (string) $this->t('Needs attention'),
+          'tone' => $result->ready ? 'ready' : 'attention',
+        ],
+        [
+          'key' => 'promotion',
+          'label' => (string) $this->t('Promotion'),
+          'value' => $promotion_ready
+            ? (string) ($promotion['short_status_label'] ?? $promotion['status_label'] ?? $this->t('Ready for homepage promotion'))
+            : (string) ($promotion['status_label'] ?? $this->t('Needs attention before homepage promotion')),
+          'detail' => '',
+          'tone' => $promotion_ready ? 'ready' : 'attention',
+        ],
+        [
+          'key' => 'boost',
+          'label' => (string) $this->t('Boost'),
+          'value' => $boost_active ? (string) $this->t('Active') : (string) $this->t('Not active'),
+          'detail' => $boost_detail,
+          'tone' => $boost_active ? 'active' : 'muted',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * AJAX publish/readiness payload from the same facade bundle as Event Health.
+   *
+   * @param array{
+   *   publish: EventReadinessResult,
+   *   promotion: array<string, mixed>,
+   *   recommended: list<string>,
+   *   promotion_ready: bool,
+   * } $readiness_bundle
+   *
+   * @return array<string, mixed>
+   */
+  public function buildAjaxReadinessPayloadFromBundle(array $readiness_bundle, NodeInterface $node): array {
+    $result = $readiness_bundle['publish'];
+    $published = $node->isPublished();
+
+    return [
+      'ready' => $result->ready,
+      'errors' => $result->errors,
+      'warnings' => $result->warnings,
+      'completed' => $result->completed,
+      'recommendations' => $readiness_bundle['recommended'] ?? [],
+      'state' => $this->operationalState($result),
+      'published' => $published,
+      'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
+      'strip_title' => $this->readinessStripTitle($result, $published),
+      'show_homepage_readiness' => $this->shouldShowHomepageReadinessCard(
+        (bool) ($readiness_bundle['promotion_ready'] ?? FALSE),
+        $published,
+      ),
+    ];
+  }
+
+  public function operationalState(EventReadinessResult $result): string {
+    if (!$result->ready) {
+      return (string) $this->t('Needs Attention');
+    }
+    return (string) $this->t('Ready');
+  }
+
+  public function readinessStripTitle(EventReadinessResult $result, bool $published): string {
+    if (!$result->ready) {
+      return (string) $this->t('Needs attention');
+    }
+    if ($published) {
+      return (string) $this->t('Published and ready');
+    }
+    return (string) $this->t('Ready to publish');
+  }
+
+  public function shouldShowPublishStrip(EventReadinessResult $result, bool $published): bool {
+    return !$published || !$result->ready || $result->errors !== [] || $result->warnings !== [];
+  }
+
+  public function shouldShowHomepageReadinessCard(bool $promotion_ready, bool $published): bool {
+    return !$promotion_ready || !$published;
+  }
+
+  private function formatLastUpdated(NodeInterface $node): string {
+    if ($node->getChangedTime() <= 0) {
+      return (string) $this->t('Not saved yet');
+    }
+    return (string) $this->t('Last updated @time', [
+      '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
+    ]);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
+use Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Single publish enforcement gate for vendor, Stripe, and event readiness checks.
+ */
+final class PublishEligibilityEvaluator {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly VendorPublishRequirementsGate $publishRequirementsGate,
+    private readonly PaidPublishStripeGate $paidPublishStripeGate,
+    private readonly EventReadinessService $eventReadiness,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Evaluates whether an event may be published for the given account.
+   *
+   * @return array{
+   *   allowed: bool,
+   *   reason: string|null,
+   *   messages: list<string>,
+   * }
+   */
+  public function evaluate(NodeInterface $event, AccountInterface $account): array {
+    try {
+      return $this->evaluateInternal($event, $account);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio publish eligibility evaluation failed for event @nid uid=@uid: @message', [
+        '@nid' => (string) ($event->id() ?? 'new'),
+        '@uid' => (string) $account->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return [
+        'allowed' => FALSE,
+        'reason' => 'evaluation_failed',
+        'messages' => [(string) $this->t('Publish eligibility could not be verified. Try again shortly.')],
+      ];
+    }
+  }
+
+  /**
+   * @return array{
+   *   allowed: bool,
+   *   reason: string|null,
+   *   messages: list<string>,
+   * }
+   */
+  private function evaluateInternal(NodeInterface $event, AccountInterface $account): array {
+    if ($event->bundle() !== 'event') {
+      return [
+        'allowed' => FALSE,
+        'reason' => 'invalid_event',
+        'messages' => [(string) $this->t('Expected event node.')],
+      ];
+    }
+
+    $denials = $this->publishRequirementsGate->getLivePublishDenialReasons($account);
+    if ($denials !== []) {
+      return [
+        'allowed' => FALSE,
+        'reason' => 'vendor_denied',
+        'messages' => array_values($denials),
+      ];
+    }
+
+    $eventType = $this->eventType($event);
+    if (in_array($eventType, ['paid', 'both'], TRUE)) {
+      $eventNodeId = $event->id() ? (int) $event->id() : NULL;
+      $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed($account, $eventNodeId);
+      if ($stripeMsg !== NULL) {
+        return [
+          'allowed' => FALSE,
+          'reason' => 'stripe',
+          'messages' => [$stripeMsg],
+        ];
+      }
+    }
+
+    $readiness = $this->eventReadiness->evaluate($event, $account);
+    if (!$readiness->ready) {
+      return [
+        'allowed' => FALSE,
+        'reason' => 'readiness',
+        'messages' => $readiness->errors !== [] ? $readiness->errors : [(string) $this->t('Cannot publish yet.')],
+      ];
+    }
+
+    return [
+      'allowed' => TRUE,
+      'reason' => NULL,
+      'messages' => [],
+    ];
+  }
+
+  private function eventType(NodeInterface $event): string {
+    if ($event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()) {
+      return (string) $event->get('field_event_type')->value;
+    }
+    return 'rsvp';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-event-health.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-event-health.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Consolidated operational event health summary for Event Studio workspace.
+ *
+ * Variables:
+ * - event_health.heading
+ * - event_health.last_updated
+ * - event_health.items (list of key, label, value, detail, tone)
+ */
+#}
+{% set event_health = event_health|default({}) %}
+{% set items = event_health.items|default([]) %}
+<section
+  class="mel-event-studio-event-health"
+  aria-labelledby="mel-event-studio-event-health-title"
+  data-mel-event-health
+  role="region"
+>
+  <div class="mel-event-studio-event-health__header">
+    <h2 id="mel-event-studio-event-health-title" class="mel-event-studio-event-health__title">
+      {{ event_health.heading|default('Event health'|t) }}
+    </h2>
+    {% if event_health.last_updated|default('') %}
+      <p class="mel-event-studio-event-health__updated" data-mel-event-health-updated>
+        {{ event_health.last_updated }}
+      </p>
+    {% endif %}
+  </div>
+  <dl class="mel-event-studio-event-health__list">
+    {% for item in items %}
+      <div class="mel-event-studio-event-health__item mel-event-studio-event-health__item--{{ item.tone|default('muted')|clean_class }}" data-mel-event-health-row="{{ item.key|default('')|e('html_attr') }}">
+        <dt class="mel-event-studio-event-health__label">{{ item.label }}</dt>
+        <dd class="mel-event-studio-event-health__value">
+          <span data-mel-event-health-value="{{ item.key|default('')|e('html_attr') }}">{{ item.value }}</span>
+          {% if item.detail|default('') %}
+            <span class="mel-event-studio-event-health__detail" data-mel-event-health-detail="{{ item.key|default('')|e('html_attr') }}">{{ item.detail }}</span>
+          {% endif %}
+        </dd>
+      </div>
+    {% endfor %}
+  </dl>
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -13,7 +13,9 @@
       {% if topbar.state %}
         <span class="mel-event-studio-topbar__state" data-mel-publish-state>{{ topbar.state }}</span>
       {% endif %}
-      <span class="mel-event-studio-topbar__saved" data-mel-publish-last-saved>{{ topbar.last_saved }}</span>
+      {% if topbar.show_last_saved|default(true) %}
+        <span class="mel-event-studio-topbar__saved" data-mel-publish-last-saved>{{ topbar.last_saved }}</span>
+      {% endif %}
       <span class="mel-event-studio-topbar__autosave{% if topbar.restore_draft %} has-draft{% endif %}" id="mel-studio-form-state" role="status">
         {% if topbar.restore_draft %}
           <a href="{{ topbar.restore_url }}">{{ 'Restore draft available'|t }}</a>
@@ -27,14 +29,14 @@
     {% endif %}
     <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'Preview'|t }}</a>
     <button
-      class="mel-btn mel-btn--primary"
+      class="mel-btn{% if topbar.published %} mel-btn--ghost mel-event-studio-topbar__status-action{% else %} mel-btn--primary{% endif %}"
       type="button"
       data-mel-publish-action
       data-mel-publish-url="{{ topbar.publish_url|e('html_attr') }}"
       data-mel-current-section="{{ topbar.current_section|e('html_attr') }}"
       data-mel-node-changed="{{ topbar.changed }}"
       data-mel-node-revision="{{ topbar.revision_id }}"
-      {% if topbar.published %}disabled aria-disabled="true"{% endif %}
+      {% if topbar.published %}disabled aria-disabled="true" aria-label="{{ 'Event is published'|t }}"{% endif %}
     >{{ topbar.published ? 'Published'|t : 'Publish'|t }}</button>
   </div>
 </header>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -7,6 +7,7 @@
 <div
   class="mel-event-studio mel-event-studio--workspace"
   data-mel-studio-shell="1"
+  data-mel-published="{{ topbar.published|default(false) ? '1' : '0' }}"
   data-current-section-id="{{ current_section_metadata.id|default(current_section) }}"
   data-current-section-state="{{ current_section_metadata.section_state|default('active') }}"
   data-current-operational-area="{{ current_section_metadata.operational_area|default('event') }}"
@@ -16,6 +17,31 @@
   {{ include('@myeventlane_event_studio/mel-event-studio-topbar.html.twig', {
     topbar: topbar
   }, with_context = false) }}
+
+  {{ include('@myeventlane_event_studio/mel-event-studio-event-health.html.twig', {
+    event_health: event_health
+  }, with_context = false) }}
+
+  {% if readiness.show_publish_strip|default(true) %}
+    <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip>
+      <div class="mel-event-studio-readiness-strip__summary">
+        <strong data-mel-readiness-title>{{ readiness.strip_title|default(readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t) }}</strong>
+        <span data-mel-readiness-state>{{ readiness.state }}</span>
+      </div>
+      <div class="mel-event-studio-readiness-strip__counts">
+        <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
+        <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
+        <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
+        <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
+      </div>
+    </section>
+  {% endif %}
+
+  {% if homepage_readiness %}
+    <div class="mel-event-studio-homepage-readiness">
+      {{ homepage_readiness }}
+    </div>
+  {% endif %}
 
   {% if boost is not null and boost.active %}
     <section class="mel-boost-active-banner" aria-labelledby="mel-boost-active-title">
@@ -52,25 +78,6 @@
       } only %}
     </section>
   {% endif %}
-
-  {% if homepage_readiness %}
-    <div class="mel-event-studio-homepage-readiness">
-      {{ homepage_readiness }}
-    </div>
-  {% endif %}
-
-  <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip>
-    <div class="mel-event-studio-readiness-strip__summary">
-      <strong data-mel-readiness-title>{{ readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t }}</strong>
-      <span data-mel-readiness-state>{{ readiness.state }}</span>
-    </div>
-    <div class="mel-event-studio-readiness-strip__counts">
-      <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
-      <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
-      <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
-      <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
-    </div>
-  </section>
 
   <section class="mel-event-studio-publish-feedback" aria-live="polite" aria-atomic="true" data-mel-publish-feedback hidden>
     <div class="mel-event-studio-publish-feedback__error" data-mel-publish-error hidden>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceRefreshControllerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioGovernanceRefreshControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceRefreshController;
+use Drupal\myeventlane_event_studio\Service\EventStudioGovernanceBuilder;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Controller\EventStudioGovernanceRefreshController
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioGovernanceRefreshControllerTest extends TestCase {
+
+  /**
+   * @covers ::refresh
+   */
+  public function testMissingSurfaceServicesReturnDisabledGovernance(): void {
+    $account = $this->createMock(AccountProxyInterface::class);
+    $account->method('isAnonymous')->willReturn(FALSE);
+    $account->method('hasPermission')->with('administer nodes')->willReturn(TRUE);
+    $account->method('id')->willReturn('9');
+
+    $controller = new EventStudioGovernanceRefreshController(
+      new EventStudioGovernanceBuilder(
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        $account,
+        NULL,
+        NULL,
+        NULL,
+        $this->createMock(LoggerInterface::class),
+        $this->translator(),
+      ),
+      $account,
+      new EventVendorAccessChecker(),
+      $this->createMock(LoggerInterface::class),
+    );
+
+    $response = $controller->refresh($this->eventNode(), Request::create('/test', 'POST'));
+    $data = json_decode((string) $response->getContent(), TRUE);
+
+    $this->assertSame(200, $response->getStatusCode());
+    $this->assertTrue($data['ok']);
+    $this->assertFalse($data['governance_enabled']);
+  }
+
+  private function eventNode(): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('event');
+    $node->method('id')->willReturn(12);
+    return $node;
+  }
+
+  private function translator(): \Drupal\Core\StringTranslation\TranslationInterface {
+    $translator = $this->createMock(\Drupal\Core\StringTranslation\TranslationInterface::class);
+    $translator
+      ->method('translateString')
+      ->willReturnCallback(static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString());
+    return $translator;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -233,7 +233,7 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
     $this->assertStringContainsString('Blank stock = unlimited. 0 = sold out. Positive numbers are enforced.', $builder);
     $this->assertStringContainsString('Limit per order is optional.', $builder);
     $this->assertStringContainsString('Product options', $builder);
-    $this->assertStringContainsString('Colour options can be added in the option label', $builder);
+    $this->assertStringContainsString('Colour options are coming soon.', $builder);
     $this->assertStringContainsString('buildProductOptionsSection', $builder);
     $this->assertStringContainsString('buildOperationalDocumentsSection', $builder);
     $this->assertStringContainsString('Packing slips, parking slips and labels', $builder);

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioProductTargetPreservationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioProductTargetPreservationTest.php
@@ -11,14 +11,12 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Image\ImageFactory;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
-use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\focal_point\FocalPointManagerInterface;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\PublishEligibilityEvaluator;
 use Drupal\myeventlane_event_studio\Service\QuestionFieldTypeRegistry;
 use Drupal\myeventlane_venue\Service\VenueManager;
-use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
-use Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -48,8 +46,8 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
     ]);
 
     $payload_service = new EventStudioMelPayloadService(
-      $this->createMock(EventHighlightHelper::class),
-      $this->createMock(QuestionFieldTypeRegistry::class),
+      (new \ReflectionClass(EventHighlightHelper::class))->newInstanceWithoutConstructor(),
+      new QuestionFieldTypeRegistry(),
     );
 
     $payload = $payload_service->buildFromFormState($form_state, $entity_type_manager);
@@ -131,7 +129,7 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
       'field_product_target',
       'field_event_type',
     ], TRUE));
-    $event->method('get')->willReturnCallback(static function (string $field) use ($product_field, $event_type_field): FieldItemListInterface {
+    $event->method('get')->willReturnCallback(static function (string $field) use ($product_field, $event_type_field): object {
       return match ($field) {
         'field_product_target' => $product_field,
         'field_event_type' => $event_type_field,
@@ -154,7 +152,7 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
       'field_external_url',
       'field_collect_per_ticket',
     ], TRUE));
-    $event->method('get')->willReturnCallback(function (string $field) use (&$state, $event_type): FieldItemListInterface {
+    $event->method('get')->willReturnCallback(function (string $field) use (&$state, $event_type): object {
       if ($field === 'field_product_target') {
         return $this->createEntityReferenceField($state['product_target_id']);
       }
@@ -181,18 +179,12 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
     return $event;
   }
 
-  private function createEntityReferenceField(?int $target_id): FieldItemListInterface {
-    $field = $this->createMock(FieldItemListInterface::class);
-    $field->method('isEmpty')->willReturn($target_id === NULL);
-    $field->target_id = $target_id;
-    return $field;
+  private function createEntityReferenceField(?int $target_id): object {
+    return new FieldTargetIdStub($target_id ?? 0);
   }
 
-  private function createListField(string $value): FieldItemListInterface {
-    $field = $this->createMock(FieldItemListInterface::class);
-    $field->method('isEmpty')->willReturn($value === '');
-    $field->value = $value;
-    return $field;
+  private function createListField(string $value): object {
+    return new FieldValueStub($value);
   }
 
   private function createEmptyField(): FieldItemListInterface {
@@ -209,11 +201,9 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
       $entity_type_manager,
       $this->createMock(VenueManager::class),
       $this->createMock(LoggerInterface::class),
-      $this->createMock(EventHighlightHelper::class),
-      $this->createMock(PaidPublishStripeGate::class),
-      $this->createMock(VendorPublishRequirementsGate::class),
-      $this->createMock(EventReadinessService::class),
-      $this->createMock(QuestionFieldTypeRegistry::class),
+      (new \ReflectionClass(EventHighlightHelper::class))->newInstanceWithoutConstructor(),
+      (new \ReflectionClass(PublishEligibilityEvaluator::class))->newInstanceWithoutConstructor(),
+      new QuestionFieldTypeRegistry(),
       $this->createMock(ImageFactory::class),
       $this->createMock(TranslationInterface::class),
       $this->createMock(\Drupal\Core\File\FileSystemInterface::class),
@@ -239,6 +229,32 @@ final class EventStudioProductTargetPreservationTest extends UnitTestCase {
     /** @var list<string> $errors */
     $errors = $method->invoke($service, $node, $payload, $event_type, $draft);
     return $errors;
+  }
+
+}
+
+/**
+ * Minimal scalar field stub with value.
+ */
+final class FieldValueStub {
+
+  public function __construct(public readonly string $value) {}
+
+  public function isEmpty(): bool {
+    return $this->value === '';
+  }
+
+}
+
+/**
+ * Minimal entity reference field stub with target_id.
+ */
+final class FieldTargetIdStub {
+
+  public function __construct(public readonly int $target_id) {}
+
+  public function isEmpty(): bool {
+    return $this->target_id < 1;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
@@ -25,6 +25,15 @@ final class EventStudioReadinessStabilityTest extends UnitTestCase {
     $this->assertStringContainsString('@logger.channel.myeventlane_event_studio', file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml'));
   }
 
+  public function testGovernanceRefreshControllerReturnsStructuredFailureJson(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioGovernanceRefreshController.php');
+
+    $this->assertIsString($source);
+    $this->assertStringContainsString('catch (\Throwable $e)', $source);
+    $this->assertStringContainsString("'ok' => FALSE", $source);
+    $this->assertStringContainsString('Governance refresh failed. Try again shortly.', $source);
+  }
+
   public function testGovernanceComponentControllerReturnsStructuredFailureJson(): void {
     $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioGovernanceComponentController.php');
 
@@ -45,6 +54,17 @@ final class EventStudioReadinessStabilityTest extends UnitTestCase {
     $this->assertStringContainsString('catch (\\Throwable $e)', $source);
   }
 
+  public function testEventStudioControllerUsesReadinessFacade(): void {
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+
+    $this->assertIsString($services);
+    $this->assertIsString($controller);
+    $this->assertStringContainsString('myeventlane_event_studio.readiness_facade', $services);
+    $this->assertStringContainsString('EventReadinessFacade', $controller);
+    $this->assertStringContainsString('buildChecklistCardFromPresentation', $controller);
+  }
+
   public function testReadinessFacadeServiceIsRegistered(): void {
     $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
 
@@ -52,6 +72,28 @@ final class EventStudioReadinessStabilityTest extends UnitTestCase {
     $this->assertStringContainsString('myeventlane_event_studio.readiness_facade', $services);
     $this->assertStringContainsString('EventReadinessFacade', $services);
     $this->assertStringContainsString('@myeventlane_event.featured_readiness', $services);
+  }
+
+  public function testBrandingFormSyncsHeroInputBeforeValidation(): void {
+    $branding = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventBrandingForm.php');
+    $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
+
+    $this->assertIsString($branding);
+    $this->assertIsString($save);
+    $this->assertStringContainsString('prepareBrandingHeroFormStateForValidation', $branding);
+    $this->assertStringContainsString('prepareBrandingHeroFormStateForValidation', $save);
+    $this->assertStringContainsString('parent::validateForm', $branding);
+  }
+
+  public function testPublishEligibilityEvaluatorIsRegistered(): void {
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
+    $evaluator = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
+
+    $this->assertIsString($services);
+    $this->assertIsString($evaluator);
+    $this->assertStringContainsString('myeventlane_event_studio.publish_eligibility', $services);
+    $this->assertStringContainsString('PublishEligibilityEvaluator', $services);
+    $this->assertStringContainsString('catch (\\Throwable $e)', $evaluator);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
@@ -25,18 +25,22 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertStringContainsString("'@myeventlane_vendor.paid_publish_stripe_gate'", $services);
   }
 
-  public function testReadinessAndSavePathsUsePaidPublishStripeGate(): void {
+  public function testReadinessAndEnforcementPathsUsePaidPublishStripeGate(): void {
     $readiness = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventReadinessService.php');
+    $evaluator = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
     $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
     $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
 
     $this->assertIsString($readiness);
+    $this->assertIsString($evaluator);
     $this->assertIsString($save);
     $this->assertIsString($publish);
     $this->assertStringContainsString('validatePaidPublishAllowed', $readiness);
     $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $readiness);
-    $this->assertStringContainsString('validatePaidPublishAllowed', $save);
-    $this->assertStringContainsString('$this->eventReadiness->evaluate', $publish);
+    $this->assertStringContainsString('validatePaidPublishAllowed', $evaluator);
+    $this->assertStringContainsString('publishEligibilityEvaluator', $save);
+    $this->assertStringNotContainsString('validatePaidPublishAllowed', $save);
+    $this->assertStringNotContainsString('if (!$readiness->ready)', $publish);
   }
 
   public function testPublishCardUsesStripeGateCopyAndConnectRoute(): void {
@@ -56,11 +60,12 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $preprocess);
   }
 
-  public function testDraftSaveSkipsStripeGateOnPublishPath(): void {
+  public function testDraftSaveSkipsPublishEligibilityOnDraftPath(): void {
     $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
 
     $this->assertIsString($save);
-    $this->assertStringContainsString('if (!$draft && $willPublish && in_array($effectiveEventType, [\'paid\', \'both\'], TRUE))', $save);
+    $this->assertStringContainsString('if (!$draft && $willPublish)', $save);
+    $this->assertStringContainsString('publishEligibilityEvaluator->evaluate', $save);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceFailureFallbackTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceFailureFallbackTest.php
@@ -10,9 +10,14 @@ use Drupal\Core\Form\FormAjaxException;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\myeventlane_event_studio\Controller\EventStudioController;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
+use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
+use Drupal\myeventlane_event_studio\EventStudioPreprocess;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
+use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
+use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService;
 use Drupal\node\NodeInterface;
@@ -75,19 +80,11 @@ final class EventStudioWorkspaceFailureFallbackTest extends UnitTestCase {
     $logger = $this->createMock(LoggerInterface::class);
     $logger->expects($this->never())->method('error');
 
-    $controller = new EventStudioController(
-      $this->createMock(EntityTypeManagerInterface::class),
-      (new ReflectionClass(VendorEventStudioCreateService::class))->newInstanceWithoutConstructor(),
+    $controller = $this->createWorkspaceController(
+      $translator,
+      $createMock,
       $logger,
-      new \Symfony\Component\HttpFoundation\RequestStack(),
-      new EventVendorAccessChecker(),
-      $this->createMock(DateFormatterInterface::class),
-      EventStudioWorkspaceTestFactory::readinessService($translator, $createMock),
-      EventStudioWorkspaceTestFactory::autosaveService($createMock),
-      (new ReflectionClass(EventStudioSectionManager::class))->newInstanceWithoutConstructor(),
       EventStudioWorkspaceTestFactory::formAjaxThrowingSectionRenderer($translator, $createMock),
-      new EventStudioEmptyStateBuilder($translator),
-      EventStudioWorkspaceTestFactory::domainDetector($createMock),
     );
 
     $method = new ReflectionMethod(EventStudioController::class, 'buildWorkspaceSectionContent');
@@ -132,19 +129,11 @@ final class EventStudioWorkspaceFailureFallbackTest extends UnitTestCase {
         }),
       );
 
-    $controller = new EventStudioController(
-      $this->createMock(EntityTypeManagerInterface::class),
-      (new ReflectionClass(VendorEventStudioCreateService::class))->newInstanceWithoutConstructor(),
+    $controller = $this->createWorkspaceController(
+      $translator,
+      $createMock,
       $logger,
-      new \Symfony\Component\HttpFoundation\RequestStack(),
-      new EventVendorAccessChecker(),
-      $this->createMock(DateFormatterInterface::class),
-      EventStudioWorkspaceTestFactory::readinessService($translator, $createMock),
-      EventStudioWorkspaceTestFactory::autosaveService($createMock),
-      (new ReflectionClass(EventStudioSectionManager::class))->newInstanceWithoutConstructor(),
       EventStudioWorkspaceTestFactory::throwingSectionRenderer($translator, $createMock),
-      new EventStudioEmptyStateBuilder($translator),
-      EventStudioWorkspaceTestFactory::domainDetector($createMock),
     );
 
     $method = new ReflectionMethod(EventStudioController::class, 'buildWorkspaceSectionContent');
@@ -160,6 +149,36 @@ final class EventStudioWorkspaceFailureFallbackTest extends UnitTestCase {
     $this->assertSame('mel_event_studio_empty_state', $content['#theme']);
     $this->assertSame('unavailable', $content['#state']);
     $this->assertSame($sectionTitle, $content['#title']);
+  }
+
+  /**
+   * @param callable(class-string): object $createMock
+   */
+  private function createWorkspaceController(
+    TranslationInterface $translator,
+    callable $createMock,
+    LoggerInterface $logger,
+    EventStudioSectionRenderer $sectionRenderer,
+  ): EventStudioController {
+    return new EventStudioController(
+      $this->createMock(EntityTypeManagerInterface::class),
+      (new ReflectionClass(VendorEventStudioCreateService::class))->newInstanceWithoutConstructor(),
+      $logger,
+      new \Symfony\Component\HttpFoundation\RequestStack(),
+      new EventVendorAccessChecker(),
+      $this->createMock(DateFormatterInterface::class),
+      EventStudioWorkspaceTestFactory::readinessFacade($translator, $createMock),
+      EventStudioWorkspaceTestFactory::autosaveService($createMock),
+      (new ReflectionClass(EventStudioSectionManager::class))->newInstanceWithoutConstructor(),
+      $sectionRenderer,
+      new EventStudioEmptyStateBuilder($translator),
+      EventStudioWorkspaceTestFactory::domainDetector($createMock),
+      (new ReflectionClass(EventStudioPreprocess::class))->newInstanceWithoutConstructor(),
+      (new ReflectionClass(BoostStatusService::class))->newInstanceWithoutConstructor(),
+      (new ReflectionClass(FeaturedEventReadinessRenderBuilder::class))->newInstanceWithoutConstructor(),
+      (new ReflectionClass(EventStudioWorkspacePresentation::class))->newInstanceWithoutConstructor(),
+      NULL,
+    );
   }
 
   private function sectionPlugin(string $sectionId, string $renderTarget, string $title): EventStudioSectionInterface&MockObject {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Proves workspace surfaces share one presentation source per state.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
+
+  private EventStudioWorkspacePresentation $presentation;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $dateFormatter = $this->createMock(DateFormatterInterface::class);
+    $dateFormatter->method('format')->willReturn('10 Jun 2026 - 16:46');
+    $translator = $this->createMock(\Drupal\Core\StringTranslation\TranslationInterface::class);
+    $translator->method('translateString')->willReturnCallback(
+      static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
+    );
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $translator);
+  }
+
+  public function testStripAndAjaxPayloadShareReadinessSummaryFields(): void {
+    $node = $this->node(TRUE, 201);
+    $bundle = $this->bundle(
+      ready: TRUE,
+      promotion_ready: FALSE,
+      warnings: ['Review capacity'],
+    );
+
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+    $ajax = $this->presentation->buildAjaxReadinessPayloadFromBundle($bundle, $node);
+
+    $this->assertSame($summary['show_publish_strip'], $ajax['show_publish_strip']);
+    $this->assertSame($summary['strip_title'], $ajax['strip_title']);
+    $this->assertSame($summary['ready'], $ajax['ready']);
+    $this->assertSame($summary['state'], $ajax['state']);
+    $this->assertSame($summary['errors'], $ajax['errors']);
+    $this->assertSame($summary['warnings'], $ajax['warnings']);
+    $this->assertSame($summary['recommendations'], $ajax['recommendations']);
+  }
+
+  public function testEventHealthPublishRowUsesSamePublishResultAsStrip(): void {
+    $node = $this->node(FALSE, 202);
+    $bundle = $this->bundle(ready: FALSE, promotion_ready: FALSE, errors: ['Add title']);
+
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+    $health = $this->presentation->buildEventHealth($bundle, $node, NULL);
+
+    $this->assertSame('Needs Attention', $summary['state']);
+    $this->assertSame('Draft', $health['items'][0]['value']);
+    $this->assertSame('Needs attention', $health['items'][0]['detail']);
+    $this->assertSame('attention', $health['items'][0]['tone']);
+  }
+
+  public function testEventHealthPromotionUsesFacadePromotionPayload(): void {
+    $node = $this->node(TRUE, 203);
+    $bundle = $this->bundle(ready: TRUE, promotion_ready: TRUE);
+    $bundle['promotion']['status_label'] = 'Ready for homepage promotion';
+
+    $health = $this->presentation->buildEventHealth($bundle, $node, NULL);
+
+    $this->assertSame('Ready for homepage promotion', $health['items'][1]['value']);
+    $this->assertSame('ready', $health['items'][1]['tone']);
+  }
+
+  public function testAjaxPayloadIncludesHomepageVisibilityFlag(): void {
+    $published = $this->node(TRUE, 204);
+    $draft = $this->node(FALSE, 205);
+    $readyBundle = $this->bundle(ready: TRUE, promotion_ready: TRUE);
+    $issueBundle = $this->bundle(ready: TRUE, promotion_ready: FALSE);
+
+    $this->assertFalse(
+      $this->presentation->buildAjaxReadinessPayloadFromBundle($readyBundle, $published)['show_homepage_readiness'],
+    );
+    $this->assertTrue(
+      $this->presentation->buildAjaxReadinessPayloadFromBundle($issueBundle, $published)['show_homepage_readiness'],
+    );
+    $this->assertTrue(
+      $this->presentation->buildAjaxReadinessPayloadFromBundle($readyBundle, $draft)['show_homepage_readiness'],
+    );
+  }
+
+  public function testDegradedPromotionPayloadDoesNotBreakEventHealth(): void {
+    $node = $this->node(TRUE, 206);
+    $bundle = [
+      'publish' => EventReadinessResult::create(completed: ['Ready']),
+      'promotion' => [
+        'ready' => FALSE,
+        'items' => [],
+        'required' => [],
+        'recommended' => [],
+      ],
+      'recommended' => [],
+      'promotion_ready' => FALSE,
+    ];
+
+    $health = $this->presentation->buildEventHealth($bundle, $node, NULL);
+
+    $this->assertCount(3, $health['items']);
+    $this->assertSame('Needs attention before homepage promotion', $health['items'][1]['value']);
+    $this->assertSame('Not active', $health['items'][2]['value']);
+  }
+
+  public function testPublishControllerUsesFacadeBundleForAjaxPayload(): void {
+    $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $this->assertIsString($publish);
+    $this->assertStringContainsString('readinessFacade->evaluate', $publish);
+    $this->assertStringContainsString('buildAjaxReadinessPayloadFromBundle', $publish);
+    $this->assertStringContainsString('buildEventHealth($readiness_bundle', $publish);
+    $this->assertStringNotContainsString('buildAjaxReadinessPayload(', $publish);
+  }
+
+  public function testShellJsSyncsHomepageReadinessVisibility(): void {
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
+    $this->assertIsString($js);
+    $this->assertStringContainsString('syncHomepageReadinessVisibility', $js);
+    $this->assertStringContainsString('show_homepage_readiness', $js);
+  }
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   *
+   * @return array<string, mixed>
+   */
+  private function bundle(bool $ready, bool $promotion_ready, array $errors = [], array $warnings = []): array {
+    return [
+      'publish' => EventReadinessResult::create($errors, $warnings, completed: $ready ? ['Ready'] : []),
+      'promotion' => [
+        'ready' => $promotion_ready,
+        'status_label' => $promotion_ready
+          ? 'Ready for homepage promotion'
+          : 'Needs attention before homepage promotion',
+        'short_status_label' => $promotion_ready ? 'Ready for homepage promotion' : 'Needs attention',
+      ],
+      'recommended' => ['Add banner image'],
+      'promotion_ready' => $promotion_ready,
+    ];
+  }
+
+  private function node(bool $published, int $nid): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('isPublished')->willReturn($published);
+    $node->method('id')->willReturn($nid);
+    $node->method('getChangedTime')->willReturn(1710000000);
+    return $node;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * State matrix and presentation contract tests for Event Studio workspace.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
+
+  private EventStudioWorkspacePresentation $presentation;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $dateFormatter = $this->createMock(DateFormatterInterface::class);
+    $dateFormatter->method('format')->willReturn('10 Jun 2026 - 16:46');
+    $translator = $this->createMock(\Drupal\Core\StringTranslation\TranslationInterface::class);
+    $translator->method('translateString')->willReturnCallback(
+      static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
+    );
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $translator);
+  }
+
+  public function testDraftReadyShowsPublishStrip(): void {
+    $node = $this->node(FALSE, 100);
+    $bundle = $this->bundle(ready: TRUE, promotion_ready: TRUE);
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+
+    $this->assertTrue($summary['show_publish_strip']);
+    $this->assertSame('Ready to publish', $summary['strip_title']);
+  }
+
+  public function testDraftBlockedShowsPublishStrip(): void {
+    $node = $this->node(FALSE, 101);
+    $bundle = $this->bundle(ready: FALSE, promotion_ready: FALSE, errors: ['Add an event title.']);
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+
+    $this->assertTrue($summary['show_publish_strip']);
+    $this->assertSame('Needs attention', $summary['strip_title']);
+  }
+
+  public function testPublishedReadyHidesPublishStripWithoutBlockers(): void {
+    $node = $this->node(TRUE, 102);
+    $bundle = $this->bundle(ready: TRUE, promotion_ready: TRUE);
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+
+    $this->assertFalse($summary['show_publish_strip']);
+    $this->assertSame('Published and ready', $summary['strip_title']);
+  }
+
+  public function testPublishedPromotionIssueShowsHomepageCard(): void {
+    $this->assertTrue(
+      $this->presentation->shouldShowHomepageReadinessCard(FALSE, TRUE),
+    );
+  }
+
+  public function testPublishedPromotionReadyHidesHomepageCard(): void {
+    $this->assertFalse(
+      $this->presentation->shouldShowHomepageReadinessCard(TRUE, TRUE),
+    );
+  }
+
+  public function testPublishedBoostActiveEventHealthIncludesBoostDetail(): void {
+    $node = $this->node(TRUE, 105);
+    $bundle = $this->bundle(ready: TRUE, promotion_ready: TRUE);
+    $health = $this->presentation->buildEventHealth($bundle, $node, [
+      'active' => TRUE,
+      'days_remaining' => 6,
+      'expires' => '16 Jun 2026',
+    ]);
+
+    $this->assertSame('Event health', $health['heading']);
+    $this->assertCount(3, $health['items']);
+    $this->assertSame('Published', $health['items'][0]['value']);
+    $this->assertSame('Active', $health['items'][2]['value']);
+    $this->assertSame('6 days remaining', $health['items'][2]['detail']);
+  }
+
+  public function testPublishAjaxPayloadIncludesStripFlags(): void {
+    $node = $this->node(FALSE, 106);
+    $bundle = $this->bundle(ready: TRUE, promotion_ready: FALSE, warnings: ['Review capacity']);
+    $payload = $this->presentation->buildAjaxReadinessPayloadFromBundle($bundle, $node);
+
+    $this->assertTrue($payload['show_publish_strip']);
+    $this->assertArrayHasKey('strip_title', $payload);
+    $this->assertSame(['Add banner image'], $payload['recommendations']);
+    $this->assertArrayHasKey('show_homepage_readiness', $payload);
+  }
+
+  public function testWorkspaceTemplateIncludesEventHealthBeforePublishStrip(): void {
+    $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
+    $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $this->assertIsString($workspace);
+    $this->assertIsString($publish);
+    $this->assertStringContainsString('mel-event-studio-event-health', $workspace);
+    $healthPos = strpos($workspace, 'mel-event-studio-event-health');
+    $stripPos = strpos($workspace, 'mel-event-studio-readiness-strip');
+    $this->assertNotFalse($healthPos);
+    $this->assertNotFalse($stripPos);
+    $this->assertLessThan($stripPos, $healthPos);
+    $this->assertStringContainsString("'event_health'", $publish);
+    $this->assertStringContainsString('buildAjaxReadinessPayloadFromBundle', $publish);
+  }
+
+  public function testShellJsUpdatesEventHealthAfterPublish(): void {
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
+    $this->assertIsString($js);
+    $this->assertStringContainsString('function updateEventHealth', $js);
+    $this->assertStringContainsString('result.event_health', $js);
+    $this->assertStringContainsString('readiness.show_publish_strip', $js);
+  }
+
+  /**
+   * @param list<string> $errors
+   * @param list<string> $warnings
+   *
+   * @return array<string, mixed>
+   */
+  private function bundle(bool $ready, bool $promotion_ready, array $errors = [], array $warnings = []): array {
+    return [
+      'publish' => EventReadinessResult::create($errors, $warnings, completed: $ready ? ['Ready'] : []),
+      'promotion' => [
+        'ready' => $promotion_ready,
+        'status_label' => $promotion_ready
+          ? 'Ready for homepage promotion'
+          : 'Needs attention before homepage promotion',
+        'short_status_label' => $promotion_ready ? 'Ready for homepage promotion' : 'Needs attention',
+      ],
+      'recommended' => ['Add banner image'],
+      'promotion_ready' => $promotion_ready,
+    ];
+  }
+
+  private function node(bool $published, int $nid): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('isPublished')->willReturn($published);
+    $node->method('id')->willReturn($nid);
+    $node->method('getChangedTime')->willReturn(1710000000);
+    return $node;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceTestFactory.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceTestFactory.php
@@ -16,6 +16,8 @@ use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event\Service\TicketProductEventOwnershipService;
 use Drupal\myeventlane_event\Service\TicketTypeManager;
+use Drupal\myeventlane_event\Service\FeaturedEventReadinessService;
+use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
@@ -68,6 +70,20 @@ final class EventStudioWorkspaceTestFactory {
       (new ReflectionClass(VendorPublishRequirementsGate::class))->newInstanceWithoutConstructor(),
       (new ReflectionClass(PaidPublishStripeGate::class))->newInstanceWithoutConstructor(),
       $questionManager,
+      new TestLoggerChannel(),
+      $translator,
+    );
+  }
+
+  /**
+   * @param callable(class-string): object $createMock
+   */
+  public static function readinessFacade(TranslationInterface $translator, callable $createMock): EventReadinessFacade {
+    $promotion = (new ReflectionClass(FeaturedEventReadinessService::class))->newInstanceWithoutConstructor();
+
+    return new EventReadinessFacade(
+      self::readinessService($translator, $createMock),
+      $promotion,
       new TestLoggerChannel(),
       $translator,
     );

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Contract tests for Event Studio workspace UX consolidation.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
+
+  public function testWorkspaceShellOrdersStatusBeforeBoost(): void {
+    $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
+    $this->assertIsString($workspace);
+    $healthPos = strpos($workspace, 'mel-event-studio-event-health');
+    $readinessPos = strpos($workspace, 'mel-event-studio-readiness-strip');
+    $homepagePos = strpos($workspace, 'mel-event-studio-homepage-readiness');
+    $boostPos = strpos($workspace, 'mel-boost-active-banner');
+    $this->assertNotFalse($healthPos);
+    $this->assertNotFalse($readinessPos);
+    $this->assertNotFalse($homepagePos);
+    $this->assertNotFalse($boostPos);
+    $this->assertLessThan($readinessPos, $healthPos);
+    $this->assertLessThan($boostPos, $readinessPos);
+    $this->assertLessThan($boostPos, $homepagePos);
+  }
+
+  public function testWorkspaceHidesPublishStripWhenConfigured(): void {
+    $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
+    $presentation = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php');
+    $this->assertIsString($workspace);
+    $this->assertIsString($presentation);
+    $this->assertStringContainsString('readiness.show_publish_strip', $workspace);
+    $this->assertStringContainsString('shouldShowPublishStrip', $presentation);
+    $this->assertStringContainsString('readinessStripTitle', $presentation);
+  }
+
+  public function testHomepageReadinessSupportsSummaryOnlyDisplay(): void {
+    $checklist = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/templates/mel-homepage-readiness-checklist.html.twig');
+    $builder = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/FeaturedEventReadinessRenderBuilder.php');
+    $this->assertIsString($checklist);
+    $this->assertIsString($builder);
+    $this->assertStringContainsString('summary_only', $checklist);
+    $this->assertStringContainsString('hide_published_item', $checklist);
+    $this->assertStringContainsString('summary_only', $builder);
+    $this->assertStringContainsString('buildHomepageReadinessCard', file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php'));
+  }
+
+  public function testOverviewSectionUsesShorterOrientationCopy(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $this->assertStringContainsString('Suggested next steps', $renderer);
+    $this->assertStringNotContainsString('Your event workspace is ready', $renderer);
+    $this->assertStringNotContainsString('What lives here', $renderer);
+  }
+
+  public function testShellJsHidesReadinessStripForPublishedReadyEvents(): void {
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
+    $this->assertIsString($js);
+    $this->assertStringContainsString('Published and ready', $js);
+    $this->assertStringContainsString('strip.hidden = !showStrip', $js);
+    $this->assertStringContainsString('dataset.melPublished', $js);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\myeventlane_event_studio\Service\PublishEligibilityEvaluator;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\PublishEligibilityEvaluator
+ *
+ * @group myeventlane_event_studio
+ */
+final class PublishEligibilityEvaluatorTest extends UnitTestCase {
+
+  /**
+   * @covers ::evaluate
+   */
+  public function testEvaluatorDeclaresStructuredPublishResult(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
+
+    $this->assertIsString($source);
+    $this->assertStringContainsString("'allowed'", $source);
+    $this->assertStringContainsString("'reason'", $source);
+    $this->assertStringContainsString("'messages'", $source);
+    $this->assertStringContainsString('getLivePublishDenialReasons', $source);
+    $this->assertStringContainsString('validatePaidPublishAllowed', $source);
+    $this->assertStringContainsString('$this->eventReadiness->evaluate', $source);
+    $this->assertStringContainsString("in_array(\$eventType, ['paid', 'both'], TRUE)", $source);
+    $this->assertStringContainsString('catch (\\Throwable $e)', $source);
+    $this->assertStringContainsString('evaluation_failed', $source);
+  }
+
+  /**
+   * @covers ::evaluate
+   */
+  public function testEvaluatorMapsFailureReasons(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
+
+    $this->assertIsString($source);
+    $this->assertStringContainsString("'vendor_denied'", $source);
+    $this->assertStringContainsString("'stripe'", $source);
+    $this->assertStringContainsString("'readiness'", $source);
+    $this->assertStringContainsString("'invalid_event'", $source);
+  }
+
+  public function testSaveAndPublishPathsDelegateToEvaluatorOnly(): void {
+    $save = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSaveService.php');
+    $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
+
+    $this->assertIsString($save);
+    $this->assertIsString($publish);
+    $this->assertIsString($services);
+    $this->assertStringContainsString('publishEligibilityEvaluator', $save);
+    $this->assertStringNotContainsString('publishRequirementsGate', $save);
+    $this->assertStringNotContainsString('paidPublishStripeGate', $save);
+    $this->assertStringNotContainsString('$this->eventReadiness->evaluate', $save);
+    $this->assertStringNotContainsString('if (!$readiness->ready)', $publish);
+    $this->assertStringContainsString('return $this->setPublishedState($node, TRUE);', $publish);
+    $this->assertStringContainsString('myeventlane_event_studio.publish_eligibility', $services);
+  }
+
+  /**
+   * @covers ::evaluate
+   */
+  public function testEvaluatorClassIsInstantiableService(): void {
+    $reflection = new \ReflectionClass(PublishEligibilityEvaluator::class);
+    $this->assertTrue($reflection->hasMethod('evaluate'));
+    $this->assertFalse($reflection->getMethod('evaluate')->isStatic());
+  }
+
+  /**
+   * @covers ::evaluate
+   */
+  public function testEvaluatorCoversPaidHybridAndRsvpEventTypes(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
+
+    $this->assertIsString($source);
+    $this->assertStringContainsString("return 'rsvp';", $source);
+    $this->assertStringContainsString("in_array(\$eventType, ['paid', 'both'], TRUE)", $source);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -320,6 +320,7 @@ services:
       - '@string_translation'
       - '@logger.factory'
       - '@myeventlane_surface.state_readiness_helper'
+      - '@myeventlane_vendor.vendor_event_removal'
       - '@myeventlane_core.domain_detector'
 
   # Vendor console controllers as services for DI.

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -234,6 +234,19 @@ final class VendorDashboardViewModelBuilder {
       return NULL;
     }
 
+    if ($this->homepageVisibilityReport instanceof HomepageVisibilityReportService) {
+      $readiness = $this->homepageVisibilityReport->buildReadinessSummary($boosted_events);
+      $total = (int) ($readiness['total'] ?? 0);
+      $ready_count = (int) ($readiness['ready_count'] ?? 0);
+      if ($total > 0) {
+        return $this->homepageReadinessRender->buildDashboardSummaryFromCounts(
+          $total,
+          $ready_count,
+          max(0, $total - $ready_count),
+        );
+      }
+    }
+
     return $this->homepageReadinessRender->buildDashboardSummary($boosted_events);
   }
 
@@ -1286,6 +1299,7 @@ final class VendorDashboardViewModelBuilder {
         'booking_state_label' => (string) ($event['booking_state_label'] ?? ''),
         'metric_label' => (string) ($event['metric_label'] ?? ''),
         'reasons' => array_values($reasons),
+        'image' => is_array($event['image'] ?? NULL) ? $event['image'] : [],
         'boost' => is_array($event['boost'] ?? NULL) ? $event['boost'] : ['active' => FALSE],
         'links' => is_array($event['links'] ?? NULL) ? $event['links'] : [],
       ];
@@ -1318,6 +1332,7 @@ final class VendorDashboardViewModelBuilder {
         'status_label' => (string) ($event['status_label'] ?? ''),
         'booking_state_label' => (string) ($event['booking_state_label'] ?? ''),
         'metric_label' => (string) ($event['metric_label'] ?? ''),
+        'image' => is_array($event['image'] ?? NULL) ? $event['image'] : [],
         'boost' => is_array($event['boost'] ?? NULL) ? $event['boost'] : ['active' => FALSE],
         'links' => is_array($event['links'] ?? NULL) ? $event['links'] : [],
       ];

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventWorkspaceViewModelBuilder.php
@@ -41,6 +41,7 @@ final class VendorEventWorkspaceViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly MelReadinessHelper $readinessHelper,
+    private readonly VendorEventRemovalService $vendorEventRemovalService,
     private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $string_translation;
@@ -239,6 +240,7 @@ final class VendorEventWorkspaceViewModelBuilder {
         'event_type' => $eventType,
         'event_type_label' => $eventTypeLabel,
         'public_url' => $publicPreviewUrl,
+        'image' => $this->vendorEventRemovalService->buildEventThumbnailData($event),
       ],
       'readiness' => [
         'score' => $score,
@@ -310,6 +312,7 @@ final class VendorEventWorkspaceViewModelBuilder {
         'event_type' => 'unknown',
         'event_type_label' => (string) $this->t('Unknown'),
         'public_url' => NULL,
+        'image' => $this->vendorEventRemovalService->buildEventThumbnailData($event),
       ],
       'readiness' => ['score' => 0, 'items' => []],
       'operational_readiness' => [

--- a/web/phpunit-event-studio.xml
+++ b/web/phpunit-event-studio.xml
@@ -13,6 +13,7 @@
     <testsuite name="event_studio">
       <directory>modules/custom/myeventlane_event_studio/tests/src</directory>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/EventExtrasBookPlacementResolverTest.php</file>
+      <file>modules/custom/myeventlane_boost/tests/src/Unit/BoostDisplayReadinessConsolidationTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-card-removal.scss
@@ -48,6 +48,17 @@
     text-transform: uppercase;
     line-height: 1;
   }
+
+  &--hero {
+    width: 80px;
+    height: 80px;
+    border-radius: r.$radius-lg;
+
+    @media (min-width: 768px) {
+      width: 96px;
+      height: 96px;
+    }
+  }
 }
 
 .mel-event-card-remove-open {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -795,6 +795,10 @@ $mel-dash-lavender: #7c83fd;
     border: 1px solid rgba($ml-vendor-navy, 0.08);
     border-radius: $radius-lg;
     background: rgba($ml-slate-50, 0.55);
+
+    .mel-event-card-thumb {
+      flex-shrink: 0;
+    }
   }
 
   &__action-queue-item--primary {
@@ -857,6 +861,24 @@ $mel-dash-lavender: #7c83fd;
     border-radius: $radius-lg;
     background: $ml-vendor-bg;
     box-shadow: $shadow-xs;
+  }
+
+  &__summary-card-layout {
+    display: flex;
+    align-items: flex-start;
+    gap: $spacing-3;
+    min-width: 0;
+
+    .mel-event-card-thumb {
+      flex-shrink: 0;
+    }
+  }
+
+  &__summary-card-body {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    flex: 1 1 auto;
   }
 
   &__summary-card-title {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_event-mission-control.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_event-mission-control.scss
@@ -18,6 +18,20 @@
     align-items: flex-start;
   }
 
+  &__hero-identity {
+    display: flex;
+    align-items: flex-start;
+    gap: $spacing-4;
+    min-width: 0;
+  }
+
+  &__hero-copy {
+    display: grid;
+    gap: $spacing-2;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
   &__hero-actions .mel-live-ops__stack {
     @include respond-to(md) {
       align-items: flex-end;

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-event-card-thumb.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-event-card-thumb.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Event card thumbnail (dashboard + events index).
+ *
+ * Variables:
+ * - image: { url, alt, is_placeholder } from buildEventThumbnailData().
+ */
+#}
+{% set img = image|default({}) %}
+{% set img_url = img.url|default('') %}
+{% set img_alt = img.alt|default('') %}
+{% set img_ph = img.is_placeholder|default(false) %}
+{% set size_class = size|default('default') == 'hero' ? ' mel-event-card-thumb--hero' : '' %}
+{% if img_url %}
+  <div class="mel-event-card-thumb{{ size_class }}{% if img_ph %} mel-event-card-thumb--placeholder{% endif %}"{% if not img_ph %} aria-hidden="true"{% endif %}>
+    <img class="mel-event-card-thumb__img" src="{{ img_url }}" alt="{{ img_ph ? '' : img_alt|e('html_attr') }}" loading="lazy" width="{{ size|default('default') == 'hero' ? 96 : 56 }}" height="{{ size|default('default') == 'hero' ? 96 : 56 }}"/>
+  </div>
+{% else %}
+  <div class="mel-event-card-thumb mel-event-card-thumb--fallback{{ size_class }}">
+    <span class="mel-event-card-thumb__fallback-label" role="img" aria-label="{{ 'Event image'|t }}">{{ 'MEL'|t }}</span>
+  </div>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -171,6 +171,7 @@
             {% set problem = 'Needs review'|t %}
           {% endif %}
           <li class="mel-vendor-dashboard__action-queue-item{% if loop.first %} mel-vendor-dashboard__action-queue-item--primary{% endif %}" role="listitem">
+            {% include '@myeventlane_vendor_theme/components/mel-event-card-thumb.html.twig' with { image: ev.image|default({}) } only %}
             <div class="mel-vendor-dashboard__action-queue-body">
               <span class="mel-vendor-dashboard__action-queue-title">{{ ev.title|default('Untitled event'|t) }}</span>
               <span class="mel-vendor-dashboard__action-queue-problem">{{ problem }}</span>
@@ -203,16 +204,21 @@
           {% set status_mod = boost.active ? 'boosted' : (event_status == 'draft' ? 'draft' : 'upcoming') %}
           {% set status_text = boost.active ? ('Boosted'|t) : (ev.status_label|default('')) %}
           <article class="mel-vendor-dashboard__summary-card" role="listitem">
-            <h3 class="mel-vendor-dashboard__summary-card-title">{{ ev.title|default('Untitled event'|t) }}</h3>
-            {% if ev.date_label is defined and ev.date_label %}
-              <p class="mel-vendor-dashboard__summary-card-date">{{ ev.date_label }}</p>
-            {% endif %}
-            {% if status_text %}
-              <p class="mel-vendor-dashboard__summary-card-status mel-vendor-dashboard__summary-card-status--{{ status_mod }}">{{ status_text }}</p>
-            {% endif %}
-            {% if links.manage is defined and links.manage %}
-              <a class="mel-live-ops__readiness-link mel-vendor-dashboard__summary-card-action" href="{{ links.manage }}">{{ 'Open'|t }} →</a>
-            {% endif %}
+            <div class="mel-vendor-dashboard__summary-card-layout">
+              {% include '@myeventlane_vendor_theme/components/mel-event-card-thumb.html.twig' with { image: ev.image|default({}) } only %}
+              <div class="mel-vendor-dashboard__summary-card-body">
+                <h3 class="mel-vendor-dashboard__summary-card-title">{{ ev.title|default('Untitled event'|t) }}</h3>
+                {% if ev.date_label is defined and ev.date_label %}
+                  <p class="mel-vendor-dashboard__summary-card-date">{{ ev.date_label }}</p>
+                {% endif %}
+                {% if status_text %}
+                  <p class="mel-vendor-dashboard__summary-card-status mel-vendor-dashboard__summary-card-status--{{ status_mod }}">{{ status_text }}</p>
+                {% endif %}
+                {% if links.manage is defined and links.manage %}
+                  <a class="mel-live-ops__readiness-link mel-vendor-dashboard__summary-card-action" href="{{ links.manage }}">{{ 'Open'|t }} →</a>
+                {% endif %}
+              </div>
+            </div>
           </article>
         {% endfor %}
       </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -33,6 +33,9 @@
         <div class="mel-live-ops__hero-surface">
           <div class="mel-event-mission-control__hero-layout mel-live-ops__hero-layout">
             <div class="mel-live-ops__hero-primary">
+              <div class="mel-event-mission-control__hero-identity">
+                {% include '@myeventlane_vendor_theme/components/mel-event-card-thumb.html.twig' with { image: model.event.image|default({}), size: 'hero' } only %}
+                <div class="mel-event-mission-control__hero-copy">
               <div class="mel-live-ops__chip-row mel-live-ops__chip-row--compact">
                 <span class="mel-live-ops__chip mel-live-ops__chip--{{ st_chip }}">{{ model.event.status_label|default('') }}</span>
                 {% if model.event.event_type_label|default('') is not empty %}
@@ -46,6 +49,8 @@
                   <span>{{ model.event.date_label }}</span>
                 {% endif %}
               </p>
+                </div>
+              </div>
             </div>
             <div class="mel-live-ops__hero-aside mel-event-mission-control__hero-actions">
               <div class="mel-live-ops__stack">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Publish eligibility and readiness presentation are centralized across save, publish AJAX, and Boost; behavior changes (strip visibility, removed duplicate publish readiness check) need regression on paid/Stripe publish paths and post-publish UI sync.
> 
> **Overview**
> This PR **consolidates publish and homepage promotion readiness** behind `EventReadinessFacade` and display-only `EventStudioWorkspacePresentation`, so Event Studio, Boost purchase/success, and AJAX publish responses share one evaluation bundle instead of re-running checks separately.
> 
> **Event Studio workspace** gains an **Event health** panel (publish, promotion, boost), a **conditional publish readiness strip** (hidden when published and clean), and smarter **homepage readiness** cards (`buildChecklistCardFromPresentation`, optional summary-only / hide published row). Shell JS syncs strip visibility, event health, and homepage card after publish.
> 
> **Publish enforcement** moves into **`PublishEligibilityEvaluator`** (vendor gates, Stripe for paid/both, readiness); save and `setNodePublishedState` use it, and the publish controller no longer pre-checks readiness before calling save (failures still return structured JSON via save/eligibility).
> 
> **Boost** depends on `myeventlane_event_studio` and builds homepage cards from the facade. **Homepage readiness** UI adds summary-only styling and copy tweaks (“ready for promotion”). **Branding** syncs hero crop form state before validation to avoid false crop rejections. **Governance refresh** returns 500 JSON on throwables.
> 
> **Vendor dashboard / mission control** show event thumbnails via shared `mel-event-card-thumb`; dashboard homepage readiness summary can use precomputed counts from the visibility report.
> 
> Broad **contract/unit tests** lock these wiring and UX contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bff0cf16e4a5282cd2c8a7e9a204198b2e3f63f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->