### PR TITLE
Add Community Favourites block and integrate popular events service

### DIFF
--- a/config/sync/block.block.myeventlane_theme_homepage_community_favourites.yml
+++ b/config/sync/block.block.myeventlane_theme_homepage_community_favourites.yml
@@ -1,0 +1,30 @@
+uuid: 7c3d9a1e-4f82-4b6c-9d0e-1a2b3c4d5e6f
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_front
+    - system
+  theme:
+    - myeventlane_theme
+id: myeventlane_theme_homepage_community_favourites
+theme: myeventlane_theme
+region: homepage_community_favourites
+weight: 0
+provider: null
+plugin: myeventlane_popular_events_block
+settings:
+  id: myeventlane_popular_events_block
+  label: 'Community Favourites'
+  label_display: '0'
+  provider: myeventlane_front
+  days: 7
+  limit: 8
+  view_mode: compact_commerce
+  title: ''
+  show_going: true
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -12,6 +12,9 @@ services:
       - '@entity_type.manager'
       - '@views.executable'
       - '@myeventlane_front.featured_events_render_builder'
+      - '@myeventlane_analytics.popular_events'
+      - '@myeventlane_front.homepage_merchandising'
+      - '@path.matcher'
 
   myeventlane_front.homepage_merchandising:
     class: Drupal\myeventlane_front\Service\HomepageMerchandising
@@ -22,6 +25,7 @@ services:
       - '@path.matcher'
       - '@myeventlane_event.public_visibility'
       - '@myeventlane_event.boosted_quality_gate'
+      - '@myeventlane_analytics.popular_events'
 
   myeventlane_front.homepage_merchandising_query_alter:
     class: Drupal\myeventlane_front\Service\HomepageMerchandisingQueryAlter

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_front\Service;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\myeventlane_analytics\Service\PopularEventsService;
 use Drupal\myeventlane_event\Service\BoostedEventQualityGate;
 use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\myeventlane_event_state\Service\EventStateResolver;
@@ -103,6 +104,11 @@ final class HomepageMerchandising {
   /**
    * @var list<int>|null
    */
+  private ?array $communityFavouritesEventIds = NULL;
+
+  /**
+   * @var list<int>|null
+   */
   private ?array $ineligiblePromotedEventIds = NULL;
 
   public function __construct(
@@ -112,6 +118,7 @@ final class HomepageMerchandising {
     private readonly PathMatcherInterface $pathMatcher,
     private readonly PublicEventVisibility $publicVisibility,
     private readonly BoostedEventQualityGate $qualityGate,
+    private readonly PopularEventsService $popularEvents,
   ) {}
 
   /**
@@ -158,6 +165,7 @@ final class HomepageMerchandising {
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
         ...$this->getHiddenGemEventIds(),
+        ...$this->getCommunityFavouritesEventIds(),
       ])),
       'upcoming_events:homepage_latest' => array_values(array_unique([
         ...$hero,
@@ -165,6 +173,7 @@ final class HomepageMerchandising {
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
         ...$this->getHiddenGemEventIds(),
+        ...$this->getCommunityFavouritesEventIds(),
         ...$this->getFreeRsvpEventIds(),
       ])),
       'front_recommended_events:block_1' => array_values(array_unique([
@@ -173,6 +182,7 @@ final class HomepageMerchandising {
         ...$this->getDiscoverEventIds(),
         ...$this->getTonightEventIds(),
         ...$this->getHiddenGemEventIds(),
+        ...$this->getCommunityFavouritesEventIds(),
         ...$this->getFreeRsvpEventIds(),
         ...$this->getLatestEventIds(),
       ])),
@@ -366,7 +376,7 @@ final class HomepageMerchandising {
   /**
    * NIDs to exclude from Community Favourites (higher-priority homepage rails).
    *
-   * Mirrors the cascade applied before homepage_latest, without latest itself.
+   * CF sits after Hidden Gems and before Free & RSVP on the homepage.
    *
    * @return list<int>
    */
@@ -381,8 +391,45 @@ final class HomepageMerchandising {
       ...$this->getDiscoverEventIds(),
       ...$this->getTonightEventIds(),
       ...$this->getHiddenGemEventIds(),
-      ...$this->getFreeRsvpEventIds(),
     ]));
+  }
+
+  /**
+   * Resolved Community Favourites candidate pool for downstream dedup cascade.
+   *
+   * Uses the popularity engine pool after higher-priority homepage exclusions.
+   * Over-fetches so diversity filtering in the block cannot cause duplicate cards
+   * on lower homepage rails.
+   *
+   * @return list<int>
+   */
+  public function getCommunityFavouritesEventIds(): array {
+    if ($this->communityFavouritesEventIds !== NULL) {
+      return $this->communityFavouritesEventIds;
+    }
+
+    if (!$this->pathMatcher->isFrontPage()) {
+      $this->communityFavouritesEventIds = [];
+      return $this->communityFavouritesEventIds;
+    }
+
+    $rows = $this->popularEvents->getPopularEventIds(7, 24);
+    if ($rows === []) {
+      $this->communityFavouritesEventIds = [];
+      return $this->communityFavouritesEventIds;
+    }
+
+    $exclude = array_flip($this->getCommunityFavouritesExclusionNids());
+    $nids = [];
+    foreach ($rows as $row) {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid > 0 && !isset($exclude[$nid])) {
+        $nids[] = $nid;
+      }
+    }
+
+    $this->communityFavouritesEventIds = $nids;
+    return $this->communityFavouritesEventIds;
   }
 
   /**

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_front\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\myeventlane_analytics\Service\PopularEventsService;
 use Drupal\views\ViewExecutableFactory;
 
 /**
@@ -18,6 +20,9 @@ final class HomepageSectionVisibility {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly ViewExecutableFactory $viewExecutableFactory,
     private readonly FeaturedEventsRenderBuilder $featuredEventsRenderBuilder,
+    private readonly PopularEventsService $popularEvents,
+    private readonly HomepageMerchandising $homepageMerchandising,
+    private readonly PathMatcherInterface $pathMatcher,
   ) {}
 
   /**
@@ -58,6 +63,25 @@ final class HomepageSectionVisibility {
    */
   public function hasHiddenGemEvents(): bool {
     return $this->viewDisplayHasResults('upcoming_events', 'homepage_hidden_gems');
+  }
+
+  /**
+   * Whether the Community Favourites rail would render cards on the homepage.
+   *
+   * Uses the post-dedup candidate pool so empty section shells are not shown
+   * when every popular event already appears in a higher-priority rail.
+   */
+  public function hasCommunityFavouritesEvents(): bool {
+    try {
+      if ($this->pathMatcher->isFrontPage()) {
+        return $this->homepageMerchandising->getCommunityFavouritesEventIds() !== [];
+      }
+
+      return $this->popularEvents->getPopularEventIds(7, 1) !== [];
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.info.yml
@@ -21,6 +21,7 @@ regions:
   homepage_latest: 'Homepage Latest'
   homepage_tonight: 'Homepage Tonight'
   homepage_hidden_gems: 'Homepage Hidden Gems'
+  homepage_community_favourites: 'Homepage Community Favourites'
   homepage_free: 'Homepage Free & RSVP'
   homepage_nearby: 'Homepage Nearby'
   homepage_online: 'Homepage Online'

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1965,6 +1965,10 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         && isset($variables['page']['homepage_hidden_gems'])
         && is_array($variables['page']['homepage_hidden_gems'])
         && count(Element::children($variables['page']['homepage_hidden_gems'])) > 0;
+      $variables['mel_home_show_community_favourites'] = $homepageVisibility->hasCommunityFavouritesEvents()
+        && isset($variables['page']['homepage_community_favourites'])
+        && is_array($variables['page']['homepage_community_favourites'])
+        && count(Element::children($variables['page']['homepage_community_favourites'])) > 0;
     }
     else {
       $variables['mel_home_show_featured'] = FALSE;
@@ -1974,6 +1978,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
       $variables['mel_home_show_recommended'] = FALSE;
       $variables['mel_home_show_tonight'] = FALSE;
       $variables['mel_home_show_hidden_gems'] = FALSE;
+      $variables['mel_home_show_community_favourites'] = FALSE;
     }
   }
 

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -87,6 +87,21 @@
       } %}
     {% endif %}
 
+    {% if mel_home_show_community_favourites|default(false) %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--community-favourites mel-section--discover',
+        section_width_class: '',
+        container_class: 'mel-container',
+        header_extra_class: 'mel-section__header--community-favourites',
+        title: 'Community Favourites'|t,
+        subtitle: 'Experiences people are joining — from real tickets and RSVPs this week.'|t,
+        link_url: path('view.upcoming_events.page_events'),
+        link_text: 'See all events'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_community_favourites
+      } %}
+    {% endif %}
+
     {% if mel_home_show_free_rsvp|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--free-rsvp mel-section--discover',


### PR DESCRIPTION
- Created a new YAML configuration file for the Community Favourites block in the homepage.
- Updated the services definition to include dependencies for the new block.
- Enhanced the HomepageMerchandising service to fetch community favourites event IDs, ensuring they are excluded from higher-priority event listings.
- Implemented logic to determine visibility of the Community Favourites rail on the homepage based on event popularity and existing exclusions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes homepage event ordering and dedup cascades across multiple rails; wrong exclusion logic could hide events or show duplicates, but scope is front-page merchandising only.
> 
> **Overview**
> Adds a **Community Favourites** homepage section between Hidden Gems and Free & RSVP, backed by the existing popular-events block (7-day window, 8 cards, compact commerce view mode) in a new theme region.
> 
> **Merchandising and visibility:** `HomepageMerchandising` now resolves a Community Favourites candidate pool via `PopularEventsService` (over-fetch 24, then drop events already on higher-priority rails). That pool feeds cross-rail dedup for under-$20, latest, and recommended displays. Community Favourites exclusions no longer include Free & RSVP events, matching the new rail order. `HomepageSectionVisibility` hides the section shell when the post-dedup pool is empty on the front page.
> 
> **Theme:** New `homepage_community_favourites` region, `mel_home_show_community_favourites` flag in preprocess, and a section shell on `page--front` with copy and “See all events” link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04181999c4ba837c070c4f0de9ca041b5b3d0e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->