### PR TITLE
Feature/footer modernisation

### DIFF
--- a/web/modules/custom/myeventlane_front/src/Service/TrustContentFoundation.php
+++ b/web/modules/custom/myeventlane_front/src/Service/TrustContentFoundation.php
@@ -163,14 +163,25 @@ final class TrustContentFoundation {
   }
 
   /**
-   * Creates or updates a published basic page at the given alias.
+   * Creates or updates a basic page at the given alias.
+   *
+   * New pages are published. Existing publish state is preserved so editorial
+   * unpublish actions are not reversed by update hooks.
    */
   private function upsertPage(string $alias, string $title, string $body): string {
     $node = $this->loadNodeByAlias($alias);
     if ($node instanceof NodeInterface) {
-      $node->setTitle($title);
-      $node->set('body', ['value' => $body, 'format' => 'basic_html']);
-      $node->setPublished();
+      $titleChanged = $node->getTitle() !== $title;
+      $bodyChanged = !$this->bodyFieldMatches($node, $body);
+      if (!$titleChanged && !$bodyChanged) {
+        return sprintf('No changes for page at %s (nid=%d).', $alias, (int) $node->id());
+      }
+      if ($titleChanged) {
+        $node->setTitle($title);
+      }
+      if ($bodyChanged) {
+        $node->set('body', ['value' => $body, 'format' => 'basic_html']);
+      }
       $node->save();
       return sprintf('Updated page at %s (nid=%d).', $alias, (int) $node->id());
     }
@@ -190,6 +201,14 @@ final class TrustContentFoundation {
     ])->save();
 
     return sprintf('Created page at %s (nid=%d).', $alias, (int) $node->id());
+  }
+
+  private function bodyFieldMatches(NodeInterface $node, string $body): bool {
+    if (!$node->hasField('body') || $node->get('body')->isEmpty()) {
+      return $body === '';
+    }
+    return (string) $node->get('body')->value === $body
+      && (string) ($node->get('body')->format ?? 'basic_html') === 'basic_html';
   }
 
   private function loadNodeByAlias(string $alias): ?NodeInterface {

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.install
@@ -1886,9 +1886,13 @@ function myeventlane_help_centre_update_10036(): string {
   if (is_readable($file)) {
     $data = \Symfony\Component\Yaml\Yaml::parseFile($file);
     if (is_array($data) && isset($data['help_articles']) && is_array($data['help_articles'])) {
-      \Drupal::configFactory()->getEditable('myeventlane_help_centre.help_content')
-        ->set('help_articles', $data['help_articles'])
-        ->save();
+      $config = \Drupal::configFactory()->getEditable('myeventlane_help_centre.help_content');
+      $existing = $config->get('help_articles');
+      $merged = is_array($existing) ? $existing : [];
+      foreach ($data['help_articles'] as $key => $article) {
+        $merged[$key] = $article;
+      }
+      $config->set('help_articles', $merged)->save();
     }
   }
 

--- a/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
+++ b/web/modules/custom/myeventlane_help_centre/src/Service/HelpContentSeeder.php
@@ -189,13 +189,13 @@ final class HelpContentSeeder {
           'title' => $item['title'],
         ]);
       }
-      $node = $existing !== [] ? reset($existing) : Node::create([
+      $isNew = $existing === [];
+      $node = $isNew ? Node::create([
         'type' => 'help_article',
         'title' => $item['title'],
         'status' => 1,
-      ]);
+      ]) : reset($existing);
       $node->setTitle($item['title']);
-      $this->applyPublishedState($node);
       $this->setTextField($node, 'field_help_seed_key', $seedKey);
       $this->setTextField($node, 'field_help_summary', (string) $item['summary']);
       $this->setBodyField($node, (string) $item['body']);
@@ -206,17 +206,23 @@ final class HelpContentSeeder {
       $this->setBoolField($node, 'field_featured_help', (bool) ($item['featured'] ?? FALSE));
       $this->setTextField($node, 'field_help_cta_label', (string) $item['cta_label']);
       $this->setLinkField($node, 'field_help_cta_link', (string) $item['cta_link']);
-      if ($node->isNew() || ($node->hasField('field_last_reviewed') && $node->get('field_last_reviewed')->isEmpty())) {
+      if ($isNew || ($node->hasField('field_last_reviewed') && $node->get('field_last_reviewed')->isEmpty())) {
         $this->setDateField($node, 'field_last_reviewed', date('Y-m-d'));
       }
       $this->setAlias($node, (string) $item['alias']);
-      $this->applyPublishedState($node);
-      if ($node->hasField('field_help_status')) {
-        $this->setTextField($node, 'field_help_status', 'published');
+      if ($isNew) {
+        $this->applyPublishedState($node);
+        if ($node->hasField('field_help_status')) {
+          $this->setTextField($node, 'field_help_status', 'published');
+        }
+        $node->save();
+        $created++;
+        continue;
       }
-      $isNew = $node->isNew();
-      $node->save();
-      $isNew ? $created++ : $updated++;
+      if ($this->nodeSeedContentChanged($node)) {
+        $node->save();
+        $updated++;
+      }
     }
 
     $this->logger->notice('Help Centre articles seeded. Created @created, updated @updated.', [
@@ -356,7 +362,44 @@ final class HelpContentSeeder {
   }
 
   /**
-   * Ensures seeded help articles are publicly visible under content moderation.
+   * Whether seed-managed fields differ from the stored node.
+   */
+  private function nodeSeedContentChanged(NodeInterface $node): bool {
+    if ($node->isNew()) {
+      return TRUE;
+    }
+    if (!$node->original instanceof NodeInterface) {
+      return TRUE;
+    }
+    if ($node->getTitle() !== $node->original->getTitle()) {
+      return TRUE;
+    }
+    foreach ([
+      'field_help_seed_key',
+      'field_help_summary',
+      'body',
+      'field_audience',
+      'field_help_topic',
+      'field_help_article_type',
+      'field_help_keywords',
+      'field_featured_help',
+      'field_help_cta_label',
+      'field_help_cta_link',
+      'field_last_reviewed',
+      'path',
+    ] as $fieldName) {
+      if (!$node->hasField($fieldName)) {
+        continue;
+      }
+      if (!$node->get($fieldName)->equals($node->original->get($fieldName))) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Ensures newly seeded help articles are publicly visible under moderation.
    */
   private function applyPublishedState(NodeInterface $node): void {
     $node->setPublished();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how update hooks and seeders mutate published nodes and config; wrong change detection could leave stale seed content or skip needed updates, but the intent reduces risk to editorial unpublish and custom help config.
> 
> **Overview**
> Makes **trust footer pages** and **Help Centre seeding** safer to re-run without undoing editorial work or writing unchanged nodes.
> 
> **Trust basic pages** (`TrustContentFoundation`): existing nodes are no longer force-published on update—only **new** pages get published. Updates skip `save()` when title and body already match seed content (via `bodyFieldMatches`), and only changed fields are written.
> 
> **Help articles** (`HelpContentSeeder`): `applyPublishedState` and forced `field_help_status = published` run **only for new** articles. Existing nodes save only when seed-managed fields differ from the loaded original (`nodeSeedContentChanged`); unpublish/moderation edits on existing articles are no longer reset on every seed pass.
> 
> **Update hook 10036**: `help_content` config from install YAML is **merged** by article key into existing `help_articles` instead of replacing the whole config, so site-specific or previously merged entries are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afafa5a0a37d9a532365af3866203ab5eaeec6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->