### PR TITLE
Feature/community favourites audit

### DIFF
--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -1948,20 +1948,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: true
-          content:
-            value: '<div class="mel-empty mel-empty--browse" role="status"><p>No events found — try adjusting your filters.</p></div>'
-            format: full_html
-          tokenize: false
       filters:
         status:
           id: status
@@ -2934,20 +2920,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: true
-          content:
-            value: '<div class="mel-empty-state mel-empty-state--governed"><h3 class="mel-empty-state__heading">No Community Favourites yet</h3><p class="mel-empty-state__what">When people start joining events this week, the most popular experiences will show up here.</p><p class="mel-empty-state__cta"><a class="mel-btn mel-btn--cta" href="/events">Browse all events</a></p></div>'
-            format: full_html
-          tokenize: false
       filters:
         status:
           id: status
@@ -3254,7 +3226,7 @@ display:
       path: events/popular
       menu:
         type: normal
-        title: Discover
+        title: Community Favourites
         description: 'Events people are joining this week'
         weight: 2
         enabled: true

--- a/docs/audits/badge-ownership-map.md
+++ b/docs/audits/badge-ownership-map.md
@@ -1,0 +1,171 @@
+# Badge Ownership Map
+
+**Audit date:** 2026-06-15  
+**Task:** CF-3F — final badge ownership consolidation (CF-3A through CF-3E follow-up)  
+**Method:** Repository-wide trace of badge producers, consumers, and render paths. No behaviour changes in this task.
+
+---
+
+## Executive summary
+
+Public event **image badges** and **body merchandising signals** on discovery cards are owned by a single PHP presenter and rendered through a single Twig component. CF-3F removes the last duplicate ViewModel mirror (`badges[]`, `is_featured`) that had no active consumers.
+
+**Community Favourite image badges remain disabled.** Community Favourites surfaces use **discovery-reason copy** only (`mel_source` attribution in Twig), not `EventMerchandisingPresenter` image badges.
+
+---
+
+## Canonical owners
+
+| Layer | Owner | File | Method / output |
+|-------|-------|------|-----------------|
+| **PHP image badge + body signal** | `EventMerchandisingPresenter` | `web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php` | `present()` → `image_badge_label`, `image_badge_modifier`, `primary`, `hero_proof`, ticket pill flags |
+| **Card variable injection** | `EventCardViewModel` | `web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php` | `build()` → `merchandising`; `applyToNodeVariables()` → `card_merchandising` |
+| **Public card render** | `mel-event-card.html.twig` | `web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig` | Reads `card_merchandising` (`_merch`) for image badge + body signal |
+| **Event full-page hero badge** | `myeventlane_event_apply_full_page_discovery_badge()` | `web/modules/custom/myeventlane_event/myeventlane_event.module` | Calls presenter → `mel_hero_discovery_badge` |
+| **Full-page hero render** | `node--event--full.html.twig` | `web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig` | Renders `mel_hero_discovery_badge` on hero image |
+
+### Image badge priority (`EventMerchandisingPresenter`)
+
+1. Sold out  
+2. Spotlight (promoted / boosted)  
+3. Hidden Gem  
+
+One image badge per card. No Community Favourite, Editor's Pick, Trending Tonight, or Nearby image badges are emitted by the presenter today.
+
+### Body signal priority (`EventMerchandisingPresenter`)
+
+Sold out → Going (attendance) → Tonight urgency → Selling fast → Limited spots. Price may appear as a ticket pill on discovery layouts when no body signal competes.
+
+---
+
+## Fallback owners (Twig only — not presenter)
+
+| Signal | Owner | File | When active |
+|--------|-------|------|-------------|
+| Sold out image badge | `event_ui.is_sold_out` | `mel-event-card.html.twig` | When `card_merchandising` has no `image_badge_label` but `event_ui` reports sold out |
+| Category image badge | Category label on card | `mel-event-card.html.twig` | Non-discovery mode only; when merchandising and sold-out fallbacks do not apply |
+| Discovery reason (not image badge) | `mel_source` rail attribution | `mel-event-card.html.twig` | Discovery/spotlight layouts; copy such as "Popular with the community" for `homepage_community_favourites` / `browse_community_favourites` |
+
+These fallbacks are presentation-layer only. They do not duplicate `EventMerchandisingPresenter` image badge types except sold-out (safety net when bridge paths lack merchandising).
+
+---
+
+## Active consumers
+
+| Consumer | Path | `card_merchandising` | `event_ui` | Status |
+|----------|------|----------------------|------------|--------|
+| Node card view modes | `node--event--*.html.twig` → `mel-event-card.html.twig` | Yes — `EventCardViewModel::applyToNodeVariables()` | Yes — `myeventlane_event_preprocess_node()` | **Active** |
+| Views `entity:node` rows | `upcoming_events`, `mel_home_events`, `mel_saved_events`, `all_events`, etc. (`row.type: entity:node`, `view_mode: compact_commerce` / `list_card`) | Yes — same node pipeline | Yes | **Active** |
+| Search `/search` events group | `SearchController::renderEventItems()` → `compact_commerce` node render | Yes — same node pipeline | Yes | **Active** |
+| Event full page | `myeventlane_event_apply_full_page_discovery_badge()` → `mel_hero_discovery_badge` | Via direct presenter call (hero layout) | Yes — sold-out input | **Active** |
+
+### Active card rendering paths (production)
+
+```
+myeventlane_event_preprocess_node()
+  → event_ui, domain state, CTA
+myeventlane_theme_preprocess_node()
+  → EventCardViewModel::applyToNodeVariables()
+    → EventMerchandisingPresenter::present()
+    → card_merchandising
+node--event--{view_mode}.html.twig
+  → mel-event-card.html.twig
+```
+
+Search and Views entity rows enter this path via `$view_builder->view($node, 'compact_commerce')` or equivalent node view modes.
+
+---
+
+## Dormant consumers
+
+| Consumer | Path | `card_merchandising` | Status | Evidence |
+|----------|------|----------------------|--------|----------|
+| Views fields bridge | `views-view-fields.html.twig` → `event/event-card.html.twig` → `mel-event-card.html.twig` | **No** | **Dormant** | No public event View in `config/sync` uses `row.type: fields` for card grids; bridge references computed fields (`field_date_day`, `field_ticket_label`) absent from Views config (CF-3E) |
+| Search bridge | `search-result.html.twig` → `event/event-card.html.twig` | **No** | **Dormant** | `mel_is_event_search_result` / `mel_event_card` never set; active search is `myeventlane_search` with node renders (CF-3E) |
+
+Preprocess on the fields bridge (`myeventlane_theme_preprocess_views_view_fields()`) sets URL, `event_id`, and `mel_source` only — not merchandising.
+
+---
+
+## Removed duplicate model (CF-3F Phase 1)
+
+| Field | Former owner | Consumers found | Action |
+|-------|--------------|-----------------|--------|
+| `badges[]` | `EventCardViewModel::build()` return + `event_card` variable | **None** (`rg 'event_card\.badges'` → no matches) | **Removed** |
+| `is_featured` | `EventCardViewModel::build()` return + `event_card` variable | **None** (`rg 'is_featured' web` → definition only) | **Removed** |
+
+Image badge data now flows only through `merchandising` / `card_merchandising`. Category and merchandising were previously duplicated into `badges[]`; Twig never read that array.
+
+---
+
+## Community Favourite image badge — disabled (governance)
+
+**Do not add** a Community Favourite image badge in `EventMerchandisingPresenter` until product and brand criteria are complete.
+
+### Current behaviour
+
+- **Homepage / browse Community Favourites rails** rank events via `PopularEventsService` (`myeventlane_analytics.popular_events`) — see `docs/audits/popularity-ownership-map.md`.
+- **Attribution** uses `DiscoveryAttributionSources` keys `homepage_community_favourites` / `browse_community_favourites`.
+- **Presentation** is a **discovery reason** string in `mel-event-card.html.twig` ("Popular with the community"), not an image badge from the presenter.
+
+### Why image badge remains disabled
+
+| Reason | Evidence |
+|--------|----------|
+| Duplicate presentation on CF surfaces | Rail already shows section title + discovery reason; adding a presenter image badge would stack two "community" signals on the same card |
+| No single eligibility boolean | `PopularEventsService` returns ranked nids; there is no `field_community_favourite` or per-card eligibility flag for the presenter to read |
+| Governance criteria incomplete | `docs/audits/brand-rollout/community-favourites-audit.md` (CF-2C community-favourites audit): badge requires documented eligibility before enablement; `docs/brand/event-card-system.md` requires evidence-based criteria |
+| Brand constraint | Community Favourite must not represent paid/boosted placement (`field_promoted`); presenter today uses Spotlight for promoted events — a CF image badge needs a distinct, non-colliding signal key |
+
+### Explicit forbidden changes (until a future CF task)
+
+- Do not inject `PopularEventsService` into `EventMerchandisingPresenter`
+- Do not add Community Favourite to image badge priority chain
+- Do not add new badge services, preprocess hooks, or eligibility APIs in presenter-adjacent code
+
+Reference audits: `docs/audits/brand-rollout/community-favourites-audit.md`, `docs/audits/popularity-ownership-map.md`, `docs/audits/brand-rollout/brand-gap-analysis.md` (badge criteria gap).
+
+---
+
+## Current state vs future state
+
+| Area | Current state | Future state (not in CF-3F) |
+|------|---------------|------------------------------|
+| Image badges on cards | Presenter: Sold out, Spotlight, Hidden Gem | Community Favourite image badge only after eligibility doc + single boolean + brand sign-off |
+| Community Favourites rails | Engine ranking + discovery reason copy | Unchanged; no new badge type |
+| ViewModel `event_card` model | No `badges[]` / `is_featured` mirror | Keep merchandising as sole badge payload |
+| Dormant bridges | No merchandising if ever activated | Optional CF follow-up: enrich `preprocess_views_view_fields()` via existing `EventCardViewModel` (CF-3E noted) |
+
+---
+
+## Known debt
+
+1. **Dormant bridge templates** — `views-view-fields.html.twig` and `search-result.html.twig` remain in theme; activating them without ViewModel enrichment would show category/sold-out fallbacks only.
+2. **Category Twig fallback** — non-discovery cards can still show category as image badge when merchandising is empty (`mel-event-card.html.twig`); intentional per CF-3E.
+3. **Account / vendor / checkout cards** — separate templates (`mel-account-event-card.html.twig`, etc.); out of public discovery badge system scope.
+4. **`event_ui.status_label` Spotlight** — CTA/status strip can still show "Spotlight" when `show_cta` is false; distinct from image badge stack but related copy surface.
+
+---
+
+## Out of scope (CF-3F)
+
+- Twig card rendering changes
+- Bridge template changes
+- New services or preprocess hooks
+- `PopularEventsService`, `DiscoveryAttributionSources`, or analytics changes
+- Views config, routes, discovery attribution, or Community Favourites ranking
+- Community Favourite image badge implementation
+
+---
+
+## Validation references
+
+After CF-3F code change:
+
+```bash
+rg "badges\[" web/modules/custom/myeventlane_event/src/EventCard/
+rg "is_featured" web/modules/custom/myeventlane_event/
+php -l web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+```
+
+`EventMerchandisingPresenterTest` remains the unit test owner for badge precedence.

--- a/web/modules/custom/myeventlane_core/myeventlane_core.module
+++ b/web/modules/custom/myeventlane_core/myeventlane_core.module
@@ -286,6 +286,37 @@ function myeventlane_core_views_pre_view(ViewExecutable $view, string $display_i
  */
 function myeventlane_core_metatags_alter(array &$metatags): void {
   $route = \Drupal::routeMatch()->getRouteName();
+
+  $discovery_copy = [
+    'view.upcoming_events.page_events' => [
+      'title' => (string) t('Find your next favourite experience.'),
+      'description' => (string) t('Discover workshops, gigs, markets, festivals, and community moments worth leaving the house for.'),
+    ],
+    'view.upcoming_events.page_popular' => [
+      'title' => (string) t('Community Favourites'),
+      'description' => (string) t('Experiences people are joining — ranked by real tickets and RSVPs this week.'),
+    ],
+    'view.upcoming_events.page_free' => [
+      'title' => (string) t('Free events and RSVP gatherings'),
+      'description' => (string) t('Community experiences with no ticket cost — easy ways to join in.'),
+    ],
+    'view.upcoming_events.page_today' => [
+      'title' => (string) t('Events happening today'),
+      'description' => (string) t('See what’s on across MyEventLane — new listings land throughout the day.'),
+    ],
+    'view.upcoming_events.page_this_weekend' => [
+      'title' => (string) t('Events this weekend'),
+      'description' => (string) t('Plan your Saturday and Sunday — markets, gigs, workshops, and community moments.'),
+    ],
+  ];
+
+  if (isset($discovery_copy[$route])) {
+    $copy = $discovery_copy[$route];
+    $metatags['title'] = $copy['title'] . ' | [site:name]';
+    $metatags['description'] = $copy['description'];
+    return;
+  }
+
   if ($route !== 'view.upcoming_events.page_category') {
     return;
   }
@@ -301,6 +332,8 @@ function myeventlane_core_metatags_alter(array &$metatags): void {
     /** @var \Drupal\myeventlane_core\Service\EventCategoryUrlService $categoryUrl */
     $categoryUrl = \Drupal::service('myeventlane_core.event_category_url');
     $metatags['canonical_url'] = $categoryUrl->getCategoryUrlString($term);
+    $metatags['title'] = $term->label() . ' | [site:name]';
+    $metatags['description'] = (string) t("Find something you'll love");
   }
 }
 

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -163,17 +163,6 @@ final class EventCardViewModel {
       'mel_source' => $context['mel_source'] ?? NULL,
     ]);
 
-    $badges = [];
-    if ($categoryLabel) {
-      $badges[] = ['label' => $categoryLabel, 'type' => 'category'];
-    }
-    if (!empty($merchandising['image_badge_label'])) {
-      $badges[] = [
-        'label' => (string) $merchandising['image_badge_label'],
-        'type' => (string) ($merchandising['image_badge_modifier'] ?? 'apricot'),
-      ];
-    }
-
     $isSaved = $this->isSavedByCurrentUser($node);
     if ($isSaved) {
       $cacheability->addCacheContexts(['user']);
@@ -193,12 +182,10 @@ final class EventCardViewModel {
       'price_label' => $badgeText ?? '',
       'availability_label' => trim((string) ($eventUi['status_label'] ?? '')),
       'availability_state' => (string) ($eventUi['status_type'] ?? ''),
-      'badges' => $badges,
       'cta_label' => $ctaLabel,
       'cta_url' => $url,
       'is_sold_out' => !empty($eventUi['is_sold_out']),
       'is_free' => $pricingType === BookingFlowResolver::MODE_RSVP,
-      'is_featured' => $isPromoted || !empty($merchandising['image_badge_label']),
       'is_saved' => $isSaved,
       'variant' => $presentation['variant'],
       'layout' => $presentation['layout'],

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -136,10 +136,6 @@
 {% elseif event_ui is defined and (event_ui.is_sold_out|default(false) == true) %}
   {% set _image_badge_label = 'Sold out'|t %}
   {% set _state_badge_type = 'warning' %}
-{% elseif event_ui is defined and event_ui.image_badge_label|default('')|trim|length > 0 %}
-  {% set _image_badge_label = event_ui.image_badge_label %}
-  {% set _st = event_ui.image_badge_type|default('apricot') %}
-  {% set _state_badge_type = _st == 'highlight' ? 'apricot' : _st %}
 {% elseif _category and _category.label and not _discovery_mode %}
   {% set _image_badge_label = _category.label %}
   {% set _state_badge_type = 'category' %}

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig
@@ -3,6 +3,8 @@
  * @file
  * Shared discovery recovery links for browse empty states.
  *
+ * Canonical runtime owner for empty-state recovery CTA copy on browse routes.
+ *
  * Variables:
  * - title: Empty state heading (required).
  * - text: Supporting copy (required).

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -2,6 +2,9 @@
 /**
  * @file
  * Shared shell for /events browse (page__events + view-specific page suggestion).
+ *
+ * Canonical runtime owner for browse-route H1, lede, prompt, and quicklink filter labels.
+ * Route-specific copy is passed from page--view--upcoming-events--page-*.html.twig overrides.
  */
 #}
 <div class="mel-page mel-page--events">

--- a/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
@@ -2,8 +2,9 @@
 /**
  * @file
  * Theme override for category filtered events pages.
- * Adds the MEL page header (title + tagline + search + category pills)
- * above the page content, without changing the results view output.
+ *
+ * Canonical runtime owner for category-route H1 and discovery lede/subtitle.
+ * Results, chips, follow CTA, and empty state remain in the view template.
  */
 #}
 
@@ -33,6 +34,15 @@
           hero_image_url_mobile: mel_hero_image_url_mobile|default(null),
           hero_hide_on_mobile: mel_hero_hide_on_mobile|default(false)
         } %}
+
+        {% if current_category is defined %}
+          <p class="mel-category-discovery__lede">
+            {{ "Find something you'll love"|t }}
+          </p>
+          <p class="mel-discovery-subtitle">
+            {{ 'Discover events in @name'|t({'@name': current_category.name}) }}
+          </p>
+        {% endif %}
 
         {{ page.content }}
       </div>

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -2,6 +2,10 @@
 /**
  * @file
  * MEL homepage — region-driven discovery.
+ *
+ * Homepage discovery section titles/subtitles are marketing-specific copy.
+ * They intentionally differ from browse-route canonical copy in
+ * mel-browse-events-page-shell.html.twig and page--view--upcoming-events--page-*.html.twig.
  */
 #}
 {% extends "page.html.twig" %}
@@ -95,7 +99,7 @@
         header_extra_class: 'mel-section__header--community-favourites',
         title: 'Community Favourites'|t,
         subtitle: 'Experiences people are joining — from real tickets and RSVPs this week.'|t,
-        link_url: path('view.upcoming_events.page_events'),
+        link_url: path('view.upcoming_events.page_popular'),
         link_text: 'See all events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_community_favourites

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -3,6 +3,8 @@
  * @file
  * Date scope pills for upcoming_events listing displays (routes, not query hacks).
  *
+ * Filter chip labels match mel-browse-events-page-shell.html.twig (canonical vocabulary).
+ *
  * @var string display_id
  *   Views display machine ID (e.g. page_events, page_today).
  */
@@ -13,7 +15,7 @@
   <a
     href="{{ path('view.upcoming_events.page_events') }}"
     class="mel-filter-chip{% if d == 'page_events' %} mel-filter-chip--active{% endif %}"
-  >{{ 'All upcoming'|t }}</a>
+  >{{ 'Browse all'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_today') }}"
     class="mel-filter-chip{% if d == 'page_today' %} mel-filter-chip--active{% endif %}"
@@ -25,7 +27,7 @@
   <a
     href="{{ path('view.upcoming_events.page_free') }}"
     class="mel-filter-chip{% if d == 'page_free' %} mel-filter-chip--active{% endif %}"
-  >{{ 'Free & RSVP'|t }}</a>
+  >{{ 'Free events'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_popular') }}"
     class="mel-filter-chip{% if d == 'page_popular' %} mel-filter-chip--active{% endif %}"

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -1,7 +1,9 @@
 {#
 /**
  * @file
- * upcoming_events — page_category: discovery copy + chip bar + grid.
+ * upcoming_events — page_category: chips, grid, and empty state.
+ *
+ * H1 and discovery lede/subtitle: page--events--category.html.twig
  */
 #}
 {% if not mel_chip_listing_fragment|default(false) %}
@@ -23,13 +25,6 @@
 {% else %}
 <div class="mel-discovery mel-discovery--category">
   {% if term %}
-    <p class="mel-category-discovery__lede">
-      {{ "Find something you'll love"|t }}
-    </p>
-    <p class="mel-discovery-subtitle">
-      {{ 'Discover events in @name'|t({'@name': term.label}) }}
-    </p>
-
     {% if mel_category_follow_flag|default(null) or mel_category_follow_login_url|default(null) %}
       <div class="mel-category-follow-region mel-category-follow-region--discovery">
         {% include '@myeventlane_theme/components/mel-category-follow-cta.html.twig' with {

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
@@ -2,6 +2,8 @@
 /**
  * @file
  * upcoming_events — page_events: browse layout, filters aside, list cards.
+ *
+ * Canonical runtime owner for /events empty-state copy and recovery CTAs.
  */
 #}
 {{ attach_library('myeventlane_theme/mel-events-discovery') }}

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig
@@ -1,8 +1,12 @@
 {#
 /**
  * @file
- * upcoming_events — shared wrapper for page_today, page_this_weekend, page_free
- * (displays without a more specific template).
+ * upcoming_events — shared wrapper for page_today, page_this_weekend, page_free,
+ * page_popular, page_hidden_gems (displays without a more specific view template).
+ *
+ * Canonical runtime owner for empty-state copy on these displays (mel_empty_copy below).
+ * page_events empty state: views-view--upcoming-events--page-events.html.twig
+ * page_category empty state: views-view--upcoming-events--page-category.html.twig
  */
 #}
 {#


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect public discovery URLs, SEO metatags, empty-state UX, and card image-badge rendering; logic is mostly copy and removal of unused ViewModel fields rather than ranking or auth.
> 
> **Overview**
> Aligns **Community Favourites** and browse discovery copy across filters, nav, homepage, and SEO, and finishes **CF-3F** badge payload consolidation on event cards.
> 
> **Discovery & SEO:** Filter chips and browse shell use shared labels (**Browse all**, **Free events**, **Community Favourites**). The popular browse menu item is renamed from **Discover** to **Community Favourites**. Homepage Community Favourites **See all** points at `/events/popular`. `hook_metatags_alter` sets titles/descriptions for main upcoming-events routes and category pages.
> 
> **Empty states:** Views **empty** areas are removed from `page_events` and `page_popular` config so theme templates (`mel-browse-empty-recovery`, display-specific view wrappers) own empty copy and recovery links.
> 
> **Event cards:** `EventCardViewModel` drops unused `badges[]` and `is_featured`; image badges flow only through `card_merchandising`. `mel-event-card.html.twig` no longer falls back to `event_ui.image_badge_label`.
> 
> **Layout copy:** Category discovery lede/subtitle moves to `page--events--category.html.twig`. Adds `docs/audits/badge-ownership-map.md` documenting badge ownership (Community Favourite image badges remain disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f428476011c163d57a8ae59de96048529c7bae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->