### PR TITLE
Update calendar page event card description and remove unused event s…

### DIFF
--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -784,24 +784,6 @@ display:
             type: date
           group: 1
           exposed: false
-        field_event_start_value:
-          id: field_event_start_value
-          table: node__field_event_start
-          field: field_event_start_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_event_start
-          plugin_id: datetime
-          operator: '>='
-          value:
-            min: ''
-            max: ''
-            value: now
-            type: offset
-          group: 1
-          exposed: false
         field_event_start_value_2:
           id: field_event_start_value_2
           table: node__field_event_start

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2302,7 +2302,7 @@ function myeventlane_theme_preprocess_page__calendar(array &$variables): void {
 /**
  * Builds the calendar page "Upcoming this week" event card rail.
  *
- * Uses upcoming_events:embed_calendar_this_week (7-day window, 3 cards).
+ * Uses upcoming_events:embed_calendar_this_week (overlaps next 7 days, 3 cards).
  *
  * @return array
  *   Render array, or empty when the view is unavailable or has no results.


### PR DESCRIPTION
…tart value field from upcoming events view configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which events appear on the public calendar rail; verify multi-day and already-started events match product intent.
> 
> **Overview**
> Adjusts the **`upcoming_events`** view display **`embed_calendar_this_week`** (calendar page “Upcoming this week” rail, 3 cards) by **removing** the **`field_event_start >= now`** datetime filter. Selection now relies on start-not-empty, **start on or before now + 7 days**, and the existing **end ≥ now** / **no-end upcoming** OR group—so **in-progress multi-day events** can appear, not only those whose start is still in the future.
> 
> Updates the docblock on **`_myeventlane_theme_build_calendar_this_week_rail()`** to describe **overlap with the next 7 days** instead of a simple 7-day start window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277119be9b1c1767e26c2926490a5bda765a1e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->