### PR TITLE
Refactor organiser hub playbook seeding functions for improved error …

### DIFF
--- a/web/modules/custom/myeventlane_front/myeventlane_front.install
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.install
@@ -49,26 +49,71 @@ function myeventlane_front_update_8004(): string {
  * Seeds organiser hub playbook draft content from config.
  */
 function myeventlane_front_update_8005(): string {
-  /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
-  $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
-  $messages = $seeder->seedPlaybooks();
-  return $messages === [] ? (string) t('No organiser hub playbook update messages returned.') : implode(' ', $messages);
-}
-
-/**
- * Re-runs organiser hub playbook seeding after config/field dependencies exist.
- */
-function myeventlane_front_update_8007(): string {
-  /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
-  $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
-  $messages = $seeder->seedPlaybooks();
-  return $messages === [] ? (string) t('No organiser hub playbook update messages returned.') : implode(' ', $messages);
+  return _myeventlane_front_run_playbook_seeding();
 }
 
 /**
  * Marks the first-event guide as organiser audience for CTA targeting.
  */
 function myeventlane_front_update_8006(): string {
+  return _myeventlane_front_apply_first_event_organiser_audience();
+}
+
+/**
+ * Re-runs organiser hub playbook seeding after config/field dependencies exist.
+ */
+function myeventlane_front_update_8007(): string {
+  $messages = [_myeventlane_front_run_playbook_seeding()];
+  $messages[] = _myeventlane_front_apply_first_event_organiser_audience();
+  return implode(' ', $messages);
+}
+
+/**
+ * Re-runs organiser hub playbook seeding after failed or skipped 8005/8007.
+ */
+function myeventlane_front_update_8009(): string {
+  return _myeventlane_front_run_playbook_seeding();
+}
+
+/**
+ * Re-applies first-event organiser audience when earlier hooks skipped.
+ */
+function myeventlane_front_update_8008(): string {
+  return _myeventlane_front_apply_first_event_organiser_audience();
+}
+
+/**
+ * Runs organiser hub playbook seeding with defensive guards for update batches.
+ */
+function _myeventlane_front_run_playbook_seeding(): string {
+  try {
+    if (!\Drupal::moduleHandler()->moduleExists('myeventlane_front')) {
+      return (string) t('Skipped organiser hub playbook seeding: myeventlane_front is unavailable.');
+    }
+    if (!\Drupal::hasService('myeventlane_front.organiser_hub_content_seeder')) {
+      return (string) t('Skipped organiser hub playbook seeding: seeder service unavailable. Run drush cr after deploy.');
+    }
+    /** @var \Drupal\myeventlane_front\Service\OrganiserHubContentSeeder $seeder */
+    $seeder = \Drupal::service('myeventlane_front.organiser_hub_content_seeder');
+    $messages = $seeder->seedPlaybooks();
+    return $messages === []
+      ? (string) t('No organiser hub playbook update messages returned.')
+      : implode(' ', $messages);
+  }
+  catch (\Throwable $exception) {
+    \Drupal::logger('myeventlane_front')->error('Organiser hub playbook seeding failed: @message', [
+      '@message' => $exception->getMessage(),
+    ]);
+    return (string) t('Organiser hub playbook seeding failed: @message', [
+      '@message' => $exception->getMessage(),
+    ]);
+  }
+}
+
+/**
+ * Sets organiser audience on the first-event guide article (idempotent).
+ */
+function _myeventlane_front_apply_first_event_organiser_audience(): string {
   if (\Drupal::entityTypeManager()->getStorage('field_storage_config')->load('node.field_blog_audience') === NULL) {
     return (string) t('Skipped first-event audience update: field_blog_audience is not installed.');
   }
@@ -86,6 +131,9 @@ function myeventlane_front_update_8006(): string {
   $node = $storage->load(reset($nids));
   if ($node === NULL || !$node->hasField('field_blog_audience')) {
     return (string) t('Blog audience field unavailable.');
+  }
+  if ($node->get('field_blog_audience')->value === 'organiser') {
+    return (string) t('First-event blog article already has organiser audience.');
   }
   $node->set('field_blog_audience', 'organiser');
   $node->save();

--- a/web/modules/custom/myeventlane_front/myeventlane_front.install
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.install
@@ -69,17 +69,19 @@ function myeventlane_front_update_8007(): string {
 }
 
 /**
- * Re-runs organiser hub playbook seeding after failed or skipped 8005/8007.
- */
-function myeventlane_front_update_8009(): string {
-  return _myeventlane_front_run_playbook_seeding();
-}
-
-/**
  * Re-applies first-event organiser audience when earlier hooks skipped.
  */
 function myeventlane_front_update_8008(): string {
   return _myeventlane_front_apply_first_event_organiser_audience();
+}
+
+/**
+ * Re-runs organiser hub playbook seeding after failed or skipped 8005/8007.
+ */
+function myeventlane_front_update_8009(): string {
+  $messages = [_myeventlane_front_run_playbook_seeding()];
+  $messages[] = _myeventlane_front_apply_first_event_organiser_audience();
+  return implode(' ', $messages);
 }
 
 /**

--- a/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/OrganiserHubContentSeeder.php
@@ -7,7 +7,6 @@ namespace Drupal\myeventlane_front\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
@@ -16,8 +15,6 @@ use Drupal\taxonomy\TermInterface;
  * Seeds organiser hub playbook article stubs from exported config.
  */
 final class OrganiserHubContentSeeder {
-
-  use StringTranslationTrait;
 
   /**
    * @var list<string>
@@ -41,7 +38,7 @@ final class OrganiserHubContentSeeder {
     $missing = $this->getMissingRequirements();
     if ($missing !== []) {
       return [
-        (string) $this->t(
+        (string) t(
           'Skipped organiser hub playbook seeding. Missing: @items. Import configuration, then re-run database updates.',
           ['@items' => implode(', ', $missing)],
         ),
@@ -51,7 +48,7 @@ final class OrganiserHubContentSeeder {
     $config = $this->configFactory->get('myeventlane_front.organiser_hub_seeds');
     $playbooks = $config->get('playbooks') ?? [];
     if (!is_array($playbooks) || $playbooks === []) {
-      return [(string) $this->t('No organiser hub playbook seeds found.')];
+      return [(string) t('No organiser hub playbook seeds found.')];
     }
 
     $messages = [];
@@ -76,7 +73,7 @@ final class OrganiserHubContentSeeder {
           '@key' => (string) $key,
           '@message' => $exception->getMessage(),
         ]);
-        $messages[] = (string) $this->t('Failed to seed playbook @title: @error', [
+        $messages[] = (string) t('Failed to seed playbook @title: @error', [
           '@title' => $title,
           '@error' => $exception->getMessage(),
         ]);
@@ -84,7 +81,7 @@ final class OrganiserHubContentSeeder {
     }
 
     if ($messages === []) {
-      return [(string) $this->t('No organiser hub playbook content was seeded.')];
+      return [(string) t('No organiser hub playbook content was seeded.')];
     }
 
     return $messages;
@@ -123,7 +120,7 @@ final class OrganiserHubContentSeeder {
     if ($node->hasField('body') && $node->get('body')->isEmpty()) {
       $node->set('body', [
         'value' => '<p>' . htmlspecialchars((string) ($definition['excerpt'] ?? $title), ENT_QUOTES) . '</p>',
-        'format' => 'basic_html',
+        'format' => $this->resolveBodyFormat(),
       ]);
     }
     $node->save();
@@ -134,8 +131,8 @@ final class OrganiserHubContentSeeder {
     ]);
 
     return $created
-      ? (string) $this->t('Created playbook draft: @title', ['@title' => $title])
-      : (string) $this->t('Updated playbook draft: @title', ['@title' => $title]);
+      ? (string) t('Created playbook draft: @title', ['@title' => $title])
+      : (string) t('Updated playbook draft: @title', ['@title' => $title]);
   }
 
   /**
@@ -156,6 +153,16 @@ final class OrganiserHubContentSeeder {
       $missing[] = 'myeventlane_front.organiser_hub_seeds config';
     }
     return $missing;
+  }
+
+  private function resolveBodyFormat(): string {
+    $storage = $this->entityTypeManager->getStorage('filter_format');
+    foreach (['basic_html', 'restricted_html', 'plain_text'] as $candidate) {
+      if ($storage->load($candidate) !== NULL) {
+        return $candidate;
+      }
+    }
+    return 'plain_text';
   }
 
   private function loadCategoryTerm(string $suffix): ?TermInterface {

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
@@ -32,4 +32,17 @@ final class BlogAudienceFilterTest extends TestCase {
     $this->assertStringNotContainsString('$isPlaybook ? $this->resourceDownloads->build($node)', $source);
   }
 
+  public function testFirstEventAudienceRunsAfterPlaybookReseed(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_front.install');
+    $this->assertIsString($source);
+    $this->assertStringContainsString('function _myeventlane_front_run_playbook_seeding(): string', $source);
+    $this->assertStringContainsString('function _myeventlane_front_apply_first_event_organiser_audience(): string', $source);
+    $this->assertStringContainsString('function myeventlane_front_update_8008(): string', $source);
+    $this->assertStringContainsString('function myeventlane_front_update_8009(): string', $source);
+    $update8007Start = strpos($source, 'function myeventlane_front_update_8007(): string');
+    $audienceHelperCall = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8007Start);
+    $this->assertNotFalse($update8007Start);
+    $this->assertNotFalse($audienceHelperCall);
+  }
+
 }

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
@@ -40,9 +40,13 @@ final class BlogAudienceFilterTest extends TestCase {
     $this->assertStringContainsString('function myeventlane_front_update_8008(): string', $source);
     $this->assertStringContainsString('function myeventlane_front_update_8009(): string', $source);
     $update8007Start = strpos($source, 'function myeventlane_front_update_8007(): string');
-    $audienceHelperCall = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8007Start);
+    $update8009Start = strpos($source, 'function myeventlane_front_update_8009(): string');
+    $audienceAfter8007 = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8007Start);
+    $audienceAfter8009 = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8009Start);
     $this->assertNotFalse($update8007Start);
-    $this->assertNotFalse($audienceHelperCall);
+    $this->assertNotFalse($update8009Start);
+    $this->assertNotFalse($audienceAfter8007);
+    $this->assertNotFalse($audienceAfter8009);
   }
 
 }


### PR DESCRIPTION
…handling and clarity. Introduced defensive checks in seeding process, updated function names for better readability, and ensured idempotency in audience assignment. Removed StringTranslationTrait usage in favour of direct t() calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy-time database updates and content seeding for organiser hub playbooks and blog audience; failures are handled more gracefully but new update hooks (8008/8009) affect production update order.
> 
> **Overview**
> **Organiser hub database updates** are refactored so playbook seeding and first-event audience assignment share helpers (`_myeventlane_front_run_playbook_seeding`, `_myeventlane_front_apply_first_event_organiser_audience`) instead of inlined seeder calls. Seeding now checks module/service availability, catches throwables, logs failures, and returns skip messages instead of breaking the update batch. Updates **8005–8009** are reordered and extended: **8006** only sets audience; **8007/8009** run seeding then audience; **8008/8009** add recovery hooks for skipped or failed earlier steps.
> 
> **First-event organiser audience** is idempotent: if `field_blog_audience` is already `organiser`, the hook returns without saving.
> 
> **OrganiserHubContentSeeder** drops `StringTranslationTrait` in favor of global `t()`, and picks body text format via `resolveBodyFormat()` (`basic_html`, `restricted_html`, or `plain_text`) instead of hardcoding `basic_html`.
> 
> A unit test asserts the install hooks and that audience runs after playbook reseed in **8007** and **8009**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a430df35ef839ce3e6dc0f736dfe31a6a8226469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->