### PR TITLE
Update link text for Community Favourites section in front page template

### DIFF
--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -100,7 +100,7 @@
         title: 'Community Favourites'|t,
         subtitle: 'Experiences people are joining — from real tickets and RSVPs this week.'|t,
         link_url: path('view.upcoming_events.page_popular'),
-        link_text: 'See all events'|t,
+        link_text: 'See all Community Favourites'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_community_favourites
       } %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single translatable string change in a Twig template; no routing, logic, or data changes.
> 
> **Overview**
> Updates the **Community Favourites** homepage block so its header link label matches the section instead of the generic browse copy.
> 
> The `link_text` passed into `mel-section-shell.html.twig` changes from **See all events** to **See all Community Favourites**; the target route (`view.upcoming_events.page_popular`) is unchanged. This follows the same pattern as other curated sections on `page--front.html.twig` (e.g. Hidden Gems, free RSVP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf2ccf18a4d52a0f7b8611766af2940605e7c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->