### PR TITLE
Feature/homepage copy phase 1a

### DIFF
--- a/config/sync/mel_maintenance.settings.yml
+++ b/config/sync/mel_maintenance.settings.yml
@@ -5,8 +5,8 @@ features:
   favicon: 1
 logo:
   use_default: 0
-  path: 'public://new-mel-logo.png'
+  path: 'public://new-mel-logo_2.png'
 favicon:
   use_default: 0
-  path: 'public://new-fal.png'
+  path: 'public://new-fal_2.png'
   mimetype: image/png

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -3226,7 +3226,7 @@ display:
       path: events/popular
       menu:
         type: normal
-        title: Community Favourites
+        title: 'Community Favourites'
         description: 'Events people are joining this week'
         weight: 2
         enabled: true

--- a/docs/audits/brand-rollout/phase-1a-implementation-plan.md
+++ b/docs/audits/brand-rollout/phase-1a-implementation-plan.md
@@ -1,185 +1,411 @@
 # Phase 1A — Implementation Plan (Public Discovery Copy Slice)
 
-**Brand territory:** The Hidden Gem + The Guide — Bright Edition
-**Plan date:** 2026-06-14
-**Branch:** `feature/event-studio-consolidation`
+**Brand territory:** The Hidden Gem + The Guide — Bright Edition  
+**Plan date:** 2026-06-17  
+**Branch (at plan time):** `feature/homepage-visual-refresh-phase-1`  
 **Status:** **Plan only. No code changed by this document.**
 
 > Scope is the **smallest safe slice**: public discovery **copy + rail order**, using surfaces and blocks that already exist. No SCSS/tokens, no mascot/art, no AI assistant, no email, no Commerce, no vendor/admin routes, no new components, no new architecture.
 >
-> Source audits: `homepage-audit.md`, `discovery-audit.md`, `event-page-audit.md`, `onboarding-audit.md`, `component-inventory.md`.
+> Source audits: `homepage-audit.md`, `discovery-audit.md`, `component-inventory.md`, `brand-gap-analysis.md`, `final-rollout-strategy.md`. Brand authority: `docs/brand/homepage-system.md`, `docs/brand/copy-guidelines.md`, `docs/brand/guide-character-system.md`, `docs/brand/event-card-system.md`.
 
 ---
 
-## 0. Pre-flight facts (verified this session)
+## 1. GOAL
 
-| Fact | Evidence |
+Re-voice public discovery surfaces so visitors feel *“What wonderful thing can I discover this weekend?”* — using existing homepage rails, hero, empty states, and card badges only, with no new architecture.
+
+---
+
+## 2. PRODUCT SURFACE
+
+**Public discovery**
+
+---
+
+## 3. AUDIT FIRST
+
+Evidence gathered from the repository on 2026-06-17. Paths are relative to the repo root unless noted.
+
+### 3.1 Routes
+
+| Route | Evidence |
 |---|---|
-| Front page route | `config/sync/system.site.yml` → `page.front: /home` |
-| Active hero = block plugin `myeventlane_home_hero` → template | `config/sync/block.block.myeventlane_theme_homeheromyeventlane.yml`; `HomeHeroBlock.php:99` `#theme => myeventlane_home_hero`; renders `myeventlane_front/templates/myeventlane-home-hero.html.twig` |
-| Homepage rail **order is template-driven** (each rail is its own region, printed top→bottom) — **not** block weight | `page--front.html.twig` lines 41,56,71,86,101,116,130,144,158 |
-| Section headings/subtitles are hardcoded `\|t` literals in the front template | `page--front.html.twig` (per heading) |
-| Recommendation block **already placed and enabled** | `block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml` → `status: true`, `region: home_recommended` |
-| Event-card badge text mostly from PHP presenter | `myeventlane_event/src/EventCard/EventMerchandisingPresenter.php` |
-| Canonical discovery empty-state copy | `templates/includes/mel-view-empty-events.html.twig` |
+| `/home` (front page) | `config/sync/system.site.yml` → `page.front: /home` |
+| `/events` | `views.view.upcoming_events` display `page_events` |
+| `/events/category/%` | display `page_category` |
+| `/events/today`, `/events/this-weekend`, `/events/free`, `/events/popular` | `views.view.upcoming_events` |
+| `/events/hidden-gems` (Hidden Gems browse) | `page--view--upcoming-events--page-hidden-gems.html.twig`; display `page_hidden_gems` in `views-view--upcoming-events.html.twig` |
+| `/search` | `myeventlane_search` module → `SearchController` |
 
-**Config-export note (applies to all items):** every copy string in scope lives in **Twig templates or PHP**, not in config entities. **No `drush cex` is required for any Phase 1A item.** The one config entity involved (the recommended block placement) is **not modified**.
+### 3.2 Services and preprocess
 
-> Proposed strings below are **illustrative, on-brand drafts for sign-off**, not final copy. The emotional target is *"What wonderful thing can I discover this weekend?"* — optimistic, welcoming, discovery-first.
+| Service / hook | Path | Role |
+|---|---|---|
+| `HomepageSectionVisibility` | `web/modules/custom/myeventlane_front/src/Service/HomepageSectionVisibility.php` | Sets `mel_home_show_*` flags; avoids empty section shells |
+| `HomepageMerchandising` | `web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php` | Community Favourites dedup pool |
+| `FeaturedEventsRenderBuilder` | `web/modules/custom/myeventlane_front/src/Service/FeaturedEventsRenderBuilder.php` | Featured rail content |
+| `HomeHeroBlock` | `web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php` | Block plugin `myeventlane_home_hero`; `#theme => myeventlane_home_hero` |
+| `EventMerchandisingPresenter` | `web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php` | Card badge + body signal labels |
+| `myeventlane_theme_preprocess_page` | `web/themes/custom/myeventlane_theme/myeventlane_theme.theme` (≈ L1940+) | Injects `mel_home_show_*` on front page |
 
----
+### 3.3 Templates (copy owners)
 
-## Change 1 — Homepage hero copy
+| Surface | Template | Copy type |
+|---|---|---|
+| Homepage layout + section headings | `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` | Hardcoded `\|t` literals in `mel-section-shell` includes |
+| Homepage hero | `web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig` | H1, sub-line, search placeholders, CTAs |
+| Hero fallback (inactive when block placed) | `web/themes/custom/myeventlane_theme/components/hero/hero.twig` | **Do not edit** — not active when `homepage_hero` region is filled |
+| Section chrome | `web/themes/custom/myeventlane_theme/components/layout/mel-section-shell.html.twig` | Structure only; headings passed in |
+| View empty (homepage embeds) | `web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig` | Default title/text/CTA |
+| Browse empty + recovery links | `web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig` | Title/text + recovery link row |
+| Browse `/events` empty | `web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig` | Inline empty copy |
+| Intent browse empties | `web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig` | `mel_empty_copy` map |
+| Category empty | `web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig` | Inline `.mel-empty-state` copy |
+| Search empty | `web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig` | Uses `mel-browse-empty-recovery` |
+| Tonight homepage empty | `web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--upcoming-events--homepage-tonight.html.twig` | Overrides `mel-view-empty-events` |
+| Event card badge consumption | `web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig` | Reads `_merch.image_badge_label` — **no badge text here** |
 
-- **Repository evidence:** `myeventlane_front/templates/myeventlane-home-hero.html.twig`
-  - L20 eyebrow `{{ 'MyEventLane'|t }}`
-  - L21 H1 `{{ 'Your lane to great events.'|t }}`
-  - L23 text `{{ 'Find workshops, gigs, markets, festivals, and community moments worth leaving the house for.'|t }}`
-  - L41 search placeholder `'Search events, organisers, or places'`; L60 `'Explore events'`
-- **File path:** `web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig`
-- **Route affected:** `/home` (front page)
-- **Current behaviour:** Hero shows "Your lane to great events." + utilitarian sub-line.
-- **Proposed behaviour:** Re-voice H1 + sub-line to discovery-wonder, e.g. H1 → `'Discover something wonderful this weekend.'`; text → `'Hidden gems, local favourites, and experiences you never knew existed — all in one place.'` (eyebrow/search/CTA labels optional). Copy-only; no markup/logic change.
-- **Risk level:** **Low** (single template, copy-only).
-- **Config export required:** **No** (template).
-- **Validation command:** `ddev drush cr` → load `/home`, confirm hero renders and rotator/search still function (`home-hero-rotator` library unaffected).
-- **Rollback step:** `git checkout -- web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig`
-- **Assumption check:** Confirmed active template (block places `myeventlane_home_hero`; `page.homepage_hero` printed first in `page--front.html.twig:10`). The fallback `templates/components/hero/hero.twig` ("Your lane to great events.") is **not active** and must **not** be edited.
+### 3.4 Block → region mapping (config)
 
----
-
-## Change 2 — Homepage discovery rail order
-
-- **Repository evidence:** `page--front.html.twig` prints regions in fixed order: featured (L41) → discover (L56) → tonight (L71) → free (L86) → latest (L101) → **recommended (L116)** → nearby (L130) → online (L144) → blog (L158). Order is the template sequence; each rail is a separate region, so block weights cannot reorder them.
-- **File path:** `web/themes/custom/myeventlane_theme/templates/page--front.html.twig`
-- **Route affected:** `/home`
-- **Current behaviour:** Generic browse rails (discover/tonight/free/latest) appear above the editorial "Featured" and "Recommended" rails sit mid-page (L116).
-- **Proposed behaviour:** Promote curated/editorial rails by **moving existing section blocks** so order becomes: hero → **Featured (Community spotlight)** → **Recommended for you** → Happening tonight → Discover → Free/RSVP → Latest → Nearby → Online → Blog → Host CTA → Newsletter. Pure block-move of existing `{% include mel-section-shell %}` sections; **all `mel_home_show_*` visibility conditions and region variables preserved verbatim**.
-- **Risk level:** **Low–moderate** (markup reorder in one template; must keep each section's `{% if %}` guard + `content:` region intact).
-- **Config export required:** **No** (template; not block weights).
-- **Validation command:** `ddev drush cr` → load `/home`; confirm each rail still renders only when it has results (toggle by data), no duplicated/dropped sections, no PHP notices in `ddev drush watchdog:show`.
-- **Rollback step:** `git checkout -- web/themes/custom/myeventlane_theme/templates/page--front.html.twig`
-- **Assumption check:** Confirmed order is template-driven (no weight mechanism). Changes 2, 3, 6 all edit this one file — execute as **one coordinated edit**.
-
----
-
-## Change 3 — Homepage section headings / subtitles
-
-- **Repository evidence:** `page--front.html.twig` literals — `'Community spotlight'` / `'Local events and creators worth showing up for'` (featured); `'Discover events'` / `'Filter by what you feel like tonight'`; `'Happening tonight'`; `'Easy ways to get involved'`; `'Freshly added'`; `'Recommended for you'` / `'Events you may enjoy'`; `'Nearby events'`; `'Online events'`; `'Guides for better nights out'`.
-- **File path:** `web/themes/custom/myeventlane_theme/templates/page--front.html.twig`
-- **Route affected:** `/home`
-- **Current behaviour:** Functional/nightlife-leaning headings (e.g. "Guides for better nights out", "Filter by what you feel like tonight").
-- **Proposed behaviour:** Re-voice the `title:`/`subtitle:` strings to the Guide, e.g. Featured → `'Hidden gems the Guide loves'`; Recommended → `'Picked for you'` / `'The Guide thinks you'll love these'`; Blog → `'Guides to discovering more'`. Copy-only; `mel-section-shell` structure and `link_url`/`path()` calls unchanged.
-- **Risk level:** **Low** (copy-only).
-- **Config export required:** **No** (template).
-- **Validation command:** `ddev drush cr` → load `/home`, confirm headings render and "See all" links still resolve.
-- **Rollback step:** `git checkout -- .../page--front.html.twig` (same file as Changes 2 & 6).
-- **Assumption check:** Confirmed all headings are template literals (not block titles, not config).
-
----
-
-## Change 4 — Event card badge language (where already supported)
-
-- **Repository evidence:**
-  - Presenter produces badge text: `EventMerchandisingPresenter.php:110` `$this->t('Featured')` (gated by `($isHero || $isSpotlight) && $isPromoted`); L100/L156 `'Selling fast'`; sold-out `'Sold out'`.
-  - Card consumes via `_merch.image_badge_label` (`mel-event-card.html.twig:94–96`); literal `'Selling fast'` also at template L335/L412.
-  - **Unit test exists:** `myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php`.
-- **File path:** `web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php` (+ test) — *and/or* literal strings in `mel-event-card.html.twig`.
-- **Route affected:** All discovery surfaces rendering event cards (`/home`, `/events`, `/events/category/%`, `/search`).
-- **Current behaviour:** Promoted hero/spotlight cards show a **"Featured"** badge; low-stock cards show **"Selling fast"**.
-- **Proposed behaviour (minimal):** Re-voice the **existing** `'Featured'` label only (e.g. → `'Hidden gem'` or `'Guide pick'`) at `EventMerchandisingPresenter.php:110`, and update the assertion in `EventMerchandisingPresenterTest`. No new badge type, no new modifier, no template logic change.
-- **Risk level:** **Moderate** (logic-bearing, **unit-tested** PHP; not pure copy). **Recommend sign-off before doing — or defer to Phase 1B** if Phase 1A must stay Twig-only.
-- **Config export required:** **No** (PHP).
-- **Validation command:** `ddev exec ./vendor/bin/phpunit web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php` then `ddev drush cr` and visual check of a promoted card.
-- **Rollback step:** `git checkout -- web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php`
-- **STOP / not confirmed:** A dedicated **"Hidden Gem" badge type/modifier is NOT present** in the repo (grep for `hidden gem`/`gem` badge returned nothing). Per the rules, **a new badge is out of scope** — *Repository evidence not found*. Only the existing `'Featured'`/`'Selling fast'` labels are re-voiceable.
-
----
-
-## Change 5 — Empty-state copy (discovery surfaces)
-
-- **Repository evidence:**
-  - Canonical include defaults: `includes/mel-view-empty-events.html.twig:10–13` title `'Nothing here yet'`, text `'Check back soon or explore more events across MyEventLane.'`, CTA `'Explore events'`.
-  - View-template literals: `views-view--upcoming-events--page-events.html.twig:42` "No events found"; `views-view--upcoming-events--page-category.html.twig:80` "No events in this category"; `views-view--mel-home-events--tonight.html.twig:15` + `views-view-unformatted--upcoming-events--homepage-tonight.html.twig:16` "Nothing listed for tonight yet"; `views-view--mel-help-search.html.twig:43` "No results found".
-- **File path:** `web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig` (primary) + the per-view templates above.
-- **Route affected:** `/events`, `/events/category/%`, `/events/today` (tonight rail on `/home`), `/search` (help search on `/help/search`).
-- **Current behaviour:** Neutral "No events found" / "Nothing here yet" messaging.
-- **Proposed behaviour:** Re-voice to optimistic Guide nudges, e.g. title `'No gems here just yet'`; text `'The Guide is always finding new experiences — check back soon or explore what's on across MyEventLane.'`; keep CTA `'Explore events'` → `/events`. Editing the **canonical include defaults** cascades to all callers that don't override. Copy-only.
-- **Risk level:** **Low** (copy-only; reuses existing `empty-state.html.twig` component — no new component).
-- **Config export required:** **No** (templates).
-- **Validation command:** `ddev drush cr` → visit `/events` with a no-result filter (e.g. `/events?keys=zzzznoresult`) and a `/search` no-result query; confirm empty state renders with new copy + working CTA.
-- **Rollback step:** `git checkout -- web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig` (+ any per-view templates touched).
-- **Assumption check:** Confirmed copy lives in Twig; `empty-state.html.twig` is the existing shared component (no duplication). Note the `.mel-empty` vs `.mel-empty-state` vocabulary split (`component-inventory.md §E`) — **do not consolidate vocab in Phase 1A** (that is structural, out of scope); only change visible text.
-
----
-
-## Change 6 — One in-flow Guide recommendation block (existing block only)
-
-- **Repository evidence:** `front_recommended_events` block is **already placed and enabled** — `config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml` (`status: true`, `region: home_recommended`, `plugin: views_block:front_recommended_events-block_1`). Rendered in-flow at `page--front.html.twig:116`, gated by `mel_home_show_recommended` = `viewDisplayHasResults('front_recommended_events','block_1')` (`myeventlane_theme.theme:1952`). Heading/subtitle literals "Recommended for you" / "Events you may enjoy" in the same template.
-- **File path:** `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` (heading copy + position handled by Changes 2 & 3).
-- **Route affected:** `/home`
-- **Current behaviour:** The recommendation rail exists, sits mid-page (L116), shows only when the View has results, headed "Recommended for you".
-- **Proposed behaviour:** **Reuse the existing block** as the in-flow Guide recommendation surface — promote its position (Change 2) and re-voice its heading to the Guide (Change 3, e.g. "Picked for you by the Guide"). **No new block, no new component, no new View, no config change.**
-- **Risk level:** **Low** (no new placement; copy + order only).
-- **Config export required:** **No** — block placement config is **reused unchanged**.
-- **Validation command:** `ddev drush cr` → load `/home` as an authenticated user with activity that yields results; confirm the recommendation rail renders in the promoted position with new heading. (If empty, confirm it hides gracefully — existing visibility logic.)
-- **Rollback step:** covered by Change 2/3 rollback (`git checkout -- .../page--front.html.twig`).
-- **Assumption check:** Confirmed an existing reusable recommendation block already supports this (`front_recommended_events`). The rule "only if an existing reusable block already supports it" is **satisfied** — no new architecture.
-
----
-
-## Execution grouping & sequencing
-
-| Group | Files | Changes | Risk |
+| Section | Block config | Region | View / plugin |
 |---|---|---|---|
-| A | `myeventlane-home-hero.html.twig` | 1 | Low |
-| B | `page--front.html.twig` (one coordinated edit) | 2, 3, 6 | Low–moderate |
-| C | `mel-view-empty-events.html.twig` (+ per-view templates) | 5 | Low |
-| D | `EventMerchandisingPresenter.php` (+ unit test) | 4 | **Moderate — sign-off / consider deferring** |
+| Hero | `config/sync/block.block.myeventlane_theme_homeheromyeventlane.yml` | `homepage_hero` | `myeventlane_home_hero` |
+| Featured | `block.block.myeventlane_theme_views_block__front_featured_events_block_featured.yml` | `homepage_featured` | `front_featured_events` |
+| Discover chips | block in `home_discover` region | `home_discover` | `mel_home_events` embed_discover |
+| Tonight | `block.block.myeventlane_theme_homepage_tonight.yml` | `homepage_tonight` | `upcoming_events` homepage_tonight |
+| Hidden Gems | `config/sync/block.block.myeventlane_theme_homepage_hidden_gems.yml` | `homepage_hidden_gems` | `upcoming_events` homepage_hidden_gems |
+| Community Favourites | `config/sync/block.block.myeventlane_theme_homepage_community_favourites.yml` | `homepage_community_favourites` | popular-events block |
+| Free & RSVP | `block.block.myeventlane_theme_homepage_free.yml` | `homepage_free` | `mel_home_events` under_20 |
+| Latest | `block.block.myeventlane_theme_homepage_latest.yml` | `homepage_latest` | `upcoming_events` homepage_latest |
+| **Recommended (Guide surface)** | `config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml` | `home_recommended` | `front_recommended_events` block_1; **visibility: authenticated users only** |
+| Blog | `block.block.myeventlane_theme_homepage_blog.yml` | `homepage_blog` | `mel_blog` homepage_preview |
 
-**Recommended order:** A → C → B → (optional, after sign-off) D. Groups A/B/C are pure Twig copy/markup; Group D is the only logic-bearing/tested change and is the natural deferral candidate if Phase 1A must remain template-only.
+### 3.5 Homepage rail order mechanism
 
-## Global validation (after all groups)
+**Confirmed:** order is **template-driven** — each rail is printed in sequence inside `page--front.html.twig`. Block weights in regions **cannot** reorder sections across regions.
+
+**Committed order (HEAD, 2026-06-17):**
+
+1. Featured (Community spotlight)  
+2. Discover (chips)  
+3. Tonight  
+4. Hidden Gems  
+5. Community Favourites  
+6. Free & RSVP  
+7. Latest  
+8. Recommended  
+9. Nearby  
+10. Online  
+11. Blog  
+12. Host CTA → Newsletter  
+
+**Uncommitted WIP** on the same branch reorders Discover to #1 and promotes Recommended above Tonight/Latest — see §8 Safety.
+
+### 3.6 Already implemented (reduces Phase 1A scope)
+
+These items were **not** in the 2026-06-14 audits but **are confirmed in HEAD today**:
+
+| Item | Evidence |
+|---|---|
+| Hidden Gems homepage rail | `page--front.html.twig` L109–122; `mel_home_show_hidden_gems` in `myeventlane_theme.theme` L1964 |
+| Community Favourites rail | `page--front.html.twig` L124–137; block config exists |
+| Hero discovery copy (partial) | `myeventlane-home-hero.html.twig` L21–23: *“Find your next favourite experience.”* |
+| **Hidden Gem** card badge | `EventMerchandisingPresenter.php` L121–124 → `'Hidden Gem'` with modifier `discovery-gold` |
+| **Spotlight** card badge (promoted) | `EventMerchandisingPresenter.php` L118–120 → `'Spotlight'` (replaces legacy `'Featured'`) |
+| Hidden Gems browse page | `page--view--upcoming-events--page-hidden-gems.html.twig` |
+| Unit tests for badge priority | `web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php` |
+
+### 3.7 Gaps vs brand (remaining Phase 1A work)
+
+| Gap | Brand reference | Current evidence |
+|---|---|---|
+| Rail order not location/Hidden-Gem-led | `homepage-system.md` § Homepage hierarchy | Tonight is #3; Hidden Gems #4; editorial Featured is #1 |
+| Blog + some subtitles still nightlife/utilitarian | `copy-guidelines.md`, `guide-character-system.md` | Blog: *“Guides for better nights out”* (`page--front.html.twig` L187) |
+| Recommended rail not Curator Guide voice | Curator phrase: *“I think you’ll love this.”* | *“Worth exploring next”* / *“Events popular with the community right now.”* |
+| Empty states neutral, not Guide-nudged | `guide-character-system.md` Helper/Explorer | *“Nothing here yet”* defaults; browse recovery links functional but not voiced |
+| **Spotlight** ≠ brand **Editor’s Pick** label | `event-card-system.md` § Approved badges | Presenter uses `'Spotlight'`, not `'Editor's Pick'` — re-voice candidate only |
+| **Community Favourite** card badge | `event-card-system.md` | **Not present** in presenter — **out of scope** (would be new badge logic) |
+
+---
+
+## 4. WHAT MUST NOT CHANGE
+
+- `HomepageSectionVisibility` query logic and `mel_home_show_*` guard conditions
+- View query filters, access checks, and Search API index configuration
+- Block placement config (regions, visibility rules, plugin IDs) — **including authenticated-only visibility on `front_recommended_events`**
+- Commerce, checkout, ticket, RSVP, capacity, and payment flows
+- Vendor/admin routes, Event Studio, and dashboard surfaces
+- `EventMerchandisingPresenter` badge **priority logic** (Sold out → Spotlight → Hidden Gem)
+- SCSS, design tokens, mascot assets, AI assistant (`myeventlane_help_assistant`), email templates
+- Entity fields (`field_hidden_gem` etc.) and badge eligibility criteria
+- Fallback hero SDC (`components/hero/hero.twig`) — inactive but must not be edited in this slice
+- Uncommitted SCSS/markup WIP in the working tree — **Phase 1A is copy + rail-order only; do not bundle visual refresh**
+
+---
+
+## 5. WHAT CAN CHANGE
+
+- Translatable string literals (`|t`) in the templates listed in §3.3
+- Order of existing `{% if mel_home_show_* %}` section blocks in `page--front.html.twig` (markup reorder only)
+- Optional re-label of **existing** presenter strings: `'Spotlight'` → `'Editor's Pick'` (PHP + unit test assertions)
+- Per-view empty-state overrides that already use `mel-view-empty-events` or `mel-browse-empty-recovery`
+- Recovery link **labels** in `mel-browse-empty-recovery.html.twig` (not route targets)
+
+---
+
+## 6. RULES
+
+- Drupal 11 presentation/logic separation: Twig for copy; services for logic.
+- Extend existing systems; no duplicate components, routes, or controllers.
+- Preserve all access boundaries and authenticated-only recommendation visibility.
+- Australian English; avoid exclusivity/FOMO vocabulary per `copy-guidelines.md`.
+- Maximum **two Guide moments** on homepage (`homepage-system.md` § Guide placement) — copy-only; no illustration in Phase 1A.
+- **Stop if unconfirmed:** do not add Community Favourite card badge, new Hidden Gem data layer, or Vibe Mixer placement (config/architecture — deferred).
+- Proposed strings below are **illustrative drafts for sign-off**, not final copy.
+
+---
+
+## 7. STEPS
+
+Work in four groups. After each group, stop, review, and run the validation command before continuing.
+
+### Group A — Homepage hero copy
+
+**Change A1 — Hero headline and supporting line**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | `myeventlane-home-hero.html.twig` L20–24: eyebrow `'MyEventLane'`, H1 `'Find your next favourite experience.'`, text `'Discover more of your city. Unexpected experiences. Real community.'`; L44 search placeholder; L69 `'Explore events'` CTA |
+| **File path** | `web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig` |
+| **Route affected** | `/home` |
+| **Current behaviour** | Hero already uses discovery-leaning copy (post–community-favourites work). Sub-line emphasises city/community, not weekend wonder. |
+| **Proposed behaviour** | Re-voice H1 + sub-line to Bright Edition wonder, e.g. H1 → `'Discover something wonderful this weekend.'`; text → `'Hidden gems, local favourites, and experiences you never knew existed — all in one place.'` Eyebrow, search placeholders, and primary CTA optional. **Copy-only; no markup/SCSS change in Phase 1A.** |
+| **Risk level** | **Low** |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` then load `/home` — confirm hero text, search form, rotator (if featured events present), and CTAs still work |
+| **Rollback step** | `git checkout -- web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig` |
+
+---
+
+### Group B — Homepage rail order + section headings + Guide recommendation block
+
+Execute as **one coordinated edit** to `page--front.html.twig`.
+
+**Change B1 — Discovery rail order**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | Template sequence in `page--front.html.twig`; brand target order in `docs/brand/homepage-system.md` § Homepage hierarchy; audits `homepage-audit.md` §2, `discovery-audit.md` §3 |
+| **File path** | `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` |
+| **Route affected** | `/home` |
+| **Current behaviour** | Featured → Discover → Tonight → Hidden Gems → Community Favourites → Free → Latest → Recommended → Nearby → Online → Blog |
+| **Proposed behaviour** | Reorder **existing** sections only (preserve each block’s `{% if %}` guard and `content:` region verbatim): **Tonight → Hidden Gems → Discover (chips) → Featured (Community spotlight) → Community Favourites → Latest → Recommended → Free → Nearby → Online → Blog → Host CTA → Newsletter**. Aligns with brand mobile priority (time-led + Hidden Gem before generic browse) without adding rails. |
+| **Risk level** | **Low–moderate** (single-template markup reorder; dedup/visibility logic unchanged) |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` → load `/home`; confirm each rail renders when data exists and hides when empty; `ddev drush watchdog:show --severity=Error` |
+| **Rollback step** | `git checkout -- web/themes/custom/myeventlane_theme/templates/page--front.html.twig` |
+
+**Change B2 — Section headings / subtitles (Guide voice)**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | Literals in `page--front.html.twig`: Featured L54–55; Discover L39–40; Tonight L100–101; Hidden Gems L115–116 (already Guide-voiced); Community Favourites L130–131; Free L145–146; Latest L85–86; Recommended L70–71; Blog L187–188 |
+| **File path** | `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` |
+| **Route affected** | `/home` |
+| **Current behaviour** | Mixed voice: Hidden Gems already uses Guide (*“The Guide has found…”*); Blog still *“Guides for better nights out”*; Recommended uses popularity framing, not Curator Guide |
+| **Proposed behaviour** | Copy-only `\|t` updates, e.g.: Featured → title `'Hidden gems the Guide loves'` / subtitle `'Come look at this — local experiences worth showing up for.'`; Recommended → `'Picked for you'` / `'The Guide thinks you'll love these.'`; Blog → `'Guides to discovering more'` / `'Ideas for finding, hosting, and growing local events.'`; Tonight subtitle → `'On tonight near you.'` Keep all `link_url` / `path()` calls unchanged. |
+| **Risk level** | **Low** |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` → `/home`; confirm headings render and “See all” links resolve |
+| **Rollback step** | Same file rollback as B1 |
+
+**Change B3 — In-flow Guide recommendation block (existing block only)**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | Block `config/sync/block.block.myeventlane_theme_views_block__front_recommended_events_block_1.yml` — `status: true`, `region: home_recommended`, `plugin: views_block:front_recommended_events-block_1`, visibility `authenticated` role; rendered via `page.home_recommended`; gated by `mel_home_show_recommended` (`myeventlane_theme.theme` L1956) |
+| **File path** | `page--front.html.twig` (position via B1; copy via B2) — **no config change** |
+| **Route affected** | `/home` (authenticated users with recommendation results) |
+| **Current behaviour** | Recommendation rail exists mid-page; heading *“Worth exploring next”*; anonymous users never see the block (by design) |
+| **Proposed behaviour** | **Reuse existing block** as the Curator Guide recommendation surface: promote position (B1, directly after Latest or Featured per sign-off) and apply Curator copy (B2). No new block, View, or component. |
+| **Risk level** | **Low** |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` → log in as authenticated user with activity; confirm rail renders in new position with updated heading; confirm anonymous `/home` unchanged except rail order of public sections |
+| **Rollback step** | Covered by B1/B2 rollback |
+
+**Assumption check:** An existing reusable recommendation block **is confirmed**. Rule satisfied — no new architecture.
+
+---
+
+### Group C — Empty-state copy (discovery surfaces)
+
+**Change C1 — Canonical view empty defaults**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | `mel-view-empty-events.html.twig` L10–15: title `'Nothing here yet'`, text `'Try a category, browse this weekend, or explore community spotlight on the homepage.'`, CTAs `'Explore events'` / `'Back to discovery'` |
+| **File path** | `web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig` |
+| **Route affected** | Homepage embeds (`mel_home_events`, tonight block fallback, etc.) |
+| **Current behaviour** | Neutral empty messaging |
+| **Proposed behaviour** | e.g. title `'No gems here just yet'`; text `'The Guide is always finding new experiences — check back soon or explore what's on across MyEventLane.'`; keep CTA targets unchanged |
+| **Risk level** | **Low** |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` → trigger a homepage rail empty state (or use a view with no results) |
+| **Rollback step** | `git checkout -- web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig` |
+
+**Change C2 — Browse recovery empty states**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | `mel-browse-empty-recovery.html.twig` (shared recovery links); `views-view--upcoming-events--page-events.html.twig` L43–46; `views-view--upcoming-events.html.twig` L42–62 `mel_empty_copy` map; `views-view--upcoming-events--page-category.html.twig` L75–76; `myeventlane-search-results.html.twig` L18–21; `views-view-unformatted--upcoming-events--homepage-tonight.html.twig` L15–21 |
+| **File path** | Templates above (primary: `mel-browse-empty-recovery.html.twig` + `views-view--upcoming-events.html.twig`) |
+| **Route affected** | `/events`, `/events/today`, `/events/this-weekend`, `/events/free`, `/events/popular`, `/events/hidden-gems`, `/events/category/%`, `/search` |
+| **Current behaviour** | Functional recovery paths; neutral titles (*“No events found”*, *“Nothing on today yet”*) |
+| **Proposed behaviour** | Re-voice titles/text to optimistic Explorer/Helper Guide tone per `copy-guidelines.md` § Empty search; **do not** change recovery link routes. Category page inline empty (L75–76) updated in same pass. **Do not** consolidate `.mel-empty` vs `.mel-empty-state` vocabulary — structural, out of scope. |
+| **Risk level** | **Low** |
+| **Config export required** | **No** |
+| **Validation command** | `ddev drush cr` → `/events?keys=zzzznoresult`, `/events/hidden-gems` (empty if no gems), `/search?q=zzzznoresult` |
+| **Rollback step** | `git checkout -- web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig web/modules/custom/myeventlane_search/templates/myeventlane-search-results.html.twig` |
+
+---
+
+### Group D — Event card badge language (optional; sign-off required)
+
+**Change D1 — Re-voice existing Spotlight label only**
+
+| Field | Detail |
+|---|---|
+| **Repository evidence** | `EventMerchandisingPresenter.php` L118–120 `'Spotlight'` when `is_promoted`; `'Hidden Gem'` L121–124 when `is_hidden_gem` (**already brand-aligned**); tests assert `'Spotlight'` and `'Hidden Gem'` in `EventMerchandisingPresenterTest.php` |
+| **File path** | `web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php` + `tests/src/Unit/EventMerchandisingPresenterTest.php` |
+| **Route affected** | All surfaces rendering event cards (`/home`, `/events`, `/search`, etc.) |
+| **Current behaviour** | Promoted events show **Spotlight** badge; hidden-gem field shows **Hidden Gem** badge |
+| **Proposed behaviour** | Re-label `'Spotlight'` → `'Editor's Pick'` only (maps to brand approved badge in `event-card-system.md`). **Do not** add Community Favourite, Trending Tonight, Nearby, or Just Added badges — not supported in presenter today. |
+| **Risk level** | **Moderate** (logic-bearing PHP + unit tests). **Recommend deferring to Phase 1B** if Phase 1A must stay Twig-only. |
+| **Config export required** | **No** |
+| **Validation command** | `ddev exec ./vendor/bin/phpunit web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php` then `ddev drush cr` + visual check of a promoted card |
+| **Rollback step** | `git checkout -- web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php` |
+
+**STOP — not in scope:** Community Favourite / Trending Tonight / Nearby / Just Added card badges — *repository evidence not found* for presenter support. Adding them would be new badge logic, not re-voice.
+
+---
+
+### Recommended execution order
+
+| Order | Group | Files | Risk |
+|---|---|---|---|
+| 1 | A | `myeventlane-home-hero.html.twig` | Low |
+| 2 | C | empty-state templates | Low |
+| 3 | B | `page--front.html.twig` (single coordinated edit) | Low–moderate |
+| 4 | D (optional) | `EventMerchandisingPresenter.php` + test | Moderate |
+
+**Global validation (after all applied groups):**
+
 ```bash
 ddev drush cr
-ddev drush watchdog:show --severity=Error    # confirm no new template/render errors
-npm run build                                # rebuild theme assets if any theme file changed
-# Manual: /home, /events, /events/category/<term>, /search, /help/search
+ddev drush watchdog:show --severity=Error
+# Manual: /home (anon + authenticated), /events, /events/hidden-gems, /search?q=zzzz
 ```
-> No `ddev drush cex` needed — Phase 1A changes no config entities.
 
-## Global rollback
+No `ddev drush cex` — Phase 1A changes no config entities.
+
+---
+
+## 8. SAFETY
+
+### Working tree status (2026-06-17)
+
+**The working tree is NOT clean.** Uncommitted changes exist on `feature/homepage-visual-refresh-phase-1`:
+
+| File | Notes |
+|---|---|
+| `web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig` | Markup wrapper changes (search shell) — **includes non–Phase 1A structure** |
+| `web/themes/custom/myeventlane_theme/templates/page--front.html.twig` | Partial rail reorder WIP |
+| `web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss` | **Out of Phase 1A scope** |
+| `web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss` | **Out of Phase 1A scope** |
+| `web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss` | **Out of Phase 1A scope** |
+
+**Last commit:** `571acb94d` — *Merge pull request #598 from anna-pye/feature/community-favourites-visibility-verification*
+
+**Before starting Phase 1A implementation:**
+
+1. Commit or stash unrelated visual-refresh WIP explicitly (human decision).
+2. Prefer a **copy-only branch** cut from `571acb94d` (or current HEAD after WIP is resolved) to avoid mixing SCSS with copy.
+
+### Rollback
+
+Per-file rollback:
+
 ```bash
 git checkout -- \
   web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig \
   web/themes/custom/myeventlane_theme/templates/page--front.html.twig \
-  web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig
-# Group D (only if applied):
-git checkout -- \
-  web/modules/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php \
-  web/modules/custom/myeventlane_event/tests/src/Unit/EventMerchandisingPresenterTest.php
+  web/themes/custom/myeventlane_theme/templates/includes/mel-view-empty-events.html.twig \
+  web/themes/custom/myeventlane_theme/templates/includes/mel-browse-empty-recovery.html.twig \
+  web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events.html.twig \
+  web/themes/custom/myeventlane_event/src/EventCard/EventMerchandisingPresenter.php
 ```
-Or revert the whole slice in one commit: `git revert <phase-1a-commit-sha>`.
+
+Whole-slice rollback (after commit):
+
+```bash
+git revert <phase-1a-commit-sha>
+```
+
+Return to last known-good commit:
+
+```bash
+git checkout 571acb94d -- <paths above>
+```
 
 ---
 
-## Explicitly OUT of Phase 1A (per rules / unconfirmed)
+## 9. DONE MEANS
+
+Phase 1A is complete when all of the following are true:
+
+| Criterion | Verify |
+|---|---|
+| Hero copy matches signed-off Bright Edition strings | Load `/home` — H1 + sub-line |
+| Homepage rails follow agreed order (§7 B1) | Visual inspection `/home`; no missing/duplicated sections |
+| Section headings use Guide/Curator voice where specified | `/home` heading scan; blog + recommended updated |
+| Empty states on browse/search use Guide-nudged copy | `/events?keys=zzzznoresult`, `/search?q=zzzznoresult` |
+| Existing recommendation block reused in promoted position (authenticated) | Logged-in `/home` when recommendations exist |
+| **Hidden Gem** badge unchanged and still renders | Card on `/events/hidden-gems` or homepage Hidden Gems rail |
+| No new components, blocks, routes, or config exports | `git diff config/sync` empty |
+| No SCSS/token/mascot/AI/email/Commerce changes in the slice | `git diff -- '*.scss' '*.yml'` empty for Phase 1A commit |
+| No PHP errors | `ddev drush watchdog:show --severity=Error` clean after cache rebuild |
+| Optional Group D only if explicitly approved | PHPUnit green + promoted card shows `'Editor's Pick'` |
+
+**Residual risks:**
+
+- `/events/nearby` and `/events/online` “See all” links on homepage point to `page_events` / `page_free` fallbacks (`page--front.html.twig` L161, L175) — routing mismatch flagged in `discovery-audit.md`; **not fixed in Phase 1A**.
+- Recommendation rail invisible to anonymous users by block visibility — intentional; Curator copy applies only when the block renders.
+- Uncommitted visual-refresh SCSS on the branch must not ship mixed into a copy-only Phase 1A PR.
+
+---
+
+## Explicitly OUT of Phase 1A
 
 | Item | Reason |
 |---|---|
-| "Hidden Gem" badge **type** | *Repository evidence not found* — no existing badge type; would be new component/architecture |
-| Token / SCSS / palette changes | Excluded by scope (Phase 2) |
-| Mascot / hero art changes | Excluded by scope |
-| AI assistant → "Ask the Guide" | Excluded by scope (Phase 3) |
-| Email / digest copy | Excluded by scope (Phase 5) |
-| Empty-state vocabulary consolidation (`.mel-empty` vs `.mel-empty-state`) | Structural, not copy — out of scope |
-| Block placement / visibility-condition changes | Reuse existing config unchanged |
-| `/events/nearby`, `/events/online` validation | Routing question, not copy — track separately (`discovery-audit.md §1`) |
+| SCSS / token / palette changes | Excluded by scope |
+| Mascot / hero art / Guide illustrations | Excluded by scope |
+| AI assistant → “Ask the Guide” | Excluded by scope |
+| Email / digest copy | Excluded by scope |
+| Vibe Mixer block placement | Config + architecture — deferred (`homepage-audit.md` §4) |
+| New Hidden Gems View/display or `field_hidden_gem` logic | Already exists in HEAD |
+| Community Favourite / Trending Tonight / Nearby / Just Added **card badges** | Not supported in presenter — would be new logic |
+| Empty-state vocabulary consolidation (`.mel-empty` vs `.mel-empty-state`) | Structural — deferred (`component-inventory.md` §E) |
+| `/events/nearby`, `/events/online` route builds | Validate separately — not copy |
+| Hero markup/SCSS visual refresh | Separate work on current branch WIP |
 
 ---
 
-## Sign-off checklist before implementation
-- [ ] Final hero + heading + empty-state copy approved (drafts above are illustrative).
-- [ ] Decision on Group D (re-voice `'Featured'` badge now, or defer to Phase 1B).
-- [ ] Confirm rail-order preference (proposed: Featured → Recommended → Tonight → Discover → …).
-- [ ] Confirm no parallel work is editing `page--front.html.twig` (single-file coordination).
+## Sign-off checklist (before implementation)
+
+- [ ] Final hero, heading, and empty-state copy approved (drafts in §7 are illustrative).
+- [ ] Rail order preference confirmed (proposed B1 order vs brand `homepage-system.md` table).
+- [ ] Decision on Group D: re-voice `'Spotlight'` → `'Editor's Pick'` now, or defer to Phase 1B.
+- [ ] Working tree cleaned or branched — no SCSS bundled into copy PR.
+- [ ] No parallel edits to `page--front.html.twig` during Group B.

--- a/web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig
+++ b/web/modules/custom/myeventlane_front/templates/myeventlane-home-hero.html.twig
@@ -23,37 +23,47 @@
         {{ 'Discover more of your city. Unexpected experiences. Real community.'|t }}
       </p>
 
-      <form
-        class="mel-home-hero__search"
-        role="search"
-        action="{{ search_events_url|default(path('view.upcoming_events.page_events')) }}"
-        method="get"
-        data-events-url="{{ search_events_url|default(path('view.upcoming_events.page_events')) }}"
-        data-search-url="{{ search_site_url|default(path('mel_search.view')) }}"
-      >
-        <div class="mel-home-hero__search-fields">
-          <label class="visually-hidden" for="mel-home-search">{{ 'Search events'|t }}</label>
-          <input
-            id="mel-home-search"
-            class="mel-home-hero__search-input mel-home-hero__search-input--query"
-            name="search"
-            type="search"
-            placeholder="{{ 'Search events, organisers, or places'|t }}"
-            autocomplete="off"
-          />
-          <span class="mel-home-hero__search-divider" aria-hidden="true"></span>
-          <label class="visually-hidden" for="mel-home-search-location">{{ 'Location'|t }}</label>
-          <input
-            id="mel-home-search-location"
-            class="mel-home-hero__search-input mel-home-hero__search-input--location"
-            name="location"
-            type="text"
-            placeholder="{{ 'Suburb or city'|t }}"
-            autocomplete="address-level2"
-          />
-        </div>
-        <button type="submit" class="mel-home-hero__search-submit">{{ 'Search'|t }}</button>
-      </form>
+      <div class="mel-home-hero__search-shell">
+        <form
+          class="mel-home-hero__search"
+          role="search"
+          action="{{ search_events_url|default(path('view.upcoming_events.page_events')) }}"
+          method="get"
+          data-events-url="{{ search_events_url|default(path('view.upcoming_events.page_events')) }}"
+          data-search-url="{{ search_site_url|default(path('mel_search.view')) }}"
+        >
+          <div class="mel-home-hero__search-fields">
+            <div class="mel-home-hero__search-field mel-home-hero__search-field--query">
+              <label class="visually-hidden" for="mel-home-search">{{ 'Search events'|t }}</label>
+              <span class="mel-home-hero__search-icon mel-home-hero__search-icon--query" aria-hidden="true"></span>
+              <input
+                id="mel-home-search"
+                class="mel-home-hero__search-input mel-home-hero__search-input--query"
+                name="search"
+                type="search"
+                placeholder="{{ 'Search events, organisers, or places'|t }}"
+                autocomplete="off"
+              />
+            </div>
+            <span class="mel-home-hero__search-divider" aria-hidden="true"></span>
+            <div class="mel-home-hero__search-field mel-home-hero__search-field--location">
+              <label class="visually-hidden" for="mel-home-search-location">{{ 'Location'|t }}</label>
+              <span class="mel-home-hero__search-icon mel-home-hero__search-icon--location" aria-hidden="true"></span>
+              <input
+                id="mel-home-search-location"
+                class="mel-home-hero__search-input mel-home-hero__search-input--location"
+                name="location"
+                type="text"
+                placeholder="{{ 'Suburb or city'|t }}"
+                autocomplete="address-level2"
+              />
+            </div>
+          </div>
+          <button type="submit" class="mel-home-hero__search-submit">
+            <span class="mel-home-hero__search-submit-label">{{ 'Search'|t }}</span>
+          </button>
+        </form>
+      </div>
 
       <div class="mel-home-hero__actions" role="group" aria-label="{{ 'Homepage actions'|t }}">
         <a class="mel-btn mel-btn--primary mel-home-hero__primary" href="{{ path('view.upcoming_events.page_events') }}">

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -23,9 +23,9 @@
   min-width: 0;
   font-family: mel.$mel-ds-font-main;
   background: transparent;
-  border-radius: clamp(20px, 2.5vw, 32px);
+  border-radius: clamp(18px, 2.2vw, 28px);
   overflow: hidden;
-  box-shadow: mel.$mel-ds-shadow-soft;
+  box-shadow: 0 10px 28px rgba(36, 48, 58, 0.08);
   border: 0;
   transition:
     transform melmotion.$mel-transition-base,
@@ -39,8 +39,8 @@
 
 @media (hover: hover) and (pointer: fine) {
   .mel-event-card:hover {
-    transform: translateY(-6px);
-    box-shadow: var(--mel-shadow-2);
+    transform: translateY(-4px);
+    box-shadow: 0 16px 40px rgba(36, 48, 58, 0.12);
   }
 
   .mel-event-card:hover:focus-within {
@@ -386,7 +386,7 @@
 
 .mel-event-card__body,
 .mel-event-card__content {
-  padding: 14px 16px 16px;
+  padding: 16px 18px 18px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -440,17 +440,16 @@
 }
 
 .mel-event-card__title {
-  font-size: 17px;
-  font-weight: 700;
-  line-height: 1.25;
-  margin: 0 0 8px;
+  font-size: clamp(1rem, 1.6vw, 1.0625rem);
+  font-weight: 800;
+  line-height: 1.22;
+  margin: 0 0 6px;
   color: mel.$mel-ds-color-text;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  min-height: calc(1.25em * 2);
-  // WebKit line-clamp can clip the first/last glyph at the box edge (listing grids).
+  min-height: calc(1.22em * 2);
   padding-inline: 1px;
 }
 
@@ -1472,6 +1471,54 @@
     &:hover {
       box-shadow: var(--mel-shadow-2, 0 12px 32px rgba(36, 48, 58, 0.14));
       transform: translateY(-2px);
+    }
+  }
+}
+
+// Poster discovery layout — image-first cards for homepage grids.
+.mel-event-card--compact.mel-event-card--poster {
+  background: transparent;
+  box-shadow: none;
+
+  .mel-event-card__link {
+    border-radius: clamp(18px, 2.2vw, 24px);
+    overflow: hidden;
+    background: mel.$mel-ds-color-surface;
+    box-shadow: 0 10px 28px rgba(36, 48, 58, 0.08);
+    transition:
+      transform 0.22s ease,
+      box-shadow 0.22s ease;
+  }
+
+  .mel-event-card__image,
+  .mel-event-card__media {
+    aspect-ratio: 4 / 3;
+  }
+
+  .mel-event-card__body,
+  .mel-event-card__content {
+    padding: 10px 14px 14px;
+    gap: 2px;
+  }
+
+  .mel-event-card__title {
+    font-size: clamp(1.0625rem, 1.7vw, 1.1875rem);
+    font-weight: 800;
+    line-height: 1.18;
+    min-height: 0;
+    margin: 0;
+    -webkit-line-clamp: 2;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      transform: none;
+      box-shadow: none;
+    }
+
+    &:hover .mel-event-card__link {
+      transform: translateY(-3px);
+      box-shadow: 0 16px 36px rgba(36, 48, 58, 0.12);
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -9,20 +9,19 @@
 .mel-home-hero {
   position: relative;
   overflow: hidden;
-  padding: clamp(2rem, 5vw, 4.75rem) 24px clamp(1.5rem, 4vw, 3rem);
+  padding: clamp(2.25rem, 6vw, 5.25rem) clamp(20px, 4vw, 32px) clamp(2rem, 5vw, 3.5rem);
   background:
-    radial-gradient(circle at 12% 18%, color-mix(in srgb, mel.$mel-ds-color-primary 20%, transparent), transparent 34rem),
-    radial-gradient(circle at 88% 10%, rgba(255, 210, 147, 0.36), transparent 28rem),
-    radial-gradient(circle at 72% 84%, rgba(186, 230, 210, 0.34), transparent 30rem),
-    linear-gradient(135deg, #fff7f2 0%, #f7f1ff 52%, #eefaf4 100%);
+    radial-gradient(circle at 10% 14%, color-mix(in srgb, mel.$mel-ds-color-primary 12%, transparent), transparent 32rem),
+    radial-gradient(circle at 90% 8%, color-mix(in srgb, mel.$mel-ds-color-accent 10%, transparent), transparent 28rem),
+    linear-gradient(180deg, #fffdfb 0%, #faf8ff 48%, #f8fbf9 100%);
 
   &::before {
     content: '';
     position: absolute;
     inset: 0;
-    background-image: radial-gradient(rgba(41, 50, 65, 0.08) 1px, transparent 1px);
-    background-size: 18px 18px;
-    mask-image: linear-gradient(90deg, #000 0%, transparent 76%);
+    background-image: radial-gradient(rgba(41, 50, 65, 0.04) 1px, transparent 1px);
+    background-size: 22px 22px;
+    mask-image: linear-gradient(90deg, #000 0%, transparent 68%);
     pointer-events: none;
   }
 }
@@ -32,14 +31,14 @@
   z-index: 1;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 28px;
-  width: min(100%, 1240px);
+  gap: clamp(32px, 5vw, 56px);
+  width: min(100%, 1200px);
   margin: 0 auto;
 
   @include breakpoints.mel-break(lg) {
-    grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr);
+    grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
     align-items: center;
-    gap: 48px;
+    gap: clamp(48px, 6vw, 72px);
   }
 }
 
@@ -60,45 +59,53 @@
 }
 
 .mel-home-hero__title {
-  max-width: 11ch;
+  max-width: 12ch;
   margin: 0;
   color: mel.$mel-ds-color-text;
   font-family: mel.$mel-ds-font-main;
-  font-size: clamp(2.75rem, 8vw, 5.6rem);
+  font-size: clamp(2.5rem, 7.5vw, 5rem);
   font-weight: 850;
-  letter-spacing: -0.055em;
-  line-height: 0.94;
+  letter-spacing: -0.05em;
+  line-height: 0.96;
 }
 
 .mel-home-hero__text {
-  max-width: 42rem;
-  margin: 18px 0 0;
-  color: color-mix(in srgb, mel.$mel-ds-color-text 74%, #fff 26%);
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  line-height: 1.58;
+  max-width: 38rem;
+  margin: clamp(16px, 2.5vw, 22px) 0 0;
+  color: color-mix(in srgb, mel.$mel-ds-color-text 68%, mel.$mel-ds-color-muted 32%);
+  font-size: clamp(1.0625rem, 2.1vw, 1.25rem);
+  line-height: 1.55;
+}
+
+.mel-home-hero__search-shell {
+  width: min(100%, 760px);
+  margin-top: clamp(24px, 4vw, 36px);
 }
 
 .mel-home-hero__search {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  width: min(100%, 720px);
-  margin-top: 24px;
-  padding: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.68);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: 0 18px 54px rgba(98, 81, 130, 0.14);
+  width: 100%;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 6%, #fff 94%);
+  border-radius: clamp(20px, 3vw, 28px);
+  background: color-mix(in srgb, #fff 88%, mel.$mel-ds-color-bg 12%);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 20px 48px rgba(74, 63, 104, 0.1);
 
   @supports (backdrop-filter: blur(1px)) {
-    backdrop-filter: blur(18px);
-    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
   }
 
   @include breakpoints.mel-break(sm) {
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
     gap: 8px;
+    padding: 8px;
+    border-radius: 999px;
   }
 }
 
@@ -110,9 +117,51 @@
   flex: 1 1 auto;
 
   @include breakpoints.mel-break(sm) {
-    grid-template-columns: minmax(0, 1.1fr) auto minmax(0, 0.9fr);
+    grid-template-columns: minmax(0, 1.15fr) auto minmax(0, 0.85fr);
     align-items: center;
     gap: 0;
+  }
+}
+
+.mel-home-hero__search-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.mel-home-hero__search-icon {
+  display: none;
+
+  @include breakpoints.mel-break(sm) {
+    position: absolute;
+    left: 14px;
+    z-index: 1;
+    display: block;
+    width: 18px;
+    height: 18px;
+    background-color: color-mix(in srgb, mel.$mel-ds-color-muted 70%, mel.$mel-ds-color-text 30%);
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    -webkit-mask-size: contain;
+    pointer-events: none;
+  }
+}
+
+.mel-home-hero__search-icon--query {
+  @include breakpoints.mel-break(sm) {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.25'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cpath d='M20 20l-3.5-3.5'/%3E%3C/svg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.25'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cpath d='M20 20l-3.5-3.5'/%3E%3C/svg%3E");
+  }
+}
+
+.mel-home-hero__search-icon--location {
+  @include breakpoints.mel-break(sm) {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.25'%3E%3Cpath d='M12 21s7-4.35 7-10a7 7 0 1 0-14 0c0 5.65 7 10 7 10z'/%3E%3Ccircle cx='12' cy='11' r='2.5'/%3E%3C/svg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.25'%3E%3Cpath d='M12 21s7-4.35 7-10a7 7 0 1 0-14 0c0 5.65 7 10 7 10z'/%3E%3Ccircle cx='12' cy='11' r='2.5'/%3E%3C/svg%3E");
   }
 }
 
@@ -129,17 +178,24 @@
 }
 
 .mel-home-hero__search-input {
+  width: 100%;
   min-width: 0;
-  min-height: 48px;
+  min-height: 52px;
   padding: 0 18px;
   border: 0;
-  border-radius: 999px;
+  border-radius: clamp(14px, 2vw, 999px);
   background: transparent;
   color: mel.$mel-ds-color-text;
   font: inherit;
+  font-size: clamp(1rem, 2vw, 1.0625rem);
+
+  @include breakpoints.mel-break(sm) {
+    min-height: 56px;
+    padding-left: 42px;
+  }
 
   &::placeholder {
-    color: mel.$mel-ds-color-muted;
+    color: color-mix(in srgb, mel.$mel-ds-color-muted 88%, mel.$mel-ds-color-text 12%);
   }
 
   &:focus {
@@ -147,22 +203,41 @@
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 3px color-mix(in srgb, mel.$mel-ds-color-primary 28%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, mel.$mel-ds-color-primary 24%, transparent);
   }
 }
 
 .mel-home-hero__search-submit {
   flex: 0 0 auto;
-  min-height: 48px;
-  padding: 0 22px;
+  min-height: 52px;
+  padding: 0 clamp(22px, 4vw, 28px);
   border: 0;
-  border-radius: 999px;
+  border-radius: clamp(14px, 2vw, 999px);
   background: mel.$mel-ds-color-primary;
   color: #fff;
   cursor: pointer;
   font-weight: 800;
+  font-size: clamp(1rem, 2vw, 1.0625rem);
   white-space: nowrap;
-  box-shadow: 0 10px 28px color-mix(in srgb, mel.$mel-ds-color-primary 32%, transparent);
+  box-shadow: 0 12px 32px color-mix(in srgb, mel.$mel-ds-color-primary 28%, transparent);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+
+  @include breakpoints.mel-break(sm) {
+    min-height: 56px;
+    align-self: stretch;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 36px color-mix(in srgb, mel.$mel-ds-color-primary 34%, transparent);
+    }
+  }
 
   &:focus-visible {
     outline: none;
@@ -176,8 +251,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 14px 18px;
-  margin-top: 18px;
+  gap: 14px 20px;
+  margin-top: clamp(20px, 3vw, 28px);
 }
 
 .mel-home-hero__secondary {
@@ -187,7 +262,7 @@
 
 .mel-home-hero__pills {
   width: min(100%, 760px);
-  margin-top: 22px;
+  margin-top: clamp(24px, 3vw, 32px);
 }
 
 .mel-home-hero__pills .mel-category-pills,
@@ -237,14 +312,14 @@
 .mel-home-hero__art-frame {
   position: relative;
   min-height: clamp(220px, 34vw, 420px);
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  border-radius: clamp(24px, 4vw, 38px);
+  border: 1px solid color-mix(in srgb, #fff 72%, mel.$mel-ds-color-text 28%);
+  border-radius: clamp(28px, 4vw, 40px);
   overflow: hidden;
   background:
-    linear-gradient(145deg, rgba(242, 109, 91, 0.22), rgba(124, 131, 253, 0.24));
+    linear-gradient(145deg, color-mix(in srgb, mel.$mel-ds-color-primary 14%, #fff), color-mix(in srgb, mel.$mel-ds-color-accent 12%, #fff));
   box-shadow:
-    0 22px 64px rgba(54, 45, 77, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    0 24px 56px rgba(54, 45, 77, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.65);
 
   picture {
     display: block;

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -270,11 +270,6 @@
   font-size: 24px;
   line-height: 1;
   box-shadow: 0 10px 28px rgba(55, 45, 82, 0.08);
-}
-
-.mel-page--home .mel-featured-carousel__button,
-.mel-page--home .mel-featured-carousel__dot {
-  border: 0;
   cursor: pointer;
 }
 
@@ -288,6 +283,8 @@
   width: 9px;
   height: 9px;
   padding: 0;
+  border: 0;
+  cursor: pointer;
   border-radius: 999px;
   background: color-mix(in srgb, mel.$mel-ds-color-text 22%, transparent);
   transition:

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -7,39 +7,38 @@
 
 .mel-page--home {
   background:
-    radial-gradient(circle at 8% 10%, rgba(242, 109, 91, 0.05), transparent 30rem),
-    radial-gradient(circle at 92% 38%, rgba(124, 131, 253, 0.06), transparent 32rem);
+    radial-gradient(circle at 6% 8%, rgba(242, 109, 91, 0.04), transparent 28rem),
+    radial-gradient(circle at 94% 32%, rgba(124, 131, 253, 0.05), transparent 30rem),
+    linear-gradient(180deg, #fffdfb 0%, #faf9fc 100%);
 }
 
-// Editorial homepage rhythm — section gaps (hero → 64px, spotlight → 56px, rails → 48px).
-.mel-page--home > .mel-section--featured {
-  padding-top: var(--mel-space-8);
-  padding-bottom: calc(var(--mel-space-7) / 2);
-}
-
+// Editorial homepage rhythm — generous whitespace between primary rails.
 .mel-page--home > .mel-section--discover-chips {
-  padding-top: calc(var(--mel-space-7) / 2);
-  padding-bottom: calc(var(--mel-space-7) / 2);
+  padding-top: clamp(32px, 5vw, 48px);
+  padding-bottom: clamp(24px, 4vw, 40px);
 }
 
-.mel-page--home > .mel-section--tonight {
-  padding-top: calc(var(--mel-space-7) / 2);
-  padding-bottom: calc(var(--mel-space-7) / 2);
-}
-
-.mel-page--home > .mel-section--free-rsvp {
-  padding-top: calc(var(--mel-space-7) / 2);
-  padding-bottom: calc(var(--mel-space-7) / 2);
-}
-
-.mel-page--home > .mel-section--latest {
-  padding-top: calc(var(--mel-space-7) / 2);
-  padding-bottom: calc(var(--mel-space-7) / 2);
+.mel-page--home > .mel-section--featured {
+  padding-top: clamp(8px, 2vw, 16px);
+  padding-bottom: clamp(32px, 5vw, 56px);
 }
 
 .mel-page--home > .mel-section--recommended {
-  padding-top: calc(var(--mel-space-7) / 2);
-  padding-bottom: calc(var(--mel-space-7) / 2);
+  padding-top: clamp(8px, 2vw, 16px);
+  padding-bottom: clamp(28px, 4vw, 48px);
+}
+
+.mel-page--home > .mel-section--latest {
+  padding-top: clamp(8px, 2vw, 16px);
+  padding-bottom: clamp(28px, 4vw, 48px);
+}
+
+.mel-page--home > .mel-section--tonight,
+.mel-page--home > .mel-section--hidden-gems,
+.mel-page--home > .mel-section--community-favourites,
+.mel-page--home > .mel-section--free-rsvp {
+  padding-top: clamp(12px, 2.5vw, 24px);
+  padding-bottom: clamp(24px, 4vw, 40px);
 }
 
 .mel-page--home .mel-section {
@@ -51,7 +50,19 @@
 }
 
 .mel-page--home .mel-section__header {
-  margin-bottom: 16px;
+  margin-bottom: clamp(18px, 3vw, 28px);
+  gap: clamp(12px, 2vw, 20px);
+}
+
+.mel-page--home .mel-section__intro {
+  max-width: 42rem;
+}
+
+.mel-page--home .mel-section__subtitle {
+  margin-top: 8px;
+  font-size: clamp(0.9375rem, 1.8vw, 1.0625rem);
+  line-height: 1.5;
+  color: color-mix(in srgb, mel.$mel-ds-color-muted 82%, mel.$mel-ds-color-text 18%);
 }
 
 // Typography hierarchy — composition only (section titles, not card chrome).
@@ -63,33 +74,31 @@
 }
 
 .mel-page--home .mel-section--discover-chips .mel-section__title {
-  font-size: clamp(1.3125rem, 2.4vw, 1.625rem);
+  font-size: clamp(1.375rem, 2.6vw, 1.75rem);
   font-weight: 800;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.03em;
 }
 
-.mel-page--home .mel-section--tonight .mel-section__title {
-  font-size: clamp(1.3125rem, 2.4vw, 1.625rem);
+.mel-page--home .mel-section--recommended .mel-section__title {
+  font-size: clamp(1.375rem, 2.6vw, 1.75rem);
   font-weight: 800;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.03em;
+  color: mel.$mel-ds-color-text;
+}
+
+.mel-page--home .mel-section--recommended .mel-section__subtitle {
+  font-size: clamp(0.9375rem, 1.8vw, 1.0625rem);
+  color: color-mix(in srgb, mel.$mel-ds-color-muted 82%, mel.$mel-ds-color-text 18%);
 }
 
 .mel-page--home .mel-section--latest .mel-section__title,
-.mel-page--home .mel-section--free-rsvp .mel-section__title {
-  font-size: 22px;
-  font-weight: 700;
+.mel-page--home .mel-section--free-rsvp .mel-section__title,
+.mel-page--home .mel-section--tonight .mel-section__title,
+.mel-page--home .mel-section--hidden-gems .mel-section__title,
+.mel-page--home .mel-section--community-favourites .mel-section__title {
+  font-size: clamp(1.25rem, 2.4vw, 1.625rem);
+  font-weight: 800;
   letter-spacing: -0.025em;
-}
-
-.mel-page--home .mel-section--recommended.mel-section--secondary .mel-section__title {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: mel.$mel-ds-color-muted;
-}
-
-.mel-page--home .mel-section--recommended.mel-section--secondary .mel-section__subtitle {
-  font-size: 13px;
-  color: color-mix(in srgb, mel.$mel-ds-color-muted 88%, mel.$mel-ds-color-text);
 }
 
 .mel-page--home .mel-section--tonight .mel-section__header {
@@ -115,6 +124,28 @@
   outline: 3px solid color-mix(in srgb, mel.$mel-ds-color-primary 36%, transparent);
   outline-offset: 3px;
   border-radius: 999px;
+}
+
+// Homepage discover chip bar — softer pills, thumb-friendly scroll.
+.mel-page--home .mel-section--discover-chips .mel-filter-chip-row {
+  gap: 12px;
+  margin: 0 0 clamp(18px, 3vw, 28px);
+  padding: 4px 2px 8px;
+}
+
+.mel-page--home .mel-section--discover-chips .mel-filter-chip {
+  min-height: 44px;
+  padding: 10px 18px;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 6%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, #fff 90%, mel.$mel-ds-color-bg 10%);
+  box-shadow: 0 8px 20px rgba(74, 63, 104, 0.06);
+  font-weight: 600;
+}
+
+.mel-page--home .mel-section--discover-chips .mel-filter-chip--active {
+  border-color: transparent;
+  box-shadow: 0 10px 24px rgba(242, 109, 91, 0.22);
 }
 
 // ---------------------------------------------------------------------------
@@ -223,28 +254,28 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  margin-top: 14px;
+  gap: 14px;
+  margin-top: clamp(16px, 2.5vw, 24px);
+}
+
+.mel-page--home .mel-featured-carousel__button {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, #fff 92%, mel.$mel-ds-color-bg 8%);
+  color: mel.$mel-ds-color-text;
+  font-size: 24px;
+  line-height: 1;
+  box-shadow: 0 10px 28px rgba(55, 45, 82, 0.08);
 }
 
 .mel-page--home .mel-featured-carousel__button,
 .mel-page--home .mel-featured-carousel__dot {
   border: 0;
   cursor: pointer;
-}
-
-.mel-page--home .mel-featured-carousel__button {
-  display: inline-grid;
-  place-items: center;
-  width: 42px;
-  height: 42px;
-  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 10%, transparent);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.78);
-  color: mel.$mel-ds-color-text;
-  font-size: 24px;
-  line-height: 1;
-  box-shadow: 0 10px 28px rgba(55, 45, 82, 0.1);
 }
 
 .mel-page--home .mel-featured-carousel__dots {
@@ -460,7 +491,10 @@
 .mel-page--home .mel-section--latest,
 .mel-page--home .mel-section--recommended,
 .mel-page--home .mel-section--tonight,
-.mel-page--home .mel-section--discover {
+.mel-page--home .mel-section--hidden-gems,
+.mel-page--home .mel-section--community-favourites,
+.mel-page--home .mel-section--free-rsvp,
+.mel-page--home .mel-section--discover:not(.mel-section--discover-chips) {
   .mel-events-date-filters,
   .mel-filter-chip-row,
   .mel-front-filters,
@@ -482,7 +516,7 @@
   width: min(34vw, 360px);
   height: min(34vw, 360px);
   border-radius: 999px;
-  background: radial-gradient(circle, rgba(124, 131, 253, 0.12), transparent 68%);
+  background: radial-gradient(circle, rgba(124, 131, 253, 0.1), transparent 68%);
   pointer-events: none;
 }
 
@@ -494,10 +528,12 @@
 .mel-page--home .mel-section--tonight .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--free-rsvp .mel-grid.mel-grid--events,
 .mel-page--home .mel-section--free .mel-grid.mel-grid--events,
-.mel-page--home .mel-section--time .mel-grid.mel-grid--events {
+.mel-page--home .mel-section--time .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--hidden-gems .mel-grid.mel-grid--events,
+.mel-page--home .mel-section--community-favourites .mel-grid.mel-grid--events {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 16px;
+  gap: clamp(16px, 2.5vw, 22px);
   align-items: stretch;
 
   @media (width <= 1024px) {
@@ -646,73 +682,30 @@
 
 // Poster emotional design — homepage discovery rails.
 .mel-page--home .mel-event-card--compact.mel-event-card--poster {
-  background: transparent;
-  box-shadow: none;
-
-  .mel-event-card__link {
-    border-radius: mel.$mel-ds-radius-md;
-    overflow: hidden;
-    background: mel.$mel-ds-color-surface;
-    box-shadow: var(--mel-shadow-1, #{mel.$mel-ds-shadow-soft});
-  }
-
-  .mel-event-card__image,
-  .mel-event-card__media {
-    aspect-ratio: 4 / 3;
-  }
-
-  .mel-event-card__body,
-  .mel-event-card__content {
-    padding: 6px 10px 8px;
-    gap: 0;
-  }
-
-  .mel-event-card__title {
-    font-size: clamp(1.0625rem, 1.6vw, 1.1875rem);
-    font-weight: 800;
-    line-height: 1.18;
-    min-height: 0;
-    margin: 0;
-    -webkit-line-clamp: 2;
-  }
-
   .mel-event-card__ticket-type-row {
-    margin: 3px 0 0;
-  }
-
-  .mel-event-card__ticket-type-pill.mel-event-pill--sm {
-    padding: 2px 8px;
-    font-size: 11px;
-    line-height: 1.2;
+    margin: 4px 0 0;
   }
 
   .mel-event-card__snapshot,
   .mel-event-card__when {
-    margin: 2px 0 0;
-    font-size: 12px;
-    color: mel.$mel-ds-color-muted;
+    margin: 3px 0 0;
+    font-size: 13px;
+    color: color-mix(in srgb, mel.$mel-ds-color-muted 88%, mel.$mel-ds-color-text 12%);
   }
 
   .mel-event-card__going--prominent {
-    margin: 2px 0 0;
+    margin: 4px 0 0;
     font-size: 13px;
   }
 
   .mel-event-card__signal-row {
-    margin-top: 2px;
+    margin-top: 4px;
   }
 
-  .mel-event-card__state-chip:not(.mel-event-card__state-chip--muted) {
-    font-size: 11px;
-    font-weight: 600;
-  }
-
-  .mel-event-card__state-chip--free {
-    background: transparent;
-    border: 0;
-    padding: 0;
-    color: mel.$mel-ds-color-muted;
-    font-weight: 600;
+  .mel-card-reason {
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 700;
   }
 }
 
@@ -734,8 +727,8 @@
 }
 
 .mel-page--home .mel-section--recommended.mel-section--secondary .mel-section__link {
-  color: mel.$mel-ds-color-muted;
-  font-weight: 600;
+  color: mel.$mel-ds-color-primary;
+  font-weight: 700;
 }
 
 // Legacy equal grid fallback (non-homepage featured placements).

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -30,6 +30,21 @@
 
   <div class="mel-page mel-page--home">
 
+    {% if mel_home_show_discover|default(false) %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--discover mel-section--discover-chips',
+        section_width_class: '',
+        container_class: 'mel-container',
+        header_extra_class: 'mel-section__header--discover',
+        title: 'Discover events'|t,
+        subtitle: 'Discover more of your city — filter by mood or moment'|t,
+        link_url: path('view.upcoming_events.page_events'),
+        link_text: 'See all events'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.home_discover
+      } %}
+    {% endif %}
+
     {% if mel_home_show_featured|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--featured mel-section--community-spotlight mel-section--discover',
@@ -46,18 +61,33 @@
       } %}
     {% endif %}
 
-    {% if mel_home_show_discover|default(false) %}
+    {% if mel_home_show_recommended|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--discover mel-section--discover-chips',
+        section_class: 'mel-section--recommended mel-section--discover',
         section_width_class: '',
         container_class: 'mel-container',
-        header_extra_class: 'mel-section__header--discover',
-        title: 'Discover events'|t,
-        subtitle: 'Discover more of your city — filter by mood or moment'|t,
+        header_extra_class: 'mel-section__header--recommended',
+        title: 'Worth exploring next'|t,
+        subtitle: 'Events popular with the community right now.'|t,
         link_url: path('view.upcoming_events.page_events'),
         link_text: 'See all events'|t,
         content_wrapper_class: 'mel-section__discover-view',
-        content: page.home_discover
+        content: page.home_recommended
+      } %}
+    {% endif %}
+
+    {% if page.homepage_latest %}
+      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
+        section_class: 'mel-section--latest mel-section--discover',
+        section_width_class: '',
+        container_class: 'mel-container',
+        header_extra_class: 'mel-section__header--latest',
+        title: 'New this week'|t,
+        subtitle: 'Recently added experiences on MyEventLane'|t,
+        link_url: path('view.upcoming_events.page_events'),
+        link_text: 'Browse all events'|t,
+        content_wrapper_class: 'mel-section__discover-view',
+        content: page.homepage_latest
       } %}
     {% endif %}
 
@@ -118,36 +148,6 @@
         link_text: 'See all free events'|t,
         content_wrapper_class: 'mel-section__discover-view',
         content: page.homepage_free
-      } %}
-    {% endif %}
-
-    {% if page.homepage_latest %}
-      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--latest mel-section--discover',
-        section_width_class: '',
-        container_class: 'mel-container',
-        header_extra_class: 'mel-section__header--latest',
-        title: 'New this week'|t,
-        subtitle: 'Recently added experiences on MyEventLane'|t,
-        link_url: path('view.upcoming_events.page_events'),
-        link_text: 'Browse all events'|t,
-        content_wrapper_class: 'mel-section__discover-view',
-        content: page.homepage_latest
-      } %}
-    {% endif %}
-
-    {% if mel_home_show_recommended|default(false) %}
-      {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
-        section_class: 'mel-section--recommended mel-section--discover mel-section--secondary',
-        section_width_class: '',
-        container_class: 'mel-container',
-        header_extra_class: 'mel-section__header--recommended',
-        title: 'Worth exploring next'|t,
-        subtitle: 'Events popular with the community right now.'|t,
-        link_url: path('view.upcoming_events.page_events'),
-        link_text: 'See all events'|t,
-        content_wrapper_class: 'mel-section__discover-view',
-        content: page.home_recommended
       } %}
     {% endif %}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad public-surface SCSS and homepage section order changes affect all `/home` visitors; config logo paths require those files to exist in the filesystem after deploy.
> 
> **Overview**
> Despite the branch name, this PR does **not** ship Phase 1A Guide copy re-voices (hero H1, empty states, and section headings are unchanged). It bundles a **homepage visual refresh** with **rail reordering** and **brand asset config**.
> 
> **Homepage layout** — `page--front.html.twig` moves **Discover chips** to the top, pulls **Recommended** and **Latest** above **Tonight / Hidden Gems / Free**, and drops the `mel-section--secondary` class from Recommended. Section titles and subtitles are the same strings as before.
> 
> **Hero** — `myeventlane-home-hero.html.twig` wraps search in `mel-home-hero__search-shell`, adds query/location icon spans, and adjusts submit markup; headline copy is unchanged.
> 
> **Theme SCSS** — `_home-hero.scss`, `_front-page.scss`, and `_event-card.scss` refresh gradients, spacing, typography, filter chips, and carousel controls; poster-style compact cards move from front-page overrides into `_event-card.scss`.
> 
> **Config** — New `mel_maintenance.settings.yml` and updated `myeventlane_theme.settings.yml` point logo/favicon at `new-mel-logo*.png` / `new-fal*.png`; `views.view.upcoming_events` only quotes the **Community Favourites** main-menu title.
> 
> **Docs** — `phase-1a-implementation-plan.md` is expanded into a full audit-backed implementation plan (scope, safety, sign-off); it explicitly warns not to mix this SCSS WIP into a copy-only Phase 1A PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919b49f14d656c4d42729f566dd67e92202894b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->