### PR TITLE
Improve discovery route integrity and browse parity

### DIFF
--- a/docs/audits/discovery-route-conversion-audit.md
+++ b/docs/audits/discovery-route-conversion-audit.md
@@ -1,0 +1,95 @@
+# Discovery Route Conversion Audit
+
+**Audit date:** 2026-06-14  
+**Branch:** `feature/discovery-route-audit`  
+**Classification:** High / Medium / Low based on visibility, intent clarity, journey quality, and route evidence only.
+
+---
+
+## Primary routes
+
+| Route | Path | Visibility | Intent | Conversion value | Notes |
+|-------|------|------------|--------|------------------|-------|
+| `view.upcoming_events.page_events` | `/events` | **High** — homepage (≥5 sections), footer, main menu, search recovery, 404, browse shell, help | Broad marketplace browse; exposed category + ticket-type filters | **High** | Richest template stack (`mel-browse-events-page-shell` + dedicated view template); only route with full browse UX |
+| `view.upcoming_events.page_popular` | `/events/popular` | **Medium** — footer, main menu ("Discover"), static menu links; **not** on homepage rails or filter chips | Boosted/promoted events (`field_promoted = 1`) | **Medium** | Commerce-adjacent (boost placement) but public listing; overlaps homepage Community spotlight (`front_featured_events`, same promoted field) |
+| `view.upcoming_events.page_this_weekend` | `/events/this-weekend` | **High** — footer, filter chips, browse quicklinks, empty-state CTAs, homepage tonight secondary CTA | Time-boxed weekend planning | **High** | Strong intent match; clear View date filter evidence |
+| `view.upcoming_events.page_today` | `/events/today` | **High** — footer, filter chips, browse quicklinks, homepage "Happening tonight" primary CTA | Same-day / tonight urgency | **High** | Distinct from weekend (today = calendar day; weekend = Sat–Sun window) — not duplicate |
+| *(none)* | `/events/nearby` | **Medium link exposure, zero route** — hardcoded in browse/category empty states; homepage section **not rendered** (no block) | Geo-proximity discovery | **Low** (broken) | Links exist in high-trust empty states → dead-end risk on conversion recovery paths |
+| *(none)* | `/events/online` | **Low visibility** — homepage section **not rendered** (no block); install demo URI only | Virtual/remote events | **Low** (broken) | No online event type in `field_event_type`; no View filter evidenced |
+
+---
+
+## Additional discovery routes
+
+| Route | Path | Visibility | Intent | Conversion value | Notes |
+|-------|------|------------|--------|------------------|-------|
+| `view.upcoming_events.page_category` | `/events/category/{slug}` | **High** — footer (5 curated categories), hero chips, discover embed, search fallback | Category-scoped browse | **High** | AJAX chip bar reuses today/weekend/free displays via `EventFilterController` |
+| `view.upcoming_events.page_free` | `/events/free` | **High** — footer, chips, browse shell, homepage free section | Free & RSVP entry (low-friction conversion) | **High** | `PublicEventDiscoveryQueryAlter` enforces no paid tickets on this surface |
+| `mel_search.view` | `/search` | **Medium** — site search; empty recovery → `/events` | Keyword discovery | **Medium** | Supporting layer; grouped results with event grid |
+| `view.events_calendar.page_1` | `/calendar` | **Low–Medium** — dedicated calendar page | Date-based exploration | **Medium** | Adjacent to time-filter routes; links back to `/events` |
+
+---
+
+## Visibility matrix (discovery surfaces)
+
+| Route | Homepage | Footer | Search recovery | Empty states | Filter chips | Browse shell | Main menu |
+|-------|----------|--------|-----------------|--------------|--------------|--------------|-----------|
+| `/events` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `/events/popular` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `/events/this-weekend` | ◑ secondary CTA | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| `/events/today` | ✅ primary CTA | ✅ | ❌ | ◑ inherited default | ✅ | ✅ | ❌ |
+| `/events/nearby` | ◑ (section inactive) | ❌ | ❌ | ✅ **broken link** | ❌ | ❌ | ❌ |
+| `/events/online` | ◑ (section inactive) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `/events/free` | ✅ | ✅ | ❌ | ✅ default empty | ✅ | ✅ | ❌ |
+| `/events/category/*` | ✅ (chips) | ✅ | ✅ fallback | ✅ | ✅ (category) | ❌ | ❌ |
+
+---
+
+## Conversion value rationale
+
+### High
+
+Routes with confirmed route owner, multiple navigation entry points, and clear user intent aligned to listing → event detail → book/RSVP journey:
+
+- `/events`, `/events/today`, `/events/this-weekend`, `/events/free`, `/events/category/*`
+
+### Medium
+
+Routes that work but have narrower placement or overlap with other surfaces:
+
+- `/events/popular` — footer + menu but duplicates promoted-content story with homepage spotlight
+- `/search` — functional recovery path, not primary browse entry
+
+### Low
+
+Routes linked without repository-backed destination or without content model support:
+
+- `/events/nearby`, `/events/online`
+
+---
+
+## Mobile quality (audit only)
+
+| Route | Mobile quality | Basis |
+|-------|----------------|-------|
+| `/events` | **Good** | Dedicated browse shell, mobile filter button, `mel-events-discovery` library |
+| `/events/category/*` | **Good** | Category page shell + chip bar; AJAX listing |
+| `/events/today`, `/events/this-weekend`, `/events/free` | **Needs review** | Shared view wrapper without browse page shell; generic `page.html.twig` — inconsistent header/quicklinks vs `/events` |
+| `/events/popular` | **Needs review** | Same as above; also excluded from `$listing_routes` hero/category header preload |
+| `/events/nearby`, `/events/online` | **Unknown** | No route/template to audit |
+| `/search` | **Needs review** | Dedicated `page--search.html.twig`; empty state uses standard MEL components |
+
+No runtime device testing performed (audit-only).
+
+---
+
+## Commerce 3 boundary check
+
+Confirmed **out of scope** for this audit (not classified as discovery conversion routes):
+
+- Checkout flows, cart routes, order views
+- `/my-saved-events` (authenticated saved list)
+- Vendor `/vendor/events/*` paths
+- Ticket/booking panes
+
+Discovery listings use `compact_commerce` view mode (presentation only); payment state not altered by these routes.

--- a/docs/audits/discovery-route-inventory.md
+++ b/docs/audits/discovery-route-inventory.md
@@ -1,0 +1,103 @@
+# Discovery Route Inventory
+
+**Audit date:** 2026-06-14  
+**Branch:** `feature/discovery-route-audit`  
+**Scope:** Public discovery routes only (no checkout, booking, or account routes).  
+**Method:** Repository evidence from `config/sync`, routing YAML, Twig, and services.
+
+---
+
+## Primary routes (audit focus)
+
+| Route | Path | Owner | Status | Evidence |
+|-------|------|-------|--------|----------|
+| `view.upcoming_events.page_events` | `/events` | Views display `page_events` on `upcoming_events` | **Active** | `config/sync/views.view.upcoming_events.yml` L1634–1978 (`path: events`); main menu link L1978–1987 |
+| `view.upcoming_events.page_popular` | `/events/popular` | Views display `page_popular` on `upcoming_events` | **Active** | `config/sync/views.view.upcoming_events.yml` L2310–2695 (`path: events/popular`); filter `field_promoted_value = 1` L2639–2650 |
+| `view.upcoming_events.page_this_weekend` | `/events/this-weekend` | Views display `page_this_weekend` on `upcoming_events` | **Active** | `config/sync/views.view.upcoming_events.yml` L2715–3012 (`path: events/this-weekend`); weekend date filter L2880–2882 |
+| `view.upcoming_events.page_today` | `/events/today` | Views display `page_today` on `upcoming_events` | **Active** | `config/sync/views.view.upcoming_events.yml` L3023–3320 (`path: events/today`); today filter `between today/tomorrow` L3186–3190 |
+| *(none)* | `/events/nearby` | **No route owner in repository** | **Broken** | No `path:` in `config/sync`; no `.routing.yml` entry; hardcoded links only (see Linked surfaces) |
+| *(none)* | `/events/online` | **No route owner in repository** | **Broken** | No `path:` in `config/sync`; no `.routing.yml` entry; hardcoded links only; no `page_online` display |
+
+---
+
+## Additional public discovery routes (`/events/*` and adjacent)
+
+| Route | Path | Owner | Status | Evidence |
+|-------|------|-------|--------|----------|
+| `view.upcoming_events.page_category` | `/events/category/{slug}` | Views display `page_category` | **Active** | `config/sync/views.view.upcoming_events.yml` L1386–1623 (`path: events/category/%`); canonical URLs via `EventCategoryUrlService` |
+| `view.upcoming_events.page_free` | `/events/free` | Views display `page_free` | **Active** | `config/sync/views.view.upcoming_events.yml` L1998–2299 (`path: events/free`); `PublicEventDiscoveryQueryAlter` FREE_RSVP display L76–79 |
+| `mel_search.view` | `/search` | `SearchController::build` | **Active** | `web/modules/custom/myeventlane_search/myeventlane_search.routing.yml` L1–7; `_access: 'TRUE'` |
+| `view.events_calendar.page_1` | `/calendar` | Views display on `events_calendar` | **Active** | `config/sync/views.view.events_calendar.yml` L302 (`path: calendar`) |
+| `myeventlane_core.event_filter` | `/mel/filter-events` | `EventFilterController::filter` (AJAX fragment) | **Active** (supporting) | `web/modules/custom/myeventlane_core/myeventlane_core.routing.yml` L124–129; not a standalone discovery page |
+| Legacy flat slug | `/events/{slug}` | Redirect to category when slug matches term | **Redirect** (conditional) | `EventCategoryCanonicalRedirectSubscriber` L85–111; skips reserved slugs L95–97 |
+| `view.mel_saved_events.page_1` | `/my-saved-events` | Views display | **Out of scope** | Account/saved list; `config/sync/views.view.mel_saved_events.yml` |
+
+---
+
+## Reserved `/events/*` segments (not category slugs)
+
+From `EventCategoryUrlService::RESERVED_EVENT_PATHS` (`web/modules/custom/myeventlane_core/src/Service/EventCategoryUrlService.php` L26–32):
+
+`category`, `today`, `this-weekend`, `free`, `popular`
+
+**Not reserved:** `nearby`, `online` — but no View route exists for them either.
+
+---
+
+## Homepage block surfaces (not standalone routes)
+
+| Region | View display | Block config | Status | Notes |
+|--------|--------------|--------------|--------|-------|
+| `homepage_featured` | `front_featured_events:block_featured` | `config/sync/block.block.front_featured_events.yml` | **Active** | Links to `/events` via `page--front.html.twig` L37 |
+| `home_discover` | `mel_home_events:embed_discover` | `config/sync/block.block.myeventlane_theme_views_block__mel_home_events_discover.yml` | **Active** | Chip filters; no dedicated `/events/*` route |
+| `homepage_tonight` | `upcoming_events:homepage_tonight` | `config/sync/block.block.myeventlane_theme_homepage_tonight.yml` | **Active** | Section link → `page_today` (`page--front.html.twig` L68) |
+| `homepage_free` | `mel_home_events:under_20` | `config/sync/block.block.myeventlane_theme_homepage_free.yml` | **Active** | Section link → `page_free` L83 |
+| `homepage_latest` | `upcoming_events:homepage_latest` | `config/sync/block.block.myeventlane_theme_homepage_latest.yml` | **Active** | Section link → `page_events` L98 |
+| `home_recommended` | `front_recommended_events:block_1` | `config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml` | **Active** | Section link → `page_events` L113 |
+| `homepage_nearby` | *(no block in config/sync)* | **None** | **Unused** | Theme region defined (`myeventlane_theme.info.yml` L24); no block placement found |
+| `homepage_online` | *(no block in config/sync)* | **None** | **Unused** | Theme region defined (`myeventlane_theme.info.yml` L25); no block placement found |
+
+`mel_home_events:near_you` block display exists in View config (L675–720) with description *"Not geo-filtered yet"* — **no block placement** in `config/sync`.
+
+---
+
+## Linked surfaces referencing discovery paths
+
+| Surface | Routes linked | File |
+|---------|---------------|------|
+| Homepage section CTAs | `page_events`, `page_today`, `page_free`, hardcoded `/events/nearby`, `/events/online` | `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` |
+| Footer Discover column | `page_events`, `page_today`, `page_this_weekend`, `page_free`, `page_popular` + category URLs | `web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php` L44–51 |
+| Search empty state | `page_events`, `<front>` | `web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig` L24–26 |
+| Browse empty state | `page_events`, `page_this_weekend`, hardcoded `/events/nearby`, `<front>` | `web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig` L44–51 |
+| Category empty state | `page_events`, hardcoded `/events/nearby`, `<front>` | `web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig` L82–86 |
+| Date filter chips | `page_events`, `page_today`, `page_this_weekend`, `page_free` | `web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig` |
+| Browse shell quicklinks | `page_events`, `page_free`, `page_this_weekend`, `page_today` | `web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig` L26–30 |
+| Main menu (View-generated) | `page_events`, `page_popular` | `config/sync/views.view.upcoming_events.yml` menu blocks L1978–1987, L2696–2704 |
+| Static footer menu links | All primary discovery routes + blog | `web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml` L28–56 |
+| Help search empty | `page_events` | `web/themes/custom/myeventlane_theme/templates/views/views-view--mel-help-search.html.twig` |
+| 404 pages | `page_events` | `web/themes/custom/myeventlane_theme/templates/system/mel-404.html.twig` |
+
+---
+
+## Access and security (read-only audit)
+
+| Route class | Access rule | Notes |
+|-------------|-------------|-------|
+| `upcoming_events` page displays | `perm: access content` | `config/sync/views.view.upcoming_events.yml` L91–94 |
+| `/search` | `_access: 'TRUE'` | Public search |
+| `/mel/filter-events` | `_permission: access content` | AJAX only; 400 without `category` query param |
+| Category redirects | 301 to canonical slug | `EventCategoryCanonicalRedirectSubscriber`; does not bypass entity access |
+
+No checkout, cart, order, or vendor-console routes included in this inventory.
+
+---
+
+## Status definitions
+
+| Status | Meaning |
+|--------|---------|
+| **Active** | Route registered in config/routing; View or controller owner confirmed |
+| **Broken** | Linked from UI but no route owner in repository |
+| **Unused** | Region/display exists but no block placement or navigation link |
+| **Duplicate** | Overlaps another discovery path (see conversion/duplication audits) |
+| **Unknown** | Cannot confirm reachability without runtime HTTP test |

--- a/docs/audits/discovery-route-ownership-map.md
+++ b/docs/audits/discovery-route-ownership-map.md
@@ -1,0 +1,185 @@
+# Discovery Route Ownership Map
+
+**Audit date:** 2026-06-14  
+**Branch:** `feature/discovery-route-audit`  
+**Method:** Trace rendering path from route → display → template → navigation source.
+
+---
+
+## Canonical owner model
+
+All primary `/events/*` listing routes (except broken `/events/nearby` and `/events/online`) are owned by:
+
+- **View:** `upcoming_events` (`config/sync/views.view.upcoming_events.yml`)
+- **Route name pattern:** `view.upcoming_events.{display_id}`
+- **Query hygiene:** `PublicEventDiscoveryQueryAlter` (`web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php`)
+- **Category URLs:** `EventCategoryUrlService` (`web/modules/custom/myeventlane_core/src/Service/EventCategoryUrlService.php`)
+- **Category redirects:** `EventCategoryCanonicalRedirectSubscriber`
+
+---
+
+## Route-by-route rendering path
+
+### `/events` — `view.upcoming_events.page_events`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_events` |
+| **View** | `config/sync/views.view.upcoming_events.yml` L1634–1978 |
+| **Page template** | `page--view--upcoming-events--page-events.html.twig` → `mel-browse-events-page-shell.html.twig` |
+| **View template** | `views-view--upcoming-events--page-events.html.twig` (browse layout + exposed filters) |
+| **Row style** | `entity:node` / `compact_commerce` |
+| **Preprocess** | `myeventlane_theme.theme` — `mel_browse_active_display`, `mel_browse_result_count`, `mel_header_categories` (L1756–1805, L3312–3341) |
+| **Navigation sources** | Homepage (multiple sections), footer, search recovery, browse shell quicklinks, main menu, 404, help search |
+
+---
+
+### `/events/popular` — `view.upcoming_events.page_popular`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_popular` |
+| **View filter** | `field_promoted_value = 1` (boosted/promoted events) L2639–2650 |
+| **Page template** | Generic `page.html.twig` (no browse shell — **no** `page--view--*` override) |
+| **View template** | `views-view--upcoming-events.html.twig` (shared discovery wrapper + date chips) |
+| **Preprocess gap** | `page_popular` **not** in `$browse_display_map` or `$listing_routes` (`myeventlane_theme.theme` L1756–1805) |
+| **Navigation sources** | Footer (`PublicFooterNavigationBuilder` L49), static menu links (`myeventlane_core.links.menu.yml` L52–56), main menu (View menu config L2696–2704) |
+| **Not linked from** | Homepage section CTAs, discovery filter chips, browse shell quicklinks |
+
+---
+
+### `/events/this-weekend` — `view.upcoming_events.page_this_weekend`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_this_weekend` |
+| **View filter** | `field_event_start` between `saturday this week` and `sunday this week 23:59:59` L2880–2882 |
+| **Page template** | Generic `page.html.twig` |
+| **View template** | `views-view--upcoming-events.html.twig` + `mel-events-discovery-filters.html.twig` |
+| **Preprocess** | In `$browse_display_map` and chip/category preprocess (L1799, L3284) |
+| **Navigation sources** | Footer, filter chips, browse shell quicklinks, empty-state CTAs, homepage tonight secondary CTA |
+
+---
+
+### `/events/today` — `view.upcoming_events.page_today`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_today` |
+| **View filter** | `field_event_start` `between today` and `tomorrow` L3186–3190; also `>= now` L3204–3231 |
+| **Page template** | Generic `page.html.twig` |
+| **View template** | `views-view--upcoming-events.html.twig` + filter chips |
+| **AJAX reuse** | `EventFilterController` type `now` → `page_today` display L87–91 |
+| **Navigation sources** | Footer, filter chips, browse shell, homepage "Happening tonight" → `page_today` L68 |
+
+---
+
+### `/events/nearby` — **no route**
+
+| Layer | Owner |
+|-------|-------|
+| **Route** | **I cannot confirm this from the repository.** |
+| **Closest data surface** | `mel_home_events:near_you` block display (not geo-filtered; no block placement) |
+| **Hardcoded link sources** | `page--front.html.twig` L127; `views-view--upcoming-events--page-events.html.twig` L49; `views-view--upcoming-events--page-category.html.twig` L84; default empty copy in `mel-view-empty-events.html.twig` L11 |
+| **Expected runtime** | No matching route in sync config → likely **404** unless path alias or taxonomy slug collision (not evidenced in config) |
+
+---
+
+### `/events/online` — **no route**
+
+| Layer | Owner |
+|-------|-------|
+| **Route** | **I cannot confirm this from the repository.** |
+| **Data model gap** | `field_event_type` allowed values: `rsvp`, `paid`, `both`, `external` only (`config/sync/field.storage.node.field_event_type.yml`) — no `online` value |
+| **Hardcoded link sources** | `page--front.html.twig` L141; demo menu URI in `myeventlane_core.install` L451 |
+| **Expected runtime** | No matching route → likely **404** |
+
+---
+
+### `/events/free` — `view.upcoming_events.page_free`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_free` |
+| **View filter** | `field_product_target` empty L2220–2230 + `PublicEventDiscoveryQueryAlter::applyFreeRsvpExclusion` |
+| **Page template** | Generic `page.html.twig` |
+| **View template** | `views-view--upcoming-events.html.twig`; chip label "Free & RSVP" |
+| **AJAX reuse** | `EventFilterController` type `free` L99–103 |
+| **Navigation sources** | Footer, filter chips, browse shell, homepage free section |
+
+---
+
+### `/events/category/{slug}` — `view.upcoming_events.page_category`
+
+| Layer | Owner |
+|-------|-------|
+| **Route / display** | `upcoming_events:page_category` |
+| **URL builder** | `EventCategoryUrlService::getCategoryUrl()` |
+| **Page template** | `page--events--category.html.twig` |
+| **View template** | `views-view--upcoming-events--page-category.html.twig` (chip bar + AJAX) |
+| **AJAX controller** | `myeventlane_core.event_filter` → `/mel/filter-events` |
+| **Navigation sources** | Footer category links, hero category chips, homepage discover, search fallback categories |
+
+---
+
+## Supporting routes (adjacent discovery)
+
+### `/search` — `mel_search.view`
+
+| Layer | Owner |
+|-------|-------|
+| **Controller** | `Drupal\myeventlane_search\Controller\SearchController::build` |
+| **Template** | `myeventlane-search-results.html.twig` |
+| **Page template** | `page--search.html.twig` |
+| **Backend** | Search API index (referenced in module; not re-audited here) |
+
+### `/calendar` — `view.events_calendar.page_1`
+
+| Layer | Owner |
+|-------|-------|
+| **View** | `config/sync/views.view.events_calendar.yml` |
+| **Page template** | `page--calendar.html.twig` |
+| **Navigation** | Calendar hero CTA → `page_events` |
+
+---
+
+## Homepage rail → route mapping
+
+| Homepage section | Visibility gate | Primary CTA route |
+|--------------------|-----------------|-------------------|
+| Community spotlight | `mel_home_show_featured` | `page_events` |
+| Discover events | `mel_home_show_discover` | `page_events` |
+| Happening tonight | `mel_home_show_tonight` | `page_today` |
+| Easy ways to join in | `mel_home_show_free_rsvp` | `page_free` |
+| New this week | `page.homepage_latest` truthy | `page_events` |
+| Picked for you | `mel_home_show_recommended` | `page_events` |
+| Nearby events | `page.homepage_nearby` truthy (no block placed) | hardcoded `/events/nearby` |
+| Online events | `page.homepage_online` truthy (no block placed) | hardcoded `/events/online` |
+
+Visibility logic: `myeventlane_theme.theme` L1931–1959 via `HomepageSectionVisibility` service.
+
+---
+
+## Template coverage summary
+
+| Display | Dedicated page shell | Dedicated view template | Shared discovery chips |
+|---------|---------------------|-------------------------|------------------------|
+| `page_events` | ✅ browse shell | ✅ | ✅ (in view template) |
+| `page_category` | ✅ category page | ✅ | ✅ (chip bar, different UX) |
+| `page_today` | ❌ generic page | shared wrapper | ✅ |
+| `page_this_weekend` | ❌ generic page | shared wrapper | ✅ |
+| `page_free` | ❌ generic page | shared wrapper | ✅ |
+| `page_popular` | ❌ generic page | shared wrapper | ✅ (but not in browse shell quicklinks) |
+| `/events/nearby` | N/A | N/A | N/A |
+| `/events/online` | N/A | N/A | N/A |
+
+---
+
+## Navigation builder ownership
+
+| Builder | Role |
+|---------|------|
+| `PublicFooterNavigationBuilder` | Single source for public footer Discover column (`web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php`) |
+| View menu config | Main menu entries for `page_events` and `page_popular` only |
+| `myeventlane_core.links.menu.yml` | Static deployable footer-find menu links (duplicate of footer builder intent) |
+| Twig hardcoded paths | `/events/nearby`, `/events/online`, `/events/this-weekend` in several templates (bypass route system) |

--- a/docs/audits/discovery-route-recommendations.md
+++ b/docs/audits/discovery-route-recommendations.md
@@ -1,0 +1,162 @@
+# Discovery Route Recommendations
+
+**Audit date:** 2026-06-14  
+**Branch:** `feature/discovery-route-audit`  
+**Scope:** Recommendations only — **no implementation** in this workstream.
+
+Classification: **Keep** | **Improve** | **Merge** | **Remove** | **Needs Investigation**
+
+---
+
+## Executive summary
+
+MEL’s discovery spine is **`upcoming_events` Views displays** at six active `/events/*` paths. Two heavily referenced paths (`/events/nearby`, `/events/online`) have **no route owner** in the repository and should be treated as **broken IA** until built or unlinked.
+
+---
+
+## Route recommendations
+
+### `/events` — `page_events`
+
+| Verdict | **Keep** |
+|---------|----------|
+| **Evidence** | Canonical browse route; richest template stack; highest cross-surface linking |
+| **Suggested follow-up (not in scope)** | None required for route existence |
+
+---
+
+### `/events/popular` — `page_popular`
+
+| Verdict | **Improve** |
+|---------|-------------|
+| **Evidence** | Active route with promoted filter; footer + main menu placement; **not** in homepage rails or browse quicklinks; overlaps `front_featured_events` (both use `field_promoted`) |
+| **Suggested follow-up** | Clarify product distinction: "Community spotlight" (homepage editorial) vs "Popular" (full listing page); align navigation (add to chips or demote menu); add to `$listing_routes` / browse shell for UX parity |
+
+---
+
+### `/events/this-weekend` — `page_this_weekend`
+
+| Verdict | **Keep** |
+|---------|----------|
+| **Evidence** | Strong footer/chip/homepage linkage; distinct weekend date filter |
+| **Suggested follow-up** | Add dedicated page shell or inherit browse header for mobile parity with `/events` |
+
+---
+
+### `/events/today` — `page_today`
+
+| Verdict | **Keep** |
+|---------|----------|
+| **Evidence** | Homepage "Happening tonight" CTA; distinct today date filter; AJAX chip reuse |
+| **Duplication note** | **Not** duplicate of `this-weekend` — different filter windows (evidence: View YAML) |
+| **Suggested follow-up** | Consider copy alignment: homepage says "tonight" but route is `/events/today` |
+
+---
+
+### `/events/nearby`
+
+| Verdict | **Needs Investigation** → then **Improve** or **Remove** links |
+|---------|----------------------------------------------------------------|
+| **Evidence** | No route in `config/sync`; links in empty states (`page-events`, `page-category`, `mel-view-empty-events`); `mel_home_events:near_you` block exists but **not geo-filtered** and **not placed** |
+| **Options (product decision)** | (A) Add `page_nearby` View display + geo filter using `field_location_*` / user `field_city`; (B) Remove hardcoded links until built; (C) Redirect to `/events` with location exposed filter |
+| **Risk** | Empty-state recovery links currently point to likely **404** |
+
+---
+
+### `/events/online`
+
+| Verdict | **Needs Investigation** → then **Improve** or **Remove** links |
+|---------|----------------------------------------------------------------|
+| **Evidence** | No route; no `online` in `field_event_type`; homepage section inactive (no block); deferred in `docs/product-reset-phase-1-deferred.md` |
+| **Options** | (A) Add `page_online` display with documented filter criterion (field TBD — **cannot confirm filter field from repository**); (B) Remove homepage/CTA references; (C) Use `/events?event_type=…` only if a suitable field value exists — **none evidenced** |
+| **Risk** | Product promise ("Join from wherever you are") without backend route |
+
+---
+
+### `/events/free` — `page_free`
+
+| Verdict | **Keep** |
+|---------|----------|
+| **Evidence** | Footer, chips, homepage section; query alter enforces free/RSVP hygiene |
+| **Note** | Chip label "Free & RSVP" vs footer "Free events" — copy inconsistency only |
+
+---
+
+### `/events/category/{slug}` — `page_category`
+
+| Verdict | **Keep** |
+|---------|----------|
+| **Evidence** | Canonical category discovery; redirect subscriber; footer category links |
+| **Suggested follow-up** | Add `nearby`/`online` to `RESERVED_EVENT_PATHS` if those routes are built (prevent slug collision) |
+
+---
+
+## Duplication audit
+
+| Pair | Duplicate? | Evidence | Recommendation |
+|------|------------|----------|----------------|
+| **today vs this-weekend** | **No** | `page_today`: start `between today/tomorrow`; `page_this_weekend`: `saturday this week`–`sunday this week` | **Keep** both |
+| **popular vs Community spotlight** | **Partial overlap** | Both filter/sort on `field_promoted`; homepage uses `front_featured_events` block; `/events/popular` is full paginated listing | **Improve** — clarify roles or **Merge** marketing copy |
+| **online vs category route** | **N/A** | No online route | **Needs Investigation** before merge decision |
+| **free vs homepage under_20** | **Related, not duplicate** | `page_free` = route; `mel_home_events:under_20` = homepage block with separate display | **Keep** both; ensure CTAs stay consistent |
+| **page_events vs search** | **No** | Search is keyword index; `/events` is faceted browse | **Keep** both |
+| **homepage tonight block vs page_today** | **Complementary** | Block embed vs full listing page; homepage CTA → `page_today` | **Keep** |
+
+---
+
+## Empty state audit
+
+| Route / surface | Empty state | Owner | Status |
+|-----------------|-------------|-------|--------|
+| `page_events` | Custom in view template (`mel-empty--browse` + recovery links) | `views-view--upcoming-events--page-events.html.twig` L41–53 | **Exists** — includes **broken** `/events/nearby` link |
+| `page_events` (View config) | Minimal HTML area | `views.view.upcoming_events.yml` L1662–1674 | **Exists** — superseded by template when no results |
+| `page_popular` | Governed empty with CTA → `/events` | View YAML L2338–2350 | **Exists** |
+| `page_today`, `page_this_weekend` | Inherits default display empty | View YAML L98–109 (default) | **Inherited** — generic governed message |
+| `page_free` | Inherits default (no display-specific empty in YAML) | default display | **Inherited** |
+| `page_category` | Custom in template (not View empty area) | `views-view--upcoming-events--page-category.html.twig` L76–88 | **Exists** — includes **broken** `/events/nearby` link |
+| Search (no results) | `mel-empty-state--listing` | `myeventlane-search-results.html.twig` L18–28 | **Exists** — links to `page_events` + front |
+| Homepage tonight block | `mel-view-empty-events.html.twig` | unformatted/tonight templates | **Exists** |
+| `/events/nearby`, `/events/online` | N/A | — | **Missing** (no route) |
+
+---
+
+## Navigation hygiene recommendations
+
+| Issue | Verdict | Evidence |
+|-------|---------|----------|
+| Hardcoded `/events/nearby` and `/events/online` in Twig | **Remove** or replace with `path()` to real routes once built | Multiple templates bypass route system |
+| `page_popular` absent from discovery filter chips | **Improve** — add chip or remove footer/menu prominence | `mel-events-discovery-filters.html.twig` omits popular |
+| Inconsistent page shells across date routes | **Improve** — extend browse shell or add `page--view--*` overrides | Only `page_events` has browse shell |
+| Duplicate footer IA (builder + static menu links) | **Keep** (both deployable) — document single source | `PublicFooterNavigationBuilder` + `myeventlane_core.links.menu.yml` |
+| Unused homepage regions `homepage_nearby` / `homepage_online` | **Improve** — place blocks or remove sections from `page--front.html.twig` | No block config in sync |
+
+---
+
+## Security recommendations (audit only)
+
+| Item | Verdict |
+|------|---------|
+| Public discovery access via `access content` | **Keep** — standard Drupal public content |
+| `/search` `_access: TRUE` | **Keep** — intentional public search |
+| Category redirect subscriber | **Keep** — 301 to canonical; preserves access checks on term resolution |
+| Reserve slug list when adding routes | **Improve** — extend `RESERVED_EVENT_PATHS` for `nearby`, `online` when implemented |
+
+---
+
+## Priority order (if implementing later)
+
+1. **Resolve `/events/nearby` and `/events/online`** — highest broken-link risk (empty-state recovery paths).
+2. **UX parity** — browse shell / hero headers for `page_today`, `page_this_weekend`, `page_free`, `page_popular`.
+3. **Clarify popular vs spotlight** — product copy and navigation alignment.
+4. **Extend reserved paths** — when new displays ship.
+
+---
+
+## Explicitly deferred (per audit scope)
+
+- View config changes
+- Route registration
+- Twig/navigation edits
+- Analytics
+- Geo-filter implementation
+- Online event field modelling

--- a/web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig
+++ b/web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig
@@ -23,6 +23,10 @@
         <p class="mel-empty-state__text">{{ 'No results for \'@query\'. Try another keyword, browse categories, or explore events on the homepage.'|t({'@query': query}) }}</p>
         <p class="mel-empty-state__cta">
           <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-btn mel-btn-accent">{{ 'Explore events'|t }}</a>
+          <a href="{{ path('view.upcoming_events.page_this_weekend') }}" class="mel-link">{{ 'This weekend'|t }}</a>
+          <span aria-hidden="true"> · </span>
+          <a href="{{ path('view.upcoming_events.page_free') }}" class="mel-link">{{ 'Free events'|t }}</a>
+          <span aria-hidden="true"> · </span>
           <a href="{{ path('<front>') }}" class="mel-link">{{ 'Back to discovery'|t }}</a>
         </p>
       </div>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1759,6 +1759,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     'view.upcoming_events.page_today',
     'view.upcoming_events.page_this_weekend',
     'view.upcoming_events.page_free',
+    'view.upcoming_events.page_popular',
     'mel_search.view',
   ];
   if (in_array($route, $listing_routes, TRUE) && empty($variables['mel_header_categories'])) {
@@ -1799,6 +1800,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     'view.upcoming_events.page_this_weekend' => 'page_this_weekend',
     'view.upcoming_events.page_today' => 'page_today',
     'view.upcoming_events.page_category' => 'page_category',
+    'view.upcoming_events.page_popular' => 'page_popular',
   ];
   if (isset($browse_display_map[$route])) {
     $variables['mel_browse_active_display'] = $browse_display_map[$route];

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Shared discovery recovery links for browse empty states.
+ *
+ * Variables:
+ * - title: Empty state heading (required).
+ * - text: Supporting copy (required).
+ * - modifier: Optional BEM modifier (default: browse).
+ */
+#}
+{% set _modifier = modifier|default('browse') %}
+<div class="mel-empty mel-empty--{{ _modifier }}" role="status">
+  <h3 class="mel-empty__title">{{ title }}</h3>
+  <p class="mel-empty__text">{{ text }}</p>
+  <p class="mel-empty__next">
+    <a href="{{ path('view.upcoming_events.page_events') }}">{{ 'Browse all events'|t }}</a>
+    <span aria-hidden="true"> · </span>
+    <a href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
+    <span aria-hidden="true"> · </span>
+    <a href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
+    <span aria-hidden="true"> · </span>
+    <a href="{{ path('<front>') }}">{{ 'Community spotlight'|t }}</a>
+  </p>
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -18,16 +18,19 @@
     <div class="mel-browse">
       <div class="mel-container mel-container--wide">
         <header class="mel-browse-header">
-          <h1>{{ 'Find your next favourite experience.'|t }}</h1>
-          <p class="mel-browse-header__lede">{{ 'Discover workshops, gigs, markets, festivals, and community moments worth leaving the house for.'|t }}</p>
-          <p class="mel-browse-header__prompt">{{ 'Search or pick a time — see what’s on soon.'|t }}</p>
+          <h1>{{ mel_browse_heading|default('Find your next favourite experience.'|t) }}</h1>
+          <p class="mel-browse-header__lede">{{ mel_browse_lede|default('Discover workshops, gigs, markets, festivals, and community moments worth leaving the house for.'|t) }}</p>
+          {% if mel_browse_prompt|default('Search or pick a time — see what’s on soon.'|t) %}
+            <p class="mel-browse-header__prompt">{{ mel_browse_prompt|default('Search or pick a time — see what’s on soon.'|t) }}</p>
+          {% endif %}
         </header>
 
         <nav class="mel-browse-quicklinks" aria-label="{{ 'Browse events'|t }}">
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_events' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_events') }}">{{ 'Browse all'|t }}</a>
-          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_free' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
-          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_this_weekend' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_today' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_today') }}">{{ 'Today'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_this_weekend' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_free' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Popular'|t }}</a>
         </nav>
 
         {% include '@myeventlane_theme/components/mel-page-header.html.twig' with {

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig
@@ -8,8 +8,8 @@
 #}
 {% include '@myeventlane_theme/components/empty-state.html.twig' with {
   title: title|default('Nothing here yet'|t),
-  text: text|default('Try a category, nearby events, or community spotlight on the homepage.'|t),
-  cta_primary_url: cta_primary_url|default('/events'),
+  text: text|default('Try a category, browse this weekend, or explore community spotlight on the homepage.'|t),
+  cta_primary_url: cta_primary_url|default(path('view.upcoming_events.page_events')),
   cta_primary_label: cta_primary_label|default('Explore events'|t),
   cta_secondary_url: cta_secondary_url|default(path('<front>')),
   cta_secondary_label: cta_secondary_label|default('Back to discovery'|t),

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -124,8 +124,8 @@
         container_class: 'mel-container mel-container--wide',
         title: 'Nearby events'|t,
         subtitle: 'Discover more of your city, close to home.'|t,
-        link_url: '/events/nearby',
-        link_text: 'Explore nearby'|t,
+        link_url: path('view.upcoming_events.page_events'),
+        link_text: 'Browse events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_nearby
       } %}
@@ -138,8 +138,8 @@
         container_class: 'mel-container mel-container--wide',
         title: 'Online events'|t,
         subtitle: 'Join from wherever you are.'|t,
-        link_url: '/events/online',
-        link_text: 'See online events'|t,
+        link_url: path('view.upcoming_events.page_free'),
+        link_text: 'See free events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_online
       } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-free.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-free.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for view.upcoming_events page_free.
+ *
+ * @see includes/mel-browse-events-page-shell.html.twig
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
+  mel_browse_heading: 'Free events and RSVP gatherings'|t,
+  mel_browse_lede: 'Community experiences with no ticket cost — easy ways to join in.'|t,
+  mel_browse_prompt: 'Browse all events or see what’s on this weekend.'|t,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for view.upcoming_events page_popular.
+ *
+ * @see includes/mel-browse-events-page-shell.html.twig
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
+  mel_browse_heading: 'Popular events'|t,
+  mel_browse_lede: 'Experiences organisers are boosting — discover what’s gaining momentum.'|t,
+  mel_browse_prompt: 'Browse all events or see what’s happening today.'|t,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-this-weekend.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-this-weekend.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for view.upcoming_events page_this_weekend.
+ *
+ * @see includes/mel-browse-events-page-shell.html.twig
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
+  mel_browse_heading: 'Events this weekend'|t,
+  mel_browse_lede: 'Plan your Saturday and Sunday — markets, gigs, workshops, and community moments.'|t,
+  mel_browse_prompt: 'Try another time or explore everything coming up.'|t,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-today.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-today.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for view.upcoming_events page_today.
+ *
+ * @see includes/mel-browse-events-page-shell.html.twig
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
+  mel_browse_heading: 'Events happening today'|t,
+  mel_browse_lede: 'See what’s on across MyEventLane — new listings land throughout the day.'|t,
+  mel_browse_prompt: 'Pick another time or browse all upcoming events.'|t,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -26,6 +26,10 @@
     href="{{ path('view.upcoming_events.page_free') }}"
     class="mel-filter-chip{% if d == 'page_free' %} mel-filter-chip--active{% endif %}"
   >{{ 'Free & RSVP'|t }}</a>
+  <a
+    href="{{ path('view.upcoming_events.page_popular') }}"
+    class="mel-filter-chip{% if d == 'page_popular' %} mel-filter-chip--active{% endif %}"
+  >{{ 'Popular'|t }}</a>
   {% if mel_show_filter_reset and d == 'page_events' %}
     <a
       href="{{ path('view.upcoming_events.page_events') }}"

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -81,7 +81,9 @@
       <p class="mel-empty-state__text">{{ 'Check back soon, browse other categories, or explore community spotlight on the homepage.'|t }}</p>
       <p class="mel-empty-state__cta">
         <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-btn mel-btn-accent">{{ 'Explore all events'|t }}</a>
-        <a href="/events/nearby" class="mel-link">{{ 'Nearby events'|t }}</a>
+        <a href="{{ path('view.upcoming_events.page_this_weekend') }}" class="mel-link">{{ 'This weekend'|t }}</a>
+        <span aria-hidden="true"> · </span>
+        <a href="{{ path('view.upcoming_events.page_free') }}" class="mel-link">{{ 'Free events'|t }}</a>
         <span aria-hidden="true"> · </span>
         <a href="{{ path('<front>') }}" class="mel-link">{{ 'Community spotlight'|t }}</a>
       </p>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
@@ -38,19 +38,10 @@
     {% if view.result %}
       {{ rows }}
     {% else %}
-      <div class="mel-empty mel-empty--browse" role="status">
-        <h3 class="mel-empty__title">{{ 'No events found'|t }}</h3>
-        <p class="mel-empty__text">{{ 'Try a different filter, browse categories, or explore community spotlight on the homepage.'|t }}</p>
-        <p class="mel-empty__next">
-          <a href="{{ path('view.upcoming_events.page_events') }}">{{ 'Clear filters (all events)'|t }}</a>
-          <span aria-hidden="true"> · </span>
-          <a href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
-          <span aria-hidden="true"> · </span>
-          <a href="/events/nearby">{{ 'Nearby events'|t }}</a>
-          <span aria-hidden="true"> · </span>
-          <a href="{{ path('<front>') }}">{{ 'Community spotlight'|t }}</a>
-        </p>
-      </div>
+      {% include '@myeventlane_theme/includes/mel-browse-empty-recovery.html.twig' with {
+        title: 'No events found'|t,
+        text: 'Try a different filter, browse categories, or explore community spotlight on the homepage.'|t,
+      } %}
     {% endif %}
 
     {{ pager }}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
@@ -34,6 +34,32 @@
       <div class="view-content">
         {{ rows }}
       </div>
+    {% elseif display_id in mel_discovery_displays and not mel_chip_listing_fragment|default(false) %}
+      {% set mel_empty_copy = {
+        'page_today': {
+          title: 'Nothing on today yet'|t,
+          text: 'Browse upcoming events across MyEventLane — new listings land throughout the day.'|t,
+        },
+        'page_this_weekend': {
+          title: 'Nothing this weekend yet'|t,
+          text: 'Check back soon or explore all upcoming events and free gatherings.'|t,
+        },
+        'page_free': {
+          title: 'No free events right now'|t,
+          text: 'Try browsing all events or see what’s on this weekend.'|t,
+        },
+        'page_popular': {
+          title: 'No popular events yet'|t,
+          text: 'Browse upcoming events while organisers boost new experiences.'|t,
+        },
+      } %}
+      {% if mel_empty_copy[display_id] is defined %}
+        {% include '@myeventlane_theme/includes/mel-browse-empty-recovery.html.twig' with mel_empty_copy[display_id] %}
+      {% else %}
+        <div class="view-empty">
+          {{ empty }}
+        </div>
+      {% endif %}
     {% elseif empty %}
       <div class="view-empty">
         {{ empty }}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-tonight.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-tonight.html.twig
@@ -17,7 +17,7 @@
     text: 'Explore what’s on this weekend or browse all upcoming events.'|t,
     cta_primary_url: path('view.upcoming_events.page_events'),
     cta_primary_label: 'Explore events'|t,
-    cta_secondary_url: '/events/this-weekend',
+    cta_secondary_url: path('view.upcoming_events.page_this_weekend'),
     cta_secondary_label: 'Browse this weekend'|t,
   } %}
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Public Twig/theme and documentation only—no routing, Views config, or access changes; link targets shift from broken paths to existing discovery routes.
> 
> **Overview**
> Adds **four discovery audit documents** under `docs/audits/` (inventory, ownership, conversion, recommendations) and implements several of their follow-ups in theme and search templates.
> 
> **Broken IA:** Replaces hardcoded `/events/nearby` and `/events/online` with real routes—empty states, category browse, homepage section CTAs, and default empty copy now use `path()` to active listings (e.g. browse all, this weekend, free events) instead of likely 404s.
> 
> **Browse parity:** New `page--view--upcoming-events--*` overrides for **today**, **this weekend**, **free**, and **popular** wire them into `mel-browse-events-page-shell` with display-specific headings. The shell gains optional `mel_browse_*` copy and quicklinks now include **Popular** (reordered chips). **`page_popular`** is added to `$listing_routes` and `$browse_display_map` in `myeventlane_theme.theme` for header categories and active chip state.
> 
> **Empty / recovery UX:** Introduces shared `mel-browse-empty-recovery.html.twig`; browse and shared view wrappers get display-specific empty copy for today/weekend/free/popular. Search no-results and category empty states gain weekend/free recovery links.
> 
> **Navigation:** Discovery filter chips include **Popular**; homepage “nearby” / “online” section links redirect to browse and free events when those regions render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2919b3ed811df7f75d9112d4687b2e7ab309d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->