### PR TITLE
Feature/community favourites audit

### DIFF
--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -2907,10 +2907,11 @@ display:
       tags: {  }
   page_popular:
     id: page_popular
-    display_title: 'Popular events'
+    display_title: 'Community Favourites'
     display_plugin: page
     position: 9
     display_options:
+      title: 'Community Favourites'
       pager:
         type: full
         options:
@@ -2944,7 +2945,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No popular events yet</h3><p class="mel-empty-state__what">Browse upcoming events while organisers boost new experiences.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Explore events</a></p></div>'
+            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No Community Favourites yet</h3><p class="mel-empty-state__what">When people start joining events this week, the most popular experiences will show up here.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Browse all events</a></p></div>'
             format: full_html
           tokenize: false
       filters:
@@ -3234,46 +3235,6 @@ display:
           hierarchy: false
           limit: true
           error_message: true
-        field_promoted_value:
-          id: field_promoted_value
-          table: node__field_promoted
-          field: field_promoted_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_promoted
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -3288,13 +3249,13 @@ display:
         pager: false
         row: false
         filters: false
-      display_description: 'Boosted and popular public event discovery route.'
+      display_description: 'Community Favourites browse — engagement-ranked public event discovery.'
       display_extenders: {  }
       path: events/popular
       menu:
         type: normal
         title: Discover
-        description: 'Discover boosted and popular events'
+        description: 'Events people are joining this week'
         weight: 2
         enabled: true
         menu_name: main

--- a/docs/audits/popularity-ownership-map.md
+++ b/docs/audits/popularity-ownership-map.md
@@ -1,0 +1,80 @@
+# Popularity Ownership Map
+
+**Audit date:** 2026-06-15  
+**Task:** CF-2C.1 — consolidate popularity ownership  
+**Method:** Repository-wide trace of service registration, DI, callers, tests, config, plugins, subscribers, cron, and queue usage.
+
+---
+
+## Canonical owner
+
+| Layer | Owner | Service id | Evidence |
+|-------|-------|------------|----------|
+| **Engine** | `Drupal\myeventlane_analytics\Service\PopularEventsService` | `myeventlane_analytics.popular_events` | `web/modules/custom/myeventlane_analytics/src/Service/PopularEventsService.php`; `myeventlane_analytics.services.yml` |
+| **Excluded-type policy** | `OrderItemClassifier` (boost + donation order items excluded from ticket scoring) | `myeventlane_analytics.order_item_classifier` | Injected into `PopularEventsService` |
+
+Scoring is owned exclusively by `PopularEventsService`. Do not add parallel ranking logic or a new popularity service.
+
+---
+
+## Active consumers
+
+| Consumer | Module | Injects | Role |
+|----------|--------|---------|------|
+| `PopularEventsBlock` | `myeventlane_front` | `@myeventlane_analytics.popular_events` | Renders ranked event cards (`PopularEventsBlock.php`) |
+| `HomepageMerchandising` | `myeventlane_front` | `@myeventlane_analytics.popular_events` | Community Favourites homepage rail nid selection (`HomepageMerchandising.php`) |
+| `HomepageSectionVisibility` | `myeventlane_front` | `@myeventlane_analytics.popular_events` | Hides Community Favourites rail when engine returns no rows (`HomepageSectionVisibility.php`) |
+| `HomepageMerchandisingQueryAlter` | `myeventlane_front` | `@myeventlane_analytics.popular_events` | Applies engine ranking to `upcoming_events:page_popular` browse (`HomepageMerchandisingQueryAlter.php`) |
+| `TrendingCategoriesService` | `myeventlane_analytics` | `@myeventlane_analytics.popular_events` | Aggregates trending categories from popular event rows (`TrendingCategoriesService.php`) |
+
+Service wiring: `web/modules/custom/myeventlane_front/myeventlane_front.services.yml` (lines 9–34); `myeventlane_analytics.services.yml` (lines 74–90).
+
+Related audit: `docs/audits/brand-rollout/popular-events-service-audit.md` (engine behaviour and gaps).
+
+---
+
+## Deprecated duplicate (retained, do not use)
+
+| Layer | Class | Service id | Status |
+|-------|-------|------------|--------|
+| Orphan | `Drupal\myeventlane_core\Service\HomepagePopularityService` | `myeventlane_core.homepage_popularity` | **Deprecated** — no active runtime consumers |
+
+Registration only: `web/modules/custom/myeventlane_core/myeventlane_core.services.yml` (lines 287–292).
+
+Class retained temporarily for backwards compatibility. Service definition retained so container compilation is unchanged. Removal is out of scope for CF-2C.1.
+
+---
+
+## HomepagePopularityService audit (CF-2C.1 Phase 1)
+
+| Check | Finding | Active? |
+|-------|---------|---------|
+| PHP callers / DI injections | None outside class + `myeventlane_core.services.yml` | **No** |
+| Dynamic `\Drupal::service('myeventlane_core.homepage_popularity')` | None | **No** |
+| Tests | None (`rg HomepagePopularityService tests/` → no matches) | **No** |
+| Config (`config/sync`) | None | **No** |
+| Block / plugin references | None | **No** |
+| Event subscribers | None | **No** |
+| Cron | None | **No** |
+| Queue workers | None | **No** |
+| Documentation | Historical audits only (`community-favourites-audit.md`, `popular-events-service-audit.md`, `PHASE2_BOOST_REFACTOR_COMPLETE.md`) | N/A |
+| Registry | Listed in `mel-services.json` (inventory only, not a runtime caller) | N/A |
+
+### Caller evidence table
+
+| Caller | Location | Active? |
+|--------|----------|---------|
+| *(none)* | — | **No active runtime consumers** |
+| Service definition | `myeventlane_core.services.yml:287–292` | Registered only (not injected elsewhere) |
+| Class definition | `HomepagePopularityService.php` | Self-reference only |
+
+**Conclusion:** Safe to deprecate in PHPDoc only. No behaviour, ranking, route, View, or config changes in CF-2C.1.
+
+---
+
+## Out of scope (CF-2C.1)
+
+- Badge eligibility and visual treatments
+- Browse route copy / SEO / redirects
+- Removing `HomepagePopularityService` class or service definition
+- Changing `PopularEventsService` scoring or sort order

--- a/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.links.menu.yml
@@ -50,7 +50,7 @@ myeventlane_core.footer_find_events.free:
   weight: 3
 
 myeventlane_core.footer_find_events.popular:
-  title: 'Popular events'
+  title: 'Community Favourites'
   route_name: view.upcoming_events.page_popular
   menu_name: footer-find
   weight: 4

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoveryAttributionSources.php
@@ -22,6 +22,8 @@ final class DiscoveryAttributionSources {
   public const SOURCE_HOMEPAGE_DISCOVER = 'homepage_discover';
   public const SOURCE_HOMEPAGE_HIDDEN_GEMS = 'homepage_hidden_gems';
   public const SOURCE_BROWSE_HIDDEN_GEMS = 'browse_hidden_gems';
+  public const SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES = 'homepage_community_favourites';
+  public const SOURCE_BROWSE_COMMUNITY_FAVOURITES = 'browse_community_favourites';
 
   /**
    * @var list<string>
@@ -35,6 +37,8 @@ final class DiscoveryAttributionSources {
     self::SOURCE_HOMEPAGE_UPCOMING,
     self::SOURCE_HOMEPAGE_HIDDEN_GEMS,
     self::SOURCE_BROWSE_HIDDEN_GEMS,
+    self::SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES,
+    self::SOURCE_BROWSE_COMMUNITY_FAVOURITES,
     self::SOURCE_SEARCH,
     self::SOURCE_CATEGORY,
     self::SOURCE_RELATED_EVENTS,
@@ -54,6 +58,7 @@ final class DiscoveryAttributionSources {
     'upcoming_events:homepage_latest' => self::SOURCE_HOMEPAGE_UPCOMING,
     'upcoming_events:homepage_hidden_gems' => self::SOURCE_HOMEPAGE_HIDDEN_GEMS,
     'upcoming_events:page_hidden_gems' => self::SOURCE_BROWSE_HIDDEN_GEMS,
+    'upcoming_events:page_popular' => self::SOURCE_BROWSE_COMMUNITY_FAVOURITES,
     'upcoming_events:page_category' => self::SOURCE_CATEGORY,
   ];
 

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoverySurfaceAnalyticsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoverySurfaceAnalyticsService.php
@@ -23,11 +23,14 @@ final class DiscoverySurfaceAnalyticsService {
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_FEATURED => 'spotlight',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_DISCOVER => 'discover',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_TONIGHT => 'tonight',
+    DiscoveryAttributionSources::SOURCE_HOMEPAGE_HIDDEN_GEMS => 'hidden_gems',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_FREE => 'free',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_RECOMMENDED => 'recommended',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_UPCOMING => 'latest',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES => 'community_favourites',
     DiscoveryAttributionSources::SOURCE_BROWSE_COMMUNITY_FAVOURITES => 'community_favourites',
+    DiscoveryAttributionSources::SOURCE_BROWSE_HIDDEN_GEMS => 'hidden_gems_browse',
+    DiscoveryAttributionSources::SOURCE_RELATED_EVENTS => 'related_events',
   ];
 
   /**
@@ -40,9 +43,12 @@ final class DiscoverySurfaceAnalyticsService {
     'recommended' => 'Recommended',
     'discover' => 'Discover Events',
     'tonight' => 'Happening Tonight',
+    'hidden_gems' => 'Hidden Gems',
     'free' => 'Free & RSVP',
     'latest' => 'Freshly Added',
     'community_favourites' => 'Community Favourites',
+    'hidden_gems_browse' => 'Hidden Gems Browse',
+    'related_events' => 'Related Events',
   ];
 
   public function __construct(
@@ -144,9 +150,12 @@ final class DiscoverySurfaceAnalyticsService {
       'recommended',
       'discover',
       'tonight',
+      'hidden_gems',
       'free',
       'latest',
       'community_favourites',
+      'hidden_gems_browse',
+      'related_events',
     ];
 
     $rows = [];

--- a/web/modules/custom/myeventlane_core/src/Service/DiscoverySurfaceAnalyticsService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DiscoverySurfaceAnalyticsService.php
@@ -26,6 +26,8 @@ final class DiscoverySurfaceAnalyticsService {
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_FREE => 'free',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_RECOMMENDED => 'recommended',
     DiscoveryAttributionSources::SOURCE_HOMEPAGE_UPCOMING => 'latest',
+    DiscoveryAttributionSources::SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES => 'community_favourites',
+    DiscoveryAttributionSources::SOURCE_BROWSE_COMMUNITY_FAVOURITES => 'community_favourites',
   ];
 
   /**
@@ -40,6 +42,7 @@ final class DiscoverySurfaceAnalyticsService {
     'tonight' => 'Happening Tonight',
     'free' => 'Free & RSVP',
     'latest' => 'Freshly Added',
+    'community_favourites' => 'Community Favourites',
   ];
 
   public function __construct(
@@ -143,6 +146,7 @@ final class DiscoverySurfaceAnalyticsService {
       'tonight',
       'free',
       'latest',
+      'community_favourites',
     ];
 
     $rows = [];

--- a/web/modules/custom/myeventlane_core/src/Service/HomepagePopularityService.php
+++ b/web/modules/custom/myeventlane_core/src/Service/HomepagePopularityService.php
@@ -10,7 +10,15 @@ use Drupal\myeventlane_boost\BoostManager;
 use Drupal\node\NodeInterface;
 
 /**
- * Service for calculating event popularity rankings.
+ * Legacy popularity rankings service (deprecated).
+ *
+ * @deprecated in myeventlane:CF-2C.1
+ *   Canonical popularity engine:
+ *   \Drupal\myeventlane_analytics\Service\PopularEventsService
+ *   (service id: myeventlane_analytics.popular_events).
+ *   See docs/audits/popularity-ownership-map.md.
+ *   Retained temporarily for backwards compatibility; no active consumers.
+ *   Do not inject for new code.
  *
  * Ranking logic: RSVP count + ticket sales + views (if available)
  * Excludes: actively boosted/promoted events (uses canonical BoostManager)

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1660,9 +1660,7 @@ function myeventlane_event_apply_full_page_discovery_badge(array &$variables, No
   }
 
   $event_ui = is_array($variables['event_ui'] ?? NULL) ? $variables['event_ui'] : [];
-  if (!empty($event_ui['is_sold_out'])) {
-    return;
-  }
+  $is_sold_out = !empty($event_ui['is_sold_out']);
 
   $domain = is_array($variables['event_domain_state'] ?? NULL) ? $variables['event_domain_state'] : [];
   $is_hidden_gem = $node->hasField('field_hidden_gem')
@@ -1679,7 +1677,7 @@ function myeventlane_event_apply_full_page_discovery_badge(array &$variables, No
     'layout' => 'hero',
     'is_hidden_gem' => $is_hidden_gem,
     'is_promoted' => $is_promoted,
-    'is_sold_out' => FALSE,
+    'is_sold_out' => $is_sold_out,
   ]);
 
   $label = trim((string) ($merchandising['image_badge_label'] ?? ''));

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1515,8 +1515,6 @@ function myeventlane_event_finalize_event_ui(
       'is_limited' => FALSE,
       'show_cta' => TRUE,
       'capacity_hint' => NULL,
-      'image_badge_label' => NULL,
-      'image_badge_type' => NULL,
     ];
   };
 
@@ -1537,8 +1535,6 @@ function myeventlane_event_finalize_event_ui(
     if ($isBoosted) {
       $out['status_label'] = (string) t('Spotlight');
       $out['status_type'] = 'highlight';
-      $out['image_badge_label'] = (string) t('Spotlight');
-      $out['image_badge_type'] = 'apricot';
     }
     if (!$isSoldOut && $rsvpState === 'limited') {
       $out['is_limited'] = TRUE;
@@ -1563,8 +1559,6 @@ function myeventlane_event_finalize_event_ui(
     $out['is_sold_out'] = TRUE;
     $out['status_label'] = (string) t('Sold out');
     $out['status_type'] = 'warning';
-    $out['image_badge_label'] = (string) t('Sold out');
-    $out['image_badge_type'] = 'warning';
     $out['cta_label'] = (string) ($eventCta['label'] ?? '');
     $out['cta_type'] = 'secondary';
   }
@@ -1611,27 +1605,18 @@ function myeventlane_event_finalize_event_ui(
   ) {
     $out['capacity_hint'] = (string) t('Limited spots remaining');
   }
-  if (
-    $out['is_sold_out'] === FALSE
-    && $isBoosted
-    && ($out['image_badge_label'] ?? NULL) === NULL
-  ) {
+  if ($out['is_sold_out'] === FALSE && $isBoosted) {
     $out['status_label'] = (string) t('Spotlight');
     $out['status_type'] = 'highlight';
-    $out['image_badge_label'] = (string) t('Spotlight');
-    $out['image_badge_type'] = 'apricot';
   }
   elseif (
     $out['is_sold_out'] === FALSE
     && $node->hasField('field_promoted')
     && !$node->get('field_promoted')->isEmpty()
     && (bool) $node->get('field_promoted')->value
-    && ($out['image_badge_label'] ?? NULL) === NULL
   ) {
     $out['status_label'] = (string) t('Spotlight');
     $out['status_type'] = 'highlight';
-    $out['image_badge_label'] = (string) t('Spotlight');
-    $out['image_badge_type'] = 'apricot';
   }
 
   if (myeventlane_event_get_social_proof_mode($node) === 'hide') {

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -167,10 +167,10 @@ final class EventCardViewModel {
     if ($categoryLabel) {
       $badges[] = ['label' => $categoryLabel, 'type' => 'category'];
     }
-    if (!empty($eventUi['image_badge_label'])) {
+    if (!empty($merchandising['image_badge_label'])) {
       $badges[] = [
-        'label' => (string) $eventUi['image_badge_label'],
-        'type' => (string) ($eventUi['image_badge_type'] ?? 'apricot'),
+        'label' => (string) $merchandising['image_badge_label'],
+        'type' => (string) ($merchandising['image_badge_modifier'] ?? 'apricot'),
       ];
     }
 
@@ -198,7 +198,7 @@ final class EventCardViewModel {
       'cta_url' => $url,
       'is_sold_out' => !empty($eventUi['is_sold_out']),
       'is_free' => $pricingType === BookingFlowResolver::MODE_RSVP,
-      'is_featured' => $isPromoted || !empty($eventUi['image_badge_label']),
+      'is_featured' => $isPromoted || !empty($merchandising['image_badge_label']),
       'is_saved' => $isSaved,
       'variant' => $presentation['variant'],
       'layout' => $presentation['layout'],

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
@@ -25,7 +25,10 @@ final class EventMerchandisingPresenter {
   /**
    * Builds merchandising presentation for a card context.
    *
-   * Priority (one body signal): Sold out → Going → Tonight urgency →
+   * Image badge priority (one badge): Sold out → Spotlight (promoted) →
+   * Hidden Gem. Spotlight applies on all card layouts when promoted.
+   *
+   * Body signal priority (one signal): Sold out → Going → Tonight urgency →
    * Selling fast → Limited spots. Price appears only when no body signal
    * competes (via optional ticket pill on paid discovery cards).
    *
@@ -112,7 +115,7 @@ final class EventMerchandisingPresenter {
       $imageBadgeLabel = (string) $this->t('Sold out');
       $imageBadgeModifier = 'warning';
     }
-    elseif (($isHero || $isDiscovery) && $isPromoted) {
+    elseif ($isPromoted) {
       $imageBadgeLabel = (string) $this->t('Spotlight');
     }
     elseif ($isHiddenGem) {

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
@@ -230,6 +230,106 @@ final class EventMerchandisingPresenterTest extends UnitTestCase {
     self::assertSame('apricot', $result['image_badge_modifier']);
   }
 
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightBadgeWhenPromotedOnListLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_promoted' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+    self::assertNull($result['secondary']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightBadgeWhenPromotedOnTeaserLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_promoted' => TRUE,
+      'card_type' => 'rsvp',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightBadgeWhenPromotedOnStandardCardLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'standard',
+      'is_promoted' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSoldOutOutranksSpotlightOnPromotedListLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_promoted' => TRUE,
+      'is_sold_out' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Sold out', $result['image_badge_label']);
+    self::assertSame('warning', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSpotlightOutranksHiddenGemOnListLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_hidden_gem' => TRUE,
+      'is_promoted' => TRUE,
+      'card_type' => 'rsvp',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertSame('apricot', $result['image_badge_modifier']);
+  }
+
+  /**
+   * @covers ::present
+   */
+  public function testSingleImageBadgeWhenPromotedAndHiddenGemOnListLayout(): void {
+    $presenter = $this->createPresenter();
+    $result = $presenter->present([
+      'layout' => '',
+      'variant' => 'list',
+      'is_hidden_gem' => TRUE,
+      'is_promoted' => TRUE,
+      'card_type' => 'paid',
+    ]);
+
+    self::assertSame('Spotlight', $result['image_badge_label']);
+    self::assertNotSame('Hidden Gem', $result['image_badge_label']);
+  }
+
   private function createPresenter(): EventMerchandisingPresenter {
     return new EventMerchandisingPresenter($this->getStringTranslationStub());
   }

--- a/web/modules/custom/myeventlane_front/myeventlane_front.module
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.module
@@ -94,6 +94,19 @@ function myeventlane_front_views_query_alter(\Drupal\views\ViewExecutable $view,
  * Applies optional homepage rail diversity without query rewrites.
  */
 function myeventlane_front_views_pre_render(\Drupal\views\ViewExecutable $view): void {
+  if ($view->id() === 'upcoming_events'
+    && ($view->current_display ?? '') === 'page_popular'
+    && !empty($view->result)
+    && !empty($view->mel_community_favourites_rank)
+    && is_array($view->mel_community_favourites_rank)) {
+    $rank = $view->mel_community_favourites_rank;
+    usort($view->result, static function ($a, $b) use ($rank): int {
+      $id_a = isset($a->_entity) ? (int) $a->_entity->id() : PHP_INT_MAX;
+      $id_b = isset($b->_entity) ? (int) $b->_entity->id() : PHP_INT_MAX;
+      return ($rank[$id_a] ?? PHP_INT_MAX) <=> ($rank[$id_b] ?? PHP_INT_MAX);
+    });
+  }
+
   if (!\Drupal::hasService('myeventlane_front.homepage_rail_diversity')) {
     return;
   }

--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -31,6 +31,7 @@ services:
     class: Drupal\myeventlane_front\Service\HomepageMerchandisingQueryAlter
     arguments:
       - '@myeventlane_front.homepage_merchandising'
+      - '@myeventlane_analytics.popular_events'
 
   myeventlane_front.homepage_rail_diversity:
     class: Drupal\myeventlane_front\Service\HomepageRailDiversityFilter

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/PopularEventsBlock.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\myeventlane_analytics\Service\PopularEventsService;
+use Drupal\myeventlane_core\Service\DiscoveryAttributionSources;
 use Drupal\myeventlane_front\Service\HomepageMerchandising;
 use Drupal\myeventlane_front\Service\HomepageRailDiversityFilter;
 use Drupal\node\NodeInterface;
@@ -240,6 +241,7 @@ final class PopularEventsBlock extends BlockBase implements ContainerFactoryPlug
       }
 
       $card = $view_builder->view($ordered_nodes[$nid], $view_mode_to_use);
+      $card['#mel_discovery_source'] = DiscoveryAttributionSources::SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES;
 
       // Render-only wrapper adds "X going" without changing card templates.
       $wrapper = [

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandisingQueryAlter.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandisingQueryAlter.php
@@ -16,6 +16,16 @@ use Drupal\views\ViewExecutable;
  */
 final class HomepageMerchandisingQueryAlter {
 
+  /**
+   * Cached Community Favourites nids keyed by lookback days (per request).
+   *
+   * Views invokes query alter for both the paged result query and the pager
+   * total query; memoize so getPopularEventRows() runs once per request.
+   *
+   * @var array<int, list<int>>
+   */
+  private array $communityFavouritesNidsByDays = [];
+
   public function __construct(
     private readonly HomepageMerchandising $merchandising,
     private readonly PopularEventsService $popularEvents,
@@ -74,15 +84,7 @@ final class HomepageMerchandisingQueryAlter {
 
     $alias = $query->getTableInfo('node_field_data')['alias'] ?? 'node_field_data';
     // Default 7-day lookback (same as homepage Community Favourites rail).
-    $rows = $this->popularEvents->getPopularEventRows(7);
-
-    $nids = [];
-    foreach ($rows as $row) {
-      $nid = (int) ($row['nid'] ?? 0);
-      if ($nid > 0) {
-        $nids[] = $nid;
-      }
-    }
+    $nids = $this->getCommunityFavouritesNids(7);
 
     if ($nids === []) {
       $query->addWhere(1, $alias . '.nid', 0);
@@ -104,6 +106,31 @@ final class HomepageMerchandisingQueryAlter {
       $rank[$nid] = $index;
     }
     $view->mel_community_favourites_rank = $rank;
+  }
+
+  /**
+   * Returns engagement-ranked nids for Community Favourites browse.
+   *
+   * @return list<int>
+   *   Ranked event nids from PopularEventsService for the lookback window.
+   */
+  private function getCommunityFavouritesNids(int $days): array {
+    if (isset($this->communityFavouritesNidsByDays[$days])) {
+      return $this->communityFavouritesNidsByDays[$days];
+    }
+
+    $rows = $this->popularEvents->getPopularEventRows($days);
+
+    $nids = [];
+    foreach ($rows as $row) {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid > 0) {
+        $nids[] = $nid;
+      }
+    }
+
+    $this->communityFavouritesNidsByDays[$days] = $nids;
+    return $nids;
   }
 
 }

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandisingQueryAlter.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandisingQueryAlter.php
@@ -4,22 +4,29 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_front\Service;
 
+use Drupal\myeventlane_analytics\Service\PopularEventsService;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\ViewExecutable;
 
 /**
  * Applies homepage hero exclusivity and cross-rail deduplication to Views.
+ *
+ * Also constrains upcoming_events:page_popular to PopularEventsService ranking.
  */
 final class HomepageMerchandisingQueryAlter {
 
   public function __construct(
     private readonly HomepageMerchandising $merchandising,
+    private readonly PopularEventsService $popularEvents,
   ) {}
 
   /**
    * Alters a View query for homepage merchandising and media quality gate.
    */
   public function alter(ViewExecutable $view, QueryPluginBase $query): void {
+    $this->applyCommunityFavouritesBrowseRanking($view, $query);
+
     $viewId = $view->id();
     $displayId = $view->current_display ?? '';
     if (!is_string($viewId) || !is_string($displayId) || $displayId === '') {
@@ -51,6 +58,52 @@ final class HomepageMerchandisingQueryAlter {
 
     $alias = $query->getTableInfo('node_field_data')['alias'] ?? 'node_field_data';
     $query->addWhere(1, $alias . '.nid', $exclude, 'NOT IN');
+  }
+
+  /**
+   * Restricts Community Favourites browse to engagement-ranked upcoming events.
+   */
+  private function applyCommunityFavouritesBrowseRanking(ViewExecutable $view, QueryPluginBase $query): void {
+    if ($view->id() !== 'upcoming_events' || ($view->current_display ?? '') !== 'page_popular') {
+      return;
+    }
+
+    if (!$query->ensureTable('node_field_data')) {
+      return;
+    }
+
+    $alias = $query->getTableInfo('node_field_data')['alias'] ?? 'node_field_data';
+    // Default 7-day lookback (same as homepage Community Favourites rail).
+    $rows = $this->popularEvents->getPopularEventRows(7);
+
+    $nids = [];
+    foreach ($rows as $row) {
+      $nid = (int) ($row['nid'] ?? 0);
+      if ($nid > 0) {
+        $nids[] = $nid;
+      }
+    }
+
+    if ($nids === []) {
+      $query->addWhere(1, $alias . '.nid', 0);
+      return;
+    }
+
+    $query->addWhere(1, $alias . '.nid', $nids, 'IN');
+
+    // Preserve engagement rank across pager pages (Views-owned pagination).
+    if ($query instanceof Sql) {
+      $query->orderby = [];
+      $nid_list = implode(', ', array_map('intval', $nids));
+      $query->addOrderBy(NULL, "FIELD($alias.nid, $nid_list)", 'ASC', 'mel_community_favourites_rank');
+    }
+
+    // Fallback for pre_render reordering when SQL ordering is unavailable.
+    $rank = [];
+    foreach ($nids as $index => $nid) {
+      $rank[$nid] = $index;
+    }
+    $view->mel_community_favourites_rank = $rank;
   }
 
 }

--- a/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
@@ -46,7 +46,7 @@ final class PublicFooterNavigationBuilder {
       $this->routeLink('Today', 'view.upcoming_events.page_today'),
       $this->routeLink('This weekend', 'view.upcoming_events.page_this_weekend'),
       $this->routeLink('Free events', 'view.upcoming_events.page_free'),
-      $this->routeLink('Popular events', 'view.upcoming_events.page_popular'),
+      $this->routeLink('Community Favourites', 'view.upcoming_events.page_popular'),
     ]));
     $discover_links = array_merge($discover_links, $this->buildCategoryLinks());
 

--- a/web/modules/custom/myeventlane_views/myeventlane_views.module
+++ b/web/modules/custom/myeventlane_views/myeventlane_views.module
@@ -115,7 +115,10 @@ function myeventlane_views_views_pre_render(ViewExecutable $view): void {
   }
   // Sort upcoming_events and mel_home_events: featured first, preserve
   // start-date order within ties (same as public discovery).
-  elseif (in_array($view->id(), ['upcoming_events', 'mel_home_events'], TRUE) && !empty($view->result)) {
+  // page_popular uses PopularEventsService rank via query alter — skip promoted reorder.
+  elseif (in_array($view->id(), ['upcoming_events', 'mel_home_events'], TRUE)
+    && !empty($view->result)
+    && !($view->id() === 'upcoming_events' && ($view->current_display ?? '') === 'page_popular')) {
     usort($view->result, function ($a, $b) {
       $promo_a = 0;
       $promo_b = 0;

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -116,6 +116,9 @@
   {% elseif _mel_src in ['homepage_hidden_gems', 'browse_hidden_gems'] %}
     {% set _discovery_reason = 'Worth discovering'|t %}
     {% set _discovery_reason_type = 'hidden-gem' %}
+  {% elseif _mel_src in ['homepage_community_favourites', 'browse_community_favourites'] %}
+    {% set _discovery_reason = 'Popular with the community'|t %}
+    {% set _discovery_reason_type = 'community-favourite' %}
   {% elseif _mel_src == 'related_events' and recommendation_context is defined and recommendation_context.label|default('')|trim|length > 0 %}
     {% set _discovery_reason = recommendation_context.label %}
     {% set _discovery_reason_type = recommendation_context.type|default('discover') %}

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -30,7 +30,7 @@
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_today' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_today') }}">{{ 'Today'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_this_weekend' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_free' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
-          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Popular'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Community Favourites'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_hidden_gems') }}">{{ 'Hidden Gems'|t }}</a>
         </nav>
 

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -100,16 +100,16 @@
         {% endif %}
       </div>
       <div class="mel-event-hero__overlay" aria-hidden="true"></div>
-      {% if event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
-        <div class="mel-event-hero__chip">
-          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--warning" role="status">
-            <span class="mel-pill__label">{{ 'Sold out'|t }}</span>
-          </span>
-        </div>
-      {% elseif mel_hero_discovery_badge is defined and mel_hero_discovery_badge.label|default('')|trim %}
+      {% if mel_hero_discovery_badge is defined and mel_hero_discovery_badge.label|default('')|trim %}
         <div class="mel-event-hero__chip">
           <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ mel_hero_discovery_badge.modifier|default('apricot') }}" role="status">
             <span class="mel-pill__label">{{ mel_hero_discovery_badge.label }}</span>
+          </span>
+        </div>
+      {% elseif event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
+        <div class="mel-event-hero__chip">
+          <span class="mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--warning" role="status">
+            <span class="mel-pill__label">{{ 'Sold out'|t }}</span>
           </span>
         </div>
       {% elseif mel_category_label %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
@@ -7,7 +7,7 @@
  */
 #}
 {% include '@myeventlane_theme/includes/mel-browse-events-page-shell.html.twig' with {
-  mel_browse_heading: 'Popular events'|t,
-  mel_browse_lede: 'Experiences organisers are boosting — discover what’s gaining momentum.'|t,
+  mel_browse_heading: 'Community Favourites'|t,
+  mel_browse_lede: 'Experiences people are joining — ranked by real tickets and RSVPs this week.'|t,
   mel_browse_prompt: 'Browse all events or see what’s happening today.'|t,
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -29,7 +29,7 @@
   <a
     href="{{ path('view.upcoming_events.page_popular') }}"
     class="mel-filter-chip{% if d == 'page_popular' %} mel-filter-chip--active{% endif %}"
-  >{{ 'Popular'|t }}</a>
+  >{{ 'Community Favourites'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_hidden_gems') }}"
     class="mel-filter-chip{% if d == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}"

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
@@ -49,8 +49,8 @@
           text: 'Try browsing all events or see what’s on this weekend.'|t,
         },
         'page_popular': {
-          title: 'No popular events yet'|t,
-          text: 'Browse upcoming events while organisers boost new experiences.'|t,
+          title: 'No Community Favourites yet'|t,
+          text: 'When people start joining events this week, the most popular experiences will show up here.'|t,
         },
         'page_hidden_gems': {
           title: 'No Hidden Gems right now'|t,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which events appear and in what order on a public browse route via Views query alter and custom ordering; merchandising badge rules affect discovery UI across layouts.
> 
> **Overview**
> Rebrands the **Popular events** discovery surface to **Community Favourites** across the `/events/popular` view, browse chips, footer/menus, and empty-state copy, while documenting that **`PopularEventsService`** is the sole popularity engine and **`HomepagePopularityService`** is deprecated (PHPDoc + `docs/audits/popularity-ownership-map.md`).
> 
> **Browse behaviour** on `upcoming_events:page_popular` shifts from a Views **`field_promoted`** filter to runtime ranking: **`HomepageMerchandisingQueryAlter`** limits results to engagement-ranked nids (7-day lookback), orders with SQL `FIELD()` (with **`views_pre_render`** reorder as fallback), and **`myeventlane_views`** skips the usual promoted-first sort for this display. The homepage popular block tags cards with **`homepage_community_favourites`**; browse uses new discovery attribution sources and analytics surface labels (including hidden gems / related events mappings).
> 
> **Event cards and hero** consolidate image badges through **`EventMerchandisingPresenter`** (Spotlight on all layouts when promoted; sold out still wins), with **`EventCardViewModel`** reading merchandising instead of `event_ui` image badges; full-page hero chip order prefers presenter badges before a sold-out fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9deb8492582f1273fdda96217a005acf4ccc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->