### PR TITLE
Align Event Studio tests with workspace presentation updates

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
@@ -57,12 +57,16 @@ final class EventStudioReadinessStabilityTest extends UnitTestCase {
   public function testEventStudioControllerUsesReadinessFacade(): void {
     $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
     $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+    $presentation = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php');
 
     $this->assertIsString($services);
     $this->assertIsString($controller);
+    $this->assertIsString($presentation);
     $this->assertStringContainsString('myeventlane_event_studio.readiness_facade', $services);
     $this->assertStringContainsString('EventReadinessFacade', $controller);
-    $this->assertStringContainsString('buildChecklistCardFromPresentation', $controller);
+    $this->assertStringContainsString('workspacePresentation', $controller);
+    $this->assertStringContainsString('buildHomepageReadinessCard', $controller);
+    $this->assertStringContainsString('buildChecklistCardFromPresentation', $presentation);
   }
 
   public function testReadinessFacadeServiceIsRegistered(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
@@ -58,7 +58,7 @@ final class PublishEligibilityEvaluatorTest extends UnitTestCase {
     $this->assertStringNotContainsString('paidPublishStripeGate', $save);
     $this->assertStringNotContainsString('$this->eventReadiness->evaluate', $save);
     $this->assertStringNotContainsString('if (!$readiness->ready)', $publish);
-    $this->assertStringContainsString('return $this->setPublishedState($node, TRUE);', $publish);
+    $this->assertStringContainsString('return $this->setPublishedState($node, TRUE, $section);', $publish);
     $this->assertStringContainsString('myeventlane_event_studio.publish_eligibility', $services);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only string-contract assertions; no runtime behavior changes in this PR.
> 
> **Overview**
> Updates **Event Studio unit contract tests** so they match the current readiness and publish wiring—no production code changes in this diff.
> 
> **Readiness / workspace presentation:** `EventStudioReadinessStabilityTest` now loads `EventStudioWorkspacePresentation.php` and asserts the controller uses `workspacePresentation` and `buildHomepageReadinessCard`, while `buildChecklistCardFromPresentation` is expected on the presentation service instead of the controller.
> 
> **Publish path:** `PublishEligibilityEvaluatorTest` updates the publish-controller string contract so successful publish calls `setPublishedState($node, TRUE, $section)` rather than the two-argument form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf87e088c0743bc8f12c47d8793b2ec5e93f17f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->