### PR TITLE
fix(event): restrict field_hidden_gem edit access to staff permission

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -13,6 +13,8 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -66,6 +68,25 @@ function myeventlane_event_paragraph_access(ParagraphInterface $entity, string $
   }
 
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_entity_field_access().
+ *
+ * Protects the Hidden Gem editorial flag (field_hidden_gem) so only staff with
+ * the dedicated permission may edit it. The flag drives the Hidden Gems
+ * discovery programme and must stay independent of vendor input, Boost, or paid
+ * promotion. Administrators (is_admin roles) hold the permission implicitly.
+ * View access is intentionally left unchanged — the badge is public.
+ */
+function myeventlane_event_entity_field_access(string $operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL): AccessResult {
+  if ($operation !== 'edit' || $field_definition->getName() !== 'field_hidden_gem') {
+    return AccessResult::neutral();
+  }
+
+  return AccessResult::forbiddenIf(!$account->hasPermission('administer hidden gem flag'))
+    ->cachePerPermissions()
+    ->setReason('Editing the Hidden Gem editorial flag requires the "administer hidden gem flag" permission.');
 }
 
 /**

--- a/web/modules/custom/myeventlane_event/myeventlane_event.permissions.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.permissions.yml
@@ -1,0 +1,4 @@
+administer hidden gem flag:
+  title: 'Administer Hidden Gem editorial flag'
+  description: 'Set the staff Hidden Gem editorial flag (field_hidden_gem) on events. Drives the Hidden Gems discovery programme and is independent of Boost or paid promotion.'
+  restrict access: true

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/HiddenGemFieldAccessTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/HiddenGemFieldAccessTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+
+// Load the procedural module file so the hook function is declared. The file
+// contains only function declarations (no top-level side effects), so this is
+// safe in a unit test.
+require_once __DIR__ . '/../../../myeventlane_event.module';
+
+/**
+ * Unit coverage for myeventlane_event_entity_field_access().
+ *
+ * The hook depends only on its arguments (no container), so it is tested as a
+ * pure function. A Kernel test is impractical here because the myeventlane_event
+ * service container requires the full module dependency chain (myeventlane_donations
+ * et al.) to compile.
+ *
+ * @group myeventlane_event
+ *
+ * @covers ::myeventlane_event_entity_field_access
+ */
+final class HiddenGemFieldAccessTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // AccessResult::cachePerPermissions() validates cache contexts against the
+    // container, so provide a minimal one.
+    $cache_contexts_manager = $this->createMock(CacheContextsManager::class);
+    $cache_contexts_manager->method('assertValidTokens')->willReturn(TRUE);
+    $container = new ContainerBuilder();
+    $container->set('cache_contexts_manager', $cache_contexts_manager);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Invokes the hook with mocked dependencies.
+   */
+  private function fieldAccess(string $operation, string $field_name, bool $has_permission): \Drupal\Core\Access\AccessResultInterface {
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $field_definition->method('getName')->willReturn($field_name);
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('hasPermission')->willReturnCallback(
+      static fn (string $perm): bool => $perm === 'administer hidden gem flag' ? $has_permission : FALSE
+    );
+
+    return myeventlane_event_entity_field_access($operation, $field_definition, $account, NULL);
+  }
+
+  /**
+   * Vendors (no permission) are forbidden from editing the Hidden Gem flag.
+   */
+  public function testEditForbiddenWithoutPermission(): void {
+    $this->assertTrue(
+      $this->fieldAccess('edit', 'field_hidden_gem', FALSE)->isForbidden(),
+      'Editing field_hidden_gem without the permission must be forbidden.'
+    );
+  }
+
+  /**
+   * Staff with the permission are not forbidden (field stays editable).
+   */
+  public function testEditAllowedWithPermission(): void {
+    $result = $this->fieldAccess('edit', 'field_hidden_gem', TRUE);
+    $this->assertFalse(
+      $result->isForbidden(),
+      'Editing field_hidden_gem with the permission must not be forbidden.'
+    );
+  }
+
+  /**
+   * Other fields are never affected by this hook (neutral).
+   */
+  public function testOtherFieldUnaffected(): void {
+    $this->assertFalse(
+      $this->fieldAccess('edit', 'field_event_start', FALSE)->isForbidden(),
+      'The hook must only constrain field_hidden_gem.'
+    );
+  }
+
+  /**
+   * View access to the flag is not restricted (badge is public).
+   */
+  public function testViewOperationUnaffected(): void {
+    $this->assertFalse(
+      $this->fieldAccess('view', 'field_hidden_gem', FALSE)->isForbidden(),
+      'View access to field_hidden_gem must not be forbidden.'
+    );
+  }
+
+}


### PR DESCRIPTION
## Summary

Follow-up to the Hidden Gem discovery work (PR #587). The audit found that the **Hidden Gem editorial flag (`field_hidden_gem`)** is visible on the **default** event form display, while the `vendor` role holds `create event content` + `edit own event content` with **no gating** — so a vendor could self-flag their own event into the Hidden Gems discovery programme. The flag is meant to be a **staff editorial signal**, independent of Boost or paid promotion.

## Change

- **`hook_entity_field_access()`** in `myeventlane_event.module`: forbids `edit` on `field_hidden_gem` unless the account holds the new permission `administer hidden gem flag`. Field- and operation-scoped (everything else returns `neutral()`); cache-per-permissions; clear reason. **View access is unchanged** — the public badge still renders.
- **Dedicated permission** `administer hidden gem flag` (`restrict access: true`) — follows the existing project permission pattern (`administer event reviews`, `administer event attendees`, …).
- **Unit test** covering vendor-denied, staff-allowed, other-field-unaffected, and view-unaffected cases.

## Behaviour

| Actor | Before | After |
|---|---|---|
| Vendor (`edit own event content`) | could set Hidden Gem on default form | **forbidden** (widget removed) |
| Administrator (`is_admin`) | could edit | still can (holds permission implicitly) |
| Staff role | n/a | grant `administer hidden gem flag` in the UI — **no code change** |
| Event Studio / wizard forms | field hidden | unchanged |

## Notes / decisions

- **Code-only change** — `ddev drush config:status` reports **no differences**. The permission takes effect on cache rebuild / deploy. No config import required.
- **`content_editor` not granted** the permission: that role has no event-edit access (article/page only), so a grant would be inert and add config drift. Kept admin-only by default; grant to a curating staff role as needed.
- **Test is a Unit test, not Kernel.** The `myeventlane_event` service container cannot compile in a Kernel test in this environment because the module hard-depends on `myeventlane_donations` (`@myeventlane_donations.vendor_event_mel_support`); the pre-existing `EventProductManagerTest` errors identically. The hook is a pure function (only `hasPermission()` + `getName()`), so it is tested directly. Worth a separate ticket to make this module's Kernel tests runnable.

## Validation

- Targeted PHPUnit (new test + `EventMerchandisingPresenterTest`, `MelReadinessHelperCustomerTest`, `MelRecommendationPresentationVocabularyTest`): **22 tests, 109 assertions, OK**
- `ddev drush cr` ✅ · `ddev drush config:status` → no differences ✅
- `npm run mel:lint` ✅ (hero guard + stylelint) · `npm run mel:build` ✅ (both themes; no stray tracked assets)
- Permission registers: "Administer Hidden Gem editorial flag" ✅

Drupal 11 + Commerce 3 safe — no Commerce/checkout/RSVP surfaces touched, no UI redesign. Small diff: 3 files, +128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authorization change on a discovery-driving editorial field; scope is narrow (edit only on one field) and view/public behaviour is unchanged.
> 
> **Overview**
> Closes a gap where vendors with **edit own event content** could toggle **`field_hidden_gem`** on the default event form and self-enter the Hidden Gems discovery programme.
> 
> Adds **`hook_entity_field_access()`** so only accounts with the new **`administer hidden gem flag`** permission may **edit** that field; other fields and **view** access stay unchanged (public badges still render). Registers the permission in **`myeventlane_event.permissions.yml`** (`restrict access: true`) for staff roles to grant in the UI—no config export in this diff.
> 
> Adds **`HiddenGemFieldAccessTest`** unit coverage for forbidden-without-permission, allowed-with-permission, scope to `field_hidden_gem` only, and view unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcc3946541553e6e49c259601a7eba98263dc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->