### PR TITLE
Fix Event Studio readiness surfaces after publish/unpublish AJAX.

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -198,6 +198,55 @@
     }
   }
 
+  function ensureReadinessStrip(shell) {
+    let strip = shell.querySelector('[data-mel-readiness-strip]');
+    if (strip) {
+      return strip;
+    }
+    strip = document.createElement('section');
+    strip.className = 'mel-event-studio-readiness-strip needs-attention';
+    strip.setAttribute('aria-label', Drupal.t('Publish readiness'));
+    strip.setAttribute('data-mel-readiness-strip', '');
+    strip.innerHTML = [
+      '<div class="mel-event-studio-readiness-strip__summary">',
+      '<strong data-mel-readiness-title></strong>',
+      '<span data-mel-readiness-state></span>',
+      '</div>',
+      '<div class="mel-event-studio-readiness-strip__counts">',
+      '<span data-mel-readiness-errors-count></span>',
+      '<span data-mel-readiness-warnings-count></span>',
+      '<span data-mel-readiness-recommendations-count></span>',
+      '<span data-mel-readiness-completed-count></span>',
+      '</div>',
+    ].join('');
+    const health = shell.querySelector('[data-mel-event-health]');
+    if (health) {
+      health.insertAdjacentElement('afterend', strip);
+    }
+    else {
+      shell.prepend(strip);
+    }
+    return strip;
+  }
+
+  function ensureHomepageReadinessWrapper(shell) {
+    let wrapper = shell.querySelector('.mel-event-studio-homepage-readiness');
+    if (wrapper) {
+      return wrapper;
+    }
+    wrapper = document.createElement('div');
+    wrapper.className = 'mel-event-studio-homepage-readiness';
+    const strip = shell.querySelector('[data-mel-readiness-strip]');
+    if (strip) {
+      strip.insertAdjacentElement('afterend', wrapper);
+    }
+    else {
+      const health = shell.querySelector('[data-mel-event-health]');
+      (health || shell).insertAdjacentElement('afterend', wrapper);
+    }
+    return wrapper;
+  }
+
   function updateReadiness(shell, readiness) {
     if (!readiness) {
       return;
@@ -207,10 +256,7 @@
     const showStrip = readiness.show_publish_strip !== undefined
       ? !!readiness.show_publish_strip
       : (!published || !readiness.ready || hasBlockers);
-    const strip = shell.querySelector('[data-mel-readiness-strip]');
-    if (!strip) {
-      return;
-    }
+    const strip = ensureReadinessStrip(shell);
     strip.hidden = !showStrip;
     if (!showStrip) {
       return;
@@ -229,12 +275,16 @@
     setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
   }
 
-  function syncHomepageReadinessVisibility(shell, showHomepageReadiness) {
-    const wrapper = shell.querySelector('.mel-event-studio-homepage-readiness');
-    if (!wrapper) {
+  function updateHomepageReadiness(shell, readiness) {
+    if (!readiness || readiness.show_homepage_readiness === undefined) {
       return;
     }
-    wrapper.hidden = showHomepageReadiness === false;
+    const wrapper = ensureHomepageReadinessWrapper(shell);
+    if (readiness.homepage_readiness_html !== undefined) {
+      wrapper.innerHTML = readiness.homepage_readiness_html;
+    }
+    wrapper.hidden = readiness.show_homepage_readiness === false
+      || wrapper.innerHTML.trim() === '';
   }
 
   function updateEventHealth(shell, health) {
@@ -330,8 +380,8 @@
     if (result.event_health) {
       updateEventHealth(shell, result.event_health);
     }
-    if (result.readiness && result.readiness.show_homepage_readiness !== undefined) {
-      syncHomepageReadinessVisibility(shell, result.readiness.show_homepage_readiness);
+    if (result.readiness) {
+      updateHomepageReadiness(shell, result.readiness);
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -16,7 +16,6 @@ services:
       - '@myeventlane_core.domain_detector'
       - '@myeventlane_event_studio.preprocess'
       - '@myeventlane_vendor.service.boost_status'
-      - '@myeventlane_event.featured_readiness_render'
       - '@myeventlane_event_studio.workspace_presentation'
       - '@myeventlane_boost.extension_recommendation'
     tags:
@@ -26,6 +25,7 @@ services:
     class: Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation
     arguments:
       - '@date.formatter'
+      - '@myeventlane_event.featured_readiness_render'
       - '@string_translation'
 
   myeventlane_event_studio.preprocess:
@@ -498,6 +498,7 @@ services:
       - '@myeventlane_vendor.event_access_checker'
       - '@current_user'
       - '@date.formatter'
+      - '@renderer'
       - '@logger.channel.myeventlane_event_studio'
       - '@string_translation'
       - '@myeventlane_event_studio.preprocess'

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -20,7 +20,6 @@ use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
 use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
-use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
 use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
 use Drupal\myeventlane_vendor\Service\BoostStatusService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
@@ -54,7 +53,6 @@ final class EventStudioController extends ControllerBase {
     private readonly DomainDetector $domainDetector,
     private readonly EventStudioPreprocess $eventStudioPreprocess,
     private readonly BoostStatusService $boostStatusService,
-    private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
     private readonly EventStudioWorkspacePresentation $workspacePresentation,
     private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
@@ -77,7 +75,6 @@ final class EventStudioController extends ControllerBase {
       $container->get('myeventlane_core.domain_detector'),
       $container->get('myeventlane_event_studio.preprocess'),
       $container->get('myeventlane_vendor.service.boost_status'),
-      $container->get('myeventlane_event.featured_readiness_render'),
       $container->get('myeventlane_event_studio.workspace_presentation'),
       $container->get('myeventlane_boost.extension_recommendation'),
     );
@@ -254,7 +251,7 @@ final class EventStudioController extends ControllerBase {
       '#topbar' => $this->buildTopbar($node, $readiness, $section),
       '#event_health' => $event_health,
       '#readiness' => $readiness_summary,
-      '#homepage_readiness' => $this->buildHomepageReadinessCard($node, $readiness_bundle, $section),
+      '#homepage_readiness' => $this->workspacePresentation->buildHomepageReadinessCard($node, $readiness_bundle, $section),
       '#boost' => $boost,
       '#boost_extension_recommendation' => $boost_extension_recommendation,
       '#publish_handoff' => $publish_handoff,
@@ -367,26 +364,6 @@ final class EventStudioController extends ControllerBase {
       'changed' => $node->getChangedTime(),
       'revision_id' => (int) $node->getRevisionId(),
     ];
-  }
-
-  private function buildHomepageReadinessCard(NodeInterface $node, array $readiness_bundle, string $section): ?array {
-    $promotion_ready = (bool) ($readiness_bundle['promotion_ready'] ?? FALSE);
-    $published = $node->isPublished();
-    if (!$this->workspacePresentation->shouldShowHomepageReadinessCard($promotion_ready, $published)) {
-      return NULL;
-    }
-    if ($section !== 'overview' && $promotion_ready) {
-      return NULL;
-    }
-
-    return $this->homepageReadinessRender->buildChecklistCardFromPresentation(
-      $node,
-      is_array($readiness_bundle['promotion'] ?? NULL) ? $readiness_bundle['promotion'] : [],
-      TRUE,
-      !$promotion_ready,
-      FALSE,
-      $published,
-    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Controller;
 
 use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
@@ -44,6 +45,7 @@ final class EventStudioPublishController {
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
     private readonly AccountProxyInterface $currentUser,
     private readonly DateFormatterInterface $dateFormatter,
+    private readonly RendererInterface $renderer,
     private readonly LoggerInterface $logger,
     TranslationInterface $stringTranslation,
     private readonly EventStudioPreprocess $eventStudioPreprocess,
@@ -74,6 +76,7 @@ final class EventStudioPublishController {
     }
 
     $data = $this->requestPayload($request);
+    $section = (string) ($data['section'] ?? '');
     $action = (string) ($data['action'] ?? 'publish');
     $publishing = $action !== 'unpublish';
     if (!empty($data['dirty'])) {
@@ -84,6 +87,7 @@ final class EventStudioPublishController {
         $node,
         NULL,
         $this->blockedHeading($publishing),
+        $section,
       );
     }
 
@@ -97,6 +101,7 @@ final class EventStudioPublishController {
         $node,
         NULL,
         $this->blockedHeading($publishing),
+        $section,
       );
     }
 
@@ -111,17 +116,18 @@ final class EventStudioPublishController {
         $node,
         $draftSection,
         $this->blockedHeading($publishing),
+        $section,
       );
     }
 
     if (!$publishing) {
-      return $this->setPublishedState($node, FALSE);
+      return $this->setPublishedState($node, FALSE, $section);
     }
 
-    return $this->setPublishedState($node, TRUE);
+    return $this->setPublishedState($node, TRUE, $section);
   }
 
-  private function setPublishedState(NodeInterface $node, bool $published): JsonResponse {
+  private function setPublishedState(NodeInterface $node, bool $published, string $section = ''): JsonResponse {
     $account = $this->currentUser;
     try {
       $this->saveService->setNodePublishedState(
@@ -147,6 +153,8 @@ final class EventStudioPublishController {
         $this->blockedHeading($published),
         $published ? 'cannot_publish' : 'cannot_unpublish',
         [$e->getMessage()],
+        NULL,
+        $section,
       );
     }
     catch (\Throwable $e) {
@@ -163,6 +171,7 @@ final class EventStudioPublishController {
         $node,
         NULL,
         $this->blockedHeading($published),
+        $section,
       );
     }
 
@@ -175,6 +184,8 @@ final class EventStudioPublishController {
       $published ? (string) $this->t('Published successfully') : (string) $this->t('Unpublished successfully'),
       $published ? 'published' : 'draft',
       [],
+      NULL,
+      $section,
     );
   }
 
@@ -212,7 +223,7 @@ final class EventStudioPublishController {
   /**
    * @param list<string> $messages
    */
-  private function blockedResponse(int $status, string $code, array $messages, NodeInterface $node, ?string $restoreSection = NULL, ?string $message = NULL): JsonResponse {
+  private function blockedResponse(int $status, string $code, array $messages, NodeInterface $node, ?string $restoreSection = NULL, ?string $message = NULL, string $section = ''): JsonResponse {
     $readiness = $this->eventReadiness->evaluate($node, $this->currentUser);
     return $this->readinessResponse(
       FALSE,
@@ -223,6 +234,7 @@ final class EventStudioPublishController {
       $code,
       $messages,
       $restoreSection,
+      $section,
     );
   }
 
@@ -238,6 +250,7 @@ final class EventStudioPublishController {
     string $state,
     array $messages,
     ?string $restoreSection = NULL,
+    string $section = '',
   ): JsonResponse {
     $readiness_bundle = $this->readinessFacade->evaluate($node, $this->currentUser);
     $publish_result = $readiness_bundle['publish'];
@@ -246,6 +259,17 @@ final class EventStudioPublishController {
       $readiness_bundle,
       $node,
     );
+    $homepage_card = $this->workspacePresentation->buildHomepageReadinessCard(
+      $node,
+      $readiness_bundle,
+      $section,
+    );
+    if ($homepage_card !== NULL) {
+      $ajax_readiness['homepage_readiness_html'] = (string) $this->renderer->renderPlain($homepage_card);
+    }
+    else {
+      $ajax_readiness['homepage_readiness_html'] = '';
+    }
 
     $payload = [
       'ok' => $ok,

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_event_studio\Service;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\node\NodeInterface;
 
@@ -21,6 +22,7 @@ final class EventStudioWorkspacePresentation {
 
   public function __construct(
     private readonly DateFormatterInterface $dateFormatter,
+    private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
     TranslationInterface $stringTranslation,
   ) {
     $this->stringTranslation = $stringTranslation;
@@ -177,6 +179,36 @@ final class EventStudioWorkspacePresentation {
 
   public function shouldShowHomepageReadinessCard(bool $promotion_ready, bool $published): bool {
     return !$promotion_ready || !$published;
+  }
+
+  /**
+   * Homepage readiness card render array for workspace shell and AJAX refresh.
+   *
+   * @param array{
+   *   promotion: array<string, mixed>,
+   *   promotion_ready: bool,
+   * } $readiness_bundle
+   *
+   * @return array<string, mixed>|null
+   */
+  public function buildHomepageReadinessCard(NodeInterface $node, array $readiness_bundle, string $section): ?array {
+    $promotion_ready = (bool) ($readiness_bundle['promotion_ready'] ?? FALSE);
+    $published = $node->isPublished();
+    if (!$this->shouldShowHomepageReadinessCard($promotion_ready, $published)) {
+      return NULL;
+    }
+    if ($section !== 'overview' && $promotion_ready) {
+      return NULL;
+    }
+
+    return $this->homepageReadinessRender->buildChecklistCardFromPresentation(
+      $node,
+      is_array($readiness_bundle['promotion'] ?? NULL) ? $readiness_bundle['promotion'] : [],
+      TRUE,
+      !$promotion_ready,
+      FALSE,
+      $published,
+    );
   }
 
   private function formatLastUpdated(NodeInterface $node): string {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -22,26 +22,24 @@
     event_health: event_health
   }, with_context = false) }}
 
-  {% if readiness.show_publish_strip|default(true) %}
-    <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip>
-      <div class="mel-event-studio-readiness-strip__summary">
-        <strong data-mel-readiness-title>{{ readiness.strip_title|default(readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t) }}</strong>
-        <span data-mel-readiness-state>{{ readiness.state }}</span>
-      </div>
-      <div class="mel-event-studio-readiness-strip__counts">
-        <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
-        <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
-        <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
-        <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
-      </div>
-    </section>
-  {% endif %}
-
-  {% if homepage_readiness %}
-    <div class="mel-event-studio-homepage-readiness">
-      {{ homepage_readiness }}
+  <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip{% if not readiness.show_publish_strip|default(true) %} hidden{% endif %}>
+    <div class="mel-event-studio-readiness-strip__summary">
+      <strong data-mel-readiness-title>{{ readiness.strip_title|default(readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t) }}</strong>
+      <span data-mel-readiness-state>{{ readiness.state }}</span>
     </div>
-  {% endif %}
+    <div class="mel-event-studio-readiness-strip__counts">
+      <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
+      <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
+      <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
+      <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
+    </div>
+  </section>
+
+  <div class="mel-event-studio-homepage-readiness"{% if not homepage_readiness %} hidden{% endif %}>
+    {% if homepage_readiness %}
+      {{ homepage_readiness }}
+    {% endif %}
+  </div>
 
   {% if boost is not null and boost.active %}
     <section class="mel-boost-active-banner" aria-labelledby="mel-boost-active-title">

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceFailureFallbackTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceFailureFallbackTest.php
@@ -13,7 +13,6 @@ use Drupal\myeventlane_event_studio\Controller\EventStudioController;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\myeventlane_event_studio\EventStudioSectionManager;
 use Drupal\myeventlane_event_studio\Plugin\EventStudioSection\EventStudioSectionInterface;
-use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
 use Drupal\myeventlane_event_studio\EventStudioPreprocess;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
 use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
@@ -175,7 +174,6 @@ final class EventStudioWorkspaceFailureFallbackTest extends UnitTestCase {
       EventStudioWorkspaceTestFactory::domainDetector($createMock),
       (new ReflectionClass(EventStudioPreprocess::class))->newInstanceWithoutConstructor(),
       (new ReflectionClass(BoostStatusService::class))->newInstanceWithoutConstructor(),
-      (new ReflectionClass(FeaturedEventReadinessRenderBuilder::class))->newInstanceWithoutConstructor(),
       (new ReflectionClass(EventStudioWorkspacePresentation::class))->newInstanceWithoutConstructor(),
       NULL,
     );

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
@@ -9,6 +9,7 @@ use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
+use ReflectionClass;
 
 /**
  * Proves workspace surfaces share one presentation source per state.
@@ -27,7 +28,9 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $translator->method('translateString')->willReturnCallback(
       static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
     );
-    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $translator);
+    $homepageReadinessRender = (new ReflectionClass(\Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder::class))
+      ->newInstanceWithoutConstructor();
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $translator);
   }
 
   public function testStripAndAjaxPayloadShareReadinessSummaryFields(): void {
@@ -118,13 +121,15 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertStringContainsString('readinessFacade->evaluate', $publish);
     $this->assertStringContainsString('buildAjaxReadinessPayloadFromBundle', $publish);
     $this->assertStringContainsString('buildEventHealth($readiness_bundle', $publish);
+    $this->assertStringContainsString('homepage_readiness_html', $publish);
     $this->assertStringNotContainsString('buildAjaxReadinessPayload(', $publish);
   }
 
   public function testShellJsSyncsHomepageReadinessVisibility(): void {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('syncHomepageReadinessVisibility', $js);
+    $this->assertStringContainsString('updateHomepageReadiness', $js);
+    $this->assertStringContainsString('homepage_readiness_html', $js);
     $this->assertStringContainsString('show_homepage_readiness', $js);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -9,6 +9,7 @@ use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
+use ReflectionClass;
 
 /**
  * State matrix and presentation contract tests for Event Studio workspace.
@@ -27,7 +28,9 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $translator->method('translateString')->willReturnCallback(
       static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
     );
-    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $translator);
+    $homepageReadinessRender = (new ReflectionClass(\Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder::class))
+      ->newInstanceWithoutConstructor();
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $translator);
   }
 
   public function testDraftReadyShowsPublishStrip(): void {
@@ -116,7 +119,8 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertIsString($js);
     $this->assertStringContainsString('function updateEventHealth', $js);
     $this->assertStringContainsString('result.event_health', $js);
-    $this->assertStringContainsString('readiness.show_publish_strip', $js);
+    $this->assertStringContainsString('ensureReadinessStrip', $js);
+    $this->assertStringContainsString('updateHomepageReadiness', $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -47,7 +47,7 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     $this->assertStringContainsString('summary_only', $checklist);
     $this->assertStringContainsString('hide_published_item', $checklist);
     $this->assertStringContainsString('summary_only', $builder);
-    $this->assertStringContainsString('buildHomepageReadinessCard', file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php'));
+    $this->assertStringContainsString('buildHomepageReadinessCard', file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php'));
   }
 
   public function testOverviewSectionUsesShorterOrientationCopy(): void {


### PR DESCRIPTION
Always render the publish readiness strip and homepage readiness wrapper in the workspace shell so AJAX can toggle visibility and update content without a full page reload. Publish responses now include rendered homepage readiness HTML, and shell JS creates or updates both surfaces from the readiness payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the publish/unpublish JSON contract and client DOM updates for vendor-facing readiness UI, but logic stays in existing readiness/presentation services rather than new auth or save paths.
> 
> **Overview**
> Fixes **Event Studio** publish/unpublish so the **publish readiness strip** and **homepage promotion readiness** card stay accurate without a full reload.
> 
> The workspace shell **always outputs** the readiness strip and homepage wrapper (using `hidden` when inactive) instead of omitting them from the DOM. Shell JS **creates or updates** those nodes from the AJAX readiness payload, including injected **`homepage_readiness_html`**.
> 
> **Publish/unpublish JSON** now carries the current section, renders the homepage checklist through **`EventStudioWorkspacePresentation`** (shared with the initial page load), and returns plain HTML for the client to swap in. Homepage card building moved out of **`EventStudioController`** into that presentation service with updated DI and unit contract tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e6e6d36eedbfe8033efd755a59c7e6ee16f0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->