### PR TITLE
Enhance blog experience and organiser resources

### DIFF
--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -6,6 +6,8 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_media_document
     - media.type.document
+  module:
+    - file
 _core:
   default_config_hash: dcpfpqyLXOSGpulacMAJW3H-G34_LeNsjdfxd1_oCfY
 id: media.document.media_library
@@ -13,6 +15,13 @@ targetEntityType: media
 bundle: document
 mode: media_library
 content:
+  field_media_document:
+    type: file_generic
+    weight: 0
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 2
@@ -22,7 +31,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_media_document: true
   name: true
   path: true
   status: true

--- a/config/sync/core.entity_form_display.node.blog_post.default.yml
+++ b/config/sync/core.entity_form_display.node.blog_post.default.yml
@@ -4,15 +4,25 @@ status: true
 dependencies:
   config:
     - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_audience
+    - field.field.node.blog_post.field_blog_author_name
+    - field.field.node.blog_post.field_blog_author_type
     - field.field.node.blog_post.field_blog_hero_image
     - field.field.node.blog_post.field_excerpt
     - field.field.node.blog_post.field_publish_date
     - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_organiser_category
+    - field.field.node.blog_post.field_featured_playbook
+    - field.field.node.blog_post.field_playbook
+    - field.field.node.blog_post.field_resource_downloads
+    - field.field.node.blog_post.field_resource_links
     - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
     - content_moderation
     - datetime
+    - link
+    - media_library
     - path
     - text
 id: node.blog_post.default
@@ -36,15 +46,33 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_blog_hero_image:
-    type: entity_reference_autocomplete
+  field_blog_audience:
+    type: options_select
     weight: 1
     region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_blog_author_name:
+    type: string_textfield
+    weight: 3
+    region: content
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_blog_author_type:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_blog_hero_image:
+    type: media_library_widget
+    weight: 3
+    region: content
+    settings:
+      media_types:
+        image: image
     third_party_settings: {  }
   field_excerpt:
     type: string_textarea
@@ -54,15 +82,55 @@ content:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
+  field_featured_playbook:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_organiser_category:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_playbook:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_publish_date:
     type: datetime_default
     weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_resource_downloads:
+    type: media_library_widget
+    weight: 8
+    region: content
+    settings:
+      media_types:
+        document: document
+    third_party_settings: {  }
+  field_resource_links:
+    type: link_default
+    weight: 9
+    region: content
+    settings:
+      placeholder_url: 'https://www.canva.com/'
+      placeholder_title: 'Event budget template'
+    third_party_settings: {  }
   field_seo_description:
     type: string_textarea
-    weight: 6
+    weight: 10
     region: content
     settings:
       rows: 3
@@ -70,7 +138,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 5
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -1,0 +1,33 @@
+uuid: 4d5e6f70-8192-0123-def0-234567890123
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image.field_media_image
+    - image.style.mel_blog_card
+    - media.type.image
+  module:
+    - image
+id: media.image.thumbnail
+targetEntityType: media
+bundle: image
+mode: thumbnail
+content:
+  field_media_image:
+    type: image
+    label: visually_hidden
+    settings:
+      image_link: ''
+      image_style: mel_blog_card
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.blog_post.default.yml
+++ b/config/sync/core.entity_view_display.node.blog_post.default.yml
@@ -4,10 +4,18 @@ status: true
 dependencies:
   config:
     - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_audience
+    - field.field.node.blog_post.field_blog_author_name
+    - field.field.node.blog_post.field_blog_author_type
     - field.field.node.blog_post.field_blog_hero_image
     - field.field.node.blog_post.field_excerpt
     - field.field.node.blog_post.field_publish_date
     - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_organiser_category
+    - field.field.node.blog_post.field_featured_playbook
+    - field.field.node.blog_post.field_playbook
+    - field.field.node.blog_post.field_resource_downloads
+    - field.field.node.blog_post.field_resource_links
     - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
@@ -55,7 +63,15 @@ content:
     weight: 100
     region: content
 hidden:
+  field_blog_audience: true
+  field_blog_author_name: true
+  field_blog_author_type: true
+  field_featured_playbook: true
+  field_organiser_category: true
+  field_playbook: true
   field_publish_date: true
+  field_resource_downloads: true
+  field_resource_links: true
   field_seo_description: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.blog_post.teaser.yml
+++ b/config/sync/core.entity_view_display.node.blog_post.teaser.yml
@@ -3,12 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.thumbnail
     - core.entity_view_mode.node.teaser
     - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_blog_author_name
+    - field.field.node.blog_post.field_blog_author_type
     - field.field.node.blog_post.field_blog_hero_image
     - field.field.node.blog_post.field_excerpt
     - field.field.node.blog_post.field_publish_date
     - field.field.node.blog_post.field_seo_description
+    - field.field.node.blog_post.field_organiser_category
+    - field.field.node.blog_post.field_playbook
+    - field.field.node.blog_post.field_resource_downloads
+    - field.field.node.blog_post.field_resource_links
     - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
@@ -41,7 +48,15 @@ content:
     region: content
 hidden:
   body: true
+  field_blog_audience: true
+  field_blog_author_name: true
+  field_blog_author_type: true
+  field_featured_playbook: true
+  field_organiser_category: true
+  field_playbook: true
   field_publish_date: true
+  field_resource_downloads: true
+  field_resource_links: true
   field_seo_description: true
   field_tags: true
   langcode: true

--- a/config/sync/core.entity_view_mode.media.thumbnail.yml
+++ b/config/sync/core.entity_view_mode.media.thumbnail.yml
@@ -1,0 +1,11 @@
+uuid: 3c4d5e6f-7081-9012-cdef-123456789012
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.thumbnail
+label: Thumbnail
+description: null
+targetEntityType: media
+cache: true

--- a/config/sync/field.field.node.blog_post.field_blog_audience.yml
+++ b/config/sync/field.field.node.blog_post.field_blog_audience.yml
@@ -1,0 +1,23 @@
+uuid: 3d7e9b0a-8c2f-4e61-a5d4-2b8f7a9c0e1d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blog_audience
+    - node.type.blog_post
+  module:
+    - options
+id: node.blog_post.field_blog_audience
+field_name: field_blog_audience
+entity_type: node
+bundle: blog_post
+label: Audience
+description: 'Editorial audience for CTA and blog landing grouping. Not access control.'
+required: false
+translatable: false
+default_value:
+  -
+    value: attendee
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.blog_post.field_blog_author_name.yml
+++ b/config/sync/field.field.node.blog_post.field_blog_author_name.yml
@@ -1,0 +1,19 @@
+uuid: 5b1c7a09-6e0d-4a58-95c3-9b7d6e8f0a1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blog_author_name
+    - node.type.blog_post
+id: node.blog_post.field_blog_author_name
+field_name: field_blog_author_name
+entity_type: node
+bundle: blog_post
+label: 'Guest author name'
+description: 'Displayed when author type is Guest.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.blog_post.field_blog_author_type.yml
+++ b/config/sync/field.field.node.blog_post.field_blog_author_type.yml
@@ -1,0 +1,23 @@
+uuid: 6a2d8c0b-7f1e-4b59-a6d4-0c8e7f9a1b2d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blog_author_type
+    - node.type.blog_post
+  module:
+    - options
+id: node.blog_post.field_blog_author_type
+field_name: field_blog_author_type
+entity_type: node
+bundle: blog_post
+label: 'Author type'
+description: 'Controls how the byline is displayed on the public blog article.'
+required: false
+translatable: false
+default_value:
+  -
+    value: staff
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.blog_post.field_featured_playbook.yml
+++ b/config/sync/field.field.node.blog_post.field_featured_playbook.yml
@@ -1,0 +1,23 @@
+uuid: 8192a3b4-c5d6-4e78-0189-abcdef123456
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_featured_playbook
+    - node.type.blog_post
+id: node.blog_post.field_featured_playbook
+field_name: field_featured_playbook
+entity_type: node
+bundle: blog_post
+label: 'Featured playbook'
+description: 'Prioritise this playbook on the Organiser Hub landing page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/sync/field.field.node.blog_post.field_organiser_category.yml
+++ b/config/sync/field.field.node.blog_post.field_organiser_category.yml
@@ -1,0 +1,29 @@
+uuid: 8d2e605b-bc7f-4eb5-d910-54617c8091ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organiser_category
+    - node.type.blog_post
+    - taxonomy.vocabulary.organiser_hub_categories
+id: node.blog_post.field_organiser_category
+field_name: field_organiser_category
+entity_type: node
+bundle: blog_post
+label: 'Organiser category'
+description: 'Primary Organiser Hub category for this guide.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      organiser_hub_categories: organiser_hub_categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.blog_post.field_playbook.yml
+++ b/config/sync/field.field.node.blog_post.field_playbook.yml
@@ -1,0 +1,23 @@
+uuid: 2b3c4d5e-6f70-4891-bc23-56789abcdef1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_playbook
+    - node.type.blog_post
+id: node.blog_post.field_playbook
+field_name: field_playbook
+entity_type: node
+bundle: blog_post
+label: Playbook
+description: 'Flagship organiser playbook. Featured on the Organiser Hub and enables download journey blocks.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/sync/field.field.node.blog_post.field_resource_downloads.yml
+++ b/config/sync/field.field.node.blog_post.field_resource_downloads.yml
@@ -1,0 +1,31 @@
+uuid: 1a2b3c4d-5e6f-7890-abcd-ef1234567890
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_resource_downloads
+    - media.type.document
+    - node.type.blog_post
+  module:
+    - media
+id: node.blog_post.field_resource_downloads
+field_name: field_resource_downloads
+entity_type: node
+bundle: blog_post
+label: 'Resource downloads'
+description: 'Reusable document media files (PDF, XLSX, DOCX) attached to this guide.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      document: document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: document
+field_type: entity_reference

--- a/config/sync/field.field.node.blog_post.field_resource_links.yml
+++ b/config/sync/field.field.node.blog_post.field_resource_links.yml
@@ -1,0 +1,23 @@
+uuid: 3c4d5e6f-7081-4923-cd34-6789abcdef12
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_resource_links
+    - node.type.blog_post
+  module:
+    - link
+id: node.blog_post.field_resource_links
+field_name: field_resource_links
+entity_type: node
+bundle: blog_post
+label: 'External resource links'
+description: 'External template links (for example Canva templates) that are not hosted as document media.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 16
+field_type: link

--- a/config/sync/field.field.taxonomy_term.organiser_hub_categories.field_organiser_hub_section.yml
+++ b/config/sync/field.field.taxonomy_term.organiser_hub_categories.field_organiser_hub_section.yml
@@ -1,0 +1,19 @@
+uuid: 6b0c4e3f-9a5d-4c93-b7f8-32495a6879cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_organiser_hub_section
+    - taxonomy.vocabulary.organiser_hub_categories
+id: taxonomy_term.organiser_hub_categories.field_organiser_hub_section
+field_name: field_organiser_hub_section
+entity_type: taxonomy_term
+bundle: organiser_hub_categories
+label: 'Hub section'
+description: 'Groups this category under a section on the Organiser Hub landing page.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_blog_audience.yml
+++ b/config/sync/field.storage.node.field_blog_audience.yml
@@ -1,0 +1,30 @@
+uuid: 4e8f2a1c-9d3b-4f72-b6e5-3a9d0c1e2b4f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_blog_audience
+field_name: field_blog_audience
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: attendee
+      label: Attendee
+    -
+      value: organiser
+      label: Organiser
+    -
+      value: both
+      label: Both
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_blog_author_name.yml
+++ b/config/sync/field.storage.node.field_blog_author_name.yml
@@ -1,0 +1,21 @@
+uuid: 7b3e9d1c-8a2f-4c60-b7e5-1d9f8a0c2b4e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_blog_author_name
+field_name: field_blog_author_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_blog_author_type.yml
+++ b/config/sync/field.storage.node.field_blog_author_type.yml
@@ -1,0 +1,30 @@
+uuid: 8c4a1f2e-9b3d-4e71-a5c6-2f8d9e0b1a3c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_blog_author_type
+field_name: field_blog_author_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: myeventlane
+      label: MyEventLane
+    -
+      value: staff
+      label: Staff
+    -
+      value: guest
+      label: Guest
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_featured_playbook.yml
+++ b/config/sync/field.storage.node.field_featured_playbook.yml
@@ -1,0 +1,18 @@
+uuid: 708192a3-b4c5-4d67-f078-9abcdef12346
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_featured_playbook
+field_name: field_featured_playbook
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_organiser_category.yml
+++ b/config/sync/field.storage.node.field_organiser_category.yml
@@ -1,0 +1,20 @@
+uuid: 7c1d5f4a-ab6e-4da4-c809-43506b7980de
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_organiser_category
+field_name: field_organiser_category
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_playbook.yml
+++ b/config/sync/field.storage.node.field_playbook.yml
@@ -1,0 +1,18 @@
+uuid: 4d5e6f70-8192-4a34-de45-789abcdef123
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_playbook
+field_name: field_playbook
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_resource_downloads.yml
+++ b/config/sync/field.storage.node.field_resource_downloads.yml
@@ -1,0 +1,20 @@
+uuid: 5e6f7081-92a3-4b45-ef56-89abcdef1234
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_resource_downloads
+field_name: field_resource_downloads
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_resource_links.yml
+++ b/config/sync/field.storage.node.field_resource_links.yml
@@ -1,0 +1,19 @@
+uuid: 6f708192-a3b4-4c56-f067-9abcdef12345
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_resource_links
+field_name: field_resource_links
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_organiser_hub_section.yml
+++ b/config/sync/field.storage.taxonomy_term.field_organiser_hub_section.yml
@@ -1,0 +1,36 @@
+uuid: 5a9b3d2e-8f4c-4b82-a6e7-2138495768bc
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_organiser_hub_section
+field_name: field_organiser_hub_section
+entity_type: taxonomy_term
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: planning_event
+      label: 'Planning an Event'
+    -
+      value: marketing_event
+      label: 'Marketing an Event'
+    -
+      value: running_event
+      label: 'Running an Event'
+    -
+      value: growing_event
+      label: 'Growing an Event'
+    -
+      value: templates_downloads
+      label: 'Templates & Downloads'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.mel_blog_card.yml
+++ b/config/sync/image.style.mel_blog_card.yml
@@ -1,0 +1,25 @@
+uuid: 8a4f1c2e-9b3d-4e7a-a1f6-2d8c5b9e0f34
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.focal_point
+  module:
+    - focal_point
+name: mel_blog_card
+label: 'MEL blog card'
+effects:
+  1a2b3c4d-5e6f-7890-abcd-ef1234567890:
+    uuid: 1a2b3c4d-5e6f-7890-abcd-ef1234567890
+    id: focal_point_scale_and_crop
+    weight: 0
+    data:
+      width: 600
+      height: 338
+      crop_type: focal_point
+  2b3c4d5e-6f70-8901-bcde-f12345678901:
+    uuid: 2b3c4d5e-6f70-8901-bcde-f12345678901
+    id: image_convert_avif
+    weight: 1
+    data:
+      extension: webp

--- a/config/sync/metatag.metatag_defaults.node__blog_post.yml
+++ b/config/sync/metatag.metatag_defaults.node__blog_post.yml
@@ -1,0 +1,15 @@
+uuid: 9e3f7a6c-bd8e-4fc6-e021-65728d9102fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+id: node__blog_post
+label: 'Content: Blog post'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:field_seo_description]'
+  canonical_url: '[node:url]'
+  og_type: article
+  og_title: '[node:title]'
+  og_description: '[node:field_seo_description]'

--- a/config/sync/myeventlane_front.organiser_hub.yml
+++ b/config/sync/myeventlane_front.organiser_hub.yml
@@ -1,0 +1,40 @@
+sections:
+  planning_event:
+    title: 'Planning an Event'
+    weight: 0
+    terms:
+      - planning
+      - budgeting
+  marketing_event:
+    title: 'Marketing an Event'
+    weight: 1
+    terms:
+      - marketing
+      - sponsorship
+  running_event:
+    title: 'Running an Event'
+    weight: 2
+    terms:
+      - operations
+      - volunteers
+      - accessibility
+  growing_event:
+    title: 'Growing an Event'
+    weight: 3
+    terms:
+      - growth
+  templates_downloads:
+    title: 'Templates & Downloads'
+    weight: 4
+    terms:
+      - templates_downloads
+feature_links:
+  -
+    title: 'Create your event'
+    url: /create-event
+  -
+    title: 'Organiser Help Centre'
+    url: /help/organisers
+  -
+    title: 'Browse events'
+    url: /events

--- a/config/sync/myeventlane_front.organiser_hub_seeds.yml
+++ b/config/sync/myeventlane_front.organiser_hub_seeds.yml
@@ -1,0 +1,26 @@
+playbooks:
+  community_event:
+    title: 'Community Event Playbook'
+    category: planning
+    featured: true
+    excerpt: 'Plan welcoming community events with confidence — from first idea to opening night.'
+  fundraiser:
+    title: 'Fundraiser Playbook'
+    category: budgeting
+    featured: true
+    excerpt: 'Build a sustainable fundraiser with clear budgets, sponsorship, and supporter journeys.'
+  workshop:
+    title: 'Workshop Playbook'
+    category: operations
+    featured: true
+    excerpt: 'Run engaging workshops with smooth operations, volunteers, and attendee care.'
+  market:
+    title: 'Market Playbook'
+    category: marketing
+    featured: true
+    excerpt: 'Promote market-style events and help stallholders, vendors, and visitors find you.'
+  pride_event:
+    title: 'Pride Event Playbook'
+    category: growth
+    featured: true
+    excerpt: 'Grow inclusive pride events with accessibility, partnerships, and community momentum.'

--- a/config/sync/myeventlane_legal.settings.yml
+++ b/config/sync/myeventlane_legal.settings.yml
@@ -1,11 +1,11 @@
 customer_terms_version: '1.0'
 vendor_terms_version: '1.0'
 privacy_version: '1.0'
-customer_terms_url: '/terms'
-vendor_terms_url: '/vendor-terms'
-privacy_url: '/privacy'
-refund_policy_url: '/help/policies/refund-policy'
-cookie_policy_url: '/cookie-policy'
+customer_terms_url: /terms
+vendor_terms_url: /vendor-terms
+privacy_url: /privacy
+refund_policy_url: /help/policies/refund-policy
+cookie_policy_url: /cookie-policy
 collection_notice_rsvp: 'We collect your name and email to process your RSVP, send confirmation, and manage your booking. Our Privacy Policy explains how we use and protect your information.'
 collection_notice_checkout: 'We collect your contact details to process your order, send tickets and receipts, and manage your booking. Our Privacy Policy explains how we use and protect your information.'
 updated_at: null

--- a/config/sync/taxonomy.term.organiser_hub_categories.accessibility.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.accessibility.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_accessibility
+vid: organiser_hub_categories
+name: Accessibility
+description: 'Make your event welcoming and accessible for everyone.'
+weight: 5
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.budgeting.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.budgeting.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_budgeting
+vid: organiser_hub_categories
+name: Budgeting
+description: 'Plan costs, pricing, and financial sustainability.'
+weight: 6
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.growth.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.growth.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_growth
+vid: organiser_hub_categories
+name: Growth
+description: 'Grow attendance, retention, and repeat audiences.'
+weight: 7
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.marketing.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.marketing.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_marketing
+vid: organiser_hub_categories
+name: Marketing
+description: 'Promote your event and reach the right audience.'
+weight: 1
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.operations.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.operations.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_operations
+vid: organiser_hub_categories
+name: Operations
+description: 'Run your event smoothly on the day.'
+weight: 2
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.planning.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.planning.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_planning
+vid: organiser_hub_categories
+name: Planning
+description: 'Plan timelines, goals, and logistics before you publish.'
+weight: 0
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.sponsorship.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.sponsorship.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_sponsorship
+vid: organiser_hub_categories
+name: Sponsorship
+description: 'Secure partners and sponsorship for your event.'
+weight: 4
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.templates_downloads.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.templates_downloads.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_templates_downloads
+vid: organiser_hub_categories
+name: 'Templates & Downloads'
+description: 'Practical templates and downloadable resources.'
+weight: 8
+parent: {  }

--- a/config/sync/taxonomy.term.organiser_hub_categories.volunteers.yml
+++ b/config/sync/taxonomy.term.organiser_hub_categories.volunteers.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+id: organiser_hub_categories_volunteers
+vid: organiser_hub_categories
+name: Volunteers
+description: 'Recruit, brief, and support volunteer teams.'
+weight: 3
+parent: {  }

--- a/config/sync/taxonomy.vocabulary.organiser_hub_categories.yml
+++ b/config/sync/taxonomy.vocabulary.organiser_hub_categories.yml
@@ -1,0 +1,9 @@
+uuid: 4f8a2c1d-9e3b-4a71-b5d6-1029384756ab
+langcode: en
+status: true
+dependencies: {  }
+name: 'Organiser Hub categories'
+vid: organiser_hub_categories
+description: 'Categories for organiser guides and resources on the Organiser Hub.'
+weight: 0
+new_revision: false

--- a/config/sync/views.view.mel_blog.yml
+++ b/config/sync/views.view.mel_blog.yml
@@ -4,8 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.storage.node.field_blog_audience
+    - field.storage.node.field_organiser_category
     - field.storage.node.field_publish_date
     - node.type.blog_post
+    - taxonomy.vocabulary.organiser_hub_categories
     - taxonomy.vocabulary.tags
   module:
     - datetime
@@ -135,6 +138,35 @@ display:
             remember: false
             multiple: false
           is_grouped: false
+        field_organiser_category_target_id:
+          id: field_organiser_category_target_id
+          table: node__field_organiser_category
+          field: field_organiser_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_organiser_category
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_organiser_category_target_id_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: field_organiser_category_target_id_op
+            identifier: category
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+          vid: organiser_hub_categories
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
         tid:
           id: tid
           table: taxonomy_index
@@ -162,6 +194,30 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        field_blog_audience_value:
+          id: field_blog_audience_value
+          table: node__field_blog_audience
+          field: field_blog_audience_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_blog_audience
+          plugin_id: list_field
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_blog_audience_value_op
+            label: Audience
+            description: ''
+            use_operator: false
+            operator: field_blog_audience_value_op
+            identifier: audience
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
       filter_groups:
         operator: AND
         groups:
@@ -255,7 +311,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: blog
+      path: blog/list
       menu:
         type: none
         title: ''

--- a/config/sync/views.view.mel_organiser_hub_admin.yml
+++ b/config/sync/views.view.mel_organiser_hub_admin.yml
@@ -1,0 +1,254 @@
+uuid: 91a2b3c4-d5e6-4f78-9012-abcdef123456
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organiser_category
+    - field.storage.node.field_playbook
+    - node.type.blog_post
+    - taxonomy.vocabulary.organiser_hub_categories
+  module:
+    - myeventlane_front
+    - node
+    - taxonomy
+    - user
+id: mel_organiser_hub_admin
+label: 'MEL Organiser Hub Admin'
+module: views
+description: 'Editorial dashboard and organiser hub content reports.'
+tag: myeventlane_front
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Organiser Hub'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          type: string
+          settings:
+            link_to_entity: true
+        field_playbook:
+          id: field_playbook
+          table: node__field_playbook
+          field: field_playbook
+          plugin_id: field
+          label: Playbook
+          type: boolean
+          settings:
+            format: yes-no
+        field_organiser_category:
+          id: field_organiser_category
+          table: node__field_organiser_category
+          field: field_organiser_category
+          plugin_id: field
+          label: Category
+          type: entity_reference_label
+          settings:
+            link: false
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Status
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Draft
+            format_custom_true: Published
+        organiser_hub_download_count:
+          id: organiser_hub_download_count
+          table: node
+          field: organiser_hub_download_count
+          plugin_id: organiser_hub_download_count
+          label: Downloads
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: Updated
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+        organiser_hub_completeness:
+          id: organiser_hub_completeness
+          table: node
+          field: organiser_hub_completeness
+          plugin_id: organiser_hub_completeness
+          label: Warnings
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+      access:
+        type: perm
+        options:
+          perm: 'access content overview'
+      cache:
+        type: tag
+        options: {  }
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          order: DESC
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          plugin_id: bundle
+          value:
+            blog_post: blog_post
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options: {  }
+  page_coverage:
+    id: page_coverage
+    display_title: Coverage
+    display_plugin: page
+    position: 3
+    display_options:
+      title: 'Organiser Hub coverage'
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: Category
+          type: string
+          settings:
+            link_to_entity: false
+        organiser_hub_category_coverage:
+          id: organiser_hub_category_coverage
+          table: taxonomy_term_field_data
+          field: organiser_hub_category_coverage
+          plugin_id: organiser_hub_category_coverage
+          label: Coverage
+      pager:
+        type: none
+        options:
+          offset: 0
+      sorts:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          order: ASC
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          plugin_id: bundle
+          value:
+            organiser_hub_categories: organiser_hub_categories
+      defaults:
+        title: false
+        pager: false
+        fields: false
+        sorts: false
+        filters: false
+      display_extenders: {  }
+      path: admin/content/organiser-hub/coverage
+      menu:
+        type: tab
+        title: Coverage
+        weight: 5
+        menu_name: admin
+      base_table: taxonomy_term_field_data
+      base_field: tid
+  page_editorial:
+    id: page_editorial
+    display_title: Editorial
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/organiser-hub
+      menu:
+        type: normal
+        title: 'Organiser Hub'
+        weight: 4
+        menu_name: admin
+  page_linking:
+    id: page_linking
+    display_title: 'Linking audit'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: 'Organiser Hub linking audit'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          type: string
+          settings:
+            link_to_entity: true
+        field_playbook:
+          id: field_playbook
+          table: node__field_playbook
+          field: field_playbook
+          plugin_id: field
+          label: Playbook
+          type: boolean
+          settings:
+            format: yes-no
+        organiser_hub_linking_issues:
+          id: organiser_hub_linking_issues
+          table: node
+          field: organiser_hub_linking_issues
+          plugin_id: organiser_hub_linking_issues
+          label: Issues
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          plugin_id: bundle
+          value:
+            blog_post: blog_post
+      defaults:
+        title: false
+        fields: false
+        filters: false
+      display_extenders: {  }
+      path: admin/content/organiser-hub/linking
+      menu:
+        type: tab
+        title: 'Linking audit'
+        weight: 6
+        menu_name: admin

--- a/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
@@ -57,7 +57,7 @@ myeventlane_core.footer_find_events.popular:
 
 myeventlane_core.footer_find_events.blog:
   title: 'Blog & guides'
-  route_name: view.mel_blog.page_blog
+  route_name: myeventlane_front.blog_landing
   menu_name: footer-find
   weight: 5
 
@@ -97,35 +97,41 @@ myeventlane_core.footer_about.about:
   menu_name: footer-about
   weight: 0
 
+myeventlane_core.footer_about.blog:
+  title: 'Blog'
+  route_name: myeventlane_front.blog_landing
+  menu_name: footer-about
+  weight: 1
+
+myeventlane_core.footer_about.organiser_hub:
+  title: 'Organiser Hub'
+  route_name: myeventlane_front.organiser_hub
+  menu_name: footer-about
+  weight: 2
+
 myeventlane_core.footer_about.story:
   title: 'Our story'
   url: 'internal:/our-story'
   menu_name: footer-about
-  weight: 1
-
-myeventlane_core.footer_about.blog:
-  title: 'Blog'
-  route_name: view.mel_blog.page_blog
-  menu_name: footer-about
-  weight: 2
+  weight: 3
 
 myeventlane_core.footer_about.contact:
   title: 'Contact'
   url: 'internal:/contact'
   menu_name: footer-about
-  weight: 3
+  weight: 4
 
 myeventlane_core.footer_about.privacy:
   title: 'Privacy policy'
   url: 'internal:/privacy'
   menu_name: footer-about
-  weight: 4
+  weight: 5
 
 myeventlane_core.footer_about.terms:
   title: 'Terms'
   url: 'internal:/terms'
   menu_name: footer-about
-  weight: 5
+  weight: 6
 
 myeventlane_core.footer_community.instagram:
   title: 'Instagram'

--- a/web/modules/custom/myeventlane_front/config/schema/myeventlane_front.schema.yml
+++ b/web/modules/custom/myeventlane_front/config/schema/myeventlane_front.schema.yml
@@ -1,0 +1,60 @@
+myeventlane_front.organiser_hub:
+  type: config_object
+  label: 'Organiser Hub landing configuration'
+  mapping:
+    sections:
+      type: mapping
+      label: 'Hub sections'
+      mapping:
+        '*':
+          type: mapping
+          label: 'Section'
+          mapping:
+            title:
+              type: label
+              label: 'Section title'
+            weight:
+              type: integer
+              label: 'Section weight'
+            terms:
+              type: sequence
+              label: 'Category term config IDs'
+              sequence:
+                type: string
+    feature_links:
+      type: sequence
+      label: 'MEL feature links for article footers'
+      sequence:
+        type: mapping
+        mapping:
+          title:
+            type: label
+            label: 'Link title'
+          url:
+            type: string
+            label: 'Internal path or URL'
+
+myeventlane_front.organiser_hub_seeds:
+  type: config_object
+  label: 'Organiser Hub content seeds'
+  mapping:
+    playbooks:
+      type: mapping
+      label: Playbooks
+      mapping:
+        '*':
+          type: mapping
+          label: Playbook
+          mapping:
+            title:
+              type: label
+              label: Title
+            category:
+              type: string
+              label: 'Category config suffix'
+            featured:
+              type: boolean
+              label: Featured
+            excerpt:
+              type: text
+              label: Excerpt

--- a/web/modules/custom/myeventlane_front/myeventlane_front.install
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.install
@@ -26,3 +26,53 @@ function myeventlane_front_update_8002(): string {
   $messages = array_merge($foundation->seedTrustPages(), $foundation->seedPricingPage());
   return implode(' ', $messages);
 }
+
+/**
+ * Seeds Organiser Hub taxonomy terms (content entities) from exported config.
+ */
+function myeventlane_front_update_8003(): string {
+  /** @var \Drupal\myeventlane_front\Service\OrganiserHubTermProvisioner $provisioner */
+  $provisioner = \Drupal::service('myeventlane_front.organiser_hub_term_provisioner');
+  return implode(' ', $provisioner->provision());
+}
+
+/**
+ * Re-runs Organiser Hub term provisioning after config suffix fix.
+ */
+function myeventlane_front_update_8004(): string {
+  /** @var \Drupal\myeventlane_front\Service\OrganiserHubTermProvisioner $provisioner */
+  $provisioner = \Drupal::service('myeventlane_front.organiser_hub_term_provisioner');
+  return implode(' ', $provisioner->provision());
+}
+
+/**
+ * Seeds organiser hub playbook draft content from config.
+ */
+function myeventlane_front_update_8005(): string {
+  /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
+  $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
+  return implode(' ', $seeder->seedPlaybooks());
+}
+
+/**
+ * Marks the first-event guide as organiser audience for CTA targeting.
+ */
+function myeventlane_front_update_8006(): string {
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+  $nids = $storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'blog_post')
+    ->condition('title', 'How to Create Your First Event on MyEventLane')
+    ->range(0, 1)
+    ->execute();
+  if (!is_array($nids) || $nids === []) {
+    return (string) t('No matching first-event blog article found.');
+  }
+  $node = $storage->load(reset($nids));
+  if ($node === NULL || !$node->hasField('field_blog_audience')) {
+    return (string) t('Blog audience field unavailable.');
+  }
+  $node->set('field_blog_audience', 'organiser');
+  $node->save();
+  return (string) t('Set organiser audience on first-event blog article.');
+}

--- a/web/modules/custom/myeventlane_front/myeventlane_front.module
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.module
@@ -6,11 +6,35 @@
 
 declare(strict_types=1);
 
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_theme().
  */
 function myeventlane_front_theme($existing, $type, $theme, $path): array {
   return [
+    'myeventlane_organiser_hub' => [
+      'variables' => [
+        'page' => [],
+      ],
+      'template' => 'myeventlane-organiser-hub',
+      'path' => $path . '/templates',
+    ],
+    'myeventlane_blog_landing' => [
+      'variables' => [
+        'page' => [],
+      ],
+      'template' => 'myeventlane-blog-landing',
+      'path' => $path . '/templates',
+    ],
+    'myeventlane_blog_filtered' => [
+      'variables' => [
+        'view' => NULL,
+        'filters' => [],
+      ],
+      'template' => 'myeventlane-blog-filtered',
+      'path' => $path . '/templates',
+    ],
     'myeventlane_front_sitemap' => [
       'variables' => [
         'sections' => [],
@@ -71,4 +95,90 @@ function myeventlane_front_views_pre_render(\Drupal\views\ViewExecutable $view):
   /** @var \Drupal\myeventlane_front\Service\HomepageRailDiversityFilter $filter */
   $filter = \Drupal::service('myeventlane_front.homepage_rail_diversity');
   $filter->filter($view);
+}
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function myeventlane_front_preprocess_node(array &$variables): void {
+  $node = $variables['node'] ?? NULL;
+  $viewMode = (string) ($variables['view_mode'] ?? '');
+  if (!$node instanceof NodeInterface || $node->bundle() !== 'blog_post') {
+    return;
+  }
+
+  if ($viewMode === 'teaser') {
+    if (!\Drupal::hasService('myeventlane_front.organiser_hub_editorial')) {
+      return;
+    }
+    /** @var \Drupal\myeventlane_front\Service\OrganiserHubEditorialService $editorial */
+    $editorial = \Drupal::service('myeventlane_front.organiser_hub_editorial');
+    $badge = $editorial->buildBlogCardBadge($node);
+    if ($badge !== NULL) {
+      $variables['mel_blog_badge'] = $badge;
+    }
+    $readingTime = $editorial->estimateReadingTime($node);
+    if ($readingTime !== NULL) {
+      $variables['mel_blog_reading_time'] = $readingTime;
+    }
+    return;
+  }
+
+  if ($viewMode !== 'full') {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_front.blog_article_presentation')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_front\Service\BlogArticlePresentationService $presentation */
+  $presentation = \Drupal::service('myeventlane_front.blog_article_presentation');
+  $built = $presentation->build($node);
+  foreach ($built as $key => $value) {
+    if ($key === '#cache' || !is_string($key) || !(str_starts_with($key, 'mel_blog_') || $key === 'mel_blog_is_playbook')) {
+      continue;
+    }
+    $variables[$key] = $value;
+  }
+  if (isset($built['#cache']) && is_array($built['#cache'])) {
+    $variables['#cache']['tags'] = array_values(array_unique(array_merge(
+      $variables['#cache']['tags'] ?? [],
+      $built['#cache']['tags'] ?? [],
+    )));
+    $variables['#cache']['contexts'] = array_values(array_unique(array_merge(
+      $variables['#cache']['contexts'] ?? [],
+      $built['#cache']['contexts'] ?? [],
+    )));
+  }
+}
+
+/**
+ * Implements hook_page_attachments().
+ */
+function myeventlane_front_page_attachments(array &$attachments): void {
+  $routeMatch = \Drupal::routeMatch();
+  $node = $routeMatch->getParameter('node');
+  if (!$node instanceof NodeInterface || $node->bundle() !== 'blog_post' || !$node->isPublished()) {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_front.blog_structured_data')) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_front\Service\BlogStructuredDataBuilder $builder */
+  $builder = \Drupal::service('myeventlane_front.blog_structured_data');
+  foreach ($builder->build($node) as $index => $schema) {
+    $encoded = json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if (!is_string($encoded)) {
+      continue;
+    }
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'script',
+        '#attributes' => ['type' => 'application/ld+json'],
+        '#value' => $encoded,
+      ],
+      'myeventlane_front_blog_schema_' . $node->id() . '_' . $index,
+    ];
+  }
 }

--- a/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.routing.yml
@@ -61,3 +61,26 @@ myeventlane_front.sitemap:
     _title: 'Sitemap'
   requirements:
     _permission: 'access content'
+
+myeventlane_front.blog_landing:
+  path: '/blog'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\BlogLandingController::page'
+    _title: 'Blog'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.organiser_hub:
+  path: '/resources'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\OrganiserHubController::page'
+    _title: 'Organiser Hub'
+  requirements:
+    _permission: 'access content'
+
+myeventlane_front.sitemap_xml:
+  path: '/sitemap.xml'
+  defaults:
+    _controller: '\Drupal\myeventlane_front\Controller\XmlSitemapController::page'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -65,3 +65,75 @@ services:
     class: Drupal\myeventlane_front\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+
+  myeventlane_front.organiser_hub_term_provisioner:
+    class: Drupal\myeventlane_front\Service\OrganiserHubTermProvisioner
+    arguments:
+      - '@config.factory'
+      - '@entity_type.manager'
+
+  myeventlane_front.organiser_hub_landing:
+    class: Drupal\myeventlane_front\Service\OrganiserHubLandingBuilder
+    arguments:
+      - '@config.factory'
+      - '@entity_type.manager'
+
+  myeventlane_front.blog_related_content:
+    class: Drupal\myeventlane_front\Service\BlogRelatedContentService
+    arguments:
+      - '@entity_type.manager'
+      - '@cache.default'
+
+  myeventlane_front.playbook_query:
+    class: Drupal\myeventlane_front\Service\PlaybookQueryService
+    arguments:
+      - '@entity_type.manager'
+      - '@cache.default'
+
+  myeventlane_front.blog_resource_downloads:
+    class: Drupal\myeventlane_front\Service\BlogResourceDownloadBuilder
+    arguments:
+      - '@file_url_generator'
+
+  myeventlane_front.blog_landing_page:
+    class: Drupal\myeventlane_front\Service\BlogLandingPageBuilder
+    arguments:
+      - '@entity_type.manager'
+      - '@cache.default'
+
+  myeventlane_front.blog_article_presentation:
+    class: Drupal\myeventlane_front\Service\BlogArticlePresentationService
+    arguments:
+      - '@date.formatter'
+      - '@entity_type.manager'
+      - '@myeventlane_front.blog_related_content'
+      - '@myeventlane_front.blog_resource_downloads'
+      - '@config.factory'
+
+  myeventlane_front.blog_structured_data:
+    class: Drupal\myeventlane_front\Service\BlogStructuredDataBuilder
+    arguments:
+      - '@date.formatter'
+
+  myeventlane_front.organiser_hub_editorial:
+    class: Drupal\myeventlane_front\Service\OrganiserHubEditorialService
+    arguments:
+      - '@entity_type.manager'
+      - '@myeventlane_front.blog_related_content'
+      - '@myeventlane_front.blog_resource_downloads'
+
+  myeventlane_front.organiser_hub_page:
+    class: Drupal\myeventlane_front\Service\OrganiserHubPageBuilder
+    arguments:
+      - '@myeventlane_front.playbook_query'
+      - '@myeventlane_front.organiser_hub_editorial'
+      - '@myeventlane_front.blog_resource_downloads'
+      - '@entity_type.manager'
+      - '@cache.default'
+
+  myeventlane_front.organiser_hub_content_seeder:
+    class: Drupal\myeventlane_front\Service\OrganiserHubContentSeeder
+    arguments:
+      - '@config.factory'
+      - '@entity_type.manager'
+      - '@logger.factory'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.views.inc
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.views.inc
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Views data hooks for organiser hub admin reports.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function myeventlane_front_views_data_alter(array &$data): void {
+  $data['node']['organiser_hub_completeness'] = [
+    'title' => t('Organiser Hub completeness warnings'),
+    'field' => [
+      'title' => t('Completeness warnings'),
+      'help' => t('Non-blocking editorial warnings for organiser hub content.'),
+      'id' => 'organiser_hub_completeness',
+    ],
+  ];
+  $data['node']['organiser_hub_download_count'] = [
+    'title' => t('Organiser Hub download count'),
+    'field' => [
+      'title' => t('Downloads'),
+      'help' => t('Count of attached resource downloads and external links.'),
+      'id' => 'organiser_hub_download_count',
+    ],
+  ];
+  $data['node']['organiser_hub_linking_issues'] = [
+    'title' => t('Organiser Hub linking issues'),
+    'field' => [
+      'title' => t('Linking issues'),
+      'help' => t('Related content and download gaps for organiser hub content.'),
+      'id' => 'organiser_hub_linking_issues',
+    ],
+  ];
+  $data['taxonomy_term_field_data']['organiser_hub_category_coverage'] = [
+    'title' => t('Organiser Hub category coverage'),
+    'field' => [
+      'title' => t('Coverage summary'),
+      'help' => t('Playbook, article, and download counts per organiser category.'),
+      'id' => 'organiser_hub_category_coverage',
+    ],
+  ];
+}

--- a/web/modules/custom/myeventlane_front/phpunit.xml
+++ b/web/modules/custom/myeventlane_front/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="tests/bootstrap-unit.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
+  <testsuites>
+    <testsuite name="myeventlane_front_unit">
+      <file>tests/src/Unit/BlogAuthorTest.php</file>
+      <file>tests/src/Unit/BlogCtaTest.php</file>
+      <file>tests/src/Unit/BlogReadingTimeTest.php</file>
+      <file>tests/src/Unit/PlaybookQueryServiceTest.php</file>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/web/modules/custom/myeventlane_front/phpunit.xml
+++ b/web/modules/custom/myeventlane_front/phpunit.xml
@@ -5,9 +5,13 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
   <testsuites>
     <testsuite name="myeventlane_front_unit">
+      <file>tests/src/Unit/BlogAudienceCountTest.php</file>
       <file>tests/src/Unit/BlogAuthorTest.php</file>
+      <file>tests/src/Unit/BlogCardBadgeTest.php</file>
       <file>tests/src/Unit/BlogCtaTest.php</file>
       <file>tests/src/Unit/BlogReadingTimeTest.php</file>
+      <file>tests/src/Unit/BlogStructuredDataAuthorTest.php</file>
+      <file>tests/src/Unit/OrganiserHubCoverageTest.php</file>
       <file>tests/src/Unit/PlaybookQueryServiceTest.php</file>
     </testsuite>
   </testsuites>

--- a/web/modules/custom/myeventlane_front/src/Controller/BlogLandingController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/BlogLandingController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_front\Service\BlogLandingPageBuilder;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Renders the public blog landing page and filtered listings at /blog.
+ */
+final class BlogLandingController extends ControllerBase {
+
+  /**
+   * @var list<string>
+   */
+  private const FILTER_QUERY_KEYS = ['category', 'tags', 'search', 'audience'];
+
+  public function __construct(
+    private readonly BlogLandingPageBuilder $pageBuilder,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('myeventlane_front.blog_landing_page'),
+    );
+  }
+
+  /**
+   * Builds the blog landing page or a filtered listing.
+   */
+  public function page(Request $request): array {
+    if ($this->hasActiveFilters($request)) {
+      return $this->buildFilteredListing();
+    }
+
+    $page = $this->pageBuilder->build();
+
+    return [
+      '#theme' => 'myeventlane_blog_landing',
+      '#page' => $page,
+      '#attached' => [
+        'library' => [
+          'myeventlane_theme/blog-landing',
+        ],
+      ],
+      '#cache' => [
+        'tags' => [
+          'node_list:blog_post',
+          'taxonomy_term_list:tags',
+          'taxonomy_term_list:organiser_hub_categories',
+        ],
+        'contexts' => ['languages:language_interface'],
+        'max-age' => 3600,
+      ],
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildFilteredListing(): array {
+    $view = Views::getView('mel_blog');
+    $viewBuild = [];
+    if ($view !== NULL) {
+      $view->setDisplay('page_blog');
+      $view->initHandlers();
+      $viewBuild = $view->buildRenderable('page_blog');
+    }
+
+    return [
+      '#theme' => 'myeventlane_blog_filtered',
+      '#view' => $viewBuild,
+      '#filters' => $this->pageBuilder->buildFilters(),
+      '#attached' => [
+        'library' => [
+          'myeventlane_theme/blog-landing',
+        ],
+      ],
+      '#cache' => [
+        'tags' => ['node_list:blog_post'],
+        'contexts' => ['languages:language_interface', 'url.query_args'],
+        'max-age' => 3600,
+      ],
+    ];
+  }
+
+  private function hasActiveFilters(Request $request): bool {
+    foreach (self::FILTER_QUERY_KEYS as $key) {
+      $value = $request->query->get($key);
+      if (is_string($value) && trim($value) !== '') {
+        return TRUE;
+      }
+      if (is_array($value) && $value !== []) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Controller/OrganiserHubController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/OrganiserHubController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_front\Service\OrganiserHubPageBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Renders the Organiser Hub landing page at /resources.
+ */
+final class OrganiserHubController extends ControllerBase {
+
+  public function __construct(
+    private readonly OrganiserHubPageBuilder $pageBuilder,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('myeventlane_front.organiser_hub_page'),
+    );
+  }
+
+  /**
+   * Builds the Organiser Hub landing page.
+   */
+  public function page(): array {
+    $page = $this->pageBuilder->build();
+
+    return [
+      '#theme' => 'myeventlane_organiser_hub',
+      '#page' => $page,
+      '#attached' => [
+        'library' => [
+          'myeventlane_theme/organiser-hub-landing',
+        ],
+      ],
+      '#cache' => [
+        'tags' => [
+          'node_list:blog_post',
+          'taxonomy_term_list:organiser_hub_categories',
+        ],
+        'contexts' => ['languages:language_interface'],
+        'max-age' => 3600,
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Controller/XmlSitemapController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/XmlSitemapController.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Serves a minimal XML sitemap for public marketing and guide URLs.
+ */
+final class XmlSitemapController extends ControllerBase {
+
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    private readonly DateFormatterInterface $dateFormatter,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('date.formatter'),
+    );
+  }
+
+  /**
+   * Returns XML sitemap entries for key public pages.
+   */
+  public function page(): Response {
+    $urls = [
+      $this->urlEntry(Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString(), time()),
+      $this->urlEntry(Url::fromRoute('myeventlane_front.organiser_hub', [], ['absolute' => TRUE])->toString(), time()),
+      $this->urlEntry(Url::fromRoute('myeventlane_front.blog_landing', [], ['absolute' => TRUE])->toString(), time()),
+      $this->urlEntry(Url::fromRoute('myeventlane_help_centre.home', [], ['absolute' => TRUE])->toString(), time()),
+    ];
+
+    $storage = $this->entityTypeManager()->getStorage('node');
+    $nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->sort('changed', 'DESC')
+      ->range(0, 500)
+      ->execute();
+
+    if (is_array($nids)) {
+      $nodes = $storage->loadMultiple($nids);
+      foreach ($nids as $nid) {
+        if (!isset($nodes[$nid])) {
+          continue;
+        }
+        $node = $nodes[$nid];
+        $urls[] = $this->urlEntry($node->toUrl('canonical', ['absolute' => TRUE])->toString(), (int) $node->getChangedTime());
+      }
+    }
+
+    $xml = ['<?xml version="1.0" encoding="UTF-8"?>'];
+    $xml[] = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+    foreach ($urls as $entry) {
+      $xml[] = '  <url>';
+      $xml[] = '    <loc>' . htmlspecialchars($entry['loc'], ENT_XML1) . '</loc>';
+      $xml[] = '    <lastmod>' . htmlspecialchars($entry['lastmod'], ENT_XML1) . '</lastmod>';
+      $xml[] = '  </url>';
+    }
+    $xml[] = '</urlset>';
+
+    return new Response(implode("\n", $xml), 200, [
+      'Content-Type' => 'application/xml; charset=utf-8',
+      'Cache-Control' => 'public, max-age=3600',
+    ]);
+  }
+
+  /**
+   * @return array{loc: string, lastmod: string}
+   */
+  private function urlEntry(string $loc, int $changed): array {
+    return [
+      'loc' => $loc,
+      'lastmod' => $this->dateFormatter->format($changed, 'custom', 'Y-m-d'),
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCategoryCoverage.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCategoryCoverage.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Plugin\views\field;
+
+use Drupal\myeventlane_front\Service\OrganiserHubEditorialService;
+use Drupal\taxonomy\TermInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @ViewsField("organiser_hub_category_coverage")
+ */
+final class OrganiserHubCategoryCoverage extends FieldPluginBase {
+
+  /**
+   * @var array<int, array<string, mixed>>|null
+   */
+  private ?array $coverage = NULL;
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly OrganiserHubEditorialService $editorial,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('myeventlane_front.organiser_hub_editorial'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): string {
+    $entity = $values->_entity ?? NULL;
+    if (!$entity instanceof TermInterface) {
+      return '';
+    }
+    $row = $this->coverageMap()[(int) $entity->id()] ?? NULL;
+    if (!is_array($row)) {
+      return $this->t('No data');
+    }
+    $gap = !empty($row['gap']) ? ' <span class="status status--warning">' . $this->t('Gap') . '</span>' : '';
+    return $this->t('Playbooks: @p · Articles: @a · Downloads: @d', [
+      '@p' => (string) $row['playbook_count'],
+      '@a' => (string) $row['article_count'],
+      '@d' => (string) $row['download_count'],
+    ]) . $gap;
+  }
+
+  /**
+   * @return array<int, array<string, mixed>>
+   */
+  private function coverageMap(): array {
+    if ($this->coverage !== NULL) {
+      return $this->coverage;
+    }
+    $this->coverage = [];
+    foreach ($this->editorial->getCategoryCoverage() as $row) {
+      $this->coverage[$row['term_id']] = $row;
+    }
+    return $this->coverage;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCompleteness.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCompleteness.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Plugin\views\field;
+
+use Drupal\myeventlane_front\Service\OrganiserHubEditorialService;
+use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Renders non-blocking organiser hub completeness warnings.
+ *
+ * @ViewsField("organiser_hub_completeness")
+ */
+final class OrganiserHubCompleteness extends FieldPluginBase {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly OrganiserHubEditorialService $editorial,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('myeventlane_front.organiser_hub_editorial'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): string {
+    $node = $this->getNode($values);
+    if ($node === NULL) {
+      return '';
+    }
+    $warnings = $this->editorial->getCompletenessWarnings($node);
+    if ($warnings === []) {
+      return '<span class="status status--enabled">' . $this->t('Complete') . '</span>';
+    }
+    $items = array_map(static fn (string $warning): string => '<li>' . htmlspecialchars($warning, ENT_QUOTES) . '</li>', $warnings);
+    return '<ul class="mel-organiser-hub-admin__warnings"><li class="visually-hidden">' . $this->t('Editorial warnings') . '</li>' . implode('', $items) . '</ul>';
+  }
+
+  private function getNode(ResultRow $values): ?NodeInterface {
+    $entity = $values->_entity ?? NULL;
+    return $entity instanceof NodeInterface ? $entity : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubDownloadCount.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubDownloadCount.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Plugin\views\field;
+
+use Drupal\myeventlane_front\Service\OrganiserHubEditorialService;
+use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @ViewsField("organiser_hub_download_count")
+ */
+final class OrganiserHubDownloadCount extends FieldPluginBase {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly OrganiserHubEditorialService $editorial,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('myeventlane_front.organiser_hub_editorial'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): string {
+    $entity = $values->_entity ?? NULL;
+    if (!$entity instanceof NodeInterface) {
+      return '0';
+    }
+    return (string) $this->editorial->getDownloadCount($entity);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubLinkingIssues.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubLinkingIssues.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Plugin\views\field;
+
+use Drupal\myeventlane_front\Service\OrganiserHubEditorialService;
+use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @ViewsField("organiser_hub_linking_issues")
+ */
+final class OrganiserHubLinkingIssues extends FieldPluginBase {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly OrganiserHubEditorialService $editorial,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('myeventlane_front.organiser_hub_editorial'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): string {
+    $entity = $values->_entity ?? NULL;
+    if (!$entity instanceof NodeInterface) {
+      return '';
+    }
+    $issues = $this->editorial->getLinkingIssues($entity);
+    if ($issues === []) {
+      return '<span class="status status--enabled">' . $this->t('OK') . '</span>';
+    }
+    $items = array_map(static fn (string $issue): string => '<li>' . htmlspecialchars($issue, ENT_QUOTES) . '</li>', $issues);
+    return '<ul class="mel-organiser-hub-admin__warnings">' . implode('', $items) . '</ul>';
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/myeventlane_front/src/Routing/RouteSubscriber.php
@@ -19,6 +19,9 @@ final class RouteSubscriber extends RouteSubscriberBase {
     if ($route = $collection->get('contact.site_page')) {
       $route->setPath('/contact/feedback');
     }
+    if ($route = $collection->get('view.mel_blog.page_blog')) {
+      $route->setPath('/blog/list');
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_front/src/Service/BlogArticlePresentationService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogArticlePresentationService.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Builds presentation variables for public blog article pages.
+ */
+final class BlogArticlePresentationService {
+
+  use StringTranslationTrait;
+
+  private const WORDS_PER_MINUTE = 200;
+
+  public function __construct(
+    private readonly DateFormatterInterface $dateFormatter,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly BlogRelatedContentService $relatedContent,
+    private readonly BlogResourceDownloadBuilder $resourceDownloads,
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function build(NodeInterface $node): array {
+    if ($node->bundle() !== 'blog_post') {
+      return [];
+    }
+
+    $viewBuilder = $this->entityTypeManager->getViewBuilder('node');
+    $relatedBlog = [];
+    $relatedTags = [];
+    foreach ($this->relatedContent->getRelatedBlogPosts($node) as $related) {
+      $build = $viewBuilder->view($related, 'teaser');
+      $relatedBlog[] = $build;
+      $relatedTags = array_merge($relatedTags, $related->getCacheTags());
+    }
+
+    $relatedHelp = [];
+    foreach ($this->relatedContent->getRelatedHelpArticles($node) as $help) {
+      $relatedHelp[] = [
+        'title' => $help->label(),
+        'url' => $help->toUrl()->toString(),
+      ];
+      $relatedTags = array_merge($relatedTags, $help->getCacheTags());
+    }
+
+    $featureLinks = [];
+    $config = $this->configFactory->get('myeventlane_front.organiser_hub');
+    foreach ($config->get('feature_links') ?? [] as $link) {
+      if (!is_array($link)) {
+        continue;
+      }
+      $title = trim((string) ($link['title'] ?? ''));
+      $url = trim((string) ($link['url'] ?? ''));
+      if ($title === '' || $url === '') {
+        continue;
+      }
+      $featureLinks[] = [
+        'title' => $title,
+        'url' => Url::fromUri(str_starts_with($url, 'http') ? $url : 'internal:' . $url)->toString(),
+      ];
+    }
+
+    $isPlaybook = $node->hasField('field_playbook') && (bool) $node->get('field_playbook')->value;
+    $resourceDownloads = $isPlaybook ? $this->resourceDownloads->build($node) : [];
+    $createEventUrl = Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString();
+
+    return [
+      'mel_blog_is_playbook' => $isPlaybook,
+      'mel_blog_category' => $this->buildCategory($node),
+      'mel_blog_excerpt' => $this->buildExcerpt($node),
+      'mel_blog_hero' => $this->buildHero($node),
+      'mel_blog_author' => $this->buildAuthor($node),
+      'mel_blog_published_date' => $this->buildPublishedDate($node),
+      'mel_blog_reading_time' => $this->buildReadingTime($node),
+      'mel_blog_tags' => $this->buildTags($node),
+      'mel_blog_resource_downloads' => $resourceDownloads,
+      'mel_blog_related_articles' => $relatedBlog,
+      'mel_blog_related_help' => $relatedHelp,
+      'mel_blog_feature_links' => $featureLinks,
+      'mel_blog_cta' => $this->buildCta($node, $isPlaybook, $createEventUrl),
+      'mel_blog_share_links' => $this->buildShareLinks($node),
+      'mel_blog_journey' => $isPlaybook ? [
+        'steps' => [
+          [
+            'id' => 'read',
+            'label' => (string) $this->t('Read'),
+            'status' => 'current',
+          ],
+          [
+            'id' => 'download',
+            'label' => (string) $this->t('Download'),
+            'status' => $resourceDownloads === [] ? 'upcoming' : 'available',
+            'anchor' => $resourceDownloads === [] ? NULL : '#mel-blog-downloads',
+          ],
+          [
+            'id' => 'create',
+            'label' => (string) $this->t('Create event'),
+            'status' => 'cta',
+            'url' => $createEventUrl,
+          ],
+        ],
+        'cta' => [
+          'title' => (string) $this->t('Ready to create your event?'),
+          'url' => $createEventUrl,
+        ],
+      ] : NULL,
+      '#cache' => [
+        'tags' => array_values(array_unique(array_merge($node->getCacheTags(), $relatedTags, ['config:myeventlane_front.organiser_hub']))),
+        'contexts' => ['languages:language_interface'],
+      ],
+    ];
+  }
+
+  /**
+   * @return array{title: string, url: string|null}|null
+   */
+  private function buildCategory(NodeInterface $node): ?array {
+    if (!$node->hasField('field_organiser_category') || $node->get('field_organiser_category')->isEmpty()) {
+      return NULL;
+    }
+    $term = $node->get('field_organiser_category')->entity;
+    if (!$term instanceof TermInterface) {
+      return NULL;
+    }
+    $title = trim((string) $term->label());
+    if ($title === '') {
+      return NULL;
+    }
+    return [
+      'title' => $title,
+      'url' => Url::fromRoute('myeventlane_front.blog_landing', [], [
+        'query' => ['category' => (string) $term->id()],
+      ])->toString(),
+    ];
+  }
+
+  private function buildExcerpt(NodeInterface $node): ?string {
+    if (!$node->hasField('field_excerpt') || $node->get('field_excerpt')->isEmpty()) {
+      return NULL;
+    }
+    $excerpt = trim((string) $node->get('field_excerpt')->value);
+    return $excerpt !== '' ? $excerpt : NULL;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildHero(NodeInterface $node): ?array {
+    if (!$node->hasField('field_blog_hero_image') || $node->get('field_blog_hero_image')->isEmpty()) {
+      return NULL;
+    }
+    $media = $node->get('field_blog_hero_image')->entity;
+    if ($media === NULL) {
+      return NULL;
+    }
+    $build = $this->entityTypeManager->getViewBuilder('media')->view($media, 'default');
+    $build['#attributes']['class'][] = 'mel-blog-article__hero-image';
+    return $build;
+  }
+
+  /**
+   * @return list<array{title: string, url: string}>
+   */
+  private function buildTags(NodeInterface $node): array {
+    if (!$node->hasField('field_tags') || $node->get('field_tags')->isEmpty()) {
+      return [];
+    }
+    $tags = [];
+    foreach ($node->get('field_tags') as $item) {
+      $term = $item->entity;
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
+      $title = trim((string) $term->label());
+      if ($title === '') {
+        continue;
+      }
+      $tags[] = [
+        'title' => $title,
+        'url' => $term->toUrl()->toString(),
+      ];
+    }
+    return $tags;
+  }
+
+  /**
+   * @return array{variant: string, title: string, body: string, button: string, url: string, secondary?: array{button: string, url: string}}
+   */
+  private function buildCta(NodeInterface $node, bool $isPlaybook, string $createEventUrl): array {
+    $audience = $this->getAudience($node);
+    $eventsUrl = Url::fromRoute('view.upcoming_events.page_events')->toString();
+    $hubUrl = Url::fromRoute('myeventlane_front.organiser_hub')->toString();
+    $playbooksUrl = $hubUrl . '#mel-organiser-hub-playbooks';
+
+    if ($isPlaybook) {
+      return [
+        'variant' => 'create_event',
+        'title' => (string) $this->t('Ready to create your event?'),
+        'body' => (string) $this->t('Put what you have learned into action on MyEventLane.'),
+        'button' => (string) $this->t('Create your event'),
+        'url' => $createEventUrl,
+        'secondary' => [
+          'button' => (string) $this->t('Browse playbooks'),
+          'url' => $playbooksUrl,
+        ],
+      ];
+    }
+
+    if ($audience === 'organiser') {
+      return [
+        'variant' => 'create_event',
+        'title' => (string) $this->t('Ready to create your event?'),
+        'body' => (string) $this->t('Put what you have learned into action on MyEventLane.'),
+        'button' => (string) $this->t('Create your event'),
+        'url' => $createEventUrl,
+        'secondary' => [
+          'button' => (string) $this->t('Organiser Hub'),
+          'url' => $hubUrl,
+        ],
+      ];
+    }
+
+    if ($audience === 'both') {
+      return [
+        'variant' => 'create_event',
+        'title' => (string) $this->t('Ready to create your event?'),
+        'body' => (string) $this->t('Host your own event or discover what is happening near you.'),
+        'button' => (string) $this->t('Create your event'),
+        'url' => $createEventUrl,
+        'secondary' => [
+          'button' => (string) $this->t('Browse events'),
+          'url' => $eventsUrl,
+        ],
+      ];
+    }
+
+    return [
+      'variant' => 'discover_events',
+      'title' => (string) $this->t('Find something to do this weekend'),
+      'body' => (string) $this->t('Discover events happening near you on MyEventLane.'),
+      'button' => (string) $this->t('Discover events'),
+      'url' => $eventsUrl,
+      'secondary' => [
+        'button' => (string) $this->t('Browse events'),
+        'url' => $eventsUrl,
+      ],
+    ];
+  }
+
+  private function getAudience(NodeInterface $node): string {
+    if ($node->hasField('field_blog_audience') && !$node->get('field_blog_audience')->isEmpty()) {
+      return (string) $node->get('field_blog_audience')->value;
+    }
+    return 'attendee';
+  }
+
+  /**
+   * @return list<array{id: string, title: string, url: string}>
+   */
+  private function buildShareLinks(NodeInterface $node): array {
+    $canonical = $node->toUrl('canonical', ['absolute' => TRUE])->toString();
+    $encodedUrl = rawurlencode($canonical);
+    $encodedTitle = rawurlencode($node->label());
+
+    return [
+      [
+        'id' => 'facebook',
+        'title' => (string) $this->t('Share on Facebook'),
+        'url' => 'https://www.facebook.com/sharer/sharer.php?u=' . $encodedUrl,
+      ],
+      [
+        'id' => 'linkedin',
+        'title' => (string) $this->t('Share on LinkedIn'),
+        'url' => 'https://www.linkedin.com/sharing/share-offsite/?url=' . $encodedUrl,
+      ],
+      [
+        'id' => 'x',
+        'title' => (string) $this->t('Share on X'),
+        'url' => 'https://twitter.com/intent/tweet?url=' . $encodedUrl . '&text=' . $encodedTitle,
+      ],
+    ];
+  }
+
+  /**
+   * @return array{name: string, url: string|null}|null
+   */
+  private function buildAuthor(NodeInterface $node): ?array {
+    $type = 'staff';
+    if ($node->hasField('field_blog_author_type') && !$node->get('field_blog_author_type')->isEmpty()) {
+      $type = (string) $node->get('field_blog_author_type')->value;
+    }
+
+    return match ($type) {
+      'myeventlane' => [
+        'name' => (string) $this->t('MyEventLane'),
+        'url' => NULL,
+      ],
+      'guest' => $this->buildGuestAuthor($node),
+      default => $this->buildStaffAuthor($node),
+    };
+  }
+
+  /**
+   * @return array{name: string, url: string|null}|null
+   */
+  private function buildGuestAuthor(NodeInterface $node): ?array {
+    if (!$node->hasField('field_blog_author_name') || $node->get('field_blog_author_name')->isEmpty()) {
+      return NULL;
+    }
+    $name = trim((string) $node->get('field_blog_author_name')->value);
+    if ($name === '') {
+      return NULL;
+    }
+    return [
+      'name' => $name,
+      'url' => NULL,
+    ];
+  }
+
+  /**
+   * @return array{name: string, url: string|null}|null
+   */
+  private function buildStaffAuthor(NodeInterface $node): ?array {
+    $owner = $node->getOwner();
+    if (!$owner instanceof UserInterface) {
+      return NULL;
+    }
+    $name = trim($owner->getDisplayName());
+    if ($name === '') {
+      return NULL;
+    }
+    return [
+      'name' => $name,
+      'url' => $owner->isAnonymous() ? NULL : $owner->toUrl()->toString(),
+    ];
+  }
+
+  private function buildPublishedDate(NodeInterface $node): string {
+    if ($node->hasField('field_publish_date') && !$node->get('field_publish_date')->isEmpty()) {
+      $date = $node->get('field_publish_date')->date;
+      if ($date !== NULL) {
+        return $this->dateFormatter->format($date->getTimestamp(), 'custom', 'j F Y');
+      }
+    }
+    return $this->dateFormatter->format((int) $node->getChangedTime(), 'custom', 'j F Y');
+  }
+
+  /**
+   * @return array{minutes: int, label: string}|null
+   */
+  private function buildReadingTime(NodeInterface $node): ?array {
+    $text = '';
+    if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
+      $text = (string) $node->get('body')->value;
+    }
+    $plain = Html::decodeEntities(strip_tags($text));
+    $words = preg_split('/\s+/u', trim($plain), -1, PREG_SPLIT_NO_EMPTY);
+    $count = is_array($words) ? count($words) : 0;
+    if ($count === 0) {
+      return NULL;
+    }
+    $minutes = max(1, (int) ceil($count / self::WORDS_PER_MINUTE));
+    return [
+      'minutes' => $minutes,
+      'label' => (string) $this->formatPlural($minutes, '1 min read', '@count min read'),
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Builds the public blog landing page sections for /blog.
+ */
+final class BlogLandingPageBuilder {
+
+  use StringTranslationTrait;
+
+  private const CACHE_ID = 'myeventlane_front:blog_landing_page';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function build(): array {
+    $cached = $this->cache->get(self::CACHE_ID);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $cached->data;
+    }
+
+    $built = [
+      'hero' => [
+        'title' => (string) $this->t('Stories, guides and ideas from MyEventLane'),
+        'subtitle' => (string) $this->t('Discover events, meet organisers, and learn how communities come together.'),
+        'primary_cta' => [
+          'title' => (string) $this->t('Browse events'),
+          'url' => Url::fromRoute('view.upcoming_events.page_events')->toString(),
+        ],
+        'secondary_cta' => [
+          'title' => (string) $this->t('Organiser Hub'),
+          'url' => Url::fromRoute('myeventlane_front.organiser_hub')->toString(),
+        ],
+      ],
+      'featured' => $this->buildArticleCards(3),
+      'audiences' => $this->buildAudienceCards(),
+      'topics' => $this->buildTopicCards(),
+      'latest' => $this->buildArticleCards(9),
+      'filters' => $this->buildFilters(),
+    ];
+
+    $this->cache->set(self::CACHE_ID, $built, CacheBackendInterface::CACHE_PERMANENT, [
+      'node_list:blog_post',
+      'taxonomy_term_list:tags',
+      'taxonomy_term_list:organiser_hub_categories',
+    ]);
+
+    return $built;
+  }
+
+  /**
+   * @return array{categories: list<array{title: string, tid: string}>, tags: list<array{title: string, tid: string}>, audiences: list<array{title: string, value: string}>, action: string}
+   */
+  public function buildFilters(): array {
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $categories = [];
+    $organiserTerms = $termStorage->loadByProperties(['vid' => 'organiser_hub_categories']);
+    if (is_array($organiserTerms)) {
+      foreach ($organiserTerms as $term) {
+        if (!$term instanceof TermInterface) {
+          continue;
+        }
+        $categories[] = [
+          'title' => $term->label(),
+          'tid' => (string) $term->id(),
+        ];
+      }
+      usort($categories, static fn (array $a, array $b): int => strcmp($a['title'], $b['title']));
+    }
+
+    $tags = [];
+    $tagTerms = $termStorage->loadByProperties(['vid' => 'tags']);
+    if (is_array($tagTerms)) {
+      foreach ($tagTerms as $term) {
+        if (!$term instanceof TermInterface) {
+          continue;
+        }
+        $tags[] = [
+          'title' => $term->label(),
+          'tid' => (string) $term->id(),
+        ];
+      }
+      usort($tags, static fn (array $a, array $b): int => strcmp($a['title'], $b['title']));
+    }
+
+    return [
+      'categories' => $categories,
+      'tags' => $tags,
+      'audiences' => [
+        ['title' => (string) $this->t('Attendee'), 'value' => 'attendee'],
+        ['title' => (string) $this->t('Organiser'), 'value' => 'organiser'],
+        ['title' => (string) $this->t('Both'), 'value' => 'both'],
+      ],
+      'action' => Url::fromRoute('myeventlane_front.blog_landing')->toString(),
+    ];
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildAudienceCards(): array {
+    $cards = [];
+    foreach ([
+      'attendee' => (string) $this->t('Attendee stories'),
+      'organiser' => (string) $this->t('Organiser stories'),
+      'both' => (string) $this->t('For everyone'),
+    ] as $value => $title) {
+      $count = $this->countByAudience($value);
+      $cards[] = [
+        'title' => $title,
+        'slug' => $value,
+        'count' => $count,
+        'count_label' => (string) $this->formatPlural($count, '1 article', '@count articles'),
+        'url' => Url::fromRoute('myeventlane_front.blog_landing', [], [
+          'query' => ['audience' => $value],
+        ])->toString(),
+      ];
+    }
+    return $cards;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildTopicCards(): array {
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    $cards = [];
+
+    $terms = $termStorage->loadByProperties(['vid' => 'tags']);
+    if (!is_array($terms)) {
+      return $cards;
+    }
+
+    foreach ($terms as $term) {
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
+      $count = (int) $nodeStorage->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('type', 'blog_post')
+        ->condition('status', 1)
+        ->condition('field_tags', $term->id())
+        ->count()
+        ->execute();
+      if ($count === 0) {
+        continue;
+      }
+      $cards[] = [
+        'title' => $term->label(),
+        'slug' => Html::getClass($term->label()),
+        'count' => $count,
+        'count_label' => (string) $this->formatPlural($count, '1 article', '@count articles'),
+        'url' => Url::fromRoute('myeventlane_front.blog_landing', [], [
+          'query' => ['tags' => (string) $term->id()],
+        ])->toString(),
+      ];
+    }
+
+    usort($cards, static fn (array $a, array $b): int => strcmp($a['title'], $b['title']));
+    return $cards;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildArticleCards(int $limit): array {
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->sort('field_publish_date', 'DESC')
+      ->range(0, $limit)
+      ->execute();
+
+    $cards = [];
+    if (!is_array($nids)) {
+      return $cards;
+    }
+    $viewBuilder = $this->entityTypeManager->getViewBuilder('node');
+    foreach ($storage->loadMultiple($nids) as $node) {
+      if ($node instanceof NodeInterface) {
+        $cards[] = $viewBuilder->view($node, 'teaser');
+      }
+    }
+    return $cards;
+  }
+
+  private function countByAudience(string $audience): int {
+    if (!$this->entityTypeManager->getStorage('node')->getEntityType()->hasKey('bundle')) {
+      return 0;
+    }
+    $query = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1);
+    if ($audience === 'both') {
+      $query->condition('field_blog_audience', 'both');
+    }
+    else {
+      $or = $query->orConditionGroup()
+        ->condition('field_blog_audience', $audience)
+        ->condition('field_blog_audience', 'both');
+      $query->condition($or);
+    }
+    return (int) $query->count()->execute();
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
@@ -214,9 +214,18 @@ final class BlogLandingPageBuilder {
     if ($audience === 'both') {
       $query->condition('field_blog_audience', 'both');
     }
+    elseif ($audience === 'attendee') {
+      $or = $query->orConditionGroup()
+        ->condition('field_blog_audience', 'attendee')
+        ->condition('field_blog_audience', 'both');
+      if ($this->entityTypeManager->getStorage('field_storage_config')->load('node.field_blog_audience') !== NULL) {
+        $or->notExists('field_blog_audience.value');
+      }
+      $query->condition($or);
+    }
     else {
       $or = $query->orConditionGroup()
-        ->condition('field_blog_audience', $audience)
+        ->condition('field_blog_audience', 'organiser')
         ->condition('field_blog_audience', 'both');
       $query->condition($or);
     }

--- a/web/modules/custom/myeventlane_front/src/Service/BlogRelatedContentService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogRelatedContentService.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Resolves related organiser hub content for blog articles.
+ */
+final class BlogRelatedContentService {
+
+  private const MAX_RELATED_BLOG = 3;
+
+  private const MAX_RELATED_HELP = 3;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+  ) {}
+
+  /**
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  public function getRelatedBlogPosts(NodeInterface $node, int $limit = self::MAX_RELATED_BLOG): array {
+    if ($node->bundle() !== 'blog_post' || !$node->isPublished() || $limit < 1) {
+      return [];
+    }
+    if (!$node->hasField('field_organiser_category') || $node->get('field_organiser_category')->isEmpty()) {
+      return [];
+    }
+
+    $categoryId = (int) $node->get('field_organiser_category')->target_id;
+    if ($categoryId <= 0) {
+      return [];
+    }
+
+    $cacheId = 'myeventlane_front:blog_related:' . $node->id() . ':' . $limit;
+    $cached = $this->cache->get($cacheId);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $this->loadNodesFromIds($cached->data);
+    }
+
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->condition('nid', (int) $node->id(), '<>')
+      ->condition('field_organiser_category', $categoryId)
+      ->sort('field_publish_date', 'DESC')
+      ->range(0, $limit)
+      ->execute();
+
+    $ids = is_array($nids) ? array_map('intval', array_values($nids)) : [];
+    $this->cache->set($cacheId, $ids, CacheBackendInterface::CACHE_PERMANENT, [
+      'node:' . $node->id(),
+      'node_list:blog_post',
+      'taxonomy_term:' . $categoryId,
+    ]);
+
+    return $this->loadNodesFromIds($ids);
+  }
+
+  /**
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  public function getRelatedHelpArticles(NodeInterface $node, int $limit = self::MAX_RELATED_HELP): array {
+    if ($node->bundle() !== 'blog_post' || !$node->isPublished() || $limit < 1) {
+      return [];
+    }
+
+    $keyword = '';
+    if ($node->hasField('field_organiser_category') && !$node->get('field_organiser_category')->isEmpty()) {
+      $term = $node->get('field_organiser_category')->entity;
+      if ($term !== NULL) {
+        $keyword = trim((string) $term->label());
+      }
+    }
+
+    $cacheId = 'myeventlane_front:blog_help_related:' . $node->id() . ':' . md5($keyword) . ':' . $limit;
+    $cached = $this->cache->get($cacheId);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $this->loadNodesFromIds($cached->data);
+    }
+
+    $storage = $this->entityTypeManager->getStorage('node');
+    $query = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'help_article')
+      ->condition('status', 1)
+      ->condition('field_audience', ['public', 'vendor'], 'IN');
+
+    if ($keyword !== '' && $storage->getEntityType()->getKey('bundle') !== NULL) {
+      $or = $query->orConditionGroup()
+        ->condition('field_help_keywords', '%' . $keyword . '%', 'LIKE')
+        ->condition('title', '%' . $keyword . '%', 'LIKE');
+      $query->condition($or);
+    }
+
+    $nids = $query
+      ->sort('changed', 'DESC')
+      ->range(0, $limit)
+      ->execute();
+
+    $ids = is_array($nids) ? array_map('intval', array_values($nids)) : [];
+    $this->cache->set($cacheId, $ids, CacheBackendInterface::CACHE_PERMANENT, [
+      'node:' . $node->id(),
+      'node_list:help_article',
+    ]);
+
+    return $this->loadNodesFromIds($ids);
+  }
+
+  /**
+   * @param list<int> $ids
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  private function loadNodesFromIds(array $ids): array {
+    if ($ids === []) {
+      return [];
+    }
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nodes = $storage->loadMultiple($ids);
+    if (!is_array($nodes)) {
+      return [];
+    }
+
+    $out = [];
+    foreach ($ids as $nid) {
+      if (isset($nodes[$nid]) && $nodes[$nid] instanceof NodeInterface) {
+        $out[] = $nodes[$nid];
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/BlogResourceDownloadBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogResourceDownloadBuilder.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\FileInterface;
+use Drupal\link\LinkItemInterface;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds download card data for organiser playbook resources.
+ */
+final class BlogResourceDownloadBuilder {
+
+  public function __construct(
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+  ) {}
+
+  /**
+   * @return list<array{
+   *   title: string,
+   *   url: string,
+   *   kind: string,
+   *   is_external: bool
+   * }>
+   */
+  public function build(NodeInterface $node): array {
+    if ($node->bundle() !== 'blog_post') {
+      return [];
+    }
+
+    $downloads = [];
+
+    if ($node->hasField('field_resource_downloads') && !$node->get('field_resource_downloads')->isEmpty()) {
+      foreach ($node->get('field_resource_downloads') as $item) {
+        $media = $item->entity;
+        if (!$media instanceof MediaInterface || $media->bundle() !== 'document') {
+          continue;
+        }
+        if (!$media->hasField('field_media_document') || $media->get('field_media_document')->isEmpty()) {
+          continue;
+        }
+        $file = $media->get('field_media_document')->entity;
+        if (!$file instanceof FileInterface) {
+          continue;
+        }
+
+        $extension = strtolower(pathinfo($file->getFilename(), PATHINFO_EXTENSION));
+        $downloads[] = [
+          'title' => $this->resolveMediaTitle($media, $file),
+          'url' => $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri()),
+          'kind' => $extension !== '' ? strtoupper($extension) : 'FILE',
+          'is_external' => FALSE,
+        ];
+      }
+    }
+
+    if ($node->hasField('field_resource_links') && !$node->get('field_resource_links')->isEmpty()) {
+      foreach ($node->get('field_resource_links') as $item) {
+        if (!$item instanceof LinkItemInterface || $item->isEmpty()) {
+          continue;
+        }
+        $url = $item->getUrl()->toString();
+        if ($url === '') {
+          continue;
+        }
+        $title = trim((string) $item->title);
+        if ($title === '') {
+          $title = (string) $item->getUrl()->toString();
+        }
+        $downloads[] = [
+          'title' => $title,
+          'url' => $url,
+          'kind' => 'LINK',
+          'is_external' => TRUE,
+        ];
+      }
+    }
+
+    return $downloads;
+  }
+
+  private function resolveMediaTitle(MediaInterface $media, FileInterface $file): string {
+    $name = trim($media->label());
+    if ($name !== '') {
+      return $name;
+    }
+    return $file->getFilename();
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
@@ -73,15 +73,9 @@ final class BlogStructuredDataBuilder {
       $data['description'] = $description;
     }
 
-    $owner = $node->getOwner();
-    if ($owner instanceof UserInterface && !$owner->isAnonymous()) {
-      $authorName = trim($owner->getDisplayName());
-      if ($authorName !== '') {
-        $data['author'] = [
-          '@type' => 'Person',
-          'name' => $authorName,
-        ];
-      }
+    $author = $this->buildSchemaAuthor($node);
+    if ($author !== NULL) {
+      $data['author'] = $author;
     }
 
     $minutes = $this->estimateReadingMinutes($node);
@@ -136,6 +130,62 @@ final class BlogStructuredDataBuilder {
 
   private function formatIso(int $timestamp): string {
     return $this->dateFormatter->format($timestamp, 'custom', 'c');
+  }
+
+  /**
+   * Mirrors blog article byline rules for schema.org author metadata.
+   *
+   * @return array<string, string>|null
+   */
+  private function buildSchemaAuthor(NodeInterface $node): ?array {
+    $type = 'staff';
+    if ($node->hasField('field_blog_author_type') && !$node->get('field_blog_author_type')->isEmpty()) {
+      $type = (string) $node->get('field_blog_author_type')->value;
+    }
+
+    return match ($type) {
+      'myeventlane' => [
+        '@type' => 'Organization',
+        'name' => 'MyEventLane',
+      ],
+      'guest' => $this->buildGuestSchemaAuthor($node),
+      default => $this->buildStaffSchemaAuthor($node),
+    };
+  }
+
+  /**
+   * @return array<string, string>|null
+   */
+  private function buildGuestSchemaAuthor(NodeInterface $node): ?array {
+    if (!$node->hasField('field_blog_author_name') || $node->get('field_blog_author_name')->isEmpty()) {
+      return NULL;
+    }
+    $name = trim((string) $node->get('field_blog_author_name')->value);
+    if ($name === '') {
+      return NULL;
+    }
+    return [
+      '@type' => 'Person',
+      'name' => $name,
+    ];
+  }
+
+  /**
+   * @return array<string, string>|null
+   */
+  private function buildStaffSchemaAuthor(NodeInterface $node): ?array {
+    $owner = $node->getOwner();
+    if (!$owner instanceof UserInterface) {
+      return NULL;
+    }
+    $name = trim($owner->getDisplayName());
+    if ($name === '') {
+      return NULL;
+    }
+    return [
+      '@type' => 'Person',
+      'name' => $name,
+    ];
   }
 
   private function estimateReadingMinutes(NodeInterface $node): ?int {

--- a/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Builds schema.org Article and BreadcrumbList JSON-LD for blog posts.
+ */
+final class BlogStructuredDataBuilder {
+
+  private const WORDS_PER_MINUTE = 200;
+
+  public function __construct(
+    private readonly DateFormatterInterface $dateFormatter,
+  ) {}
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  public function build(NodeInterface $node): array {
+    if ($node->bundle() !== 'blog_post' || !$node->isPublished()) {
+      return [];
+    }
+
+    $schemas = [];
+    $article = $this->buildArticle($node);
+    if ($article !== NULL) {
+      $schemas[] = $article;
+    }
+
+    $breadcrumb = $this->buildBreadcrumb($node);
+    if ($breadcrumb !== NULL) {
+      $schemas[] = $breadcrumb;
+    }
+
+    return $schemas;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildArticle(NodeInterface $node): ?array {
+    $canonical = $node->toUrl('canonical', ['absolute' => TRUE])->toString();
+    $description = '';
+    if ($node->hasField('field_seo_description') && !$node->get('field_seo_description')->isEmpty()) {
+      $description = trim((string) $node->get('field_seo_description')->value);
+    }
+    elseif ($node->hasField('field_excerpt') && !$node->get('field_excerpt')->isEmpty()) {
+      $description = trim((string) $node->get('field_excerpt')->value);
+    }
+    elseif ($node->hasField('body') && !$node->get('body')->isEmpty()) {
+      $description = trim(Html::decodeEntities(strip_tags((string) $node->get('body')->summary ?: $node->get('body')->value)));
+    }
+
+    $data = [
+      '@context' => 'https://schema.org',
+      '@type' => 'Article',
+      'headline' => $node->label(),
+      'url' => $canonical,
+      'mainEntityOfPage' => $canonical,
+      'dateModified' => $this->formatIso((int) $node->getChangedTime()),
+      'datePublished' => $this->resolvePublishedDate($node),
+    ];
+
+    if ($description !== '') {
+      $data['description'] = $description;
+    }
+
+    $owner = $node->getOwner();
+    if ($owner instanceof UserInterface && !$owner->isAnonymous()) {
+      $authorName = trim($owner->getDisplayName());
+      if ($authorName !== '') {
+        $data['author'] = [
+          '@type' => 'Person',
+          'name' => $authorName,
+        ];
+      }
+    }
+
+    $minutes = $this->estimateReadingMinutes($node);
+    if ($minutes !== NULL) {
+      $data['timeRequired'] = 'PT' . $minutes . 'M';
+    }
+
+    return $data;
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function buildBreadcrumb(NodeInterface $node): ?array {
+    $items = [
+      [
+        '@type' => 'ListItem',
+        'position' => 1,
+        'name' => 'Resources',
+        'item' => Url::fromRoute('myeventlane_front.organiser_hub', [], ['absolute' => TRUE])->toString(),
+      ],
+      [
+        '@type' => 'ListItem',
+        'position' => 2,
+        'name' => 'Guides',
+        'item' => Url::fromRoute('view.mel_blog.page_blog', [], ['absolute' => TRUE])->toString(),
+      ],
+      [
+        '@type' => 'ListItem',
+        'position' => 3,
+        'name' => $node->label(),
+        'item' => $node->toUrl('canonical', ['absolute' => TRUE])->toString(),
+      ],
+    ];
+
+    return [
+      '@context' => 'https://schema.org',
+      '@type' => 'BreadcrumbList',
+      'itemListElement' => $items,
+    ];
+  }
+
+  private function resolvePublishedDate(NodeInterface $node): string {
+    if ($node->hasField('field_publish_date') && !$node->get('field_publish_date')->isEmpty()) {
+      $date = $node->get('field_publish_date')->date;
+      if ($date !== NULL) {
+        return $this->formatIso($date->getTimestamp());
+      }
+    }
+    return $this->formatIso((int) $node->getCreatedTime());
+  }
+
+  private function formatIso(int $timestamp): string {
+    return $this->dateFormatter->format($timestamp, 'custom', 'c');
+  }
+
+  private function estimateReadingMinutes(NodeInterface $node): ?int {
+    $text = '';
+    if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
+      $text = (string) $node->get('body')->value;
+    }
+    $plain = Html::decodeEntities(strip_tags($text));
+    $words = preg_split('/\s+/u', trim($plain), -1, PREG_SPLIT_NO_EMPTY);
+    $count = is_array($words) ? count($words) : 0;
+    if ($count === 0) {
+      return NULL;
+    }
+    return max(1, (int) ceil($count / self::WORDS_PER_MINUTE));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Seeds organiser hub playbook article stubs from exported config.
+ */
+final class OrganiserHubContentSeeder {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * @return list<string>
+   */
+  public function seedPlaybooks(): array {
+    $config = $this->configFactory->get('myeventlane_front.organiser_hub_seeds');
+    $playbooks = $config->get('playbooks') ?? [];
+    if (!is_array($playbooks) || $playbooks === []) {
+      return [(string) t('No organiser hub playbook seeds found.')];
+    }
+
+    $messages = [];
+    $logger = $this->loggerFactory->get('myeventlane_front');
+    foreach ($playbooks as $key => $definition) {
+      if (!is_array($definition)) {
+        continue;
+      }
+      $title = trim((string) ($definition['title'] ?? ''));
+      if ($title === '') {
+        continue;
+      }
+
+      $existing = $this->entityTypeManager->getStorage('node')->loadByProperties([
+        'type' => 'blog_post',
+        'title' => $title,
+      ]);
+      $node = is_array($existing) && $existing !== [] ? reset($existing) : NULL;
+      $created = FALSE;
+      if (!$node instanceof NodeInterface) {
+        $node = Node::create([
+          'type' => 'blog_post',
+          'title' => $title,
+          'status' => 0,
+        ]);
+        $created = TRUE;
+      }
+
+      $node->set('field_playbook', 1);
+      $node->set('field_featured_playbook', !empty($definition['featured']) ? 1 : 0);
+      if (!empty($definition['excerpt'])) {
+        $node->set('field_excerpt', (string) $definition['excerpt']);
+      }
+      $term = $this->loadCategoryTerm((string) ($definition['category'] ?? ''));
+      if ($term instanceof TermInterface) {
+        $node->set('field_organiser_category', ['target_id' => $term->id()]);
+      }
+      if ($node->get('body')->isEmpty()) {
+        $node->set('body', [
+          'value' => '<p>' . htmlspecialchars((string) ($definition['excerpt'] ?? $title), ENT_QUOTES) . '</p>',
+          'format' => 'basic_html',
+        ]);
+      }
+      $node->save();
+
+      $messages[] = $created
+        ? (string) t('Created playbook draft: @title', ['@title' => $title])
+        : (string) t('Updated playbook draft: @title', ['@title' => $title]);
+      $logger->notice('Organiser hub seed @key: @title', ['@key' => (string) $key, '@title' => $title]);
+    }
+
+    return $messages;
+  }
+
+  private function loadCategoryTerm(string $suffix): ?TermInterface {
+    $suffix = trim($suffix);
+    if ($suffix === '') {
+      return NULL;
+    }
+    $config = $this->configFactory->get('taxonomy.term.organiser_hub_categories.' . $suffix);
+    if (!$config->isNew()) {
+      $name = trim((string) $config->get('name'));
+      if ($name !== '') {
+        $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
+          'vid' => 'organiser_hub_categories',
+          'name' => $name,
+        ]);
+        if (is_array($terms) && $terms !== []) {
+          $term = reset($terms);
+          if ($term instanceof TermInterface) {
+            return $term;
+          }
+        }
+      }
+    }
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubEditorialService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubEditorialService.php
@@ -83,14 +83,16 @@ final class OrganiserHubEditorialService {
       }
       $tid = (int) $term->id();
       $baseQuery = $nodeStorage->getQuery()
-        ->accessCheck(FALSE)
+        ->accessCheck(TRUE)
         ->condition('type', 'blog_post')
+        ->condition('status', 1)
         ->condition('field_organiser_category', $tid);
 
       $articleCount = (int) $baseQuery->count()->execute();
       $playbookCount = (int) $nodeStorage->getQuery()
-        ->accessCheck(FALSE)
+        ->accessCheck(TRUE)
         ->condition('type', 'blog_post')
+        ->condition('status', 1)
         ->condition('field_organiser_category', $tid)
         ->condition('field_playbook', 1)
         ->count()
@@ -98,7 +100,7 @@ final class OrganiserHubEditorialService {
 
       $downloadCount = 0;
       $nids = $nodeStorage->getQuery()
-        ->accessCheck(FALSE)
+        ->accessCheck(TRUE)
         ->condition('type', 'blog_post')
         ->condition('status', 1)
         ->condition('field_organiser_category', $tid)

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubEditorialService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubEditorialService.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Editorial completeness, coverage, and linking audit helpers for organiser hub.
+ */
+final class OrganiserHubEditorialService {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly BlogRelatedContentService $relatedContent,
+    private readonly BlogResourceDownloadBuilder $resourceDownloads,
+  ) {}
+
+  /**
+   * @return list<string>
+   */
+  public function getCompletenessWarnings(NodeInterface $node): array {
+    if ($node->bundle() !== 'blog_post') {
+      return [];
+    }
+
+    $warnings = [];
+    if ($node->hasField('field_blog_hero_image') && $node->get('field_blog_hero_image')->isEmpty()) {
+      $warnings[] = (string) $this->t('Hero image missing');
+    }
+    if ($node->hasField('field_excerpt') && $node->get('field_excerpt')->isEmpty()) {
+      $warnings[] = (string) $this->t('Excerpt missing');
+    }
+    if ($node->hasField('field_seo_description') && $node->get('field_seo_description')->isEmpty()) {
+      $warnings[] = (string) $this->t('SEO description missing');
+    }
+    if ($node->hasField('field_organiser_category') && $node->get('field_organiser_category')->isEmpty()) {
+      $warnings[] = (string) $this->t('Category missing');
+    }
+    if ($node->hasField('field_playbook') && (bool) $node->get('field_playbook')->value) {
+      if ($this->getDownloadCount($node) === 0) {
+        $warnings[] = (string) $this->t('Download missing');
+      }
+    }
+
+    return $warnings;
+  }
+
+  public function getDownloadCount(NodeInterface $node): int {
+    return count($this->resourceDownloads->build($node));
+  }
+
+  /**
+   * @return list<array{
+   *   term_id: int,
+   *   title: string,
+   *   slug: string,
+   *   playbook_count: int,
+   *   article_count: int,
+   *   download_count: int,
+   *   gap: bool
+   * }>
+   */
+  public function getCategoryCoverage(): array {
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->loadByProperties(['vid' => 'organiser_hub_categories']);
+    if (!is_array($terms) || $terms === []) {
+      return [];
+    }
+
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    $coverage = [];
+    foreach ($terms as $term) {
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
+      $tid = (int) $term->id();
+      $baseQuery = $nodeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('type', 'blog_post')
+        ->condition('field_organiser_category', $tid);
+
+      $articleCount = (int) $baseQuery->count()->execute();
+      $playbookCount = (int) $nodeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('type', 'blog_post')
+        ->condition('field_organiser_category', $tid)
+        ->condition('field_playbook', 1)
+        ->count()
+        ->execute();
+
+      $downloadCount = 0;
+      $nids = $nodeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('type', 'blog_post')
+        ->condition('status', 1)
+        ->condition('field_organiser_category', $tid)
+        ->execute();
+      if (is_array($nids)) {
+        $nodes = $nodeStorage->loadMultiple($nids);
+        foreach ($nodes as $node) {
+          if ($node instanceof NodeInterface) {
+            $downloadCount += $this->getDownloadCount($node);
+          }
+        }
+      }
+
+      $coverage[] = [
+        'term_id' => $tid,
+        'title' => $term->label(),
+        'slug' => $this->slugify((string) $term->label()),
+        'playbook_count' => $playbookCount,
+        'article_count' => $articleCount,
+        'download_count' => $downloadCount,
+        'gap' => $playbookCount === 0 || $downloadCount === 0,
+      ];
+    }
+
+    usort($coverage, static fn (array $a, array $b): int => strcmp($a['title'], $b['title']));
+    return $coverage;
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function getLinkingIssues(NodeInterface $node): array {
+    if ($node->bundle() !== 'blog_post') {
+      return [];
+    }
+
+    $issues = [];
+    if ($this->relatedContent->getRelatedBlogPosts($node, 1) === []) {
+      $issues[] = (string) $this->t('No related articles');
+    }
+    if ($node->hasField('field_playbook') && (bool) $node->get('field_playbook')->value && $this->getDownloadCount($node) === 0) {
+      $issues[] = (string) $this->t('Playbook has no downloads');
+    }
+
+    return $issues;
+  }
+
+  /**
+   * @return list<array{tid: int, title: string, slug: string, count: int, url: string}>
+   */
+  public function getLowVolumeCategories(int $threshold = 2): array {
+    $low = [];
+    foreach ($this->getCategoryCoverage() as $row) {
+      if ($row['article_count'] <= $threshold) {
+        $low[] = [
+          'tid' => $row['term_id'],
+          'title' => $row['title'],
+          'slug' => $row['slug'],
+          'count' => $row['article_count'],
+          'url' => '/blog?category=' . $row['term_id'],
+        ];
+      }
+    }
+    return $low;
+  }
+
+  /**
+   * Builds a short badge label for blog card teasers from existing node metadata.
+   */
+  public function buildBlogCardBadge(NodeInterface $node): ?string {
+    if ($node->bundle() !== 'blog_post') {
+      return NULL;
+    }
+    if ($node->hasField('field_playbook') && (bool) $node->get('field_playbook')->value) {
+      return (string) $this->t('Playbook');
+    }
+    if ($node->hasField('field_organiser_category') && !$node->get('field_organiser_category')->isEmpty()) {
+      $term = $node->get('field_organiser_category')->entity;
+      if ($term instanceof TermInterface) {
+        $title = trim((string) $term->label());
+        if ($title !== '') {
+          return $title;
+        }
+      }
+    }
+    if ($node->hasField('field_blog_audience') && !$node->get('field_blog_audience')->isEmpty()) {
+      return match ((string) $node->get('field_blog_audience')->value) {
+        'organiser' => (string) $this->t('Organiser'),
+        'both' => (string) $this->t('For everyone'),
+        default => (string) $this->t('Attendee'),
+      };
+    }
+    return NULL;
+  }
+
+  /**
+   * @return array{minutes: int, label: string}|null
+   */
+  public function estimateReadingTime(NodeInterface $node): ?array {
+    $text = '';
+    if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
+      $text = (string) $node->get('body')->value;
+    }
+    $plain = Html::decodeEntities(strip_tags($text));
+    $words = preg_split('/\s+/u', trim($plain), -1, PREG_SPLIT_NO_EMPTY);
+    $count = is_array($words) ? count($words) : 0;
+    if ($count === 0) {
+      return NULL;
+    }
+    $minutes = max(1, (int) ceil($count / 200));
+    return [
+      'minutes' => $minutes,
+      'label' => (string) $this->formatPlural($minutes, '1 min read', '@count min read'),
+    ];
+  }
+
+  private function slugify(string $label): string {
+    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '_', $label) ?? '');
+    return trim($slug, '_');
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubLandingBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubLandingBuilder.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Builds grouped Organiser Hub landing sections from config and taxonomy.
+ */
+final class OrganiserHubLandingBuilder {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * @return list<array{
+   *   id: string,
+   *   title: string,
+   *   categories: list<array{title: string, description: string, url: string}>
+   * }>
+   */
+  public function buildSections(): array {
+    $config = $this->configFactory->get('myeventlane_front.organiser_hub');
+    $rawSections = $config->get('sections') ?? [];
+    if (!is_array($rawSections) || $rawSections === []) {
+      return [];
+    }
+
+    $weighted = [];
+    foreach ($rawSections as $sectionId => $section) {
+      if (!is_string($sectionId) || !is_array($section)) {
+        continue;
+      }
+      $title = trim((string) ($section['title'] ?? ''));
+      if ($title === '') {
+        continue;
+      }
+      $termConfigIds = $section['terms'] ?? [];
+      if (!is_array($termConfigIds) || $termConfigIds === []) {
+        continue;
+      }
+
+      $categories = [];
+      foreach ($termConfigIds as $termSuffix) {
+        $termSuffix = trim((string) $termSuffix);
+        if ($termSuffix === '') {
+          continue;
+        }
+        $term = $this->loadTermBySuffix($termSuffix);
+        if (!$term instanceof TermInterface) {
+          continue;
+        }
+
+        $categories[] = [
+          'title' => $term->label(),
+          'description' => trim(strip_tags((string) $term->getDescription())),
+          'url' => Url::fromRoute('view.mel_blog.page_blog', [], [
+            'query' => ['category' => (string) $term->id()],
+          ])->toString(),
+        ];
+      }
+
+      if ($categories === []) {
+        continue;
+      }
+
+      $weighted[] = [
+        'id' => $sectionId,
+        'title' => $title,
+        'weight' => (int) ($section['weight'] ?? 0),
+        'categories' => $categories,
+      ];
+    }
+
+    usort($weighted, static fn (array $a, array $b): int => $a['weight'] <=> $b['weight']);
+
+    return array_map(static function (array $section): array {
+      unset($section['weight']);
+      return $section;
+    }, $weighted);
+  }
+
+  /**
+   * Loads a taxonomy term using the exported config suffix.
+   */
+  private function loadTermBySuffix(string $suffix): ?TermInterface {
+    $config = $this->configFactory->get('taxonomy.term.organiser_hub_categories.' . $suffix);
+    if (!$config->isNew()) {
+      $name = trim((string) $config->get('name'));
+      if ($name !== '') {
+        $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
+          'vid' => 'organiser_hub_categories',
+          'name' => $name,
+        ]);
+        if (is_array($terms) && $terms !== []) {
+          $term = reset($terms);
+          if ($term instanceof TermInterface) {
+            return $term;
+          }
+        }
+      }
+    }
+
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->loadByProperties(['vid' => 'organiser_hub_categories']);
+    foreach ($terms as $term) {
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
+      if ($this->slugify((string) $term->label()) === $suffix) {
+        return $term;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Normalises a label to a config-safe slug.
+   */
+  private function slugify(string $label): string {
+    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '_', $label) ?? '');
+    return trim($slug, '_');
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubPageBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubPageBuilder.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Builds premium Organiser Hub landing page sections for /resources.
+ */
+final class OrganiserHubPageBuilder {
+
+  use StringTranslationTrait;
+
+  private const CACHE_ID = 'myeventlane_front:organiser_hub_page';
+
+  public function __construct(
+    private readonly PlaybookQueryService $playbookQuery,
+    private readonly OrganiserHubEditorialService $editorial,
+    private readonly BlogResourceDownloadBuilder $resourceDownloads,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function build(): array {
+    $cached = $this->cache->get(self::CACHE_ID);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $cached->data;
+    }
+
+    $built = [
+      'hero' => [
+        'title' => (string) $this->t('Everything you need to run a successful event'),
+        'subtitle' => (string) $this->t('Playbooks, templates, guides and practical advice for community organisers.'),
+        'primary_cta' => [
+          'title' => (string) $this->t('Create event'),
+          'url' => Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString(),
+        ],
+        'secondary_cta' => [
+          'title' => (string) $this->t('Browse playbooks'),
+          'url' => '#mel-organiser-hub-playbooks',
+        ],
+      ],
+      'featured_playbooks' => $this->buildFeaturedPlaybookCards(),
+      'topics' => $this->buildTopicCards(),
+      'downloads' => $this->buildDownloadCards(),
+      'latest_guides' => $this->buildLatestGuides(),
+      'filters' => $this->buildFilters(),
+      'footer_cta' => [
+        'title' => (string) $this->t('Ready to put your plan into action?'),
+        'body' => (string) $this->t('Create your event on MyEventLane and start reaching your community.'),
+        'url' => Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString(),
+        'button' => (string) $this->t('Create your event'),
+      ],
+    ];
+
+    $this->cache->set(self::CACHE_ID, $built, CacheBackendInterface::CACHE_PERMANENT, [
+      'node_list:blog_post',
+      'taxonomy_term_list:organiser_hub_categories',
+    ]);
+
+    return $built;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildFeaturedPlaybookCards(): array {
+    $cards = [];
+    foreach ($this->playbookQuery->getFeaturedPlaybooks() as $node) {
+      $cards[] = $this->buildGuideCard($node, TRUE);
+    }
+    return $cards;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildTopicCards(): array {
+    $cards = [];
+    foreach ($this->editorial->getCategoryCoverage() as $row) {
+      $cards[] = [
+        'title' => $row['title'],
+        'slug' => $row['slug'],
+        'count' => $row['article_count'],
+        'count_label' => (string) $this->formatPlural(
+          $row['article_count'],
+          '1 guide',
+          '@count guides',
+        ),
+        'url' => Url::fromRoute('myeventlane_front.blog_landing', [], [
+          'query' => ['category' => (string) $row['term_id']],
+        ])->toString(),
+      ];
+    }
+    return $cards;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildDownloadCards(): array {
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->condition('field_playbook', 1)
+      ->sort('changed', 'DESC')
+      ->range(0, 12)
+      ->execute();
+
+    $cards = [];
+    if (!is_array($nids)) {
+      return $cards;
+    }
+
+    foreach ($storage->loadMultiple($nids) as $node) {
+      if (!$node instanceof NodeInterface) {
+        continue;
+      }
+      foreach ($this->resourceDownloads->build($node) as $download) {
+        $cards[] = array_merge($download, [
+          'source_title' => $node->label(),
+          'source_url' => $node->toUrl()->toString(),
+        ]);
+        if (count($cards) >= 9) {
+          break 2;
+        }
+      }
+    }
+
+    return $cards;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function buildLatestGuides(): array {
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->sort('field_publish_date', 'DESC')
+      ->range(0, 6)
+      ->execute();
+
+    $cards = [];
+    if (!is_array($nids)) {
+      return $cards;
+    }
+    foreach ($storage->loadMultiple($nids) as $node) {
+      if ($node instanceof NodeInterface) {
+        $cards[] = $this->buildGuideCard($node, (bool) $node->get('field_playbook')->value);
+      }
+    }
+    return $cards;
+  }
+
+  /**
+   * @return array{categories: list<array{title: string, url: string}>, action: string}
+   */
+  private function buildFilters(): array {
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->loadByProperties(['vid' => 'organiser_hub_categories']);
+    $categories = [];
+    if (is_array($terms)) {
+      foreach ($terms as $term) {
+        if (!$term instanceof TermInterface) {
+          continue;
+        }
+        $categories[] = [
+          'title' => $term->label(),
+          'tid' => (string) $term->id(),
+          'url' => Url::fromRoute('myeventlane_front.blog_landing', [], [
+            'query' => ['category' => (string) $term->id()],
+          ])->toString(),
+        ];
+      }
+      usort($categories, static fn (array $a, array $b): int => strcmp($a['title'], $b['title']));
+    }
+
+    return [
+      'categories' => $categories,
+      'action' => Url::fromRoute('myeventlane_front.blog_landing')->toString(),
+    ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildGuideCard(NodeInterface $node, bool $isPlaybook): array {
+    $excerpt = '';
+    if ($node->hasField('field_excerpt') && !$node->get('field_excerpt')->isEmpty()) {
+      $excerpt = trim((string) $node->get('field_excerpt')->value);
+    }
+    $readingTime = $this->editorial->estimateReadingTime($node);
+
+    return [
+      'title' => $node->label(),
+      'url' => $node->toUrl()->toString(),
+      'excerpt' => $excerpt,
+      'is_playbook' => $isPlaybook,
+      'reading_time' => $readingTime['label'] ?? NULL,
+      'download_count' => $this->editorial->getDownloadCount($node),
+      'download_label' => (string) $this->formatPlural(
+        $this->editorial->getDownloadCount($node),
+        '1 download',
+        '@count downloads',
+      ),
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubTermProvisioner.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubTermProvisioner.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Ensures Organiser Hub taxonomy terms exist after config import.
+ */
+final class OrganiserHubTermProvisioner {
+
+  /**
+   * Maps exported term config suffixes to hub section list values.
+   *
+   * @var array<string, string>
+   */
+  private const TERM_SECTIONS = [
+    'planning' => 'planning_event',
+    'budgeting' => 'planning_event',
+    'marketing' => 'marketing_event',
+    'sponsorship' => 'marketing_event',
+    'operations' => 'running_event',
+    'volunteers' => 'running_event',
+    'accessibility' => 'running_event',
+    'growth' => 'growing_event',
+    'templates_downloads' => 'templates_downloads',
+  ];
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Creates missing organiser hub taxonomy terms from exported config.
+   *
+   * @return list<string>
+   *   Status messages.
+   */
+  public function provision(): array {
+    $messages = [];
+    $storage = $this->entityTypeManager->getStorage('taxonomy_term');
+
+    foreach (self::TERM_SECTIONS as $suffix => $section) {
+      $configName = 'taxonomy.term.organiser_hub_categories.' . $suffix;
+      $config = $this->configFactory->get($configName);
+      if ($config->isNew()) {
+        $messages[] = (string) t('Skipped missing config @id.', ['@id' => $configName]);
+        continue;
+      }
+
+      $name = trim((string) $config->get('name'));
+      if ($name === '') {
+        continue;
+      }
+
+      $existing = $storage->loadByProperties([
+        'vid' => 'organiser_hub_categories',
+        'name' => $name,
+      ]);
+      $term = NULL;
+      if (is_array($existing) && $existing !== []) {
+        $term = reset($existing);
+      }
+
+      if (!$term instanceof TermInterface) {
+        $term = Term::create([
+          'vid' => 'organiser_hub_categories',
+          'name' => $name,
+          'description' => (string) $config->get('description'),
+          'weight' => (int) $config->get('weight'),
+        ]);
+        $term->save();
+        $messages[] = (string) t('Created organiser hub term @name.', ['@name' => $name]);
+      }
+
+      if ($term->hasField('field_organiser_hub_section')) {
+        $term->set('field_organiser_hub_section', $section);
+        $term->save();
+      }
+    }
+
+    return $messages;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/PlaybookQueryService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/PlaybookQueryService.php
@@ -48,7 +48,7 @@ final class PlaybookQueryService {
       ->condition('status', 1)
       ->condition('field_playbook', 1);
     if ($this->entityTypeManager->getStorage('field_storage_config')->load('node.field_featured_playbook') !== NULL) {
-      $query->sort('field_featured_playbook', 'DESC');
+      $query->condition('field_featured_playbook', 1);
     }
     $nids = $query
       ->sort('field_publish_date', 'DESC')

--- a/web/modules/custom/myeventlane_front/src/Service/PlaybookQueryService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/PlaybookQueryService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Cached queries for organiser playbook blog posts.
+ */
+final class PlaybookQueryService {
+
+  private const CACHE_ID = 'myeventlane_front:featured_playbooks';
+
+  private const MAX_FEATURED = 6;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly CacheBackendInterface $cache,
+  ) {}
+
+  /**
+   * Returns published playbook nodes for the Organiser Hub landing page.
+   *
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  public function getFeaturedPlaybooks(int $limit = self::MAX_FEATURED): array {
+    if ($limit < 1) {
+      return [];
+    }
+    if ($limit > self::MAX_FEATURED) {
+      $limit = self::MAX_FEATURED;
+    }
+
+    $cacheId = self::CACHE_ID . ':' . $limit;
+    $cached = $this->cache->get($cacheId);
+    if ($cached !== FALSE && is_array($cached->data)) {
+      return $this->loadNodesFromIds($cached->data);
+    }
+
+    $storage = $this->entityTypeManager->getStorage('node');
+    $query = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'blog_post')
+      ->condition('status', 1)
+      ->condition('field_playbook', 1);
+    if ($this->entityTypeManager->getStorage('field_storage_config')->load('node.field_featured_playbook') !== NULL) {
+      $query->sort('field_featured_playbook', 'DESC');
+    }
+    $nids = $query
+      ->sort('field_publish_date', 'DESC')
+      ->range(0, $limit)
+      ->execute();
+
+    $ids = is_array($nids) ? array_map('intval', array_values($nids)) : [];
+    $this->cache->set($cacheId, $ids, CacheBackendInterface::CACHE_PERMANENT, [
+      'node_list:blog_post',
+    ]);
+
+    return $this->loadNodesFromIds($ids);
+  }
+
+  /**
+   * @param list<int> $ids
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  private function loadNodesFromIds(array $ids): array {
+    if ($ids === []) {
+      return [];
+    }
+    $storage = $this->entityTypeManager->getStorage('node');
+    $nodes = $storage->loadMultiple($ids);
+    if (!is_array($nodes)) {
+      return [];
+    }
+
+    $out = [];
+    foreach ($ids as $nid) {
+      if (isset($nodes[$nid]) && $nodes[$nid] instanceof NodeInterface) {
+        $out[] = $nodes[$nid];
+      }
+    }
+    return $out;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
@@ -71,10 +71,11 @@ final class PublicFooterNavigationBuilder {
 
     $about_links = [
       $this->internalLink('About', '/about'),
-      $this->internalLink('Our story', '/our-story'),
       ...array_values(array_filter([
-        $this->routeLink('Blog', 'view.mel_blog.page_blog'),
+        $this->routeLink('Blog', 'myeventlane_front.blog_landing'),
+        $this->routeLink('Organiser Hub', 'myeventlane_front.organiser_hub'),
       ])),
+      $this->internalLink('Our story', '/our-story'),
       [
         'title' => $this->t('Instagram'),
         'url' => 'https://www.instagram.com/myeventlane',

--- a/web/modules/custom/myeventlane_front/templates/myeventlane-blog-filtered.html.twig
+++ b/web/modules/custom/myeventlane_front/templates/myeventlane-blog-filtered.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Filtered blog listing at /blog with query parameters.
+ */
+#}
+{% set filters = filters|default({}) %}
+
+<div class="mel-blog-landing mel-blog-landing--filtered">
+  <section class="mel-blog-landing__hero mel-blog-landing__hero--compact" aria-labelledby="mel-blog-filtered-title">
+    <div class="mel-container mel-blog-landing__hero-inner">
+      <div class="mel-blog-landing__hero-copy">
+        <h1 id="mel-blog-filtered-title" class="mel-blog-landing__hero-title">{{ 'Blog'|t }}</h1>
+        <p class="mel-blog-landing__hero-subtitle">{{ 'Filtered articles from MyEventLane.'|t }}</p>
+        <div class="mel-blog-landing__hero-actions">
+          <a class="mel-btn mel-btn--secondary" href="{{ path('myeventlane_front.blog_landing') }}">{{ 'Back to blog home'|t }}</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="mel-container mel-blog-landing__body">
+    {% if view %}
+      <div class="mel-blog-landing__results">
+        {{ view }}
+      </div>
+    {% endif %}
+
+    {% if filters.action %}
+      <details class="mel-blog-landing__filters">
+        <summary class="mel-blog-landing__filters-summary">{{ 'Filter articles'|t }}</summary>
+        <form class="mel-blog-landing__filters-form" action="{{ filters.action }}" method="get">
+          {% if filters.audiences %}
+            <label class="mel-blog-landing__filters-label" for="mel-blog-filtered-audience">{{ 'Audience'|t }}</label>
+            <select id="mel-blog-filtered-audience" name="audience" class="mel-blog-landing__filters-select">
+              <option value="">{{ 'All audiences'|t }}</option>
+              {% for audience in filters.audiences %}
+                <option value="{{ audience.value }}">{{ audience.title }}</option>
+              {% endfor %}
+            </select>
+          {% endif %}
+          {% if filters.categories %}
+            <label class="mel-blog-landing__filters-label" for="mel-blog-filtered-category">{{ 'Category'|t }}</label>
+            <select id="mel-blog-filtered-category" name="category" class="mel-blog-landing__filters-select">
+              <option value="">{{ 'All categories'|t }}</option>
+              {% for category in filters.categories %}
+                <option value="{{ category.tid }}">{{ category.title }}</option>
+              {% endfor %}
+            </select>
+          {% endif %}
+          <label class="mel-blog-landing__filters-label" for="mel-blog-filtered-search">{{ 'Search'|t }}</label>
+          <input id="mel-blog-filtered-search" class="mel-blog-landing__filters-input" type="search" name="search" />
+          <button class="mel-btn mel-btn--secondary" type="submit">{{ 'Apply filters'|t }}</button>
+        </form>
+      </details>
+    {% endif %}
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_front/templates/myeventlane-blog-landing.html.twig
+++ b/web/modules/custom/myeventlane_front/templates/myeventlane-blog-landing.html.twig
@@ -1,0 +1,132 @@
+{#
+/**
+ * @file
+ * Public blog landing page at /blog.
+ */
+#}
+{% set hero = page.hero|default({}) %}
+{% set featured = page.featured|default([]) %}
+{% set audiences = page.audiences|default([]) %}
+{% set topics = page.topics|default([]) %}
+{% set latest = page.latest|default([]) %}
+{% set filters = page.filters|default({}) %}
+
+<div class="mel-blog-landing">
+  <section class="mel-blog-landing__hero" aria-labelledby="mel-blog-landing-hero-title">
+    <div class="mel-container mel-blog-landing__hero-inner">
+      <div class="mel-blog-landing__hero-copy">
+        <h1 id="mel-blog-landing-hero-title" class="mel-blog-landing__hero-title">{{ hero.title }}</h1>
+        {% if hero.subtitle %}
+          <p class="mel-blog-landing__hero-subtitle">{{ hero.subtitle }}</p>
+        {% endif %}
+        <div class="mel-blog-landing__hero-actions">
+          {% if hero.primary_cta %}
+            <a class="mel-btn mel-btn--cta" href="{{ hero.primary_cta.url }}">{{ hero.primary_cta.title }}</a>
+          {% endif %}
+          {% if hero.secondary_cta %}
+            <a class="mel-btn mel-btn--secondary" href="{{ hero.secondary_cta.url }}">{{ hero.secondary_cta.title }}</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="mel-container mel-blog-landing__body">
+    {% if featured %}
+      <section class="mel-blog-landing__section" aria-labelledby="mel-blog-landing-featured-title">
+        <h2 id="mel-blog-landing-featured-title" class="mel-blog-landing__section-title">{{ 'Latest stories'|t }}</h2>
+        <ul class="mel-blog-card-grid mel-blog-landing__card-grid" role="list">
+          {% for card in featured %}
+            <li>{{ card }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if audiences %}
+      <section class="mel-blog-landing__section" aria-labelledby="mel-blog-landing-audiences-title">
+        <h2 id="mel-blog-landing-audiences-title" class="mel-blog-landing__section-title">{{ 'Browse by audience'|t }}</h2>
+        <ul class="mel-blog-landing__topic-grid" role="list">
+          {% for audience in audiences %}
+            <li>
+              <a class="mel-card mel-card--governed mel-card--clickable mel-blog-landing__topic-card mel-blog-landing__topic-card--{{ audience.slug }}" href="{{ audience.url }}">
+                <div class="mel-card__body">
+                  <span class="mel-blog-landing__topic-icon" aria-hidden="true">{{ audience.title|first|upper }}</span>
+                  <h3 class="mel-card__title">{{ audience.title }}</h3>
+                  <p class="mel-card__meta">{{ audience.count_label }}</p>
+                </div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if topics %}
+      <section class="mel-blog-landing__section" aria-labelledby="mel-blog-landing-topics-title">
+        <h2 id="mel-blog-landing-topics-title" class="mel-blog-landing__section-title">{{ 'Browse by topic'|t }}</h2>
+        <ul class="mel-blog-landing__topic-grid" role="list">
+          {% for topic in topics %}
+            <li>
+              <a class="mel-card mel-card--governed mel-card--clickable mel-blog-landing__topic-card mel-blog-landing__topic-card--{{ topic.slug }}" href="{{ topic.url }}">
+                <div class="mel-card__body">
+                  <span class="mel-blog-landing__topic-icon" aria-hidden="true">{{ topic.title|first|upper }}</span>
+                  <h3 class="mel-card__title">{{ topic.title }}</h3>
+                  <p class="mel-card__meta">{{ topic.count_label }}</p>
+                </div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if latest %}
+      <section class="mel-blog-landing__section" aria-labelledby="mel-blog-landing-latest-title">
+        <h2 id="mel-blog-landing-latest-title" class="mel-blog-landing__section-title">{{ 'All articles'|t }}</h2>
+        <ul class="mel-blog-card-grid mel-blog-landing__card-grid" role="list">
+          {% for card in latest %}
+            <li>{{ card }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if filters.action %}
+      <details class="mel-blog-landing__filters">
+        <summary class="mel-blog-landing__filters-summary">{{ 'Filter articles'|t }}</summary>
+        <form class="mel-blog-landing__filters-form" action="{{ filters.action }}" method="get">
+          {% if filters.audiences %}
+            <label class="mel-blog-landing__filters-label" for="mel-blog-filter-audience">{{ 'Audience'|t }}</label>
+            <select id="mel-blog-filter-audience" name="audience" class="mel-blog-landing__filters-select">
+              <option value="">{{ 'All audiences'|t }}</option>
+              {% for audience in filters.audiences %}
+                <option value="{{ audience.value }}">{{ audience.title }}</option>
+              {% endfor %}
+            </select>
+          {% endif %}
+          {% if filters.categories %}
+            <label class="mel-blog-landing__filters-label" for="mel-blog-filter-category">{{ 'Category'|t }}</label>
+            <select id="mel-blog-filter-category" name="category" class="mel-blog-landing__filters-select">
+              <option value="">{{ 'All categories'|t }}</option>
+              {% for category in filters.categories %}
+                <option value="{{ category.tid }}">{{ category.title }}</option>
+              {% endfor %}
+            </select>
+          {% endif %}
+          {% if filters.tags %}
+            <label class="mel-blog-landing__filters-label" for="mel-blog-filter-tags">{{ 'Tags'|t }}</label>
+            <select id="mel-blog-filter-tags" name="tags[]" class="mel-blog-landing__filters-select" multiple>
+              {% for tag in filters.tags %}
+                <option value="{{ tag.tid }}">{{ tag.title }}</option>
+              {% endfor %}
+            </select>
+          {% endif %}
+          <label class="mel-blog-landing__filters-label" for="mel-blog-filter-search">{{ 'Search'|t }}</label>
+          <input id="mel-blog-filter-search" class="mel-blog-landing__filters-input" type="search" name="search" />
+          <button class="mel-btn mel-btn--secondary" type="submit">{{ 'Apply filters'|t }}</button>
+        </form>
+      </details>
+    {% endif %}
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_front/templates/myeventlane-organiser-hub.html.twig
+++ b/web/modules/custom/myeventlane_front/templates/myeventlane-organiser-hub.html.twig
@@ -1,0 +1,161 @@
+{#
+/**
+ * @file
+ * Premium Organiser Hub landing page at /resources.
+ */
+#}
+{% set hero = page.hero|default({}) %}
+{% set featured = page.featured_playbooks|default([]) %}
+{% set topics = page.topics|default([]) %}
+{% set downloads = page.downloads|default([]) %}
+{% set latest = page.latest_guides|default([]) %}
+{% set filters = page.filters|default({}) %}
+{% set footer_cta = page.footer_cta|default({}) %}
+
+<div class="mel-organiser-hub-landing">
+  <section class="mel-organiser-hub-landing__hero" aria-labelledby="mel-organiser-hub-hero-title">
+    <div class="mel-container mel-organiser-hub-landing__hero-inner">
+      <div class="mel-organiser-hub-landing__hero-copy">
+        <h1 id="mel-organiser-hub-hero-title" class="mel-organiser-hub-landing__hero-title">{{ hero.title }}</h1>
+        {% if hero.subtitle %}
+          <p class="mel-organiser-hub-landing__hero-subtitle">{{ hero.subtitle }}</p>
+        {% endif %}
+        <div class="mel-organiser-hub-landing__hero-actions">
+          {% if hero.primary_cta %}
+            <a class="mel-btn mel-btn--cta" href="{{ hero.primary_cta.url }}">{{ hero.primary_cta.title }}</a>
+          {% endif %}
+          {% if hero.secondary_cta %}
+            <a class="mel-btn mel-btn--secondary" href="{{ hero.secondary_cta.url }}">{{ hero.secondary_cta.title }}</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="mel-container mel-organiser-hub-landing__body">
+    {% if featured %}
+      <section id="mel-organiser-hub-playbooks" class="mel-organiser-hub-landing__section" aria-labelledby="mel-organiser-hub-playbooks-title">
+        <h2 id="mel-organiser-hub-playbooks-title" class="mel-organiser-hub-landing__section-title">{{ 'Featured playbooks'|t }}</h2>
+        <ul class="mel-organiser-hub-landing__card-grid" role="list">
+          {% for card in featured %}
+            <li>
+              <a class="mel-card mel-card--governed mel-card--clickable mel-organiser-hub-landing__guide-card" href="{{ card.url }}">
+                <div class="mel-card__header">
+                  {% if card.is_playbook %}
+                    <p class="mel-organiser-hub-landing__badge">{{ 'Playbook'|t }}</p>
+                  {% endif %}
+                  <h3 class="mel-card__title">{{ card.title }}</h3>
+                </div>
+                <div class="mel-card__body">
+                  {% if card.excerpt %}
+                    <p class="mel-card__meta">{{ card.excerpt }}</p>
+                  {% endif %}
+                  <p class="mel-organiser-hub-landing__guide-meta">
+                    {% if card.reading_time %}<span>{{ card.reading_time }}</span>{% endif %}
+                    {% if card.download_count %}<span>{{ card.download_label }}</span>{% endif %}
+                  </p>
+                </div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if topics %}
+      <section class="mel-organiser-hub-landing__section" aria-labelledby="mel-organiser-hub-topics-title">
+        <h2 id="mel-organiser-hub-topics-title" class="mel-organiser-hub-landing__section-title">{{ 'Browse by topic'|t }}</h2>
+        <ul class="mel-organiser-hub-landing__topic-grid" role="list">
+          {% for topic in topics %}
+            <li>
+              <a class="mel-card mel-card--governed mel-card--clickable mel-organiser-hub-landing__topic-card mel-organiser-hub-landing__topic-card--{{ topic.slug }}" href="{{ topic.url }}">
+                <div class="mel-card__body">
+                  <span class="mel-organiser-hub-landing__topic-icon" aria-hidden="true">{{ topic.title|first|upper }}</span>
+                  <h3 class="mel-card__title">{{ topic.title }}</h3>
+                  <p class="mel-card__meta">{{ topic.count_label }}</p>
+                </div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if downloads %}
+      <section class="mel-organiser-hub-landing__section" aria-labelledby="mel-organiser-hub-downloads-title">
+        <h2 id="mel-organiser-hub-downloads-title" class="mel-organiser-hub-landing__section-title">{{ 'Downloadable resources'|t }}</h2>
+        <ul class="mel-organiser-hub-landing__card-grid" role="list">
+          {% for download in downloads %}
+            <li>
+              <a
+                class="mel-card mel-card--governed mel-card--clickable mel-organiser-hub-landing__download-card"
+                href="{{ download.url }}"
+                {% if download.is_external %}target="_blank" rel="noopener noreferrer"{% else %}download{% endif %}
+              >
+                <div class="mel-card__header">
+                  <h3 class="mel-card__title">{{ download.title }}</h3>
+                </div>
+                <div class="mel-card__body">
+                  <p class="mel-card__meta">{{ download.kind }}{% if download.source_title %} · {{ download.source_title }}{% endif %}</p>
+                </div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if latest %}
+      <section class="mel-organiser-hub-landing__section" aria-labelledby="mel-organiser-hub-latest-title">
+        <h2 id="mel-organiser-hub-latest-title" class="mel-organiser-hub-landing__section-title">{{ 'Latest guides'|t }}</h2>
+        <ul class="mel-organiser-hub-landing__card-grid" role="list">
+          {% for card in latest %}
+            <li>
+              <a class="mel-card mel-card--governed mel-card--clickable mel-organiser-hub-landing__guide-card" href="{{ card.url }}">
+                <div class="mel-card__header">
+                  {% if card.is_playbook %}
+                    <p class="mel-organiser-hub-landing__badge">{{ 'Playbook'|t }}</p>
+                  {% endif %}
+                  <h3 class="mel-card__title">{{ card.title }}</h3>
+                </div>
+                {% if card.excerpt %}
+                  <div class="mel-card__body">
+                    <p class="mel-card__meta">{{ card.excerpt }}</p>
+                  </div>
+                {% endif %}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if filters.categories %}
+      <details class="mel-organiser-hub-landing__filters">
+        <summary class="mel-organiser-hub-landing__filters-summary">{{ 'Filter guides'|t }}</summary>
+        <form class="mel-organiser-hub-landing__filters-form" action="{{ filters.action }}" method="get">
+          <label class="mel-organiser-hub-landing__filters-label" for="mel-organiser-hub-filter-category">{{ 'Topic'|t }}</label>
+          <select id="mel-organiser-hub-filter-category" name="category" class="mel-organiser-hub-landing__filters-select">
+            <option value="">{{ 'All topics'|t }}</option>
+            {% for category in filters.categories %}
+              <option value="{{ category.tid }}">{{ category.title }}</option>
+            {% endfor %}
+          </select>
+          <button class="mel-btn mel-btn--secondary" type="submit">{{ 'Apply filters'|t }}</button>
+        </form>
+      </details>
+    {% endif %}
+
+    {% if footer_cta.url %}
+      <section class="mel-organiser-hub-landing__footer-cta mel-card mel-card--highlight" aria-labelledby="mel-organiser-hub-footer-cta-title">
+        <div class="mel-card__body">
+          <h2 id="mel-organiser-hub-footer-cta-title" class="mel-card__title">{{ footer_cta.title }}</h2>
+          {% if footer_cta.body %}
+            <p>{{ footer_cta.body }}</p>
+          {% endif %}
+          <a class="mel-btn mel-btn--cta" href="{{ footer_cta.url }}">{{ footer_cta.button }}</a>
+        </div>
+      </section>
+    {% endif %}
+  </div>
+</div>

--- a/web/modules/custom/myeventlane_front/tests/bootstrap-unit.php
+++ b/web/modules/custom/myeventlane_front/tests/bootstrap-unit.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 5) . '/vendor/autoload.php';

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceCountTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceCountTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group myeventlane_front
+ */
+final class BlogAudienceCountTest extends TestCase {
+
+  /**
+   * Mirrors audience matching used by BlogLandingPageBuilder::countByAudience().
+   */
+  private function matchesAudience(?string $storedAudience, string $cardAudience): bool {
+    $resolved = ($storedAudience === NULL || $storedAudience === '') ? 'attendee' : $storedAudience;
+    return match ($cardAudience) {
+      'both' => $resolved === 'both',
+      'attendee' => in_array($resolved, ['attendee', 'both'], TRUE),
+      'organiser' => in_array($resolved, ['organiser', 'both'], TRUE),
+      default => FALSE,
+    };
+  }
+
+  public function testEmptyAudienceCountsAsAttendee(): void {
+    $this->assertTrue($this->matchesAudience(NULL, 'attendee'));
+    $this->assertFalse($this->matchesAudience(NULL, 'organiser'));
+  }
+
+  public function testBothAudienceIncludedInAttendeeAndOrganiserCards(): void {
+    $this->assertTrue($this->matchesAudience('both', 'attendee'));
+    $this->assertTrue($this->matchesAudience('both', 'organiser'));
+    $this->assertTrue($this->matchesAudience('both', 'both'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAuthorTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAuthorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_front\Service\BlogArticlePresentationService
+ * @group myeventlane_front
+ */
+final class BlogAuthorTest extends TestCase {
+
+  /**
+   * Mirrors author-type resolution used by blog presentation services.
+   *
+   * @return array{name: string, url: string|null}|null
+   */
+  private function resolveAuthor(
+    string $type,
+    string $ownerName,
+    ?string $guestName,
+    bool $ownerAnonymous = FALSE,
+  ): ?array {
+    return match ($type) {
+      'myeventlane' => [
+        'name' => 'MyEventLane',
+        'url' => NULL,
+      ],
+      'guest' => ($guestName !== NULL && trim($guestName) !== '') ? [
+        'name' => trim($guestName),
+        'url' => NULL,
+      ] : NULL,
+      default => ($ownerName !== '') ? [
+        'name' => $ownerName,
+        'url' => $ownerAnonymous ? NULL : '/user/1',
+      ] : NULL,
+    };
+  }
+
+  public function testMyeventlaneAuthor(): void {
+    $author = $this->resolveAuthor('myeventlane', 'Editor', NULL);
+    $this->assertSame('MyEventLane', $author['name']);
+    $this->assertNull($author['url']);
+  }
+
+  public function testStaffAuthorUsesNodeOwner(): void {
+    $author = $this->resolveAuthor('staff', 'Anna', NULL);
+    $this->assertSame('Anna', $author['name']);
+    $this->assertSame('/user/1', $author['url']);
+  }
+
+  public function testGuestAuthorUsesCustomName(): void {
+    $author = $this->resolveAuthor('guest', 'Anna', 'Jordan Lee');
+    $this->assertSame('Jordan Lee', $author['name']);
+    $this->assertNull($author['url']);
+  }
+
+  public function testGuestAuthorWithoutNameReturnsNull(): void {
+    $this->assertNull($this->resolveAuthor('guest', 'Anna', ''));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogCardBadgeTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogCardBadgeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_front\Service\OrganiserHubEditorialService
+ * @group myeventlane_front
+ */
+final class BlogCardBadgeTest extends TestCase {
+
+  /**
+   * Mirrors badge priority used by OrganiserHubEditorialService::buildBlogCardBadge().
+   */
+  private function resolveBadge(bool $isPlaybook, ?string $category, string $audience): ?string {
+    if ($isPlaybook) {
+      return 'Playbook';
+    }
+    if ($category !== NULL && $category !== '') {
+      return $category;
+    }
+    return match ($audience) {
+      'organiser' => 'Organiser',
+      'both' => 'For everyone',
+      default => 'Attendee',
+    };
+  }
+
+  /**
+   * @covers ::buildBlogCardBadge
+   */
+  public function testPlaybookTakesPriority(): void {
+    $this->assertSame('Playbook', $this->resolveBadge(TRUE, 'Marketing', 'attendee'));
+  }
+
+  /**
+   * @covers ::buildBlogCardBadge
+   */
+  public function testOrganiserCategoryWhenNotPlaybook(): void {
+    $this->assertSame('Marketing', $this->resolveBadge(FALSE, 'Marketing', 'organiser'));
+  }
+
+  /**
+   * @covers ::buildBlogCardBadge
+   */
+  public function testAudienceFallback(): void {
+    $this->assertSame('For everyone', $this->resolveBadge(FALSE, NULL, 'both'));
+    $this->assertSame('Attendee', $this->resolveBadge(FALSE, NULL, 'attendee'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogCtaTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogCtaTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_front\Service\BlogArticlePresentationService
+ * @group myeventlane_front
+ */
+final class BlogCtaTest extends TestCase {
+
+  /**
+   * @return array{variant: string, primary: string, secondary: string}
+   */
+  private function resolveCta(bool $isPlaybook, string $audience): array {
+    if ($isPlaybook) {
+      return [
+        'variant' => 'create_event',
+        'primary' => '/create-event',
+        'secondary' => '/resources#mel-organiser-hub-playbooks',
+      ];
+    }
+    if ($audience === 'organiser') {
+      return [
+        'variant' => 'create_event',
+        'primary' => '/create-event',
+        'secondary' => '/resources',
+      ];
+    }
+    if ($audience === 'both') {
+      return [
+        'variant' => 'create_event',
+        'primary' => '/create-event',
+        'secondary' => '/events',
+      ];
+    }
+    return [
+      'variant' => 'discover_events',
+      'primary' => '/events',
+      'secondary' => '/events',
+    ];
+  }
+
+  public function testPlaybookUsesCreateEventAndPlaybooksSecondary(): void {
+    $cta = $this->resolveCta(TRUE, 'attendee');
+    $this->assertSame('create_event', $cta['variant']);
+    $this->assertStringContainsString('playbooks', $cta['secondary']);
+  }
+
+  public function testOrganiserAudienceUsesCreateEventAndHubSecondary(): void {
+    $cta = $this->resolveCta(FALSE, 'organiser');
+    $this->assertSame('create_event', $cta['variant']);
+    $this->assertSame('/resources', $cta['secondary']);
+  }
+
+  public function testBothAudienceUsesCreateEventAndEventsSecondary(): void {
+    $cta = $this->resolveCta(FALSE, 'both');
+    $this->assertSame('create_event', $cta['variant']);
+    $this->assertSame('/events', $cta['secondary']);
+  }
+
+  public function testAttendeeAudienceUsesDiscoverEventsCta(): void {
+    $cta = $this->resolveCta(FALSE, 'attendee');
+    $this->assertSame('discover_events', $cta['variant']);
+    $this->assertSame('/events', $cta['primary']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogReadingTimeTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogReadingTimeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use Drupal\Component\Utility\Html;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_front\Service\BlogArticlePresentationService
+ * @group myeventlane_front
+ */
+final class BlogReadingTimeTest extends TestCase {
+
+  /**
+   * Mirrors the reading-time algorithm used by blog presentation services.
+   */
+  private function estimateMinutes(string $html): ?int {
+    $plain = Html::decodeEntities(strip_tags($html));
+    $words = preg_split('/\s+/u', trim($plain), -1, PREG_SPLIT_NO_EMPTY);
+    $count = is_array($words) ? count($words) : 0;
+    if ($count === 0) {
+      return NULL;
+    }
+    return max(1, (int) ceil($count / 200));
+  }
+
+  /**
+   * @covers ::buildReadingTime
+   */
+  public function testEmptyBodyReturnsNull(): void {
+    $this->assertNull($this->estimateMinutes(''));
+  }
+
+  /**
+   * @covers ::buildReadingTime
+   */
+  public function testShortArticleIsAtLeastOneMinute(): void {
+    $this->assertSame(1, $this->estimateMinutes('<p>Plan your event with confidence.</p>'));
+  }
+
+  /**
+   * @covers ::buildReadingTime
+   */
+  public function testLongArticleRoundsUp(): void {
+    $words = implode(' ', array_fill(0, 401, 'guide'));
+    $this->assertSame(3, $this->estimateMinutes('<p>' . $words . '</p>'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogStructuredDataAuthorTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogStructuredDataAuthorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_front\Service\BlogStructuredDataBuilder
+ * @group myeventlane_front
+ */
+final class BlogStructuredDataAuthorTest extends TestCase {
+
+  /**
+   * Mirrors schema author resolution used by BlogStructuredDataBuilder.
+   *
+   * @return array<string, string>|null
+   */
+  private function resolveSchemaAuthor(string $type, string $ownerName, ?string $guestName): ?array {
+    return match ($type) {
+      'myeventlane' => [
+        '@type' => 'Organization',
+        'name' => 'MyEventLane',
+      ],
+      'guest' => ($guestName !== NULL && trim($guestName) !== '') ? [
+        '@type' => 'Person',
+        'name' => trim($guestName),
+      ] : NULL,
+      default => ($ownerName !== '') ? [
+        '@type' => 'Person',
+        'name' => $ownerName,
+      ] : NULL,
+    };
+  }
+
+  public function testMyeventlaneAuthorUsesOrganization(): void {
+    $author = $this->resolveSchemaAuthor('myeventlane', 'Editor', NULL);
+    $this->assertSame('Organization', $author['@type']);
+    $this->assertSame('MyEventLane', $author['name']);
+  }
+
+  public function testGuestAuthorUsesGuestName(): void {
+    $author = $this->resolveSchemaAuthor('guest', 'Editor', 'Jordan Lee');
+    $this->assertSame('Person', $author['@type']);
+    $this->assertSame('Jordan Lee', $author['name']);
+  }
+
+  public function testStaffAuthorUsesOwnerDisplayName(): void {
+    $author = $this->resolveSchemaAuthor('staff', 'Anna', NULL);
+    $this->assertSame('Person', $author['@type']);
+    $this->assertSame('Anna', $author['name']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/OrganiserHubCoverageTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/OrganiserHubCoverageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group myeventlane_front
+ */
+final class OrganiserHubCoverageTest extends TestCase {
+
+  /**
+   * Public category coverage must count published, access-checked nodes only.
+   */
+  public function testCategoryCoverageQueryUsesPublishedAccessCheckedNodes(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/OrganiserHubEditorialService.php');
+    $this->assertIsString($source);
+    $this->assertStringContainsString('public function getCategoryCoverage(): array', $source);
+    $this->assertStringContainsString("->accessCheck(TRUE)", $source);
+    $this->assertStringContainsString("->condition('status', 1)", $source);
+    $this->assertStringNotContainsString("->accessCheck(FALSE)", $source);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/PlaybookQueryServiceTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/PlaybookQueryServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+require_once dirname(__DIR__, 3) . '/src/Service/PlaybookQueryService.php';
+
+/**
+ * @group myeventlane_front
+ */
+final class PlaybookQueryServiceTest extends TestCase {
+
+  /**
+   * Ensures featured playbook cap matches Organiser Hub requirements.
+   */
+  public function testFeaturedPlaybookCapIsSix(): void {
+    $reflection = new ReflectionClass(\Drupal\myeventlane_front\Service\PlaybookQueryService::class);
+    $this->assertTrue($reflection->hasConstant('MAX_FEATURED'));
+    $this->assertSame(6, $reflection->getConstant('MAX_FEATURED'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/PlaybookQueryServiceTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/PlaybookQueryServiceTest.php
@@ -23,4 +23,14 @@ final class PlaybookQueryServiceTest extends TestCase {
     $this->assertSame(6, $reflection->getConstant('MAX_FEATURED'));
   }
 
+  /**
+   * Documents that featured playbooks must be explicitly flagged, not merely sorted.
+   */
+  public function testFeaturedPlaybookQueryRequiresFeaturedFlag(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PlaybookQueryService.php');
+    $this->assertIsString($source);
+    $this->assertStringContainsString("->condition('field_featured_playbook', 1)", $source);
+    $this->assertStringNotContainsString("->sort('field_featured_playbook', 'DESC')", $source);
+  }
+
 }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -84,6 +84,14 @@ help_search:
 
 # Listing headers (taxonomy/search/filtered views).
 # Reuses the front "above-the-cards" CSS without loading front-only JS.
+organiser-hub-landing:
+  dependencies:
+    - myeventlane_theme/global-styling
+
+blog-landing:
+  dependencies:
+    - myeventlane_theme/global-styling
+
 mel-listing-header:
   css:
     theme:

--- a/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/layout/_mel-public-layout.scss
@@ -171,7 +171,8 @@
 }
 
 // Discover rail: unwrap Views wrappers so `.mel-grid` lays out cards.
-.mel-section__discover-view {
+.mel-section__discover-view,
+.mel-section__blog-view {
   width: 100%;
   max-width: 100%;
 

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -228,6 +228,10 @@
 @use 'pages/contact';
 @use 'pages/discovery';
 @use 'pages/vendor';
+@use 'pages/organiser-hub';
+@use 'pages/organiser-hub-landing';
+@use 'pages/blog-article';
+@use 'pages/blog-landing';
 
 // Event page Classic/Immersive themes — load after pages/event so Mockup 1 rules win cascade.
 @use 'components/event-page-themes';

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_blog-article.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_blog-article.scss
@@ -1,0 +1,505 @@
+@use '../abstracts/mixins';
+@use '../tokens/spacing';
+@use '../tokens/colors';
+@use '../tokens/breakpoints';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/typography';
+
+// ---------------------------------------------------------------------------
+// Article page shell
+// ---------------------------------------------------------------------------
+
+$mel-blog-editorial-max: 47.5rem; // 760px — comfortable editorial measure.
+
+.mel-blog-article-page {
+  background: colors.$mel-color-bg;
+  padding-block: spacing.mel-space(5) spacing.mel-space(8);
+}
+
+.mel-blog-article {
+  color: colors.$mel-color-text;
+}
+
+// ---------------------------------------------------------------------------
+// Hero region
+// ---------------------------------------------------------------------------
+
+.mel-blog-article__hero {
+  margin-bottom: spacing.mel-space(6);
+}
+
+.mel-blog-article__hero-copy {
+  display: grid;
+  gap: spacing.mel-space(4);
+  width: 100%;
+  max-width: $mel-blog-editorial-max;
+  margin-inline: auto;
+  padding-block: spacing.mel-space(2) spacing.mel-space(5);
+}
+
+.mel-blog-article__category {
+  margin: 0;
+  color: colors.$mel-color-accent;
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.mel-blog-article__title {
+  margin: 0;
+  color: colors.$mel-color-text;
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: clamp(1.75rem, 6vw, typography.mel-font-size(3xl));
+  font-weight: typography.$mel-font-bold;
+  line-height: typography.$mel-leading-tight;
+  overflow-wrap: break-word;
+}
+
+.mel-blog-article__summary {
+  margin: 0;
+  max-width: 42rem;
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(md);
+  line-height: typography.$mel-leading-relaxed;
+}
+
+.mel-blog-article__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2) spacing.mel-space(4);
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+  line-height: typography.$mel-leading-normal;
+}
+
+.mel-blog-article__meta-item {
+  margin: 0;
+
+  a {
+    color: colors.$mel-color-text;
+    font-weight: typography.$mel-font-medium;
+    text-decoration: none;
+
+    &:hover {
+      color: colors.$mel-color-primary;
+      text-decoration: underline;
+    }
+  }
+}
+
+.mel-blog-article__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-blog-article__tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid rgba(124, 131, 253, 0.28);
+  border-radius: radii.$mel-radius-pill;
+  background: rgba(124, 131, 253, 0.1);
+  color: colors.$mel-color-accent;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    border-color: colors.$mel-color-accent;
+    background: rgba(124, 131, 253, 0.18);
+  }
+}
+
+.mel-blog-article__hero-media {
+  width: 100%;
+  max-width: $mel-blog-editorial-max;
+  margin: spacing.mel-space(4) auto 0;
+}
+
+.mel-blog-article__hero-media,
+.mel-blog-article__hero-image {
+  overflow: hidden;
+  aspect-ratio: 16 / 6;
+  border-radius: radii.$mel-radius-md;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-blog-article__hero-media img,
+.mel-blog-article__hero-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+// ---------------------------------------------------------------------------
+// Prose body
+// ---------------------------------------------------------------------------
+
+.mel-blog-article__body {
+  margin-bottom: spacing.mel-space(7);
+}
+
+.mel-blog-article__prose {
+  width: 100%;
+  max-width: $mel-blog-editorial-max;
+  margin-inline: auto;
+  font-size: typography.mel-font-size(base);
+  line-height: typography.$mel-leading-relaxed;
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  p {
+    margin: 0 0 spacing.mel-space(4);
+    color: colors.$mel-color-text;
+  }
+
+  h2,
+  h3,
+  h4 {
+    margin: spacing.mel-space(6) 0 spacing.mel-space(3);
+    color: colors.$mel-color-text;
+    font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+    font-weight: typography.$mel-font-bold;
+    line-height: typography.$mel-leading-snug;
+    overflow-wrap: anywhere;
+  }
+
+  h2 {
+    font-size: typography.mel-font-size(xl);
+  }
+
+  h3 {
+    font-size: typography.mel-font-size(lg);
+  }
+
+  h4 {
+    font-size: typography.mel-font-size(md);
+  }
+
+  ul,
+  ol {
+    margin: 0 0 spacing.mel-space(4);
+    padding-left: 1.35rem;
+  }
+
+  li + li {
+    margin-top: spacing.mel-space(2);
+  }
+
+  blockquote {
+    margin: spacing.mel-space(5) 0;
+    padding: spacing.mel-space(4) spacing.mel-space(5);
+    border-left: 4px solid colors.$mel-color-accent;
+    border-radius: 0 radii.$mel-radius-md radii.$mel-radius-md 0;
+    background: rgba(124, 131, 253, 0.08);
+    color: colors.$mel-color-text;
+    font-size: typography.mel-font-size(md);
+    font-style: italic;
+  }
+
+  a {
+    color: colors.$mel-color-primary;
+    font-weight: typography.$mel-font-medium;
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+
+    &:hover {
+      color: colors.$mel-color-primary-hover;
+    }
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: spacing.mel-space(5) 0;
+    border-radius: radii.$mel-radius-md;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+.mel-blog-article__section-title {
+  margin: 0 0 spacing.mel-space(4);
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: typography.mel-font-size(xl);
+  font-weight: typography.$mel-font-bold;
+  line-height: typography.$mel-leading-snug;
+}
+
+.mel-blog-article__downloads,
+.mel-blog-article__journey,
+.mel-blog-article__cta {
+  margin-bottom: spacing.mel-space(7);
+}
+
+.mel-blog-article__download-cards {
+  display: grid;
+  gap: spacing.mel-space(4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-blog-article__download-card {
+  display: block;
+  min-height: 2.75rem;
+  text-decoration: none;
+}
+
+.mel-blog-article__journey-steps {
+  display: grid;
+  gap: spacing.mel-space(3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-blog-article__journey-step {
+  display: grid;
+  gap: spacing.mel-space(2);
+  padding: spacing.mel-space(4);
+  border: 1px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-md;
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-blog-article__journey-step--current {
+  border-color: colors.$mel-color-primary;
+}
+
+.mel-blog-article__journey-label {
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-blog-article__cta-card {
+  max-width: $mel-blog-editorial-max;
+  margin-inline: auto;
+  border-radius: radii.$mel-radius-md;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-blog-article__cta-body {
+  margin: 0 0 spacing.mel-space(4);
+  color: colors.$mel-color-text-muted;
+  line-height: typography.$mel-leading-relaxed;
+}
+
+.mel-blog-article__cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(3);
+}
+
+.mel-blog-article__cta-actions .mel-btn {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+}
+
+// ---------------------------------------------------------------------------
+// Footer
+// ---------------------------------------------------------------------------
+
+.mel-blog-article__footer {
+  display: grid;
+  gap: spacing.mel-space(7);
+  padding-top: spacing.mel-space(7);
+  border-top: 1px solid colors.$mel-color-border;
+}
+
+.mel-blog-article__related-grid {
+  // Grid rules inherited from .mel-blog-card-grid in _blog-landing.scss.
+}
+
+.mel-blog-article__resource-group + .mel-blog-article__resource-group {
+  margin-top: spacing.mel-space(4);
+}
+
+.mel-blog-article__resource-heading {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(base);
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-blog-article__resource-links,
+.mel-blog-article__share-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-blog-article__resource-links a {
+  color: colors.$mel-color-primary;
+  font-weight: typography.$mel-font-medium;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.mel-blog-article__share-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-pill;
+  background: colors.$mel-color-surface;
+  color: colors.$mel-color-text;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  text-decoration: none;
+  box-shadow: shadows.$mel-shadow-1;
+
+  &:hover {
+    border-color: colors.$mel-color-accent;
+    color: colors.$mel-color-accent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Blog teaser cards (landing, filtered listings, related reading)
+// ---------------------------------------------------------------------------
+
+.mel-blog-card {
+  height: 100%;
+  min-width: 0;
+}
+
+.mel-blog-card__link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.mel-blog-card__media {
+  aspect-ratio: 16 / 9;
+  flex-shrink: 0;
+}
+
+.mel-blog-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mel-blog-card__placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.mel-blog-card .mel-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: spacing.mel-space(2);
+  min-height: 0;
+  padding: spacing.mel-space(4);
+}
+
+.mel-blog-card .mel-card__title {
+  @include mixins.line-clamp(2);
+}
+
+.mel-blog-card__badge {
+  margin: 0;
+  color: colors.$mel-color-accent;
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mel-blog-card__excerpt {
+  margin: 0;
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+  line-height: typography.$mel-leading-relaxed;
+
+  @include mixins.line-clamp(3);
+}
+
+.mel-blog-card__meta {
+  margin: auto 0 0;
+  padding-top: spacing.mel-space(2);
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+}
+
+// ---------------------------------------------------------------------------
+// Playbook variant
+// ---------------------------------------------------------------------------
+
+.mel-blog-article--playbook .mel-blog-article__hero-copy {
+  padding: spacing.mel-space(5);
+  border-radius: radii.$mel-radius-md;
+  background: linear-gradient(135deg, rgba(242, 109, 91, 0.08) 0%, rgba(124, 131, 253, 0.08) 100%);
+}
+
+// ---------------------------------------------------------------------------
+// Responsive
+// ---------------------------------------------------------------------------
+
+@include breakpoints.mel-break(md) {
+  .mel-blog-article__title {
+    font-size: typography.mel-font-size(4xl);
+    line-height: typography.$mel-leading-tight;
+  }
+
+  .mel-blog-article__prose {
+    font-size: typography.mel-font-size(md);
+    line-height: 1.7;
+  }
+
+  .mel-blog-article__download-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mel-blog-article__journey-steps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@include breakpoints.mel-break(lg) {
+  .mel-blog-article__download-cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_blog-landing.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_blog-landing.scss
@@ -1,0 +1,158 @@
+@use '../tokens/spacing';
+@use '../tokens/colors';
+@use '../tokens/breakpoints';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/typography';
+
+.mel-blog-landing {
+  background: colors.$mel-color-bg;
+  color: colors.$mel-color-text;
+}
+
+.mel-blog-landing__hero {
+  background: linear-gradient(135deg, rgba(124, 131, 253, 0.12) 0%, rgba(242, 109, 91, 0.1) 100%);
+  border-radius: 0 0 radii.$mel-radius-md radii.$mel-radius-md;
+  padding-block: spacing.mel-space(7) spacing.mel-space(6);
+}
+
+.mel-blog-landing__hero--compact {
+  padding-block: spacing.mel-space(5) spacing.mel-space(4);
+}
+
+.mel-blog-landing__hero-title {
+  margin: 0 0 spacing.mel-space(3);
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  line-height: 1.15;
+}
+
+.mel-blog-landing__hero-subtitle {
+  margin: 0 0 spacing.mel-space(5);
+  max-width: 38rem;
+  font-size: typography.mel-font-size(md);
+  line-height: typography.$mel-leading-relaxed;
+}
+
+.mel-blog-landing__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(3);
+}
+
+.mel-blog-landing__hero-actions .mel-btn {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+}
+
+.mel-blog-landing__body {
+  display: grid;
+  gap: spacing.mel-space(7);
+  padding-block: spacing.mel-space(6) spacing.mel-space(8);
+}
+
+.mel-blog-landing__section-title {
+  margin: 0 0 spacing.mel-space(4);
+  font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  font-size: typography.mel-font-size(xl);
+  font-weight: typography.$mel-font-bold;
+}
+
+// Shared with homepage preview and related reading (_blog-article.scss).
+.mel-blog-card-grid,
+.mel-blog-landing__card-grid,
+.mel-blog-landing__topic-grid,
+.mel-blog-landing__view.view-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: spacing.mel-space(4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-blog-landing__topic-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.mel-blog-card-grid > li,
+.mel-blog-card-grid > .views-row,
+.mel-blog-card-grid > .mel-blog-preview-grid__item,
+.mel-blog-card-grid > .mel-blog-article__related-item,
+.mel-blog-landing__card-grid > li,
+.mel-blog-landing__view .views-row {
+  display: flex;
+  min-width: 0;
+}
+
+.mel-blog-card-grid .mel-blog-card,
+.mel-blog-landing__card-grid .mel-blog-card,
+.mel-blog-landing__view .mel-blog-card {
+  width: 100%;
+}
+
+.mel-blog-landing__topic-card {
+  display: block;
+  height: 100%;
+  border-radius: radii.$mel-radius-md;
+  text-decoration: none;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-blog-landing__topic-card .mel-card__body {
+  display: grid;
+  gap: spacing.mel-space(2);
+}
+
+.mel-blog-landing__topic-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: radii.$mel-radius-full;
+  background: rgba(124, 131, 253, 0.16);
+  color: colors.$mel-color-accent;
+  font-weight: typography.$mel-font-bold;
+}
+
+.mel-blog-landing__filters {
+  border: 1px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-md;
+  padding: spacing.mel-space(4);
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-1;
+}
+
+.mel-blog-landing__filters-summary {
+  cursor: pointer;
+  font-weight: typography.$mel-font-semibold;
+  min-height: 2.75rem;
+}
+
+.mel-blog-landing__filters-form {
+  display: grid;
+  gap: spacing.mel-space(3);
+  margin-top: spacing.mel-space(4);
+}
+
+.mel-blog-landing__filters-select,
+.mel-blog-landing__filters-input,
+.mel-blog-landing__filters-form .mel-btn {
+  min-height: 2.75rem;
+}
+
+.mel-blog-landing__results {
+  margin-bottom: spacing.mel-space(4);
+}
+
+.mel-blog-landing__view .views-row {
+  list-style: none;
+}
+
+@include breakpoints.mel-break(md) {
+  .mel-blog-landing__filters-form {
+    grid-template-columns: 1fr 1fr auto;
+    align-items: end;
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -840,43 +840,18 @@
 }
 
 // ---------------------------------------------------------------------------
-// Blog preview - editorial, lightweight, no homepage exposed filters.
+// Blog preview — reuses .mel-blog-card-grid from blog landing styles.
 // ---------------------------------------------------------------------------
-
-.mel-page--home .mel-blog-preview-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 18px;
-
-  @media (width <= 900px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  @media (width <= 640px) {
-    grid-template-columns: 1fr;
-  }
-}
-
-.mel-page--home .mel-blog-preview-grid__item {
-  min-width: 0;
-}
 
 .mel-page--home .mel-section--blog .views-exposed-form,
 .mel-page--home .mel-section--blog form.views-exposed-form {
   display: none;
 }
 
-.mel-page--home .mel-section--blog article,
+.mel-page--home .mel-blog-preview-grid__item,
 .mel-page--home .mel-blog-preview-grid__item > * {
   height: 100%;
-}
-
-.mel-page--home .mel-section--blog .node {
-  padding: 18px;
-  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.74);
-  box-shadow: 0 12px 36px rgba(55, 45, 82, 0.08);
+  min-width: 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_organiser-hub-landing.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_organiser-hub-landing.scss
@@ -1,0 +1,150 @@
+@use '../tokens/spacing';
+@use '../tokens/breakpoints';
+@use '../tokens/colors';
+
+.mel-organiser-hub-landing {
+  background: #fff9f5;
+  color: colors.$mel-color-text;
+}
+
+.mel-organiser-hub-landing__hero {
+  background: linear-gradient(135deg, rgba(242, 109, 91, 0.14) 0%, rgba(124, 131, 253, 0.12) 100%);
+  border-radius: 0 0 24px 24px;
+  padding-block: spacing.mel-space(7) spacing.mel-space(6);
+}
+
+.mel-organiser-hub-landing__hero-title {
+  margin: 0 0 spacing.mel-space(3);
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  line-height: 1.15;
+}
+
+.mel-organiser-hub-landing__hero-subtitle {
+  margin: 0 0 spacing.mel-space(5);
+  max-width: 38rem;
+  font-size: var(--mel-font-size-lg, 1.125rem);
+  line-height: 1.6;
+}
+
+.mel-organiser-hub-landing__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(3);
+}
+
+.mel-organiser-hub-landing__hero-actions .mel-btn {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+}
+
+.mel-organiser-hub-landing__body {
+  display: grid;
+  gap: spacing.mel-space(7);
+  padding-block: spacing.mel-space(6) spacing.mel-space(8);
+}
+
+.mel-organiser-hub-landing__section-title {
+  margin: 0 0 spacing.mel-space(4);
+}
+
+.mel-organiser-hub-landing__card-grid,
+.mel-organiser-hub-landing__topic-grid {
+  display: grid;
+  gap: spacing.mel-space(4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-organiser-hub-landing__guide-card,
+.mel-organiser-hub-landing__download-card,
+.mel-organiser-hub-landing__topic-card {
+  display: block;
+  height: 100%;
+  border-radius: 16px;
+  text-decoration: none;
+}
+
+.mel-organiser-hub-landing__badge {
+  margin: 0 0 spacing.mel-space(2);
+  color: #7c83fd;
+  font-size: var(--mel-font-size-sm, 0.875rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mel-organiser-hub-landing__guide-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2) spacing.mel-space(4);
+  margin: spacing.mel-space(3) 0 0;
+  color: colors.$mel-color-text-muted;
+  font-size: var(--mel-font-size-sm, 0.875rem);
+}
+
+.mel-organiser-hub-landing__topic-card .mel-card__body {
+  display: grid;
+  gap: spacing.mel-space(2);
+}
+
+.mel-organiser-hub-landing__topic-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  background: rgba(124, 131, 253, 0.16);
+  color: #7c83fd;
+  font-weight: 700;
+}
+
+.mel-organiser-hub-landing__filters {
+  border: 1px solid colors.$mel-color-border;
+  border-radius: 16px;
+  padding: spacing.mel-space(4);
+  background: #fff;
+}
+
+.mel-organiser-hub-landing__filters-summary {
+  cursor: pointer;
+  font-weight: 600;
+  min-height: 2.75rem;
+}
+
+.mel-organiser-hub-landing__filters-form {
+  display: grid;
+  gap: spacing.mel-space(3);
+  margin-top: spacing.mel-space(4);
+}
+
+.mel-organiser-hub-landing__filters-select,
+.mel-organiser-hub-landing__filters-form .mel-btn {
+  min-height: 2.75rem;
+}
+
+.mel-organiser-hub-landing__footer-cta {
+  border-radius: 24px;
+}
+
+@include breakpoints.mel-break(md) {
+  .mel-organiser-hub-landing__card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mel-organiser-hub-landing__topic-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .mel-organiser-hub-landing__filters-form {
+    grid-template-columns: 1fr auto;
+    align-items: end;
+  }
+}
+
+@include breakpoints.mel-break(lg) {
+  .mel-organiser-hub-landing__card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_organiser-hub.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_organiser-hub.scss
@@ -1,0 +1,69 @@
+@use '../tokens/spacing';
+@use '../tokens/breakpoints';
+
+.mel-organiser-hub {
+  padding-block: spacing.mel-space(6);
+}
+
+.mel-organiser-hub__header {
+  margin-bottom: spacing.mel-space(6);
+}
+
+.mel-organiser-hub__title {
+  margin: 0 0 spacing.mel-space(3);
+}
+
+.mel-organiser-hub__intro {
+  margin: 0 0 spacing.mel-space(3);
+  max-width: 42rem;
+}
+
+.mel-organiser-hub__playbooks {
+  margin-bottom: spacing.mel-space(6);
+}
+
+.mel-organiser-hub__playbook-grid {
+  display: grid;
+  gap: spacing.mel-space(4);
+}
+
+.mel-organiser-hub__playbook-item > * {
+  height: 100%;
+}
+
+.mel-organiser-hub__sections {
+  display: grid;
+  gap: spacing.mel-space(6);
+}
+
+.mel-organiser-hub__cards {
+  display: grid;
+  gap: spacing.mel-space(4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-organiser-hub__card-item {
+  margin: 0;
+}
+
+.mel-organiser-hub__card {
+  display: block;
+  height: 100%;
+  text-decoration: none;
+}
+
+@include breakpoints.mel-break(md) {
+  .mel-organiser-hub__playbook-grid,
+  .mel-organiser-hub__cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@include breakpoints.mel-break(lg) {
+  .mel-organiser-hub__playbook-grid,
+  .mel-organiser-hub__cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--blog-post--teaser.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--blog-post--teaser.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Teaser card for blog_post listings, landing sections, and related reading.
+ */
+#}
+<article{{ attributes.addClass('mel-blog-card') }}>
+  <a href="{{ url }}" class="mel-card mel-card--governed mel-card--clickable mel-blog-card__link" rel="bookmark">
+    <div class="mel-card__media mel-blog-card__media">
+      {% if content.field_blog_hero_image %}
+        {{ content.field_blog_hero_image }}
+      {% else %}
+        <div class="mel-card__media--placeholder mel-blog-card__placeholder" aria-hidden="true"></div>
+      {% endif %}
+    </div>
+    <div class="mel-card__body">
+      {% if mel_blog_badge %}
+        <p class="mel-blog-card__badge">{{ mel_blog_badge }}</p>
+      {% endif %}
+      <h3 class="mel-card__title">{{ label }}</h3>
+      {% set excerpt = content.field_excerpt|render|striptags|trim %}
+      {% if excerpt %}
+        <p class="mel-blog-card__excerpt">{{ excerpt }}</p>
+      {% endif %}
+      {% if mel_blog_reading_time %}
+        <p class="mel-blog-card__meta">{{ mel_blog_reading_time.label }}</p>
+      {% endif %}
+    </div>
+  </a>
+</article>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--blog-post.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--blog-post.html.twig
@@ -1,0 +1,216 @@
+{#
+/**
+ * @file
+ * Full-page template for public blog articles (blog_post).
+ */
+#}
+<article{{ attributes.addClass('node', 'node--type-blog-post', 'mel-blog-article', mel_blog_is_playbook ? 'mel-blog-article--playbook') }}>
+  {{ title_prefix }}
+  {% if not page %}
+    <h2{{ title_attributes.addClass('mel-blog-article__title') }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+  {% else %}
+    <header class="mel-blog-article__hero">
+      <div class="mel-blog-article__hero-copy mel-container">
+        {% if mel_blog_category %}
+          <p class="mel-blog-article__category">
+            {% if mel_blog_category.url %}
+              <a href="{{ mel_blog_category.url }}">{{ mel_blog_category.title }}</a>
+            {% else %}
+              {{ mel_blog_category.title }}
+            {% endif %}
+          </p>
+        {% elseif mel_blog_is_playbook %}
+          <p class="mel-blog-article__category">{{ 'Organiser playbook'|t }}</p>
+        {% endif %}
+
+        <h1{{ title_attributes.addClass('mel-blog-article__title') }}>{{ label }}</h1>
+
+        {% if mel_blog_excerpt %}
+          <p class="mel-blog-article__summary">{{ mel_blog_excerpt }}</p>
+        {% endif %}
+
+        {% if mel_blog_author or mel_blog_published_date or mel_blog_reading_time %}
+          <div class="mel-blog-article__meta" aria-label="{{ 'Article details'|t }}">
+            {% if mel_blog_author %}
+              <span class="mel-blog-article__meta-item">
+                {{ 'By'|t }}
+                {% if mel_blog_author.url %}
+                  <a href="{{ mel_blog_author.url }}">{{ mel_blog_author.name }}</a>
+                {% else %}
+                  {{ mel_blog_author.name }}
+                {% endif %}
+              </span>
+            {% endif %}
+            {% if mel_blog_published_date %}
+              <span class="mel-blog-article__meta-item">{{ mel_blog_published_date }}</span>
+            {% endif %}
+            {% if mel_blog_reading_time %}
+              <span class="mel-blog-article__meta-item">{{ mel_blog_reading_time.label }}</span>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        {% if mel_blog_tags %}
+          <ul class="mel-blog-article__tags" role="list" aria-label="{{ 'Article tags'|t }}">
+            {% for tag in mel_blog_tags %}
+              <li>
+                <a class="mel-blog-article__tag" href="{{ tag.url }}">{{ tag.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+
+      {% if mel_blog_hero %}
+        <figure class="mel-blog-article__hero-media mel-container">
+          {{ mel_blog_hero }}
+        </figure>
+      {% endif %}
+    </header>
+  {% endif %}
+  {{ title_suffix }}
+
+  {% if page %}
+    <div class="mel-blog-article__body mel-container">
+      <div{{ content_attributes.addClass('mel-blog-article__prose') }}>
+        {{ content|without(
+          'links',
+          'field_blog_hero_image',
+          'field_excerpt',
+          'field_tags',
+          'field_organiser_category',
+          'field_playbook',
+          'field_resource_downloads',
+          'field_resource_links',
+          'search_api_excerpt'
+        ) }}
+      </div>
+    </div>
+  {% else %}
+    <div{{ content_attributes.addClass('mel-blog-article__content') }}>
+      {{ content }}
+    </div>
+  {% endif %}
+
+  {% if page and mel_blog_is_playbook and mel_blog_resource_downloads %}
+    <section id="mel-blog-downloads" class="mel-blog-article__downloads mel-container" aria-labelledby="mel-blog-downloads-title">
+      <h2 id="mel-blog-downloads-title" class="mel-blog-article__section-title">{{ 'Downloads included'|t }}</h2>
+      <ul class="mel-blog-article__download-cards" role="list">
+        {% for download in mel_blog_resource_downloads %}
+          <li class="mel-blog-article__download-item">
+            <a
+              class="mel-card mel-card--governed mel-card--clickable mel-blog-article__download-card"
+              href="{{ download.url }}"
+              {% if download.is_external %}target="_blank" rel="noopener noreferrer"{% else %}download{% endif %}
+            >
+              <div class="mel-card__header">
+                <h3 class="mel-card__title">{{ download.title }}</h3>
+              </div>
+              <div class="mel-card__body">
+                <p class="mel-card__meta">{{ download.kind }}</p>
+              </div>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if page and mel_blog_journey %}
+    <section class="mel-blog-article__journey mel-container" aria-labelledby="mel-blog-journey-title">
+      <h2 id="mel-blog-journey-title" class="mel-blog-article__section-title">{{ 'Your organiser journey'|t }}</h2>
+      <ol class="mel-blog-article__journey-steps">
+        {% for step in mel_blog_journey.steps %}
+          <li class="mel-blog-article__journey-step mel-blog-article__journey-step--{{ step.status }}">
+            <span class="mel-blog-article__journey-label">{{ step.label }}</span>
+            {% if step.anchor %}
+              <a class="mel-link" href="{{ step.anchor }}">{{ 'Get templates'|t }}</a>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ol>
+    </section>
+  {% endif %}
+
+  {% if page and mel_blog_cta %}
+    <aside class="mel-blog-article__cta mel-container" aria-labelledby="mel-blog-cta-title">
+      <div class="mel-blog-article__cta-card mel-card mel-card--highlight">
+        <div class="mel-card__body">
+          <h2 id="mel-blog-cta-title" class="mel-card__title">{{ mel_blog_cta.title }}</h2>
+          {% if mel_blog_cta.body %}
+            <p class="mel-blog-article__cta-body">{{ mel_blog_cta.body }}</p>
+          {% endif %}
+          <div class="mel-blog-article__cta-actions">
+            <a class="mel-btn mel-btn--cta" href="{{ mel_blog_cta.url }}">{{ mel_blog_cta.button }}</a>
+            {% if mel_blog_cta.secondary %}
+              <a class="mel-btn mel-btn--secondary" href="{{ mel_blog_cta.secondary.url }}">{{ mel_blog_cta.secondary.button }}</a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </aside>
+  {% endif %}
+
+  {% if page and (mel_blog_related_articles or mel_blog_related_help or mel_blog_feature_links or mel_blog_share_links) %}
+    <footer class="mel-blog-article__footer mel-container">
+      {% if mel_blog_related_articles %}
+        <section class="mel-blog-article__related" aria-labelledby="mel-blog-related-articles-title">
+          <h2 id="mel-blog-related-articles-title" class="mel-blog-article__section-title">{{ 'Related reading'|t }}</h2>
+          <ul class="mel-blog-card-grid mel-blog-article__related-grid" role="list">
+            {% for article in mel_blog_related_articles %}
+              <li class="mel-blog-article__related-item">{{ article }}</li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+
+      {% if mel_blog_related_help or mel_blog_feature_links %}
+        <section class="mel-blog-article__resources" aria-labelledby="mel-blog-resources-title">
+          <h2 id="mel-blog-resources-title" class="mel-blog-article__section-title">{{ 'Related resources'|t }}</h2>
+          {% if mel_blog_related_help %}
+            <div class="mel-blog-article__resource-group">
+              <h3 class="mel-blog-article__resource-heading">{{ 'Help Centre'|t }}</h3>
+              <ul class="mel-blog-article__resource-links" role="list">
+                {% for link in mel_blog_related_help %}
+                  <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+          {% if mel_blog_feature_links %}
+            <div class="mel-blog-article__resource-group">
+              <h3 class="mel-blog-article__resource-heading">{{ 'Explore MyEventLane'|t }}</h3>
+              <ul class="mel-blog-article__resource-links" role="list">
+                {% for link in mel_blog_feature_links %}
+                  <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        </section>
+      {% endif %}
+
+      {% if mel_blog_share_links %}
+        <section class="mel-blog-article__share" aria-labelledby="mel-blog-share-title">
+          <h2 id="mel-blog-share-title" class="mel-blog-article__section-title">{{ 'Share this article'|t }}</h2>
+          <ul class="mel-blog-article__share-links" role="list">
+            {% for link in mel_blog_share_links %}
+              <li>
+                <a
+                  class="mel-blog-article__share-link mel-blog-article__share-link--{{ link.id }}"
+                  href="{{ link.url }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ link.title }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+    </footer>
+  {% endif %}
+</article>

--- a/web/themes/custom/myeventlane_theme/templates/page--node--blog-post.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--node--blog-post.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Page wrapper for full blog article pages.
+ */
+#}
+{% extends "page.html.twig" %}
+
+{% block content %}
+  <div class="mel-blog-article-page">
+    {{ page.content }}
+  </div>
+{% endblock %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-blog--homepage-preview.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-blog--homepage-preview.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Homepage blog preview — single grid only (no landing card-grid wrapper).
+ *
+ * Avoids nesting mel-blog-preview-grid inside mel-blog-landing__card-grid, which
+ * collapses cards into narrow columns on the front page.
+ */
+#}
+{%
+  set classes = [
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    'mel-blog-home-preview',
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+
+  {% if rows %}
+    {{ rows }}
+  {% elseif empty %}
+    <div class="view-empty mel-empty-state mel-empty-state--governed" role="status">
+      {{ empty }}
+    </div>
+  {% endif %}
+
+  {{ pager }}
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-blog.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-blog.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Blog view — results first, exposed filters rendered by landing wrapper.
+ */
+#}
+{%
+  set classes = [
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    'mel-blog-landing__view',
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+
+  {% if rows %}
+    <div class="mel-blog-card-grid mel-blog-landing__card-grid view-content" role="list">
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    <div class="view-empty mel-empty-state mel-empty-state--governed" role="status">
+      {{ empty }}
+    </div>
+  {% endif %}
+
+  {{ pager }}
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-blog--homepage-preview.html.twig
@@ -5,11 +5,11 @@
  */
 #}
 {% if rows %}
-  <div class="mel-blog-preview-grid">
+  <ul class="mel-blog-card-grid mel-blog-preview-grid" role="list">
     {% for row in rows %}
-      <div class="mel-blog-preview-grid__item">
+      <li class="mel-blog-preview-grid__item">
         {{ row.content }}
-      </div>
+      </li>
     {% endfor %}
-  </div>
+  </ul>
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large config and routing surface (blog URL split, new fields, sitemap) affects public URLs and editorial workflows; no auth/payment changes, but deploy needs config import and update hooks for taxonomy/playbook seeds.
> 
> **Overview**
> Adds an **Organiser Hub** at `/resources` and a dedicated **blog landing** at `/blog`, with filtered listings delegated to `mel_blog` at `/blog/list`. Blog posts gain editorial fields (audience, author type/name, organiser category, playbook flags, document downloads, external resource links) plus a new **Organiser Hub categories** vocabulary, `mel_blog_card` image style, and blog metatag defaults.
> 
> **`myeventlane_front`** wires controllers, page builders, JSON-LD on articles, `/sitemap.xml`, admin Views (editorial dashboard, coverage, linking audit), update hooks to seed terms and playbook drafts, and footer/menu routes now point at the new landing routes instead of the raw blog View.
> 
> **Theme** adds full article and landing SCSS, teaser/full node templates, and shared blog card grids (including homepage preview layout fixes). **`mel_blog`** exposes category and audience filters; document media is uploadable in the media library form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df8127d7d9bfc0e2f514e75ead0eacaca761d026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->