### PR TITLE
Defer first-event organiser audience application to update 8007 after…

### DIFF
--- a/web/modules/custom/myeventlane_front/myeventlane_front.install
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.install
@@ -53,10 +53,10 @@ function myeventlane_front_update_8005(): string {
 }
 
 /**
- * Marks the first-event guide as organiser audience for CTA targeting.
+ * Deferred: first-event organiser audience runs in 8007 after playbook seeding.
  */
 function myeventlane_front_update_8006(): string {
-  return _myeventlane_front_apply_first_event_organiser_audience();
+  return (string) t('Deferred first-event organiser audience to update 8007 (runs after playbook seeding).');
 }
 
 /**

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/BlogAudienceFilterTest.php
@@ -39,14 +39,44 @@ final class BlogAudienceFilterTest extends TestCase {
     $this->assertStringContainsString('function _myeventlane_front_apply_first_event_organiser_audience(): string', $source);
     $this->assertStringContainsString('function myeventlane_front_update_8008(): string', $source);
     $this->assertStringContainsString('function myeventlane_front_update_8009(): string', $source);
+
+    $update8006Start = strpos($source, 'function myeventlane_front_update_8006(): string');
     $update8007Start = strpos($source, 'function myeventlane_front_update_8007(): string');
+    $update8008Start = strpos($source, 'function myeventlane_front_update_8008(): string');
     $update8009Start = strpos($source, 'function myeventlane_front_update_8009(): string');
-    $audienceAfter8007 = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8007Start);
-    $audienceAfter8009 = strpos($source, '_myeventlane_front_apply_first_event_organiser_audience()', $update8009Start);
+    $this->assertNotFalse($update8006Start);
     $this->assertNotFalse($update8007Start);
+    $this->assertNotFalse($update8008Start);
     $this->assertNotFalse($update8009Start);
+
+    $update8006Body = substr($source, $update8006Start, $update8007Start - $update8006Start);
+    $this->assertStringNotContainsString(
+      '_myeventlane_front_apply_first_event_organiser_audience()',
+      $update8006Body,
+      '8006 must not apply organiser audience before playbook reseed in 8007.',
+    );
+
+    $update8007Body = substr($source, $update8007Start, $update8008Start - $update8007Start);
+    $playbookReseedPos = strpos($update8007Body, '_myeventlane_front_run_playbook_seeding()');
+    $audienceAfter8007 = strpos($update8007Body, '_myeventlane_front_apply_first_event_organiser_audience()');
+    $this->assertNotFalse($playbookReseedPos);
     $this->assertNotFalse($audienceAfter8007);
+    $this->assertLessThan(
+      $audienceAfter8007,
+      $playbookReseedPos,
+      '8007 must reseed playbooks before applying first-event organiser audience.',
+    );
+
+    $update8009Body = substr($source, $update8009Start);
+    $playbookReseedIn8009 = strpos($update8009Body, '_myeventlane_front_run_playbook_seeding()');
+    $audienceAfter8009 = strpos($update8009Body, '_myeventlane_front_apply_first_event_organiser_audience()');
+    $this->assertNotFalse($playbookReseedIn8009);
     $this->assertNotFalse($audienceAfter8009);
+    $this->assertLessThan(
+      $audienceAfter8009,
+      $playbookReseedIn8009,
+      '8009 must reseed playbooks before applying first-event organiser audience.',
+    );
   }
 
 }


### PR DESCRIPTION
… playbook seeding. Updated unit tests to ensure correct execution order and verify that audience is applied only after reseeding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Drupal update-hook ordering and idempotent content seeding only; no auth, API, or runtime behavior changes beyond deploy-time migrations.
> 
> **Overview**
> **Update hook 8006** no longer sets organiser audience on the first-event blog article; it only returns a deferred status message so that work runs in **8007** after playbook content exists.
> 
> **8007** and **8009** still run playbook seeding first, then apply first-event organiser audience—the change removes the premature audience step from 8006 that could run before reseeding.
> 
> **BlogAudienceFilterTest** now parses `myeventlane_front.install` to lock in that order: 8006 must not call the audience helper, and both 8007 and 8009 must call `_myeventlane_front_run_playbook_seeding()` before `_myeventlane_front_apply_first_event_organiser_audience()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20978a65c57734cda0d2a2fa8274f0d62e7a0566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->