### PR TITLE
Feature/hidden gem discovery audit

### DIFF
--- a/config/sync/block.block.myeventlane_theme_homepage_hidden_gems.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_hidden_gems.yml
@@ -1,0 +1,30 @@
+uuid: 4a2b8c1d-5e6f-4a7b-9c0d-1e2f3a4b5c6d
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.upcoming_events
+  module:
+    - system
+    - views
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_hidden_gems
+theme: myeventlane_theme
+region: homepage_hidden_gems
+weight: 0
+provider: null
+plugin: 'views_block:upcoming_events-homepage_hidden_gems'
+settings:
+  id: 'views_block:upcoming_events-homepage_hidden_gems'
+  label: 'Homepage hidden gems events'
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: null
+  exposed: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.event.field_external_url
     - field.field.node.event.field_event_setup_complete
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_location
     - field.field.node.event.field_mel_sup_amt
     - field.field.node.event.field_mel_sup_chk
@@ -187,6 +188,13 @@ content:
   field_featured:
     type: boolean_checkbox
     weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_hidden_gem:
+    type: boolean_checkbox
+    weight: 17
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -134,6 +135,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -159,6 +161,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_1.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_1.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -129,6 +130,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -146,6 +152,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -172,6 +179,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_2.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_2.yml
@@ -37,6 +37,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -134,6 +135,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_geo: true
   field_event_highlights: true
@@ -150,6 +156,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
@@ -175,6 +182,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_3.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_3.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -91,6 +92,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -109,6 +115,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -135,6 +142,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_4.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_4.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -155,6 +156,11 @@ hidden:
   field_category: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -171,6 +177,7 @@ hidden:
   field_event_vendor: true
   field_event_visibility: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -196,6 +203,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_5.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_5.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -99,6 +100,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -117,6 +123,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -143,6 +150,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_form_display.node.event.wizard_step_details.yml
+++ b/config/sync/core.entity_form_display.node.event.wizard_step_details.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -187,6 +188,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -203,6 +209,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -228,6 +235,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.compact_commerce.yml
+++ b/config/sync/core.entity_view_display.node.event.compact_commerce.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.compact_commerce
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_venue_name
@@ -77,6 +78,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -93,6 +99,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -119,6 +126,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.editorial_magazine.yml
+++ b/config/sync/core.entity_view_display.node.event.editorial_magazine.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.editorial_magazine
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_venue_name
@@ -77,6 +78,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -93,6 +99,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -119,6 +126,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.event.yml
+++ b/config/sync/core.entity_view_display.node.event.event.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -265,6 +266,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_geo: true
   field_event_highlights: true
@@ -277,6 +283,7 @@ hidden:
   field_event_summary: true
   field_event_vendor: true
   field_event_visibility: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_place_id: true
   field_mel_event_gallery: true
@@ -299,6 +306,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.event_card.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -265,6 +266,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_geo: true
   field_event_highlights: true
@@ -277,6 +283,7 @@ hidden:
   field_event_summary: true
   field_event_vendor: true
   field_event_visibility: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_place_id: true
   field_mel_event_gallery: true
@@ -299,6 +306,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.event_card_compact.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card_compact.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.event_card_compact
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_location
@@ -74,6 +75,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -90,6 +96,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -116,6 +123,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.event_card_poster.yml
+++ b/config/sync/core.entity_view_display.node.event.event_card_poster.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.event_card_poster
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_location
@@ -62,6 +63,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -79,6 +85,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -105,6 +112,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.event_home_card.yml
+++ b/config/sync/core.entity_view_display.node.event.event_home_card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.event_home_card
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_venue_name
@@ -76,6 +77,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -92,6 +98,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -118,6 +125,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_mel_event_gallery
     - field.field.node.event.field_event_intro
@@ -90,6 +91,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -106,6 +112,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
@@ -131,6 +138,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.list_card.yml
+++ b/config/sync/core.entity_view_display.node.event.list_card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.list_card
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_location
@@ -78,6 +79,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -94,6 +100,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -120,6 +127,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - image.style.mel_event_card_standard
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_location
@@ -89,6 +90,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -105,6 +111,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
@@ -130,6 +137,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.teaser_featured.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser_featured.yml
@@ -33,6 +33,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -265,6 +266,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_geo: true
   field_event_highlights: true
@@ -277,6 +283,7 @@ hidden:
   field_event_summary: true
   field_event_vendor: true
   field_event_visibility: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_place_id: true
   field_mel_event_gallery: true
@@ -299,6 +306,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser_tonight.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.event.teaser_tonight
     - field.field.node.event.field_category
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_start
     - field.field.node.event.field_location
@@ -89,6 +90,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -105,6 +111,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location_latitude: true
   field_location_longitude: true
@@ -130,6 +137,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue: true

--- a/config/sync/core.entity_view_display.node.event.vendor_card.yml
+++ b/config/sync/core.entity_view_display.node.event.vendor_card.yml
@@ -37,6 +37,7 @@ dependencies:
     - field.field.node.event.field_event_vendor
     - field.field.node.event.field_external_url
     - field.field.node.event.field_featured
+    - field.field.node.event.field_hidden_gem
     - field.field.node.event.field_is_series_template
     - field.field.node.event.field_location
     - field.field.node.event.field_location_latitude
@@ -129,6 +130,11 @@ hidden:
   field_collect_per_ticket: true
   field_contact_email: true
   field_contact_phone: true
+  field_donation_default: true
+  field_donation_label: true
+  field_donation_options: true
+  field_donation_suggested_amount: true
+  field_enable_donations: true
   field_event_capacity_total: true
   field_event_end: true
   field_event_geo: true
@@ -144,6 +150,7 @@ hidden:
   field_event_visibility: true
   field_external_url: true
   field_featured: true
+  field_hidden_gem: true
   field_is_series_template: true
   field_location: true
   field_location_latitude: true
@@ -170,6 +177,7 @@ hidden:
   field_series_parent: true
   field_series_rrule: true
   field_series_timezone: true
+  field_social_proof_visibility: true
   field_tags: true
   field_ticket_types: true
   field_venue_address: true

--- a/config/sync/field.field.node.event.field_hidden_gem.yml
+++ b/config/sync/field.field.node.event.field_hidden_gem.yml
@@ -1,0 +1,23 @@
+uuid: 7b3e1f9a-2c4d-4e8b-a1f0-5d9c6b7e8a4f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hidden_gem
+    - node.type.event
+id: node.event.field_hidden_gem
+field_name: field_hidden_gem
+entity_type: node
+bundle: event
+label: 'Hidden Gem'
+description: 'Staff editorial flag for the Hidden Gems discovery programme. Independent of Boost or paid promotion.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Hidden Gem'
+  off_label: 'Not a Hidden Gem'
+field_type: boolean

--- a/config/sync/field.storage.node.field_hidden_gem.yml
+++ b/config/sync/field.storage.node.field_hidden_gem.yml
@@ -1,0 +1,18 @@
+uuid: 8c4f2a1b-9d3e-4f7a-b2c1-6e8d5a0f3c2b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hidden_gem
+field_name: field_hidden_gem
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -7,12 +7,14 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.event.field_product_target
     - field.field.node.event.field_promoted
+    - field.field.node.event.field_hidden_gem
     - field.storage.node.field_category
     - field.storage.node.field_event_end
     - field.storage.node.field_event_state
     - field.storage.node.field_event_type
     - field.storage.node.field_product_target
     - field.storage.node.field_promoted
+    - field.storage.node.field_hidden_gem
     - node.type.event
     - system.menu.main
     - taxonomy.vocabulary.categories
@@ -26,7 +28,7 @@ dependencies:
 id: upcoming_events
 label: 'Upcoming Events'
 module: views
-description: 'Canonical public discovery: /events, category, today, weekend, free. Block uses same filters; homepage sidebar block.'
+description: 'Canonical public discovery: /events, category, today, weekend, free, hidden gems. Block uses same filters; homepage sidebar block.'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -848,6 +850,293 @@ display:
         filters: false
       display_extenders: {  }
       block_description: 'Calendar: Upcoming this week'
+      block_category: MyEventLane
+      block_hide_empty: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  homepage_hidden_gems:
+    id: homepage_hidden_gems
+    display_title: 'Homepage hidden gems'
+    display_plugin: block
+    position: 10
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 6
+      sorts:
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_hidden_gem_value:
+          id: field_hidden_gem_value
+          table: node__field_hidden_gem
+          field: field_hidden_gem_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_hidden_gem
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: compact_commerce
+      defaults:
+        empty: true
+        pager: false
+        row: false
+        sorts: false
+        filters: false
+      display_extenders: {  }
+      block_description: 'Homepage: Hidden Gems'
       block_category: MyEventLane
       block_hide_empty: true
     cache_metadata:
@@ -2297,6 +2586,315 @@ display:
         filters: false
       display_extenders: {  }
       path: events/free
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_hidden_gems:
+    id: page_hidden_gems
+    display_title: 'Hidden Gems'
+    display_plugin: page
+    position: 4
+    display_options:
+      title: 'Hidden Gems'
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 12
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+          group: 1
+          expose:
+            operator: ''
+        field_event_state_value:
+          id: field_event_state_value
+          table: node__field_event_state
+          field: field_event_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_state
+          plugin_id: list_field
+          operator: not
+          value:
+            draft: draft
+            cancelled: cancelled
+            archived: archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        title_not_empty:
+          id: title_not_empty
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_event_start_not_empty:
+          id: field_event_start_not_empty
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_start_value:
+          id: field_event_start_value
+          table: node__field_event_start
+          field: field_event_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_start
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        field_event_end_value:
+          id: field_event_end_value
+          table: node__field_event_end
+          field: field_event_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_event_end
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+          is_grouped: false
+        mel_event_no_end_upcoming:
+          id: mel_event_no_end_upcoming
+          table: node_field_data
+          field: mel_event_no_end_upcoming
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: mel_event_no_end_upcoming
+          group: 2
+          exposed: false
+        field_hidden_gem_value:
+          id: field_hidden_gem_value
+          table: node__field_hidden_gem
+          field: field_hidden_gem_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_hidden_gem
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_category
+          plugin_id: taxonomy_index_tid
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Category
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: category
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              anonymous: anonymous
+              authenticated: authenticated
+          is_grouped: false
+          vid: categories
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: compact_commerce
+      defaults:
+        title: false
+        pager: false
+        row: false
+        filters: false
+      display_extenders: {  }
+      path: events/hidden-gems
     cache_metadata:
       max-age: -1
       contexts:

--- a/docs/audits/brand-rollout/brand-gap-analysis.md
+++ b/docs/audits/brand-rollout/brand-gap-analysis.md
@@ -1,0 +1,198 @@
+# Brand Gap Analysis — Current MEL vs `docs/brand/*`
+
+**Date:** 2026-06-14
+**Branch:** `feature/event-studio-consolidation`
+**Brand source of truth:** `docs/brand/` (v1.0 — README declares it authoritative)
+**Scope (as requested):** Homepage · Event cards · Onboarding flow · Discovery surfaces
+**Method:** Evidence-based. Current-state claims cite repository paths; brand requirements cite `docs/brand/*`. **No code changed.**
+
+> Severity key: **🔴 Critical** (contradicts a core pillar/promise) · **🟠 High** (visible brand miss) · **🟡 Medium** (partial / inconsistent) · **🟢 Low** (minor/polish) · **✅ Aligned**.
+
+---
+
+## 0. Cross-cutting finding: token / colour system diverges from brand
+
+This underpins all four scoped surfaces, so it is stated once up front.
+
+| Brand token (`design-tokens.md`) | Brand value | Current implementation (`myeventlane_theme/src/scss/base/_tokens.scss`) | Status |
+|---|---|---|---|
+| **Primary Purple** (primary actions) | `#6B46FF` | `--mel-color-primary: #f26d5b` (**coral**) | 🔴 **Primary colour is wrong hue** — brand primary is purple; coral is only a *secondary accent* in brand |
+| Coral (secondary accent) | `#FF6B4A` | primary slot = `#f26d5b` | 🟡 Coral exists but occupies the *primary* role |
+| Lavender | `#CDBDFF` | `--mel-color-accent: #7c83fd` (periwinkle) | 🟡 Approximate, not the brand value |
+| **Discovery Gold** (Hidden Gem) | `#FFC83D` | **absent** | 🔴 No Discovery Gold token → Hidden Gem cannot be styled per brand |
+| Warm Cream (canvas) | `#FFF7EE` | `--mel-color-bg: #fff9f5` | 🟢 Close but not exact |
+| Soft Sky | `#EAF4FF` | not a named token | 🟡 Missing |
+
+**Notable:** the brand's Primary Purple `#6B46FF` **is already in the codebase — but only on vendor surfaces** (`_vendor-events.scss:111,295`, `_vendor-studio-layout.scss:32-33`), i.e. applied to the *operational* theme rather than the *public* brand primary. The public consumer surface still leads with coral.
+
+> Per `design-tokens.md` governance, alignment = update brand doc first (done — it's the target), then a dedicated token implementation task. This is a **Phase 2 (brand layer)** item, not a copy fix.
+
+---
+
+## 1. Homepage — gap analysis
+
+**Brand spec:** `homepage-system.md` + `mel-brand-system-v1.md` (Discovery Principles).
+**Current implementation:** `web/themes/custom/myeventlane_theme/templates/page--front.html.twig`, hero block `myeventlane_front/templates/myeventlane-home-hero.html.twig`.
+
+### 1.1 Hero
+| Brand requirement | Current state (evidence) | Gap | Severity |
+|---|---|---|---|
+| Headline states discovery promise ("Discover what's on near you") | H1 = `'Your lane to great events.'` (`myeventlane-home-hero.html.twig:21`) | "Lane" metaphor, not discovery/local promise | 🟠 High |
+| Supporting line reinforces *local* exploration | `'Find workshops, gigs, markets, festivals, and community moments worth leaving the house for.'` (:23) | Lists formats; no *local/nearby* framing | 🟡 Medium |
+| **One locked hero, no rotating carousel with competing CTAs** (`homepage-system.md` Hero constraints; `DESIGN_SYSTEM.md` locks `.mel-event-hero--featured-style`) | Homepage uses a **different** hero (`.mel-home-hero`) with a **feature rotator** (`mel-home-hero__feature-rotator`, `data-mel-home-hero-rotator`, lib `home-hero-rotator`) | Homepage hero is not the locked `.mel-event-hero--featured-style`; contains a rotating element | 🟠 High (contract review) |
+| Single primary CTA | Primary `'Explore events'` + secondary `'Create event'` (:60,:63) | Acceptable (1 primary), but "Create event" is a vendor action in a discovery hero | 🟢 Low |
+| Location/date quick filters | Hero has search + "Suburb or city" input (:51) | ✅ Present | ✅ |
+
+### 1.2 Section order & hierarchy
+**Brand canonical mobile order:** Hero → **Tonight/This week near you** → **Hidden Gems** → Browse by category → Editor's Pick → Community Favourites → Just Added → Blog → Footer.
+**Current order** (`page--front.html.twig` region sequence): Hero → Featured ("Community spotlight") → Discover → Tonight → Free/RSVP → Latest → Recommended → Nearby → Online → Blog → Host CTA → Newsletter.
+
+| Brand-required section | Present today? | Gap | Severity |
+|---|---|---|---|
+| Tonight/This week **near you** as #2 | Tonight exists but is #4; not location-led | Re-prioritise + add location framing | 🟠 High |
+| **Hidden Gems rail** | ❌ **Absent** (no gem View/section) | Core differentiator missing from homepage | 🔴 Critical |
+| Browse by category (high priority) | Category pills exist (`myeventlane_category_pills`) but not prioritised in stack | Promote | 🟡 Medium |
+| Editor's Pick / Curator rail | ❌ Absent (Featured ≈ editorial but not named/curated per brand) | Missing | 🟠 High |
+| Community Favourites | ❌ Absent | Missing | 🟡 Medium |
+| Just Added | "Freshly added"/Latest exists | ✅ Conceptually present (rename) | 🟢 Low |
+| Max **two guide moments** | 0 guide moments present | No guides at all (see §5) | 🟠 High |
+| Location-aware "Near you" (prompt area when unknown) | "Nearby" rail exists; `/events/nearby` link unverified (`discovery-audit.md §1`) | Location-first not enforced; possible broken link | 🟠 High |
+
+> Current homepage is **format/recency-led**; brand wants **location-led + Hidden-Gem-led**. The structural shell (region-driven rails, shared `mel-section-shell`) is reusable — the gap is *which rails exist and their order/voice*.
+
+---
+
+## 2. Event cards — gap analysis
+
+**Brand spec:** `event-card-system.md`, `copy-guidelines.md`.
+**Current implementation:** `templates/components/event-card/mel-event-card.html.twig`; badges from `myeventlane_event/src/EventCard/EventMerchandisingPresenter.php`.
+
+### 2.1 Structure & reuse
+| Brand requirement | Current state | Gap | Severity |
+|---|---|---|---|
+| Title, date·time, location(+distance), price/RSVP, one badge | Card renders title, date badge, time, price label, status — single image badge (`_image_badge_label`, :94) | Distance ("2 km away") not shown; otherwise aligned | 🟡 Medium |
+| **One canonical card, no parallel systems** | `mel-event-card.html.twig` is canonical; variants are modifiers (featured/compact/editorial) | ✅ Aligned (no parallel card) | ✅ |
+| One badge per card | Card sets a single `_image_badge_label` | ✅ Aligned | ✅ |
+| Mobile full-width, truncation, lazy-load | Card system + skeleton/lazy patterns present | ✅ Largely aligned | ✅ |
+
+### 2.2 Badge system — **the biggest card gap**
+**Brand approved badges:** Hidden Gem, Community Favourite, Trending Tonight, Editor's Pick, Just Added, Nearby (`event-card-system.md`).
+**Current badges produced** (`EventMerchandisingPresenter.php`): `'Featured'` (:110), `'Selling fast'` (:100,:156), `'Sold out'`; plus category label fallback.
+
+| Brand badge | Implemented? | Gap | Severity |
+|---|---|---|---|
+| **Hidden Gem** (Discovery Gold) | ❌ No badge, no Gold token | Flagship discovery badge absent | 🔴 Critical |
+| Community Favourite | ❌ | Absent | 🟠 High |
+| Trending Tonight | ❌ | Absent | 🟡 Medium |
+| Editor's Pick | ◑ `'Featured'` is the nearest analogue | Not named per brand; criteria undocumented | 🟡 Medium |
+| Just Added | ◑ "Freshly added" rail, not a card badge | Partial | 🟢 Low |
+| Nearby | ❌ (no distance/location on card) | Absent | 🟠 High |
+| **Not approved:** scarcity framing | `'Selling fast'` is shown | Borderline vs "no fake scarcity" — allowed only "when true"; needs criteria governance | 🟡 Medium |
+
+> Badge text originates in a **unit-tested PHP presenter** (`EventMerchandisingPresenterTest`) — re-voicing/adding badges is a governed code change with criteria documentation (`drupal-design-governance.md` badge governance), not a copy tweak.
+
+### 2.3 On-card copy
+Brand prefers "Free / From $25 / Donation", human dates, suburb+distance. Current card supports price label + human date; **distance/suburb context missing**. No avoided vocabulary detected on cards (✅).
+
+---
+
+## 3. Onboarding flow — gap analysis
+
+**Brand spec:** `guide-character-system.md` (Helper + Celebrating archetypes), `drupal-design-governance.md` (Event Studio onboarding = Helper Guide).
+**Current implementation:** post-login hub (`mel-post-login-hub.html.twig`, `PostLoginHubBuilder`), vendor onboarding flow (`/vendor/onboard/*`), customer onboard steps (`myeventlane_core/templates/customer-onboard-step.html.twig`), empty states.
+
+| Brand requirement | Current state (evidence) | Gap | Severity |
+|---|---|---|---|
+| **Helper Guide** "Let's get started" at account creation / first steps | Standard Drupal `user.register` (altered) + customer onboard steps; **no Helper Guide voice/persona** | No guide presence in onboarding | 🟠 High |
+| Post-login welcome with recommendation (**Curator** tone) | Post-login hub has `headline`/`body`/**`recommendation` slot** (`mel-post-login-hub.html.twig`) | Structure ready, but **copy is generic, no Curator Guide voice** | 🟡 Medium |
+| **Celebrating Guide** on success ("Great choice — see you there") | Vendor onboarding has `vendor-onboard-complete-celebration.html.twig`; RSVP/checkout success copy exists | Celebration moment exists but **not branded to Celebrating Guide** | 🟡 Medium |
+| Location-first onboarding (choose your area) | Registration captures **no interest/vibe/location** preference (`onboarding-audit.md §3`) | No "choose your area / what are you into" step | 🟠 High |
+| One guide voice per screen, AU English, short | N/A — no guides yet | Cannot assess; absent | 🟠 High |
+| Vendor Event Studio = Helper Guide (professional/supportive) | Onboarding wizard/tooltips exist (`vendor-onboard-tooltip.js`); operational tone | No Helper Guide persona | 🟡 Medium |
+
+> **Strong reuse positive:** the post-login hub's built-in `recommendation` slot is the ideal Curator-Guide entry point (`onboarding-audit.md §1`). The gap is **voice + a location/interest step**, not architecture.
+
+---
+
+## 4. Discovery surfaces — gap analysis
+
+**Brand spec:** `mel-brand-system-v1.md` (Discovery Principles), `homepage-system.md`, `event-card-system.md` (search/browse parity), `copy-guidelines.md` (empty states).
+**Current implementation:** `upcoming_events` View (`/events`, `/events/category/%`, `/events/free`, `/events/popular`, `/events/this-weekend`, `/events/today`), `/search` (Search API), `/calendar`, category pills; empty states in `includes/mel-view-empty-events.html.twig` + view templates.
+
+| Brand discovery principle | Current state (evidence) | Gap | Severity |
+|---|---|---|---|
+| **Local first** (nearby before generic) | Browse is recency/category-led; `myeventlane_location` module exists; `/events/nearby` link unverified | Discovery is **browse-first, not location-first**; nearby surface unconfirmed | 🟠 High |
+| **Surface the unexpected** (Hidden Gems, not only top sellers) | No Hidden Gem / discovery-score surface anywhere | Core promise ("experiences you never knew existed") not operational in discovery | 🔴 Critical |
+| Scannable hierarchy (title/time/place + 1 action) | Cards follow this | ✅ Aligned | ✅ |
+| Honest badges, no stacking | Single badge enforced; but approved discovery badges absent (§2.2) | Badge *vocabulary* gap | 🟠 High |
+| **Search & browse parity** (same card) | `/search` and `/events` both use `mel-event-card` | ✅ Aligned | ✅ |
+| Optimistic empty states | `'No events found'` (`views-view--upcoming-events--page-events.html.twig:42`); include default `'Nothing here yet'` / `'Check back soon…'` (`mel-view-empty-events.html.twig:10-13`) | Functional, **not** the brand's "widen your date range / explore nearby suburbs" Explorer optimism | 🟡 Medium |
+| Discovery copy uses preferred vocabulary (Discover/Explore/Find/Nearby/Local) | Mixed; some nightlife-leaning ("Filter by what you feel like tonight", "better nights out") | Voice inconsistent with brand | 🟡 Medium |
+
+---
+
+## 5. Guide system — cross-surface gap (Critical)
+
+The **Guide framework** (`guide-character-system.md`) defines 5 archetypes (Explorer, Host, Curator, Helper, Celebrating) expressed as tone + placement + illustration.
+
+| Where brand wants a Guide | Current state | Severity |
+|---|---|---|
+| Homepage Hidden Gems (Explorer) | No Hidden Gems rail, no Explorer voice | 🔴 Critical |
+| Homepage Editor's Pick (Curator) | No Editor's Pick | 🟠 High |
+| Onboarding (Helper "Let's get started") | None | 🟠 High |
+| Post-login recommendation (Curator) | Slot exists, no voice | 🟡 Medium |
+| Success states (Celebrating) | Celebration markup exists, no voice | 🟡 Medium |
+| Empty states (Explorer/Helper) | Neutral copy | 🟡 Medium |
+
+**Finding:** the Guide tone-and-placement system is **entirely unimplemented** today (0 of 5 archetypes present as copy/persona). No avoided vocabulary (VIP/exclusive/secret) was found in current copy — so there is **nothing to remove**, only Guide voice to **add**. Illustration assets are Phase-2 per the roadmap (`docs/brand/assets/guide/` not yet populated).
+
+---
+
+## 6. Summary scorecard
+
+| Surface | Structure/architecture | Visual tokens | Copy/voice | Guide system | Overall |
+|---|---|---|---|---|---|
+| **Homepage** | 🟢 Reusable shell | 🔴 Coral≠Purple, no Gold | 🟠 Off-brand hero/headings | 🔴 No guides, no Hidden Gems | 🟠 **High gap** |
+| **Event cards** | ✅ Canonical, single-badge | 🔴 No Discovery Gold | 🟡 No distance/local copy | 🔴 No Hidden Gem / approved badges | 🟠 **High gap** |
+| **Onboarding** | 🟢 Hub + recommendation slot | 🟡 | 🟡 Generic | 🟠 No Helper/Celebrating voice | 🟡 **Medium gap** |
+| **Discovery** | ✅ Browse+search parity | 🟡 | 🟡 Functional empties | 🔴 No "surface the unexpected" | 🟠 **High gap** |
+
+**Headline:** the **engineering scaffolding is strongly aligned** (one canonical card, region-driven rails, search/browse parity, a recommendation-ready post-login hub). The gaps are concentrated in **(a) the token/colour system (coral-led, no Discovery Gold), (b) the missing Hidden Gem discovery surface + badge, and (c) the entirely unimplemented Guide voice.** None of these are blocked by architecture.
+
+---
+
+## 7. Prioritised gap list (for planning — no code changed here)
+
+| # | Gap | Surfaces | Severity | Brand ref | Likely phase |
+|---|---|---|---|---|---|
+| 1 | **No Hidden Gem surface or badge** (+ no Discovery Gold token) | Homepage, cards, discovery | 🔴 Critical | `mel-brand-system-v1` Hidden Gem Framework; `event-card-system` | 2–4 |
+| 2 | **Primary colour is coral, not Purple `#6B46FF`** (purple only on vendor) | All public surfaces | 🔴 Critical | `design-tokens` | 2 (token layer) |
+| 3 | **Guide voice unimplemented** (0/5 archetypes) | All four | 🔴 Critical | `guide-character-system` | 1A copy + 3 |
+| 4 | Hero off-brand (headline "Your lane…"; rotator vs locked hero) | Homepage | 🟠 High | `homepage-system` Hero | 1A copy / 2 contract |
+| 5 | Homepage order not location/gem-led; missing Editor's Pick & Community Favourites | Homepage, discovery | 🟠 High | `homepage-system` hierarchy | 1A order + 4 |
+| 6 | No location-first discovery / unverified `/events/nearby`; no distance on cards | Discovery, cards, onboarding | 🟠 High | Discovery Principle 1 | 4 |
+| 7 | Approved discovery badges absent (Community Favourite, Trending Tonight, Nearby) | Cards | 🟠 High | `event-card-system` | 4 |
+| 8 | No interest/location capture in onboarding | Onboarding | 🟠 High | governance / discovery | 3 |
+| 9 | Empty-state & section copy not optimistic/preferred-vocabulary | Discovery, homepage | 🟡 Medium | `copy-guidelines` | 1A copy |
+| 10 | Success/celebration not branded to Celebrating Guide | Onboarding | 🟡 Medium | `guide-character-system` | 3 |
+| 11 | `'Selling fast'` scarcity needs honest-criteria governance | Cards | 🟡 Medium | `event-card-system` badge rules | 4 |
+| 12 | Lavender/Soft Sky/Warm Cream not exact brand values | All | 🟡 Medium | `design-tokens` | 2 |
+
+### What is already aligned (no action)
+- One canonical event card, single-badge discipline (`event-card-system` ✅).
+- Search/browse card parity (`mel-event-card` on both ✅).
+- Region-driven homepage shell reusable for brand rails (✅).
+- Post-login hub recommendation slot ready for Curator Guide (✅).
+- No avoided/exclusivity vocabulary present to remove (✅).
+- `prefers-reduced-motion` respected; 44px touch targets (per `mobile-audit.md` ✅).
+
+---
+
+## 8. Notes & unverified items (no guessing)
+
+- **Locked hero tension:** `homepage-system.md` references working "within the existing `.mel-event-hero--featured-style` contract", but the live homepage hero is `.mel-home-hero` (a separate hero with a rotator). Whether this is an accepted exception or a drift requires a **team decision against `DESIGN_SYSTEM.md`** — *repository shows two distinct hero systems; brand intent is one.*
+- **Location-first:** `myeventlane_location` module exists; the degree of geo/suburb prioritisation in discovery rails was **not fully traced** — flagged for verification before Phase 4 (consistent with `discovery-audit.md §1`'s `/events/nearby` `/events/online` validation note).
+- **Badge criteria:** brand requires documented eligibility before enabling badges (`drupal-design-governance.md`). No such criteria doc was found for Hidden Gem/Community Favourite — *Repository evidence not found.*
+- Guide illustration assets (`docs/brand/assets/guide/`) are **Phase-2 per roadmap and not yet produced** — voice/copy gaps can close before art lands.
+
+**This document is analysis only. No homepage, card, onboarding, or discovery code was modified.**

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -1,0 +1,71 @@
+# MEL Brand System
+
+**Brand name:** MyEventLane (MEL)  
+**Version:** 1.0  
+**Status:** Source of truth for brand strategy, voice, visual language, and Drupal design governance
+
+---
+
+## Strategy at a glance
+
+MEL is built around two complementary ideas:
+
+1. **Hidden Gem** — surfacing experiences people did not know existed nearby. Discovery is the product promise, not a marketing tagline.
+2. **Guide** — a human, encouraging presence that helps people explore, join, and feel welcome. Guides are not mascots; they are tone, placement, and illustration direction.
+
+Together, Hidden Gem + Guide shape how MEL looks, reads, and behaves across the public site, vendor tools, email, and marketing.
+
+---
+
+## Reading order
+
+Read documents in this order when onboarding to the brand system or starting implementation work:
+
+| Order | Document | Purpose |
+|-------|----------|---------|
+| 1 | [mel-brand-system-v1.md](mel-brand-system-v1.md) | Primary reference — vision, pillars, frameworks, principles |
+| 2 | [mel-brand-strategy.md](mel-brand-strategy.md) | Condensed strategy — promise, positioning, emotional outcomes |
+| 3 | [design-tokens.md](design-tokens.md) | Colour, type, spacing, radius, shadow, motion tokens |
+| 4 | [guide-character-system.md](guide-character-system.md) | Guide archetypes, phrases, usage rules |
+| 5 | [homepage-system.md](homepage-system.md) | Homepage hierarchy, hero, discovery patterns |
+| 6 | [event-card-system.md](event-card-system.md) | Card structure, badges, discovery language |
+| 7 | [copy-guidelines.md](copy-guidelines.md) | Preferred and avoided language, tone examples |
+| 8 | [photography-guidelines.md](photography-guidelines.md) | Photo direction and exclusions |
+| 9 | [illustration-guidelines.md](illustration-guidelines.md) | Illustration direction and exclusions |
+| 10 | [drupal-design-governance.md](drupal-design-governance.md) | How brand maps to Drupal surfaces |
+| 11 | [implementation-roadmap.md](implementation-roadmap.md) | Phased rollout plan |
+
+---
+
+## Source of truth
+
+**`docs/brand/` is the authoritative brand documentation for MyEventLane v2.**
+
+- Brand strategy, voice, visual language, and governance live here.
+- Runtime implementation contracts (SCSS tokens, Twig components, locked hero variants) remain in repository implementation files such as `DESIGN_SYSTEM.md` and `web/themes/custom/myeventlane_theme/`.
+- Brand audits and rollout analysis live in `docs/audits/brand-rollout/` and inform implementation but do not override this brand system.
+
+When brand documentation and implementation diverge, treat `docs/brand/` as the strategic target and open a scoped implementation task to align code — do not silently reinterpret brand rules in theme or module code.
+
+---
+
+## Asset directories
+
+Brand assets are organised under `docs/brand/assets/`:
+
+| Directory | Contents |
+|-----------|----------|
+| `guide/` | Guide character illustrations and usage variants |
+| `discovery/` | Hidden Gem and discovery illustration assets |
+| `ui/` | UI pattern references and annotated screenshots |
+| `photography/` | Approved photography direction and reference images |
+| `social/` | Social and marketing asset templates |
+| `logo/` | Logo files and usage specifications |
+
+Assets are added in later implementation phases. See [implementation-roadmap.md](implementation-roadmap.md).
+
+---
+
+## Cursor governance
+
+Agents and contributors working on brand-adjacent UI should follow `.cursor/rules/mel-brand-system.mdc`, which references this directory.

--- a/docs/brand/assets/discovery/.gitkeep
+++ b/docs/brand/assets/discovery/.gitkeep
@@ -1,0 +1,1 @@
+# Discovery and Hidden Gem illustration assets — see docs/brand/illustration-guidelines.md

--- a/docs/brand/assets/guide/.gitkeep
+++ b/docs/brand/assets/guide/.gitkeep
@@ -1,0 +1,1 @@
+# Guide character illustrations — see docs/brand/guide-character-system.md

--- a/docs/brand/assets/logo/.gitkeep
+++ b/docs/brand/assets/logo/.gitkeep
@@ -1,0 +1,1 @@
+# Logo files and usage specifications — see docs/brand/implementation-roadmap.md Phase 7

--- a/docs/brand/assets/photography/.gitkeep
+++ b/docs/brand/assets/photography/.gitkeep
@@ -1,0 +1,1 @@
+# Photography reference and approved direction — see docs/brand/photography-guidelines.md

--- a/docs/brand/assets/social/.gitkeep
+++ b/docs/brand/assets/social/.gitkeep
@@ -1,0 +1,1 @@
+# Social and marketing asset templates — see docs/brand/implementation-roadmap.md Phase 7

--- a/docs/brand/assets/ui/.gitkeep
+++ b/docs/brand/assets/ui/.gitkeep
@@ -1,0 +1,1 @@
+# UI pattern references and empty-state illustrations — see docs/brand/illustration-guidelines.md

--- a/docs/brand/copy-guidelines.md
+++ b/docs/brand/copy-guidelines.md
@@ -1,0 +1,128 @@
+# MEL Copy Guidelines
+
+**Version:** 1.0  
+**Purpose:** Define preferred vocabulary, avoided language, tone by context, and Australian English conventions.
+
+---
+
+## Brand voice summary
+
+MEL sounds like a knowledgeable local friend — curious, welcoming, clear, and optimistic. We invite people to discover and join; we do not gatekeep or pressure.
+
+---
+
+## Preferred words
+
+Use these verbs and nouns for headings, CTAs, badges, and body copy:
+
+| Word | Typical use |
+|------|-------------|
+| **Discover** | Homepage, browse, search empty states |
+| **Explore** | Category pages, location browsing |
+| **Find** | Search results, filters |
+| **Join** | RSVPs, community events, waitlists |
+| **Experience** | Event descriptions, marketing |
+| **Community** | Social proof, local culture, organisers |
+
+### Supporting vocabulary
+
+- **Nearby** — location context
+- **Local** — place-based discovery
+- **This week / Tonight** — time context
+- **Welcome** — belonging moments
+- **Get tickets / RSVP** — transactional CTAs
+- **See what’s on** — low-commitment exploration
+
+---
+
+## Words and phrases to avoid
+
+| Avoid | Why | Use instead |
+|-------|-----|-------------|
+| **Exclusive** | Implies gatekeeping | “Popular”, “Community favourite” |
+| **VIP** | Elitist framing | “Front row”, “Premium seating” (factual tier names only) |
+| **Members Only** | Exclusion | “Ticket holders”, “Registered attendees” |
+| **Secret Access** | False scarcity | “Early access” only if factually true and time-limited |
+| **Limited Access** | Pressure | State actual capacity: “Few tickets left” only when true |
+| **Don’t miss out** | FOMO manipulation | “On this weekend” |
+| **Unlock** | Gamified pressure | “View”, “Get tickets”, “Continue” |
+| **Insider** | Exclusivity theatre | “Local pick”, “Hidden gem” |
+
+---
+
+## Tone examples
+
+### Homepage hero
+
+**Preferred:** “Discover what’s on near you this week.”  
+**Avoid:** “Unlock exclusive events in your city.”
+
+### Hidden Gem rail
+
+**Preferred:** “Hidden gems — local favourites you might not have found yet.”  
+**Avoid:** “Secret events only locals know about.”
+
+### Event detail — free community event
+
+**Preferred:** “You’re welcome here. Free entry — just register so the organisers know you’re coming.”  
+**Avoid:** “Members-only community — apply for access.”
+
+### Sold out
+
+**Preferred:** “This event is sold out. Join the waitlist or explore similar events nearby.”  
+**Avoid:** “You missed out — limited VIP releases only.”
+
+### Empty search
+
+**Preferred:** “No events match those filters. Try a different date or explore nearby suburbs.”  
+**Avoid:** “No results. Refine your exclusive search.”
+
+### Checkout success
+
+**Preferred:** “Great choice — you’re all set. Your tickets are on the way.”  
+**Avoid:** “VIP access confirmed. Don’t miss this exclusive experience.”
+
+### Vendor dashboard
+
+**Preferred:** “Your event is live. Here’s how to reach more people in your area.”  
+**Avoid:** “Crush your sales with exclusive marketing hacks.”
+
+---
+
+## CTA guidelines
+
+| Action | Preferred CTA |
+|--------|---------------|
+| Browse | Explore events, See what’s on |
+| Search | Find events |
+| Ticket purchase | Get tickets |
+| Free registration | RSVP, Register free |
+| Save for later | Save event |
+| Share | Share with friends |
+
+Use **one primary CTA** per screen on mobile.
+
+---
+
+## Australian English
+
+- **Spelling:** favourite, colour, organise, centre, neighbour, licence (noun), practice (noun).
+- **Date format:** “Sat 14 Jun 2026” or “14 June 2026” in formal contexts.
+- **Time:** 12-hour clock with am/pm in consumer UI: “7:00 pm”.
+- **Place:** Suburb and city names as commonly used locally (e.g. “Newtown”, “Meanjin/Brisbane” — follow editorial style for Indigenous place names when provided by content team).
+
+---
+
+## Accessibility in copy
+
+- Link text must describe the destination (“View Summer Markets event”), not “Click here”.
+- Error messages state the problem and fix: “Enter a valid email address.”
+- Do not rely on colour words alone (“red events”) for meaning.
+
+---
+
+## Governance
+
+Product, content, and engineering should run customer-facing strings through these guidelines. Vendor-facing copy may be slightly more operational but must not use avoided exclusivity language for public-facing event fields that surface on the public site.
+
+See [mel-brand-system-v1.md](mel-brand-system-v1.md) for voice attributes and [guide-character-system.md](guide-character-system.md) for guide phrases.

--- a/docs/brand/design-tokens.md
+++ b/docs/brand/design-tokens.md
@@ -1,0 +1,165 @@
+# MEL Design Tokens
+
+**Version:** 1.0  
+**Purpose:** Document the MEL brand token system for colour, typography, spacing, radius, shadow, and motion.
+
+This document defines **brand tokens**. Runtime SCSS and CSS custom properties in `web/themes/custom/myeventlane_theme/` implement these values. Do not introduce a second token system in theme code — align implementation to this document and `DESIGN_SYSTEM.md`.
+
+---
+
+## Colour palette
+
+### Primary colours
+
+| Token name | Hex | Role |
+|------------|-----|------|
+| **Primary Purple** | `#6B46FF` | Primary actions, key brand moments, active states |
+| **Lavender** | `#CDBDFF` | Secondary surfaces, soft highlights, badge backgrounds |
+| **Coral** | `#FF6B4A` | Warm accent, energy, secondary CTAs where appropriate |
+| **Discovery Gold** | `#FFC83D` | Discovery highlights, Hidden Gem accents, editorial emphasis |
+| **Warm Cream** | `#FFF7EE` | Page background, card surfaces, warm neutral base |
+| **Soft Sky** | `#EAF4FF` | Informational panels, calm secondary backgrounds |
+
+### Colour usage principles
+
+- **Warm Cream** is the default page canvas — the brand should feel light and welcoming, not clinical white or dark nightlife.
+- **Primary Purple** anchors primary buttons and key links; use sparingly on large text fields to maintain contrast.
+- **Discovery Gold** is reserved for discovery moments (Hidden Gem, editorial picks) — not generic warnings or errors.
+- **Coral** adds warmth; avoid overuse alongside Discovery Gold on the same component.
+- **Lavender** and **Soft Sky** support hierarchy without competing with primary actions.
+
+### Semantic pairings (documentation reference)
+
+| Pairing | Use |
+|---------|-----|
+| Primary Purple on Warm Cream | Primary buttons, key headings (verify contrast for small text) |
+| White on Primary Purple | Primary button labels, inverse chips |
+| Discovery Gold on Warm Cream | Hidden Gem badge, discovery callouts |
+| Coral on Warm Cream | Secondary promotional accents |
+| Dark neutral on Warm Cream | Body copy (implementation uses theme neutral tokens) |
+
+---
+
+## Typography scale
+
+MEL uses a clear, readable sans-serif stack in implementation. Brand documentation defines the **scale**, not font files.
+
+| Token | Size (mobile) | Size (desktop) | Weight | Use |
+|-------|---------------|----------------|--------|-----|
+| **Display** | 2rem (32px) | 2.75rem (44px) | Bold (700) | Homepage hero headline |
+| **H1** | 1.75rem (28px) | 2.25rem (36px) | Bold (700) | Page titles |
+| **H2** | 1.5rem (24px) | 1.875rem (30px) | Semibold (600) | Section headings |
+| **H3** | 1.25rem (20px) | 1.5rem (24px) | Semibold (600) | Card titles, subsections |
+| **Body** | 1rem (16px) | 1rem (16px) | Regular (400) | Default copy |
+| **Body small** | 0.875rem (14px) | 0.875rem (14px) | Regular (400) | Meta, captions, badges |
+| **Label** | 0.75rem (12px) | 0.8125rem (13px) | Medium (500) | Uppercase labels sparingly; prefer sentence case |
+
+### Typography principles
+
+- Minimum **16px body** on mobile for readability.
+- **Line height:** 1.5 for body; 1.2–1.3 for headings.
+- **Sentence case** for UI labels and badges (not ALL CAPS except where space is severely constrained).
+- Limit display size to one hero per page to preserve hierarchy.
+
+---
+
+## Spacing scale
+
+Based on a **4px base unit**. Use consistent steps across components.
+
+| Token | Value | Typical use |
+|-------|-------|-------------|
+| `space-1` | 4px | Tight inline gaps, icon padding |
+| `space-2` | 8px | Badge padding, compact stacks |
+| `space-3` | 12px | Form field internal padding |
+| `space-4` | 16px | Card internal padding (mobile) |
+| `space-5` | 20px | Between card elements |
+| `space-6` | 24px | Section gaps (mobile) |
+| `space-8` | 32px | Card padding (desktop), rail gaps |
+| `space-10` | 40px | Section padding (mobile) |
+| `space-12` | 48px | Large section breaks |
+| `space-16` | 64px | Hero vertical rhythm |
+| `space-20` | 80px | Major section separation (desktop) |
+
+### Spacing principles
+
+- Mobile card padding: **space-4** minimum; **space-8** on desktop.
+- Between discovery rails: **space-10** mobile, **space-12** desktop.
+- Maintain consistent gutter alignment with `.mel-container` in theme implementation.
+
+---
+
+## Radius scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `radius-sm` | 6px | Badges, small chips |
+| `radius-md` | 12px | Buttons, inputs |
+| `radius-lg` | 16px | Cards, panels |
+| `radius-xl` | 24px | Hero media containers, featured modules |
+| `radius-full` | 9999px | Pills, avatars |
+
+### Radius principles
+
+- Cards and buttons share the **rounded, friendly** MEL shape — avoid sharp 0px corners on public surfaces.
+- Hero media may use **radius-xl** on bottom corners or full container per locked hero contract in `DESIGN_SYSTEM.md`.
+
+---
+
+## Shadow scale
+
+| Token | Description | Use |
+|-------|-------------|-----|
+| `shadow-sm` | Subtle lift | Badges, hover hint |
+| `shadow-md` | Standard card | Event cards, panels |
+| `shadow-lg` | Elevated | Modals, dropdowns, sticky mobile bars |
+| `shadow-none` | Flat | On Warm Cream sections where separation is by spacing alone |
+
+### Shadow principles
+
+- Prefer **shadow-md** for event cards on Warm Cream backgrounds.
+- Avoid heavy shadows that suggest dark or exclusive nightlife aesthetics.
+- Sticky mobile CTAs may use **shadow-lg** for separation from content.
+
+---
+
+## Motion guidance
+
+### Duration tokens
+
+| Token | Duration | Use |
+|-------|----------|-----|
+| `motion-fast` | 120ms | Hover, focus colour transitions |
+| `motion-base` | 200ms | Card hover lift, accordion |
+| `motion-slow` | 320ms | Page section reveal (optional) |
+| `motion-enter` | 400ms | Modal enter (max) |
+
+### Easing
+
+- **Standard:** ease-out for entrances; ease-in-out for toggles.
+- **Avoid:** Bouncy or playful overshoot — brand is warm, not childish.
+
+### Motion principles
+
+1. **Respect `prefers-reduced-motion`** — disable non-essential transitions when requested.
+2. **No essential information in animation alone** — badges, errors, and CTAs must be visible without motion.
+3. **Subtle card hover** — slight lift or shadow change; no large scale transforms on mobile.
+4. **Guide illustrations** — may use gentle looped motion in marketing; static in core UI flows unless performance-tested.
+
+### What not to animate
+
+- Checkout payment fields
+- Ticket quantity changes that affect price (instant update preferred)
+- Accessibility focus rings
+
+---
+
+## Token governance
+
+| Layer | Authority |
+|-------|-----------|
+| Brand definition | This document (`docs/brand/design-tokens.md`) |
+| Runtime implementation | `web/themes/custom/myeventlane_theme/src/scss/base/_tokens.scss` and related token partials |
+| Locked contracts | `DESIGN_SYSTEM.md` at repository root |
+
+Changes to brand colours or scale require updating this document first, then aligning theme tokens in a dedicated implementation task.

--- a/docs/brand/drupal-design-governance.md
+++ b/docs/brand/drupal-design-governance.md
@@ -1,0 +1,170 @@
+# MEL Drupal Design Governance
+
+**Version:** 1.0  
+**Purpose:** Map the MEL Brand System to Drupal surfaces, components, and implementation rules.
+
+This document governs **how brand principles apply in the MEL Drupal 11 codebase** without duplicating runtime SCSS contracts in `DESIGN_SYSTEM.md`.
+
+---
+
+## Governance principles
+
+1. **Mobile first** — Design and accept at 390px baseline; enhance upward.
+2. **WCAG AA** — All public surfaces meet contrast, focus, and touch target requirements.
+3. **Component reuse** — Extend canonical theme components before creating new patterns.
+4. **No duplicate UI patterns** — One event card, one button system, one hero contract on the public theme.
+5. **Repository-first** — Do not invent fields, routes, or plugins; verify in codebase before implementation.
+6. **Brand docs lead strategy** — `docs/brand/` defines intent; theme/module code implements it.
+
+---
+
+## Surface map
+
+### Homepage
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Hero | Discovery promise, one primary CTA | Blocks and front module templates; locked hero variant per `DESIGN_SYSTEM.md` |
+| Discovery rails | Hidden Gems, Tonight, categories | Views or custom block plugins; consistent card render mode |
+| Guide placement | Max two guide moments | Rendered via block content or illustration library — Phase 2+ |
+| Location | Nearby content prioritised | Geo or suburb filter integration — verify active implementation |
+
+**Audit reference:** `docs/audits/brand-rollout/homepage-audit.md`
+
+### Event cards
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Structure | Title, date, location, one badge, price | Event view modes; `myeventlane_theme` `_event-card.scss` |
+| Badges | Approved list only | Field or computed badge service — criteria documented before enablement |
+| Discovery language | Copy guidelines | String overrides in templates or translation |
+| Mobile | Full-width single column | `.mel-grid--events` layout |
+
+**Audit reference:** `docs/audits/brand-rollout/component-inventory.md`
+
+### Browse pages
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Filters | Clear, non-intimidating | Views exposed filters; Helper Guide only if filters need explanation |
+| Sort | Sensible defaults (date, nearby) | Document default sort in view config |
+| Cards | Same as homepage | Shared view mode — no browse-specific card chrome |
+| Empty states | Optimistic copy | Custom empty text in views or templates |
+
+### Event detail pages
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Hero | Featured-style hero contract | `myeventlane_theme` event full/book templates |
+| Belonging | Host Guide tone in supportive copy | Body field and organiser messaging |
+| Badge | Max one on hero or header | Same badge rules as cards |
+| CTA | Get tickets / RSVP primary | Commerce and RSVP modules — high-risk; no checkout bypass |
+| Photography | Participation-focused gallery | Event media fields; vendor upload guidance |
+
+**Audit reference:** `docs/audits/brand-rollout/event-page-audit.md`
+
+### Blog
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Tone | Curious, local, optimistic | `myeventlane_front` blog templates |
+| Imagery | Photography and illustration guidelines | Featured image field |
+| Discovery | Link to relevant events where natural | Editorial workflow — manual linking |
+| Cards | Distinct from event cards but shared tokens | Reuse spacing, radius, typography tokens |
+
+### Help Centre
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Voice | Clear Helper Guide tone | Help content types; audience boundaries per workflow rules |
+| Access | Public vs vendor vs staff separation | Route and search access — never leak staff playbooks |
+| UI | Same tokens and components | Radix or custom help theme — verify active theme |
+
+**Audit reference:** `docs/audits/brand-rollout/help-centre-audit.md`
+
+### Event Studio (vendor)
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Onboarding | Helper Guide | Vendor dashboard modules and wizard |
+| Public impact | Copy guidelines apply to public fields | Event title, description, imagery shown on public site |
+| Tone | Professional, supportive | Distinct from consumer marketing but not cold enterprise |
+| Components | Vendor theme aligns to token bridge where shared | `myeventlane_vendor_theme` — avoid divergent button/card systems long term |
+
+**Audit reference:** `docs/audits/brand-rollout/onboarding-audit.md`, `docs/event-studio-section-contracts.md`
+
+### Emails
+
+| Aspect | Brand requirement | Drupal / theme notes |
+|--------|-------------------|----------------------|
+| Transactional | Celebrating Guide on success | Commerce email templates |
+| Discovery digests | Curator Guide tone | Marketing modules — opt-in only |
+| Imagery | Photography guidelines | Inline images; alt text required |
+| Exclusivity | Avoided vocabulary enforced | Template review checklist |
+
+**Audit reference:** `docs/audits/brand-rollout/email-audit.md`
+
+---
+
+## Component reuse hierarchy
+
+When implementing brand changes, use this order:
+
+1. **Existing theme component** — e.g. `.mel-card`, `.mel-btn`, `.mel-event-hero--featured-style`
+2. **Token adjustment** — colours, spacing in `_tokens.scss` after `design-tokens.md` update
+3. **Template copy change** — Twig string or translation only
+4. **New variant of existing component** — requires design review
+5. **New component** — requires brand and architecture review; document in component inventory
+
+**Never** create a parallel event card or hero variant on the public theme without updating `DESIGN_SYSTEM.md`.
+
+---
+
+## Badge implementation governance
+
+Before enabling a badge in Drupal:
+
+1. Document eligibility criteria in this file or a linked ops doc.
+2. Ensure one-badge-per-card rule in render logic.
+3. Map badge to translation strings for Australian English.
+4. Verify contrast for badge chip colours.
+
+| Badge | Suggested ownership |
+|-------|---------------------|
+| Hidden Gem | Editorial flag or discovery score service |
+| Community Favourite | Aggregated attendance/favourite metric |
+| Trending Tonight | Time-boxed view or cron job |
+| Editor’s Pick | Manual taxonomy or boolean field |
+| Just Added | Created date threshold |
+| Nearby | Location query context |
+
+Exact field names and services must be verified in the repository before implementation — do not invent.
+
+---
+
+## Accessibility checklist (per change)
+
+- [ ] Colour contrast AA for text and badges
+- [ ] Focus visible on interactive cards and CTAs
+- [ ] Touch targets ≥ 44×44px on mobile
+- [ ] `prefers-reduced-motion` respected
+- [ ] Meaningful alt text on images
+- [ ] Heading hierarchy logical on page
+
+---
+
+## Cache and performance
+
+Brand-related block and view changes must set appropriate cache contexts (e.g. user location), tags, and max-age. Do not disable caching to fix stale badges without review.
+
+---
+
+## Related documents
+
+| Document | Role |
+|----------|------|
+| [mel-brand-system-v1.md](mel-brand-system-v1.md) | Principles |
+| [design-tokens.md](design-tokens.md) | Tokens |
+| `DESIGN_SYSTEM.md` | Locked theme contracts |
+| [implementation-roadmap.md](implementation-roadmap.md) | Phased delivery |
+| `docs/audits/brand-rollout/final-rollout-strategy.md` | Rollout analysis |

--- a/docs/brand/event-card-system.md
+++ b/docs/brand/event-card-system.md
@@ -1,0 +1,131 @@
+# MEL Event Card System
+
+**Version:** 1.0  
+**Purpose:** Define event card hierarchy, structure, badge system, discovery language, and mobile-first requirements.
+
+Event cards are the **primary discovery unit** across homepage, browse, search results, maps, and related-event rails.
+
+---
+
+## Card hierarchy
+
+Information priority on every card:
+
+1. **Event title** — Scannable, truncated with ellipsis if needed.
+2. **Date and time** — Human-readable (e.g. “Sat 14 Jun · 7:00 pm”).
+3. **Location** — Venue or suburb; distance when “near you” context applies.
+4. **Badge** (optional) — One badge maximum.
+5. **Price or entry type** — “Free”, “From $25”, or “RSVP”.
+6. **Primary action** — Entire card clickable to event detail; optional explicit “View event” on desktop.
+
+---
+
+## Card structure
+
+### Anatomy
+
+```
+┌─────────────────────────────┐
+│  Image (16:9 or 4:3)        │
+│  [Badge]                    │
+├─────────────────────────────┤
+│  Title (H3)                 │
+│  Date · time                │
+│  Location · distance        │
+│  Price / RSVP               │
+└─────────────────────────────┘
+```
+
+### Regions
+
+| Region | Requirements |
+|--------|--------------|
+| **Media** | Photography showing participation or venue character; fallback illustration per illustration guidelines |
+| **Badge** | Top-left or top-right overlay; contrast-safe background |
+| **Body** | Warm Cream or white card surface; `radius-lg`; `shadow-md` |
+| **Meta** | Body small typography; neutral text colour |
+| **Interaction** | Full-card link; visible focus ring; hover lift on desktop only |
+
+### Theme alignment
+
+Public cards extend the canonical `.mel-card` contract in `DESIGN_SYSTEM.md` and `web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss`. Do not create parallel card systems.
+
+---
+
+## Badge system
+
+### Approved badges
+
+| Badge | Meaning | When to use |
+|-------|---------|-------------|
+| **Hidden Gem** | High-value local experience with low mainstream visibility | Editorial or scored discovery programmes only |
+| **Community Favourite** | Strong repeat attendance or local sentiment | Evidence-based; not paid placement |
+| **Trending Tonight** | High interest for events happening today/tonight | Time-bound; auto or editorial with clear criteria |
+| **Editor’s Pick** | Human editorial selection | Staff-curated lists with documented criteria |
+| **Just Added** | Published within a defined recent window | Typically 7 days; configurable in implementation |
+| **Nearby** | Within proximity threshold of user location | Requires location context |
+
+### Badge rules
+
+1. **One badge per card** — Never stack `Hidden Gem` + `Editor’s Pick` on the same card.
+2. **Honest labels** — Badges must reflect real criteria; document criteria in Drupal governance.
+3. **No exclusivity badges** — “VIP”, “Exclusive”, “Members Only” are not approved.
+4. **Colour** — Hidden Gem uses Discovery Gold accent; others use Lavender or neutral chips per design tokens.
+5. **Accessible text** — Badge text in sentence case; sufficient contrast on overlay.
+
+---
+
+## Discovery language
+
+### On-card copy patterns
+
+| Field | Preferred | Avoid |
+|-------|-----------|-------|
+| Title | Event name as published | Clickbait prefixes (“SHOCKING:”) |
+| Time | “Sat 14 Jun · 7:00 pm” | Unix timestamps, ambiguous “soon” |
+| Location | “Newtown Community Hall · 2 km away” | Vague “Sydney area” when suburb known |
+| Price | “Free”, “From $25”, “Donation” | “Unlock price” |
+| CTA (implicit) | Card links to detail | “Get exclusive access” |
+
+### Section headers paired with cards
+
+- “Hidden Gems near you”
+- “On this week in Brisbane”
+- “Community favourites in your area”
+- “Just added”
+
+Avoid: “Exclusive picks”, “VIP events”, “Secret listings”.
+
+---
+
+## Mobile-first requirements
+
+1. **Full-width cards** in single-column browse on viewports under 768px.
+2. **Minimum tap target** — Entire card is tappable; no micro-buttons-only navigation on mobile.
+3. **Image height cap** — Prevent oversized images pushing meta below the fold on small screens.
+4. **Text truncation** — Title max two lines; location one line; ellipsis with full text on detail page.
+5. **Badge size** — Readable at 14px; does not obscure critical image content.
+6. **Grid** — Use `.mel-grid--events` and container contracts from theme layout files.
+7. **Performance** — Lazy-load images below the fold; responsive image styles when configured.
+
+---
+
+## States
+
+| State | Behaviour |
+|-------|-----------|
+| **Default** | Standard card |
+| **Hover (desktop)** | Subtle shadow lift |
+| **Focus** | Visible focus outline for keyboard users |
+| **Sold out** | Meta line “Sold out”; card may remain for discovery but CTA on detail handles waitlist |
+| **Cancelled** | Remove from discovery rails; detail page shows status |
+| **Past event** | Exclude from discovery rails; archive behaviour per product rules |
+
+---
+
+## Related documents
+
+- [homepage-system.md](homepage-system.md) — Where cards appear on homepage
+- [copy-guidelines.md](copy-guidelines.md) — Vocabulary
+- [design-tokens.md](design-tokens.md) — Visual tokens
+- [drupal-design-governance.md](drupal-design-governance.md) — Drupal views and fields

--- a/docs/brand/guide-character-system.md
+++ b/docs/brand/guide-character-system.md
@@ -1,0 +1,122 @@
+# MEL Guide Character System
+
+**Version:** 1.0  
+**Purpose:** Define guide archetypes, phrases, placement, and rules for the MEL Guide framework.
+
+Guides are a **tone and illustration system**, not a mascot. They appear at moments where users benefit from encouragement, orientation, or affirmation.
+
+---
+
+## Guide archetypes
+
+### Explorer Guide
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Discovery |
+| **Phrase** | “Come look at this.” |
+| **When to use** | Homepage discovery rails, Hidden Gem callouts, “Near you” empty-to-content transitions, browse nudges |
+| **Tone** | Curious, inviting, peer-to-peer |
+| **MEL example** | Beside a “Hidden Gems this weekend” rail: Explorer Guide illustration with short copy “Come look at this — locals are loving these.” |
+
+### Host Guide
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Welcome |
+| **Phrase** | “You’re welcome here.” |
+| **When to use** | First visit prompts, event detail reassurance, inclusive event types, community listings |
+| **Tone** | Warm, grounding, inclusive |
+| **MEL example** | On a free community event page: “You’re welcome here — no experience needed, just turn up.” |
+
+### Curator Guide
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Recommendations |
+| **Phrase** | “I think you’ll love this.” |
+| **When to use** | Editor’s Pick, personalised rails, “Because you liked…”, email recommendations |
+| **Tone** | Thoughtful, confident but not pushy |
+| **MEL example** | Editor’s Pick card footer: “I think you’ll love this — hand-picked for curious locals.” |
+
+### Helper Guide
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Onboarding |
+| **Phrase** | “Let’s get started.” |
+| **When to use** | Account creation, vendor Event Studio first steps, filter tutorials, RSVP walkthrough |
+| **Tone** | Patient, clear, step-oriented |
+| **MEL example** | New vendor in Event Studio: Helper Guide with “Let’s get started — publish your first event in a few steps.” |
+
+### Celebrating Guide
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Success moments |
+| **Phrase** | “Great choice.” |
+| **When to use** | Post-purchase, RSVP confirmed, saved event, review submitted |
+| **Tone** | Affirming, brief, joyful without exaggeration |
+| **MEL example** | Checkout complete: “Great choice — your tickets are confirmed. See you there.” |
+
+---
+
+## Visual direction
+
+- **Style:** Simple, modern illustration — human figures or abstract guide forms, not cartoon mascots with names and costumes.
+- **Colour:** Use brand tokens (Primary Purple, Lavender, Discovery Gold, Warm Cream) — see [design-tokens.md](design-tokens.md).
+- **Scale:** Guides support content; they do not dominate the layout. On mobile, illustration height should not push primary CTAs below the fold.
+- **Diversity:** Guides should read as inclusive and age-neutral; avoid stereotyped characters.
+
+---
+
+## Placement rules
+
+| Surface | Allowed guides | Notes |
+|---------|----------------|-------|
+| Homepage | Explorer, Curator | Hero or first discovery rail only — not every section |
+| Event browse | Explorer | Sparse — prefer badge and copy over illustration |
+| Event detail | Host, Curator | One guide moment maximum per page |
+| Checkout / RSVP | Helper | Only if a step needs explanation |
+| Success states | Celebrating | Single affirmation line + optional small illustration |
+| Vendor Event Studio | Helper | Onboarding and milestone moments |
+| Email | Curator, Celebrating | Transactional emails — Celebrating; digests — Curator |
+
+---
+
+## Copy rules
+
+1. **Use the archetype phrase as inspiration**, not a mandatory exact string every time. Variations must keep the same intent.
+2. **One guide voice per screen** — do not mix Explorer and Helper on the same view.
+3. **Australian English** — “organise”, “favourite”, “neighbourhood”.
+4. **Short** — One sentence plus optional subline; never a paragraph from the guide.
+
+---
+
+## Hard rules
+
+| Rule | Rationale |
+|------|-----------|
+| **Not a mascot** | No named character universe, merchandise, or child-targeted branding |
+| **Not childish** | No baby talk, excessive exclamation marks, or clipart aesthetic |
+| **Not sarcastic** | MEL is warm and sincere |
+| **Not sales-focused** | No “Buy now”, “Don’t miss out”, or fake urgency in guide copy |
+| **Always encouraging** | Even empty states suggest a positive next step |
+
+---
+
+## What guides must never say
+
+- “Exclusive access”
+- “VIP only”
+- “Secret event”
+- “You’d be crazy to miss this”
+- “Members only”
+
+See [copy-guidelines.md](copy-guidelines.md) for the full avoided vocabulary.
+
+---
+
+## Asset location
+
+Guide illustrations are stored under `docs/brand/assets/guide/` as they are produced in Phase 2 of the [implementation roadmap](implementation-roadmap.md).

--- a/docs/brand/homepage-system.md
+++ b/docs/brand/homepage-system.md
@@ -1,0 +1,142 @@
+# MEL Homepage System
+
+**Version:** 1.0  
+**Purpose:** Define homepage hierarchy, hero structure, discovery patterns, guide placement, and mobile-first behaviour.
+
+---
+
+## Homepage goals
+
+1. **Immediate discovery** — User understands what MEL offers within five seconds.
+2. **Local relevance** — Content feels tied to place (city, suburb, or detected region).
+3. **Clear next step** — One primary action: explore events near the user.
+4. **Hidden Gem surfacing** — Editorial and algorithmic rails highlight worthwhile local experiences.
+5. **Welcoming tone** — Host and Explorer guide energy without clutter.
+
+---
+
+## Hero structure
+
+### Required elements (mobile-first order)
+
+1. **Headline** — Discovery-oriented; states the brand promise in plain language.
+2. **Supporting line** — One sentence reinforcing local exploration.
+3. **Location / date quick filters** — Low-friction way to personalise the feed.
+4. **Primary CTA** — Single action, e.g. “Explore events near you”.
+5. **Hero media** — Photography or restrained illustration showing participation and community (not empty venues).
+
+### Hero copy direction
+
+| Element | Example |
+|---------|---------|
+| Headline | “Discover what’s on near you” |
+| Supporting line | “Markets, gigs, workshops, and community events — all in one place.” |
+| Primary CTA | “Explore events” or “See what’s on this week” |
+
+### Hero constraints
+
+- **One locked hero variant** on the public theme per `DESIGN_SYSTEM.md` — brand refreshes work within the existing `.mel-event-hero--featured-style` contract unless a formal hero change is approved.
+- No rotating carousels with competing CTAs in the hero.
+- Hero must not use exclusivity or urgency language.
+
+---
+
+## Homepage hierarchy
+
+Top to bottom on mobile:
+
+| Section | Priority | Purpose |
+|---------|----------|---------|
+| 1. Hero | Critical | Promise, filters, primary CTA |
+| 2. Tonight / This week near you | Critical | Immediate discovery |
+| 3. Hidden Gems | High | Brand differentiator |
+| 4. Browse by category | High | Wayfinding |
+| 5. Editor’s Pick / Curator rail | Medium | Editorial trust |
+| 6. Community Favourites | Medium | Social proof without pressure |
+| 7. Just Added | Medium | Freshness signal |
+| 8. Blog / stories (if present) | Lower | Inspiration, SEO |
+| 9. Footer | Standard | Trust, help, legal |
+
+On desktop, rails may sit in two columns where grid contracts allow, but **mobile order is the canonical priority**.
+
+---
+
+## Recommended sections
+
+### Tonight near you
+
+- Time-scoped events within the user’s selected or detected area.
+- Cards use standard event card system — see [event-card-system.md](event-card-system.md).
+- Badge: `Nearby` or `Trending Tonight` where criteria are met.
+
+### Hidden Gems
+
+- Curated or scored list of high-value, low-visibility local events.
+- Badge: `Hidden Gem` (Discovery Gold accent).
+- Explorer Guide placement: optional single illustration or copy line — “Come look at this.”
+
+### Browse by category
+
+- Scannable category chips or cards (Music, Markets, Workshops, Sport, etc.).
+- Links to filtered browse views — same card patterns on destination pages.
+
+### Editor’s Pick
+
+- Human-curated selection; limited count (e.g. 4–6 items).
+- Badge: `Editor’s Pick`.
+- Curator Guide tone in section intro.
+
+---
+
+## Guide placement
+
+| Section | Guide | Max presence |
+|---------|-------|--------------|
+| Hero | Explorer (optional) | Illustration or one line only |
+| Hidden Gems | Explorer | Section intro copy |
+| Editor’s Pick | Curator | Section intro copy |
+| Empty location state | Helper | “Let’s get started — choose your area.” |
+
+**Do not** place guides in every rail. Maximum **two guide moments** on the full homepage.
+
+---
+
+## Discovery patterns
+
+1. **Rails over walls** — Horizontal scroll or stacked cards on mobile; avoid endless undifferentiated grids above the fold.
+2. **Consistent cards** — Every event uses the canonical event card; no homepage-only card chrome.
+3. **Badge discipline** — Maximum one badge per card; see approved badge list in event card system.
+4. **See all links** — Each rail links to a filtered browse page with the same sort and filters applied.
+5. **Location awareness** — When location is unknown, prompt to select suburb or city before showing “Near you” rails.
+
+---
+
+## Content priorities
+
+| Priority | Content type |
+|----------|--------------|
+| P0 | Events happening soon near the user |
+| P1 | Hidden Gems and Community Favourites |
+| P2 | Categories and Editor’s Pick |
+| P3 | Blog teasers and static promo blocks |
+
+Paid promotion, if introduced later, must be labelled clearly and must not use Hidden Gem or Editor’s Pick badges.
+
+---
+
+## Mobile-first behaviour
+
+1. **Single column** default; no side-by-side hero + rails on narrow viewports.
+2. **Sticky optional** — Location or date filter may stick on scroll; primary nav remains theme-standard.
+3. **Touch targets** — Category chips and CTAs meet 44×44px minimum.
+4. **Image aspect ratios** — Card images consistent with browse to prevent layout shift when navigating.
+5. **Performance** — Hero image optimised; lazy-load below-the-fold rails.
+6. **Reduced motion** — Rail scroll and hero animations respect `prefers-reduced-motion`.
+
+---
+
+## Governance
+
+Homepage implementation spans Drupal blocks, views, and theme templates. Map technical ownership in [drupal-design-governance.md](drupal-design-governance.md).
+
+Brand rollout audits: `docs/audits/brand-rollout/homepage-audit.md`.

--- a/docs/brand/illustration-guidelines.md
+++ b/docs/brand/illustration-guidelines.md
@@ -1,0 +1,111 @@
+# MEL Illustration Guidelines
+
+**Version:** 1.0  
+**Purpose:** Direct illustration style for guides, empty states, discovery moments, and marketing supporting the MEL brand.
+
+---
+
+## Strategic intent
+
+Illustration fills gaps where photography is unavailable and reinforces **optimism, curiosity, and community** — especially in guide moments and discovery UI.
+
+Illustration is **supporting**, not dominant. It must not become a cartoon mascot universe.
+
+---
+
+## Focus on
+
+### Optimism
+
+Light palettes, open compositions, upward or forward movement.
+
+**MEL example:** Figures walking toward a market strip under Soft Sky background — open, bright scene.
+
+### Curiosity
+
+Characters or abstract guides looking toward something interesting — a map pin, a small stage, a market stall.
+
+**MEL example:** Explorer Guide gesturing toward a cluster of event pins on a simplified neighbourhood map.
+
+### Discovery
+
+Visual metaphors for finding the unexpected nearby — paths, doors opening, map reveals — without “treasure chest” clichés.
+
+**MEL example:** Turning a corner to reveal a small outdoor gig — subtle, not dramatic.
+
+### Community
+
+Groups in casual interaction; shared tables, lawns, workshops.
+
+**MEL example:** Diverse figures at a community picnic illustration for an empty-state “no events yet in this suburb”.
+
+### Participation
+
+Hands making, clapping, planting, cooking — aligned with photography pillars.
+
+**MEL example:** Workshop illustration with hands on materials, not passive silhouettes.
+
+---
+
+## Avoid
+
+| Avoid | Why |
+|-------|-----|
+| **Isolation** | Single figure alone in empty space contradicts belonging |
+| **Mystery** | Hooded figures, fog, locked doors — wrong emotional outcome |
+| **Darkness** | Heavy shadows, night-only scenes, neon noir |
+| **Exclusivity** | Velvet ropes, VIP badges, crown icons, gated doors |
+| **Childish clipart** | Thick outlines, emoji style, mascot costumes |
+| **Corporate stock flat art** | Generic office people at whiteboards |
+
+---
+
+## Style attributes
+
+| Attribute | Guidance |
+|-----------|----------|
+| **Line** | Soft, rounded; not sharp corporate geometric |
+| **Colour** | Brand tokens: Primary Purple, Lavender, Coral, Discovery Gold, Warm Cream, Soft Sky |
+| **Detail** | Moderate — readable at small sizes on mobile |
+| **Characters** | Simplified human forms; inclusive; no branded mascot names |
+| **Background** | Minimal or Warm Cream / Soft Sky; avoid busy patterns behind text |
+
+---
+
+## Usage by context
+
+| Context | Illustration role |
+|---------|-------------------|
+| Guide moments | Small figure or abstract guide per [guide-character-system.md](guide-character-system.md) |
+| Empty states | One illustration + helpful copy + CTA |
+| Onboarding | Step-by-step Helper Guide scenes |
+| Marketing email | Header illustration; keep file size modest |
+| Event card fallback | When no photo uploaded — venue category iconography or neutral participation scene |
+
+**Do not** illustrate every card — photography is preferred when available.
+
+---
+
+## Motion
+
+- Optional gentle loop for marketing pages only.
+- UI core flows: prefer static SVG or PNG unless performance-tested.
+- Respect `prefers-reduced-motion` — see [design-tokens.md](design-tokens.md).
+
+---
+
+## Relationship to guides
+
+Illustration implements the five guide archetypes (Explorer, Host, Curator, Helper, Celebrating) without giving them names, backstories, or merchandise.
+
+---
+
+## Asset location
+
+Illustration files are organised under:
+
+- `docs/brand/assets/guide/` — guide archetype artwork
+- `docs/brand/assets/discovery/` — Hidden Gem and map/discovery motifs
+- `docs/brand/assets/ui/` — empty states and UI-specific scenes
+
+Produced in Phases 2–3 of [implementation-roadmap.md](implementation-roadmap.md).

--- a/docs/brand/implementation-roadmap.md
+++ b/docs/brand/implementation-roadmap.md
@@ -1,0 +1,194 @@
+# MEL Brand Implementation Roadmap
+
+**Version:** 1.0  
+**Purpose:** Phased plan to implement the MEL Brand System from documentation through marketing.
+
+Each phase completes before the next begins unless explicitly parallelised by product approval. **Phase 1 is complete** with the creation of `docs/brand/`.
+
+---
+
+## Phase 1 — Brand documentation
+
+**Status:** Complete (v1.0)
+
+**Deliverables:**
+
+- `docs/brand/` document set (strategy, tokens, guides, surfaces, governance)
+- `.cursor/rules/mel-brand-system.mdc` Cursor governance
+- Asset directory structure under `docs/brand/assets/`
+
+**Exit criteria:**
+
+- All brand docs reviewed by product and design stakeholders
+- No conflict with `DESIGN_SYSTEM.md` hero and card contracts
+- Reading order published in `docs/brand/README.md`
+
+**Validation:**
+
+```bash
+find docs/brand -type f
+```
+
+---
+
+## Phase 2 — Guide asset system
+
+**Goal:** Produce and catalogue guide illustrations for five archetypes.
+
+**Deliverables:**
+
+- Explorer, Host, Curator, Helper, Celebrating guide artwork in `docs/brand/assets/guide/`
+- Usage sheet per archetype (placement, max size, colour variants)
+- SVG or optimised PNG suitable for theme library attachment
+
+**Dependencies:** Phase 1 approved illustration and guide-character guidelines.
+
+**Exit criteria:**
+
+- All five guides available in brand assets
+- Contrast-checked on Warm Cream and Soft Sky backgrounds
+- No mascot naming or childish styling
+
+---
+
+## Phase 3 — Discovery illustration system
+
+**Goal:** Hidden Gem and discovery motif library.
+
+**Deliverables:**
+
+- Discovery illustrations in `docs/brand/assets/discovery/`
+- Empty-state UI illustrations in `docs/brand/assets/ui/`
+- Map pin, neighbourhood, and “near you” visual vocabulary
+
+**Dependencies:** Phase 2 guide style established.
+
+**Exit criteria:**
+
+- Discovery assets usable in homepage and browse empty states
+- Consistent with `illustration-guidelines.md`
+
+---
+
+## Phase 4 — Homepage refresh
+
+**Goal:** Align homepage hierarchy, copy, and rails to brand system.
+
+**Deliverables:**
+
+- Hero copy and CTA per `homepage-system.md`
+- Hidden Gems and Tonight rails with correct badges
+- Guide placement (max two moments)
+- Mobile-first validation at 390px
+
+**Dependencies:** Phases 1–3 for illustration; may start copy-only earlier.
+
+**Technical touchpoints:**
+
+- Drupal blocks/views for homepage
+- `myeventlane_theme` homepage templates and SCSS
+- Audit against `docs/audits/brand-rollout/homepage-audit.md`
+
+**Exit criteria:**
+
+- Homepage matches documented hierarchy
+- No duplicate card patterns introduced
+- WCAG AA spot check passed
+
+---
+
+## Phase 5 — Event card refresh
+
+**Goal:** Unified card structure, badges, and discovery language across surfaces.
+
+**Deliverables:**
+
+- Badge rendering with one-badge rule
+- Card copy patterns per `event-card-system.md`
+- Shared view mode for homepage, browse, search, related events
+
+**Dependencies:** Phase 4 homepage rails; badge criteria documented in `drupal-design-governance.md`.
+
+**Technical touchpoints:**
+
+- `web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss`
+- Event view modes and badge fields/services
+
+**Exit criteria:**
+
+- Cards identical across discovery surfaces
+- Approved badges only
+- Mobile card audit passed
+
+---
+
+## Phase 6 — Email refresh
+
+**Goal:** Align transactional and discovery emails to brand voice and visuals.
+
+**Deliverables:**
+
+- Order confirmation and ticket email templates — Celebrating Guide tone
+- Discovery digest template — Curator Guide tone
+- Photography and illustration usage per guidelines
+
+**Dependencies:** Phases 2–3 assets optional but recommended.
+
+**Technical touchpoints:**
+
+- Commerce email templates
+- Marketing email modules
+
+**Audit reference:** `docs/audits/brand-rollout/email-audit.md`
+
+**Exit criteria:**
+
+- Avoided vocabulary removed from templates
+- Alt text on hero images
+- Mobile-readable email layout spot check
+
+---
+
+## Phase 7 — Marketing system
+
+**Goal:** Extend brand to social, campaigns, and external touchpoints.
+
+**Deliverables:**
+
+- Social templates in `docs/brand/assets/social/`
+- Logo usage pack in `docs/brand/assets/logo/`
+- Campaign copy cheat sheet derived from `copy-guidelines.md`
+- Paid social and partner co-brand rules
+
+**Dependencies:** Phases 1–6 stable public experience.
+
+**Exit criteria:**
+
+- Asset library complete for marketing self-service
+- Hidden Gem and Guide strategy consistent off-platform
+- No exclusivity-led campaign framing
+
+---
+
+## Cross-phase rules
+
+| Rule | Applies to all phases |
+|------|------------------------|
+| Mobile first | Yes |
+| WCAG AA | Yes |
+| Component reuse | Yes |
+| No duplicate UI patterns | Yes |
+| Australian English | Yes |
+| Repository verification before Drupal changes | Yes |
+
+---
+
+## Reporting
+
+After each phase, report:
+
+- What changed (files and surfaces)
+- Validation commands run and results
+- Residual risks (cache, Commerce, access, config drift)
+
+Do not skip verification per `mel-workflow-verification.mdc`.

--- a/docs/brand/mel-brand-strategy.md
+++ b/docs/brand/mel-brand-strategy.md
@@ -1,0 +1,90 @@
+# MEL Brand Strategy
+
+**Version:** 1.0  
+**Audience:** Product, design, content, engineering, marketing
+
+---
+
+## Brand Promise
+
+**There is always something amazing happening nearby.**
+
+MEL exists to help people notice what is already around them — local gigs, markets, workshops, community gatherings, and one-off experiences they would otherwise miss. The promise is optimistic and grounded: not hype, not FOMO, but genuine discovery.
+
+---
+
+## Positioning
+
+**MyEventLane helps people discover experiences they never knew existed.**
+
+MEL is not a generic events listing site. It is a discovery platform for local culture — where curiosity is rewarded and belonging is the default outcome of showing up.
+
+| Dimension | MEL position |
+|-----------|--------------|
+| Category | Local experience discovery |
+| Primary job | Help people find and join nearby events |
+| Differentiator | Hidden gems and community-led experiences surfaced with warmth, not exclusivity |
+| Competitive frame | Humanitix-level polish with a distinctly local, inclusive discovery voice |
+
+---
+
+## Brand Pillars
+
+### Discovery
+
+Surface what is worth finding — especially events that do not have big marketing budgets but have real community value.
+
+**MEL example:** A weekend pottery workshop in a suburban studio appears in a “Hidden Gems near you” rail, not buried on page three of a generic search.
+
+### Belonging
+
+Everyone should feel welcome before they buy a ticket. Language, imagery, and layout must signal inclusion, not gatekeeping.
+
+**MEL example:** Event detail copy uses “You’re welcome here” energy — clear pricing, accessible venue notes, and no VIP framing.
+
+### Participation
+
+MEL celebrates people doing things together — attending, volunteering, performing, making. The brand shows arrival and involvement, not passive consumption.
+
+**MEL example:** Photography and cards foreground attendees mid-experience: laughing at a comedy night, browsing a makers’ market, joining a community run.
+
+### Local Culture
+
+MEL amplifies neighbourhood character — small venues, independent organisers, grassroots creativity, and the rhythm of a place.
+
+**MEL example:** Browse filters and editorial rails highlight “What’s on in Newtown” or “Brisbane Southside this week,” not abstract national categories alone.
+
+### Optimism
+
+The brand tone is warm, forward-looking, and encouraging. MEL makes trying something new feel low-risk and rewarding.
+
+**MEL example:** Empty-state copy reads “Nothing here yet — widen your date range or explore a nearby suburb” rather than “No results found.”
+
+---
+
+## Emotional Outcomes
+
+### Users should feel
+
+| Feeling | What it means on MEL |
+|---------|----------------------|
+| **Curious** | Layout and copy invite exploration; badges and guides point to the unexpected |
+| **Welcome** | No exclusivity language; inclusive imagery; clear “how to join” paths |
+| **Included** | Pricing, access, and community context are transparent |
+| **Inspired** | Photography and illustration show real participation and creativity |
+| **Optimistic** | Tone assumes good experiences are available nearby |
+
+### Users should not feel
+
+| Feeling | What to avoid |
+|---------|---------------|
+| **Excluded** | VIP, members-only, secret-access framing |
+| **Intimidated** | Dark, elitist, or overly polished corporate aesthetics |
+| **Overwhelmed** | Dense listings without hierarchy, too many competing CTAs |
+| **Pressured** | Aggressive urgency, scarcity manipulation, hard-sell countdowns |
+
+---
+
+## Relationship to the full brand system
+
+This document is the strategic summary. For frameworks, principles, voice, and Drupal governance, see [mel-brand-system-v1.md](mel-brand-system-v1.md) and the [README reading order](README.md).

--- a/docs/brand/mel-brand-system-v1.md
+++ b/docs/brand/mel-brand-system-v1.md
@@ -1,0 +1,183 @@
+# MEL Brand System v1.0
+
+**Primary brand system document for MyEventLane**
+
+---
+
+## Brand Vision
+
+MyEventLane is Australia’s most welcoming way to discover local experiences. We connect curious people with community-led events, independent organisers, and hidden gems — making it easy to explore, join, and belong.
+
+---
+
+## Brand Promise
+
+**There is always something amazing happening nearby.**
+
+Every surface should reinforce that promise through discovery patterns, encouraging guides, and optimistic visual language.
+
+---
+
+## Positioning
+
+**MyEventLane helps people discover experiences they never knew existed.**
+
+MEL competes on discovery quality and belonging — not exclusivity, not corporate event management aesthetics, not anxiety-driven urgency.
+
+---
+
+## Brand Pillars
+
+| Pillar | Definition | MEL example |
+|--------|------------|-------------|
+| **Discovery** | Reveal worthwhile nearby experiences | “Hidden Gem” badge on a neighbourhood jazz night with 40 seats |
+| **Belonging** | Welcome all audiences without gatekeeping | RSVP and ticket flows use plain language; no “members only” framing |
+| **Participation** | Show people doing things, not empty venues | Event cards use photography of audiences and makers in action |
+| **Local Culture** | Reflect place and community | Homepage rails scoped to city or suburb, not generic national feeds |
+| **Optimism** | Encourage trying something new | Guide copy: “Come look at this” — inviting, not salesy |
+
+---
+
+## Hidden Gem Framework
+
+**Purpose:** Identify and present experiences that are high value but low visibility — the events people are glad they found.
+
+### What qualifies as a Hidden Gem
+
+- Strong community or creative merit with limited mainstream promotion
+- Local relevance (venue, organiser, or audience rooted in place)
+- Genuine discovery moment for a typical MEL user
+
+### How Hidden Gem appears
+
+- **Badge:** `Hidden Gem` on event cards and detail pages (see [event-card-system.md](event-card-system.md))
+- **Copy:** “A local favourite you might not have found yet” — not “secret” or “exclusive”
+- **Placement:** Discovery rails, “Near you” sections, editorial picks
+- **Photography:** Participation and warmth, not empty stages
+
+### What Hidden Gem is not
+
+- A pay-to-play label for vendors
+- A synonym for “obscure” or “underground”
+- An exclusivity signal
+
+---
+
+## Guide Framework
+
+**Purpose:** Provide a consistent, human presence that helps users explore, decide, and complete actions — without becoming a mascot or sales character.
+
+Guides are expressed through:
+
+- Illustration direction (see [guide-character-system.md](guide-character-system.md))
+- Microcopy tone
+- Placement at decision points (homepage hero, empty states, onboarding, success moments)
+
+### Guide principles
+
+- Encouraging, never sarcastic
+- Helpful, never pushy
+- Warm, never childish
+- Present at moments of uncertainty, absent when the UI is self-explanatory
+
+**MEL example:** After a successful ticket purchase, Celebrating Guide energy: “Great choice — see you there.” Not: “You’re in the VIP club now.”
+
+---
+
+## Voice & Tone
+
+### Voice attributes
+
+| Attribute | Description |
+|-----------|-------------|
+| **Warm** | Friendly Australian English; contractions acceptable where natural |
+| **Clear** | Short sentences; plain words for actions and outcomes |
+| **Curious** | Questions and invitations, not commands |
+| **Inclusive** | No assumed insider knowledge |
+| **Optimistic** | Assume good options exist nearby |
+
+### Tone by context
+
+| Context | Tone | Example |
+|---------|------|---------|
+| Homepage hero | Inviting discovery | “Discover what’s on near you this week” |
+| Event card | Informative, light | “Community market · Sat 9am · 2 km away” |
+| Empty state | Helpful, calm | “No events match those filters. Try a wider date range or explore nearby suburbs.” |
+| Checkout success | Affirming | “You’re all set. Your tickets are on the way.” |
+| Vendor-facing | Professional, supportive | “Your event is live. Here’s how to reach more locals.” |
+
+### Words to prefer and avoid
+
+See [copy-guidelines.md](copy-guidelines.md) for the full vocabulary list.
+
+---
+
+## Discovery Principles
+
+1. **Local first** — Default to nearby and place-relevant content before national or generic feeds.
+2. **Surface the unexpected** — Editorial and algorithmic rails should include Hidden Gems, not only top sellers.
+3. **Scannable hierarchy** — Title, time, place, and one primary action per card or screen on mobile.
+4. **Honest badges** — Only use approved badges with clear meaning; never stack badges to create false urgency.
+5. **Progressive disclosure** — Show enough to decide; full detail on the event page.
+6. **Search and browse parity** — Discovery language and card patterns stay consistent across entry points.
+
+**MEL example:** The homepage “Tonight near you” rail uses the same card component and badge rules as `/events` browse — no duplicate card chrome.
+
+---
+
+## Belonging Principles
+
+1. **Welcome before transaction** — Users should understand what the event is and who it is for before payment.
+2. **No exclusivity theatre** — Avoid VIP, members-only, and secret-access language (see copy guidelines).
+3. **Accessible information** — Venue access, pricing, and age suitability visible where possible.
+4. **Inclusive imagery** — Show diverse ages, bodies, and community contexts authentically.
+5. **Error states that respect the user** — Explain what happened and offer a next step; never blame the user.
+
+**MEL example:** An all-ages community picnic lists “Free entry · Dogs welcome · Wheelchair access via side gate” in the card meta line.
+
+---
+
+## Participation Principles
+
+1. **Show people in action** — Photography and illustration prioritise arrival, making, performing, and gathering.
+2. **Celebrate organisers** — Credit community hosts and local creators where appropriate.
+3. **Join-oriented CTAs** — “Get tickets”, “RSVP”, “Join waitlist” — not “Unlock access”.
+4. **Post-purchase affirmation** — Success states reinforce participation (“See you there”) not status (“You’re in”).
+5. **Social proof without pressure** — “Community Favourite” is acceptable; fake scarcity is not.
+
+---
+
+## Accessibility Principles
+
+1. **WCAG AA minimum** — Colour contrast, focus states, and touch targets meet AA for all public surfaces.
+2. **Readable type** — Body text legible on mobile without zoom; avoid low-contrast pastel-on-pastel combinations.
+3. **Keyboard and screen reader support** — Interactive cards, filters, and CTAs have accessible names and focus order.
+4. **Motion respect** — Honour `prefers-reduced-motion`; essential information never conveyed by animation alone.
+5. **Plain language** — Short sentences, meaningful link text, no jargon for core actions.
+
+**MEL example:** Primary Purple (`#6B46FF`) on Warm Cream (`#FFF7EE`) is used for text only where contrast passes AA; large button labels may use white on purple.
+
+---
+
+## Mobile First Principles
+
+1. **390px baseline** — Design and review at mobile width first; enhance for tablet and desktop.
+2. **One primary action per screen** — Especially on checkout, RSVP, and filter flows.
+3. **Thumb-friendly targets** — Minimum 44×44px touch targets for primary controls.
+4. **Vertical hierarchy** — Hero → discovery rails → categories → footer; no horizontal-only critical paths.
+5. **Performance-aware** — Hero and card images use responsive styles; avoid layout shift on load.
+6. **Consistent components** — Reuse event cards, buttons, and badges; no one-off mobile patterns.
+
+**MEL example:** Homepage hero collapses to a single-column stack: headline, location/date quick filters, primary CTA, supporting discovery rail below the fold.
+
+---
+
+## Related documents
+
+| Document | Topic |
+|----------|-------|
+| [mel-brand-strategy.md](mel-brand-strategy.md) | Strategy summary |
+| [design-tokens.md](design-tokens.md) | Visual tokens |
+| [guide-character-system.md](guide-character-system.md) | Guide archetypes |
+| [drupal-design-governance.md](drupal-design-governance.md) | Drupal surface mapping |
+| [implementation-roadmap.md](implementation-roadmap.md) | Rollout phases |

--- a/docs/brand/photography-guidelines.md
+++ b/docs/brand/photography-guidelines.md
@@ -1,0 +1,110 @@
+# MEL Photography Guidelines
+
+**Version:** 1.0  
+**Purpose:** Direct photography selection, commissioning, and curation for MEL public surfaces.
+
+---
+
+## Strategic intent
+
+Photography should make users feel they can **arrive, participate, and belong**. Images prove that real experiences happen on MEL — not abstract “events industry” stock.
+
+---
+
+## Focus on
+
+### Arrival
+
+People entering venues, finding seats, opening markets, gathering before a workshop starts.
+
+**MEL example:** Attendees walking into a neighbourhood hall for a community dinner — coats, conversation, warm lighting.
+
+### Participation
+
+Hands-on activity: making, dancing, eating, learning, volunteering.
+
+**MEL example:** Pottery class with clay on hands; park run mid-stride; open-mic audience engaged.
+
+### Belonging
+
+Groups that read as welcoming and mixed — ages, backgrounds, casual dress.
+
+**MEL example:** Families and friends at a local festival lawn; seniors at a community centre workshop.
+
+### Community
+
+Local organisers, volunteers, and small vendors as part of the scene — not staged corporate teams.
+
+**MEL example:** Market stall holder serving a customer; volunteer greeting at a charity event entrance.
+
+### Creativity
+
+Independent artists, makers, performers in their context.
+
+**MEL example:** Busker on a main street; gallery opening with guests viewing work; maker market tables.
+
+### Discovery
+
+Moments of pleasant surprise — finding something unexpected in a familiar area.
+
+**MEL example:** Hidden laneway gig; small pop-up in a suburb shopfront; “didn’t know this was here” framing in editorial crops.
+
+---
+
+## Avoid
+
+| Avoid | Why |
+|-------|-----|
+| **Empty venues** | Suggests low energy; contradicts participation pillar |
+| **Dark nightlife** | Reads as exclusive or intimidating; conflicts with warm brand |
+| **Corporate boardrooms** | Wrong category signal for community discovery |
+| **Generic stock imagery** | Smiling models with laptops, handshake clichés, fake diversity tableaux |
+| **Heavy filters** | Neon noir, extreme desaturation, or elitist luxury grading |
+| **Crowd chaos without context** | Overwhelming mosh pits without belonging narrative |
+
+---
+
+## Technical and UX requirements
+
+- **Aspect ratios** — Align with event card media (16:9 or 4:3) to reduce crop surprises.
+- **Focal point** — Faces and activity centres should survive centre-weighted crops on mobile.
+- **Alt text** — Describe the activity and setting for screen readers; not “image123.jpg”.
+- **Rights** — Use vendor-uploaded, commissioned, or properly licensed images only.
+- **Performance** — Responsive styles and compression per theme image pipeline.
+
+---
+
+## Hero vs card usage
+
+| Surface | Direction |
+|---------|-----------|
+| **Homepage hero** | Wide, optimistic, participation or community; text overlay zone kept clear |
+| **Event cards** | Single strong moment; readable at thumbnail size |
+| **Event detail** | Gallery may mix venue, crowd, and detail shots; lead image sets expectation |
+| **Blog** | Editorial storytelling; same avoid list applies |
+
+---
+
+## Vendor-uploaded images
+
+Encourage organisers to upload:
+
+- Photos from past events with people present
+- Well-lit venue shots during setup with staff or early guests
+- Clear signage or activity focal points
+
+Discourage:
+
+- Flyer graphics as sole hero image (low quality at card sizes)
+- Blurry phone photos with no clear subject
+- Stock photos misrepresenting the event
+
+Vendor guidance may be reinforced in Event Studio help content in a later phase.
+
+---
+
+## Asset location
+
+Reference and approved photography direction files live under `docs/brand/assets/photography/` as the library grows.
+
+See [event-card-system.md](event-card-system.md) and [homepage-system.md](homepage-system.md) for placement rules.

--- a/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
+++ b/web/modules/custom/myeventlane_core/src/GovernedOperationalTemplates.php
@@ -46,7 +46,7 @@ final class GovernedOperationalTemplates {
       'what_happened' => $s['what_happened'],
       'why_empty' => $s['why_empty'],
       'next_action' => $s['next_action'],
-      'cta' => $this->browseEventsPrimaryLink(),
+      'cta' => $this->postBookingDiscoveryRecoveryCtas(),
     ]);
   }
 
@@ -296,7 +296,7 @@ final class GovernedOperationalTemplates {
   /**
    * @return array<string, mixed>
    */
-  private function browseEventsPrimaryLink(string $route = 'view.upcoming_events.page_events', ?string $title = NULL): array {
+  private function browseEventsPrimaryLink(string $route = 'view.upcoming_events.page_events', ?string $title = NULL, string $variant = 'primary'): array {
     $label = $title ?? (string) $this->readiness->customerPrimaryBrowseEventsCta();
     try {
       $url = Url::fromRoute($route);
@@ -304,11 +304,34 @@ final class GovernedOperationalTemplates {
     catch (\Throwable) {
       $url = Url::fromRoute('<front>');
     }
+    $btn_class = $variant === 'secondary' ? 'mel-btn--secondary' : 'mel-btn--primary';
     return [
       '#type' => 'link',
       '#title' => $label,
       '#url' => $url,
-      '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+      '#attributes' => ['class' => ['mel-btn', $btn_class]],
+    ];
+  }
+
+  /**
+   * Discovery recovery CTAs aligned with mel-browse-empty-recovery routes.
+   *
+   * @return array<string, mixed>
+   */
+  private function postBookingDiscoveryRecoveryCtas(): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-empty-state__cta', 'mel-empty-state__cta--discovery']],
+      'hidden_gems' => $this->browseEventsPrimaryLink(
+        'view.upcoming_events.page_hidden_gems',
+        (string) $this->readiness->customerContinuityExploreHiddenGemsCta(),
+        'primary',
+      ),
+      'browse' => $this->browseEventsPrimaryLink(
+        'view.upcoming_events.page_events',
+        (string) $this->readiness->customerPrimaryBrowseEventsCta(),
+        'secondary',
+      ),
     ];
   }
 

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -385,7 +385,7 @@ final class MelReadinessHelper {
   }
 
   public function customerCheckoutCompletionHeadline(): string {
-    return (string) $this->t('Booking complete');
+    return (string) $this->t("Great choice. You're all set.");
   }
 
   /**
@@ -700,7 +700,7 @@ final class MelReadinessHelper {
   // --- Customer-facing confirmation & lifecycle (MELStateSystem vocabulary) ----
 
   public function customerRsvpConfirmationHeadline(): string {
-    return (string) $this->t("You're going");
+    return (string) $this->t("You're in. See you there.");
   }
 
   /**
@@ -795,6 +795,14 @@ final class MelReadinessHelper {
     return (string) $this->t('Add a contribution');
   }
 
+  public function customerContinuityExploreHiddenGemsCta(): string {
+    return (string) $this->t('Explore Hidden Gems');
+  }
+
+  public function customerContinuityBrowseMoreEventsCta(): string {
+    return (string) $this->t('Browse more events');
+  }
+
   /**
    * Governed Commerce order state wording for customer self-service (not raw workflow ids).
    *
@@ -828,7 +836,7 @@ final class MelReadinessHelper {
       'heading' => (string) $this->t('No ticket orders to show'),
       'what_happened' => (string) $this->t('We are not showing any completed ticket purchases on this account yet.'),
       'why_empty' => (string) $this->t('Orders appear here when you are signed in as the same user who completed checkout, or when guest checkout used this email address.'),
-      'next_action' => (string) $this->t('Browse events to find something you would like to attend.'),
+      'next_action' => (string) $this->t('Explore Hidden Gems or browse discoverable events while you wait for your first booking.'),
     ];
   }
 
@@ -1067,8 +1075,8 @@ final class MelReadinessHelper {
   public function intelligenceRecommendationCopy(string $definition_id, MelSurfaceId $surface): array {
     return match ($definition_id) {
       'recommended_events' => [
-        'headline' => (string) $this->t('Events picked for you'),
-        'action' => (string) $this->t('Explore personalised picks inspired by how you browse MyEventLane.'),
+        'headline' => (string) $this->t('Worth exploring next'),
+        'action' => (string) $this->t('Discover more events popular with the community on MyEventLane.'),
       ],
       'continue_saved_event' => [
         'headline' => (string) $this->t('Pick up where you left off'),

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
@@ -20,6 +20,8 @@ final class DiscoveryAttributionSources {
   public const SOURCE_VENDOR_PROFILE = 'vendor_profile';
 
   public const SOURCE_HOMEPAGE_DISCOVER = 'homepage_discover';
+  public const SOURCE_HOMEPAGE_HIDDEN_GEMS = 'homepage_hidden_gems';
+  public const SOURCE_BROWSE_HIDDEN_GEMS = 'browse_hidden_gems';
 
   /**
    * @var list<string>
@@ -31,6 +33,8 @@ final class DiscoveryAttributionSources {
     self::SOURCE_HOMEPAGE_FREE,
     self::SOURCE_HOMEPAGE_RECOMMENDED,
     self::SOURCE_HOMEPAGE_UPCOMING,
+    self::SOURCE_HOMEPAGE_HIDDEN_GEMS,
+    self::SOURCE_BROWSE_HIDDEN_GEMS,
     self::SOURCE_SEARCH,
     self::SOURCE_CATEGORY,
     self::SOURCE_RELATED_EVENTS,
@@ -48,6 +52,8 @@ final class DiscoveryAttributionSources {
     'mel_home_events:under_20' => self::SOURCE_HOMEPAGE_FREE,
     'front_recommended_events:block_1' => self::SOURCE_HOMEPAGE_RECOMMENDED,
     'upcoming_events:homepage_latest' => self::SOURCE_HOMEPAGE_UPCOMING,
+    'upcoming_events:homepage_hidden_gems' => self::SOURCE_HOMEPAGE_HIDDEN_GEMS,
+    'upcoming_events:page_hidden_gems' => self::SOURCE_BROWSE_HIDDEN_GEMS,
     'upcoming_events:page_category' => self::SOURCE_CATEGORY,
   ];
 

--- a/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/EventRecommendationService.php
@@ -147,10 +147,18 @@ final class EventRecommendationService {
       }
     }
 
+    if ($event->hasField('field_hidden_gem')
+      && !$event->get('field_hidden_gem')->isEmpty()
+      && (bool) $event->get('field_hidden_gem')->value) {
+      $context['type'] = 'hidden-gem';
+      $context['label'] = (string) $t->translate('Worth discovering');
+      return $context;
+    }
+
     $save_count = $prefetchedSaveCount ?? $this->getSaveCountCached((int) $event->id());
     if ($save_count > 10) {
       $context['type'] = 'trending';
-      $context['label'] = (string) $t->translate('Trending right now');
+      $context['label'] = (string) $t->translate('Popular with the community');
       return $context;
     }
 
@@ -319,6 +327,11 @@ final class EventRecommendationService {
       }
       if ($this->routeMatch->getRouteName() === 'view.upcoming_events.page_category') {
         $score += 10;
+      }
+      if ($event->hasField('field_hidden_gem')
+        && !$event->get('field_hidden_gem')->isEmpty()
+        && (bool) $event->get('field_hidden_gem')->value) {
+        $score += 8;
       }
 
       $intent_weight = 1;

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1251,6 +1251,8 @@ function myeventlane_event_preprocess_node(array &$variables): void {
     ]);
   }
 
+  myeventlane_event_apply_full_page_discovery_badge($variables, $node);
+
   // Hide obvious placeholder strings on public event teasers and summaries.
   $public_visibility_modes = [
     'full',
@@ -1623,6 +1625,51 @@ function myeventlane_event_finalize_event_ui(
   }
 
   return $out;
+}
+
+/**
+ * Applies a single discovery hero badge on full event pages via merchandising.
+ */
+function myeventlane_event_apply_full_page_discovery_badge(array &$variables, NodeInterface $node): void {
+  if (($variables['view_mode'] ?? '') !== 'full') {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_event.event_merchandising_presenter')) {
+    return;
+  }
+
+  $event_ui = is_array($variables['event_ui'] ?? NULL) ? $variables['event_ui'] : [];
+  if (!empty($event_ui['is_sold_out'])) {
+    return;
+  }
+
+  $domain = is_array($variables['event_domain_state'] ?? NULL) ? $variables['event_domain_state'] : [];
+  $is_hidden_gem = $node->hasField('field_hidden_gem')
+    && !$node->get('field_hidden_gem')->isEmpty()
+    && (bool) $node->get('field_hidden_gem')->value;
+  $is_promoted = !empty($domain['is_boosted'])
+    || ($node->hasField('field_promoted')
+      && !$node->get('field_promoted')->isEmpty()
+      && (bool) $node->get('field_promoted')->value);
+
+  /** @var \Drupal\myeventlane_event\EventCard\EventMerchandisingPresenter $presenter */
+  $presenter = \Drupal::service('myeventlane_event.event_merchandising_presenter');
+  $merchandising = $presenter->present([
+    'layout' => 'hero',
+    'is_hidden_gem' => $is_hidden_gem,
+    'is_promoted' => $is_promoted,
+    'is_sold_out' => FALSE,
+  ]);
+
+  $label = trim((string) ($merchandising['image_badge_label'] ?? ''));
+  if ($label === '') {
+    return;
+  }
+
+  $variables['mel_hero_discovery_badge'] = [
+    'label' => $label,
+    'modifier' => (string) ($merchandising['image_badge_modifier'] ?? 'apricot'),
+  ];
 }
 
 /**

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -126,6 +126,9 @@ final class EventCardViewModel {
     $domainState = is_array($context['event_domain_state'] ?? NULL) ? $context['event_domain_state'] : [];
     $isPromoted = !empty($domainState['is_boosted'])
       || ($node->hasField('field_promoted') && !$node->get('field_promoted')->isEmpty() && (bool) $node->get('field_promoted')->value);
+    $isHiddenGem = $node->hasField('field_hidden_gem')
+      && !$node->get('field_hidden_gem')->isEmpty()
+      && (bool) $node->get('field_hidden_gem')->value;
 
     $categoryLabel = $context['mel_category_label'] ?? NULL;
     $categoryUrl = $context['mel_category_url'] ?? NULL;
@@ -153,6 +156,7 @@ final class EventCardViewModel {
       'is_low_stock' => $lowStock,
       'capacity_hint' => $capacityHint !== '' ? $capacityHint : NULL,
       'is_promoted' => $isPromoted,
+      'is_hidden_gem' => $isHiddenGem,
       'price_label' => $badgeText,
       'card_type' => $cardType,
       'tonight_urgency_label' => $context['mel_tonight_urgency_label'] ?? NULL,

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
@@ -37,6 +37,7 @@ final class EventMerchandisingPresenter {
    *   is_low_stock?: bool,
    *   capacity_hint?: string|null,
    *   is_promoted?: bool,
+   *   is_hidden_gem?: bool,
    *   price_label?: string|null,
    *   card_type?: string,
    *   tonight_urgency_label?: string|null,
@@ -72,6 +73,7 @@ final class EventMerchandisingPresenter {
     $capacityHint = trim(strip_tags((string) ($context['capacity_hint'] ?? '')));
     $capacityHint = $capacityHint !== '' ? $capacityHint : NULL;
     $isPromoted = !empty($context['is_promoted']);
+    $isHiddenGem = !empty($context['is_hidden_gem']);
     $priceLabel = trim(strip_tags((string) ($context['price_label'] ?? '')));
     $priceLabel = $priceLabel !== '' ? $priceLabel : NULL;
     $cardType = (string) ($context['card_type'] ?? 'none');
@@ -112,6 +114,10 @@ final class EventMerchandisingPresenter {
     }
     elseif (($isHero || $isDiscovery) && $isPromoted) {
       $imageBadgeLabel = (string) $this->t('Spotlight');
+    }
+    elseif ($isHiddenGem) {
+      $imageBadgeLabel = (string) $this->t('Hidden Gem');
+      $imageBadgeModifier = 'discovery-gold';
     }
 
     $ticketPill = $this->resolveTicketPill($cardType, $priceLabel, $isSoldOut);

--- a/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
+++ b/web/modules/custom/myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php
@@ -28,8 +28,10 @@ final class PublicEventDiscoveryQueryAlter {
       'page_this_weekend',
       'page_popular',
       'page_category',
+      'page_hidden_gems',
       'homepage_latest',
       'homepage_tonight',
+      'homepage_hidden_gems',
     ],
     'front_featured_events' => [
       'block_featured',

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
@@ -155,6 +155,69 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
   /**
    * @covers ::present
    */
+  public function testHiddenGemBadgeWhenFlagged(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => 'poster',
+      'is_hidden_gem' => TRUE,
+      'card_type' => 'rsvp',
+    ]);
+
+    self::assertSame('Hidden Gem', $result['image_badge_label']);
+    self::assertSame('discovery-gold', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testHiddenGemBadgeOnStandardListLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_hidden_gem' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Hidden Gem', $result['image_badge_label']);
+    self::assertSame('discovery-gold', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSoldOutOutranksHiddenGem(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => 'poster',
+      'is_hidden_gem' => TRUE,
+      'is_sold_out' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Sold out', $result['image_badge_label']);
+    self::assertSame('warning', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightOutranksHiddenGemOnPoster(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => 'poster',
+      'is_hidden_gem' => TRUE,
+      'is_promoted' => TRUE,
+      'card_type' => 'rsvp',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
   public function testSpotlightBadgeWhenPromotedOnPoster(): void {
     $presenter = $this->createPresenter();
     $result = $presenter->present([

--- a/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php
@@ -16,6 +16,8 @@ final class FeaturedEventsRenderBuilder {
   private const VIEW_ID = 'front_featured_events';
   private const DISPLAY_ID = 'block_featured';
   private const HERO_DISPLAY_ID = 'block_hero';
+  private const HIDDEN_GEMS_VIEW_ID = 'upcoming_events';
+  private const HIDDEN_GEMS_DISPLAY_ID = 'homepage_hidden_gems';
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -42,6 +44,13 @@ final class FeaturedEventsRenderBuilder {
    */
   public function build(): array {
     return $this->buildDisplay(self::DISPLAY_ID);
+  }
+
+  /**
+   * Builds Hidden Gems discovery cards for zero-result search recovery.
+   */
+  public function buildHiddenGemsDiscoveryFallback(): array {
+    return $this->buildViewDisplay(self::HIDDEN_GEMS_VIEW_ID, self::HIDDEN_GEMS_DISPLAY_ID);
   }
 
   /**
@@ -83,49 +92,85 @@ final class FeaturedEventsRenderBuilder {
    * Builds a featured events View display render array.
    */
   private function buildDisplay(string $displayId): array {
+    return $this->buildViewDisplay(self::VIEW_ID, $displayId);
+  }
+
+  /**
+   * Builds a View display render array when the display has results.
+   */
+  private function buildViewDisplay(string $viewId, string $displayId): array {
     try {
-      if (!$this->displayHasResults($displayId)) {
-        return $this->emptyBuild();
+      if (!$this->viewDisplayHasResults($viewId, $displayId)) {
+        return $this->emptyBuild($viewId);
       }
 
       $storage = $this->entityTypeManager
         ->getStorage('view')
-        ->load(self::VIEW_ID);
+        ->load($viewId);
 
       if ($storage === NULL) {
-        $this->loggerFactory->get('myeventlane_front')->error('Homepage featured View "@view" was not found.', [
-          '@view' => self::VIEW_ID,
+        $this->loggerFactory->get('myeventlane_front')->error('View "@view" was not found.', [
+          '@view' => $viewId,
         ]);
 
-        return $this->emptyBuild();
+        return $this->emptyBuild($viewId);
       }
 
       $view = $this->viewExecutableFactory->get($storage);
       if (!$view->access($displayId)) {
-        return $this->emptyBuild();
+        return $this->emptyBuild($viewId);
       }
 
       return $view->buildRenderable($displayId);
     }
     catch (\Throwable $e) {
-      $this->loggerFactory->get('myeventlane_front')->error('Could not build homepage featured events (@display): @message', [
+      $this->loggerFactory->get('myeventlane_front')->error('Could not build View @view (@display): @message', [
+        '@view' => $viewId,
         '@display' => $displayId,
         '@message' => $e->getMessage(),
       ]);
 
-      return $this->emptyBuild();
+      return $this->emptyBuild($viewId);
+    }
+  }
+
+  /**
+   * Whether a View display returns at least one row (after access checks).
+   */
+  private function viewDisplayHasResults(string $viewId, string $displayId): bool {
+    try {
+      $storage = $this->entityTypeManager
+        ->getStorage('view')
+        ->load($viewId);
+
+      if ($storage === NULL) {
+        return FALSE;
+      }
+
+      $view = $this->viewExecutableFactory->get($storage);
+      if (!$view->access($displayId)) {
+        return FALSE;
+      }
+
+      $view->setDisplay($displayId);
+      $view->execute();
+
+      return $view->result !== [];
+    }
+    catch (\Throwable) {
+      return FALSE;
     }
   }
 
   /**
    * Returns cacheable empty output for failure or denied access.
    */
-  private function emptyBuild(): array {
+  private function emptyBuild(string $viewId = self::VIEW_ID): array {
     return [
       '#markup' => '',
       '#cache' => [
         'contexts' => ['user.permissions'],
-        'tags' => ['config:views.view.' . self::VIEW_ID],
+        'tags' => ['config:views.view.' . $viewId],
       ],
     ];
   }

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -33,6 +33,7 @@ final class HomepageMerchandising {
     ],
     'upcoming_events' => [
       'homepage_tonight',
+      'homepage_hidden_gems',
       'homepage_latest',
     ],
     'mel_home_events' => [
@@ -92,6 +93,11 @@ final class HomepageMerchandising {
   /**
    * @var list<int>|null
    */
+  private ?array $hiddenGemEventIds = NULL;
+
+  /**
+   * @var list<int>|null
+   */
   private ?array $recommendedEventIds = NULL;
 
   /**
@@ -140,17 +146,25 @@ final class HomepageMerchandising {
         ...$spotlight,
         ...$this->getDiscoverEventIds(),
       ])),
+      'upcoming_events:homepage_hidden_gems' => array_values(array_unique([
+        ...$hero,
+        ...$spotlight,
+        ...$this->getDiscoverEventIds(),
+        ...$this->getTonightEventIds(),
+      ])),
       'mel_home_events:under_20' => array_values(array_unique([
         ...$hero,
         ...$spotlight,
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
+        ...$this->getHiddenGemEventIds(),
       ])),
       'upcoming_events:homepage_latest' => array_values(array_unique([
         ...$hero,
         ...$spotlight,
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
+        ...$this->getHiddenGemEventIds(),
         ...$this->getFreeRsvpEventIds(),
       ])),
       'front_recommended_events:block_1' => array_values(array_unique([
@@ -158,6 +172,7 @@ final class HomepageMerchandising {
         ...$spotlight,
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
+        ...$this->getHiddenGemEventIds(),
         ...$this->getFreeRsvpEventIds(),
         ...$this->getLatestEventIds(),
       ])),
@@ -259,6 +274,20 @@ final class HomepageMerchandising {
 
     $this->tonightEventIds = $this->executeViewResultNids('upcoming_events', 'homepage_tonight');
     return $this->tonightEventIds;
+  }
+
+  /**
+   * Hidden Gems editorial rail (upcoming_events:homepage_hidden_gems).
+   *
+   * @return list<int>
+   */
+  public function getHiddenGemEventIds(): array {
+    if ($this->hiddenGemEventIds !== NULL) {
+      return $this->hiddenGemEventIds;
+    }
+
+    $this->hiddenGemEventIds = $this->executeViewResultNids('upcoming_events', 'homepage_hidden_gems');
+    return $this->hiddenGemEventIds;
   }
 
   /**

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageRailDiversityFilter.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageRailDiversityFilter.php
@@ -21,7 +21,7 @@ final class HomepageRailDiversityFilter {
    */
   private const DIVERSITY_DISPLAYS = [
     'mel_home_events' => ['embed_discover', 'under_20'],
-    'upcoming_events' => ['homepage_tonight', 'homepage_latest'],
+    'upcoming_events' => ['homepage_tonight', 'homepage_hidden_gems', 'homepage_latest'],
     'front_recommended_events' => ['block_1'],
   ];
 

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
@@ -54,6 +54,13 @@ final class HomepageSectionVisibility {
   }
 
   /**
+   * Whether the homepage Hidden Gems display returns at least one row.
+   */
+  public function hasHiddenGemEvents(): bool {
+    return $this->viewDisplayHasResults('upcoming_events', 'homepage_hidden_gems');
+  }
+
+  /**
    * Whether a View display returns at least one row (after access checks).
    */
   public function viewDisplayHasResults(string $viewId, string $displayId): bool {

--- a/web/modules/custom/myeventlane_schema/config/install/field.field.node.event.field_hidden_gem.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.field.node.event.field_hidden_gem.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hidden_gem
+    - node.type.event
+id: node.event.field_hidden_gem
+field_name: field_hidden_gem
+entity_type: node
+bundle: event
+label: 'Hidden Gem'
+description: 'Staff editorial flag for the Hidden Gems discovery programme. Independent of Boost or paid promotion.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Hidden Gem'
+  off_label: 'Not a Hidden Gem'
+field_type: boolean

--- a/web/modules/custom/myeventlane_schema/config/install/field.storage.node.field_hidden_gem.yml
+++ b/web/modules/custom/myeventlane_schema/config/install/field.storage.node.field_hidden_gem.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hidden_gem
+field_name: field_hidden_gem
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
+++ b/web/modules/custom/myeventlane_search/src/Controller/SearchController.php
@@ -136,9 +136,11 @@ final class SearchController extends ControllerBase {
       $total_items += count($group['items']);
     }
     $featured_events_fallback = [];
+    $hidden_gems_fallback = [];
     if ($total_items === 0) {
       $fallback = $this->buildEmptyStateFallback();
       $featured_events_fallback = $this->buildFeaturedEventsFallback();
+      $hidden_gems_fallback = $this->buildHiddenGemsFallback();
     }
 
     $build = [
@@ -151,6 +153,9 @@ final class SearchController extends ControllerBase {
     if ($featured_events_fallback !== []) {
       // Render child — do not nest View builds inside #fallback theme variables.
       $build['featured_events_fallback'] = $featured_events_fallback;
+    }
+    if ($hidden_gems_fallback !== []) {
+      $build['hidden_gems_fallback'] = $hidden_gems_fallback;
     }
 
     return $build;
@@ -480,6 +485,15 @@ final class SearchController extends ControllerBase {
    */
   private function buildFeaturedEventsFallback(): array {
     return $this->featuredEventsRenderBuilder->build();
+  }
+
+  /**
+   * Hidden Gems View for zero-result search fallback (after featured, before categories).
+   *
+   * @return array<string, mixed>
+   */
+  private function buildHiddenGemsFallback(): array {
+    return $this->featuredEventsRenderBuilder->buildHiddenGemsDiscoveryFallback();
   }
 
   /**

--- a/web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig
+++ b/web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig
@@ -15,21 +15,23 @@
     {% endfor %}
 
     {% if total_items == 0 %}
-      <div class="mel-empty-state mel-empty-state--listing mel-search-empty">
-        <div class="mel-empty-state__image">
-          <img src="{{ directory|default('') }}/images/mel/empty/mel-empty-events.png" alt="" role="presentation" width="240" height="240" loading="lazy" onerror="this.style.display='none'">
-        </div>
-        <h3 class="mel-empty-state__title">{{ 'No results found'|t }}</h3>
-        <p class="mel-empty-state__text">{{ 'No results for \'@query\'. Try another keyword, browse categories, or explore events on the homepage.'|t({'@query': query}) }}</p>
-        <p class="mel-empty-state__cta">
-          <a href="{{ path('view.upcoming_events.page_events') }}" class="mel-btn mel-btn-accent">{{ 'Explore events'|t }}</a>
-          <a href="{{ path('view.upcoming_events.page_this_weekend') }}" class="mel-link">{{ 'This weekend'|t }}</a>
-          <span aria-hidden="true"> · </span>
-          <a href="{{ path('view.upcoming_events.page_free') }}" class="mel-link">{{ 'Free events'|t }}</a>
-          <span aria-hidden="true"> · </span>
-          <a href="{{ path('<front>') }}" class="mel-link">{{ 'Back to discovery'|t }}</a>
-        </p>
-      </div>
+      {% include '@myeventlane_theme/includes/mel-browse-empty-recovery.html.twig' with {
+        title: 'No results found'|t,
+        text: 'No results for \'@query\'. Try another keyword or explore these paths instead.'|t({'@query': query}),
+        modifier: 'search',
+      } %}
+      {% if featured_events_fallback is not empty %}
+        <section class="mel-search-results__fallback" aria-labelledby="mel-search-fallback-featured">
+          <h2 id="mel-search-fallback-featured" class="mel-search-results__group-title">{{ 'Discover events'|t }}</h2>
+          {{ featured_events_fallback }}
+        </section>
+      {% endif %}
+      {% if hidden_gems_fallback is not empty %}
+        <section class="mel-search-results__fallback" aria-labelledby="mel-search-fallback-hidden-gems">
+          <h2 id="mel-search-fallback-hidden-gems" class="mel-search-results__group-title">{{ 'Hidden Gems'|t }}</h2>
+          {{ hidden_gems_fallback }}
+        </section>
+      {% endif %}
       {% if fallback.categories|default([])|length > 0 %}
         <section class="mel-search-results__fallback" aria-labelledby="mel-search-fallback-categories">
           <h2 id="mel-search-fallback-categories" class="mel-search-results__group-title">{{ 'Suggested categories'|t }}</h2>
@@ -38,12 +40,6 @@
               <li><a href="{{ item.url }}">{{ item.title }}</a></li>
             {% endfor %}
           </ul>
-        </section>
-      {% endif %}
-      {% if featured_events_fallback is not empty %}
-        <section class="mel-search-results__fallback" aria-labelledby="mel-search-fallback-featured">
-          <h2 id="mel-search-fallback-featured" class="mel-search-results__group-title">{{ 'Discover events'|t }}</h2>
-          {{ featured_events_fallback }}
         </section>
       {% endif %}
     {% else %}

--- a/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
+++ b/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
@@ -137,6 +137,8 @@ final class MelCustomerContinuityPresenter {
       ];
     }
 
+    $actions = array_merge($actions, $this->buildPostBookingDiscoveryActions(FALSE));
+
     if ($cancel_url !== '') {
       $actions[] = [
         'key' => 'cancel_rsvp',
@@ -246,8 +248,55 @@ final class MelCustomerContinuityPresenter {
       'primary_action' => $primary_action,
       'calendar' => $calendar,
       'view_event' => $view_event,
+      'continuity_actions' => $this->buildPostBookingDiscoveryActions(TRUE),
       'donation_total_formatted' => $donation_total_formatted,
     ];
+  }
+
+  /**
+   * Post-booking discovery bridge — shared RSVP thank-you + checkout completion.
+   *
+   * @return list<array<string, string|bool>>
+   */
+  private function buildPostBookingDiscoveryActions(bool $browse_more_label): array {
+    /** @var list<array<string, string|bool>> $actions */
+    $actions = [];
+
+    try {
+      $hidden_gems_url = Url::fromRoute('view.upcoming_events.page_hidden_gems')->toString();
+    }
+    catch (\Throwable) {
+      $hidden_gems_url = '';
+    }
+    if ($hidden_gems_url !== '') {
+      $actions[] = [
+        'key' => 'explore_hidden_gems',
+        'label' => $this->readinessHelper->customerContinuityExploreHiddenGemsCta(),
+        'url' => $hidden_gems_url,
+        'variant' => 'secondary',
+        'download' => FALSE,
+      ];
+    }
+
+    try {
+      $browse_url = Url::fromRoute('view.upcoming_events.page_events')->toString();
+    }
+    catch (\Throwable) {
+      $browse_url = '';
+    }
+    if ($browse_url !== '') {
+      $actions[] = [
+        'key' => 'browse_events',
+        'label' => $browse_more_label
+          ? $this->readinessHelper->customerContinuityBrowseMoreEventsCta()
+          : $this->readinessHelper->customerPrimaryBrowseEventsCta(),
+        'url' => $browse_url,
+        'variant' => 'secondary',
+        'download' => FALSE,
+      ];
+    }
+
+    return $actions;
   }
 
   /**

--- a/web/modules/custom/myeventlane_surface/tests/src/Unit/MelReadinessHelperCustomerTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Unit/MelReadinessHelperCustomerTest.php
@@ -34,12 +34,15 @@ final class MelReadinessHelperCustomerTest extends UnitTestCase {
    * @covers ::customerCategoryFollowWeeklyQuietSlots
    * @covers ::customerMyEventsDashboardUpcomingEmptySlots
    * @covers ::customerPrimaryBrowseEventsCta
+   * @covers ::customerContinuityExploreHiddenGemsCta
+   * @covers ::customerContinuityBrowseMoreEventsCta
    */
   public function testOperationalEmptySlotsAreNonEmptyStrings(): void {
     $h = $this->helper();
     $tickets = $h->customerMyTicketsOverviewEmptySlots();
     $this->assertNotSame('', $tickets['heading']);
     $this->assertNotSame('', $tickets['what_happened']);
+    $this->assertNotSame('', $tickets['next_action']);
     $categories = $h->customerCategoryFollowEmptySlots();
     $this->assertNotSame('', $categories['heading']);
     $quiet = $h->customerCategoryFollowWeeklyQuietSlots();
@@ -49,6 +52,8 @@ final class MelReadinessHelperCustomerTest extends UnitTestCase {
     $this->assertNotSame('', $my_events['heading']);
     $this->assertNotSame('', $my_events['why_empty']);
     $this->assertNotSame('', $h->customerPrimaryBrowseEventsCta());
+    $this->assertNotSame('', $h->customerContinuityExploreHiddenGemsCta());
+    $this->assertNotSame('', $h->customerContinuityBrowseMoreEventsCta());
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
@@ -20,6 +20,7 @@ regions:
   homepage_categories: 'Homepage Categories'
   homepage_latest: 'Homepage Latest'
   homepage_tonight: 'Homepage Tonight'
+  homepage_hidden_gems: 'Homepage Hidden Gems'
   homepage_free: 'Homepage Free & RSVP'
   homepage_nearby: 'Homepage Nearby'
   homepage_online: 'Homepage Online'

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1760,6 +1760,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     'view.upcoming_events.page_this_weekend',
     'view.upcoming_events.page_free',
     'view.upcoming_events.page_popular',
+    'view.upcoming_events.page_hidden_gems',
     'mel_search.view',
   ];
   if (in_array($route, $listing_routes, TRUE) && empty($variables['mel_header_categories'])) {
@@ -1801,6 +1802,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     'view.upcoming_events.page_today' => 'page_today',
     'view.upcoming_events.page_category' => 'page_category',
     'view.upcoming_events.page_popular' => 'page_popular',
+    'view.upcoming_events.page_hidden_gems' => 'page_hidden_gems',
   ];
   if (isset($browse_display_map[$route])) {
     $variables['mel_browse_active_display'] = $browse_display_map[$route];
@@ -1959,6 +1961,10 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         && isset($variables['page']['homepage_tonight'])
         && is_array($variables['page']['homepage_tonight'])
         && count(Element::children($variables['page']['homepage_tonight'])) > 0;
+      $variables['mel_home_show_hidden_gems'] = $homepageVisibility->hasHiddenGemEvents()
+        && isset($variables['page']['homepage_hidden_gems'])
+        && is_array($variables['page']['homepage_hidden_gems'])
+        && count(Element::children($variables['page']['homepage_hidden_gems'])) > 0;
     }
     else {
       $variables['mel_home_show_featured'] = FALSE;
@@ -1967,6 +1973,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
       $variables['mel_home_show_free_rsvp'] = FALSE;
       $variables['mel_home_show_recommended'] = FALSE;
       $variables['mel_home_show_tonight'] = FALSE;
+      $variables['mel_home_show_hidden_gems'] = FALSE;
     }
   }
 
@@ -3283,7 +3290,7 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
 
   if (
     $view->id() === 'upcoming_events'
-    && in_array($view->current_display, ['page_category', 'page_today', 'page_this_weekend', 'page_free'], TRUE)
+    && in_array($view->current_display, ['page_category', 'page_today', 'page_this_weekend', 'page_free', 'page_hidden_gems'], TRUE)
   ) {
     $args = $view->args ?? [];
     if ($view->current_display === 'page_category' && !empty($args[0])) {
@@ -3311,7 +3318,7 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
     }
   }
 
-  if ($view->id() === 'upcoming_events' && in_array($view->current_display, ['page_events', 'page_category', 'page_today', 'page_this_weekend', 'page_free'], TRUE)) {
+  if ($view->id() === 'upcoming_events' && in_array($view->current_display, ['page_events', 'page_category', 'page_today', 'page_this_weekend', 'page_free', 'page_hidden_gems'], TRUE)) {
     $request = \Drupal::request();
     $query_all = $request->query->all();
     $active = FALSE;

--- a/web/themes/custom/myeventlane_theme/src/scss/base/_mel-ds-tokens.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_mel-ds-tokens.scss
@@ -10,6 +10,7 @@ $mel-ds-color-bg: colors.$mel-color-bg;
 $mel-ds-color-surface: colors.$mel-color-surface;
 $mel-ds-color-text: colors.$mel-color-text;
 $mel-ds-color-muted: colors.$mel-color-text-muted;
+$mel-ds-color-discovery-gold: colors.$mel-color-discovery-gold;
 
 $mel-ds-space-xs: spacing.mel-space(1);
 $mel-ds-space-sm: spacing.mel-space(2);

--- a/web/themes/custom/myeventlane_theme/src/scss/base/_tokens.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/base/_tokens.scss
@@ -68,6 +68,8 @@
   --mel-mint: color-mix(in srgb, var(--mel-color-accent) 12%, #fff);
   --mel-sky: color-mix(in srgb, var(--mel-color-accent) 8%, #fff);
   --mel-butter: color-mix(in srgb, var(--mel-color-primary) 14%, #fff);
+  --mel-color-discovery-gold: #ffc83d;
+  --mel-discovery-gold: var(--mel-color-discovery-gold);
   --mel-focus: var(--mel-color-primary);
 
   --mel-radius-1: var(--mel-radius-sm);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -315,6 +315,16 @@
   border-radius: 16px;
 }
 
+.mel-event-card__image .mel-pill--on-image.mel-event-card__state-pill--discovery-gold,
+.mel-event-card__media .mel-pill--on-image.mel-event-card__state-pill--discovery-gold,
+.mel-event-card--hero .mel-pill--on-image.mel-event-card__state-pill--discovery-gold,
+.mel-event-hero--featured-style .mel-pill--on-image.mel-event-card__state-pill--discovery-gold {
+  background: color-mix(in srgb, mel.$mel-ds-color-discovery-gold 58%, #fff 42%);
+  color: mel.$mel-ds-color-text;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-discovery-gold 36%, transparent);
+  border-radius: 16px;
+}
+
 // Category on image: single apricot pill (overrides .mel-pill--on-image defaults).
 .mel-event-card__image .mel-event__category.mel-pill--on-image,
 .mel-event-card__media .mel-event__category.mel-pill--on-image {

--- a/web/themes/custom/myeventlane_theme/src/scss/tokens/_colors.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/tokens/_colors.scss
@@ -46,6 +46,9 @@ $mel-color-text-inverse: #ffffff;
 // MEL highlight apricot — category pill on cards & event hero.
 $mel-color-highlight-apricot: #f6c47a;
 
+// MEL Discovery Gold — Hidden Gem badge and discovery highlights (brand token).
+$mel-color-discovery-gold: #ffc83d;
+
 $mel-color-border: #e9e3de;
 $mel-color-border-strong: color.scale($mel-color-border, $lightness: -16%);
 

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig
@@ -204,6 +204,12 @@
           {{ mcc.view_event.label }}
         </a>
       {% endif %}
+
+      {% for action in mcc.continuity_actions|default([]) %}
+        <a href="{{ action.url }}" class="mel-confirmation-button mel-confirmation-button--secondary" data-mel-continuity-key="{{ action.key }}">
+          {{ action.label }}
+        </a>
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -113,6 +113,12 @@
       {% set _discovery_reason = 'Starts soon'|t %}
     {% endif %}
     {% set _discovery_reason_type = 'tonight' %}
+  {% elseif _mel_src in ['homepage_hidden_gems', 'browse_hidden_gems'] %}
+    {% set _discovery_reason = 'Worth discovering'|t %}
+    {% set _discovery_reason_type = 'hidden-gem' %}
+  {% elseif _mel_src == 'related_events' and recommendation_context is defined and recommendation_context.label|default('')|trim|length > 0 %}
+    {% set _discovery_reason = recommendation_context.label %}
+    {% set _discovery_reason_type = recommendation_context.type|default('discover') %}
   {% endif %}
 {% elseif _discovery_mode and _type in ['rsvp'] and (_price_label in ['Free', 'Free RSVP'] or _status_mod == 'free') %}
   {% set _discovery_reason = 'Free to attend'|t %}

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
@@ -20,6 +20,8 @@
     <span aria-hidden="true"> · </span>
     <a href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
     <span aria-hidden="true"> · </span>
+    <a href="{{ path('view.upcoming_events.page_hidden_gems') }}">{{ 'Hidden Gems'|t }}</a>
+    <span aria-hidden="true"> · </span>
     <a href="{{ path('<front>') }}">{{ 'Community spotlight'|t }}</a>
   </p>
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -31,6 +31,7 @@
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_this_weekend' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_free' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Popular'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_hidden_gems') }}">{{ 'Hidden Gems'|t }}</a>
         </nav>
 
         {% include '@myeventlane_theme/components/mel-page-header.html.twig' with {

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -102,8 +102,14 @@
       <div class="mel-event-hero__overlay" aria-hidden="true"></div>
       {% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
         <div class="mel-event-hero__chip">
-          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--warning" aria-hidden="true">
+          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--warning" role="status">
             <span class="mel-pill__label">{{ 'Sold out'|t }}</span>
+          </span>
+        </div>
+      {% elseif mel_hero_discovery_badge is defined and mel_hero_discovery_badge.label|default('')|trim %}
+        <div class="mel-event-hero__chip">
+          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ mel_hero_discovery_badge.modifier|default('apricot') }}" role="status">
+            <span class="mel-pill__label">{{ mel_hero_discovery_badge.label }}</span>
           </span>
         </div>
       {% elseif mel_category_label %}

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -72,6 +72,21 @@
       } %}
     {% endif %}
 
+    {% if mel_home_show_hidden_gems|default(false) %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--hidden-gems mel-section--discover',
+        section_width_class: '',
+        container_class: 'mel-container',
+        header_extra_class: 'mel-section__header--hidden-gems',
+        title: 'Hidden Gems Near You'|t,
+        subtitle: 'The Guide has found a few experiences worth discovering.'|t,
+        link_url: path('view.upcoming_events.page_hidden_gems'),
+        link_text: 'See all Hidden Gems'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_hidden_gems
+      } %}
+    {% endif %}
+
     {% if mel_home_show_free_rsvp|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--free-rsvp mel-section--discover',
@@ -108,8 +123,8 @@
         section_width_class: '',
         container_class: 'mel-container',
         header_extra_class: 'mel-section__header--recommended',
-        title: 'Picked for you'|t,
-        subtitle: 'Curated from what’s happening nearby'|t,
+        title: 'Worth exploring next'|t,
+        subtitle: 'Events popular with the community right now.'|t,
         link_url: path('view.upcoming_events.page_events'),
         link_text: 'See all events'|t,
         content_wrapper_class: 'mel-section__discover-view',

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-hidden-gems.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-hidden-gems.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for view.upcoming_events page_hidden_gems.
+ *
+ * @see includes/mel-browse-events-page-shell.html.twig
+ */
+#}
+{% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
+  mel_browse_heading: 'Hidden Gems'|t,
+  mel_browse_lede: 'High-value local experiences you might not have found yet.'|t,
+  mel_browse_prompt: 'Browse all events or see what’s on this weekend.'|t,
+} %}

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -30,6 +30,10 @@
     href="{{ path('view.upcoming_events.page_popular') }}"
     class="mel-filter-chip{% if d == 'page_popular' %} mel-filter-chip--active{% endif %}"
   >{{ 'Popular'|t }}</a>
+  <a
+    href="{{ path('view.upcoming_events.page_hidden_gems') }}"
+    class="mel-filter-chip{% if d == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}"
+  >{{ 'Hidden Gems'|t }}</a>
   {% if mel_show_filter_reset and d == 'page_events' %}
     <a
       href="{{ path('view.upcoming_events.page_events') }}"

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -27,7 +27,7 @@
       {{ "Find something you'll love"|t }}
     </p>
     <p class="mel-discovery-subtitle">
-      {{ 'Events picked for you in @name'|t({'@name': term.label}) }}
+      {{ 'Discover events in @name'|t({'@name': term.label}) }}
     </p>
 
     {% if mel_category_follow_flag|default(null) or mel_category_follow_login_url|default(null) %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
@@ -8,7 +8,7 @@
 {#
   Listing pages only — homepage block displays use display-specific templates.
 #}
-{% set mel_discovery_displays = ['page_events', 'page_today', 'page_this_weekend', 'page_free', 'page_category', 'page_popular'] %}
+{% set mel_discovery_displays = ['page_events', 'page_today', 'page_this_weekend', 'page_free', 'page_category', 'page_popular', 'page_hidden_gems'] %}
 <div class="mel-discovery mel-discovery--upcoming">
   {% if display_id in mel_discovery_displays and not mel_chip_listing_fragment|default(false) %}
     {{ attach_library('myeventlane_theme/mel-events-discovery') }}
@@ -51,6 +51,10 @@
         'page_popular': {
           title: 'No popular events yet'|t,
           text: 'Browse upcoming events while organisers boost new experiences.'|t,
+        },
+        'page_hidden_gems': {
+          title: 'No Hidden Gems right now'|t,
+          text: 'Check back soon or browse all upcoming events.'|t,
         },
       } %}
       {% if mel_empty_copy[display_id] is defined %}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-recommended-events--block-1.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-recommended-events--block-1.html.twig
@@ -14,7 +14,7 @@
 
 {% if rows %}
   {% include '@myeventlane_theme/includes/mel-event-skeleton-block.html.twig' %}
-  <div class="mel-event-grid mel-grid mel-grid--events" data-loaded="false" aria-label="{{ 'Recommended events'|t }}">
+  <div class="mel-event-grid mel-grid mel-grid--events" data-loaded="false" aria-label="{{ 'Events worth exploring'|t }}">
     {% for row in rows %}
       {{- row.content -}}
     {% endfor %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches public discovery Views, merchandising badge precedence, and many config sync files; editorial flag misuse could skew homepage rails but does not affect checkout or auth.
> 
> **Overview**
> Introduces the **Hidden Gems** discovery programme: a staff-only boolean **`field_hidden_gem`** on events (independent of Boost/promotion), exposed on the default event edit form and wired through entity display config.
> 
> **Discovery surfaces:** `upcoming_events` gains **`homepage_hidden_gems`** (6 items, `field_hidden_gem = 1`, front-only block in `homepage_hidden_gems` region) and **`page_hidden_gems`** at **`/events/hidden-gems`**. Public discovery query alters and attribution sources include these displays.
> 
> **Merchandising:** Cards and full event pages show a single **Hidden Gem** image badge (`discovery-gold`) via `EventMerchandisingPresenter`, with precedence after sold out and Spotlight on poster layouts. Recommendations gain a hidden-gem context label and a small score boost; post-booking empty states and checkout/RSVP copy nudge **Explore Hidden Gems**.
> 
> Also adds the full **`docs/brand/`** v1.0 system (tokens, guides, governance, roadmap) plus a **brand gap analysis** audit. Wizard form displays pick up incidental hidden-field list updates (donations, social proof) alongside `field_hidden_gem`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fbe16a998617987fe3752937cbc30362c44e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->