### PR TITLE
Feature/calendar discovery refresh

### DIFF
--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -685,6 +685,198 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  embed_calendar_this_week:
+    id: embed_calendar_this_week
+    display_title: 'Calendar: Upcoming this week'
+    display_plugin: block
+    position: 10
+    display_options:
+      title: 'Upcoming this week'
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: ''
+            format: full_html
+          tokenize: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+        field_event_start_value_2:
+          id: field_event_start_value_2
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '<='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+            offset: '+7 days'
+          group: 1
+          exposed: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: compact_commerce
+      defaults:
+        empty: false
+        pager: false
+        row: false
+        filters: false
+      display_extenders: {  }
+      block_description: 'Calendar: Upcoming this week'
+      block_category: MyEventLane
+      block_hide_empty: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
   homepage_latest:
     id: homepage_latest
     display_title: 'Homepage latest'

--- a/docs/audits/dead-event-routes.md
+++ b/docs/audits/dead-event-routes.md
@@ -1,0 +1,93 @@
+# Dead Event Route Candidates — Phase 1A (WP-7)
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-13  
+**Method:** Routes with **no menu links**, and **no references** in Twig, JS, or PHP outside their own routing file, controller, redirect subscriber, or test fixtures. "Dead" here means **no user-facing navigation or external caller found** — not proof of zero HTTP traffic.
+
+**No routes were removed in Phase 1A.**
+
+---
+
+## 1. High-confidence dead / redirect-only candidates
+
+| Route | Evidence | Candidate Action |
+|-------|----------|------------------|
+| `myeventlane_event_studio.edit_basic` | Only `VendorLegacyWizardRedirectSubscriber.php` + routing YAML; no Twig/JS/menu links | **Remove Later** (after redirect-only period) |
+| `myeventlane_event_studio.edit_datetime` | Same as above | **Remove Later** |
+| `myeventlane_event_studio.edit_tickets` | Same as above | **Remove Later** |
+| `myeventlane_event_studio.edit_description` | Same as above | **Remove Later** |
+| `myeventlane_event_studio.edit_preview` | Same as above | **Remove Later** |
+| `myeventlane_event_studio.edit_publish` | Same as above | **Remove Later** |
+| `myeventlane_vendor.manage_event.promote` | `ManageEventPlaceholderController` stub; listed in `ManageEventNavigation.php` and `ManageEventPlaceholderNoIndexSubscriber.php` only; **not linked from contextual help** per routing comment | **Remove Later** |
+| `myeventlane_vendor.manage_event.payments` | Placeholder stub; one Twig link in legacy `event/tickets.html.twig` nav to non-functional page | **Redirect** → Studio section or **Remove Later** |
+| `myeventlane_vendor.manage_event.comms` | Placeholder stub; nav service only | **Remove Later** |
+| `myeventlane_vendor.manage_event.advanced` | Placeholder stub; nav service only | **Remove Later** |
+| `myeventlane_vendor.console.events_add` | Only `VendorEventCreateController` (redirect) + launch allowlist; no menu/Twig links | **Redirect** → gateway or **Keep** as bookmark alias |
+
+---
+
+## 2. Legacy wizard routes (vendor redirect-only)
+
+| Route | Evidence | Candidate Action |
+|-------|----------|------------------|
+| `myeventlane_event.wizard.basics` | Vendors redirected by `VendorLegacyWizardRedirectSubscriber`; forms/templates remain for staff path | **Keep** until staff-only gate confirmed; then **Remove Later** |
+| `myeventlane_event.wizard.when_where` | Same | **Keep** / **Remove Later** |
+| `myeventlane_event.wizard.tickets` | Same + wizard twig (unreachable for vendors) | **Keep** / **Remove Later** |
+| `myeventlane_event.wizard.details` | Same | **Keep** / **Remove Later** |
+| `myeventlane_event.wizard.review` | Same | **Keep** / **Remove Later** |
+| `myeventlane_event.wizard.publish` | Same | **Keep** / **Remove Later** |
+| `myeventlane_event.wizard.success` | Same | **Keep** / **Remove Later** |
+
+**Evidence:** `myeventlane_event.routing.yml:1-3` (comment: vendors redirected to Studio); `VendorLegacyWizardRedirectSubscriber.php:31-37`.
+
+---
+
+## 3. Alias routes (keep for bookmarks)
+
+| Route | Evidence | Candidate Action |
+|-------|----------|------------------|
+| `myeventlane_vendor.manage_event.edit` | Redirect-only; subscriber reference only | **Keep** (alias) |
+| `myeventlane_vendor.console.studio` | Redirect in `VendorStudioController::studio` | **Keep** (alias) → **Remove Later** after traffic audit |
+| `myeventlane_vendor.console.event_editor` | Redirect in `VendorStudioController::eventEditor` | **Keep** (alias) |
+| `myeventlane_vendor.manage_event.tickets` | Redirect to canonical tickets route | **Keep** (alias) |
+| `myeventlane_event_studio.workspace_promotions` | Documented legacy bookmark → messaging | **Keep** (alias) |
+| `myeventlane_event_studio.workspace_{merchandise,addons,add_ons}` | Redirect → extras | **Keep** (alias) |
+
+---
+
+## 4. Parallel surfaces (active — not dead)
+
+These routes **duplicate** Event Studio but **have live references** and must not be classified as dead in this phase.
+
+| Route | Evidence of use | Candidate Action |
+|-------|-----------------|------------------|
+| `myeventlane_vendor.console.studio.event_*` (JSON save API) | `VendorStudioController.php` builds endpoint URLs | **Redirect** / retire write API (WP-4) |
+| `myeventlane_vendor.console.event_workspace` | `VendorEventTabsService.php`, workspace controllers | **Redirect** → Studio workspace (WP-5) |
+| `myeventlane_vendor.console.event_overview` | Redirect subscriber + overview controller | **Redirect** → Studio |
+| `myeventlane_vendor.manage_event.{design,content,checkout_questions,series}` | Active controllers + twig/dashboard links | **Redirect** → Studio sections (WP-5) |
+
+---
+
+## 5. Canonical routes (never candidates for removal)
+
+| Route | Role |
+|-------|------|
+| `myeventlane_vendor.create_event_gateway` | Public create entry |
+| `myeventlane_event_studio.create` | Authoring create (post-gateway) |
+| `myeventlane_event_studio.edit` | Authoring edit entry |
+| `myeventlane_event_studio.workspace*` | Unified management |
+| `myeventlane_event_studio.publish` | Canonical publish POST |
+| `myeventlane_event.duplicate` | Distinct rebook feature |
+
+---
+
+## 6. Verification commands (before any removal in a future phase)
+
+```bash
+# Replace ROUTE_NAME before running in a future phase:
+ddev drush php:eval "print_r(array_keys(\Drupal::service('router.route_provider')->getRoutesByPattern('')));"
+rg -l "ROUTE_NAME" web/modules/custom web/themes/custom --glob '*.{php,twig,yml,js}'
+rg -l "/vendor/events/add" web/modules/custom web/themes/custom
+```
+
+**Residual risk:** Bookmarked URLs, external marketing links, and email templates may hit alias/legacy paths not captured in PHP/Twig grep (e.g. hard-coded `https://myeventlane.com.au/create-event` in email template).

--- a/docs/audits/event-route-ownership-map.md
+++ b/docs/audits/event-route-ownership-map.md
@@ -1,0 +1,212 @@
+# Event Route Ownership Map — Phase 1A (WP-0)
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-13  
+**Scope:** Event creation, editing, publishing, and management routes only. Evidence from routing YAML and controller/form class declarations in the repository.
+
+**Status legend**
+
+| Status | Meaning |
+|--------|---------|
+| **Canonical** | Intended primary surface for this workflow step |
+| **Alias** | Registered route that redirects or wraps the canonical route |
+| **Legacy** | Superseded; redirect-only or staff-only per code comments |
+| **Duplicate** | Parallel surface rendering or writing the same capability |
+| **Unknown** | Route exists; ownership not documented in repository |
+
+---
+
+## 1. Event creation
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_vendor.create_event_gateway` | `/create-event` | `CreateEventGatewayController::gateway` | Public/vendor entry: login, organiser onboarding, draft resume, then redirect to Event Studio create or edit | **Canonical** (entry gateway) |
+| `myeventlane_event_studio.create` | `/vendor/events/create` | `myeventlane_event_studio.controller:buildCreate` (`EventStudioController`) | Event Studio create (draft + edit redirect) | **Canonical** (authoring create) |
+| `myeventlane_vendor.console.events_add` | `/vendor/events/add` | `VendorEventCreateController::buildForm` | Legacy add URL; redirects to `myeventlane_event_studio.create` | **Alias** |
+| `myeventlane_vendor.onboard.first_event` | `/vendor/onboard/first-event` | `VendorOnboardFirstEventController::firstEvent` | Onboarding step linking to Event Studio create | **Alias** (onboarding funnel) |
+| `entity.node.add_form` (event bundle) | `/node/add/event` | Core node add form | Access denied for vendors via `EventNodeFormAccessSubscriber` | **Legacy** (blocked) |
+
+**Evidence:** `myeventlane_vendor.routing.yml:167-176`, `508-514`, `237-247`; `myeventlane_event_studio.routing.yml:1-8`; `CreateEventGatewayController.php:79-214`; `VendorEventCreateController.php:48-59`.
+
+---
+
+## 2. Event editing
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_event_studio.edit` | `/vendor/events/{node}/edit` | `EventStudioController::buildEdit` | Event Studio unified edit entry | **Canonical** |
+| `myeventlane_vendor.manage_event.edit` | `/vendor/event/{event}/edit` | `ManageEventEditController::edit` | Redirects to `myeventlane_event_studio.edit` | **Alias** |
+| `myeventlane_vendor.console.event_editor` | `/vendor/events/{event}/editor` | `VendorStudioController::eventEditor` | Redirects to Event Studio edit | **Alias** |
+| `myeventlane_vendor.console.studio` | `/vendor/studio` | `VendorStudioController::studio` | Redirects to Event Studio create/edit | **Alias** |
+| `myeventlane_event_studio.edit_basic` | `/vendor/events/{node}/edit/basic` | `EventStudioBasicForm` | Legacy step form; vendor redirect via subscriber | **Legacy** |
+| `myeventlane_event_studio.edit_datetime` | `/vendor/events/{node}/edit/datetime` | `EventStudioDateForm` | Legacy step form | **Legacy** |
+| `myeventlane_event_studio.edit_tickets` | `/vendor/events/{node}/edit/tickets` | `EventStudioTicketsForm` | Legacy step form | **Legacy** |
+| `myeventlane_event_studio.edit_description` | `/vendor/events/{node}/edit/description` | `EventStudioDescriptionForm` | Legacy step form | **Legacy** |
+| `myeventlane_event_studio.edit_preview` | `/vendor/events/{node}/edit/preview` | `EventStudioPreviewController::build` | Legacy preview step | **Legacy** |
+| `myeventlane_event_studio.edit_publish` | `/vendor/events/{node}/edit/publish` | `EventStudioPublishForm` | Legacy publish step form | **Legacy** |
+| `myeventlane_event.wizard.basics` | `/vendor/events/{event}/build/basics` | `EventWizardBasicsForm` | Form-API wizard step | **Legacy** |
+| `myeventlane_event.wizard.when_where` | `/vendor/events/{event}/build/when-where` | `EventWizardWhenWhereForm` | Wizard step | **Legacy** |
+| `myeventlane_event.wizard.tickets` | `/vendor/events/{event}/build/tickets` | `EventWizardTicketsForm` | Wizard step | **Legacy** |
+| `myeventlane_event.wizard.details` | `/vendor/events/{event}/build/details` | `EventWizardDetailsForm` | Wizard step | **Legacy** |
+| `myeventlane_event.wizard.review` | `/vendor/events/{event}/build/review` | `EventWizardReviewForm` | Wizard step | **Legacy** |
+| `myeventlane_event.wizard.publish` | `/vendor/events/{event}/build/publish` | `EventWizardPublishForm` | Wizard publish step | **Legacy** |
+| `myeventlane_event.wizard.success` | `/vendor/events/{event}/build/success` | `VendorEventWizardController::success` | Wizard success page | **Legacy** |
+| `entity.node.edit_form` (event) | `/node/{node}/edit` | Core node edit | Blocked for vendor event editing | **Legacy** (blocked) |
+
+**Evidence:** `myeventlane_event_studio.routing.yml:10-345`; `myeventlane_event.routing.yml:1-107`; `VendorLegacyWizardRedirectSubscriber.php:31-69`; `myeventlane_vendor.routing.yml:274-286, 322-346`.
+
+---
+
+## 3. Event publishing
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_event_studio.publish` | `/vendor/events/{node}/studio/publish` | `publish_controller:publish` (POST) | Canonical Event Studio publish action | **Canonical** |
+| `myeventlane_event_studio.edit_publish` | `/vendor/events/{node}/edit/publish` | `EventStudioPublishForm` | Legacy publish form (redirect for vendors) | **Legacy** |
+| `myeventlane_event.wizard.publish` | `/vendor/events/{event}/build/publish` | `EventWizardPublishForm` | Legacy wizard publish | **Legacy** |
+| `myeventlane_vendor.console.event_publish` | `/vendor/events/{event}/publish` | `EventWorkspaceController::publish` | Vendor console workspace publish | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_publish` | `/vendor/studio/event/{event}/publish` | `VendorStudioController::publishEvent` (POST) | Legacy Vendor Studio JSON publish | **Duplicate** |
+| `myeventlane_vendor.console.event_unpublish` | `/vendor/events/{event}/unpublish` | `EventUnpublishForm` | Unpublish event | **Canonical** (unpublish) |
+
+**Evidence:** `myeventlane_event_studio.routing.yml:334-370`; `myeventlane_vendor.routing.yml:461-474, 686-699, 735-748`.
+
+---
+
+## 4. Event management (workspace / console)
+
+### 4.1 Event Studio workspace (canonical)
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_event_studio.workspace` | `/vendor/events/{node}/studio` | `EventStudioController::workspace` | Overview section | **Canonical** |
+| `myeventlane_event_studio.workspace_information` | `…/studio/information` | `EventStudioController::workspace` | Information section | **Canonical** |
+| `myeventlane_event_studio.workspace_branding` | `…/studio/branding` | `EventStudioController::workspace` | Branding section | **Canonical** |
+| `myeventlane_event_studio.workspace_content` | `…/studio/content` | `EventStudioController::workspace` | Content section | **Canonical** |
+| `myeventlane_event_studio.workspace_tickets` | `…/studio/tickets` | `EventStudioController::workspace` | Tickets section | **Canonical** |
+| `myeventlane_event_studio.workspace_questions` | `…/studio/questions` | `EventStudioController::workspace` | Questions section | **Canonical** |
+| `myeventlane_event_studio.workspace_capacity` | `…/studio/capacity` | `EventStudioController::workspace` | Capacity section | **Canonical** |
+| `myeventlane_event_studio.workspace_extras` | `…/studio/extras` | `EventStudioController::workspace` | Extras section | **Canonical** |
+| `myeventlane_event_studio.workspace_messaging` | `…/studio/messaging` | `EventStudioController::workspace` | Messaging section | **Canonical** |
+| `myeventlane_event_studio.workspace_attendees` | `…/studio/attendees` | `EventStudioController::workspace` | Attendees section | **Canonical** |
+| `myeventlane_event_studio.workspace_fulfilment` | `…/studio/fulfilment` | `EventStudioController::workspace` | Fulfilment section | **Canonical** |
+| `myeventlane_event_studio.workspace_orders` | `…/studio/orders` | `EventStudioController::workspace` | Orders section | **Canonical** |
+| `myeventlane_event_studio.workspace_analytics` | `…/studio/analytics` | `EventStudioController::workspace` | Analytics section | **Canonical** |
+| `myeventlane_event_studio.workspace_settings` | `…/studio/settings` | `EventStudioController::workspace` | Settings section | **Canonical** |
+| `myeventlane_event_studio.workspace_merchandise` | `…/studio/merchandise` | `redirectToExtrasWorkspace` | Alias → extras | **Alias** |
+| `myeventlane_event_studio.workspace_addons` | `…/studio/addons` | `redirectToExtrasWorkspace` | Alias → extras | **Alias** |
+| `myeventlane_event_studio.workspace_add_ons` | `…/studio/add-ons` | `redirectToExtrasWorkspace` | Alias → extras | **Alias** |
+| `myeventlane_event_studio.workspace_promotions` | `…/studio/promotions` | `redirectToMessagingWorkspace` | Alias → messaging | **Alias** |
+
+**Evidence:** `myeventlane_event_studio.routing.yml:24-267`.
+
+### 4.2 Event Studio API (authoring support)
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_event_studio.autosave` | `/vendor/events/autosave` | `autosave_controller:handle` | Autosave POST | **Canonical** |
+| `myeventlane_event_studio.governance_refresh` | `…/studio/governance-refresh` | `governance_refresh_controller:refresh` | Governance refresh POST | **Canonical** |
+| `myeventlane_event_studio.governance_component` | `…/studio/component/{component}` | `governance_component_controller:render` | Governance component POST | **Canonical** |
+| `myeventlane_event_studio.ai_assist` | `…/studio/ai/assist` | `ai_controller:assist` | AI assist POST | **Canonical** |
+| `myeventlane_event_studio.ticket_link_suggestions` | `/vendor/events/studio/ticket-link-suggestions` | `EventStudioTicketSuggestionsController::suggest` | Ticket link suggestions POST | **Canonical** |
+
+**Evidence:** `myeventlane_event_studio.routing.yml:347-431`.
+
+### 4.3 Vendor console event workspace (parallel management UI)
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_vendor.console.events` | `/vendor/events` | `vendor_events:list` | Event list | **Duplicate** (list; not authoring) |
+| `myeventlane_vendor.console.event_workspace` | `/vendor/events/{event}` | `event_workspace:workspace` | Event Manager shell | **Duplicate** |
+| `myeventlane_vendor.console.event_overview` | `/vendor/events/{event}/overview` | `vendor_event_overview:overview` | Manage event overview | **Duplicate** |
+| `myeventlane_vendor.console.event_orders` | `/vendor/events/{event}/orders` | `vendor_event_orders:orders` | Event orders | **Duplicate** |
+| `myeventlane_vendor.console.event_operational_addon_orders` | `/vendor/events/{event}/addons` | `vendor_operational_addon_orders:addons` | Add-on orders | **Duplicate** |
+| `myeventlane_vendor.console.event_order_view` | `/vendor/events/{event}/orders/{order}` | `vendor_event_order_view:view` | Order detail | **Duplicate** |
+| `myeventlane_vendor.console.event_tickets` | `/vendor/events/{event}/tickets` | `EventTicketManagerForm` | Ticket manager form | **Duplicate** |
+| `myeventlane_vendor.console.event_rsvps` | `/vendor/events/{event}/rsvps` | `vendor_event_rsvps:rsvps` | RSVPs | **Duplicate** |
+| `myeventlane_vendor.console.event_analytics` | `/vendor/events/{event}/analytics` | `vendor_event_analytics:analytics` | Event analytics page | **Duplicate** |
+| `myeventlane_vendor.console.event_settings` | `/vendor/events/{event}/settings` | `vendor_event_settings:settings` | Event settings | **Duplicate** |
+| `myeventlane_vendor.console.event_archive` | `/vendor/events/{event}/archive` | `vendor_event_archive:handle` | Archive POST | **Duplicate** |
+| `myeventlane_vendor.console.event_promotion` | `/vendor/events/{event}/promotion` | `VendorEventCommsForm` | Attendee messaging | **Duplicate** |
+| `myeventlane_vendor_comms.branding` | `/vendor/events/{event}/promotion/branding` | `EventBrandOverrideForm` | Message branding | **Duplicate** |
+
+**Evidence:** `myeventlane_vendor.routing.yml:500-716`.
+
+### 4.4 Singular `/vendor/event/{event}/*` manage routes
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_vendor.manage_event.design` | `/vendor/event/{event}/design` | `ManageEventDesignController::design` | Page design | **Duplicate** |
+| `myeventlane_vendor.manage_event.content` | `/vendor/event/{event}/content` | `ManageEventContentController::content` | Page content | **Duplicate** |
+| `myeventlane_vendor.manage_event.tickets` | `/vendor/event/{event}/tickets` | `ManageEventTicketsController::redirectToCanonicalTickets` | Redirect to tickets | **Alias** |
+| `myeventlane_vendor.manage_event.checkout_questions` | `/vendor/event/{event}/checkout-questions` | `ManageEventCheckoutQuestionsController` | Checkout questions | **Duplicate** |
+| `myeventlane_vendor.manage_event.series` | `/vendor/event/{event}/series` | `ManageSeriesInstancesController::listInstances` | Series instances | **Duplicate** |
+| `myeventlane_vendor.manage_event.promote` | `/vendor/event/{event}/promote` | `ManageEventPlaceholderController::placeholder` | Placeholder stub | **Legacy** |
+| `myeventlane_vendor.manage_event.payments` | `/vendor/event/{event}/payments` | `ManageEventPlaceholderController::placeholder` | Placeholder stub | **Legacy** |
+| `myeventlane_vendor.manage_event.comms` | `/vendor/event/{event}/comms` | `ManageEventPlaceholderController::placeholder` | Placeholder stub | **Legacy** |
+| `myeventlane_vendor.manage_event.advanced` | `/vendor/event/{event}/advanced` | `ManageEventPlaceholderController::placeholder` | Placeholder stub | **Legacy** |
+
+**Evidence:** `myeventlane_vendor.routing.yml:786-921`; comment at lines 856-858.
+
+### 4.5 Legacy Vendor Studio JSON write API
+
+| Route Name | Path | Controller/Form | Purpose | Status |
+|------------|------|-----------------|---------|--------|
+| `myeventlane_vendor.studio_event_schema` | `/vendor/studio/schema/event` | `VendorStudioSchemaController::eventSchema` | Event schema GET | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_data` | `/vendor/studio/event/{event}/data` | `VendorStudioController::eventData` | Event data GET | **Duplicate** |
+| `myeventlane_vendor.studio_event_save` | `/vendor/studio/event/{event}/save` | `VendorStudioController::saveEvent` | Save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_overview_save` | `…/overview` | `VendorStudioController::saveOverview` | Overview save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_tickets_save` | `…/tickets` | `VendorStudioController::saveTickets` | Tickets save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_attendees_save` | `…/attendees` | `VendorStudioController::saveAttendees` | Attendees save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_promotion_save` | `…/promotion` | `VendorStudioController::savePromotion` | Promotion save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_settings_save` | `…/settings` | `VendorStudioController::saveSettings` | Settings save POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.event_publish` | `…/publish` | `VendorStudioController::publishEvent` | Publish POST | **Duplicate** |
+| `myeventlane_vendor.console.studio.submit_review` | `…/submit-review` | `VendorStudioController::submitReview` | Submit review POST | **Duplicate** |
+
+**Evidence:** `myeventlane_vendor.routing.yml:348-490`; `VendorStudioController.php` (entry redirects at lines 101-114, 151).
+
+### 4.6 Related event operations (out of consolidation scope but listed)
+
+| Route Name | Path | Purpose | Status |
+|------------|------|---------|--------|
+| `myeventlane_event.duplicate` | `/vendor/events/{node}/duplicate` | Duplicate/rebook event | **Canonical** (feature) |
+| `myeventlane_event.generate_series_instances` | `/vendor/event/{event}/series/generate` | Generate series instances | **Canonical** |
+| `myeventlane_event.calendar_ics` | `/event/{node}/calendar.ics` | ICS download | **Canonical** (public) |
+| `myeventlane_event.checkin_door` | `/event/{event}/checkin` | Door check-in | **Canonical** |
+| `myeventlane_event.passcode_gate` | `/event/{node}/passcode` | Private event passcode | **Canonical** |
+
+**Evidence:** `myeventlane_event.routing.yml:109-197`.
+
+---
+
+## 5. Target canonical flow (repository-confirmed)
+
+```
+Create Event (public/vendor nav)
+  → myeventlane_vendor.create_event_gateway  (/create-event)
+      → onboarding / draft checks (CreateEventGatewayController)
+      → myeventlane_event_studio.create      (/vendor/events/create)
+      → myeventlane_event_studio.edit          (draft resume)
+
+Edit / Manage
+  → myeventlane_event_studio.edit
+  → myeventlane_event_studio.workspace_{section}
+
+Publish
+  → myeventlane_event_studio.publish (POST)
+```
+
+**Evidence:** `CreateEventGatewayController.php:79-214`; Phase 2 audit §2.5 in `docs/audits/phase-2-event-studio-consolidation-audit.md`.
+
+---
+
+## 6. Route count summary
+
+| Category | Canonical | Alias | Legacy | Duplicate |
+|----------|-----------|-------|--------|-----------|
+| Creation | 2 | 2 | 1 | 0 |
+| Editing | 1 | 3 | 13 | 0 |
+| Publishing | 2 | 0 | 2 | 3 |
+| Management (Studio) | 18 + 5 API | 4 | 0 | 0 |
+| Management (Vendor parallel) | 0 | 1 | 4 | 22+ |
+
+**Total event workflow routes inventoried:** 80+ (across `myeventlane_event_studio`, `myeventlane_vendor`, `myeventlane_event` routing files).

--- a/docs/audits/event-route-reference-map.md
+++ b/docs/audits/event-route-reference-map.md
@@ -1,0 +1,153 @@
+# Event Route Reference Map — Phase 1A (WP-3)
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-13  
+**Method:** Static grep across `web/modules/custom` and `web/themes/custom` for `*.php`, `*.twig`, `*.yml`, `*.js`. Test fixtures and `*.routing.yml` definition files excluded from "Referenced By" unless they are the only reference.
+
+**Legend:** `DYNAMIC_REFERENCE` = route name built at runtime (variable, config key, or string prefix match), not a static literal in the file.
+
+---
+
+## A. Create-event entry routes
+
+| Route | Referenced By | File |
+|-------|---------------|------|
+| `myeventlane_vendor.create_event_gateway` | Footer host menu link | `web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml` |
+| `myeventlane_vendor.create_event_gateway` | Blog CTA URL builder | `web/modules/custom/myeventlane_front/src/Service/BlogArticlePresentationService.php` |
+| `myeventlane_vendor.create_event_gateway` | Organiser hub CTAs | `web/modules/custom/myeventlane_front/src/Service/OrganiserHubPageBuilder.php` |
+| `myeventlane_vendor.create_event_gateway` | Public footer nav builder | `web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php` |
+| `myeventlane_vendor.create_event_gateway` | Home hero secondary CTA | `web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig` |
+| `myeventlane_vendor.create_event_gateway` | Header create button | `web/themes/custom/myeventlane_theme/templates/region--header.html.twig` |
+| `myeventlane_vendor.create_event_gateway` | Hero, footer CTA, host CTA, calendar | `web/themes/custom/myeventlane_theme/components/hero/hero.twig`, `templates/includes/mel-*-default.html.twig`, `templates/page--calendar.html.twig`, `templates/components/mel-calendar-hero.html.twig` |
+| `myeventlane_vendor.create_event_gateway` | Radix header (theme on disk) | `web/themes/custom/myeventlane_radix/templates/includes/header.html.twig` |
+| `myeventlane_vendor.create_event_gateway` | Public create-event URL helper | `web/themes/custom/myeventlane_theme/myeventlane_theme.theme` (`_myeventlane_theme_public_create_event_url`) |
+| `myeventlane_vendor.create_event_gateway` | Hard-coded path alias | `web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-latest.html.twig` (`/create-event`) |
+| `myeventlane_vendor.create_event_gateway` | Hard-coded path alias | `web/themes/custom/myeventlane_theme/components/mobile-drawer/mobile-drawer.twig` (default `/create-event`) |
+| `myeventlane_vendor.create_event_gateway` | Config URL | `config/sync/myeventlane_front.organiser_hub.yml` (`url: /create-event`) |
+| `myeventlane_vendor.create_event_gateway` | Post-auth destination | `web/modules/custom/myeventlane_auth/src/Service/PostAuthRedirectResolver.php` |
+| `myeventlane_vendor.create_event_gateway` | Destination normalizer | `web/modules/custom/myeventlane_core/src/Service/MelDestinationNormalizer.php`, `VendorLoginDestinationNormalizer.php` |
+| `myeventlane_event_studio.create` | Account menu "Create event" (pre-consolidation) | `web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml` |
+| `myeventlane_event_studio.create` | Vendor footer URL map | `web/themes/custom/myeventlane_theme/myeventlane_theme.theme`, `web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme` |
+| `myeventlane_event_studio.create` | Dashboard / events index CTAs | `VendorDashboardController.php`, `VendorDashboardViewModelBuilder.php`, `VendorEventIndexViewModelBuilder.php`, `VendorActionQueueBuilder.php` |
+| `myeventlane_event_studio.create` | Organiser context block | `web/modules/custom/myeventlane_core/src/Plugin/Block/OrganiserContextBlock.php` |
+| `myeventlane_event_studio.create` | Legacy dashboard module | `web/modules/custom/myeventlane_dashboard/src/Controller/VendorDashboardController.php`, `templates/myeventlane-vendor-dashboard.html.twig` |
+| `myeventlane_event_studio.create` | Analytics / reporting empty states | `VendorAnalyticsViewModelBuilder.php`, `myeventlane-reporting-vendor-insights.html.twig` |
+| `myeventlane_event_studio.create` | Vendor theme empty-state CTAs | `event-table.html.twig`, `vendor-event-performance.html.twig`, `mel-vendor-event-performance.html.twig` |
+| `myeventlane_event_studio.create` | Gateway redirect target | `CreateEventGatewayController.php` |
+| `myeventlane_event_studio.create` | Legacy `/vendor/events/add` redirect | `VendorEventCreateController.php` |
+| `myeventlane_event_studio.create` | Onboarding completion CTAs | `VendorOnboardCompleteController.php`, `VendorOnboardFirstEventController.php`, `VendorOnboardProfileForm.php`, `VendorOnboardStripeController.php`, `VendorOnboardController.php` |
+| `myeventlane_event_studio.create` | Post-login router | `PostLoginRouter.php` |
+| `myeventlane_event_studio.create` | Growth insight action | `GrowthInsightService.php` |
+| `myeventlane_event_studio.create` | Operational templates link | `GovernedOperationalTemplates.php` |
+| `myeventlane_event_studio.create` | Bulk actions form | `VendorEventsBulkActionsForm.php` |
+| `myeventlane_event_studio.create` | Launch protection allowlist | `LaunchRequestProtectionSubscriber.php` |
+| `myeventlane_event_studio.create` | Vendor theme negotiator | `VendorThemeNegotiator.php` |
+| `myeventlane_event_studio.create` | Onboarding gate subscriber | `EventStudioVendorOnboardingGateSubscriber.php` |
+| `myeventlane_event_studio.create` | DYNAMIC_REFERENCE | `OnboardingManager.php` (help listen/ask routes; milestone flags) |
+| `myeventlane_vendor.console.events_add` | Controller log + redirect | `VendorEventCreateController.php` |
+| `myeventlane_vendor.console.events_add` | Launch protection allowlist | `LaunchRequestProtectionSubscriber.php` |
+
+---
+
+## B. Event Studio edit and workspace routes
+
+| Route | Referenced By | File |
+|-------|---------------|------|
+| `myeventlane_event_studio.edit` | Gateway draft resume redirect | `CreateEventGatewayController.php` |
+| `myeventlane_event_studio.edit` | Vendor card edit link | `web/themes/custom/myeventlane_vendor_theme/templates/node--event--vendor-card.html.twig` |
+| `myeventlane_event_studio.edit` | Manage event / boost / ticket forms | `EventDesignForm.php`, `EventTicketManagerForm.php`, `BoostPerformanceService.php` |
+| `myeventlane_event_studio.edit` | Vendor Studio redirect target | `VendorStudioController.php` |
+| `myeventlane_event_studio.edit` | Legacy redirect subscriber | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.workspace` | Dashboard deep links | `web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig` |
+| `myeventlane_event_studio.workspace_analytics` | Dashboard analytics links | `dashboard.html.twig`, `mel-vendor-event-performance.html.twig` |
+| `myeventlane_event_studio.workspace_*` (sections) | Section plugins | `web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/*.php` |
+| `myeventlane_event_studio.workspace_extras` | Commerce sales summary | `EventOperationalExtrasSalesSummaryBuilder.php` |
+| `myeventlane_event_studio.workspace_*` | DYNAMIC_REFERENCE | `VendorLegacyWizardRedirectSubscriber.php` (redirect map) |
+| `myeventlane_event_studio.publish` | Studio template / JS | `mel-event-studio.html.twig`, Event Studio libraries |
+| `myeventlane_event_studio.autosave` | Autosave controller access check | `EventStudioAutosaveController.php` |
+| `myeventlane_event_studio.ai_assist` | AI assist builder | `EventStudioAiAssistBuilder.php` |
+| `myeventlane_event_studio.edit_basic` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.edit_datetime` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.edit_tickets` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.edit_description` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.edit_preview` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event_studio.edit_publish` | Legacy redirect subscriber only | `VendorLegacyWizardRedirectSubscriber.php` |
+
+---
+
+## C. Vendor console event workspace routes
+
+| Route | Referenced By | File |
+|-------|---------------|------|
+| `myeventlane_vendor.console.events` | Account menu, footer URLs, dashboard | `myeventlane_vendor.links.menu.yml`, theme footer helpers, `VendorDashboardViewModelBuilder.php` |
+| `myeventlane_vendor.console.event_workspace` | DYNAMIC_REFERENCE | `VendorEventTabsService.php`, `EventWorkspaceController.php` |
+| `myeventlane_vendor.console.event_overview` | Legacy redirect subscriber | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_vendor.console.event_orders` | Event tabs / orders controllers | `VendorEventOrdersController.php`, `VendorEventTabsService.php` |
+| `myeventlane_vendor.console.event_tickets` | Ticket manager form redirect | `EventTicketManagerForm.php`, `ManageEventTicketsController.php` |
+| `myeventlane_vendor.console.event_analytics` | Analytics controller | `VendorEventAnalyticsController.php` |
+| `myeventlane_vendor.console.event_promotion` | Vendor comms | `VendorEventCommsForm.php` |
+| `myeventlane_vendor.console.studio` | Redirect entry only | `VendorStudioController.php` |
+| `myeventlane_vendor.console.studio.event_*` | Vendor Studio JSON API URLs | `VendorStudioController.php` (lines ~1162-1168) |
+| `myeventlane_vendor.manage_event.edit` | Legacy redirect subscriber | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_vendor.manage_event.design` | Manage event navigation + redirect subscriber | `ManageEventNavigation.php`, `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_vendor.manage_event.content` | Manage controllers + twig tickets nav | `ManageEventContentController.php`, `event/tickets.html.twig` |
+| `myeventlane_vendor.manage_event.tickets` | Twig nav + redirect subscriber | `event/tickets.html.twig`, `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_vendor.manage_event.checkout_questions` | Twig nav | `event/tickets.html.twig` |
+| `myeventlane_vendor.manage_event.series` | Series forms + dashboard | `GenerateSeriesInstancesForm.php`, `VendorDashboardController.php` |
+| `myeventlane_vendor.manage_event.promote` | Placeholder subscriber + nav | `ManageEventPlaceholderNoIndexSubscriber.php`, `ManageEventNavigation.php`, `VendorDashboardViewModelBuilder.php` |
+| `myeventlane_vendor.manage_event.payments` | Twig nav (stub target) | `event/tickets.html.twig` |
+| `myeventlane_vendor.manage_event.{comms,advanced}` | Placeholder subscriber + nav | `ManageEventPlaceholderNoIndexSubscriber.php`, `ManageEventNavigation.php` |
+
+---
+
+## D. Legacy wizard routes (`myeventlane_event.wizard.*`)
+
+| Route | Referenced By | File |
+|-------|---------------|------|
+| `myeventlane_event.wizard.basics` | Wizard base form steps | `EventWizardBaseForm.php` |
+| `myeventlane_event.wizard.when_where` | Wizard base form + twig | `EventWizardBaseForm.php`, `event-wizard-tickets.html.twig` |
+| `myeventlane_event.wizard.tickets` | Wizard forms + review | `EventWizardReviewForm.php`, `event-wizard-tickets.html.twig`, `WizardReviewSummaryBuilder.php` |
+| `myeventlane_event.wizard.details` | Wizard base + review twig | `EventWizardBaseForm.php`, `event-wizard-review.html.twig` |
+| `myeventlane_event.wizard.review` | Wizard controller + publish form | `VendorEventWizardController.php`, `EventWizardPublishForm.php`, twig templates |
+| `myeventlane_event.wizard.publish` | Wizard base + review form | `EventWizardBaseForm.php`, `EventWizardReviewForm.php` |
+| `myeventlane_event.wizard.success` | Publish form redirect | `EventWizardPublishForm.php` |
+| `myeventlane_event.wizard.*` | Vendor redirect (all steps) | `VendorLegacyWizardRedirectSubscriber.php` |
+| `myeventlane_event.wizard.*` | DYNAMIC_REFERENCE | `HelpContextResolver.php` (`str_starts_with($route_name, 'myeventlane_event.wizard')`) |
+| `myeventlane_event.wizard.*` | Page template docblock | `page--vendor--event-wizard.html.twig` |
+
+---
+
+## E. Prefix / dynamic reference patterns
+
+| Pattern | Referenced By | File |
+|---------|---------------|------|
+| `myeventlane_event_studio.*` | Help context | `HelpContextResolver.php` |
+| `myeventlane_event_studio.*` | Vendor theme negotiator list | `VendorThemeNegotiator.php` |
+| `myeventlane_event_studio.*` | Surface workflow registry | `MelWorkflowRegistry.php` |
+| `myeventlane_vendor.console.*` | DYNAMIC_REFERENCE | `VendorConsoleAccess.php` (path prefix checks) |
+| `/create-event` (path) | Email template hard-coded | `mimemail-message--user--register-no-approval-required.html.twig` |
+| `/create-event` (path) | Trust content foundation | `TrustContentFoundation.php` |
+
+---
+
+## F. Reference counts (grep, 2026-06-13)
+
+| Pattern | Match lines (approx.) | Files (approx.) |
+|---------|----------------------|-----------------|
+| `myeventlane_event_studio.*` | 251 | 80+ |
+| `myeventlane_vendor.*` (console/manage/onboard/studio) | 426 | 60+ |
+| `myeventlane_event.wizard.*` | 54 | 15 |
+
+Reproduce:
+
+```bash
+rg -n "myeventlane_event_studio\." web/modules/custom web/themes/custom --glob '*.{php,twig,yml,js}'
+rg -n "myeventlane_vendor\.(console|manage_event|create_event|onboard|studio)" web/modules/custom web/themes/custom --glob '*.{php,twig,yml,js}'
+rg -n "myeventlane_event\.wizard" web/modules/custom web/themes/custom --glob '*.{php,twig,yml,js}'
+```
+
+---
+
+## G. Phase 1A consolidation note
+
+After WP-3 navigation consolidation, user-facing **Create event** links should reference `myeventlane_vendor.create_event_gateway`. Internal post-gateway redirects and onboarding flow continuations may still reference `myeventlane_event_studio.create` by design (`CreateEventGatewayController.php:213`).

--- a/docs/audits/phase-2-event-studio-consolidation-audit.md
+++ b/docs/audits/phase-2-event-studio-consolidation-audit.md
@@ -1,0 +1,410 @@
+# MEL Phase 2 Audit — Event Studio Consolidation + Mobile-First Architecture
+
+**Project:** MyEventLane (MEL) — Drupal 11 / Commerce 3
+**Audited repository:** `/Users/anna/myeventlane` (active git repo only)
+**Branch:** `feature/klaro-consent-ux`
+**Date:** 2026-06-13
+**Mode:** Audit only. No code changes. No implementation. Evidence-based findings drawn from the repository.
+
+---
+
+## 0. Method, scope and honesty notes
+
+- This is a **static (code-evidence) audit**. Routes, controllers, subscribers, templates, SCSS and library files were read directly. File paths and route names below are quoted from the repository.
+- Backup/sibling directories (`myeventlane_backup_*`, `myeventlane-archives`, `myeventlane-booking-polish`, `myeventlane-event-polish`, `mel-git-safety-backups`, `myeventlane-v1-backup`, `myeventlane-bugbot-fix`, `/Users/anna/custom/*`) were **excluded** per instruction.
+- **Runtime behaviour was not exercised.** Mobile usability/accessibility scores in Part 3 are derived from template structure, SCSS, breakpoint usage and CTA markup — **not** from a running browser, device lab, Lighthouse or axe run. Where a score depends on runtime rendering it is marked accordingly.
+- Where the repository does not confirm something, the audit states **"Evidence not found in repository."** rather than guessing.
+
+### Enabled themes (evidence: `_myeventlane_audit/core.extension.yml`)
+`myeventlane_theme`, `myeventlane_vendor_theme`, `myeventlane_admin` are present in `core.extension`. `myeventlane_radix` exists on disk (`web/themes/custom/myeventlane_radix`) but is **not listed as enabled** — treated as non-canonical. Both primary themes declare `base theme: stable9`.
+
+---
+
+## PART 1 — Executive Summary: Top 10 issues (ranked by impact)
+
+| # | Issue | Evidence | Impact | Severity |
+|---|-------|----------|--------|----------|
+| 1 | **Five overlapping event create/edit/manage surfaces coexist** under `/vendor/*`. | `myeventlane_event_studio.routing.yml`, `myeventlane_vendor.routing.yml`, `myeventlane_event.routing.yml` | Violates "single event workflow / no parallel experiences". Maintenance + UX confusion. | **P1 / High** |
+| 2 | **Event Studio itself has two generations of edit UI**: legacy per-section step forms (`/vendor/events/{node}/edit/{basic,datetime,tickets,description,preview,publish}`) superseded by the unified `/studio/{section}` workspace — and the legacy forms are now redirect-only. | `VendorLegacyWizardRedirectSubscriber.php:41-51` | Dead/legacy routes still registered; double mental model. | **P1 / Medium** |
+| 3 | **A second, partially-migrated "Vendor Studio"** (`/vendor/studio`, `/vendor/studio/event/{event}/*`) still exposes live JSON save/publish endpoints (`VendorStudioController::saveEvent/publishEvent/eventData/submitReview`). Entry points redirect to Event Studio, but the write API remains. | `myeventlane_vendor.routing.yml:322-479`, `VendorStudioController.php:187-959` | Zombie write-path to event data outside the canonical editor; data-integrity + security surface. | **P1 / High** |
+| 4 | **Two divergent navigation entry points for "Create event"** point to two different routes. | `myeventlane_core.links.menu.yml:64` → `myeventlane_vendor.create_event_gateway`; `myeventlane_vendor.links.menu.yml:33` → `myeventlane_event_studio.create` | Duplicate navigation; inconsistent onboarding/gateway logic. | **P1 / Medium** |
+| 5 | **Two divergent SCSS breakpoint systems** with different APIs and no `breakpoints.yml`. | `myeventlane_theme/.../tokens/_breakpoints.scss` (`$mel-breakpoints` map + `width >=` range syntax) vs `myeventlane_vendor_theme/.../tokens/_breakpoints.scss` (`$breakpoint-sm/md/lg/xl` + `respond-to`/`respond-down` mixins) | No single source of truth for responsive behaviour; mobile-first not enforceable. | **P1 / High** |
+| 6 | **Main theme skews desktop-first**: 337 `max-width` vs 286 `min-width` media queries; many hardcoded `@media (max-width: 768px)` bypass the mixin layer. | `grep` counts in `myeventlane_theme/src/scss`, `myeventlane_vendor_theme/.../_vendor-wizard.scss:19/35/156` | Contradicts the 390px-up mobile-first baseline. | **P1 / High** |
+| 7 | **Massive component duplication within and across themes.** Main theme has both `_buttons.scss` and `_mel-buttons.scss`; `_cards.scss` + `_mel-cards.scss` + 7 more card partials; 7 form partials; `_tables.scss` + `_mel-tables.scss`; 3 nav partials. Vendor theme re-implements buttons/cards/forms/tables/tabs/badges. | component partial inventory, Part 3.2 | No single component system; style drift; high regression risk. | **P1 / High** |
+| 8 | **Event Studio ships its own 14-file CSS system (10,159 lines, 68 `!important`)** including its own nav and shell, instead of consuming vendor-theme components. | `myeventlane_event_studio/css/*`, `myeventlane_event_studio.libraries.yml` | Module owns presentation that should live in the theme; duplicates vendor nav/cards/forms. | **P1 / High** |
+| 9 | **High `!important` load: 381 total** (229 in theme SCSS, 152 in module CSS/SCSS, +68 in Event Studio CSS). | grep counts | Specificity wars; fragile overrides; symptom of competing component systems. | **P2 / Medium** |
+| 10 | **Dead legacy node-form theming + placeholder management routes.** Bare `entity.node.add_form`/`edit_form` for events are access-denied (`EventNodeFormAccessSubscriber.php:8-23`) yet theme still ships `page--node--add--event.html.twig`, `form--node--event--form.html.twig`, `page--node--%--edit.html.twig`; `/vendor/event/{event}/{promote,payments,comms,advanced}` all resolve to `ManageEventPlaceholderController::placeholder`. | routing + templates | Dead code; misleads contributors; confuses Cursor. | **P2 / Low-Med** |
+
+---
+
+## PART 2 — Event Studio Consolidation
+
+### 2.1 Route inventory
+
+**Canonical: `myeventlane_event_studio`** (file: `myeventlane_event_studio.routing.yml`)
+
+| Route | Path | Purpose | Active | Used (linked) | Duplicate of | Recommended action |
+|-------|------|---------|--------|---------------|--------------|--------------------|
+| `…create` | `/vendor/events/create` | Create event (canonical) | Yes | Yes — `myeventlane_vendor.links.menu.yml:33` | — | **Keep (canonical create).** |
+| `…edit` | `/vendor/events/{node}/edit` | Edit entry (canonical) | Yes | Yes — redirect target from legacy | — | **Keep (canonical edit).** |
+| `…workspace` + `…workspace_{information,branding,content,tickets,questions,capacity,extras,messaging,attendees,fulfilment,orders,analytics,settings}` | `/vendor/events/{node}/studio[/section]` | Unified studio workspace | Yes | Yes | — | **Keep (canonical management).** |
+| `…workspace_{merchandise,addons,add_ons}` | `/studio/{merchandise,addons,add-ons}` | Redirect → `extras` | Yes (redirect) | n/a | — | **Keep as alias** (`redirectToExtrasWorkspace`). |
+| `…workspace_promotions` | `/studio/promotions` | Redirect → `messaging` | Yes (redirect) | n/a | — | **Keep as alias** (documented legacy bookmark). |
+| `…edit_{basic,datetime,tickets,description,preview,publish}` | `/vendor/events/{node}/edit/{…}` | Legacy per-section step forms | **Redirect-only** | No | Superseded by `workspace_*` | **Deprecate → confirm redirect, then remove forms** (see WP-2). |
+| `…autosave`, `…publish`, `…governance_refresh`, `…governance_component`, `…ai_assist`, `…ticket_link_suggestions` | POST endpoints | Studio AJAX/JSON | Yes | Yes (Studio JS) | — | **Keep.** |
+
+**Legacy wizard: `myeventlane_event`** (file: `myeventlane_event.routing.yml`)
+
+| Route | Path | Purpose | Active | Used | Duplicate of | Recommended action |
+|-------|------|---------|--------|------|--------------|--------------------|
+| `…wizard.{basics,when_where,tickets,details,review,publish,success}` | `/vendor/events/{event}/build/{…}` | Form-API step wizard | **Redirect-only for vendors** | No (vendors redirected) | Event Studio create/edit | **Deprecate.** Staff-only per file header comment; confirm + remove or gate behind `administer nodes`. See WP-1. |
+| `…duplicate` | `/vendor/events/{node}/duplicate` | Duplicate/rebook event | Yes | Likely (overview action) | — | **Keep** (distinct feature). |
+| `…calendar_ics`, `…checkin_door`, `…checkin_validate`, `…generate_series_instances`, `…passcode_gate` | various | Non-authoring features | Yes | Yes | — | **Keep** (out of consolidation scope). |
+
+**Vendor surfaces: `myeventlane_vendor`** (file: `myeventlane_vendor.routing.yml`)
+
+| Route | Path | Controller | Active | Duplicate of | Recommended action |
+|-------|------|-----------|--------|--------------|--------------------|
+| `…create_event_gateway` | `/create-event` | `CreateEventGatewayController::gateway` → redirects to `event_studio.create` after login/onboarding checks | Yes | Entry wrapper for Studio create | **Keep as the single public create entry**, fold the account-menu link into it (WP-3). |
+| `…manage_event.edit` | `/vendor/event/{event}/edit` | `ManageEventEditController::edit` → **redirects** to `event_studio.edit` (`:48`) | Yes (redirect) | `event_studio.edit` | **Keep as alias** or remove after link sweep. |
+| `…shell.dashboard` `/dashboard`, `…shell.vendor_root` `/vendor`, `…console.dashboard` `/vendor/dashboard` | dashboards | `vendor_dashboard:*` | Yes | — | **Keep** (dashboard, not authoring). |
+| `…console.studio` | `/vendor/studio` | `VendorStudioController::studio` → redirects to `event_studio.edit`/`create` (`:101-114`) | Yes (redirect) | Event Studio | **Keep redirect / retire route.** |
+| `…console.event_editor` | `/vendor/events/{event}/editor` | `VendorStudioController::eventEditor` → redirects to `event_studio.edit` (`:151`) | Yes (redirect) | Event Studio | **Keep redirect / retire.** |
+| `/vendor/studio/event/{event}/{data,save,overview,tickets,attendees,promotion,settings,publish,submit-review}` | JSON write API | `VendorStudioController::{eventData,saveEvent,saveOverview,saveTickets,saveAttendees,savePromotion,saveSettings,publishEvent,submitReview}` | **Yes — live write endpoints** | Parallel to Studio autosave/publish | **P1: retire** — confirm no caller, then remove (WP-4). Zombie write path. |
+| `/vendor/events/{event}` + `/overview,/orders,/addons,/orders/{order},/tickets,/rsvps,/analytics,/settings,/archive,/unpublish,/promotion,/promotion/branding,/publish` | Event workspace (renders own UI) | `event_workspace`, `vendor_event_overview`, `vendor_event_orders`, `vendor_event_rsvps`, `vendor_event_analytics`, `vendor_event_settings`, `vendor_event_archive`, forms | **Yes — active, renders own pages** | Overlaps Studio `workspace_*` sections | **Decide ownership** (WP-5): either these become the Studio sub-tabs or redirect into Studio. Currently both exist. |
+| `/vendor/event/{event}/{design,content,checkout-questions,series}` | singular mgmt | `ManageEvent{Design,Content,CheckoutQuestions}Controller`, `ManageSeriesInstancesController` | Yes | Overlaps Studio sections | **Fold into Studio sections.** |
+| `/vendor/event/{event}/tickets` | redirect | `ManageEventTicketsController::redirectToCanonicalTickets` | Yes (redirect) | — | Keep alias / remove. |
+| `/vendor/event/{event}/{promote,payments,comms,advanced}` | placeholders | `ManageEventPlaceholderController::placeholder` | **Dead stubs** | — | **Remove** (WP-6). |
+
+> **Evidence note:** "Used (linked)" reflects menu/task/action link files and in-controller `Url::fromRoute()` references found during the audit. A full link-graph crawl (every Twig `path()`/`url()`) was **not** exhaustively performed — see WP-7 (link sweep) before deletion.
+
+### 2.2 Current workflow maps (as-built)
+
+**Create (multiple entries, converging):**
+```
+Footer "Create event" (myeventlane_core)
+   → /create-event  (CreateEventGatewayController)
+        → login / organiser-onboarding checks
+        → redirect → myeventlane_event_studio.create  (/vendor/events/create)
+
+Account menu "Create event" (myeventlane_vendor)
+   → /vendor/events/create  (DIRECT — bypasses gateway checks)
+
+Onboarding
+   → /vendor/onboard/first-event → (Studio create)
+```
+
+**Edit / manage (fragmented, partially converging):**
+```
+/vendor/event/{event}/edit          → 302 → event_studio.edit          (alias OK)
+/vendor/studio                       → 302 → event_studio.edit/create   (alias OK)
+/vendor/events/{event}/editor        → 302 → event_studio.edit          (alias OK)
+/vendor/events/{event}/build/*       → 302 → Studio (vendors)           (legacy wizard)
+/vendor/events/{node}/edit/{section} → 302 → unified studio             (legacy step forms)
+
+CANONICAL:
+/vendor/events/{node}/edit
+/vendor/events/{node}/studio/{section}
+
+STILL-LIVE PARALLELS (not redirecting):
+/vendor/events/{event}/{overview,orders,tickets,rsvps,analytics,settings,…}   (renders own UI)
+/vendor/event/{event}/{design,content,checkout-questions,series}              (renders own UI)
+/vendor/studio/event/{event}/{save,publish,data,…}                            (JSON write API)
+```
+
+**Publish:** canonical `myeventlane_event_studio.publish` (`POST /studio/publish`) and `EventStudioPublishForm` (redirects to `entity.node.canonical`). Parallel publish exists at `VendorStudioController::publishEvent` and `EventWorkspaceController::publish`.
+
+### 2.3 Navigation audit
+
+| Navigation system | Location (file) | User type | Duplicate? | Remove/Consolidate? |
+|-------------------|-----------------|-----------|------------|---------------------|
+| Footer host "Create event" | `myeventlane_core.links.menu.yml:64` → `create_event_gateway` | Vendor/host | **Yes** (2nd create entry) | Make this the single create entry. |
+| Account menu "Create event" | `myeventlane_vendor.links.menu.yml:33` → `event_studio.create` | Vendor | **Yes** | Point to gateway (or remove duplication). |
+| Event Studio local task tab | `myeventlane_event_studio.links.task.yml:1` ("Event Studio") | Vendor/staff | No | Keep. |
+| Vendor dashboard nav | `VendorDashboardController` / vendor theme `layout/_navigation.scss` | Vendor | Partially (links to both Studio + vendor workspace routes) | Normalise targets to Studio. |
+| Event Studio internal nav | `myeventlane_event_studio/css/mel-event-studio-nav.css` + `mel-event-studio-nav.html.twig` | Vendor | **Yes** (separate nav system from vendor theme) | Consolidate into one nav component. |
+| Vendor "Studio" entry | `/vendor/studio` (`console.studio`) | Vendor | **Yes** (redirects, but still advertised) | Retire route + any link. |
+
+### 2.4 Route usage classification (evidence-based)
+
+- **Active & canonical:** all `myeventlane_event_studio.*` workspace + create/edit + POST endpoints.
+- **Active alias (302 → canonical):** `manage_event.edit`, `console.studio`, `console.event_editor`, `/vendor/event/{event}/tickets`, the `edit_*` step forms, the `build/*` wizard (for vendors), the `studio/{promotions,addons,…}` redirects.
+- **Active but parallel (renders own UI — true duplication):** `/vendor/events/{event}/{overview,orders,addons,rsvps,analytics,settings,archive,unpublish,promotion}`, `/vendor/event/{event}/{design,content,checkout-questions,series}`.
+- **Active write API parallel (highest risk):** `/vendor/studio/event/{event}/{save,overview,tickets,attendees,promotion,settings,publish,submit-review,data}`.
+- **Dead code:** `/vendor/event/{event}/{promote,payments,comms,advanced}` (placeholder); themed bare-node-form templates for an access-denied route.
+- **Evidence not found in repository:** an explicit, single, documented "canonical route map" config that marks legacy routes deprecated — the deprecation intent lives only in code comments/subscribers.
+
+### 2.5 Consolidation plan
+
+**Target canonical flow:**
+```
+Create Event  →  Event Studio (/vendor/events/create)
+       ↓
+Event Studio workspace  (/vendor/events/{node}/studio/{section})
+       ↓
+Publish  (myeventlane_event_studio.publish)
+       ↓
+Manage   (same studio workspace sections)
+```
+
+Everything else must become **(a) a 301/302 alias**, **(b) a Studio section**, or **(c) removed**.
+
+| Action | Priority | Effort | Risk |
+|--------|----------|--------|------|
+| Retire the `/vendor/studio/event/{event}/*` JSON write API (after caller sweep) | P1 | M | High |
+| Decide ownership of `/vendor/events/{event}/{overview,orders,…}` vs Studio sections; converge | P1 | L | High |
+| Remove legacy `edit_*` step-form routes/forms (already redirect-only) | P1 | S | Low |
+| Confirm + remove `build/*` wizard for vendors (keep staff path or delete) | P2 | M | Medium |
+| Unify "Create event" entries to one gateway | P1 | S | Low |
+| Delete placeholder routes `/promote,/payments,/comms,/advanced` | P2 | S | Low |
+| Remove dead node-form templates | P3 | S | Low |
+| Fold `/vendor/event/{event}/{design,content,checkout-questions,series}` into Studio sections | P2 | L | Medium |
+
+---
+
+## PART 3 — Mobile-First Architecture
+
+### 3.1 Breakpoint inventory
+
+| Location | Definition | Mobile-first? | Notes |
+|----------|-----------|---------------|-------|
+| `myeventlane_theme/src/scss/tokens/_breakpoints.scss` | `$mel-breakpoints` map; emits `@media (width >= $breakpoint)` and `(width <= upper-bound)` | Mixed (range syntax) | Modern CSS range syntax; its own API. |
+| `myeventlane_vendor_theme/src/scss/tokens/_breakpoints.scss` | `$breakpoint-sm:640 / md:768 / lg:1024 / xl:1280 / 2xl`; mixins `respond-to` (min-width, mobile-first), `respond-down` (max-width), `container-query` | Mostly mobile-first via `respond-to` | Different variable names + mixin API from main theme. |
+| Hardcoded media queries (both themes) | e.g. `_vendor-wizard.scss:19/35/156` `@media (max-width:768px)`; `workspace.scss:329/343`; `pages/_vendor-events.scss:213/217` | **Desktop-first leakage** | Bypass the mixin layer; duplicate magic numbers. |
+| Drupal `*.breakpoints.yml` | **None found** anywhere in `web/themes/custom` or `web/modules/custom` | n/a | No responsive image/breakpoint config; `responsive_image` mappings cannot be driven from a shared source. |
+
+**Media-query direction counts (evidence):**
+- `myeventlane_theme/src/scss`: **286 `min-width` vs 337 `max-width`** → net desktop-first lean.
+- `myeventlane_vendor_theme/src/scss`: **146 `min-width` vs 136 `max-width`** → roughly balanced, but many raw `max-width:768px`.
+
+**Conclusion:** No single source of truth. Two token systems + ad-hoc media queries. **Canonical recommendation:** one shared `_breakpoints.scss` (vendor theme's `$breakpoint-*` + `respond-to`/`respond-down`/`container-query` is the stronger candidate; add a 390px `xs` baseline), consumed by both themes; ban raw `@media` in component partials via stylelint.
+
+### 3.2 Component inventory
+
+| Component | Variants found (files) | Canonical candidate | Consolidation required |
+|-----------|------------------------|---------------------|------------------------|
+| Buttons | theme: `_buttons.scss`, `_mel-buttons.scss`; vendor: `_buttons.scss` | `_mel-buttons.scss` (newer `mel-` system) | **Yes — 3 systems** |
+| Cards | theme: `_cards.scss`, `_mel-cards.scss`, `_event-card.scss`, `_event-cards.scss`, `_event-cards-festival.scss`, `_account-cards.scss`, `_value-cards.scss`, `_vendor-card.scss`, `_attendees-event-card.scss`; vendor: `_cards.scss`, `_kpi-cards.scss`, `_boost-extension-card.scss`, `_attendees-event-card.scss`; Studio: `mel-event-studio-extra-card` | `_mel-cards.scss` + a shared event-card | **Yes — 13+ variants** |
+| Forms | theme: `base/_forms.scss`, `_mel-forms.scss`, `_mel-form-states.scss`, `_event-form.scss`, `pages/_event-form.scss`, `pages/_vendor-form.scss`, `onboarding/_onboarding-forms.scss`; vendor: `base/_forms.scss`, `_forms.scss`, `_form.scss`, `_event-form.scss`, `pages/_event-form.scss` | `_mel-forms.scss` + shared base | **Yes — 12 partials, incl. vendor `_forms.scss` vs `_form.scss`** |
+| Tables | theme: `_tables.scss`, `_mel-tables.scss`; vendor: `_tables.scss`, `_event-table.scss` | `_mel-tables.scss` | **Yes — 4** |
+| Navigation | theme: `_mel-navigation.scss`, `layout/_navigation.scss`, `_account-nav.scss`; vendor: `layout/_navigation.scss`; Studio: `mel-event-studio-nav.css` | one shared nav | **Yes — 5 nav systems** |
+| Tabs | vendor: `_tabs.scss`; theme: none dedicated | vendor `_tabs.scss` | Promote to shared. |
+| Modals | theme: `_mel-modals.scss` | `_mel-modals.scss` | Single — promote/share with vendor. |
+| Drawers | theme: `_mobile-drawer.scss` | `_mobile-drawer.scss` | Single — share with vendor. |
+| Badges | theme: `_featured-badge.scss`, `_sla-badge.scss`; vendor: `_badges.scss` | vendor `_badges.scss` | **Yes — 3** |
+| Chips | theme: `_chips.scss` | `_chips.scss` | Single — share. |
+| Filters | theme: `_mel-events-filters.scss`, `_search-form.scss` | `_mel-events-filters.scss` | Consolidate with search. |
+
+**Does Event Studio duplicate vendor-theme components?** **Yes.** Event Studio ships its own nav (`mel-event-studio-nav.css`), shell (`mel-event-studio-shell.css`), cards and form styling as a **module-owned** 14-file/10,159-line CSS system (`myeventlane_event_studio/css/*`, attached via `myeventlane_event_studio.libraries.yml`) rather than consuming vendor-theme components.
+
+### 3.3 CSS ownership map
+
+| File / scope | Owns | Conflicts with |
+|--------------|------|----------------|
+| `myeventlane_theme/src/scss/components/_mel-*` | Public-site buttons/cards/forms/tables/nav/modals | Older `_buttons/_cards/_tables/_navigation` in same theme |
+| `myeventlane_vendor_theme/src/scss/components/*` | Vendor console buttons/cards/forms/tables/tabs/badges | Main theme equivalents; Event Studio module CSS |
+| `myeventlane_event_studio/css/*` (14 files, 10,159 lines, 68 `!important`) | Studio nav/shell/cards/forms/panels | **Vendor theme nav/cards/forms** (module overriding theme territory) |
+| 36 custom modules ship `css/` | Per-feature styling (e.g. `myeventlane_vendor`, `myeventlane_dashboard`, `myeventlane_checkin`, `myeventlane_commerce`, …) | Themes; each other |
+| Committed compiled CSS in `themes/.../css/` (`auth-pages.css`, `errors.css`) | Built output checked into repo | Source `src/scss` — drift risk if rebuilt elsewhere |
+
+**`!important` load (specificity-war indicator):** **381 total** — 229 (theme `src/scss`) + 152 (module `css`/`scss`) + 68 inside Event Studio CSS (subset of module count noted separately for emphasis).
+
+**Ownership model recommendation:** Themes own all presentation; modules ship behaviour (JS) + structural Twig only. Migrate `myeventlane_event_studio/css/*` into `myeventlane_vendor_theme` component partials; modules should attach **theme** libraries, not ship component CSS.
+
+### 3.4 Route-by-route mobile audit
+
+> Scores are **code-evidence-based** (template + SCSS + breakpoint + CTA structure), 1–10, **not runtime-tested**. "Evidence not found" is used where no dedicated template/SCSS was located. Recommend confirming with WP-8 (device/Lighthouse pass) before acting on conversion/accessibility numbers.
+
+**Homepage** — `page--front.html.twig`, `node--view--front-featured-events--block-hero.html.twig`, card-carousel, `_mel-events-filters.scss`
+
+| Category | Score | Evidence / note |
+|----------|-------|-----------------|
+| Mobile usability | 6 | Hero + carousel templates exist; mixed breakpoint direction. |
+| Accessibility | 5 | Not verified at runtime; no axe evidence. |
+| Consistency | 5 | Multiple card variants in play (`_event-card*`). |
+| Conversion | 6 | Single hero CTA present in template. |
+| Trust | 5 | Organiser trust not strongly templated on front. |
+| Technical debt | 4 | Multiple card/filter partials. |
+
+**Event page** — `page--node--event.html.twig`, `node--event--*`
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 6 | Dedicated page template + event-card system. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 5 | Competing event-card partials. |
+| Conversion | 6 | Ticketing/CTA block themed; sticky mobile footer not confirmed — **Evidence not found**. |
+| Trust | 6 | Organiser block present. |
+| Technical debt | 5 | Card duplication. |
+
+**Checkout** — `commerce/commerce-checkout-form*.html.twig`, `commerce-checkout-order-summary`, `commerce-checkout-progress`, `mel-checkout-order-summary-grouped`
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 6 | Multiple checkout templates incl. with-sidebar variant. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 5 | `myeventlane_checkout_flow` ships **no CSS** (relies on theme) — good, but a Radix checkout template also exists (`myeventlane_radix/.../commerce-checkout-form.html.twig`) for a disabled theme = dead. |
+| Conversion | 6 | Progress + summary themed; mobile sticky CTA not confirmed — **Evidence not found**. |
+| Trust | 5 | Trust signals not strongly evident in templates. |
+| Technical debt | 6 | Radix dead template. |
+
+**Vendor dashboard** — `myeventlane-vendor-dashboard.html.twig`, `VendorDashboardController`, vendor `layout/_navigation.scss`, `_quick-actions.scss`
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 6 | `_quick-actions.scss:38` uses `max-width:768px` (desktop-first patch). |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 4 | Links to both Studio + parallel `/vendor/events/{event}/*` surfaces. |
+| Conversion | 6 | Quick-actions present. |
+| Trust | 5 | n/a |
+| Technical debt | 3 | Duplicate CTAs to overlapping management routes. |
+
+**Event Studio** — `mel-event-studio-workspace.html.twig` (+ ~27 templates), `myeventlane_event_studio/css/*`
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 6 | Dedicated shell; `_workspace.scss:151/167` uses `min-width:768px` (mobile-first). |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 4 | Own nav/shell diverges from vendor theme. |
+| Conversion | 6 | Step flow + publish CTA present. |
+| Trust | 6 | Governance/health components present. |
+| Technical debt | 3 | 14 module CSS files, 68 `!important`, two edit generations. |
+
+**Orders** — `myeventlane-order-detail.html.twig`, `vendor/_event-table.scss`, `views-view-table--commerce-checkout-order-summary`
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 5 | Table-based; card fallback for mobile not confirmed — **Evidence not found**. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 5 | Two table systems (`_tables` vs `_event-table`). |
+| Conversion | n/a | — |
+| Trust | n/a | — |
+| Technical debt | 5 | Table duplication. |
+
+**Attendees** — `myeventlane-vendor-event-attendees.html.twig`, `myeventlane-vendor-attendees-dashboard.html.twig`, `_attendees-event-card.scss` (in **both** themes)
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 5 | Card partial duplicated across themes. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 4 | Same component in two themes. |
+| Conversion | n/a | — |
+| Trust | n/a | — |
+| Technical debt | 4 | Duplication; export/filter UX not confirmed — **Evidence not found**. |
+
+**Messaging** — Studio `messaging` section + `mel-event-studio-*`; `myeventlane_messaging` module CSS
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 5 | Thread layout template not individually confirmed — **Evidence not found** for a dedicated thread template. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 5 | Studio-owned. |
+| Technical debt | 5 | Module CSS + Studio CSS overlap. |
+
+**Analytics** — `vendor_event_analytics` controller, `myeventlane_analytics` module CSS, `_vendor-event-performance.scss` (`:188 min-width:1024px`)
+
+| Category | Score | Note |
+|----------|-------|------|
+| Mobile usability | 4 | Performance component gated at `min-width:1024px` → likely thin on mobile. |
+| Accessibility | 5 | Runtime not verified. |
+| Consistency | 5 | Charts responsiveness not confirmed — **Evidence not found** (no chart lib config inspected). |
+| Technical debt | 5 | Module + theme split. |
+
+---
+
+## PART 4 — Cursor Work Packages
+
+> Each package is **implementation-ready specification only** — no code. Validation commands assume the DDEV workflow from `CLAUDE.md`.
+
+### WP-1 — Decommission the legacy `/build/*` event wizard
+- **Objective:** Remove (or staff-gate) the `myeventlane_event.wizard.*` step wizard now that vendors are redirected to Studio.
+- **Files likely affected:** `myeventlane_event.routing.yml`; `src/Form/EventWizard*Form.php`; `src/Controller/VendorEventWizardController.php`; `EventSubscriber/VendorLegacyWizardRedirectSubscriber.php`; any Twig with `path('myeventlane_event.wizard.*')`.
+- **Risks:** Staff still rely on wizard (file header says staff keep it); hidden links; tests referencing wizard routes.
+- **Validation:** `ddev drush cr`; `ddev drush route:info | grep build`; `grep -rn "myeventlane_event.wizard" web/` ; `npm run build`; manual: vendor hitting `/vendor/events/{id}/build/basics` → 302 to Studio.
+- **Acceptance:** No vendor-reachable `/build/*` route renders a form; either fully removed or returns 403/redirect for non-staff; no broken `path()` references; config export clean.
+
+### WP-2 — Remove redirect-only Event Studio `edit_*` step forms
+- **Objective:** Delete `myeventlane_event_studio.edit_{basic,datetime,tickets,description,preview,publish}` routes + `EventStudioBasic/Date/Tickets/Description/Publish` forms now superseded by the unified `/studio` workspace.
+- **Files likely affected:** `myeventlane_event_studio.routing.yml`; `src/Form/EventStudio{Basic,Date,Tickets,Description,Publish}Form.php`; `EventStudioPreviewController.php`; `VendorLegacyWizardRedirectSubscriber.php` (`:46-51`).
+- **Risks:** Forms reused by the unified workspace controller (verify `EventStudioController::workspace` does not embed these form classes); bookmarked URLs.
+- **Validation:** `grep -rn "edit_basic\|EventStudioBasicForm\|edit_datetime\|edit_tickets" web/`; `ddev drush cr`; manual: `/vendor/events/{id}/edit/basic` → 302 to studio section.
+- **Acceptance:** Routes removed or 301 to `studio/{section}`; unified workspace unaffected; no orphaned form classes; PHPUnit green.
+
+### WP-3 — Unify "Create event" navigation to a single gateway
+- **Objective:** One create entry. Point account-menu "Create event" at `create_event_gateway` (or remove the duplicate), keeping gateway login/onboarding checks authoritative.
+- **Files likely affected:** `myeventlane_vendor.links.menu.yml:33`; `myeventlane_core.links.menu.yml:64`; any Twig/button using `event_studio.create` directly.
+- **Risks:** Gateway adds redirects/latency for already-onboarded vendors; deep links expecting direct create.
+- **Validation:** `grep -rn "event_studio.create\|create_event_gateway" web/`; `ddev drush cr`; manual: both menu items reach Studio create after gateway checks.
+- **Acceptance:** Exactly one user-facing create entry; `event_studio.create` only reached via gateway (direct nav links removed); onboarding/Stripe checks still enforced.
+
+### WP-4 — Retire the parallel `/vendor/studio/event/{event}/*` JSON write API
+- **Objective:** Remove the zombie write/publish endpoints on `VendorStudioController` after confirming no live caller; canonical writes go through Studio autosave/publish.
+- **Files likely affected:** `myeventlane_vendor.routing.yml:357-479`; `src/Controller/VendorStudioController.php` (`eventData/saveEvent/saveOverview/saveTickets/saveAttendees/savePromotion/saveSettings/publishEvent/submitReview`); any JS posting to `/vendor/studio/event/*`.
+- **Risks:** **High** — these write event data; an active JS client would silently break; security/data-integrity if left half-removed.
+- **Validation:** `grep -rn "/vendor/studio/event" web/ --include=*.js --include=*.twig --include=*.php`; check `myeventlane_vendor.console.event_*` route usages; `ddev drush cr`; smoke-test Studio save/publish still works.
+- **Acceptance:** No reachable parallel write endpoints; Studio autosave/publish is the sole write path; no JS 404/405s in network log; tests green.
+
+### WP-5 — Resolve Studio vs `/vendor/events/{event}/*` workspace ownership
+- **Objective:** Decide whether `/vendor/events/{event}/{overview,orders,tickets,rsvps,analytics,settings,…}` become Studio sections or redirect into Studio; eliminate the parallel rendered surface.
+- **Files likely affected:** `myeventlane_vendor.routing.yml:501-738`; `EventWorkspaceController`, `VendorEventOverviewController`, `VendorEvent{Orders,Rsvps,Analytics,Settings}Controller`; `myeventlane_event_studio` workspace controller/sections; vendor dashboard nav.
+- **Risks:** **High** — large surface; orders/analytics data views; deep links; permissions differ between the two.
+- **Validation:** route inventory diff; `ddev drush cr`; `grep -rn "vendor.console.event_" web/`; manual walk of each section pre/post.
+- **Acceptance:** One rendered management surface per concern; the other redirects; navigation points to a single set of routes; no feature regression in orders/analytics/attendees.
+
+### WP-6 — Delete placeholder management routes
+- **Objective:** Remove `/vendor/event/{event}/{promote,payments,comms,advanced}` and `ManageEventPlaceholderController`.
+- **Files likely affected:** `myeventlane_vendor.routing.yml:860-910`; `src/Controller/ManageEventPlaceholderController.php`; any nav linking to them.
+- **Risks:** Low — stubs; confirm not linked from dashboard nav.
+- **Validation:** `grep -rn "ManageEventPlaceholderController\|/promote\|/advanced" web/`; `ddev drush cr`.
+- **Acceptance:** Routes + controller removed; no broken links; config export clean.
+
+### WP-7 — Route link-graph sweep (prerequisite for deletions)
+- **Objective:** Produce the authoritative list of every reference to legacy/alias routes before any removal, so deletions are safe.
+- **Files likely affected:** read-only across `web/modules/custom`, `web/themes/custom`, config.
+- **Risks:** Missing dynamic route building (`Url::fromUserInput`, string concatenation) → false "unused".
+- **Validation:** `grep -rn "fromRoute('myeventlane_" web/`; `grep -rn "path('myeventlane_\|url('myeventlane_" web/themes web/modules`; `grep -rn "/vendor/event" web/ --include=*.js`.
+- **Acceptance:** A reference table (route → callers) committed alongside this audit; WP-1/2/4/5/6 reference it.
+
+### WP-8 — Establish canonical breakpoint + component foundation
+- **Objective:** One shared breakpoint system (390px-up) and one component library; ban raw media queries in partials.
+- **Files likely affected:** new shared `tokens/_breakpoints.scss`; `myeventlane_theme/src/scss/tokens/_breakpoints.scss`; `myeventlane_vendor_theme/src/scss/tokens/_breakpoints.scss`; all hardcoded `@media` partials (`_vendor-wizard.scss`, `workspace.scss`, `pages/_vendor-events.scss`, `_quick-actions.scss`, …); `.stylelintrc`.
+- **Risks:** Visual regressions across many surfaces; build pipeline (Vite) recompilation; two themes consuming one source.
+- **Validation:** `npm run lint`; `npm run build`; visual diff of homepage/event/checkout/dashboard/studio at 390/768/1024/1280; Lighthouse + axe pass (currently unverified).
+- **Acceptance:** Single `$breakpoint-*` + `respond-to/respond-down/container-query` API used everywhere; stylelint forbids raw `@media (max-width…)` in `components/*`; net `min-width` ≥ `max-width` per theme; no visual regressions.
+
+### WP-9 — Collapse duplicate component partials
+- **Objective:** One buttons, one cards (+ event-card), one forms, one tables, one nav, one badges system; share modals/drawers/chips/tabs across themes.
+- **Files likely affected:** all partials listed in Part 3.2; Twig referencing removed classes.
+- **Risks:** High regression surface; `!important` removal exposes layout bugs.
+- **Validation:** `npm run build`; `grep -rn "_mel-buttons\|_buttons\b" web/themes`; visual diff; `!important` count should drop from 381.
+- **Acceptance:** One canonical partial per component; deprecated partials removed/`@forward`-aliased; `!important` materially reduced; no visual regressions on the 9 audited surfaces.
+
+### WP-10 — Move Event Studio CSS into the theme
+- **Objective:** Relocate `myeventlane_event_studio/css/*` (nav/shell/cards/forms) into `myeventlane_vendor_theme` components so the module ships behaviour + structure only.
+- **Files likely affected:** `myeventlane_event_studio.libraries.yml`; `myeventlane_event_studio/css/*` (14 files); vendor theme `components/`; library attachments in Studio controllers/templates.
+- **Risks:** High — Studio is a flagship surface; cache/library weight ordering (`mel-event-studio-shell.css: { weight: 200 }`).
+- **Validation:** `ddev drush cr`; `npm run build`; manual Studio walk at 390/768/1024; confirm nav/shell render identically.
+- **Acceptance:** Studio styling owned by the theme; module CSS files removed or reduced to genuinely module-specific behaviour; Studio visually unchanged; `!important` in Studio CSS (68) reduced.
+
+### WP-11 — Remove dead node-form theming + Radix checkout template
+- **Objective:** Delete templates serving access-denied/disabled surfaces.
+- **Files likely affected:** `myeventlane_theme/templates/page--node--add--event.html.twig`, `form--node--event--form.html.twig`, `page--node--%--edit.html.twig`; `myeventlane_radix/templates/commerce/commerce-checkout-form.html.twig`.
+- **Risks:** Low — confirm `EventNodeFormAccessSubscriber` still denies and Radix stays disabled.
+- **Validation:** `ddev drush cr`; confirm `entity.node.add_form` (event) → 403 for vendors; `ddev drush theme:list | grep radix`.
+- **Acceptance:** Dead templates removed; no theme-registry warnings; event authoring still routes to Studio only.
+
+---
+
+## Appendix A — Primary evidence files
+
+- Routing: `myeventlane_event_studio.routing.yml`, `myeventlane_event.routing.yml`, `myeventlane_vendor.routing.yml`, `myeventlane_core.links.menu.yml`, `myeventlane_vendor.links.menu.yml`, `myeventlane_event_studio.links.task.yml`
+- Controllers: `CreateEventGatewayController.php`, `ManageEventEditController.php`, `VendorStudioController.php`, `EventWorkspaceController.php`, `VendorEventOverviewController.php`, `VendorEventSettingsController.php`, `ManageEventPlaceholderController.php`
+- Subscribers: `VendorLegacyWizardRedirectSubscriber.php`, `EventNodeFormAccessSubscriber.php`
+- Themes: `myeventlane_theme/src/scss/**`, `myeventlane_vendor_theme/src/scss/**` (tokens, components, pages), `*.info.yml` (both `base theme: stable9`)
+- Studio CSS/libraries: `myeventlane_event_studio/css/*` (14 files), `myeventlane_event_studio.libraries.yml`, `myeventlane_event_studio/templates/*`
+- Config snapshot: `_myeventlane_audit/core.extension.yml`
+
+## Appendix B — Not verified (recommend follow-up)
+- Runtime mobile usability/accessibility (Lighthouse, axe, real-device) — Part 3.4 scores are static only.
+- Exhaustive Twig/JS link graph for every legacy route (WP-7 delivers this).
+- Chart/analytics responsiveness; messaging thread template; checkout sticky mobile CTA; orders mobile card fallback — marked "Evidence not found in repository" above.

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -410,10 +410,10 @@ final class VendorAnalyticsViewModelBuilder {
     $actionLabel = $copy['action_label'];
     $url = NULL;
 
-    if ($this->routeExists('myeventlane_event_studio.create')) {
+    if ($this->routeExists('myeventlane_vendor.create_event_gateway')) {
       try {
-        if ($this->accessManager->checkNamedRoute('myeventlane_event_studio.create', [], $account, TRUE)->isAllowed()) {
-          $url = $this->safeUrlFromRoute('myeventlane_event_studio.create');
+        if ($this->accessManager->checkNamedRoute('myeventlane_vendor.create_event_gateway', [], $account, TRUE)->isAllowed()) {
+          $url = $this->safeUrlFromRoute('myeventlane_vendor.create_event_gateway');
         }
       }
       catch (\Throwable) {

--- a/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
+++ b/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
@@ -317,7 +317,7 @@ final class GovernedOperationalTemplates {
    */
   private function optionalStudioCreateLink(string $title): ?array {
     try {
-      $url = Url::fromRoute('myeventlane_event_studio.create');
+      $url = Url::fromRoute('myeventlane_vendor.create_event_gateway');
     }
     catch (\Throwable) {
       return NULL;

--- a/web/modules/custom/myeventlane_core/src/Plugin/Block/OrganiserContextBlock.php
+++ b/web/modules/custom/myeventlane_core/src/Plugin/Block/OrganiserContextBlock.php
@@ -175,7 +175,7 @@ final class OrganiserContextBlock extends BlockBase implements ContainerFactoryP
       ],
       [
         'title' => $this->t('Create event'),
-        'url' => Url::fromRoute('myeventlane_event_studio.create'),
+        'url' => Url::fromRoute('myeventlane_vendor.create_event_gateway'),
       ],
       [
         'title' => $this->t('Settings'),

--- a/web/modules/custom/myeventlane_dashboard/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_dashboard/src/Controller/VendorDashboardController.php
@@ -375,7 +375,7 @@ final class VendorDashboardController extends ControllerBase {
     $quickLinks = [
       [
         'title' => $this->t('Create Event'),
-        'url' => Url::fromRoute('myeventlane_event_studio.create')->toString(),
+        'url' => Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString(),
         'icon' => 'add',
       ],
     ];

--- a/web/modules/custom/myeventlane_dashboard/templates/myeventlane-vendor-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_dashboard/templates/myeventlane-vendor-dashboard.html.twig
@@ -323,7 +323,7 @@
     <section class="mel-dashboard-section">
       <div class="mel-card mel-card--empty">
         <p>{{ 'You have no upcoming events.'|t }}</p>
-        <a href="{{ path('myeventlane_event_studio.create') }}" class="mel-btn mel-btn-primary">{{ 'Create Your First Event'|t }}</a>
+        <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn-primary">{{ 'Create Your First Event'|t }}</a>
       </div>
     </section>
   {% endif %}

--- a/web/modules/custom/myeventlane_growth/src/Service/GrowthInsightService.php
+++ b/web/modules/custom/myeventlane_growth/src/Service/GrowthInsightService.php
@@ -287,7 +287,7 @@ final class GrowthInsightService {
             'info',
             'Your draft is nearly ready',
             'Publish when you are ready to start building momentum.',
-            'myeventlane_event_studio.create',
+            'myeventlane_vendor.create_event_gateway',
             [],
             'organiser',
             TRUE,

--- a/web/modules/custom/myeventlane_reporting/templates/myeventlane-reporting-vendor-insights.html.twig
+++ b/web/modules/custom/myeventlane_reporting/templates/myeventlane-reporting-vendor-insights.html.twig
@@ -78,7 +78,7 @@
   {% if event_count == 0 %}
     <div class="mel-empty-state">
       <p>{{ 'You haven\'t created any events yet.'|t }}</p>
-      <a href="{{ path('myeventlane_event_studio.create') }}" class="mel-btn mel-btn--primary">{{ 'Create your first event'|t }}</a>
+      <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--primary">{{ 'Create your first event'|t }}</a>
     </div>
   {% endif %}
 </div>

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
@@ -32,7 +32,7 @@ myeventlane_vendor.menu_account.events:
   weight: -49
 myeventlane_vendor.menu_account.create_event:
   title: 'Create event'
-  route_name: myeventlane_event_studio.create
+  route_name: myeventlane_vendor.create_event_gateway
   menu_name: account
   weight: -48
 myeventlane_vendor.menu_account.settings:

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -2171,7 +2171,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     return [
       [
         'label' => 'Create Event',
-        'url' => Url::fromRoute('myeventlane_event_studio.create')->toString(),
+        'url' => Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString(),
         'icon' => 'plus',
         'style' => 'primary',
       ],
@@ -2539,7 +2539,7 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'type' => 'info',
         'title' => (string) $this->t('Ready for your first launch'),
         'message' => (string) $this->t('Create your first event and we will guide you through publishing.'),
-        'url' => $this->safeRouteUrl('myeventlane_event_studio.create'),
+        'url' => $this->safeRouteUrl('myeventlane_vendor.create_event_gateway'),
         'link_label' => (string) $this->t('Create event'),
       ];
     }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardCompleteController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardCompleteController.php
@@ -105,7 +105,7 @@ final class VendorOnboardCompleteController extends ControllerBase {
 
     if ($auto_redirect) {
       return new RedirectResponse(
-        Url::fromRoute('myeventlane_event_studio.create')->toString()
+        Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString()
       );
     }
 
@@ -114,7 +114,7 @@ final class VendorOnboardCompleteController extends ControllerBase {
       '#attached' => [
         'library' => ['myeventlane_vendor/onboarding'],
       ],
-      '#create_event_url' => Url::fromRoute('myeventlane_event_studio.create')->toString(),
+      '#create_event_url' => Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString(),
       '#dashboard_url' => Url::fromRoute('myeventlane_vendor.console.dashboard')->toString(),
     ];
   }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardFirstEventController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardFirstEventController.php
@@ -76,7 +76,7 @@ final class VendorOnboardFirstEventController extends ControllerBase {
       $content['create_more'] = [
         '#type' => 'link',
         '#title' => $this->t('Create another event'),
-        '#url' => Url::fromRoute('myeventlane_event_studio.create'),
+        '#url' => Url::fromRoute('myeventlane_vendor.create_event_gateway'),
         '#attributes' => [
           'class' => ['mel-btn', 'mel-btn-primary', 'mel-btn-lg'],
         ],
@@ -125,7 +125,7 @@ final class VendorOnboardFirstEventController extends ControllerBase {
       $content['create'] = [
         '#type' => 'link',
         '#title' => $this->t('Create your first event'),
-        '#url' => Url::fromRoute('myeventlane_event_studio.create'),
+        '#url' => Url::fromRoute('myeventlane_vendor.create_event_gateway'),
         '#attributes' => [
           'class' => ['mel-btn', 'mel-btn-primary', 'mel-btn-lg'],
         ],

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardStripeController.php
@@ -160,7 +160,7 @@ final class VendorOnboardStripeController extends ControllerBase {
     ]);
 
     $back_url = Url::fromRoute('myeventlane_vendor.onboard.profile')->toString();
-    $skip_url = Url::fromRoute('myeventlane_event_studio.create')->toString();
+    $skip_url = Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString();
 
     $onboard_footer = [
       'back_url' => $back_url,
@@ -181,7 +181,7 @@ final class VendorOnboardStripeController extends ControllerBase {
           '#markup' => '<p>' . $done_text . '</p>',
         ],
       ];
-      $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_event_studio.create')->toString();
+      $onboard_footer['continue_url'] = Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString();
       $onboard_footer['continue_label'] = $this->t('Continue to create your event');
       unset($onboard_footer['skip_url'], $onboard_footer['skip_label']);
     }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorEventsBulkActionsForm.php
@@ -82,7 +82,7 @@ final class VendorEventsBulkActionsForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $form['#attributes']['class'][] = 'mel-vendor-events-form';
-    $form['#create_event_url'] = Url::fromRoute('myeventlane_event_studio.create')->toString();
+    $form['#create_event_url'] = Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString();
     $form['#attached']['library'][] = 'myeventlane_vendor_theme/mel_vendor_events';
 
     $executable = $this->loadVendorEventsViewExecutable();
@@ -125,7 +125,7 @@ final class VendorEventsBulkActionsForm extends FormBase {
         'action' => [
           '#type' => 'link',
           '#title' => $this->t('Create event'),
-          '#url' => Url::fromRoute('myeventlane_event_studio.create'),
+          '#url' => Url::fromRoute('myeventlane_vendor.create_event_gateway'),
           '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
         ],
       ];

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorActionQueueBuilder.php
@@ -188,7 +188,7 @@ final class VendorActionQueueBuilder {
         'title' => $copy['title'],
         'message' => $copy['message'],
         'action_label' => $copy['action_label'],
-        'url' => $this->routeUrlIfAccessible('myeventlane_event_studio.create', [], $account),
+        'url' => $this->routeUrlIfAccessible('myeventlane_vendor.create_event_gateway', [], $account),
         'context' => [
           'type' => 'events',
           'entity_id' => NULL,

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -1060,10 +1060,10 @@ final class VendorDashboardViewModelBuilder {
     $actionLabel = $copy['empty_action_label'];
     $url = NULL;
 
-    if ($noEvents && $this->routeExists('myeventlane_event_studio.create')) {
+    if ($noEvents && $this->routeExists('myeventlane_vendor.create_event_gateway')) {
       try {
-        if ($this->accessManager->checkNamedRoute('myeventlane_event_studio.create', [], $account, TRUE)->isAllowed()) {
-          $url = $this->safeUrlFromRoute('myeventlane_event_studio.create');
+        if ($this->accessManager->checkNamedRoute('myeventlane_vendor.create_event_gateway', [], $account, TRUE)->isAllowed()) {
+          $url = $this->safeUrlFromRoute('myeventlane_vendor.create_event_gateway');
         }
       }
       catch (\Throwable) {
@@ -1238,7 +1238,7 @@ final class VendorDashboardViewModelBuilder {
       $actions,
       'create',
       (string) $this->t('Create event'),
-      $this->safeUrlFromRouteIfAccessible('myeventlane_event_studio.create', [], $account),
+      $this->safeUrlFromRouteIfAccessible('myeventlane_vendor.create_event_gateway', [], $account),
     );
     $this->appendOrganiserAction(
       $actions,

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventIndexViewModelBuilder.php
@@ -94,7 +94,7 @@ final class VendorEventIndexViewModelBuilder {
     $filteredInternal = $this->sortRowsInternal($filteredInternal, $sortParam);
     $filtered = $this->stripInternals($filteredInternal);
 
-    $primaryUrl = $this->routeUrlIfAccessible('myeventlane_event_studio.create', [], $account);
+    $primaryUrl = $this->routeUrlIfAccessible('myeventlane_vendor.create_event_gateway', [], $account);
 
     return [
       'title' => (string) $this->t('Events'),

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -32,7 +32,9 @@ use Drupal\node\NodeInterface;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_event\Service\EventCtaResolver;
 use Drupal\myeventlane_core\VendorConsoleTrust;
+use Drupal\myeventlane_shared\Service\ColorService;
 use Drupal\views\ResultRow;
+use Drupal\views\Views;
 
 /**
  * Public marketing create-event URL via onboarding gateway (/create-event).
@@ -58,7 +60,7 @@ function _myeventlane_theme_vendor_console_footer_urls(): array {
     'events' => 'myeventlane_vendor.console.events',
     'analytics' => 'myeventlane_analytics.dashboard',
     'payouts' => 'myeventlane_vendor.console.payouts',
-    'create_event' => 'myeventlane_event_studio.create',
+    'create_event' => 'myeventlane_vendor.create_event_gateway',
     'settings' => 'myeventlane_vendor.console.settings',
     'support' => 'myeventlane_escalations_portal.vendor_list',
   ];
@@ -2294,6 +2296,171 @@ function myeventlane_theme_preprocess_page__calendar(array &$variables): void {
   }
 
   $variables['calendar_events'] = $events;
+  $variables['mel_calendar_this_week_rail'] = _myeventlane_theme_build_calendar_this_week_rail();
+}
+
+/**
+ * Builds the calendar page "Upcoming this week" event card rail.
+ *
+ * Uses upcoming_events:embed_calendar_this_week (7-day window, 3 cards).
+ *
+ * @return array
+ *   Render array, or empty when the view is unavailable or has no results.
+ */
+function _myeventlane_theme_build_calendar_this_week_rail(): array {
+  $view = Views::getView('upcoming_events');
+  if ($view === NULL) {
+    return [];
+  }
+  $view->setDisplay('embed_calendar_this_week');
+  $view->preExecute();
+  $view->execute();
+  if (empty($view->result)) {
+    return [];
+  }
+  $build = $view->buildRenderable('embed_calendar_this_week');
+  $build['#cache']['contexts'] = array_values(array_unique(array_merge(
+    $build['#cache']['contexts'] ?? [],
+    ['languages:language_interface', 'timezone']
+  )));
+  return $build;
+}
+
+/**
+ * Implements hook_preprocess_views_view_fullcalendar().
+ *
+ * Applies MEL category palette to FullCalendar events via drupalSettings.
+ *
+ * fullcalendar_view injects backgroundColor/borderColor inline when
+ * color_taxonomies is configured; MEL leaves that map empty in sync config,
+ * so events otherwise fall back to FullCalendar default blue (#3788d8).
+ */
+function myeventlane_theme_preprocess_views_view_fullcalendar(array &$variables): void {
+  if (($variables['view_id'] ?? '') !== 'events_calendar') {
+    return;
+  }
+
+  $view_index = $variables['view_index'] ?? 0;
+  $settings = $variables['#attached']['drupalSettings']['fullCalendarView'][$view_index] ?? NULL;
+  if (!is_array($settings) || empty($settings['calendar_options'])) {
+    return;
+  }
+
+  $options = json_decode($settings['calendar_options'], TRUE);
+  if (!is_array($options) || empty($options['events']) || !is_array($options['events'])) {
+    return;
+  }
+
+  /** @var \Drupal\views\ViewExecutable|null $view */
+  $view = $variables['view'] ?? NULL;
+  if (!$view instanceof ViewExecutable) {
+    return;
+  }
+
+  $style_options = $view->getDisplay()->getOption('style')['options'] ?? [];
+  $tax_field = $style_options['tax_field'] ?? 'field_category';
+
+  $color_service = \Drupal::hasService('myeventlane_shared.color_service')
+    ? \Drupal::service('myeventlane_shared.color_service')
+    : new ColorService();
+
+  $entity_colors = _myeventlane_theme_calendar_entity_colors($view, $tax_field, $color_service);
+
+  foreach ($options['events'] as &$event) {
+    if (!is_array($event)) {
+      continue;
+    }
+    $entity_id = $event['eid'] ?? NULL;
+    if ($entity_id === NULL || !isset($entity_colors[$entity_id])) {
+      $palette = _myeventlane_theme_calendar_default_event_colors($color_service);
+    }
+    else {
+      $palette = $entity_colors[$entity_id];
+    }
+    $event['backgroundColor'] = $palette['background'];
+    $event['borderColor'] = $palette['border'];
+    $event['textColor'] = $palette['text'];
+  }
+  unset($event);
+
+  $variables['#attached']['drupalSettings']['fullCalendarView'][$view_index]['calendar_options'] = json_encode($options);
+}
+
+/**
+ * Builds entity ID => MEL calendar colour palette from view results.
+ *
+ * @return array<int|string, array{background: string, border: string, text: string}>
+ *   Palette keyed by node ID.
+ */
+function _myeventlane_theme_calendar_entity_colors(ViewExecutable $view, string $tax_field, ColorService $color_service): array {
+  $colors = [];
+  foreach ($view->result as $row) {
+    if (!$row instanceof ResultRow || !isset($row->_entity)) {
+      continue;
+    }
+    $entity = $row->_entity;
+    if (!$entity instanceof NodeInterface) {
+      continue;
+    }
+    $label = '';
+    if ($entity->hasField($tax_field) && !$entity->get($tax_field)->isEmpty()) {
+      $term = $entity->get($tax_field)->entity;
+      if ($term instanceof TermInterface) {
+        $label = $term->label();
+      }
+    }
+    $colors[$entity->id()] = _myeventlane_theme_calendar_palette_for_category($label, $color_service);
+  }
+  return $colors;
+}
+
+/**
+ * Resolves MEL-branded background/border/text colours for a category label.
+ *
+ * @return array{background: string, border: string, text: string}
+ */
+function _myeventlane_theme_calendar_palette_for_category(string $category_label, ColorService $color_service): array {
+  $background = $color_service->getColorForTerm($category_label);
+  if ($background === NULL) {
+    return _myeventlane_theme_calendar_default_event_colors($color_service);
+  }
+  return [
+    'background' => $background,
+    'border' => _myeventlane_theme_calendar_border_color($background),
+    'text' => '#24303a',
+  ];
+}
+
+/**
+ * Default event colours when category is unknown (MEL lavender, not FC blue).
+ *
+ * @return array{background: string, border: string, text: string}
+ */
+function _myeventlane_theme_calendar_default_event_colors(ColorService $color_service): array {
+  $background = $color_service->getFallbackColor();
+  // Prefer MEL pastel lavender over grey when fallback is the shared default.
+  if ($background === '#cccccc') {
+    $background = '#E6D9FF';
+  }
+  return [
+    'background' => $background,
+    'border' => _myeventlane_theme_calendar_border_color($background),
+    'text' => '#24303a',
+  ];
+}
+
+/**
+ * Darkens a hex colour slightly for event borders.
+ */
+function _myeventlane_theme_calendar_border_color(string $hex): string {
+  $hex = ltrim($hex, '#');
+  if (strlen($hex) !== 6 || !ctype_xdigit($hex)) {
+    return $hex;
+  }
+  $r = max(0, (int) round(hexdec(substr($hex, 0, 2)) * 0.78));
+  $g = max(0, (int) round(hexdec(substr($hex, 2, 2)) * 0.78));
+  $b = max(0, (int) round(hexdec(substr($hex, 4, 2)) * 0.78));
+  return sprintf('#%02x%02x%02x', $r, $g, $b);
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -232,6 +232,7 @@
 @use 'pages/organiser-hub-landing';
 @use 'pages/blog-article';
 @use 'pages/blog-landing';
+@use 'pages/calendar';
 
 // Event page Classic/Immersive themes — load after pages/event so Mockup 1 rules win cascade.
 @use 'components/event-page-themes';

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_calendar.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_calendar.scss
@@ -1,0 +1,426 @@
+// ==========================================================================
+// Public Events Calendar page (/calendar) — presentation only
+// ==========================================================================
+// FullCalendar engine + Views data source unchanged; styles scoped to
+// .mel-calendar-page so other .mel-calendar (add-to-calendar) UI is untouched.
+
+@use '../base/mel-ds-tokens' as mel;
+@use '../tokens/colors';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/spacing';
+@use '../tokens/typography';
+@use '../tokens/breakpoints';
+
+.mel-calendar-page {
+  padding-bottom: spacing.mel-space(8);
+}
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+
+.mel-calendar-hero {
+  margin: spacing.mel-space(4) 0 spacing.mel-space(6);
+  padding: spacing.mel-space(6) spacing.mel-space(4);
+  border-radius: radii.$mel-radius-lg;
+  background:
+    radial-gradient(circle at 14% 22%, color-mix(in srgb, colors.$mel-color-primary 16%, transparent), transparent 42%),
+    radial-gradient(circle at 88% 18%, color-mix(in srgb, colors.$mel-color-accent 18%, transparent), transparent 38%),
+    linear-gradient(135deg, colors.$mel-color-bg 0%, colors.$mel-color-pastel-lavender 100%);
+}
+
+.mel-calendar-hero__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: spacing.mel-space(6);
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  @include breakpoints.mel-break(md) {
+    grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+    gap: spacing.mel-space(7);
+  }
+}
+
+.mel-calendar-hero__content {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 0;
+  text-align: center;
+
+  @include breakpoints.mel-break(md) {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+
+.mel-calendar-hero__title {
+  margin: 0;
+  font-family: mel.$mel-ds-font-main;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: colors.$mel-color-text;
+}
+
+.mel-calendar-hero__lede {
+  margin: spacing.mel-space(3) 0 0;
+  max-width: 36rem;
+  font-size: typography.mel-font-size(lg);
+  line-height: 1.55;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-calendar-hero__actions {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(3);
+  width: 100%;
+  margin-top: spacing.mel-space(5);
+
+  @include breakpoints.mel-break(sm) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: auto;
+  }
+}
+
+.mel-calendar-hero__cta {
+  width: 100%;
+  min-height: 44px;
+
+  @include breakpoints.mel-break(sm) {
+    width: auto;
+  }
+}
+
+.mel-calendar-hero__art {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.mel-calendar-hero__art--hide-mobile {
+  @include breakpoints.mel-break(md, max) {
+    display: none;
+  }
+}
+
+.mel-calendar-hero__img {
+  display: block;
+  width: min(100%, 420px);
+  height: auto;
+  border-radius: radii.$mel-radius-lg;
+  box-shadow: shadows.$mel-shadow-2;
+}
+
+.mel-calendar-hero__img--placeholder {
+  width: min(100%, 320px);
+  aspect-ratio: 4 / 3;
+  background:
+    radial-gradient(circle at 30% 28%, rgba(255, 255, 255, 0.55), transparent 24%),
+    linear-gradient(145deg, color-mix(in srgb, colors.$mel-color-accent 28%, #fff), color-mix(in srgb, colors.$mel-color-primary 22%, #fff));
+}
+
+// Category discovery strip (existing taxonomy pills; links to browse, not calendar filter).
+.mel-calendar-page .mel-page-header {
+  margin-bottom: spacing.mel-space(5);
+  padding: 0;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar card container
+// ---------------------------------------------------------------------------
+
+.mel-calendar-card {
+  padding: spacing.mel-space(4);
+  border-radius: radii.$mel-radius-lg;
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-1;
+  overflow: hidden;
+
+  @include breakpoints.mel-break(md) {
+    padding: spacing.mel-space(6);
+  }
+}
+
+.mel-calendar-page .mel-content--calendar {
+  min-width: 0;
+}
+
+// ---------------------------------------------------------------------------
+// FullCalendar toolbar + controls (presentation only)
+// ---------------------------------------------------------------------------
+
+.mel-calendar-page {
+  .fc-toolbar {
+    flex-wrap: wrap;
+    gap: spacing.mel-space(3);
+    margin-bottom: spacing.mel-space(5);
+  }
+
+  .fc-toolbar.fc-header-toolbar {
+    margin-bottom: spacing.mel-space(5);
+  }
+
+  .fc-toolbar h2,
+  .fc-center h2 {
+    flex: 1 1 100%;
+    order: -1;
+    margin: 0 0 spacing.mel-space(2);
+    font-family: mel.$mel-ds-font-main;
+    font-size: clamp(1.35rem, 3.5vw, 1.85rem);
+    font-weight: 800;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: colors.$mel-color-text;
+    text-align: center;
+
+    @include breakpoints.mel-break(md) {
+      flex: 1 1 auto;
+      order: 0;
+      margin: 0;
+      text-align: center;
+    }
+  }
+
+  .fc-left,
+  .fc-right,
+  .fc-center {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: spacing.mel-space(2);
+  }
+
+  .fc-button {
+    min-width: 44px;
+    min-height: 44px;
+    padding: spacing.mel-space(2) spacing.mel-space(4);
+    border-radius: radii.$mel-radius-sm;
+    border: 1px solid colors.$mel-color-border;
+    background: colors.$mel-color-surface;
+    color: colors.$mel-color-text;
+    font-family: mel.$mel-ds-font-main;
+    font-size: typography.mel-font-size(base);
+    font-weight: typography.$mel-font-semibold;
+    box-shadow: none;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+
+    &:hover {
+      background: colors.$mel-color-surface-alt;
+      color: colors.$mel-color-text;
+    }
+
+    &:focus-visible {
+      @include colors.mel-focus-ring;
+    }
+  }
+
+  .fc-button-primary:not(:disabled).fc-button-active,
+  .fc-button-primary:not(:disabled):active {
+    background: colors.$mel-color-primary;
+    border-color: colors.$mel-color-primary;
+    color: colors.$mel-color-text-inverse;
+  }
+
+  // Today control — MEL primary pill.
+  .fc-today-button {
+    background: colors.$mel-color-primary;
+    border-color: colors.$mel-color-primary;
+    color: colors.$mel-color-text-inverse;
+    border-radius: radii.$mel-radius-sm;
+
+    &:hover {
+      background: colors.$mel-color-primary-hover;
+      border-color: colors.$mel-color-primary-hover;
+      color: colors.$mel-color-text-inverse;
+    }
+
+    &:disabled {
+      opacity: 0.55;
+    }
+  }
+
+  .fc-button-group > .fc-button {
+    min-height: 44px;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Today date cell
+// ---------------------------------------------------------------------------
+
+.mel-calendar-page {
+  .fc-unthemed td.fc-today {
+    background: color-mix(in srgb, colors.$mel-color-primary 8%, colors.$mel-color-surface);
+  }
+
+  .fc-day-top.fc-today .fc-day-number,
+  .fc-daygrid-day.fc-day-today .fc-daygrid-day-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    margin: 2px;
+    border-radius: radii.$mel-radius-sm;
+    background: colors.$mel-color-primary;
+    color: colors.$mel-color-text-inverse;
+    font-weight: typography.$mel-font-bold;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event bars — category colours from drupalSettings (inline); structure only
+// ---------------------------------------------------------------------------
+
+.mel-calendar-page {
+  .fc-event,
+  .fc-event-dot {
+    border-radius: 8px;
+    border-width: 1px;
+    border-style: solid;
+    box-shadow: none;
+    // background/border come from FullCalendar inline styles (MEL palette).
+  }
+
+  .fc-event,
+  .fc-event:hover,
+  .fc-event:focus-visible {
+    text-decoration: none;
+  }
+
+  .fc-event .fc-title,
+  .fc-event .fc-time,
+  .fc-list-item-title a {
+    font-weight: typography.$mel-font-semibold;
+  }
+
+  .fc-list-item-title a {
+    color: inherit;
+  }
+
+  .fc-day-grid-event {
+    margin-top: 2px;
+    padding: 2px 6px;
+  }
+
+  .fc-day-grid-event .fc-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .fc-list-item:hover td {
+    background: color-mix(in srgb, colors.$mel-color-pastel-lavender 35%, colors.$mel-color-surface);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+.mel-calendar-page .mel-empty--calendar {
+  padding: spacing.mel-space(8) spacing.mel-space(4);
+  margin-top: spacing.mel-space(4);
+  border-radius: radii.$mel-radius-lg;
+  background: colors.$mel-color-surface;
+  border: 1px solid colors.$mel-color-border;
+  box-shadow: shadows.$mel-shadow-1;
+  text-align: center;
+
+  .mel-empty__illustration {
+    margin: 0 auto spacing.mel-space(5);
+    max-width: 280px;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+      margin: 0 auto;
+      border-radius: radii.$mel-radius-md;
+    }
+  }
+
+  .mel-empty__title {
+    margin: 0 0 spacing.mel-space(3);
+    font-size: typography.mel-font-size(2xl);
+    font-weight: typography.$mel-font-bold;
+    color: colors.$mel-color-text;
+  }
+
+  .mel-empty__text {
+    margin: 0 auto;
+    max-width: 32rem;
+    font-size: typography.mel-font-size(base);
+    line-height: typography.$mel-leading-relaxed;
+    color: colors.$mel-color-text-muted;
+  }
+
+  .mel-empty__actions {
+    display: flex;
+    flex-direction: column;
+    gap: spacing.mel-space(3);
+    justify-content: center;
+    align-items: stretch;
+    margin-top: spacing.mel-space(6);
+    max-width: 360px;
+    margin-inline: auto;
+
+    @include breakpoints.mel-break(sm) {
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      max-width: none;
+    }
+
+    .mel-btn {
+      width: 100%;
+      min-height: 44px;
+
+      @include breakpoints.mel-break(sm) {
+        width: auto;
+      }
+    }
+  }
+}
+
+// Prevent horizontal scroll on narrow viewports.
+.mel-calendar-page .fc-view-container,
+.mel-calendar-page .fc-scroller {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+// ---------------------------------------------------------------------------
+// Upcoming this week rail (event cards below calendar)
+// ---------------------------------------------------------------------------
+
+.mel-calendar-page .mel-section--calendar-rail {
+  margin-top: spacing.mel-space(8);
+  padding-top: spacing.mel-space(2);
+}
+
+.mel-calendar-page .mel-calendar-rail__grid {
+  .mel-event-grid.mel-grid--events {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: spacing.mel-space(4);
+
+    @include breakpoints.mel-break(md) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: spacing.mel-space(5);
+    }
+  }
+
+  .mel-event-card {
+    height: 100%;
+  }
+}

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-calendar-hero.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-calendar-hero.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Branded hero for the public Events Calendar page (/calendar).
+ *
+ * Variables:
+ * - hero_image_url: Desktop illustration URL (Page Visuals Manager).
+ * - hero_image_url_mobile: Optional mobile illustration URL.
+ * - hero_hide_on_mobile: When TRUE, hide illustration on small viewports.
+ * - create_event_url: Public create-event gateway URL (from preprocess).
+ */
+#}
+{% set hero_desktop = hero_image_url|default(mel_hero_image_url|default(null)) %}
+{% set hero_mobile = hero_image_url_mobile|default(mel_hero_image_url_mobile|default(null)) %}
+{% set hero_hide_mobile = hero_hide_on_mobile|default(mel_hero_hide_on_mobile|default(false)) %}
+{% set create_url = create_event_url|default(path('myeventlane_vendor.create_event_gateway')) %}
+
+<section class="mel-calendar-hero" aria-labelledby="mel-calendar-hero-title">
+  <div class="mel-calendar-hero__inner">
+    <div class="mel-calendar-hero__content">
+      <h1 id="mel-calendar-hero-title" class="mel-calendar-hero__title">
+        {{ 'Events Calendar'|t }}
+      </h1>
+      <p class="mel-calendar-hero__lede">
+        {{ 'Discover what’s happening near you this month.'|t }}
+      </p>
+      <div class="mel-calendar-hero__actions" role="group" aria-label="{{ 'Calendar actions'|t }}">
+        <a class="mel-btn mel-btn--primary mel-calendar-hero__cta" href="{{ path('view.upcoming_events.page_events') }}">
+          {{ 'Browse Events'|t }}
+        </a>
+        <a class="mel-btn mel-btn--secondary mel-calendar-hero__cta" href="{{ create_url }}">
+          {{ 'Create Event'|t }}
+        </a>
+      </div>
+    </div>
+
+    <div class="mel-calendar-hero__art{% if hero_hide_mobile %} mel-calendar-hero__art--hide-mobile{% endif %}">
+      {% if hero_desktop or hero_mobile %}
+        <picture>
+          {% if hero_mobile %}
+            <source media="(max-width: 767px)" srcset="{{ hero_mobile }}">
+          {% endif %}
+          <img
+            class="mel-calendar-hero__img"
+            src="{{ hero_desktop ?: hero_mobile }}"
+            alt="{{ page_visual.alt|default('Calendar illustration'|t) }}"
+            width="640"
+            height="480"
+            loading="eager"
+            decoding="async"
+          />
+        </picture>
+      {% else %}
+        <div class="mel-calendar-hero__img mel-calendar-hero__img--placeholder" aria-hidden="true"></div>
+      {% endif %}
+    </div>
+  </div>
+</section>

--- a/web/themes/custom/myeventlane_theme/templates/page--calendar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--calendar.html.twig
@@ -3,40 +3,68 @@
  * @file
  * Calendar page template.
  *
- * Policy:
- * - No inline script/style tags.
- * - No CDN JS/CSS in Twig.
- *
- * Calendar UI should be provided by placed blocks/views and theme assets.
- * When no published events with dates exist, show an intentional empty state
- * (preprocess sets calendar_events in myeventlane_theme.theme).
+ * FullCalendar output comes from view.events_calendar.page_calendar.
+ * Empty state uses calendar_events from preprocess_page__calendar.
  */
 #}
-
 {% extends "page.html.twig" %}
 
 {% block content %}
-  <div class="mel-container">
-    {% include '@myeventlane_theme/components/mel-page-header.html.twig' with {
-      title: 'Events calendar'|t,
-      show_search: false,
-      show_categories: false
+  <div class="mel-container mel-calendar-page">
+    {% include '@myeventlane_theme/components/mel-calendar-hero.html.twig' with {
+      hero_image_url: mel_hero_image_url|default(null),
+      hero_image_url_mobile: mel_hero_image_url_mobile|default(null),
+      hero_hide_on_mobile: mel_hero_hide_on_mobile|default(false),
+      create_event_url: create_event_url|default(null)
     } only %}
 
     {% if calendar_events is defined and calendar_events is empty %}
       <div class="mel-empty mel-empty--calendar" role="status">
-        <h2 class="mel-empty__title">{{ 'Nothing on the calendar yet'|t }}</h2>
-        <p class="mel-empty__text">{{ 'When events are published with dates, they appear here. Browse the marketplace for what’s on near you.'|t }}</p>
-        <p class="mel-empty__text mel-empty__text--secondary">{{ 'Try exploring featured events or browsing by category from the homepage.'|t }}</p>
-        <p class="mel-empty__actions">
-          <a class="mel-btn mel-btn--primary" href="{{ path('view.upcoming_events.page_events') }}">{{ 'Browse events'|t }}</a>
-          <a class="mel-link mel-empty__link-home" href="{{ path('<front>') }}">{{ 'Featured on homepage'|t }}</a>
-        </p>
+        {% if mel_hero_image_url %}
+          <div class="mel-empty__illustration" aria-hidden="true">
+            <picture>
+              {% if mel_hero_image_url_mobile %}
+                <source media="(max-width: 767px)" srcset="{{ mel_hero_image_url_mobile }}">
+              {% endif %}
+              <img
+                src="{{ mel_hero_image_url }}"
+                alt=""
+                width="320"
+                height="240"
+                loading="lazy"
+                decoding="async"
+              />
+            </picture>
+          </div>
+        {% endif %}
+        <h2 class="mel-empty__title">{{ 'No events scheduled yet.'|t }}</h2>
+        <p class="mel-empty__text">{{ 'Explore upcoming events or create your own.'|t }}</p>
+        <div class="mel-empty__actions">
+          <a class="mel-btn mel-btn--primary" href="{{ path('view.upcoming_events.page_events') }}">{{ 'Browse Events'|t }}</a>
+          <a class="mel-btn mel-btn--secondary" href="{{ create_event_url|default(path('myeventlane_vendor.create_event_gateway')) }}">{{ 'Create Event'|t }}</a>
+        </div>
       </div>
     {% else %}
-      <div class="mel-content mel-content--calendar">
-        {{ page.content }}
+      <div class="mel-calendar-card">
+        <div class="mel-content mel-content--calendar">
+          {{ page.content }}
+        </div>
       </div>
+
+      {% if mel_calendar_this_week_rail|default([]) is not empty %}
+        {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+          section_class: 'mel-section--calendar-rail mel-section--discover',
+          section_width_class: '',
+          container_class: 'mel-container',
+          header_extra_class: 'mel-section__header--calendar-rail',
+          title: 'Upcoming this week'|t,
+          subtitle: 'Events starting soon — browse cards or explore the full marketplace.'|t,
+          link_url: path('view.upcoming_events.page_events'),
+          link_text: 'Browse all events'|t,
+          content_wrapper_class: 'mel-section__discover-view mel-calendar-rail__grid',
+          content: mel_calendar_this_week_rail
+        } %}
+      {% endif %}
     {% endif %}
   </div>
 {% endblock %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--embed-calendar-this-week.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--embed-calendar-this-week.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Calendar page — upcoming this week rail wrapper (grid only).
+ */
+#}
+{% if rows %}
+  <div class="view-content">
+    {{ rows }}
+  </div>
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--embed-calendar-this-week.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--embed-calendar-this-week.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Calendar page — upcoming this week rail (3 event cards).
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-event-rows-wrapper.html.twig' with {
+  rows: rows,
+  mel_is_event_view: true,
+  wrapper_aria_label: 'Upcoming events this week'|t,
+} only %}

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -78,7 +78,7 @@ function _myeventlane_vendor_theme_vendor_console_footer_urls(): array {
     'events' => 'myeventlane_vendor.console.events',
     'analytics' => 'myeventlane_analytics.dashboard',
     'payouts' => 'myeventlane_vendor.console.payouts',
-    'create_event' => 'myeventlane_event_studio.create',
+    'create_event' => 'myeventlane_vendor.create_event_gateway',
     'settings' => 'myeventlane_vendor.console.settings',
     'support' => 'myeventlane_escalations_portal.vendor_list',
   ];

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
@@ -107,7 +107,7 @@
         <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
       </svg>
       <p class="mel-empty-state__text">{{ 'No events yet. Create your first event to get started.'|t }}</p>
-      <a href="{{ path('myeventlane_event_studio.create') }}" class="mel-btn mel-btn--cta">{{ 'Create Event'|t }}</a>
+      <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--cta">{{ 'Create Event'|t }}</a>
     </div>
   {% endif %}
 </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-event-performance.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-event-performance.html.twig
@@ -98,7 +98,7 @@
         </div>
       {% else %}
         <div class="mel-empty-state__actions">
-          <a href="{{ path('myeventlane_event_studio.create') }}" class="mel-btn mel-btn--primary">{{ 'Create event'|t }}</a>
+          <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--primary">{{ 'Create event'|t }}</a>
         </div>
       {% endif %}
     </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-performance.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/vendor-event-performance.html.twig
@@ -61,6 +61,6 @@
 {% else %}
   <div class="mel-empty-state mel-empty-state--compact">
     <p class="mel-empty-state__text">{{ 'No events yet. Create your first event to get started.'|t }}</p>
-    <a href="{{ path('myeventlane_event_studio.create') }}" class="mel-btn mel-btn--cta">{{ 'Create Event'|t }}</a>
+    <a href="{{ path('myeventlane_vendor.create_event_gateway') }}" class="mel-btn mel-btn--cta">{{ 'Create Event'|t }}</a>
   </div>
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Vendor create flows change entry URL (gateway redirects); calendar coloring and the new view display affect public `/calendar` caching and rendering—low security impact but worth smoke-testing onboarding and the calendar page.
> 
> **Overview**
> **Calendar discovery** gets a full presentation pass on `/calendar`: a new hero component, card-wrapped FullCalendar, updated empty state, and dedicated `_calendar.scss`. Theme preprocess now injects MEL category colors into FullCalendar via `drupalSettings` (replacing default blue) and builds an **“Upcoming this week”** rail from a new `upcoming_events:embed_calendar_this_week` Views display (now through +7 days, up to 3 `compact_commerce` cards, hide when empty).
> 
> **Create event entry** is consolidated: user-facing links that pointed at `myeventlane_event_studio.create` now use `myeventlane_vendor.create_event_gateway` across vendor menus, dashboards, onboarding, analytics/growth empty states, organiser blocks, and both public/vendor theme footers—so login/onboarding gateway checks run before Studio create.
> 
> **Documentation only:** four new audit files under `docs/audits/` (route ownership, reference map, dead-route candidates, Phase 2 consolidation audit)—no application behavior changes from those files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995c987653883bbc3995136eb31ac007b7a94f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->