### PR TITLE
Cf 1 a

### DIFF
--- a/docs/audits/brand-rollout/community-favourites-audit.md
+++ b/docs/audits/brand-rollout/community-favourites-audit.md
@@ -1,0 +1,235 @@
+# MEL Audit — Community Favourites Discovery Route
+
+**Date:** 2026-06-15
+**Branch:** `feature/community-favourites-audit`
+**Scope:** Audit `/events/popular`; determine rename / repurpose / replace to become **Community Favourites**.
+**Status:** **Audit only. No code or config changed.** Every conclusion cites repository evidence.
+
+> **Mandatory-reading note:** `docs/brand/discovery-principles.md` was listed for reading but **does not exist** (*Repository evidence not found*). The Discovery Principles live in `docs/brand/mel-brand-system-v1.md` (§"Discovery Principles") and are used as the source here. All other mandatory docs were read.
+
+---
+
+## Executive Summary
+
+**Should `/events/popular` become Community Favourites? — YES, by REPURPOSE + RENAME. NOT by rename alone, and NOT by replacement.**
+
+Evidence-based reasoning:
+
+1. **`/events/popular` is not popularity-driven today.** The `page_popular` display inherits the default display sorts: `field_promoted_value DESC` then `field_event_start_value ASC` (`config/sync/views.view.upcoming_events.yml` default `sorts:`, lines ~115–141; `page_popular` `defaults:` does **not** override `sorts`, only `empty/pager/row/filters`, lines 3286–3290). Its own description reads *"Boosted and promoted public event discovery route."* So it ranks **paid/boosted events first**, then by soonest date. It contains **no** RSVP, sales, save, or view metric.
+
+2. **A pure rename would breach the brand.** `docs/brand/event-card-system.md` defines **Community Favourite** as *"Strong repeat attendance or local sentiment… Evidence-based; not paid placement,"* and `mel-brand-system-v1.md` (Participation Principle 5) demands *"Social proof without pressure; fake scarcity is not [acceptable]."* Renaming a **promoted-first** route to "Community Favourites" would label paid placement as community sentiment — a direct violation.
+
+3. **A genuine engine already exists — so replacement is unnecessary.** `myeventlane_analytics\PopularEventsService` computes real engagement: `score = tickets_sold×3 + rsvp×1` from Commerce paid tickets (**excluding boost order items**, `order_item.type <> 'boost'`) + canonical `rsvp_submission` storage, last N days (`PopularEventsService.php:79–160`, header lines 20–23). This is exactly "evidence-based, not paid placement."
+
+**Conclusion:** **Repurpose** the surface to be driven by `PopularEventsService` (swap the ranking source away from `field_promoted`), **rename** to *Community Favourites*, and add honest attribution + a repository-backed badge. The engine, card system, rail shell, diversity filter, and attribution pattern all already exist — **no new tables, entities, recommendation engines, or ranking infrastructure are required** (see §3).
+
+---
+
+## 1. What is `/events/popular` today?
+
+| Aspect | Evidence | Finding |
+|---|---|---|
+| **Route owner** | Views page display `view.upcoming_events.page_popular`; `path: events/popular` (`views.view.upcoming_events.yml:3293`) | Views-owned page route |
+| **Display owner** | `upcoming_events:page_popular` (line 2908), `display_plugin: page`, `display_title: 'Popular events'` | One display of the shared `upcoming_events` View |
+| **Menu** | In `main` menu as title **"Discover"**, weight 2, desc *"Discover boosted and popular events"* (page_popular `menu:` block) | User-facing nav entry |
+| **Filters** | Overridden (`defaults: { filters: false }`): published (`status=1`), `type=event`, `field_event_state` exclusions, title-not-empty, `field_event_start >= now` (upcoming) | Standard "published upcoming events" — **no popularity filter** |
+| **Sorts** | **Inherited** from default display (not overridden): `field_promoted_value DESC`, then `field_event_start_value ASC` | **Boosted-first, then soonest — not popularity** |
+| **Access** | Inherited from default display: `access: { type: perm, perm: 'access content' }` (default display, line ~93–96) | **Public** |
+| **Query alter** | `page_popular` is allow-listed in `PublicEventDiscoveryQueryAlter` (`PublicEventDiscoveryQueryAlter.php:29`) | Canonical public discovery filters applied |
+| **Cards used** | Row `view_mode: compact_commerce` (page_popular `row:`, lines ~3282–3284) → canonical event card | Shared card system (`compact_commerce` node view display) |
+| **Attribution** | **Not present** in `DiscoveryAttributionSources::VIEW_DISPLAY_MAP` (lines 47–58) — no `popular`/`community` source constant exists | **No click attribution** for this route |
+| **Empty state** | Inline `mel-empty-state` markup: *"No popular events yet… Browse upcoming events while organisers boost new experiences."* (line ~2947) | Empty copy reinforces the boost framing |
+| **Visibility logic** | Always-on page route (no `HomepageSectionVisibility` gating — that governs homepage rails, not this route) | Route is always reachable |
+
+---
+
+## 2. Is Popular actually Popular?
+
+**No.** The route's ranking signal is `field_promoted` (a boolean boost/promotion flag), not engagement.
+
+| Signal the brand expects | Present in `/events/popular`? | Evidence |
+|---|---|---|
+| RSVP counts | ❌ | No RSVP join/sort in `page_popular` or its inherited sorts |
+| Ticket sales | ❌ | No Commerce metric in the View |
+| Save counts | ❌ | No saved-events metric in the View |
+| View / pageview counts | ❌ | No pageview metric in the View |
+| `field_promoted` (boost) | ✅ **only signal** | Default sort `field_promoted_value DESC` |
+
+**What `/events/popular` actually shows:** **boosted/promoted events first**, then upcoming events by soonest start. That is **promoted events**, not community popularity, editorial selection, or recommendation output.
+
+### Real popularity DOES exist elsewhere (but is disconnected from this route)
+| Service | Status | Logic | Evidence |
+|---|---|---|---|
+| **`myeventlane_analytics\PopularEventsService`** | **LIVE** | `score = tickets_sold×3 + rsvp×1`; sources = Commerce paid tickets (**excludes** `order_item.type='boost'`, excludes carts) + canonical `rsvp_submission`; sort: upcoming-first, score DESC, going DESC, nid DESC | `PopularEventsService.php:79–160`, header 20–23, 175 |
+| `myeventlane_front\…\PopularEventsBlock` ("Popular this week", id `myeventlane_popular_events_block`) | Defined; **not placed in any `block.block.*` config** | Injects `@myeventlane_analytics.popular_events` | `PopularEventsBlock.php:12,20,54`; no block config found |
+| `myeventlane_core\HomepagePopularityService` | **ORPHANED** (injected nowhere) | Duplicate RSVP+sales logic, excludes boosted via `BoostManager` | `HomepagePopularityService.php`; no callers found |
+
+> **Three "popular" implementations exist, and the one named on the route (`/events/popular`) is the only one that is *not* engagement-based.** The live engine (`PopularEventsService`) is genuine community popularity and **explicitly excludes boost spend** — but it is surfaced only via an **unplaced** block. The core `HomepagePopularityService` is an orphaned third copy (duplicate logic — flag for cleanup; `drupal-design-governance.md` "no duplicate UI/logic patterns").
+
+---
+
+## 3. Community Favourites viability
+
+**YES — Community Favourites can be built entirely on existing architecture.**
+
+| Required capability | Exists? | Evidence | New infra needed? |
+|---|---|---|---|
+| Engagement ranking engine | ✅ `PopularEventsService` (sales+RSVP, excludes boost) | `PopularEventsService.php` | **No** |
+| Data sources | ✅ Commerce `order_item` + canonical `rsvp_submission` (existing tables) | `PopularEventsService.php:175,264–284` | **No new tables** |
+| Render block | ✅ `PopularEventsBlock` already consumes the engine | `PopularEventsBlock.php:54` | **No** |
+| Card rendering | ✅ canonical card via `compact_commerce` view mode (used by `page_popular`) + `EventCardViewModel` | view config; `EventCardViewModel.php` | **No** |
+| Rail shell | ✅ `mel-section-shell.html.twig` (used by every homepage rail) | `page--front.html.twig` | **No** |
+| Diversity / anti-dominance | ✅ `HomepageRailDiversityFilter` (category/venue/organiser, post-query, no SQL) | `HomepageRailDiversityFilter.php` | **No** |
+| Public discovery filters | ✅ `PublicEventDiscoveryQueryAlter` (allow-listed displays) | `PublicEventDiscoveryQueryAlter.php` | **No** |
+| Attribution pattern | ✅ `DiscoveryAttributionSources` (extensible allowlist; Hidden Gems added 2 keys) | `DiscoveryAttributionSources.php:23–24,57` | New **constant only** (mirrors Hidden Gems), not new infra |
+| Badge signal | ✅ `EventMerchandisingPresenter` ("repository-backed signals only — no invented popularity labels") | `EventMerchandisingPresenter.php` header | A Community-Favourite signal must be **engine-backed** (governance constraint, not new infra) |
+
+**No new database tables, entities, recommendation engines, or custom ranking infrastructure are required.** The only net-new code at implementation time is wiring (route/rail → `PopularEventsService`), one attribution constant, copy, and an engine-backed badge — all mirroring the existing Hidden Gems precedent.
+
+---
+
+## 4. Homepage placement
+
+**Brand-canonical position (`docs/brand/homepage-system.md`, "Homepage hierarchy"):**
+Hero → Tonight/This week near you → **Hidden Gems** → Browse by category → Editor's Pick → **Community Favourites (item 6, "Social proof without pressure")** → Just Added → Blog.
+
+**Current homepage order** (`page--front.html.twig` region sequence): Hero → Featured → Discover → Tonight → Free/RSVP → Latest → Recommended → Nearby → Online → Blog.
+
+**Recommended placement (no redesign):** place a **Community Favourites** rail **after Hidden Gems and after the Tonight/Discover cluster, and before "Latest/Freshly added."** This matches the brand's "social proof after discovery, before recency" intent. Concretely: position it adjacent to and **after** the existing `home_recommended`/Hidden-Gems rails and **above** `homepage_latest`.
+
+| Rail | Relationship to Community Favourites |
+|---|---|
+| Tonight | Above CF (immediate/time-scoped discovery leads) |
+| Hidden Gems | Above CF (brand differentiator leads) |
+| Free & RSVP | Sibling discovery cluster; CF sits near it |
+| **Community Favourites** | **Social-proof layer — after discovery, before recency** |
+| Latest / Freshly added | **Below** CF (recency is lower priority than social proof) |
+| Recommended | Adjacent; CF is community-wide, Recommended is per-user (keep distinct) |
+
+> Placement recommendation only; brand cap of **two guide moments per homepage** (`homepage-system.md`) still applies — CF should use copy/badge, not a third guide illustration.
+
+---
+
+## 5. Discovery continuity (reuse surfaces)
+
+Community Favourites (engine output) can be reused across surfaces using existing patterns:
+
+| Surface | Existing reusable mechanism | Evidence |
+|---|---|---|
+| **Homepage rail** | block placement in a homepage region + `mel-section-shell` | `page--front.html.twig`; `PopularEventsBlock` |
+| **Browse route** | `upcoming_events` page display + `PublicEventDiscoveryQueryAlter` allowlist (as Hidden Gems did with `page_hidden_gems`) | `views.view.upcoming_events.yml`; `PublicEventDiscoveryQueryAlter.php:31` |
+| **Related events** | `EventRecommendationService` (same-category next-step) + `mel_related_events` rail | `EventRecommendationService.php`; `node--event--full.html.twig` |
+| **Search fallback** | `FeaturedEventsRenderBuilder` zero-result fallbacks (featured + hidden-gems already wired) — a CF fallback mirrors these | `SearchController.php` (PR #587 pattern), `FeaturedEventsRenderBuilder` |
+| **Empty-state recovery** | `includes/mel-view-empty-events.html.twig` + `empty-state.html.twig` (CTA-driven) | shared templates |
+| **Checkout continuity** | `MelCustomerContinuityPresenter` → `continuity_actions` slot in `commerce-checkout-completion.html.twig` | PR #588 review evidence |
+| **RSVP continuity** | RSVP confirmation templates (`myeventlane_rsvp/templates/*`) | discovery/email audits |
+
+All reuse paths exist; CF requires wiring + copy, not new surfaces.
+
+---
+
+## 6. Naming audit
+
+Evaluated against `copy-guidelines.md`, `guide-character-system.md`, and Discovery Principles (`mel-brand-system-v1.md`).
+
+| Candidate | Brand fit | Evidence / verdict |
+|---|---|---|
+| **Popular** | ❌ | Functional, not brand voice; current route is boosted-first so the word is misleading; `copy-guidelines.md` prefers Community-framed social proof and avoids hype/FOMO |
+| **Community Favourites** | ✅ **canonical** | Used verbatim in brand docs: `homepage-system.md` hierarchy item 6; `event-card-system.md` badge "Community Favourite"; `copy-guidelines.md` header *"Community favourites in your area"*; `mel-brand-system-v1.md` *"Community Favourite is acceptable."* AU spelling "Favourites" matches `copy-guidelines.md` (favourite). |
+| Community Picks | ◑ | "Picks" implies **editorial selection** → collides with **Editor's Pick** (a distinct brand badge). Misleading for an engagement-ranked rail. |
+| Community Loved | ❌ | Not in brand docs; awkward grammar; childish risk vs. `guide-character-system.md` "Not childish." |
+| Popular with the Community | ◑ | Retains "Popular"; verbose; weaker than the established term. |
+
+**Recommended canonical label: "Community Favourites"** (Australian spelling), with optional Curator-guide section intro per `guide-character-system.md` ("I think you'll love this"). Card badge: **"Community Favourite"** (engine-backed only).
+
+---
+
+## Ownership Map
+
+| Layer | Owner | Evidence |
+|---|---|---|
+| **Route** | `view.upcoming_events.page_popular` → `/events/popular` (menu "Discover") | `views.view.upcoming_events.yml:2908,3293` |
+| **View** | `upcoming_events` (multi-display); ranking inherited (`field_promoted DESC`, start ASC) | default `sorts:` ~115–141 |
+| **Related view** | `front_recommended_events` — also `field_promoted DESC` + start ASC (promoted-first, not personalised) | `views.view.front_recommended_events.yml:53–75` |
+| **Live popularity engine** | `myeventlane_analytics\PopularEventsService` | `PopularEventsService.php` |
+| **Popularity block** | `myeventlane_front\…\PopularEventsBlock` (unplaced) | `PopularEventsBlock.php` |
+| **Orphaned duplicate** | `myeventlane_core\HomepagePopularityService` | `HomepagePopularityService.php` (no callers) |
+| **Query filters** | `PublicEventDiscoveryQueryAlter` (allow-lists `page_popular`, `page_hidden_gems`, …) | `PublicEventDiscoveryQueryAlter.php:25–34` |
+| **Merchandising/hero** | `HomepageMerchandising` (promoted hero + spotlight cascade) | `HomepageMerchandising.php` |
+| **Diversity** | `HomepageRailDiversityFilter` | `HomepageRailDiversityFilter.php` |
+| **Attribution** | `DiscoveryAttributionSources` (no `popular`/`community` key) | `DiscoveryAttributionSources.php:12–24,47–58` |
+| **Cards** | `compact_commerce` view mode + `EventCardViewModel` + `EventMerchandisingPresenter` (repo-backed signals only) | view config; `EventCard/*` |
+| **Templates** | `page--front.html.twig`, `mel-section-shell.html.twig`, `mel-event-card.html.twig`, inline empty-state | theme |
+| **Recommendation** | `EventRecommendationService` (same-category next-step) | `EventRecommendationService.php` |
+
+---
+
+## Existing Reusable Architecture (repository evidence only)
+
+1. `PopularEventsService` — engagement engine (sales+RSVP, excludes boost). *Reuse as CF ranking source.*
+2. `PopularEventsBlock` — block already consuming the engine. *Reuse as CF rail.*
+3. `compact_commerce` view mode + `EventCardViewModel` — canonical cards. *Reuse unchanged.*
+4. `mel-section-shell.html.twig` — rail chrome. *Reuse for CF rail.*
+5. `HomepageRailDiversityFilter` — anti-dominance. *Reuse to diversify CF rail.*
+6. `PublicEventDiscoveryQueryAlter` — discovery filters + display allowlist. *Reuse; add CF display to allowlist at build time.*
+7. `DiscoveryAttributionSources` — extensible attribution (Hidden Gems precedent). *Mirror with a CF source constant.*
+8. `EventMerchandisingPresenter` — repo-backed badge signals. *Reuse for an engine-backed "Community Favourite" badge.*
+9. `upcoming_events` View display pattern (`page_hidden_gems` precedent) — *clone shape for a CF browse display.*
+10. Continuity surfaces (search fallback builder, empty-state include, `MelCustomerContinuityPresenter`). *Reuse per §5.*
+
+---
+
+## Gap Analysis
+
+| Severity | Gap | Evidence |
+|---|---|---|
+| 🔴 **Critical** | `/events/popular` ranks by `field_promoted` (paid/boosted), labelled/marketed as "Popular" — contradicts brand "Community Favourite = not paid placement" | default sorts ~115; display desc |
+| 🔴 **Critical** | The genuine engagement engine (`PopularEventsService`) is **not connected** to the `/events/popular` route | route inherits promoted sort; engine used only by an unplaced block |
+| 🟠 **High** | No **Community Favourites** rail, route, badge, or attribution source exists (brand hierarchy item 6 + badge unfulfilled) | `homepage-system.md`; `DiscoveryAttributionSources` has no key |
+| 🟠 **High** | `PopularEventsBlock` (real engine) is **unplaced** — community popularity is computed but not surfaced | no `block.block.*` config |
+| 🟡 **Medium** | **Duplicate logic**: orphaned `HomepagePopularityService` vs live `PopularEventsService` — violates "no duplicate patterns" | both compute RSVP+sales |
+| 🟡 **Medium** | `front_recommended_events` is also promoted-first (not personalised) — "Recommended" vs CF distinction is currently blurred | `front_recommended_events.yml:53` |
+| 🟢 **Low** | `/events/popular` has no click attribution (analytics blind spot) | not in `VIEW_DISPLAY_MAP` |
+| 🟢 **Low** | Empty-state copy references "boost" framing, off-brand for CF | line ~2947 |
+
+---
+
+## Recommended Implementation Plan (future phases — not executed)
+
+> Each phase is independently reviewable, reuses existing systems, and adds no duplicate logic. **No code/config changed in this audit.**
+
+### Phase CF-1 — Smallest safe implementation (honest rail, existing block)
+- Place the existing **`PopularEventsBlock`** (engine-backed) into a homepage region as a **"Community Favourites"** rail; set its title to "Community Favourites" via the block's existing title config.
+- Use the canonical card + `mel-section-shell`. Apply `HomepageRailDiversityFilter` if the block doesn't already.
+- **Do not** touch `/events/popular`'s ranking yet. No new tables/entities/engines.
+- *Outcome:* a genuine, brand-honest Community Favourites rail with zero new infra.
+
+### Phase CF-2 — Continuity + attribution + badge
+- Add a `SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES` (and `SOURCE_BROWSE_COMMUNITY_FAVOURITES`) constant to `DiscoveryAttributionSources` + map the CF display (mirror Hidden Gems).
+- Add an **engine-backed** "Community Favourite" badge signal in `EventMerchandisingPresenter` (repo-backed only; one-badge-per-card rule preserved).
+- Wire CF into reuse surfaces per §5 (search fallback, empty-state recovery, checkout/RSVP continuity).
+
+### Phase CF-3 — Homepage integration + route repurpose
+- Repurpose the `/events/popular` **browse route** to a Community Favourites browse display driven by the engine (or add a dedicated `page_community_favourites` display mirroring `page_hidden_gems`), update menu label, and redirect/retire the misleading "Popular/boosted" semantics.
+- Retire the orphaned `HomepagePopularityService` (dedupe) under review.
+- Confirm brand homepage order (CF after Hidden Gems, before Latest).
+
+---
+
+## Validation (run for this audit)
+
+| Command | Result |
+|---|---|
+| `git status -sb` | `## feature/community-favourites-audit` (clean) |
+| `ddev drush cr` | success |
+| `ddev drush config:status` | **No differences between DB and sync directory** |
+| `rg "popular" web/modules/custom web/themes/custom config/sync` | Confirms three implementations: `upcoming_events:page_popular` (View, promoted-sort), `PopularEventsService`/`PopularEventsBlock` (engine), `HomepagePopularityService` (orphaned) |
+| `rg "HomepagePopularityService" web/modules/custom` | `myeventlane_core/src/Service/HomepagePopularityService.php` + `myeventlane_core.services.yml` only — **no callers (orphaned)** |
+| `rg "field_promoted" config/sync/views.view.*` | Present in `upcoming_events`, `front_recommended_events`, `front_featured_events`, `mel_home_events`, `featured_events_carousel`, `featured_events` — confirms promoted-sort is the shared discovery ranking |
+
+---
+
+## Rules compliance
+Audit-first ✅ · Drupal 11 safe (no code) ✅ · Commerce 3 safe (read-only; engine excludes boost order items) ✅ · Security aware (public `access content`, no leakage) ✅ · Config aware (no config changed; `config:status` clean) ✅ · Mobile-first (reuses existing responsive rail/card) ✅ · MEL style-guide compliant (canonical card, no duplicate patterns recommended) ✅ · No guessing — every claim cited ✅ · No code/config changes ✅.
+
+**Repository contradicted the implicit assumption that `/events/popular` reflects popularity. It does not — it reflects paid promotion. Findings reported; nothing implemented.**

--- a/docs/audits/brand-rollout/popular-events-service-audit.md
+++ b/docs/audits/brand-rollout/popular-events-service-audit.md
@@ -1,0 +1,186 @@
+# Audit — PopularEventsService
+
+**Date:** 2026-06-15
+**Branch:** `feature/community-favourites-audit`
+**Status:** **Findings only. No code or config changed.** Every claim cites repository evidence.
+**Subject:** `web/modules/custom/myeventlane_analytics/src/Service/PopularEventsService.php` (service id `myeventlane_analytics.popular_events`).
+
+---
+
+## 1. Exactly where PopularEventsService is called
+
+| Caller | Location | Method | Notes |
+|---|---|---|---|
+| `PopularEventsBlock::build()` | `myeventlane_front/src/Plugin/Block/PopularEventsBlock.php:133` | `getPopularEventIds($days, $limit)` | Injected via `create()` line 54 (`@myeventlane_analytics.popular_events`) |
+| `TrendingCategoriesService` | `myeventlane_analytics/src/Service/TrendingCategoriesService.php:103` | `getPopularEventIds($days, $eventScanLimit)` | Injected ctor arg (`services.yml:88`) |
+| `TrendingCategoriesService` | `TrendingCategoriesService.php:216` | `getPopularEventRows($days)` | Uncapped rows for category aggregation |
+
+**Service registration:** `myeventlane_analytics.services.yml:74–80` — args `@database`, `@datetime.time`, `@logger.factory`, `@myeventlane_analytics.order_item_classifier`.
+
+> **Not a caller:** `myeventlane_core/src/Service/HomepagePopularityService.php:71` matches only because it *defines its own* method also named `getPopularEventIds()`. It is a **separate, orphaned** duplicate service (no callers) — see `community-favourites-audit.md §2`.
+
+**Total real callers: 2** — one render block (`PopularEventsBlock`) and one backend aggregator (`TrendingCategoriesService`).
+
+---
+
+## 2. Which homepage blocks currently consume it
+
+| Block | Plugin id | Consumes | Placed? |
+|---|---|---|---|
+| `PopularEventsBlock` | `myeventlane_popular_events_block` | `PopularEventsService` directly (renders event cards) | **NO** — not in any `block.block.*.yml`, and no code/layout placement (`rg` confirmed) |
+| `TrendingCategoriesBlock` | (myeventlane_front) | `PopularEventsService` **indirectly** via `TrendingCategoriesService` (renders *categories*, not events) | **NO** — not placed |
+| `TrendingInCategoryBlock` | (myeventlane_front) | indirectly via `TrendingCategoriesService` | **NO** — not placed |
+
+**Finding: ZERO placed homepage blocks currently consume PopularEventsService.** Community popularity is computed but **never surfaced** on the homepage today. The only event-rendering consumer (`PopularEventsBlock`) is **defined but unplaced**.
+
+---
+
+## 3. Which event IDs it returns
+
+`getPopularEventIds(int $days = 7, int $limit = 8)` → top-`$limit` ranked rows; `getPopularEventRows(int $days = 7)` → full uncapped ranked list.
+
+Each row (`PopularEventsService.php:76, 141–148`):
+```
+{ nid, score, tickets_sold, rsvps, going, is_past }
+```
+
+- **nids** = `event`-bundle, **published** nodes that had ≥1 paid ticket OR ≥1 RSVP within the lookback window (default 7 days).
+- **score** = `tickets_sold × 3 + rsvps × 1` (line 135, "locked by spec").
+- **going** = `tickets_sold + rsvps`.
+- **Sort** (lines 156–167): upcoming-first (`is_past` last), then `score DESC`, then `going DESC`, then `nid DESC` (deterministic).
+- **Sources:** tickets from Commerce `commerce_order_item__field_target_event` joined to orders (lines 217–250); RSVPs from `rsvp_submission` field tables, schema-introspected (lines 273–336).
+
+---
+
+## 4. Exclusions
+
+| Candidate | Excluded? | Evidence |
+|---|---|---|
+| **Draft / unpublished events** | ✅ **YES** | Both source queries `innerJoin node_field_data … n.status = 1` (lines 224, 306) |
+| **Boosted events** | ❌ **NO** (events not excluded) | Only **boost order *items*** are removed from ticket scoring via `OrderItemClassifier::getExcludedTypes()` = `['boost','checkout_donation','platform_donation','rsvp_donation']` (`OrderItemClassifier.php:46–51`; applied at `PopularEventsService.php:229`). A boosted event with genuine sales/RSVPs **still appears**, ranked on real engagement. |
+| **Cancelled events** | ❌ **NO** (event-state not checked) | Only **cancelled *orders*** are excluded (`o.state <> 'canceled'`, line 239, if column exists). There is **no `field_event_state` filter** anywhere in the service. |
+| **Archived events** | ❌ **NO** | No `field_event_state` / archival filter in the service. |
+| **(also) Past events** | ❌ not hidden | `is_past` only **deprioritises** at sort time (lines 137–139, 157); "do not hide past events" (header line 26). |
+| **(also) Carts / draft orders** | ✅ excluded | `o.cart = 0` (line 233, if column exists) |
+| **(also) Boost/donation spend** | ✅ excluded from scoring | `oi.type NOT IN EXCLUDED_TYPES` (line 229) |
+
+> **Critical gap for a public rail:** the service filters **publication status** but **not event lifecycle state**. Cancelled, archived, or past events with recent engagement **can be returned**. Any Community Favourites rail built directly on this output must add an event-state/visibility guard (see §6).
+
+---
+
+## 5. Does output pass through the discovery pipelines?
+
+| Pipeline | Applies? | Evidence |
+|---|---|---|
+| **PublicEventDiscoveryQueryAlter** | ❌ **NO** | It is a **Views** `hook_views_query_alter` over allow-listed *Views displays*. `PopularEventsService` runs **direct `$this->database->select(...)`** queries, not Views — so none of the canonical public discovery filters (state, visibility, dedupe) apply. |
+| **HomepageMerchandising** | ❌ **NO** | `PopularEventsBlock::build()` never calls it; no hero/spotlight cross-rail dedup. (`rg` over block + analytics: none.) |
+| **HomepageRailDiversityFilter** | ❌ **NO** | Never invoked by the block; no category/venue/organiser anti-dominance applied. |
+
+**Consequence:** the engine output is rendered **raw**. No cross-rail dedup (an event may appear in Featured/Tonight *and* this rail), no diversity capping, and **no state/visibility filtering beyond `status=1` + `type=event`**.
+
+---
+
+## 6. Smallest implementation path — Community Favourites homepage rail (existing architecture only)
+
+**Smallest path = place the existing `PopularEventsBlock`** (it already consumes the engine and renders the canonical `compact_commerce` card). No new service, View, table, or engine is required.
+
+### Minimal steps (config + copy only)
+1. Place block `myeventlane_popular_events_block` into a homepage region (per `theme-architecture.md` region model), via block placement config.
+2. Set block title → **"Community Favourites"** (existing `title` config field, `PopularEventsBlock.php:74–79`).
+3. Position after Hidden Gems / before "Latest" (per `community-favourites-audit.md §4`).
+
+### Mandatory guards before this is *safe* (each reuses existing architecture — no new infra)
+Because the block bypasses all three pipelines (§5) and the engine omits lifecycle filtering (§4), the smallest **safe** path must additionally:
+
+| Gap | Existing mechanism to reuse |
+|---|---|
+| Cancelled / archived / past events can appear | Filter loaded nodes by `field_event_state` / upcoming, mirroring the filters `PublicEventDiscoveryQueryAlter` already applies to discovery Views — applied to the nid set after `getPopularEventIds()` |
+| No diversity (organiser/venue/category dominance) | Pass the nid set through **`HomepageRailDiversityFilter`** (already designed for "homepage discovery rails", post-query, no SQL) |
+| Cross-rail duplication with Featured/Tonight | Reuse **`HomepageMerchandising`** dedup/cascade set (it already computes "exclude higher-priority sections") |
+| Honest badge / attribution | Add a `community_favourites` source to `DiscoveryAttributionSources` (mirrors the Hidden Gems precedent) + engine-backed badge in `EventMerchandisingPresenter` |
+
+> **Recommendation (not implemented):** the truly smallest *correct* path is **place `PopularEventsBlock` + apply the existing `HomepageRailDiversityFilter` and an event-state guard to its nid set**. This stays within existing architecture, adds no duplicate ranking logic, and closes the §4/§5 gaps. A Views-display alternative (so the rail inherits `PublicEventDiscoveryQueryAlter`) is larger because Views cannot natively rank by the engine's score without a custom sort/contextual-nid feed.
+
+---
+
+## Ownership map
+
+| Layer | Owner | Evidence |
+|---|---|---|
+| Engine | `myeventlane_analytics\PopularEventsService` (`myeventlane_analytics.popular_events`) | service file |
+| Excluded-type policy | `myeventlane_analytics\OrderItemClassifier` (`getExcludedTypes()` → boost + donations) | `OrderItemClassifier.php:46–51,97–99` |
+| Render block | `myeventlane_front\…\PopularEventsBlock` (`myeventlane_popular_events_block`) — **unplaced** | block file; no block config |
+| Indirect consumer | `myeventlane_analytics\TrendingCategoriesService` → `TrendingCategoriesBlock`/`TrendingInCategoryBlock` (unplaced) | service + blocks |
+| Orphaned duplicate | `myeventlane_core\HomepagePopularityService` (no callers) | service file |
+
+## Route map
+
+- **No route** is owned by `PopularEventsService` — it is a service consumed by blocks, not a controller/Views route.
+- The separate `/events/popular` route (`view.upcoming_events.page_popular`) is **not** wired to this service (ranks by `field_promoted`; see `community-favourites-audit.md §1–2`).
+
+## Service map
+
+```
+PopularEventsService (engine)
+  ├─ OrderItemClassifier::getExcludedTypes()  → excludes boost + donation order items
+  ├─ database (direct SQL: commerce_order_item__field_target_event, rsvp_submission, node__field_event_start)
+  └─ consumed by:
+       ├─ PopularEventsBlock  (renders event cards)            [UNPLACED]
+       └─ TrendingCategoriesService → Trending*Block (categories) [UNPLACED]
+NOT connected to: HomepageMerchandising · HomepageRailDiversityFilter · PublicEventDiscoveryQueryAlter
+```
+
+## View map
+
+- **None.** `PopularEventsService` does **not** use Views; it issues direct DB queries. (Contrast: `/events/popular` and the Hidden Gems rails are Views-driven and therefore pass through `PublicEventDiscoveryQueryAlter`.)
+
+## Rendering path
+
+```
+PopularEventsBlock::build()
+  → getPopularEventIds(days=7, limit=8)            // ranked rows
+  → extract nids → entityTypeManager.node.loadMultiple(nids)
+  → preserve popularity order
+  → node view_builder->view(node, 'compact_commerce')   // canonical event card
+  → wrap each in .mel-popular-event (+ optional "X going", gated by
+      myeventlane_event_should_show_block_going() social-proof mode)
+  → container .mel-popular-events-block > .mel-event-grid
+```
+View-mode fallback to `teaser` is described in config text but **not implemented** in `build()` (it uses the configured view mode as-is) — minor robustness note.
+
+## Cache implications
+
+| Property | Value | Note |
+|---|---|---|
+| `max-age` | **900s (15 min)** | Engine reads RSVP/order tables that are **not cache-tagged**; TTL is the staleness safety net (block comment lines 234–235) |
+| `contexts` | `languages:language_interface` only | No `user`/`url`/permission context → treated as identical for all viewers (fine for public, anon-safe popularity) |
+| `tags` | `node_list` + per-node `node:{nid}` (lines 226, 238) | Node edits/creates invalidate; **RSVP and ticket-sale changes do NOT invalidate** (no order/rsvp tags) — only the 900s TTL refreshes ranking |
+| Empty result branch | `max-age 900` + language context, **no tags** (lines 135–141, 160–166) | An empty rail won't re-evaluate until TTL even if events gain engagement |
+
+**Implications for a homepage rail:** placing this block caps the homepage block's cache at 15 min and makes popularity eventually-consistent (≤15 min lag). Acceptable for anonymous discovery; no security/permission caching concern (no private data, public `node` access enforced by the view builder per node).
+
+## Validation commands (run for this audit)
+
+```bash
+git status -sb                                   # ## feature/community-favourites-audit (clean)
+ddev drush cr                                    # success
+ddev drush config:status                         # No differences between DB and sync directory
+rg -n "PopularEventsService|myeventlane_analytics.popular_events" web/modules/custom   # 2 callers
+rg -l "myeventlane_popular_events_block" config/sync     # (no output) → block UNPLACED
+rg -n "RailDiversityFilter|HomepageMerchandising|PublicEventDiscoveryQueryAlter" \
+   web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php   # (none) → bypasses pipelines
+rg -nA6 "EXCLUDED_TYPES = " web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+```
+
+---
+
+## Summary of findings
+
+1. **Called by 2 consumers**: `PopularEventsBlock` (render) and `TrendingCategoriesService` (aggregate). The core `HomepagePopularityService` is an unrelated orphan.
+2. **Zero placed homepage blocks consume it** — the engine is live but unsurfaced.
+3. **Returns** ranked `{nid,score,tickets_sold,rsvps,going,is_past}` for published events with sales/RSVP engagement (score = sales×3 + rsvp×1).
+4. **Excludes drafts** (✅) and boost/donation *spend*; **does NOT exclude** boosted events, cancelled events, archived events, or past events (only deprioritises past).
+5. **Bypasses all three pipelines** (Merchandising, RailDiversityFilter, PublicEventDiscoveryQueryAlter) — it is direct-SQL, not Views.
+6. **Smallest path** to a Community Favourites rail = **place the existing `PopularEventsBlock`** + apply the existing `HomepageRailDiversityFilter` and an event-state guard to its nid set (no new tables/entities/engines). The block-only placement is smallest but unsafe until §4/§5 gaps are closed with existing services.
+
+**No code or config modified. Findings only.**

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 lifecycle: stable
 
 dependencies:
+  - myeventlane_event:myeventlane_event
   - myeventlane_surface:myeventlane_surface
   - myeventlane_core:myeventlane_core
   - myeventlane_vendor:myeventlane_vendor

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
@@ -78,6 +78,8 @@ services:
       - '@datetime.time'
       - '@logger.factory'
       - '@myeventlane_analytics.order_item_classifier'
+      - '@entity_type.manager'
+      - '@myeventlane_event.public_visibility'
 
   myeventlane_analytics.trending_categories:
     class: Drupal\myeventlane_analytics\Service\TrendingCategoriesService

--- a/web/modules/custom/myeventlane_analytics/src/Service/PopularEventsService.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/PopularEventsService.php
@@ -7,7 +7,10 @@ namespace Drupal\myeventlane_analytics\Service;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Schema;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\node\NodeInterface;
 
 /**
  * Computes "Popular this week" events using real engagement.
@@ -22,8 +25,8 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
  * Hard rules:
  * - Exclude Boost purchases/spend: order_item.type <> 'boost'
  * - Only published events (node_field_data.status = 1)
+ * - Only publicly listable upcoming events (PublicEventVisibility)
  * - No N+1: single query per source, merged in PHP.
- * - Do not hide past events; optionally deprioritise past events at sort time.
  */
 final class PopularEventsService {
 
@@ -57,17 +60,31 @@ final class PopularEventsService {
    */
   private OrderItemClassifier $orderItemClassifier;
 
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * @var \Drupal\myeventlane_event\Service\PublicEventVisibility
+   */
+  private PublicEventVisibility $publicEventVisibility;
+
   public function __construct(
     Connection $database,
     TimeInterface $time,
     LoggerChannelFactoryInterface $logger_factory,
     OrderItemClassifier $orderItemClassifier,
+    EntityTypeManagerInterface $entity_type_manager,
+    PublicEventVisibility $public_event_visibility,
   ) {
     $this->database = $database;
     $this->time = $time;
     $this->schema = $database->schema();
     $this->logger = $logger_factory->get('myeventlane_analytics');
     $this->orderItemClassifier = $orderItemClassifier;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->publicEventVisibility = $public_event_visibility;
   }
 
   /**
@@ -134,7 +151,7 @@ final class PopularEventsService {
       // Spec: Deterministic score formula.
       $score = ($tickets_sold * 3) + ($rsvp_count * 1);
 
-      // Past handling: do not hide; only used for sort tie-breaking.
+      // Past handling: retained for sort stability among listable rows.
       $start_ts = (int) ($starts[$nid] ?? 0);
       $is_past = ($start_ts > 0) ? ($start_ts < $this->time->getRequestTime()) : FALSE;
 
@@ -166,7 +183,38 @@ final class PopularEventsService {
       return $b['nid'] <=> $a['nid'];
     });
 
-    return $rows;
+    return $this->filterPubliclyListableRows($rows);
+  }
+
+  /**
+   * Restricts rows to canonical public discovery eligibility.
+   *
+   * @param array<int, array{nid:int, score:int, tickets_sold:int, rsvps:int, going:int, is_past:bool}> $rows
+   *
+   * @return array<int, array{nid:int, score:int, tickets_sold:int, rsvps:int, going:int, is_past:bool}>
+   */
+  private function filterPubliclyListableRows(array $rows): array {
+    if ($rows === []) {
+      return [];
+    }
+
+    $nids = array_values(array_unique(array_map(static fn (array $row): int => (int) ($row['nid'] ?? 0), $rows)));
+    $nids = array_values(array_filter($nids, static fn (int $nid): bool => $nid > 0));
+    if ($nids === []) {
+      return [];
+    }
+
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+
+    return array_values(array_filter($rows, function (array $row) use ($nodes): bool {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid < 1) {
+        return FALSE;
+      }
+      $node = $nodes[$nid] ?? NULL;
+      return $node instanceof NodeInterface
+        && $this->publicEventVisibility->isPubliclyListable($node);
+    }));
   }
 
   /**
@@ -434,4 +482,3 @@ final class PopularEventsService {
   }
 
 }
-

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
@@ -8,8 +8,11 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\myeventlane_analytics\Service\PopularEventsService;
+use Drupal\myeventlane_front\Service\HomepageMerchandising;
+use Drupal\myeventlane_front\Service\HomepageRailDiversityFilter;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -34,16 +37,37 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
    */
   private EntityTypeManagerInterface $entityTypeManager;
 
+  /**
+   * @var \Drupal\myeventlane_front\Service\HomepageMerchandising
+   */
+  private HomepageMerchandising $merchandising;
+
+  /**
+   * @var \Drupal\myeventlane_front\Service\HomepageRailDiversityFilter
+   */
+  private HomepageRailDiversityFilter $diversityFilter;
+
+  /**
+   * @var \Drupal\Core\Path\PathMatcherInterface
+   */
+  private PathMatcherInterface $pathMatcher;
+
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     PopularEventsService $popular,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
+    HomepageMerchandising $merchandising,
+    HomepageRailDiversityFilter $diversity_filter,
+    PathMatcherInterface $path_matcher,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->popular = $popular;
     $this->entityTypeManager = $entity_type_manager;
+    $this->merchandising = $merchandising;
+    $this->diversityFilter = $diversity_filter;
+    $this->pathMatcher = $path_matcher;
   }
 
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
@@ -52,7 +76,10 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
       $plugin_id,
       $plugin_definition,
       $container->get('myeventlane_analytics.popular_events'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('myeventlane_front.homepage_merchandising'),
+      $container->get('myeventlane_front.homepage_rail_diversity'),
+      $container->get('path.matcher'),
     );
   }
 
@@ -129,8 +156,12 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
     $view_mode = (string) ($this->configuration['view_mode'] ?? 'compact_commerce');
     $title = (string) ($this->configuration['title'] ?? 'Popular this week');
     $show_going = (bool) ($this->configuration['show_going'] ?? TRUE);
+    $onHomepage = $this->pathMatcher->isFrontPage();
 
-    $rows = $this->popular->getPopularEventIds($days, $limit);
+    // Over-fetch on homepage so merchandising/diversity filters can still fill the rail.
+    $fetchLimit = $onHomepage ? min(max($limit * 3, $limit), 24) : $limit;
+
+    $rows = $this->popular->getPopularEventIds($days, $fetchLimit);
     if (empty($rows)) {
       return [
         '#markup' => '',
@@ -176,6 +207,24 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
       if (isset($nodes[$nid])) {
         $ordered_nodes[$nid] = $nodes[$nid];
       }
+    }
+
+    if ($onHomepage) {
+      $rows = $this->applyHomepageMerchandising($rows, $ordered_nodes);
+      $rows = $this->applyHomepageDiversity($rows, $ordered_nodes, $limit);
+    }
+    else {
+      $rows = array_slice($rows, 0, $limit);
+    }
+
+    if ($rows === []) {
+      return [
+        '#markup' => '',
+        '#cache' => [
+          'max-age' => 900,
+          'contexts' => ['languages:language_interface'],
+        ],
+      ];
     }
 
     // Fallback if the provided view mode doesn't exist.
@@ -259,5 +308,67 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
     return $build;
   }
 
-}
+  /**
+   * Removes events already shown in higher-priority homepage rails.
+   *
+   * @param array<int, array<string, mixed>> $rows
+   * @param array<int, \Drupal\node\NodeInterface> $ordered_nodes
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function applyHomepageMerchandising(array $rows, array $ordered_nodes): array {
+    $exclude = array_flip($this->merchandising->getCommunityFavouritesExclusionNids());
+    if ($exclude === []) {
+      return $rows;
+    }
 
+    $filtered = [];
+    foreach ($rows as $row) {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid < 1 || !isset($ordered_nodes[$nid]) || isset($exclude[$nid])) {
+        continue;
+      }
+      $filtered[] = $row;
+    }
+
+    return $filtered;
+  }
+
+  /**
+   * Applies homepage rail diversity to the popularity-ordered rows.
+   *
+   * @param array<int, array<string, mixed>> $rows
+   * @param array<int, \Drupal\node\NodeInterface> $ordered_nodes
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function applyHomepageDiversity(array $rows, array $ordered_nodes, int $limit): array {
+    $rowsByNid = [];
+    $nodesForDiversity = [];
+
+    foreach ($rows as $row) {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid < 1 || !isset($ordered_nodes[$nid])) {
+        continue;
+      }
+      $rowsByNid[$nid] = $row;
+      $nodesForDiversity[] = $ordered_nodes[$nid];
+    }
+
+    if ($nodesForDiversity === []) {
+      return [];
+    }
+
+    $diverseNodes = $this->diversityFilter->filterEventNodes($nodesForDiversity, $limit);
+    $filteredRows = [];
+    foreach ($diverseNodes as $node) {
+      $nid = (int) $node->id();
+      if (isset($rowsByNid[$nid])) {
+        $filteredRows[] = $rowsByNid[$nid];
+      }
+    }
+
+    return $filteredRows;
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -364,6 +364,28 @@ final class HomepageMerchandising {
   }
 
   /**
+   * NIDs to exclude from Community Favourites (higher-priority homepage rails).
+   *
+   * Mirrors the cascade applied before homepage_latest, without latest itself.
+   *
+   * @return list<int>
+   */
+  public function getCommunityFavouritesExclusionNids(): array {
+    if (!$this->pathMatcher->isFrontPage()) {
+      return [];
+    }
+
+    return array_values(array_unique([
+      ...$this->getHeroEventIds(),
+      ...$this->getSpotlightEventIds(),
+      ...$this->getDiscoverEventIds(),
+      ...$this->getTonightEventIds(),
+      ...$this->getHiddenGemEventIds(),
+      ...$this->getFreeRsvpEventIds(),
+    ]));
+  }
+
+  /**
    * Recommended events rail (front_recommended_events:block_1).
    *
    * @return list<int>

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageRailDiversityFilter.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageRailDiversityFilter.php
@@ -45,6 +45,47 @@ final class HomepageRailDiversityFilter {
   }
 
   /**
+   * Applies diversity filtering to an ordered event node list (non-Views rails).
+   *
+   * @param list<\Drupal\node\NodeInterface> $nodes
+   *   Events in rank order.
+   * @param int $targetCount
+   *   Desired result count; backfills from deferred rows when diversity is thin.
+   *
+   * @return list<\Drupal\node\NodeInterface>
+   */
+  public function filterEventNodes(array $nodes, int $targetCount): array {
+    $targetCount = max(1, $targetCount);
+    if ($nodes === []) {
+      return [];
+    }
+    if (count($nodes) <= 1) {
+      return array_slice($nodes, 0, $targetCount);
+    }
+
+    $preferred = [];
+    $deferred = [];
+
+    foreach ($nodes as $node) {
+      if ($this->passesDiversityForNode($node, $preferred)) {
+        $preferred[] = $node;
+      }
+      else {
+        $deferred[] = $node;
+      }
+    }
+
+    foreach ($deferred as $node) {
+      if (count($preferred) >= $targetCount) {
+        break;
+      }
+      $preferred[] = $node;
+    }
+
+    return array_slice($preferred, 0, $targetCount);
+  }
+
+  /**
    * Filters view results to improve category/venue/organiser spread.
    *
    * Prefers diverse rows first but backfills so rails keep their query count.
@@ -91,6 +132,27 @@ final class HomepageRailDiversityFilter {
       return TRUE;
     }
 
+    $preferredNodes = [];
+    foreach ($preferred as $preferredRow) {
+      $preferredEntity = $preferredRow->_entity ?? NULL;
+      if ($preferredEntity instanceof NodeInterface) {
+        $preferredNodes[] = $preferredEntity;
+      }
+    }
+
+    return $this->passesDiversityForNode($entity, $preferredNodes);
+  }
+
+  /**
+   * Whether an event can join the preferred set without repeating organiser/category/venue.
+   *
+   * @param list<\Drupal\node\NodeInterface> $preferred
+   */
+  private function passesDiversityForNode(NodeInterface $entity, array $preferred): bool {
+    if ($entity->bundle() !== 'event') {
+      return TRUE;
+    }
+
     $organiserKey = (string) (int) $entity->getOwnerId();
     $categoryKey = $this->categoryKey($entity);
     $venueKey = $this->venueKey($entity);
@@ -99,8 +161,7 @@ final class HomepageRailDiversityFilter {
     $seenCategories = [];
     $seenVenues = [];
 
-    foreach ($preferred as $preferredRow) {
-      $preferredEntity = $preferredRow->_entity ?? NULL;
+    foreach ($preferred as $preferredEntity) {
       if (!$preferredEntity instanceof NodeInterface || $preferredEntity->bundle() !== 'event') {
         continue;
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes public homepage discovery output and adds entity loads per popular-events query; behavior is scoped to front-page block rendering and shared visibility rules, but ranking/dedup shifts are user-visible.
> 
> **Overview**
> Implements **Phase CF-1-style** wiring so engagement-ranked “popular” output can surface safely as a **Community Favourites** rail, plus two **audit-only** brand-rollout docs (no config in those files).
> 
> **`PopularEventsService`** now depends on `PublicEventVisibility` and filters ranked rows through **`filterPubliclyListableRows()`** after scoring, so cancelled/archived/ended/non-listable events drop out of engine results (not just `status=1`). Module **`myeventlane_event`** is declared as a dependency.
> 
> **`PopularEventsBlock`** on the **front page** over-fetches candidates, then applies **`HomepageMerchandising::getCommunityFavouritesExclusionNids()`** (new cascade: hero, spotlight, discover, tonight, hidden gems, free/RSVP) and **`HomepageRailDiversityFilter::filterEventNodes()`** before rendering; non-homepage behavior stays a simple limit slice.
> 
> **`HomepageRailDiversityFilter`** refactors diversity checks into **`passesDiversityForNode()`** and exposes **`filterEventNodes()`** for block-driven rails that bypass Views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0076d914a2a078dd007704afa3db1f64d63fccff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->