### PR TITLE
Improve mobile booking and checkout experience

### DIFF
--- a/docs/audits/mobile-conversion-opportunities.md
+++ b/docs/audits/mobile-conversion-opportunities.md
@@ -1,0 +1,276 @@
+# Mobile Conversion Opportunities
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-14  
+**Scope:** Public conversion funnel friction — homepage, discovery, event page, checkout, RSVP  
+**Method:** Repository evidence only (Twig, SCSS, JS, routing, prior audits). No code proposals.
+
+---
+
+## Branch verification
+
+| Check | Expected | Actual |
+|-------|----------|--------|
+| Branch | `feature/mobile-foundation` | `feature/brand-rollout-phase-1a-discovery-copy` |
+| Working tree | Clean | Dirty |
+
+**Browser testing:** Not executed in this audit. Findings from static code review and prior audit documents.
+
+---
+
+## Summary — highest conversion opportunity
+
+| Rank | Surface | Opportunity | Revenue lever |
+|------|---------|-------------|---------------|
+| 1 | **Book / checkout** | Reduce multi-step density and align mobile summary/CTA | Direct ticket revenue |
+| 2 | **Event detail → book** | Mobile CTA visibility and booking panel order | Funnel conversion |
+| 3 | **Discovery filters** | Touch targets and active state clarity | Browse → click-through |
+| 4 | **Homepage hero** | Category chip discoverability + search | Top-of-funnel |
+| 5 | **RSVP path reliability** | Tier data completeness on book page | Free event conversion |
+
+---
+
+## Homepage friction
+
+### O1 — Header breakpoint mismatch (768 vs 900px)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `_site-header.scss`: desktop nav hidden `@media (width <= 900px)` (lines 58, 117, 177, 253); `header.js` line 221: `matchMedia('(min-width: 768px)')` |
+| **User impact** | Between 768–899px, JS and CSS may disagree on mobile vs desktop nav state — confusing nav, hidden CTAs, or double menus |
+| **Implementation risk** | **Low–medium** — SCSS + JS alignment only; no routing changes |
+| **Estimated effort** | **S** (1–2 days) — token decision + test header drawer |
+
+### O2 — Hero category chip styling gap (partially addressed)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mel-discovery-event-page-polish-audit.md` P1: hero used `mel-category-chip` while `_hero.scss` styled `.mel-chip`; Task 9 added unified rules |
+| **User impact** | Category shortcuts below fold on mobile reduce discovery depth |
+| **Implementation risk** | **Low** — SCSS/Twig only |
+| **Estimated effort** | **S** — verify Task 9 merged; retest `/home` |
+
+### O3 — Featured carousel + hero density
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mobile-route-priority-map.md`: homepage 7/10; `_featured-carousel.scss`, `_home-hero.scss` |
+| **User impact** | Carousel swipe/scroll competition with primary "Find events" CTA |
+| **Implementation risk** | **Low** — locked hero variants rule applies; layout polish only |
+| **Estimated effort** | **M** — hero is high-visibility; careful diff |
+
+### O4 — Create-event CTA prominence on mobile
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `myeventlane-home-hero.html.twig`, `region--header.html.twig`, `mobile-drawer.twig` reference `myeventlane_vendor.create_event_gateway` |
+| **User impact** | Vendor acquisition secondary to attendee discovery on mobile drawer |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** — IA/copy decision, not Commerce |
+
+---
+
+## Discovery friction
+
+### O5 — Category pill / chip class fragmentation
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `component-system-inventory.md`: `.mel-chip`, `.mel-category-chip`, `.mel-pill`, `.mel-filter-chip`; templates: `mel-page-header.html.twig`, `hero.html.twig`, `mel-events-discovery-filters.html.twig` |
+| **User impact** | Inconsistent tap targets and active states across `/events`, category pages, homepage |
+| **Implementation risk** | **Low–medium** — multiple SCSS files; regression on listing pages |
+| **Estimated effort** | **M** — consolidate naming in docs first; incremental SCSS |
+
+### O6 — Horizontal category strip overflow
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mel-page-header.html.twig` — `.mel-category-strip` horizontal pills; `_mel-browse.scss` strip rules |
+| **User impact** | Horizontal scroll without clear affordance on 390px; categories off-screen |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S–M** — scroll snap / fade edge pattern |
+
+### O7 — Event card touch and motion
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | Task 9 added `prefers-reduced-motion` on `_event-card.scss`; card hover lift/zoom |
+| **User impact** | Cards are primary click target to event detail |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** — verify 44px min touch on card meta links |
+
+### O8 — Search route integration
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `myeventlane_search.routing.yml`: `/search`, `/search/autocomplete` |
+| **User impact** | Mobile search UX not scored in Phase 2A map |
+| **Implementation risk** | **Unknown** — autocomplete mobile keyboard behavior not audited in depth |
+| **Estimated effort** | **M** — needs dedicated pass; **repository evidence not found** for mobile-specific search SCSS |
+
+---
+
+## Event page friction
+
+### O9 — Booking sidebar below long main column (addressed in Task 10)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mel-event-full-page-polish-audit.md` P1: mobile flex order — sidebar `order: 1`, main `order: 2` |
+| **User impact** | Users scroll past content before seeing book CTA |
+| **Implementation risk** | **Low** if fix present on branch |
+| **Estimated effort** | **S** — verify CSS deployed |
+
+### O10 — Multi-column hero / gallery breakpoint splits
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `_event-full.scss` (29 `@media`); `_event-gallery.scss` (900px, 767px, 899px) |
+| **User impact** | Layout shifts, cropped images, horizontal scroll on gallery |
+| **Implementation risk** | **Medium** — large SCSS file |
+| **Estimated effort** | **L** — phased breakpoint alignment |
+
+### O11 — Mobile sticky CTA bar vs in-page booking panel
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `_event-mobile-cta.scss`; `node--event--full.html.twig` mobile bar; `mel-booking-summary.js` |
+| **User impact** | Duplicate CTAs or obscured content if bar overlaps footer |
+| **Implementation risk** | **Medium** — JS + CSS coordination |
+| **Estimated effort** | **M** |
+
+### O12 — CTA label consistency (partially addressed)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | Task 10: `mel_booking_action_label`, "Book free RSVP" copy; `BookController` CTA resolver |
+| **User impact** | Wrong label reduces trust on RSVP vs paid |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** |
+
+### O13 — Share control touch targets (partially addressed)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | Task 10: `.mel-social` 40px → 44px |
+| **User impact** | Secondary to conversion but affects viral loop |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** |
+
+---
+
+## Checkout friction
+
+### O14 — Multi-pane density on single column
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `_checkout.scss` (20 `@media`); checkout flow panes: `mel_buyer_details`, `ticket_holder_paragraph`, `mel_donation`, `mel_legal_consent`, `payment_information`, sidebar `order_summary` (`mel-booking-checkout-verification.md`) |
+| **User impact** | Long scroll before payment; abandonment on mobile |
+| **Implementation risk** | **High** if pane order/visibility touched — Commerce config |
+| **Estimated effort** | **L** — visual-only reorder already done in cart audit Twig |
+
+### O15 — Sidebar order summary on narrow viewports
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `commerce-checkout-form--with-sidebar.html.twig`; `mel-operational-checkout.css` |
+| **User impact** | Summary below fold or squeezed — users lack price anchor while filling forms |
+| **Implementation risk** | **Medium** — layout only |
+| **Estimated effort** | **M** — sticky summary pattern |
+
+### O16 — Table-like order review
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `views-view-table--commerce-checkout-order-summary.html.twig`; `mobile-route-priority-map.md` checkout "table-like order review" |
+| **User impact** | Horizontal scroll on line items |
+| **Implementation risk** | **Medium** |
+| **Estimated effort** | **M** |
+
+### O17 — Trust copy repetition (addressed Task 11)
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mel-cart-checkout-visual-trust-polish.md`: reduced to two compact trust strings |
+| **User impact** | Scroll fatigue before pay button |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** — verify on branch |
+
+### O18 — Cart → checkout handoff clarity
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | Task 11: `mel-cart-event-overview` chips vs misleading grouped table |
+| **User impact** | Users unsure which event tickets belong to |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** |
+
+---
+
+## RSVP friction
+
+### O19 — RSVP redirect to unified book page
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `myeventlane_rsvp.routing.yml`: `/event/{event}/rsvp` → `RsvpRedirectController::redirectToBooking`; book builds `RsvpPublicForm` when RSVP tiers exist |
+| **User impact** | Extra redirect hop; URL expectations (`/rsvp` vs `/book`) |
+| **Implementation risk** | **Low** for UX copy; **medium** if route changed |
+| **Estimated effort** | **S** (copy/labels) / **M** (route IA) |
+
+### O20 — Missing ticket tiers blocks RSVP
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `mel-booking-checkout-verification.md`: events 1375/1377 show RSVP CTA but `field_ticket_types` count = 0 → "RSVP is not yet available" |
+| **User impact** | **High** — dead-end after marketing RSVP event |
+| **Implementation risk** | **High** — data model / Event Studio publish pipeline, not CSS |
+| **Estimated effort** | **L** — vendor tooling + validation; outside mobile SCSS scope |
+
+### O21 — RSVP thank-you mobile layout
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `rsvp-thankyou.css`; route `/event/{event}/rsvp/thank-you` |
+| **User impact** | Post-conversion calendar/add-to-wallet CTAs |
+| **Implementation risk** | **Low** |
+| **Estimated effort** | **S** |
+
+### O22 — Paid vs RSVP book form density
+
+| Field | Detail |
+|-------|--------|
+| **Evidence** | `myeventlane-event-book.html.twig` — `mel-booking-summary` mobile panel; `_booking-page.scss` |
+| **User impact** | Ticket selection + summary visibility drives add-to-cart |
+| **Implementation risk** | **Medium** — Commerce form |
+| **Estimated effort** | **M** |
+
+---
+
+## Opportunity priority for Phase 1
+
+| ID | Opportunity | User impact | Risk | Effort | Phase 1? |
+|----|-------------|-------------|------|--------|----------|
+| O1 | Header 768/900 alignment | High | Low–med | S | **Yes** |
+| O14–O16 | Checkout mobile density | **Critical** | Med–high | L | **Yes** (visual scope) |
+| O22 | Book page summary panel | **Critical** | Med | M | **Yes** |
+| O9–O11 | Event detail CTA order/bar | High | Med | M | **Yes** |
+| O5–O6 | Discovery chips/strip | High | Low–med | M | Partial |
+| O20 | RSVP tier data gaps | High | **High** | L | **No** — data/vendor |
+| O10 | Event gallery breakpoints | Med | Med | L | Phase 2 |
+
+---
+
+## What not to treat as mobile conversion work
+
+| Item | Reason |
+|------|--------|
+| Stripe / payment gateway changes | Commerce safety rules |
+| Checkout pane enable/disable in config | Config export + Commerce risk |
+| Event Studio publish logic | Vendor backend |
+| Vendor orders table redesign | Blocked on design system (`mobile-design-system-readiness.md`) |
+
+---
+
+**Mobile conversion audit complete. No code proposed.**

--- a/docs/audits/mobile-css-review.md
+++ b/docs/audits/mobile-css-review.md
@@ -1,0 +1,171 @@
+# Mobile CSS Ownership Review
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-14  
+**Input:** `css-ownership-map.md`, `mobile-breakpoint-inventory.md`, `component-system-inventory.md`  
+**Status:** Audit only — document conflicts; do not remove code
+
+---
+
+## Branch verification
+
+| Check | Expected | Actual |
+|-------|----------|--------|
+| Branch | `feature/mobile-foundation` | `feature/brand-rollout-phase-1a-discovery-copy` |
+| Working tree | Clean | Dirty (unrelated Twig edits) |
+
+---
+
+## Ownership model (confirmed)
+
+| Owner | Build output | Scope | Entry |
+|-------|--------------|-------|-------|
+| `myeventlane_theme` | Vite → `dist/main.css` | Public site, shared `mel-*` system | `src/scss/main.scss` |
+| `myeventlane_vendor_theme` | Vite → `dist/main.css`, `dist/workspace.css` | Vendor console under `.mel-vendor` | `src/scss/main.scss`, `workspace.scss` |
+| Custom modules | Static CSS libraries | Per-route attachments | `*.libraries.yml` |
+| `myeventlane_radix` | Sub-theme SCSS | Legacy overlap | Partial duplication with public theme |
+
+Event Studio shell header in `mel-event-studio-shell.css` states: **module owns layout grid**; theme may layer colour/typography only.
+
+---
+
+## Canonical component owners (recommended targets)
+
+Per `canonical-design-system.md` and repository structure:
+
+| Component | Canonical owner | Responsibility |
+|-----------|-----------------|----------------|
+| **Breakpoints / media** | `myeventlane_theme/src/scss/tokens/_breakpoints.scss` + `@mixin mel-break` | Cross-surface token map (once unified) |
+| **Buttons `.mel-btn`** | `myeventlane_theme/src/scss/components/_buttons.scss` | Global variants, touch sizes |
+| **Form actions** | `_mel-buttons.scss` (`.mel-form-system` scope) | Drupal submit mapping only |
+| **Cards `.mel-card`** | `_cards.scss` + `_mel-cards.scss` | Base + governed modifiers |
+| **Forms** | `_mel-forms.scss`, `_mel-form-states.scss`, `base/_forms.scss` | Governed form shell |
+| **Tables** | `_mel-tables.scss` + legacy `_tables.scss` | Responsive stack/scroll |
+| **Public navigation** | `_site-header.scss`, `layout/_navigation.scss`, `header.js` | Mobile overlay nav |
+| **Empty states** | `_mel-empty-states.scss` | Single BEM block target |
+| **Modals / overlays** | `_mel-modals.scss`, `_mel-overlays.scss` | Governed surfaces |
+| **Checkout layout** | `_checkout.scss` | Public commerce flow |
+| **Event page layout** | `_event-full.scss`, `_booking-page.scss`, `_event-mobile-cta.scss` | Public event + book |
+| **Event Studio layout** | `myeventlane_event_studio/css/mel-event-studio-shell.css` | Grid, sidebar, topbar (module) |
+| **Event Studio nav polish** | `mel-event-studio-nav.css` | Section list styling |
+| **Vendor shell nav** | `myeventlane_vendor_theme.theme` + `layout/_navigation.scss` | PHP + SCSS split |
+
+---
+
+## Duplicate ownership
+
+| Component | Locations | Conflict nature |
+|-----------|-----------|-----------------|
+| **`.mel-btn`** | Public `_buttons.scss`; vendor `_buttons.scss`; `mel-event-studio.css`; RSVP/checkout module CSS | Gradient vs flat; vendor redefines base under `.mel-vendor` |
+| **`.mel-card`** | Public `_cards.scss` + `_mel-cards.scss`; vendor `_cards.scss`; `_event-card.scss`; module teasers | Different token sources (`$mel-color-surface` vs `$ml-vendor-card`) |
+| **Forms** | `_mel-forms.scss`; vendor `_forms.scss`, `_event-form.scss` (94× `!important`) | Drupal markup override wars |
+| **Tables** | `_mel-tables.scss`, `_tables.scss`; vendor `_event-table.scss`; commerce module CSS | Multiple 767/768px stack rules |
+| **Tabs** | Vendor `_tabs.scss`; `simple-tabs.css`; `_wizard.scss` | Three styling sources |
+| **Empty states** | `_mel-empty-states.scss`; vendor `_empty-states.scss`; `_mel-browse.scss` `.mel-empty` | Class fragmentation (`.mel-empty` vs `.mel-empty-state`) |
+| **Toasts / alerts** | `_toasts.scss`; vendor `_vendor-alert.scss`, `_notifications.scss` | Parallel patterns |
+| **Category filters** | `_category-pills.scss`; `_mel-events-filters.scss`; hero `.mel-chip` vs `.mel-category-chip` | Naming fragmentation |
+| **KPI cards** | Vendor `_kpi-cards.scss`; `_mel-metrics.scss` | Duplicate metric card patterns |
+| **Breakpoint systems** | Public `sm: 480px`; vendor `sm: 640px`; parallel mixins `mel-break` vs `respond-to` | **Structural duplication** |
+| **Vendor compiles public SCSS** | Vendor `main.scss` lines 90–103 `@mel-theme/components/*` | Second copy of public rules inside `.mel-vendor` **plus** local `_buttons.scss`, `_cards.scss` |
+
+---
+
+## Conflicting ownership (highest risk)
+
+| Surface | Parties | Evidence | Mobile impact |
+|---------|---------|----------|---------------|
+| **Event Studio shell** | `mel-event-studio-shell.css` (~5.4k lines, 23 `@media`); theme `_event-studio.scss`; vendor `_mel-builder.scss` (21 `@media`, 30× `!important`) | `grid-template-columns: 280px 1fr` at line 19; onboarding `200px 280px 1fr` | Horizontal scroll / unusable sidebar at 390px |
+| **Event Studio buttons/forms** | `mel-event-studio.css` vs theme `_buttons.scss` / `_mel-forms.scss` | Module redefines `.mel-btn` base | Inconsistent touch targets |
+| **Vendor event forms** | `_event-form.scss` (94× `!important`) vs module + Drupal core form CSS | Highest `!important` count in themes | Unpredictable mobile field layout |
+| **Public header** | `_site-header.scss` uses **900px**; `header.js` uses **768px** matchMedia | 4+ `@media (width <= 900px)` in `_site-header.scss` | Nav drawer/state mismatch between 768–900px |
+| **Event gallery** | `_event-gallery.scss` — 900px, 767px, 899px | Hardcoded cuts alongside tokens | Layout jumps on event detail |
+| **Checkout** | `_checkout.scss` (20 `@media`); `mel-operational-checkout.css`; `mel-checkout.js` | Module + theme both style checkout | Multi-column bleed on narrow viewports |
+| **Live ops / dashboard** | `_live-operations.scss` (31× `!important`); vendor dashboard pages | Grid density | KPI overflow on mobile |
+| **Cart** | `commerce/_commerce.scss` (active) vs `components/_cart.scss` (**not** in `main.scss`) | Legacy duplicate file | Dead-code confusion risk |
+
+---
+
+## Potential dead code (flag only — do not remove)
+
+| Item | Evidence | Status |
+|------|----------|--------|
+| **`components/_cart.scss`** | Not `@use`'d in public `main.scss`; cart rules in `commerce/_commerce.scss` per cart audit | **Likely dead / legacy duplicate** |
+| **Vendor `vendor-studio-editor` import** | `myeventlane_vendor_theme/src/scss/main.scss` line 92 | Staff shell retired Phase 1E — **orphan import risk** |
+| **Vendor `studio-inspector` import** | Same file line 93 | **Orphan import risk** |
+| **`myeventlane_core/css/studio-layout.css`** | Listed in css-ownership-map; relationship to Event Studio shell **not fully traced** | **Unknown** |
+| **`myeventlane_radix` component SCSS** | `_event-card.scss` with 700px/1100px breakpoints | **Legacy** — may still load if radix active |
+| **`myeventlane_vendor/css/manage-event.css`** | Marked legacy in ownership map | Legacy manage-event overrides |
+| **Parallel sm token (640 vs 480)** | Not dead but **duplicate system** — vendor rules at 640px may never align with public 480px components on shared surfaces | Consolidation candidate |
+
+---
+
+## `!important` hotspots (ownership fight markers)
+
+| File | Approx. count | Interpretation |
+|------|---------------|----------------|
+| `myeventlane_vendor_theme/.../_event-form.scss` | 94 | Form layout vs Drupal/Gin markup |
+| `myeventlane_vendor_theme/.../_settings.scss` | 34 | Settings page overrides |
+| `myeventlane_theme/.../_live-operations.scss` | 31 | Dashboard live ops grid |
+| `myeventlane_vendor_theme/.../_mel-builder.scss` | 30 | Event Studio builder vs module shell |
+| `mel-event-studio-shell.css` | Present (e.g. `.mel-builder` grid) | Module layout enforcement |
+
+**Interpretation:** Clusters mark boundaries where mobile consolidation will fail if attempted via overrides alone. Markup/ownership fixes required (`canonical-design-system.md` §8).
+
+---
+
+## Module CSS overlap (selected)
+
+70+ module CSS files under `web/modules/custom/*/css/` contain `.mel-` classes. Highest mobile overlap risk:
+
+| Module CSS | Role | Overlap |
+|------------|------|---------|
+| `mel-event-studio-shell.css` | Studio grid, sidebar, topbar | **High** — layout owner |
+| `mel-event-studio.css` | Forms, buttons, touch targets | **High** — duplicates theme buttons |
+| `event-builder-preview.css` | Public booking preview | **Medium** |
+| `mel-operational-checkout.css` | Checkout columns | **Medium** |
+| `analytics.css` | Vendor charts/tables | **Medium** |
+| `rsvp-thankyou.css` | Confirmation cards | **Low** |
+
+---
+
+## Breakpoint fragmentation (CSS-level mobile blocker)
+
+From `mobile-breakpoint-inventory.md`:
+
+| Classification | Evidence |
+|----------------|----------|
+| **Canonical (public)** | `mel-break`; sm 480, md 768, lg 1024, xl 1280 |
+| **Duplicate (vendor)** | `respond-to`; sm **640** (≠ public 480) |
+| **Conflicting hardcoded** | 479, 600, 767, 900, 959px across theme + module CSS |
+| **390px style guide** | **Evidence not found** in theme SCSS |
+| **Drupal breakpoints.yml** | **Evidence not found** |
+
+**Mobile CSS conclusion:** Implementation must start with **token unification** before route-level layout work, or each surface will continue using incompatible cut points.
+
+---
+
+## Consolidation readiness by component
+
+| Component | Ready to implement mobile fixes? | Blocker |
+|-----------|----------------------------------|---------|
+| Public header | **Partial** | 900px vs 768px conflict |
+| Buttons | **No** | Triple definition |
+| Cards | **No** | Dual token systems |
+| Forms (vendor) | **No** | 94× `!important` |
+| Event Studio layout | **No** | Module owns grid; theme fights |
+| Checkout SCSS | **Partial** | Visual-only scope OK; module CSS parallel |
+| Tables (vendor orders) | **No** | No single stack pattern |
+| Empty states | **Partial** | Class name fragmentation |
+
+---
+
+## Audit actions (documentation only)
+
+1. Treat `mel-event-studio-shell.css` as **layout source of truth** for Studio — theme must not re-grid without module coordination.
+2. Treat public `_buttons.scss` + `_mel-buttons.scss` as **target canonical** for buttons — vendor base redeclaration is tech debt.
+3. Flag orphan vendor imports (`vendor-studio-editor`, `studio-inspector`) for Phase 2B verification before removal.
+4. Do not delete `_cart.scss` until grep confirms zero references and build output parity.
+
+---
+
+**Mobile CSS review complete. No files removed or edited.**

--- a/docs/audits/mobile-design-system-readiness.md
+++ b/docs/audits/mobile-design-system-readiness.md
@@ -1,0 +1,141 @@
+# Mobile Design System Readiness
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-14  
+**Inputs:** `canonical-design-system.md`, `component-system-inventory.md`, `mobile-breakpoint-inventory.md`, `css-ownership-map.md`  
+**Status:** Readiness assessment only — no implementation
+
+---
+
+## Branch verification
+
+| Check | Expected | Actual |
+|-------|----------|--------|
+| Branch | `feature/mobile-foundation` | `feature/brand-rollout-phase-1a-discovery-copy` |
+| Working tree | Clean | Dirty |
+
+---
+
+## Readiness categories
+
+| Status | Meaning |
+|--------|---------|
+| **Ready** | Repository evidence supports implementation with a single canonical owner and acceptable mobile baseline |
+| **Needs Consolidation** | Component exists but conflicting patterns, duplicate owners, or token mismatch block safe mobile work |
+| **Blocked** | Missing repository evidence, unresolved ownership, or high Commerce/vendor risk |
+
+---
+
+## Ready
+
+Components with sufficient evidence and a clear canonical path for Phase 1 mobile work (visual/breakpoint alignment only):
+
+| Component | Canonical owner | Evidence | Mobile notes |
+|-----------|-----------------|----------|--------------|
+| **Public container / layout spacing** | `layout/_container.scss` | Uses `mel-break(md)`, `mel-break(lg)` | Token-aligned |
+| **Governed form states** | `_mel-form-states.scss` | Part of `.mel-form-system` | Touch targets documented in `_mel-buttons.scss` for form actions |
+| **Governed modals / overlays** | `_mel-modals.scss`, `_mel-overlays.scss` | Single BEM system | Drawer patterns exist |
+| **Governance states / readiness** | `_mel-states.scss`, `_mel-readiness.scss` | Studio/vendor governed UI | Not primary mobile funnel |
+| **Trust / policy banners** | `_mel-trust-policy.scss`, `_mel-reassurance.scss` | Checkout/cart trust copy patterns | Used in cart/checkout polish |
+| **RSVP thank-you** | `myeventlane_rsvp/css/rsvp-thankyou.css` | Low overlap risk per css-ownership-map | Small surface |
+| **Checkout completion** | `commerce-checkout-completion.html.twig` | Post-purchase; visual-only scope | Lower risk than checkout form |
+| **Public mobile CTA bar (event)** | `_event-mobile-cta.scss` | Imported in `main.scss` | Exists; may need breakpoint alignment only |
+| **Klaro consent** | `_klaro-consent.scss` | Cross-theme intentional include | Mobile overlay styling present |
+
+**Caveat:** "Ready" means **safe to touch for breakpoint/token alignment**, not that the component is fully mobile-optimized at 390px.
+
+---
+
+## Needs Consolidation
+
+Components with repository-confirmed duplication or conflicting patterns — mobile implementation requires consolidation first or strict scoped diffs:
+
+| Component | Conflicting patterns | Owners | Blocker for mobile |
+|-----------|---------------------|--------|-------------------|
+| **Breakpoint system** | Public `sm: 480px`; vendor `sm: 640px`; hardcoded 900/767/479px | `_breakpoints.scss` (both themes); 470+ `@media` in theme SCSS | Inconsistent collapse points across funnel |
+| **Buttons `.mel-btn`** | Variants: primary, secondary, ghost, destructive, sm, lg, touch, coral | Public + vendor `_buttons.scss`; `mel-event-studio.css` | Touch size inconsistency; gradient vs flat |
+| **Cards `.mel-card`** | `--static`, `--governed`, event extensions | Public + vendor + `_event-card.scss` | Different surface tokens |
+| **Forms (vendor Event Studio)** | `.mel-form-system` vs heavy overrides | `_mel-forms.scss` vs vendor `_event-form.scss` (94× `!important`) | Field layout unpredictable on narrow screens |
+| **Tables** | Stack at 767px in multiple files | `_tables.scss`, `_mel-tables.scss`, vendor `_event-table.scss` | No single mobile card-stack pattern for orders |
+| **Tabs** | Console, wizard, simple-tabs | Vendor `_tabs.scss`, `simple-tabs.css`, `_wizard.scss` | Three sources |
+| **Public navigation** | Overlay nav + drawer | `_site-header.scss` (900px) vs `header.js` (768px) | State mismatch 768–900px |
+| **Empty states** | `.mel-empty` vs `.mel-empty-state` | `_mel-empty-states.scss`, vendor `_empty-states.scss`, `_mel-browse.scss` | Markup/class drift |
+| **Category chips / pills** | `.mel-chip`, `.mel-category-chip`, `.mel-pill`, `.mel-filter-chip` | Hero, browse, event-full, category-pills | Partially fixed in Task 9; naming still fragmented |
+| **Toasts / alerts** | `.mel-toast` vs vendor alert | `_toasts.scss`, `_vendor-alert.scss` | Duplicate stacks |
+| **Badges / status** | `.mel-badge`, `.mel-status`, `.mel-status-badge` | Vendor `_badges.scss`, `_sla-badge.scss` | Naming duplication |
+| **Event page layout** | 29 `@media` in `_event-full.scss`; gallery 900px cuts | Theme SCSS + `event-builder-preview.css` | Large surface; incremental only |
+| **Checkout layout** | 20 `@media`; module `mel-operational-checkout.css` | `_checkout.scss` + module | Sidebar + pane density |
+| **Cart layout** | Active `commerce/_commerce.scss` vs orphan `_cart.scss` | Theme | Confusion risk |
+| **Event Studio shell** | Module grid + theme polish + vendor builder | `mel-event-studio-shell.css`, `_event-studio.scss`, `_mel-builder.scss` | **Primary consolidation target** before mobile layout |
+| **Event Studio navigation** | Section nav CSS split | `mel-event-studio-nav.css`, `_event-studio.scss` | Drawer pattern proposed, not implemented |
+| **Vendor KPI / metrics** | `.mel-kpi-card` vs `_mel-metrics.scss` | Vendor theme | 479px hardcoded stack |
+| **Vendor theme public SCSS recompile** | `@mel-theme/components/*` in vendor `main.scss` | Structural duplication | Changes to public tokens affect vendor twice |
+
+---
+
+## Blocked
+
+Components or system claims that **cannot** be implemented safely without additional evidence, product sign-off, or prerequisite work:
+
+| Item | Reason | Evidence |
+|------|--------|----------|
+| **390px enforced baseline** | No 390px token in theme SCSS | `mobile-breakpoint-inventory.md`: "Evidence not found" |
+| **Drupal responsive image breakpoints** | No `*.breakpoints.yml` in repo | `mobile-breakpoint-inventory.md` |
+| **Single design system (implemented)** | Acceptance criteria in `canonical-design-system.md` §8 not met | Multiple button/card/breakpoint owners |
+| **Event Studio mobile sidebar → drawer** | Module owns layout grid; 280px fixed columns | `mel-event-studio-shell.css` lines 19–42 |
+| **Vendor orders mobile table → cards** | No canonical responsive table component; table-first UI score 3/10 | `mobile-route-priority-map.md`; `_event-table.scss` |
+| **Vendor form `!important` reduction** | Requires Drupal/Gin markup alignment | 94× in `_event-form.scss` |
+| **Commerce checkout logic / pane changes** | High Commerce/Stripe risk | Project rules; checkout flow config |
+| **`myeventlane_core/css/studio-layout.css` role** | Relationship to Event Studio shell not traced | `css-ownership-map.md` |
+| **Dead SCSS import removal** | `vendor-studio-editor`, `studio-inspector` — usage not verified in this audit | Vendor `main.scss` 92–93 |
+| **Unified sm token (480 vs 640)** | Requires product sign-off per `canonical-design-system.md` | Conflicting today |
+| **Legacy radix components** | Parallel breakpoints (700px, 1100px) | `myeventlane_radix` — active theme status not re-verified in this audit |
+
+---
+
+## Component readiness matrix
+
+| Component | Status | Phase 1 touch? |
+|-----------|--------|----------------|
+| Breakpoint tokens | **Needs Consolidation** | **Yes** — prerequisite |
+| `.mel-btn` | **Needs Consolidation** | Scoped public-only OK |
+| `.mel-card` | **Needs Consolidation** | Scoped public-only OK |
+| `.mel-form-system` | **Needs Consolidation** (vendor) | Public checkout panes only |
+| Public header nav | **Needs Consolidation** | **Yes** — align 900→768 |
+| Event mobile CTA | **Ready** | **Yes** |
+| Checkout SCSS | **Needs Consolidation** | Visual-only **Yes** |
+| Event full layout | **Needs Consolidation** | Incremental only |
+| Event Studio shell | **Blocked** | **No** — Phase 2+ |
+| Vendor orders tables | **Blocked** | **No** — needs pattern |
+| Empty states | **Needs Consolidation** | Low priority |
+| Modals / overlays | **Ready** | As needed |
+| RSVP thank-you | **Ready** | Low priority |
+
+---
+
+## Design system acceptance gap
+
+From `canonical-design-system.md` §8, MEL cannot claim a single implemented design system until:
+
+1. One breakpoint map in both themes — **not met** (480 vs 640 sm)
+2. One `.mel-btn` definition — **not met**
+3. One `.mel-card` base — **not met**
+4. Event Studio 390px without horizontal scroll — **not verified** (manual QA required)
+5. Reduced `!important` in `_event-form.scss` and `_mel-builder.scss` — **not met**
+
+---
+
+## Recommended consolidation sequence (documentation)
+
+| Step | Component | Unblocks |
+|------|-----------|----------|
+| 1 | Breakpoint token map + deprecate 900px header cut | Public nav, event gallery, checkout |
+| 2 | Public `.mel-btn` touch sizes documented as canonical | Book, checkout CTAs |
+| 3 | Remove dead vendor SCSS imports (after grep verification) | Build clarity |
+| 4 | Event Studio shell mobile (module-led) | Vendor P0 routes |
+| 5 | Table → card stack pattern in `_mel-tables.scss` | Orders, attendees |
+| 6 | Vendor button/card dedup | Vendor dashboard |
+
+---
+
+**Design system readiness review complete. No implementation.**

--- a/docs/audits/mobile-foundation-implementation-roadmap.md
+++ b/docs/audits/mobile-foundation-implementation-roadmap.md
@@ -1,0 +1,261 @@
+# Mobile Foundation Implementation Roadmap
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-14  
+**Inputs:** All Phase 2A audits + this review suite (`mobile-phase-1-priority-review.md`, `mobile-css-review.md`, `mobile-design-system-readiness.md`, `mobile-conversion-opportunities.md`)  
+**Status:** Recommendation only — no implementation on this pass
+
+---
+
+## Branch verification (preflight for implementation)
+
+| Check | Expected | Actual at review time |
+|-------|----------|----------------------|
+| Branch | `feature/mobile-foundation` | **`feature/brand-rollout-phase-1a-discovery-copy`** |
+| Working tree | Clean | **Dirty** — 3 modified Twig files |
+
+**Action before implementation:** `git checkout feature/mobile-foundation` (or branch from it) and ensure clean tree.
+
+---
+
+## Executive summary
+
+MEL's mobile foundation work should **not** start with Event Studio or vendor orders despite their low mobile scores. Repository evidence shows **triple CSS ownership** (public theme, vendor theme, module CSS) and **breakpoint fragmentation** (480 vs 640 sm, 900px vs 768px nav). The safest Phase 1 delivers **public conversion funnel** improvements with **visual/breakpoint-only** diffs, anchored on token unification and five bounded components.
+
+**Highest UX risk:** Vendor Event Studio shell (280px grid) and orders tables — defer.  
+**Highest technical risk:** Event Studio CSS ownership + vendor `_event-form.scss` (94× `!important`).  
+**Highest mobile conversion opportunity:** Book page + checkout completion path.
+
+---
+
+## Recommended Phase 1
+
+**Goal:** Mobile-first public conversion path at unified `md` (768px) breakpoint without Commerce logic changes.
+
+### Routes (maximum 3)
+
+| # | Route | Path | Rationale |
+|---|-------|------|-----------|
+| 1 | `myeventlane_commerce.event_book` | `/event/{node}/book` | Unified paid + RSVP cart entry; `mel-booking-summary` mobile panel |
+| 2 | `commerce_checkout.form` | `/checkout/{commerce_order}/{step}` | Revenue completion; 20 `@media` in `_checkout.scss`; visual-only scope |
+| 3 | `entity.node.canonical` (event full) | Event detail alias | Funnel step before book; `_event-mobile-cta.scss` + sidebar order |
+
+**Explicitly excluded from Phase 1 routes:** Homepage (7/10 — defer to Phase 2 token pass), Event Studio, vendor orders.
+
+### Components (maximum 5)
+
+| # | Component | Owner file(s) | Phase 1 scope |
+|---|-----------|---------------|---------------|
+| 1 | **Breakpoint tokens** | `myeventlane_theme/src/scss/tokens/_breakpoints.scss` | Document canonical map; align public header cut to `md` (768px) — **no vendor sm change yet** |
+| 2 | **Public header nav** | `_site-header.scss`, `header.js` | Resolve 900px vs 768px mismatch (conversion O1) |
+| 3 | **Event mobile CTA** | `_event-mobile-cta.scss` | Sticky bar spacing/overlap at md max |
+| 4 | **Booking page layout** | `_booking-page.scss`, book Twig | Summary panel visibility on narrow viewports |
+| 5 | **Checkout layout** | `_checkout.scss` | Sidebar/summary stack; pane spacing — **no pane plugin/config changes** |
+
+### Phase 1 deliverable shape
+
+- Small, reviewable diffs in **theme SCSS/JS + Twig only**
+- No `config/sync` export
+- No module PHP or Commerce checkout flow changes
+- No Event Studio shell CSS
+
+---
+
+## Recommended Phase 2
+
+**Goal:** Discovery + homepage alignment; begin vendor-readiness without Event Studio grid surgery.
+
+### Routes
+
+| Route | Path | Focus |
+|-------|------|-------|
+| Homepage | `/home` | Hero chips, carousel, featured events |
+| Discovery | `/events`, `/events/category/*`, `/search` | Category strip, filter chips, event cards |
+| Cart | `/cart` | Trust copy, event chips (verify Task 11 merged) |
+
+### Components
+
+| Component | Work |
+|-----------|------|
+| Category chips/pills | Consolidate `.mel-chip` / `.mel-category-chip` / `.mel-pill` active states |
+| Event cards | Touch targets, reduced-motion (extend Task 9 patterns) |
+| Event full layout | Incremental `_event-full.scss` breakpoint alignment (not full rewrite) |
+| Vendor breakpoint import | Vendor theme consumes public `@mel-theme/tokens/breakpoints` for **new** rules only |
+| Dead SCSS audit | Verify and remove orphan `vendor-studio-editor` / `studio-inspector` imports if unused |
+
+### Prerequisites from Phase 1
+
+- Phase 1 breakpoint/header alignment merged and QA'd at 390px and 768px
+- `npm run mel:lint` + `npm run mel:build` green
+
+---
+
+## Recommended Phase 3
+
+**Goal:** Vendor mobile — module-led Event Studio layout; orders responsive pattern.
+
+### Routes
+
+| Route | Path | Focus |
+|-------|------|-------|
+| Event Studio | `/vendor/events/{node}/studio/*` | Sidebar → drawer (module `mel-event-studio-shell.css` led) |
+| Vendor orders | `/vendor/event/{event}/orders` | Table → card stack via `_mel-tables.scss` pattern |
+| Vendor dashboard | `/vendor/dashboard` | KPI grid stack; live ops density |
+
+### Components
+
+| Component | Work |
+|-----------|------|
+| Event Studio shell | Coordinated module + theme; reduce `_mel-builder.scss` override wars |
+| Responsive tables | Canonical stack pattern in `_mel-tables.scss` |
+| Vendor button/card dedup | Remove vendor base redeclaration per `canonical-design-system.md` |
+| Module CSS slimming | Stop `.mel-btn` redefinition in `mel-event-studio.css` |
+
+### Blockers
+
+- Product sign-off on sm token (480 vs 640 vs 390)
+- Manual QA: Event Studio at 390px without horizontal scroll
+- Orders pattern must not break CSV export / row actions
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Breakpoint change regressions** | High | Limit Phase 1 to public theme; visual QA at 390, 768, 900, 1024 |
+| **Commerce checkout pane order** | High | Twig render order only; do not alter `commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml` |
+| **Event Studio ownership fight** | Very high | Defer to Phase 3; module owns grid |
+| **Vendor theme recompiles public SCSS** | Medium | Phase 1 avoids vendor `main.scss`; Phase 2 token import is additive |
+| **RSVP tier data gaps (O20)** | High (conversion) | Separate vendor/data ticket — not mobile CSS |
+| **Locked hero variants** | Medium | Homepage Phase 2 respects hero lock rule |
+| **Parallel branch dirty state** | Process | Clean checkout from `feature/mobile-foundation` |
+| **390px token not in repo** | Medium | Use 768 md max as interim; flag 390 for product sign-off |
+
+---
+
+## Dependencies
+
+```mermaid
+flowchart TD
+  A[Phase 1: Breakpoint + public header align] --> B[Phase 1: Book + event CTA + checkout SCSS]
+  B --> C[Phase 2: Discovery + homepage]
+  C --> D[Phase 2: Vendor token import]
+  D --> E[Phase 3: Event Studio shell mobile]
+  E --> F[Phase 3: Orders table pattern]
+  F --> G[Phase 3: Vendor component dedup]
+```
+
+| Dependency | Blocks |
+|------------|--------|
+| Breakpoint token decision | All responsive work |
+| Phase 1 QA sign-off | Phase 2 discovery |
+| `_mel-tables.scss` mobile pattern | Vendor orders |
+| Module coordination | Event Studio sidebar drawer |
+| Task 9/10/11 merges on target branch | Avoid redoing discovery/event/checkout polish |
+
+---
+
+## Validation requirements
+
+### After each phase
+
+```bash
+git status --short
+composer validate
+ddev drush cr
+npm run mel:lint
+npm run mel:build
+```
+
+### Manual mobile QA matrix (390px primary)
+
+| Phase | URLs |
+|-------|------|
+| 1 | `/event/1540/book` (RSVP), `/event/1567/book` (paid), checkout with 1 ticket, paid event full page |
+| 2 | `/home`, `/events`, `/events/category/{tid}`, `/cart` |
+| 3 | `/vendor/events/{nid}/studio`, `/vendor/event/{event}/orders`, `/vendor/dashboard` |
+
+### Regression checks
+
+- Public header drawer open/close at 767px and 901px
+- Checkout payment still completes (staging Stripe test mode)
+- No horizontal scroll on Phase 1 routes at 390px
+- `prefers-reduced-motion` on animated chips/cards (Phase 2)
+
+### Acceptance (Phase 1 complete when)
+
+1. Header CSS and JS use same breakpoint for mobile nav
+2. Book page summary visible without horizontal scroll at 390px
+3. Checkout form panes readable single-column; payment reachable
+4. Event mobile CTA does not obscure footer content
+5. Build/lint green; no config export required
+
+---
+
+## Rollback considerations
+
+| Change type | Rollback |
+|-------------|----------|
+| Theme SCSS/JS/Twig only | Revert commit; `npm run mel:build`; `ddev drush cr` |
+| Compiled `dist/*.css` | Regenerate from reverted SCSS via build |
+| Accidental config export | **Do not commit** — `ddev drush cim --preview` before any config PR |
+| Event Studio module CSS (Phase 3) | Module version revert; cache rebuild; higher blast radius — feature-flag or branch isolation |
+
+**Prefer:** One route group per PR for easy revert (e.g. book-only PR, checkout-only PR).
+
+---
+
+## What should NOT be implemented yet
+
+| Item | Phase | Reason |
+|------|-------|--------|
+| Event Studio sidebar drawer | 3+ | Module grid ownership; 280px columns |
+| Vendor orders card stack | 3+ | No canonical table pattern |
+| `_event-form.scss` !important reduction | 3+ | Markup alignment required |
+| 390px sm token enforcement | TBD | Repository evidence not found; product sign-off |
+| Commerce checkout flow / pane config | Never in mobile CSS phases | Stripe/Commerce risk |
+| RSVP tier validation fixes | Separate track | Data/vendor pipeline (O20) |
+| Visual redesign / brand changes | Out of scope | `canonical-design-system.md` non-goals |
+
+---
+
+## Priority matrix (implementation order)
+
+| Order | Item | P-tier | Conversion | Tech risk |
+|-------|------|--------|------------|-----------|
+| 1 | Breakpoint + header align | Foundation | Medium | Low |
+| 2 | Book page mobile | P0 | **Highest** | Medium |
+| 3 | Checkout layout | P0 | **Highest** | High (scope control) |
+| 4 | Event detail CTA | P0 | High | Medium |
+| 5 | Discovery/homepage | P1 | High | Low–med |
+| 6 | Event Studio | P0 vendor | N/A vendor | **Very high** |
+| 7 | Vendor orders | P0 vendor | N/A vendor | **Very high** |
+
+---
+
+## Recommended first implementation branch
+
+```
+feature/mobile-phase-1-public-conversion
+```
+
+**Branch from:** `feature/mobile-foundation` (commit `247644010` — "Add mobile foundation audit and design system recommendations")
+
+**First PR scope:** Breakpoint/header alignment + `/event/{node}/book` SCSS/Twig only (~smallest conversion win with lowest Commerce risk).
+
+---
+
+## Review artifacts produced
+
+| File | Purpose |
+|------|---------|
+| `docs/audits/mobile-phase-1-priority-review.md` | Route P0–P3 classification |
+| `docs/audits/mobile-css-review.md` | CSS ownership, duplicates, dead code flags |
+| `docs/audits/mobile-design-system-readiness.md` | Ready / consolidation / blocked components |
+| `docs/audits/mobile-conversion-opportunities.md` | Funnel friction with evidence |
+| `docs/audits/mobile-foundation-implementation-roadmap.md` | This document |
+
+---
+
+**Roadmap complete. Ready for Phase 1 implementation planning on a clean `feature/mobile-foundation` branch.**

--- a/docs/audits/mobile-phase-1-priority-review.md
+++ b/docs/audits/mobile-phase-1-priority-review.md
@@ -1,0 +1,297 @@
+# Mobile Phase 1 Priority Review
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-14  
+**Inputs:** `mobile-route-priority-map.md`, `event-route-reference-map.md`, `mel-v2-current-build-audit.md`, routing YAML, SCSS/JS evidence  
+**Status:** Audit only — no implementation
+
+---
+
+## Branch verification (required preflight)
+
+| Check | Expected | Actual |
+|-------|----------|--------|
+| Branch | `feature/mobile-foundation` | **`feature/brand-rollout-phase-1a-discovery-copy`** |
+| Working tree | Clean | **Dirty** — modified Twig on homepage/discovery |
+
+**Note:** Audit documents from Phase 2A exist on disk; this review was produced from repository evidence despite branch mismatch. Switch to `feature/mobile-foundation` with a clean tree before implementation work.
+
+---
+
+## Priority scale
+
+| Tier | Definition |
+|------|------------|
+| **P0** | Critical mobile routes — primary conversion or vendor revenue operations; poor mobile score or funnel-blocking friction |
+| **P1** | High-value routes — significant traffic or revenue adjacency; moderate mobile risk |
+| **P2** | Secondary routes — operational or supporting surfaces; can follow P0/P1 |
+| **P3** | Defer — acceptable baseline today or low traffic/complexity ratio |
+
+Scores reference `mobile-route-priority-map.md` (10 = likely OK at 390px; 1 = high risk).
+
+---
+
+## Public conversion funnel
+
+### P0 — Homepage
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | `view.frontpage.page_1` → `/home` (`config/sync/system.site.yml`: `front: /home`) |
+| **Mobile score** | **7/10** (`mobile-route-priority-map.md`) |
+| **Why P0** | Primary entry point for discovery and organiser CTAs; hero, featured carousel, category chips |
+| **User impact** | First impression; mobile nav (`header.js`, `_site-header.scss`); category chip touch targets |
+| **Revenue impact** | Indirect — routes users to events and `/create-event` gateway |
+| **Risk** | **Medium UX** — 900px header breakpoint vs 768px md token and `header.js` matchMedia at 768px (`_site-header.scss`, `header.js` line 221) |
+| **Effort** | **Low–medium** — better baseline than vendor surfaces; breakpoint alignment + hero/carousel polish |
+
+**Evidence:** `_homepage.scss` (6 `@media`), `_front-page.scss` (9), `_home-hero.scss`, `_featured-carousel.scss`, `myeventlane-home-hero.html.twig`.
+
+---
+
+### P0 — Discovery (events listing)
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | `view.upcoming_events.page_events` → `/events`; `page_category`, `page_today`, `page_this_weekend`, `page_free`; `myeventlane_search` → `/search` |
+| **Mobile score** | **Not scored separately** in Phase 2A map; grouped with homepage funnel |
+| **Why P0** | Core browse path between homepage and event detail; filter chips and event cards |
+| **User impact** | Horizontal category strips, filter chips, card grid density |
+| **Revenue impact** | Direct — drives event page and book/checkout entry |
+| **Risk** | **Medium UX** — chip/pill class fragmentation (`.mel-chip`, `.mel-category-chip`, `.mel-pill`, `.mel-filter-chip` per `component-system-inventory.md`); 44px touch targets partially addressed in Task 9 audit |
+| **Effort** | **Medium** — multiple Views templates + `_event-card.scss`, `_mel-browse.scss`, `_category-pills.scss` |
+
+**Evidence:** `mel-discovery-event-page-polish-audit.md`; templates under `views-view--upcoming-events--*`, `mel-page-header.html.twig`.
+
+---
+
+### P0 — Event detail (public full page)
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | `entity.node.canonical` (event bundle); path alias typical |
+| **Mobile score** | **6/10** |
+| **Why P0** | Decision point before book/RSVP; sticky mobile CTA bar exists |
+| **User impact** | Multi-column hero/gallery; booking sidebar order on mobile; share/CTA hierarchy |
+| **Revenue impact** | **High** — primary CTA to `/event/{node}/book` |
+| **Risk** | **Medium–high UX** — `_event-full.scss` (29 `@media`), `_event-gallery.scss` (900px/767px splits), `_event-mobile-cta.scss` |
+| **Effort** | **High** — large SCSS surface; JS mobile bar (`mel-booking-summary.js`) |
+
+**Evidence:** `node--event--full.html.twig`, `mel-event-full-page-polish-audit.md`, `_event-full.scss`.
+
+---
+
+### P0 — Book / RSVP entry
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | `myeventlane_commerce.event_book` → `/event/{node}/book`; `myeventlane_rsvp.public_rsvp_form` → `/event/{event}/rsvp` (redirects to unified booking per `RsvpRedirectController`) |
+| **Mobile score** | **Inherits checkout/booking** (~5–6/10) |
+| **Why P0** | Unified paid + RSVP conversion hinge; ticket selection form → cart |
+| **User impact** | Ticket selector density; mobile booking summary panel |
+| **Revenue impact** | **Critical** — cart creation via `TicketSelectionForm` / `RsvpPublicForm` |
+| **Risk** | **Medium technical** — Commerce form markup; `event-builder-preview.css` overlap; tier data gaps (events without `field_ticket_types` per booking verification audit) |
+| **Effort** | **Medium–high** — `myeventlane-event-book.html.twig`, `_booking-page.scss`, module CSS |
+
+**Evidence:** `myeventlane_commerce.routing.yml`, `myeventlane_rsvp.routing.yml`, `mel-booking-checkout-verification.md`.
+
+---
+
+### P0 — Checkout
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | `commerce_checkout.checkout` → `/checkout`; `commerce_checkout.form` → `/checkout/{commerce_order}/{step}`; flow `mel_event_checkout` |
+| **Mobile score** | **5/10** |
+| **Why P0** | Revenue completion; multi-pane buyer + attendee + payment |
+| **User impact** | Sidebar order summary on narrow viewports; pane density; table-like order review |
+| **Revenue impact** | **Critical** — payment capture |
+| **Risk** | **High technical + Commerce** — `_checkout.scss` (20 `@media`), `mel-operational-checkout.css`, checkout pane order/weights; **do not change payment logic** |
+| **Effort** | **High** — Twig + SCSS + Commerce pane layout; visual-only scope safest |
+
+**Evidence:** `config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`, `mel-cart-checkout-visual-trust-polish.md`, `_checkout.scss`.
+
+---
+
+### P1 — Cart
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | Commerce cart routes (e.g. `/cart`) |
+| **Mobile score** | Not in Phase 2A map |
+| **Why P1** | Pre-checkout step; trust copy and event grouping |
+| **User impact** | Cart table layout; remove control touch targets |
+| **Revenue impact** | Medium — abandonment risk |
+| **Risk** | **Medium** — duplicate `_cart.scss` vs `commerce/_commerce.scss` (legacy, not imported per cart audit) |
+| **Effort** | **Low–medium** — mostly visual |
+
+**Evidence:** `mel-cart-checkout-visual-trust-polish.md`.
+
+---
+
+### P1 — Post-purchase / confirmation
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | Checkout complete step; `myeventlane_checkout_flow.my_tickets` → `/my-tickets`; `myeventlane_rsvp.thankyou` → `/event/{event}/rsvp/thank-you` |
+| **Mobile score** | Not scored |
+| **Why P1** | Retention and ticket access; lower friction than checkout |
+| **User impact** | Confirmation layout, my-tickets list |
+| **Revenue impact** | Indirect — repeat attendance, trust |
+| **Risk** | **Low–medium** |
+| **Effort** | **Low** |
+
+**Evidence:** `commerce-checkout-completion.html.twig`, `rsvp-thankyou.css`.
+
+---
+
+## Vendor / operations surfaces
+
+### P0 — Event Studio (vendor)
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | `myeventlane_event_studio.*` → `/vendor/events/{node}/studio/*` (sections: information, branding, content, tickets, etc.) |
+| **Mobile score** | **4/10** |
+| **Why P0 (vendor)** | Canonical post-consolidation vendor workflow; referenced across dashboard, onboarding, gateway |
+| **User impact** | Fixed 280px sidebar grid; section nav; topbar publish/autosave |
+| **Revenue impact** | **High (vendor)** — event creation/publish gates ticket sales |
+| **Risk** | **Very high technical** — `mel-event-studio-shell.css` (~5.4k lines, 23 `@media`, `grid-template-columns: 280px 1fr`); module + theme + vendor `_mel-builder.scss` (30× `!important`) ownership conflict |
+| **Effort** | **Very high** — defer layout to Phase 2+ after token unification |
+
+**Evidence:** `mel-event-studio-shell.css` lines 19–34; `css-ownership-map.md`; `event-route-reference-map.md` §B.
+
+---
+
+### P0 — Vendor orders
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | `myeventlane_vendor.console.event_orders` → `/vendor/event/{event}/orders` (and Studio orders sections) |
+| **Mobile score** | **3/10** |
+| **Why P0 (vendor)** | Table-primary UI; revenue reconciliation |
+| **User impact** | Horizontal scroll or unreadable columns on 390px |
+| **Revenue impact** | **High (vendor ops)** |
+| **Risk** | **High** — `_event-table.scss`, commerce module order CSS; table→card pattern not established |
+| **Effort** | **High** — needs responsive table pattern first |
+
+**Evidence:** `mobile-route-priority-map.md`; vendor `_event-table.scss`.
+
+---
+
+### P1 — Vendor dashboard
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | `/vendor/dashboard` |
+| **Mobile score** | **4/10** |
+| **Why P1** | Vendor entry hub; KPI grids, live ops |
+| **User impact** | Dashboard density; quick actions |
+| **Revenue impact** | Medium (vendor productivity) |
+| **Risk** | **High** — `_live-operations.scss` (31× `!important`) |
+| **Effort** | **High** |
+
+---
+
+### P2 — Attendees / check-in
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | Attendee ops, RSVP check-in (`myeventlane_rsvp.checkin_*`, vendor event operations) |
+| **Mobile score** | **4/10** |
+| **Why P2** | Door ops often tablet; mixed tables + cards |
+| **User impact** | Check-in scan flows may need mobile |
+| **Revenue impact** | Operational |
+| **Risk** | **Medium–high** — `_mel-attendee-operations.scss` |
+| **Effort** | **Medium–high** |
+
+---
+
+### P2 — Vendor analytics
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | `myeventlane_event_studio.workspace_analytics`, `/vendor/events/{event}/analytics` |
+| **Mobile score** | **4/10** |
+| **Why P2** | Charts + wide metrics; KPI cards stack at 479/640px |
+| **User impact** | Read-only insights; less conversion-critical |
+| **Revenue impact** | Low direct |
+| **Risk** | **Medium** — `analytics.css`, `pages/_analytics.scss` |
+| **Effort** | **Medium** |
+
+---
+
+### P3 — Vendor messaging / promotion
+
+| Field | Detail |
+|-------|--------|
+| **Route / path** | Studio messaging/promotions sections |
+| **Mobile score** | **5/10** |
+| **Why P3** | Form-heavy; fewer tables; lower traffic complexity per Phase 2A |
+| **User impact** | Secondary vendor task |
+| **Revenue impact** | Low–medium |
+| **Risk** | **Low–medium** |
+| **Effort** | **Medium** |
+
+---
+
+### P3 — Help / trust / blog / organiser hub
+
+| Field | Detail |
+|-------|--------|
+| **Routes / paths** | Help centre, `/trust`, blog landing, organiser hub |
+| **Mobile score** | Not in Phase 2A map |
+| **Why P3** | Supporting content; not primary conversion path |
+| **User impact** | Lower |
+| **Revenue impact** | Indirect |
+| **Risk** | **Low** |
+| **Effort** | **Low–medium** |
+
+**Evidence:** Route grep; not scored in mobile-route-priority-map.
+
+---
+
+## Priority matrix (summary)
+
+| Priority | Route / surface | Score | Primary driver |
+|----------|---------------|-------|----------------|
+| **P0** | Homepage `/home` | 7 | Funnel entry |
+| **P0** | Discovery `/events`, `/search` | — | Browse → detail |
+| **P0** | Event detail | 6 | CTA → book |
+| **P0** | Book / RSVP `/event/{node}/book` | ~5–6 | Cart creation |
+| **P0** | Checkout `/checkout` | 5 | Payment |
+| **P0** | Event Studio `/vendor/events/{node}/studio/*` | 4 | Vendor workflow (high tech risk) |
+| **P0** | Vendor orders | 3 | Vendor revenue ops (high UX risk) |
+| **P1** | Cart, post-purchase, vendor dashboard | 4–5 | Adjacent conversion / hub |
+| **P2** | Attendees, analytics, public event polish gaps | 4–6 | Operational / secondary |
+| **P3** | Messaging, help, homepage breakpoint-only | 5–7 | Defer or token-only |
+
+---
+
+## Reconciliation with Phase 2A map
+
+Phase 2A ranked **Event Studio** and **Orders** as P0 for **vendor mobile implementation**, and **Homepage** as P3 (better baseline).
+
+This review **splits public conversion (P0)** from **vendor ops (P0 with defer recommendation for implementation)** because:
+
+1. Public P0 routes have **repository-confirmed revenue paths** (`BookController`, `mel_event_checkout`, RSVP redirect).
+2. Vendor P0 routes have **lower mobile scores** but **highest CSS ownership conflict** — implementing them before token/component consolidation increases regression risk (`css-ownership-map.md`).
+
+**Recommended implementation order:** public conversion foundation first (tokens + book + checkout), vendor Event Studio/orders in Phase 2+ after consolidation.
+
+---
+
+## What not to implement yet
+
+| Item | Reason |
+|------|--------|
+| Event Studio shell sidebar → drawer | Module owns grid; 280px fixed columns; 30+ `!important` in builder SCSS |
+| Orders table → card stack | No canonical mobile table pattern; P0 UX but blocked on design system |
+| Vendor `_event-form.scss` dedup | 94× `!important`; needs markup alignment |
+| Commerce/checkout logic changes | High Stripe/Commerce risk per project rules |
+| 390px token enforcement | **Evidence not found** for 390px in theme SCSS (`mobile-breakpoint-inventory.md`); requires product sign-off |
+| Dead vendor SCSS import removal | Document only until verified unused (`vendor-studio-editor`, `studio-inspector` in vendor `main.scss` lines 92–93) |
+
+---
+
+**Phase 1 priority review complete. No code changes.**

--- a/web/themes/custom/myeventlane_theme/components/site-header/site-header.scss
+++ b/web/themes/custom/myeventlane_theme/components/site-header/site-header.scss
@@ -1,3 +1,5 @@
+@use '../../src/scss/tokens/breakpoints';
+
 .site-header {
   background: #fff;
   border-bottom: 1px solid var(--mel-border);
@@ -42,7 +44,7 @@
     align-items: center;
     gap: 16px;
 
-    @media (max-width: 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: none;
     }
 
@@ -74,7 +76,7 @@
   }
 
   &__organiser {
-    @media (max-width: 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: none;
     }
   }
@@ -88,7 +90,7 @@
   &__burger {
     display: none;
 
-    @media (max-width: 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: flex;
       align-items: center;
     }

--- a/web/themes/custom/myeventlane_theme/src/js/header.js
+++ b/web/themes/custom/myeventlane_theme/src/js/header.js
@@ -217,8 +217,9 @@ export function initMobileNav() {
     }
   });
 
-  // Close on resize to desktop
-  const mediaQuery = window.matchMedia('(min-width: 768px)');
+  // Close on resize to desktop — keep aligned with tokens/_breakpoints.scss md (768px).
+  const MEL_BREAKPOINT_MD_MIN = 768;
+  const mediaQuery = window.matchMedia(`(min-width: ${MEL_BREAKPOINT_MD_MIN}px)`);
   if (mediaQuery.addEventListener) {
     mediaQuery.addEventListener('change', function(e) {
       if (e.matches && mobileNavState.checkbox.checked) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -11,6 +11,8 @@
 @use '../tokens/breakpoints';
 
 $mel-book-max: 72.5rem; // ~1160px
+// Paid book two-column / in-panel CTA — keep at 960px (not lg 1024px).
+$mel-book-layout-min: 960px;
 
 .mel-page:has(.mel-book-page.mel-event-page--classic) {
   background-color: #fff9f5;
@@ -402,7 +404,7 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@include breakpoints.mel-break(lg) {
+@media (width >= $mel-book-layout-min) {
   .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
     position: static;
     bottom: auto;
@@ -441,7 +443,7 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@include breakpoints.mel-break(lg, max) {
+@media (width <= #{$mel-book-layout-min - 1px}) {
   .mel-book-page {
     padding-bottom: calc(#{spacing.mel-space(7)} + env(safe-area-inset-bottom, 0));
   }
@@ -524,7 +526,7 @@ $mel-book-max: 72.5rem; // ~1160px
   min-height: 44px;
 }
 
-@include breakpoints.mel-break(lg) {
+@media (width >= $mel-book-layout-min) {
   .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky .mel-mobile-booking-bar--rsvp {
     display: none;
   }
@@ -543,7 +545,7 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@include breakpoints.mel-break(lg, max) {
+@media (width <= #{$mel-book-layout-min - 1px}) {
   .mel-book-layout {
     display: flex;
     flex-direction: column;
@@ -566,7 +568,8 @@ $mel-book-max: 72.5rem; // ~1160px
 
     .mel-book-trust,
     .mel-book-next-steps,
-    .mel-booking-extras {
+    .mel-booking-extras,
+    .mel-addon-teaser {
       order: 3;
     }
   }
@@ -648,13 +651,13 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@include breakpoints.mel-break(lg) {
+@media (width >= $mel-book-layout-min) {
   .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
     border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
   }
 }
 
-@include breakpoints.mel-break(lg, max) {
+@media (width <= #{$mel-book-layout-min - 1px}) {
   .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
     background: color-mix(in srgb, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 94%, transparent);
     border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_booking-page.scss
@@ -402,7 +402,7 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@media (min-width: 960px) {
+@include breakpoints.mel-break(lg) {
   .mel-book-page .mel-event-book__form-body .mel-booking__cta--panel {
     position: static;
     bottom: auto;
@@ -441,7 +441,7 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@media (max-width: 959px) {
+@include breakpoints.mel-break(lg, max) {
   .mel-book-page {
     padding-bottom: calc(#{spacing.mel-space(7)} + env(safe-area-inset-bottom, 0));
   }
@@ -524,7 +524,7 @@ $mel-book-max: 72.5rem; // ~1160px
   min-height: 44px;
 }
 
-@media (min-width: 960px) {
+@include breakpoints.mel-break(lg) {
   .mel-book-page[data-event-mode='rsvp'] .mel-rsvp-submit--book-sticky .mel-mobile-booking-bar--rsvp {
     display: none;
   }
@@ -543,19 +543,32 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@media (max-width: 959px) {
+@include breakpoints.mel-break(lg, max) {
   .mel-book-layout {
     display: flex;
     flex-direction: column;
   }
 
-  .mel-book-main {
-    order: 1;
-  }
+  // Summary above ticket matrix; trust/next steps follow selection (display: contents).
+  .mel-book-layout:not(.mel-book-layout--single):not(.mel-book-layout--rsvp) {
+    .mel-book-sidebar,
+    .mel-book-sidebar__inner {
+      display: contents;
+    }
 
-  .mel-book-sidebar {
-    order: 2;
-    margin-top: 0;
+    .mel-book-summary[data-mel-booking-summary] {
+      order: 1;
+    }
+
+    .mel-book-main {
+      order: 2;
+    }
+
+    .mel-book-trust,
+    .mel-book-next-steps,
+    .mel-booking-extras {
+      order: 3;
+    }
   }
 
   .mel-book-header__inner {
@@ -635,13 +648,13 @@ $mel-book-max: 72.5rem; // ~1160px
   }
 }
 
-@media (min-width: 960px) {
+@include breakpoints.mel-break(lg) {
   .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
     border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));
   }
 }
 
-@media (max-width: 959px) {
+@include breakpoints.mel-break(lg, max) {
   .mel-book-page.mel-event-page--immersive .mel-event-book__form-body .mel-booking__cta--panel {
     background: color-mix(in srgb, var(--mel-event-surface-raised, rgba(34, 44, 60, 0.78)) 94%, transparent);
     border-top-color: var(--mel-event-divider, rgba(255, 255, 255, 0.1));

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -3278,10 +3278,61 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   color: colors.$mel-color-text;
 }
 
-@media (width <= 768px) {
+@include breakpoints.mel-break(md, max) {
+  .mel-checkout-shell .mel-checkout--v2-shell {
+    min-width: 0;
+    overflow-x: clip;
+  }
+
+  .mel-checkout--v2-shell .mel-checkout__grid--sidebar-flow {
+    min-width: 0;
+
+    .mel-checkout__summary.mel-checkout-summary--v2 {
+      order: -1;
+      min-width: 0;
+    }
+
+    .mel-checkout__main {
+      min-width: 0;
+      padding-bottom: calc(120px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+
+  .mel-checkout--v2-shell .mel-card-surface,
+  .mel-checkout--v2-shell .mel-checkout-section {
+    min-width: 0;
+  }
+
+  // O16 — order summary table: readable without page-level horizontal scroll.
+  .mel-checkout-summary--v2 .mel-checkout-order-summary__table {
+    width: 100%;
+    table-layout: fixed;
+  }
+
+  .mel-checkout-summary--v2 .mel-checkout-order-summary__table td {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .mel-checkout-summary--v2 .mel-checkout-order-summary__table td[class*='views-field-total-price'] {
+    width: 30%;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  // Stripe / payment pane containment on narrow viewports.
   .mel-commerce-checkout .mel-checkout--v2-shell .mel-checkout-section--payment {
     margin-bottom: spacing.mel-space(4);
     padding-bottom: spacing.mel-space(2);
+    min-width: 0;
+    overflow-x: clip;
+
+    .commerce-payment-form,
+    [id*='stripe-payment-element'],
+    .payment-method {
+      max-width: 100%;
+      min-width: 0;
+    }
   }
 
   .mel-checkout-sticky--v2 {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-mobile-cta.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-mobile-cta.scss
@@ -24,6 +24,7 @@
   backdrop-filter: blur(20px);
   border-top: 2px solid var(--mel-peach);
   padding: space.mel-space(4);
+  padding-bottom: calc(#{space.mel-space(4)} + env(safe-area-inset-bottom, 0));
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
   z-index: 1000;
   display: none;
@@ -73,7 +74,7 @@
 
 .mel-event--detail {
   @include mel-break(lg, max) {
-    padding-bottom: 100px; // Space for sticky CTA
+    padding-bottom: calc(100px + env(safe-area-inset-bottom, 0));
   }
 }
 

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
@@ -6,7 +6,9 @@
 //
 // Duplicated chrome on staging is usually from Layout Builder / block regions
 // (e.g. branding + menu blocks in content) — page.html.twig only renders
-// {{ site_header }} once. Desktop nav is hidden below 900px; drawer below.
+// {{ site_header }} once. Desktop nav hidden at mel-break(md, max); drawer below.
+
+@use '../tokens/breakpoints';
 
 .site-header {
   position: relative;
@@ -55,7 +57,7 @@
     align-items: center;
     gap: 16px;
 
-    @media (width <= 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: none;
     }
 
@@ -114,7 +116,7 @@
     display: flex;
     align-items: center;
 
-    @media (width <= 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: none;
     }
   }
@@ -174,7 +176,7 @@
   }
 
   &__organiser {
-    @media (width <= 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: none;
     }
   }
@@ -250,7 +252,7 @@
   &__burger {
     display: none;
 
-    @media (width <= 900px) {
+    @include breakpoints.mel-break(md, max) {
       display: flex;
       align-items: center;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/tokens/_breakpoints.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/tokens/_breakpoints.scss
@@ -1,3 +1,8 @@
+// Canonical public breakpoint map (myeventlane_theme).
+// Vendor theme sm (640px) is not unified yet — public Phase 1 uses md for nav/layout.
+// Style-guide 390px baseline: no dedicated token yet (product sign-off pending).
+// Deprecate ad-hoc 900px public header cuts — use mel-break(md, max) instead.
+
 @use 'sass:map';
 
 $mel-breakpoints: (
@@ -7,6 +12,9 @@ $mel-breakpoints: (
   lg: 1024px,
   xl: 1280px
 );
+
+// Desktop nav / mobile drawer: width >= md (768px). Keep header.js in sync.
+$mel-breakpoint-md: map.get($mel-breakpoints, md);
 
 @mixin mel-break($size, $direction: min) {
   $breakpoint: map.get($mel-breakpoints, $size);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches high-traffic conversion surfaces (book, checkout, header) and a large `_checkout.scss` block; layout-only but needs mobile QA at 390px/768px and a staging checkout payment smoke test.
> 
> **Overview**
> Adds **Phase 2A mobile foundation audit docs** under `docs/audits/` (conversion opportunities, CSS ownership, design-system readiness, route priorities, implementation roadmap) and implements **Phase 1 public-funnel layout** in the public theme—SCSS/JS only, no Commerce config or PHP.
> 
> **Breakpoint and header:** Documents the canonical public map in `_breakpoints.scss` (768px `md` for nav; deprecates ad-hoc 900px cuts). Replaces `@media (max-width: 900px)` with `mel-break(md, max)` in `_site-header.scss` and the `site-header` component; `header.js` documents and keeps the desktop resize listener at 768px so CSS and JS agree.
> 
> **Book page:** Introduces `$mel-book-layout-min` (960px) for layout media queries. On narrow viewports, paid two-column layouts use `display: contents` so **booking summary appears above** the ticket matrix (trust/next steps follow).
> 
> **Checkout:** Expands the `md` max block in `_checkout.scss`—summary first in sidebar-flow grid, overflow clipping, fixed table layout for order summary (O16), and payment/Stripe element width containment.
> 
> **Event detail:** `_event-mobile-cta.scss` adds **safe-area-inset** padding on the sticky bar and event detail bottom spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1ce166452ac95ab61b3bb869761daf81dfa890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->