### PR TITLE
Refine Klaro consent styling and configuration

### DIFF
--- a/config/sync/klaro.settings.yml
+++ b/config/sync/klaro.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: OE3ByQ7OzSlI54C2RfXPanzIytXm5DBLVA467r3020U
 langcode: en
-dialog_mode: manager
+dialog_mode: notice
 auto_decorate_final_html: false
 auto_decorate_js_alter: true
 auto_decorate_page_attachments: true
@@ -32,7 +32,7 @@ library:
   hide_decline_all: false
   hide_learn_more: false
   learn_more_as_button: true
-  additional_class: ''
+  additional_class: mel-klaro
   disable_powered_by: true
   html_texts: false
-  auto_focus: true
+  auto_focus: false

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_klaro-consent.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_klaro-consent.scss
@@ -4,6 +4,7 @@
 // Theme class appended by KlaroHelper::processDrupalSettings().
 // ==========================================================================
 
+
 @use 'sass:color';
 @use '../tokens/colors';
 @use '../tokens/radii';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small consent UX/config changes with no backend or data impact; notice mode may change how users first see cookie choices site-wide.
> 
> **Overview**
> Updates **synced Klaro config** so consent uses **`dialog_mode: notice`** instead of the full manager modal, adds the **`mel-klaro`** library **`additional_class`** for theme hooks, and sets **`auto_focus: false`** so the banner does not grab keyboard focus on open.
> 
> The only theme change is a **blank line** in `_klaro-consent.scss` (no styling logic changes in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fa75544170de734225231a3c999c841ac2f684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->