### PR TITLE
CF-6B Discovery Signal Ownership Consolidation

### DIFF
--- a/docs/audits/community-favourites-ranking-ownership.md
+++ b/docs/audits/community-favourites-ranking-ownership.md
@@ -1,0 +1,140 @@
+# CF-7A — Community Favourites Ranking Ownership Audit
+
+**Date:** 2026-06-16
+**Branch:** `feature/community-favourites-signal-consolidation`
+**Status:** **AUDIT ONLY — no code/config/Views/services modified.** Builds on `docs/audits/discovery-signal-ownership-map.md` and `docs/audits/brand-rollout/popular-events-service-audit.md`. Every conclusion cites repository evidence.
+
+---
+
+## Executive answer
+
+Community Favourites ranking has a **single owner: `PopularEventsService`**. Every CF surface (homepage rail, `/events/popular` browse, visibility gate, merchandising exclusion) **delegates** to it; none re-implements scoring. `HomepageMerchandisingQueryAlter` is an **ordering bridge, not a second ranker**. Two *other* popularity rankers exist but **do not feed Community Favourites** and are removable as stale code.
+
+---
+
+## Q1 — What actually determines Community Favourites ranking?
+
+**`PopularEventsService` engagement score**, computed in one place:
+
+| Element | Evidence |
+|---|---|
+| **Score formula** | `score = (tickets_sold × 3) + (rsvps × 1)` — `PopularEventsService.php:152` (spec docblock `:19`) |
+| **Lookback** | 7 days (default `DEFAULT_DAYS`), used by all CF callers (below) |
+| **Ticket source** | Commerce paid tickets via `commerce_order_item__field_target_event`, `SUM(quantity)`, **excluding** boost + donation order-item types (`OrderItemClassifier` → `boost, checkout_donation, platform_donation, rsvp_donation`), **excluding** cancelled orders (`o.state <> 'canceled'`) and carts (`o.cart = 0`); published `event` nodes only (`n.status = 1`) — `PopularEventsService.php:180–261` |
+| **RSVP source** | canonical `rsvp_submission` storage (schema-introspected), published events only — `:273–336` |
+| **Sort** | upcoming-first → score DESC → going DESC → nid DESC (deterministic) — `:156–167` |
+
+This single ranked list is what every Community Favourites surface renders.
+
+---
+
+## Q2 — Is PopularEventsService the sole owner?
+
+**Yes, for Community Favourites.** All CF consumers delegate to it (no consumer re-scores):
+
+| Consumer | Call | Purpose |
+|---|---|---|
+| `PopularEventsBlock` (homepage rail) | `getPopularEventIds($days, $fetchLimit)` — `:165` | renders the homepage CF rail |
+| `HomepageMerchandisingQueryAlter` (browse) | `getPopularEventRows($days)` — `:122` | constrains `/events/popular` to CF ranking |
+| `HomepageSectionVisibility` (gate) | `getPopularEventIds(7, 1)` — `:80` | hides the rail when no CF results |
+| `HomepageMerchandising` (dedup/exclusion) | `getPopularEventIds(7, 24)` — `:416` | cross-rail exclusion sets |
+| `TrendingCategoriesService` (category trending) | `getPopularEventIds/Rows` — `:103,216` | category aggregation (not a CF surface) |
+
+> **Sole CF ranking owner confirmed.** No CF surface contains its own scoring; each pulls the ranked list from `PopularEventsService`. The score formula exists in exactly one location (`:152`).
+
+**Caveat (non-CF):** two other popularity-style rankers exist but **do not feed Community Favourites** — see Q6.
+
+---
+
+## Q3 — Does HomepageMerchandisingQueryAlter duplicate ranking logic?
+
+**No.** It is an **ordering bridge** that delegates to `PopularEventsService`:
+
+- Injects the service: `private readonly PopularEventsService $popularEvents` (`HomepageMerchandisingQueryAlter.php:31`).
+- Pulls the ranked nids: `$rows = $this->popularEvents->getPopularEventRows($days)` (`:122`, via `getCommunityFavouritesNids(7)` at `:87,117`).
+- Re-applies the **engine's** order to the Views query so the rank survives pagination: `nid IN (…)` + `FIELD($alias.nid, <ranked nids>)` (`:94–100`), memoised per request (`:23`).
+
+There is **no independent score, weight, or sort formula** in the QueryAlter — it only translates the engine's ranking into a Views-compatible ordering. **Not duplication.**
+
+---
+
+## Q4 — Are homepage and /events/popular using the same ranking source?
+
+**Yes — identical source and formula.**
+
+| | Homepage CF rail | `/events/popular` (browse CF) |
+|---|---|---|
+| Ranker | `PopularEventsService` | `PopularEventsService` (via QueryAlter) |
+| Method | `getPopularEventIds(7, limit)` | `getPopularEventRows(7)` |
+| Lookback | 7 days | 7 days |
+| Formula | tickets×3 + rsvp×1 | tickets×3 + rsvp×1 |
+| Cap | display `limit` (default 8; block may over-fetch then trim — `:165`) | uncapped; Views pager paginates the full ranked list |
+
+The only difference is **presentation cap** (rail = top N; browse = all, paginated) — **not** the ranking source. Both render the same ordered engine output.
+
+---
+
+## Q5 — Are RSVPs and paid tickets weighted correctly?
+
+**Internally consistent and uniformly applied.** Single formula `tickets_sold × 3 + rsvps × 1` (`:152`, "locked by spec" `:15`):
+
+- Both signals counted once; **paid tickets weighted 3× a free RSVP** (paid intent > RSVP). Same weights on every CF surface (single source).
+- Exclusions are correct for "community engagement, not paid placement": boost + donation order items excluded, cancelled orders excluded, carts excluded, unpublished excluded.
+
+**Gap (filtering, not weighting) — cross-referenced, not new:** the engine filters **publication status** but **not event lifecycle state** — cancelled/archived events with recent engagement, and past events, are not removed by the engine (`popular-events-service-audit.md §4`). This affects *which events qualify*, not the weight ratio. Whether the 3:1 ratio is the desired product value is a **product decision** (the formula is spec-locked); no evidence of a second/competing weighting exists.
+
+---
+
+## Q6 — Is there stale ranking code that can be removed?
+
+**Yes — two orphaned popularity rankers, neither feeding Community Favourites:**
+
+| Stale item | Why removable | Evidence |
+|---|---|---|
+| `myeventlane_core\HomepagePopularityService` | Duplicate popularity logic (`rsvp + tickets`, excludes boosted); **no callers** | own `getPopularEventIds()` at `:79`; `rg` shows no consumers (still orphaned) |
+| `myeventlane_analytics\TrendingScoreService` | Score (`recent RSVPs×2 + boost bonus`) consumed only by an **unrouted** controller | `TrendingEventsController` has **no route** in `myeventlane_analytics.routing.yml` |
+| `TrendingEventsController` + `myeventlane-trending-events.html.twig` | Controller unreachable (no route); template serves it | routing.yml has no mapping |
+
+**Independence check:** `TrendingCategoriesService` (live) depends on **`PopularEventsService`** (`:103,216`), **not** `TrendingScoreService` — so removing the Trending* trio does not affect category trending or Community Favourites.
+
+> Removal is **out of scope for CF-7A** (audit only) and should be a separate bounded task (e.g. CF-7B — Stale Popularity Ranker Removal), since it touches `myeventlane_core` and `myeventlane_analytics` services.
+
+---
+
+## Ownership summary
+
+```
+Community Favourites RANKING
+  └─ PopularEventsService  (sole owner; score = tickets×3 + rsvp×1, 7-day)
+       ├─ PopularEventsBlock ............. homepage rail
+       ├─ HomepageMerchandisingQueryAlter  /events/popular browse (FIELD() order bridge)
+       ├─ HomepageSectionVisibility ...... rail visibility gate
+       ├─ HomepageMerchandising .......... cross-rail exclusion sets
+       └─ TrendingCategoriesService ...... category trending (non-CF)
+
+STALE / NON-CF popularity rankers (removable, separate task)
+  ├─ HomepagePopularityService ........... orphaned duplicate (no callers)
+  └─ TrendingScoreService → TrendingEventsController (NO ROUTE)
+```
+
+## Findings vs the 6 questions
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | What determines CF ranking? | `PopularEventsService` engagement score (tickets×3+rsvp×1, 7-day, exclusions) |
+| 2 | Sole owner? | **Yes** — all CF surfaces delegate to it; one formula location |
+| 3 | Does QueryAlter duplicate ranking? | **No** — it injects the service and only re-applies order (FIELD) |
+| 4 | Homepage & /events/popular same source? | **Yes** — same service, formula, 7-day; only display cap differs |
+| 5 | RSVPs vs tickets weighted correctly? | Consistent 3:1, uniformly applied; lifecycle-state filtering gap cross-referenced |
+| 6 | Stale ranking code? | **Yes** — `HomepagePopularityService` + `TrendingScoreService`/`TrendingEventsController`/template (separate removal task) |
+
+## Validation
+
+| Command | Result |
+|---|---|
+| `git diff --stat` | (this audit adds one doc only; CF-6B committed at `647851c89`) |
+| `ddev drush cr` | success (run during CF-6B commit) |
+| `ddev drush config:status` | No differences between DB and sync directory |
+| `rg` ranking consumers | all CF surfaces resolve to `PopularEventsService` (evidence above) |
+
+**No code, config, Views, routes, ranking, or analytics modified. Audit only.** CF-7B (stale-ranker removal) can proceed from this evidence without re-auditing ranking ownership.

--- a/docs/audits/discovery-signal-ownership-map.md
+++ b/docs/audits/discovery-signal-ownership-map.md
@@ -1,0 +1,295 @@
+# MEL CF-6A — Discovery Signal Ownership, Ranking, Attribution & Merchandising Map
+
+**Date:** 2026-06-16
+**Branch:** `feature/community-favourites-audit`
+**Status:** **AUDIT ONLY — no code/config/Views/Twig/services modified.** `git diff --stat` empty; working tree clean.
+**Authority:** This is the single source of truth for discovery ranking, signals, attribution, merchandising, badges, overlays, and analytics. Every conclusion cites repository evidence; where ownership cannot be proven it states **"Ownership not proven."**
+
+> **Supersession note:** earlier same-branch audits (`brand-rollout/community-favourites-audit.md`, `popular-events-service-audit.md`) described `/events/popular` as promoted-first and `PopularEventsBlock` as unplaced. **Both are now superseded by current repository state** (a Community Favourites implementation has since landed). This document reflects current `HEAD` and is authoritative.
+
+---
+
+## Validation evidence
+
+| Command | Result |
+|---|---|
+| `git diff --stat` | (empty — audit only) |
+| `ddev drush cr` | success |
+| `ddev drush config:status` | No differences between DB and sync directory |
+| `composer validate` | `./composer.json is valid` |
+| `npm run mel:lint` | hero-variant guard pass; stylelint clean |
+| `npm run mel:build` | both themes built; tree clean |
+| `rg` signal counts | Spotlight 19 · Hidden Gem 21 · Community Favourite 13 · Popular 28 · Trending 14 · mel_signal 5 (files, excl. contrib/dist) |
+| `rg` owner counts | DiscoveryAttributionSources 8 · DiscoverySurfaceAnalyticsService 3 · EventMerchandisingPresenter 6 · HomepageMerchandisingQueryAlter 3 |
+
+---
+
+## 1. Discovery Signal Inventory
+
+| Signal | Defining file (evidence) | Owner | Consumer | Purpose |
+|---|---|---|---|---|
+| **Spotlight** (image badge) | `EventMerchandisingPresenter.php:119` (`$this->t('Spotlight')`, promoted) | `EventMerchandisingPresenter` | `EventCardViewModel` → `mel-event-card.html.twig` | Promoted-event image badge |
+| **Hidden Gem** (image badge) | `EventMerchandisingPresenter.php:122`; data `field_hidden_gem` | `EventMerchandisingPresenter` | card; hero via `myeventlane_event.module` (`mel_hero_discovery_badge`) | Editorial discovery badge |
+| **Sold out** (badge + body) | `EventMerchandisingPresenter.php:115,156` | `EventMerchandisingPresenter` | card | Availability state |
+| **Going / attendance** (body) | `EventMerchandisingPresenter.php:159` (`signal('attendance', …, 'community')`) | `EventMerchandisingPresenter` | card | Social proof (real counts) |
+| **Tonight urgency** (body) | `EventMerchandisingPresenter.php:162` | `EventMerchandisingPresenter` | card | Time urgency |
+| **Selling fast / capacity hint** (body) | `EventMerchandisingPresenter.php:165,168` | `EventMerchandisingPresenter` | card | Scarcity (real) |
+| **Community Favourites** (rail/surface, **not a card badge**) | `PopularEventsBlock.php:244`; `DiscoveryAttributionSources.php:25–26,61` | `PopularEventsService` (rank) + `DiscoveryAttributionSources` (attribution) | homepage rail + `/events/popular` browse | Engagement-ranked rail identity |
+| **Featured** (rail) | `views.view.front_featured_events.yml`; `HomepageMerchandising` | `HomepageMerchandising` + `field_promoted` | homepage featured/hero | Promoted merchandising |
+| **Promoted** (data flag) | `field_promoted` (35 files); `BoostManager` | field + `BoostManager` | Spotlight badge, Featured rail, merchandising sorts | Boost/promotion state |
+| **Recommended** (rail) | `views.view.front_recommended_events.yml`; `EventRecommendationService` | View (`field_promoted DESC`) + `EventRecommendationService` (related) | homepage recommended; related events | Suggestion rail |
+| **Popular / Trending / Just added** (card chip) | `myeventlane_theme.theme:2779–2785` (`['Popular','Trending','Just added']` by `node->id() % 3`) | **`myeventlane_theme.theme` (placeholder)** | `mel-event-card.html.twig:226`, `node--event--full.html.twig:127`, sidebar booking | **Placeholder chip — not real data** (see §7) |
+| **Trending (scored)** | `TrendingScoreService.php:35` (`recent RSVPs×2 + boost bonus`) | `TrendingScoreService` | `TrendingEventsController` (**no route**) | Orphaned trending score (see §8) |
+| **Booking signals** (`mel_signal_remaining_spots`, `_trust_label`, `_urgency_label`, `_booked_count`) | `myeventlane_theme.theme:4739–4918` | `myeventlane_theme.theme` (capacity-derived, real) | `myeventlane-event-book.html.twig`, sidebar booking | Real capacity/trust on booking page |
+| **Staff Pick / Editor Choice** | — | — | — | **Ownership not proven** — `rg "Staff Pick"` = 0 files; not present in repo |
+
+---
+
+## 2. Discovery Ranking Ownership
+
+| Ranking system | File | Owner | Consumer |
+|---|---|---|---|
+| **Engagement popularity** | `myeventlane_analytics/src/Service/PopularEventsService.php` | `PopularEventsService` | homepage CF rail (`PopularEventsBlock`), browse CF (via query alter), `TrendingCategoriesService` |
+| **Browse CF ranking bridge** | `myeventlane_front/src/Service/HomepageMerchandisingQueryAlter.php:76–134` | `HomepageMerchandisingQueryAlter` | Views `upcoming_events:page_popular` |
+| **Merchandising exclusions / hero** | `myeventlane_front/src/Service/HomepageMerchandising.php`; `HomepageMerchandisingQueryAlter.php:46–71` | `HomepageMerchandising` | homepage rails (hero/spotlight + cross-rail dedup) |
+| **Canonical discovery filters** | `myeventlane_event/src/Service/PublicEventDiscoveryQueryAlter.php` | `PublicEventDiscoveryQueryAlter` | allow-listed Views displays (`page_events`, `page_popular`, `page_hidden_gems`, `homepage_*`) |
+| **Default View sorts** | `config/sync/views.view.upcoming_events.yml` (default `sorts:`) | Views config | tonight/free/latest/category/hidden_gems displays |
+| **Recommended/Featured sorts** | `views.view.front_recommended_events.yml:53`, `front_featured_events.yml` | Views config | recommended/featured rails |
+| **Trending score** | `myeventlane_analytics/src/Service/TrendingScoreService.php:35` | `TrendingScoreService` | `TrendingEventsController` (unrouted) |
+| **Category trending** | `myeventlane_analytics/src/Service/TrendingCategoriesService.php` | `TrendingCategoriesService` | `TrendingCategoriesBlock`/`TrendingInCategoryBlock` |
+| **Orphaned popularity** | `myeventlane_core/src/Service/HomepagePopularityService.php` | (orphaned) | **none** (no callers) |
+
+### Ranking logic evidence
+1. **Sort logic** — Default discovery displays: `field_promoted_value DESC, field_event_start_value ASC` (`upcoming_events.yml` default sorts). CF browse: overridden to `FIELD(nid, <ranked nids>)` (`HomepageMerchandisingQueryAlter.php:94–100`).
+2. **Weight logic** — Engagement score `= tickets_sold×3 + rsvps×1` (`PopularEventsService.php:135`). Trending score `= recent RSVPs×2 + boost bonus` (`TrendingScoreService.php`). Orphan `HomepagePopularityService` `= rsvp + tickets` (`:168`). **Three different formulas.**
+3. **Promoted logic** — `field_promoted DESC` is the shared discovery primary sort; `HomepageMerchandising` builds hero = top promoted, spotlight = other promoted; ineligible promoted excluded (`HomepageMerchandisingQueryAlter.php:62`).
+4. **Engagement logic** — Commerce paid tickets (`order_item.type NOT IN [boost,checkout_donation,platform_donation,rsvp_donation]`) + canonical `rsvp_submission`, last 7 days (`PopularEventsService.php:180–336`).
+5. **Recency logic** — `field_event_start >= now` filters (published upcoming); past events deprioritised not hidden (`PopularEventsService.php:137–139`); "Just added" = latest display sort, but the **card "Just added" chip is the fake `mel_signal`** (§7), not the latest rail.
+
+---
+
+## 3. Attribution Ownership
+
+**SSOT: `myeventlane_core/src/Service/DiscoveryAttributionSources.php`** (allowlist + `VIEW_DISPLAY_MAP` + `ROUTE_MAP`).
+
+| Attribution source (const) | Owner (set where) | Consumer |
+|---|---|---|
+| `homepage_featured` | `VIEW_DISPLAY_MAP` `front_featured_events:block_featured/block_hero` | analytics `spotlight` |
+| `homepage_discover` | `mel_home_events:embed_discover` | analytics `discover` |
+| `homepage_tonight` | `upcoming_events:homepage_tonight` | analytics `tonight` |
+| `homepage_free` | `mel_home_events:under_20` | analytics `free` |
+| `homepage_recommended` | `front_recommended_events:block_1` | analytics `recommended` |
+| `homepage_upcoming` | `upcoming_events:homepage_latest` | analytics `latest` |
+| `homepage_hidden_gems` | `upcoming_events:homepage_hidden_gems` | analytics `hidden_gems` |
+| `homepage_community_favourites` | **`PopularEventsBlock.php:244`** (`#mel_discovery_source`) — not via display map | analytics `community_favourites` |
+| `browse_hidden_gems` | `upcoming_events:page_hidden_gems` | analytics `hidden_gems_browse` |
+| `browse_community_favourites` | **`upcoming_events:page_popular`** (`VIEW_DISPLAY_MAP:61`) | analytics `community_favourites` |
+| `category` | `upcoming_events:page_category` | analytics `category` |
+| `search` | `ROUTE_MAP` `mel_search.view` | analytics `search` |
+| `related_events` | `SOURCE_RELATED_EVENTS` (set by related builder) | analytics `related_events` |
+| `vendor_profile` | `ROUTE_MAP` `entity.myeventlane_vendor.canonical` | (attribution only) |
+
+Resolution API: `isAllowed()`, `forViewDisplay($view,$display)`, `forRoute($route)` (`DiscoveryAttributionSources.php:76–99`).
+
+---
+
+## 4. Analytics Ownership
+
+| Event | Source (writer) | Analytics surface (reader/reporting) |
+|---|---|---|
+| **Event click** | `PublicAnalyticsController::eventClick` → `/mel/analytics/event-click` (`myeventlane_core.routing.yml:145`) | recorded with `mel_source` (attribution) |
+| **Attachment / tracking JS** | `DiscoveryAnalyticsPageAttachments` ("Attaches public event-click analytics to discovery listing surfaces") | card `data-mel-track-event-click` / `data-mel-source` on `mel-event-card.html.twig` |
+| **Surface reporting** | `DiscoverySurfaceAnalyticsService` (`SOURCE_SURFACE_MAP`, `SURFACE_LABELS`) | organiser-facing click counts/labels per surface: `getHomepageClickLabelsBySurface()`, `getAggregateHomepageSurfacePerformance()` |
+
+- **Which signals feed analytics:** every `DiscoveryAttributionSources` source that appears in `SOURCE_SURFACE_MAP` (`DiscoverySurfaceAnalyticsService.php:22–33`) — featured→spotlight, discover, tonight, hidden_gems, free, recommended, latest, community_favourites (homepage+browse), related_events.
+- **Which analytics feed reporting:** surface click aggregates → vendor analytics dashboards (`AnalyticsDashboardController` at `/vendor/analytics/event/{node}`), via `DiscoverySurfaceAnalyticsService` labels.
+- **Impression tracking:** **Ownership not proven** as a discovery-surface metric — only **click** ingestion (`/mel/analytics/event-click`) was found; no impression endpoint located. `mel_signal` chips feed **no** analytics.
+
+---
+
+## 5. Merchandising Ownership
+
+| Merchandising element | File (owner) | Consumer |
+|---|---|---|
+| Image badge (Sold out → Spotlight → Hidden Gem) | `EventMerchandisingPresenter::present()` | `EventCardViewModel.php:151,202` → `mel-event-card.html.twig` |
+| Body signal (Sold out → Going → Tonight → Selling fast → Capacity) | `EventMerchandisingPresenter::bodySignal()` (`:146–169`) | card body |
+| Hero discovery badge | `myeventlane_event.module` `mel_hero_discovery_badge` (calls presenter) | `node--event--full.html.twig:125–131` |
+| Ticket pill / price pill | `EventMerchandisingPresenter` (`ticket_pill`, price) | card |
+| Card assembly (vars + attribution) | `EventCardViewModel` (`mel_source`, `card_merchandising`) | card preprocess |
+| "X going" wrapper | `PopularEventsBlock.php:206–219` + `myeventlane_event_should_show_block_going()` | CF rail cards |
+| **Placeholder chip** (`mel_signal`) | `myeventlane_theme.theme:2779–2785` | card/hero/sidebar (parallel to presenter) |
+
+**Presenter contract (`EventMerchandisingPresenter.php:11–32`):** *"Resolves a single primary merchandising signal… repository-backed signals only — no invented popularity labels… one badge / one body signal."*
+
+---
+
+## 6. Badge Ownership Validation (CF-3A–CF-3F)
+
+| Badge | Owner | Singular? | Evidence |
+|---|---|---|---|
+| **Spotlight** | `EventMerchandisingPresenter` | ✅ singular | `:119` only producer |
+| **Hidden Gem** | `EventMerchandisingPresenter` (+ `field_hidden_gem` data; hero via module re-calls presenter) | ✅ singular (presenter is the single label source) | `:122`; `myeventlane_event.module` `mel_hero_discovery_badge` |
+| **Sold Out** | `EventMerchandisingPresenter` | ✅ singular | `:115,156` |
+| **Community Favourite** | **Not a card badge** — rail identity (`PopularEventsService` + `DiscoveryAttributionSources`) | N/A (no per-card badge exists) | no presenter label; rail-only |
+
+**DRIFT FOUND:** `mel_signal` emits **"Popular" / "Trending" / "Just added"** chips on the **same cards** that the presenter governs, from `myeventlane_theme.theme` (not the presenter). This **violates the presenter's "single primary signal / repository-backed only" contract** and is the primary badge-ownership drift (see §7–§8).
+
+---
+
+## 7. Overlay & Visual Signal Audit
+
+Visual indicators **not** produced by `EventMerchandisingPresenter`:
+
+| Indicator | Source | Consumer |
+|---|---|---|
+| **`mel_signal` chip** ("Popular"/"Trending"/"Just added") | `myeventlane_theme.theme:2769–2786` — **`$node->id() % 3`** over a hardcoded array; comment: *"Event Intelligence Layer: placeholder chip (node-id derived)"* | `mel-event-card.html.twig:226`, `node--event--full.html.twig:127`, `mel-event-sidebar-slide-booking.html.twig:27` |
+| `mel_signal_remaining_spots` / `_trust_label` / `_urgency_label` / `_booked_count` | `myeventlane_theme.theme:4739–4918` (capacity/vendor-derived, **real**) | `myeventlane-event-book.html.twig`, sidebar booking |
+| Carousel "spotlight" nav UI | `card-carousel.js`, `carousel-nav.twig`, `_event-card.scss` | carousel chrome (presentation, not a signal) |
+
+**Proven:** `mel_signal` (the Popular/Trending/Just-added chip) **is generated outside presenter ownership** and is backed by **no real data** (deterministic node-id modulo). Gated only by `social_proof_mode==='auto'` and not sold-out/cancelled (`:2774–2778`). The booking `mel_signal_*` variables are a **different, real** capacity system and should not be conflated with the placeholder chip.
+
+---
+
+## 8. Dead / Orphaned Signal Audit
+
+| Item | Why dead/orphaned | Evidence |
+|---|---|---|
+| `mel_signal` chip (Popular/Trending/Just added) | Placeholder; node-id-derived; no data source; no analytics; competes with presenter | `myeventlane_theme.theme:2769–2786` (comment "placeholder") |
+| `HomepagePopularityService` | Duplicate popularity logic; **no callers** | `myeventlane_core/.../HomepagePopularityService.php`; `rg` shows only self + service def |
+| `TrendingScoreService` | Score computed but only consumer is an **unrouted** controller | `TrendingScoreService.php`; `TrendingEventsController` has **no route** in `myeventlane_analytics.routing.yml` |
+| `TrendingEventsController` | **No route** → publicly unreachable | routing.yml contains no controller mapping |
+| `myeventlane-trending-events.html.twig` | Template for the unrouted Trending controller | `myeventlane_analytics/templates/` |
+| Staff Pick / Editor Choice | Declared nowhere (absent, not dead) | `rg "Staff Pick"` = 0; **Ownership not proven** |
+
+> **Not dead (verified reachable):** `SOURCE_HOMEPAGE_COMMUNITY_FAVOURITES` — set by `PopularEventsBlock.php:244` and rendered via region `homepage_community_favourites` (`page--front.html.twig:105`, block config `block.block.myeventlane_theme_homepage_community_favourites.yml`, `status: true`).
+
+---
+
+## 9. Consumer Matrix
+
+| Surface | Ranking owner | Signal/badge owner | Attribution owner | Notes (evidence) |
+|---|---|---|---|---|
+| **Homepage (hero/featured)** | `HomepageMerchandising` (promoted) | `EventMerchandisingPresenter` | `homepage_featured` | hero=top promoted |
+| **Community Favourites (homepage rail)** | `PopularEventsService` | presenter (+ "X going" wrapper) | `homepage_community_favourites` (block-set) | `PopularEventsBlock` placed, status true |
+| **Community Favourites (browse `/events/popular`)** | `HomepageMerchandisingQueryAlter` → `PopularEventsService` | presenter | `browse_community_favourites` | heading `'Community Favourites'`; engagement `FIELD()` order |
+| **Browse (`/events` page_events)** | View default sorts (`field_promoted`,start) + `PublicEventDiscoveryQueryAlter` | presenter | (no mapped source) | canonical filters apply |
+| **Search (`/search`)** | `myeventlane_search` (Search API) | presenter | `search` (route map) | |
+| **Related Events** | `EventRecommendationService` (same-category) | presenter | `related_events` | event detail |
+| **Event Detail** | n/a | presenter hero badge (`mel_hero_discovery_badge`) + **`mel_signal` (placeholder)** | n/a | drift: two signal systems on detail |
+| **Hidden Gems (homepage + browse)** | View (`field_hidden_gem` filter) + `PublicEventDiscoveryQueryAlter` | presenter (Hidden Gem badge) | `homepage_hidden_gems` / `browse_hidden_gems` | |
+| **Featured** | `HomepageMerchandising` / `front_featured_events` | presenter (Spotlight) | `homepage_featured` | |
+| **Category (`/events/category/%`)** | View default sorts + query alter | presenter | `category` | |
+| **Today (`/events/today`)** | View `homepage_tonight`/today sorts | presenter | `homepage_tonight` (tonight) | |
+| **Weekend (`/events/this-weekend`)** | View display sorts | presenter | (no mapped source) | **Ownership not proven** for a dedicated attribution source |
+
+All public cards across all surfaces additionally render the **`mel_signal` placeholder chip** (theme preprocess) unless suppressed by social-proof mode — a cross-surface overlay independent of the matrix above.
+
+---
+
+## 10. Single Source Of Truth Assessment (repository-backed; current owners)
+
+| Concern | Current repository SSOT (evidence) | Drift / competing owners |
+|---|---|---|
+| **Ranking** | Engagement: `PopularEventsService`; promoted/hero: `HomepageMerchandising(+QueryAlter)`; canonical filters: `PublicEventDiscoveryQueryAlter` | `HomepagePopularityService` (orphan dup), `TrendingScoreService` (orphan) — **3 popularity formulas exist** |
+| **Signal / badge** | `EventMerchandisingPresenter` (declares itself the single, repository-backed signal owner) | `mel_signal` placeholder (theme) emits competing Popular/Trending/Just-added chips |
+| **Attribution** | `DiscoveryAttributionSources` (allowlist + maps) | none competing; `homepage_community_favourites` is block-set rather than display-mapped (minor inconsistency) |
+| **Analytics** | Write: `PublicAnalyticsController::eventClick`; read/report: `DiscoverySurfaceAnalyticsService`; attach: `DiscoveryAnalyticsPageAttachments` | no impression pipeline proven |
+| **Badge (subset of signal)** | `EventMerchandisingPresenter` | `mel_signal` (theme) |
+
+*(Statements above are the repository's de facto owners per concern — not a redesign or opinion.)*
+
+---
+
+## 11. Consolidation Readiness Report
+
+### Before (current architecture)
+```
+                         ┌───────────────────────────── EventMerchandisingPresenter ──┐
+                         │  image badge: Sold out / Spotlight / Hidden Gem             │  (repo-backed SSOT)
+ EventCardViewModel ─────┤  body signal: Going / Tonight / Selling fast / Capacity     │
+   (mel_source, card)    └────────────────────────────────────────────────────────────┘
+                         ┌──────────── myeventlane_theme.theme (PLACEHOLDER) ──────────┐
+   SAME CARD  ──────────►│  mel_signal = ['Popular','Trending','Just added'][nid % 3]  │  ◄── DRIFT (fake)
+                         └────────────────────────────────────────────────────────────┘
+ RANKING:  PopularEventsService (tickets×3+rsvp×1) ──► HomepageMerchandisingQueryAlter ──► page_popular (CF browse)
+                                                  └──► PopularEventsBlock ──────────────► homepage CF rail
+           HomepagePopularityService (rsvp+tickets) ── ORPHAN (no callers)
+           TrendingScoreService (rsvp×2+boost) ──► TrendingEventsController (NO ROUTE) ── ORPHAN
+           field_promoted DESC (Views default) ──► tonight/free/latest/category/featured/recommended
+ ATTRIBUTION: DiscoveryAttributionSources ──► DiscoverySurfaceAnalyticsService ──► /mel/analytics/event-click
+```
+
+### Recommended (consolidated — direction only, no redesign of formulas)
+```
+ SIGNALS/BADGES:  EventMerchandisingPresenter  ── single producer (retire mel_signal placeholder)
+ RANKING:         PopularEventsService  ── single engagement owner
+                  (retire HomepagePopularityService + TrendingScoreService/Controller, or route+back with data)
+ ATTRIBUTION:     DiscoveryAttributionSources  ── (add page-level map for block-set CF source for consistency)
+ ANALYTICS:       PublicAnalyticsController (write) + DiscoverySurfaceAnalyticsService (read)
+```
+
+### Consolidation candidates
+| Candidate | Risk | Complexity | Evidence |
+|---|---|---|---|
+| `mel_signal` placeholder chip | **Low** (fake data; removing only drops a misleading chip) | Low (1 preprocess block + 3 template guards) | `theme:2769–2786`; consumers in 3 templates |
+| `HomepagePopularityService` (duplicate ranking) | **Low** (orphan, no callers) | Low | no callers |
+| `TrendingScoreService` + `TrendingEventsController` + trending template (duplicate ranking, unrouted) | **Medium** (confirm truly unused; `TrendingCategoriesService` is separate and live) | Medium | controller unrouted; categories service distinct |
+| Duplicate attribution wiring (`homepage_community_favourites` block-set vs display-mapped) | **Low** | Low | `PopularEventsBlock:244` vs `VIEW_DISPLAY_MAP` |
+| Duplicate popularity formulas (3) | **Medium** | Medium | `PopularEventsService:135` / `HomepagePopularityService:168` / `TrendingScoreService:35` |
+
+---
+
+## CF-6B readiness
+
+This document provides: every discovery signal + owner + consumer (§1), every ranking owner with formula evidence (§2), the attribution SSOT with full maps (§3), the analytics write/read/attach owners (§4), merchandising ownership (§5), badge singularity validation with the one proven drift (§6), the proven non-presenter overlay `mel_signal` (§7), dead/orphaned items with evidence (§8), a full consumer matrix (§9), repository-backed SSOT per concern (§10), and ranked consolidation candidates (§11). **CF-6B can proceed to implementation without re-auditing ownership.**
+
+**No code, config, Views, Twig, or services were modified. Audit only.**
+
+---
+
+# CF-6B — Signal Ownership Consolidation (Implementation Outcome)
+
+**Date:** 2026-06-16 · **Branch:** `feature/community-favourites-signal-consolidation`
+
+Implements §6–§8 of this audit: removes the `mel_signal` placeholder chip so that **`EventMerchandisingPresenter` is the sole discovery signal/badge owner**. No ranking, attribution, analytics, Views, routes, or merchandising were touched.
+
+## Validation re-confirmation (Phase 1)
+Re-verified at implementation time — matched the audit exactly, so implementation proceeded:
+- Single generator: `myeventlane_theme.theme:2770/2785`, `['Popular','Trending','Just added'][ node->id() % 3 ]`, comment *"placeholder chip (node-id derived)"*.
+- Not ranking-, engagement-, attribution-, analytics-, or merchandising-backed (no data source; no `DiscoveryAttributionSources`/`PopularEventsService`/analytics wiring).
+- Consumers (exactly three): `mel-event-card.html.twig:226`, `node--event--full.html.twig:125`, `mel-event-sidebar-slide-booking.html.twig:27`.
+
+## Before → After
+
+| Aspect | Before | After |
+|---|---|---|
+| Card chip "Popular/Trending/Just added" | Generated in theme by `node->id() % 3` (fake) | **Removed** |
+| Signal generator | `myeventlane_theme.theme` (placeholder block) | **Removed** (replaced with breadcrumb comment) |
+| Card consumer | `mel-event-card.html.twig` `{% if mel_signal … %}` | Removed |
+| Hero consumer | `node--event--full.html.twig` `{% elseif mel_signal %}` | Removed (category-chip if/elseif chain preserved) |
+| Sidebar consumer | `mel-event-sidebar-slide-booking.html.twig` `{% if mel_signal %}` | Removed |
+| Signal/badge owner | `EventMerchandisingPresenter` **+ competing `mel_signal`** | **`EventMerchandisingPresenter` (sole owner)** |
+
+## Retained (Phase 3 — real booking signals, untouched)
+`mel_signal_remaining_spots`, `mel_signal_trust_label`, `mel_signal_urgency_label`, `mel_signal_booked_count`, `mel_signal_is_community` (`myeventlane_theme.theme:4739–4918`) — capacity/vendor-derived, unrelated to the removed chip. **10 lines verified intact.**
+
+## Final ownership (post-CF-6B)
+- **Signals & badges:** `EventMerchandisingPresenter` — sole owner. The presenter's image badges (Sold out → Spotlight → Hidden Gem) and body signals (Going / Tonight / Selling fast / Capacity) are now the only discovery signals on cards/hero/sidebar.
+- **Ranking / attribution / analytics / merchandising:** unchanged (`PopularEventsService`, `HomepageMerchandising(QueryAlter)`, `DiscoveryAttributionSources`, `DiscoverySurfaceAnalyticsService` / `PublicAnalyticsController` / `DiscoveryAnalyticsPageAttachments`). **Not modified.**
+
+## Files changed
+| File | +/− |
+|---|---|
+| `myeventlane_theme/myeventlane_theme.theme` | generator block → comment |
+| `templates/components/event-card/mel-event-card.html.twig` | −3 |
+| `templates/node/node--event--full.html.twig` | −4 |
+| `templates/event/sidebar/mel-event-sidebar-slide-booking.html.twig` | −3 |
+
+Total: **4 files, +6 / −28.**
+
+## Out of scope / follow-up
+- **Orphaned SCSS** `.mel-event-card__signal` (exact), `.mel-event__signal`, `--strong`, `--hero-chip` are now unused but intermingled with the **live** `.mel-event-card__signal-row` (presenter body signal) across 6 partials. Left untouched to avoid visual-regression risk; flagged for a separate bounded SCSS-cleanup task.
+- `HomepagePopularityService`, `TrendingScoreService`, `TrendingEventsController`, trending template — **not** in CF-6B scope (separate audit/implementation).
+
+## CF-6B validation report
+`php -l` clean · `ddev drush cr` success · `ddev drush config:status` **no differences** (code-only change) · `composer validate` valid · `npm run mel:lint` pass (hero guard + stylelint) · `npm run mel:build` both themes built; no stray tracked assets.

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2766,24 +2766,12 @@ function myeventlane_theme_preprocess_node(array &$variables): void {
       $variables['directory'] = $base_path . $theme_path;
     }
 
-    // Event Intelligence Layer: placeholder chip (node-id derived); suppressed in show/hide modes.
-    $variables['mel_signal'] = NULL;
-    $mel_state = (string) ($variables['mel_event_state'] ?? '');
-    $event_ui_signal = is_array($variables['event_ui'] ?? NULL) ? $variables['event_ui'] : [];
-    $signal_sold_out = !empty($event_ui_signal['is_sold_out']);
-    $signal_hide = ($mel_state === 'cancelled')
-      || ($mel_state === 'sold_out')
-      || $signal_sold_out;
-    $social_proof_mode = (string) ($variables['mel_social_proof_mode'] ?? 'auto');
-    if (!$signal_hide && $social_proof_mode === 'auto') {
-      $mel_signals = [
-        (string) t('Popular'),
-        (string) t('Trending'),
-        (string) t('Just added'),
-      ];
-      $mel_signal_idx = (int) $node->id() % count($mel_signals);
-      $variables['mel_signal'] = $mel_signals[$mel_signal_idx];
-    }
+    // CF-6B: removed the node-id-derived placeholder "mel_signal" chip
+    // (Popular/Trending/Just added). It was fake — not ranking-, engagement-,
+    // attribution-, or analytics-backed. EventMerchandisingPresenter is the sole
+    // discovery signal/badge owner. See docs/audits/discovery-signal-ownership-map.md.
+    // NOTE: the real booking signals ($variables['mel_signal_*']) are unrelated
+    // and set later in this file — they are intentionally retained.
 
     // 1. Compute event image URL if it exists.
     $event_image_url = NULL;

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -223,9 +223,6 @@
           <span class="mel-pill__label">{{ _image_badge_label }}</span>
         </span>
       {% endif %}
-      {% if mel_signal and not _is_hero %}
-        <div class="mel-event-card__signal">{{ mel_signal }}</div>
-      {% endif %}
     </div>
 
     <div class="mel-event-card__body mel-event-card__content">

--- a/web/themes/custom/myeventlane_theme/templates/event/sidebar/mel-event-sidebar-slide-booking.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/event/sidebar/mel-event-sidebar-slide-booking.html.twig
@@ -24,9 +24,6 @@
     {% if mel_show_sidebar_scarcity_badge %}
       <div class="mel-event__badge">{{ 'Limited availability'|t }}</div>
     {% endif %}
-    {% if mel_signal %}
-      <div class="mel-event__signal mel-event__signal--strong">{{ mel_signal }}</div>
-    {% endif %}
     {% if mel_sidebar_pricing|default('')|striptags|trim is not empty %}
       <div class="mel-booking-panel__price mel-price" aria-label="{{ 'Price'|t }}">
         {{ mel_sidebar_pricing }}

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -122,10 +122,6 @@
             {{ content.field_category }}
           </div>
         </div>
-      {% elseif mel_signal %}
-        <div class="mel-event-hero__chip" aria-hidden="true">
-          <div class="mel-event__signal mel-event__signal--hero-chip">{{ mel_signal }}</div>
-        </div>
       {% endif %}
       <div class="mel-event-hero__content">
         <div class="mel-event-hero__info">


### PR DESCRIPTION
Removes deprecated mel_signal discovery chips.

Changes:
- Removes fake Popular / Trending / Just Added signal generation
- Preserves EventMerchandisingPresenter ownership
- Preserves Sold Out, Spotlight and Hidden Gem badges
- Preserves booking urgency and trust signals
- No ranking changes
- No attribution changes
- No analytics changes

Validation:
- drush cr
- config status clean
- composer validate
- lint passed
- 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only theme/Twig removal of misleading placeholder chips; no ranking, analytics, or config changes. Residual unused SCSS for removed chips is noted as follow-up.
> 
> **Overview**
> **CF-6B (implementation):** Drops the node-id–derived **Popular / Trending / Just added** discovery chip. Theme preprocess no longer sets `mel_signal`, and event card, full node hero, and sidebar booking templates no longer render it. **EventMerchandisingPresenter** remains the sole discovery badge/signal path; real booking `mel_signal_*` capacity/trust variables are unchanged. Ranking, attribution, analytics, Views, and presenter merchandising are untouched.
> 
> **Documentation:** Adds **`discovery-signal-ownership-map.md`** (CF-6A/6B ownership map plus post-6B outcome) and **`community-favourites-ranking-ownership.md`** (CF-7A audit: `PopularEventsService` as sole Community Favourites ranker; stale rankers flagged for follow-up). Audit-only sections describe evidence; no config or service changes in those docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326f918271dfbe7d2651fc60379bdf184953b2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->