### PR TITLE
Feature/event studio consolidation

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -130,7 +130,7 @@ final class EventStudioController extends ControllerBase {
       '@eid' => (string) $node->id(),
       '@uid' => (string) $this->currentUser()->id(),
     ]);
-    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $node->id()])->toString());
+    return new RedirectResponse(Url::fromRoute('myeventlane_event_studio.workspace_information', ['node' => $node->id()])->toString());
   }
 
   public function redirectEventToTicketsWorkspace(NodeInterface $event): RedirectResponse {

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -202,7 +202,7 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       'myeventlane_event.wizard.details',
       'myeventlane_event.wizard.review',
       'myeventlane_vendor.manage_event.content' => 'myeventlane_event_studio.workspace_content',
-      'myeventlane_vendor.manage_event.edit' => 'myeventlane_event_studio.edit',
+      'myeventlane_vendor.manage_event.edit' => 'myeventlane_event_studio.workspace_information',
       'myeventlane_vendor.manage_event.design',
       'myeventlane_vendor_comms.branding' => 'myeventlane_event_studio.workspace_branding',
       'myeventlane_vendor.manage_event.checkout_questions' => 'myeventlane_event_studio.workspace_questions',

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioRedirectController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorStudioRedirectController.php
@@ -80,7 +80,7 @@ final class VendorStudioRedirectController extends VendorConsoleBaseController i
       throw new AccessDeniedHttpException('Only event nodes can be edited in Event Studio.');
     }
 
-    $url = Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event->id()])->toString();
+    $url = Url::fromRoute('myeventlane_event_studio.workspace_information', ['node' => $event->id()])->toString();
     return new RedirectResponse($url, 302);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Redirect-only routing changes with no auth or data logic; low risk aside from vendors landing on a different default studio tab.
> 
> **Overview**
> **Event Studio edit entry** now redirects vendors to the **Information** workspace section instead of the default **Overview** shell.
> 
> The `buildEdit` handler, legacy **`manage_event.edit`** mapping in `VendorLegacyWizardRedirectSubscriber`, and the **`/vendor/events/{event}/editor`** redirect in `VendorStudioRedirectController` all target `myeventlane_event_studio.workspace_information` rather than `myeventlane_event_studio.workspace`. That matches how other “basic edit” legacy paths (e.g. wizard basics / when_where) already land, so “edit event” flows open on event details instead of overview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eccc54107d4b4123e2ba1f87aaf44636450e59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->