### PR TITLE
Rename featured event cues to spotlight

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1512,9 +1512,9 @@ function myeventlane_event_finalize_event_ui(
     $out['cta_label'] = '';
     $out['cta_type'] = 'disabled';
     if ($isBoosted) {
-      $out['status_label'] = (string) t('Featured');
+      $out['status_label'] = (string) t('Spotlight');
       $out['status_type'] = 'highlight';
-      $out['image_badge_label'] = (string) t('Featured');
+      $out['image_badge_label'] = (string) t('Spotlight');
       $out['image_badge_type'] = 'apricot';
     }
     if (!$isSoldOut && $rsvpState === 'limited') {
@@ -1593,9 +1593,9 @@ function myeventlane_event_finalize_event_ui(
     && $isBoosted
     && ($out['image_badge_label'] ?? NULL) === NULL
   ) {
-    $out['status_label'] = (string) t('Featured');
+    $out['status_label'] = (string) t('Spotlight');
     $out['status_type'] = 'highlight';
-    $out['image_badge_label'] = (string) t('Featured');
+    $out['image_badge_label'] = (string) t('Spotlight');
     $out['image_badge_type'] = 'apricot';
   }
   elseif (
@@ -1605,9 +1605,9 @@ function myeventlane_event_finalize_event_ui(
     && (bool) $node->get('field_promoted')->value
     && ($out['image_badge_label'] ?? NULL) === NULL
   ) {
-    $out['status_label'] = (string) t('Featured');
+    $out['status_label'] = (string) t('Spotlight');
     $out['status_type'] = 'highlight';
-    $out['image_badge_label'] = (string) t('Featured');
+    $out['image_badge_label'] = (string) t('Spotlight');
     $out['image_badge_type'] = 'apricot';
   }
 

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
@@ -106,7 +106,7 @@ final class EventMerchandisingPresenter {
 
     $imageBadgeLabel = NULL;
     $imageBadgeModifier = 'apricot';
-    if (($isHero || $isSpotlight) && $isPromoted) {
+    if (($isHero || $isDiscovery) && $isPromoted) {
       $imageBadgeLabel = (string) $this->t('Spotlight');
     }
     elseif ($isSoldOut) {

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
@@ -106,12 +106,12 @@ final class EventMerchandisingPresenter {
 
     $imageBadgeLabel = NULL;
     $imageBadgeModifier = 'apricot';
-    if (($isHero || $isDiscovery) && $isPromoted) {
-      $imageBadgeLabel = (string) $this->t('Spotlight');
-    }
-    elseif ($isSoldOut) {
+    if ($isSoldOut) {
       $imageBadgeLabel = (string) $this->t('Sold out');
       $imageBadgeModifier = 'warning';
+    }
+    elseif (($isHero || $isDiscovery) && $isPromoted) {
+      $imageBadgeLabel = (string) $this->t('Spotlight');
     }
 
     $ticketPill = $this->resolveTicketPill($cardType, $priceLabel, $isSoldOut);

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
@@ -67,6 +67,8 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
     ]);
 
     self::assertSame('sold_out', $result['primary']['signal_key'] ?? '');
+    self::assertSame('Sold out', $result['image_badge_label']);
+    self::assertSame('warning', $result['image_badge_modifier']);
     self::assertFalse($result['show_ticket_type_pill']);
   }
 
@@ -132,6 +134,22 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
 
     self::assertSame('Spotlight', $result['image_badge_label']);
     self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSoldOutOutranksSpotlightOnPromotedPoster(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => 'poster',
+      'is_promoted' => TRUE,
+      'is_sold_out' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Sold out', $result['image_badge_label']);
+    self::assertSame('warning', $result['image_badge_modifier']);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
@@ -122,7 +122,7 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
   /**
    * @covers ::present
    */
-  public function testFeaturedBadgeWhenPromotedOnSpotlight(): void {
+  public function testSpotlightBadgeWhenPromotedOnSpotlight(): void {
     $presenter = $this->createPresenter();
     $result = $presenter->present([
       'layout' => 'spotlight',
@@ -130,7 +130,22 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
       'card_type' => 'rsvp',
     ]);
 
-    self::assertNotEmpty($result['image_badge_label']);
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightBadgeWhenPromotedOnPoster(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => 'poster',
+      'is_promoted' => TRUE,
+      'card_type' => 'rsvp',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
     self::assertSame('apricot', $result['image_badge_modifier']);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy and merchandising badge ordering only; no booking, auth, or data model changes.
> 
> **Overview**
> Event card **status and image badge copy** now uses **Spotlight** instead of **Featured** wherever boosted or `field_promoted` events get highlight labels in `myeventlane_event_finalize_event_ui`.
> 
> **EventMerchandisingPresenter** reorders image badges so **Sold out** wins over promotion, and **Spotlight** shows for promoted cards on **hero** or **discovery** layouts (`poster` / spotlight), not spotlight-only.
> 
> Unit tests were renamed and extended to lock in badge text, modifiers, and sold-out vs spotlight precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb8cdcd7209b8d6a20394f83d813db490a495f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->