### PR TITLE
Add BlogAudienceFilterService for audience-based filtering in blog views

### DIFF
--- a/web/modules/custom/myeventlane_front/myeventlane_front.install
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.install
@@ -51,13 +51,28 @@ function myeventlane_front_update_8004(): string {
 function myeventlane_front_update_8005(): string {
   /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
   $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
-  return implode(' ', $seeder->seedPlaybooks());
+  $messages = $seeder->seedPlaybooks();
+  return $messages === [] ? (string) t('No organiser hub playbook update messages returned.') : implode(' ', $messages);
+}
+
+/**
+ * Re-runs organiser hub playbook seeding after config/field dependencies exist.
+ */
+function myeventlane_front_update_8007(): string {
+  /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
+  $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
+  $messages = $seeder->seedPlaybooks();
+  return $messages === [] ? (string) t('No organiser hub playbook update messages returned.') : implode(' ', $messages);
 }
 
 /**
  * Marks the first-event guide as organiser audience for CTA targeting.
  */
 function myeventlane_front_update_8006(): string {
+  if (\Drupal::entityTypeManager()->getStorage('field_storage_config')->load('node.field_blog_audience') === NULL) {
+    return (string) t('Skipped first-event audience update: field_blog_audience is not installed.');
+  }
+
   $storage = \Drupal::entityTypeManager()->getStorage('node');
   $nids = $storage->getQuery()
     ->accessCheck(FALSE)

--- a/web/modules/custom/myeventlane_front/myeventlane_front.module
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.module
@@ -73,6 +73,12 @@ function myeventlane_front_preprocess_myeventlane_home_hero(array &$variables): 
  * Homepage hero exclusivity and cross-rail deduplication (front page only).
  */
 function myeventlane_front_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query): void {
+  if (\Drupal::hasService('myeventlane_front.blog_audience_filter')) {
+    /** @var \Drupal\myeventlane_front\Service\BlogAudienceFilterService $blogAudience */
+    $blogAudience = \Drupal::service('myeventlane_front.blog_audience_filter');
+    $blogAudience->alterMelBlogView($view, $query);
+  }
+
   if (!\Drupal::hasService('myeventlane_front.homepage_merchandising_query_alter')) {
     return;
   }

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -95,10 +95,16 @@ services:
     arguments:
       - '@file_url_generator'
 
+  myeventlane_front.blog_audience_filter:
+    class: Drupal\myeventlane_front\Service\BlogAudienceFilterService
+    arguments:
+      - '@entity_type.manager'
+
   myeventlane_front.blog_landing_page:
     class: Drupal\myeventlane_front\Service\BlogLandingPageBuilder
     arguments:
       - '@entity_type.manager'
+      - '@myeventlane_front.blog_audience_filter'
       - '@cache.default'
 
   myeventlane_front.blog_article_presentation:

--- a/web/modules/custom/myeventlane_front/phpunit.xml
+++ b/web/modules/custom/myeventlane_front/phpunit.xml
@@ -6,6 +6,7 @@
   <testsuites>
     <testsuite name="myeventlane_front_unit">
       <file>tests/src/Unit/BlogAudienceCountTest.php</file>
+      <file>tests/src/Unit/BlogAudienceFilterTest.php</file>
       <file>tests/src/Unit/BlogAuthorTest.php</file>
       <file>tests/src/Unit/BlogCardBadgeTest.php</file>
       <file>tests/src/Unit/BlogCtaTest.php</file>

--- a/web/modules/custom/myeventlane_front/src/Service/BlogArticlePresentationService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogArticlePresentationService.php
@@ -75,7 +75,7 @@ final class BlogArticlePresentationService {
     }
 
     $isPlaybook = $node->hasField('field_playbook') && (bool) $node->get('field_playbook')->value;
-    $resourceDownloads = $isPlaybook ? $this->resourceDownloads->build($node) : [];
+    $resourceDownloads = $this->resourceDownloads->build($node);
     $createEventUrl = Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString();
 
     return [

--- a/web/modules/custom/myeventlane_front/src/Service/BlogAudienceFilterService.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogAudienceFilterService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Shared audience matching for blog landing counts and filtered listings.
+ */
+final class BlogAudienceFilterService {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Applies audience conditions to an entity query for published blog posts.
+   */
+  public function applyToEntityQuery(QueryInterface $query, string $audience): void {
+    if ($audience === 'both') {
+      $query->condition('field_blog_audience', 'both');
+      return;
+    }
+
+    if ($audience === 'attendee') {
+      $or = $query->orConditionGroup()
+        ->condition('field_blog_audience', 'attendee')
+        ->condition('field_blog_audience', 'both');
+      if ($this->audienceFieldExists()) {
+        $or->notExists('field_blog_audience.value');
+      }
+      $query->condition($or);
+      return;
+    }
+
+    $or = $query->orConditionGroup()
+      ->condition('field_blog_audience', 'organiser')
+      ->condition('field_blog_audience', 'both');
+    $query->condition($or);
+  }
+
+  /**
+   * Aligns mel_blog exposed audience filters with landing card count rules.
+   */
+  public function alterMelBlogView(ViewExecutable $view, QueryPluginBase $query): void {
+    if ($view->id() !== 'mel_blog' || !$query instanceof Sql) {
+      return;
+    }
+
+    $exposed = $view->getExposedInput();
+    $audience = is_array($exposed) && isset($exposed['audience']) && is_string($exposed['audience'])
+      ? trim($exposed['audience'])
+      : '';
+    if ($audience === '' || !in_array($audience, ['attendee', 'organiser', 'both'], TRUE)) {
+      return;
+    }
+
+    $this->removeAudienceWhereConditions($query);
+
+    $alias = $query->ensureTable('node__field_blog_audience');
+    if (!$alias) {
+      return;
+    }
+
+    $field = $alias . '.field_blog_audience_value';
+    $group = 1;
+
+    if ($audience === 'both') {
+      $query->addWhere($group, $field, 'both');
+      return;
+    }
+
+    if ($audience === 'attendee') {
+      $query->addWhereExpression(
+        $group,
+        "($field IN (:audience_attendee, :audience_both) OR $field IS NULL OR $field = '')",
+        [
+          ':audience_attendee' => 'attendee',
+          ':audience_both' => 'both',
+        ],
+      );
+      return;
+    }
+
+    $query->addWhere($group, $field, ['organiser', 'both'], 'IN');
+  }
+
+  private function removeAudienceWhereConditions(Sql $query): void {
+    foreach ($query->where as $group => &$condition_group) {
+      if (!isset($condition_group['conditions']) || !is_array($condition_group['conditions'])) {
+        continue;
+      }
+      foreach ($condition_group['conditions'] as $key => $condition) {
+        $field = $condition['field'] ?? '';
+        if (is_string($field) && str_contains($field, 'field_blog_audience')) {
+          unset($condition_group['conditions'][$key]);
+        }
+      }
+      if ($condition_group['conditions'] === []) {
+        unset($query->where[$group]);
+      }
+    }
+  }
+
+  private function audienceFieldExists(): bool {
+    return $this->entityTypeManager->getStorage('field_storage_config')->load('node.field_blog_audience') !== NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogLandingPageBuilder.php
@@ -23,6 +23,7 @@ final class BlogLandingPageBuilder {
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly BlogAudienceFilterService $audienceFilter,
     private readonly CacheBackendInterface $cache,
   ) {}
 
@@ -211,24 +212,7 @@ final class BlogLandingPageBuilder {
       ->accessCheck(TRUE)
       ->condition('type', 'blog_post')
       ->condition('status', 1);
-    if ($audience === 'both') {
-      $query->condition('field_blog_audience', 'both');
-    }
-    elseif ($audience === 'attendee') {
-      $or = $query->orConditionGroup()
-        ->condition('field_blog_audience', 'attendee')
-        ->condition('field_blog_audience', 'both');
-      if ($this->entityTypeManager->getStorage('field_storage_config')->load('node.field_blog_audience') !== NULL) {
-        $or->notExists('field_blog_audience.value');
-      }
-      $query->condition($or);
-    }
-    else {
-      $or = $query->orConditionGroup()
-        ->condition('field_blog_audience', 'organiser')
-        ->condition('field_blog_audience', 'both');
-      $query->condition($or);
-    }
+    $this->audienceFilter->applyToEntityQuery($query, $audience);
     return (int) $query->count()->execute();
   }
 

--- a/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/BlogStructuredDataBuilder.php
@@ -101,7 +101,7 @@ final class BlogStructuredDataBuilder {
         '@type' => 'ListItem',
         'position' => 2,
         'name' => 'Guides',
-        'item' => Url::fromRoute('view.mel_blog.page_blog', [], ['absolute' => TRUE])->toString(),
+        'item' => Url::fromRoute('myeventlane_front.blog_landing', [], ['absolute' => TRUE])->toString(),
       ],
       [
         '@type' => 'ListItem',

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_front\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
@@ -15,6 +16,17 @@ use Drupal\taxonomy\TermInterface;
  * Seeds organiser hub playbook article stubs from exported config.
  */
 final class OrganiserHubContentSeeder {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var list<string>
+   */
+  private const REQUIRED_NODE_FIELDS = [
+    'field_playbook',
+    'field_featured_playbook',
+    'field_excerpt',
+  ];
 
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
@@ -26,10 +38,20 @@ final class OrganiserHubContentSeeder {
    * @return list<string>
    */
   public function seedPlaybooks(): array {
+    $missing = $this->getMissingRequirements();
+    if ($missing !== []) {
+      return [
+        (string) $this->t(
+          'Skipped organiser hub playbook seeding. Missing: @items. Import configuration, then re-run database updates.',
+          ['@items' => implode(', ', $missing)],
+        ),
+      ];
+    }
+
     $config = $this->configFactory->get('myeventlane_front.organiser_hub_seeds');
     $playbooks = $config->get('playbooks') ?? [];
     if (!is_array($playbooks) || $playbooks === []) {
-      return [(string) t('No organiser hub playbook seeds found.')];
+      return [(string) $this->t('No organiser hub playbook seeds found.')];
     }
 
     $messages = [];
@@ -43,45 +65,97 @@ final class OrganiserHubContentSeeder {
         continue;
       }
 
-      $existing = $this->entityTypeManager->getStorage('node')->loadByProperties([
+      try {
+        $message = $this->seedPlaybook((string) $key, $title, $definition);
+        if ($message !== NULL) {
+          $messages[] = $message;
+        }
+      }
+      catch (\Throwable $exception) {
+        $logger->error('Organiser hub seed failed for @key: @message', [
+          '@key' => (string) $key,
+          '@message' => $exception->getMessage(),
+        ]);
+        $messages[] = (string) $this->t('Failed to seed playbook @title: @error', [
+          '@title' => $title,
+          '@error' => $exception->getMessage(),
+        ]);
+      }
+    }
+
+    if ($messages === []) {
+      return [(string) $this->t('No organiser hub playbook content was seeded.')];
+    }
+
+    return $messages;
+  }
+
+  /**
+   * @param array<string, mixed> $definition
+   */
+  private function seedPlaybook(string $key, string $title, array $definition): ?string {
+    $existing = $this->entityTypeManager->getStorage('node')->loadByProperties([
+      'type' => 'blog_post',
+      'title' => $title,
+    ]);
+    $node = is_array($existing) && $existing !== [] ? reset($existing) : NULL;
+    $created = FALSE;
+    if (!$node instanceof NodeInterface) {
+      $node = Node::create([
         'type' => 'blog_post',
         'title' => $title,
+        'status' => 0,
       ]);
-      $node = is_array($existing) && $existing !== [] ? reset($existing) : NULL;
-      $created = FALSE;
-      if (!$node instanceof NodeInterface) {
-        $node = Node::create([
-          'type' => 'blog_post',
-          'title' => $title,
-          'status' => 0,
-        ]);
-        $created = TRUE;
-      }
+      $created = TRUE;
+    }
 
-      $node->set('field_playbook', 1);
-      $node->set('field_featured_playbook', !empty($definition['featured']) ? 1 : 0);
-      if (!empty($definition['excerpt'])) {
-        $node->set('field_excerpt', (string) $definition['excerpt']);
-      }
+    $node->set('field_playbook', 1);
+    $node->set('field_featured_playbook', !empty($definition['featured']) ? 1 : 0);
+    if (!empty($definition['excerpt'])) {
+      $node->set('field_excerpt', (string) $definition['excerpt']);
+    }
+    if ($node->hasField('field_organiser_category')) {
       $term = $this->loadCategoryTerm((string) ($definition['category'] ?? ''));
       if ($term instanceof TermInterface) {
         $node->set('field_organiser_category', ['target_id' => $term->id()]);
       }
-      if ($node->get('body')->isEmpty()) {
-        $node->set('body', [
-          'value' => '<p>' . htmlspecialchars((string) ($definition['excerpt'] ?? $title), ENT_QUOTES) . '</p>',
-          'format' => 'basic_html',
-        ]);
-      }
-      $node->save();
-
-      $messages[] = $created
-        ? (string) t('Created playbook draft: @title', ['@title' => $title])
-        : (string) t('Updated playbook draft: @title', ['@title' => $title]);
-      $logger->notice('Organiser hub seed @key: @title', ['@key' => (string) $key, '@title' => $title]);
     }
+    if ($node->hasField('body') && $node->get('body')->isEmpty()) {
+      $node->set('body', [
+        'value' => '<p>' . htmlspecialchars((string) ($definition['excerpt'] ?? $title), ENT_QUOTES) . '</p>',
+        'format' => 'basic_html',
+      ]);
+    }
+    $node->save();
 
-    return $messages;
+    $this->loggerFactory->get('myeventlane_front')->notice('Organiser hub seed @key: @title', [
+      '@key' => $key,
+      '@title' => $title,
+    ]);
+
+    return $created
+      ? (string) $this->t('Created playbook draft: @title', ['@title' => $title])
+      : (string) $this->t('Updated playbook draft: @title', ['@title' => $title]);
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function getMissingRequirements(): array {
+    $missing = [];
+    $fieldStorage = $this->entityTypeManager->getStorage('field_storage_config');
+    foreach (self::REQUIRED_NODE_FIELDS as $fieldName) {
+      if ($fieldStorage->load('node.' . $fieldName) === NULL) {
+        $missing[] = $fieldName;
+      }
+    }
+    if (!$this->entityTypeManager->getStorage('node_type')->load('blog_post')) {
+      $missing[] = 'blog_post bundle';
+    }
+    if ($this->configFactory->get('myeventlane_front.organiser_hub_seeds')->isNew()) {
+      $missing[] = 'myeventlane_front.organiser_hub_seeds config';
+    }
+    return $missing;
   }
 
   private function loadCategoryTerm(string $suffix): ?TermInterface {

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group myeventlane_front
+ */
+final class BlogAudienceFilterTest extends TestCase {
+
+  public function testMelBlogAudienceAlterIsWiredInModuleHook(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_front.module');
+    $this->assertIsString($source);
+    $this->assertStringContainsString('myeventlane_front.blog_audience_filter', $source);
+    $this->assertStringContainsString('alterMelBlogView', $source);
+  }
+
+  public function testStructuredDataBreadcrumbUsesBlogLandingRoute(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/BlogStructuredDataBuilder.php');
+    $this->assertIsString($source);
+    $this->assertStringContainsString("Url::fromRoute('myeventlane_front.blog_landing'", $source);
+    $this->assertStringNotContainsString("Url::fromRoute('view.mel_blog.page_blog'", $source);
+  }
+
+  public function testResourceDownloadsAreNotPlaybookGatedInPresentation(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/BlogArticlePresentationService.php');
+    $this->assertIsString($source);
+    $this->assertStringContainsString('$resourceDownloads = $this->resourceDownloads->build($node);', $source);
+    $this->assertStringNotContainsString('$isPlaybook ? $this->resourceDownloads->build($node)', $source);
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--blog-post.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--blog-post.html.twig
@@ -94,9 +94,11 @@
     </div>
   {% endif %}
 
-  {% if page and mel_blog_is_playbook and mel_blog_resource_downloads %}
+  {% if page and mel_blog_resource_downloads %}
     <section id="mel-blog-downloads" class="mel-blog-article__downloads mel-container" aria-labelledby="mel-blog-downloads-title">
-      <h2 id="mel-blog-downloads-title" class="mel-blog-article__section-title">{{ 'Downloads included'|t }}</h2>
+      <h2 id="mel-blog-downloads-title" class="mel-blog-article__section-title">
+        {{ mel_blog_is_playbook ? 'Downloads included'|t : 'Resources'|t }}
+      </h2>
       <ul class="mel-blog-article__download-cards" role="list">
         {% for download in mel_blog_resource_downloads %}
           <li class="mel-blog-article__download-item">


### PR DESCRIPTION
- Introduced BlogAudienceFilterService to manage audience conditions for blog posts.
- Updated myeventlane_front_views_query_alter to utilize the new service for altering blog view queries.
- Registered BlogAudienceFilterService in services.yml and injected it into BlogLandingPageBuilder.
- Added unit test for BlogAudienceFilterService.
- Fixed resourceDownloads assignment in BlogArticlePresentationService.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public blog listing SQL and audience matching logic, which can affect which posts appear in filtered views and landing counts; seeder/update-hook changes affect deploy-time content seeding but not auth or payments.
> 
> **Overview**
> Introduces **`BlogAudienceFilterService`** so blog landing audience card counts and the **`mel_blog`** exposed audience filter use the same rules (including treating empty **`field_blog_audience`** as attendee). The service is registered in DI, **`BlogLandingPageBuilder`** delegates counting to it, and **`hook_views_query_alter`** rewrites SQL audience conditions instead of relying on the default view filter alone.
> 
> Blog articles now build and show **resource downloads for all posts**, not only playbooks; the Twig template shows a **“Resources”** heading for non-playbooks and **“Downloads included”** for playbooks.
> 
> **Organiser hub playbook seeding** is hardened with prerequisite checks, per-playbook try/catch, clearer update-hook messages, a new **`8007`** re-seed hook, and **`8006`** skips if **`field_blog_audience`** is missing. JSON-LD breadcrumbs point **Guides** at **`myeventlane_front.blog_landing`** instead of the old Views route. Unit tests assert wiring for the filter hook, breadcrumb route, and download gating removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cd886c2d267773edfff4071836ded6c095a36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->