### PR TITLE
Refine homepage hero and category icon system

### DIFF
--- a/web/modules/custom/myeventlane_blocks/myeventlane_blocks.module
+++ b/web/modules/custom/myeventlane_blocks/myeventlane_blocks.module
@@ -26,6 +26,8 @@ function myeventlane_blocks_theme($existing, $type, $theme, $path) {
       'variables' => [
         'categories' => [],
         'hero_icons' => FALSE,
+        'show_icons' => TRUE,
+        'active_tid' => NULL,
       ],
       'template' => 'myeventlane-category-pills',
     ],

--- a/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
+++ b/web/modules/custom/myeventlane_blocks/templates/myeventlane-category-pills.html.twig
@@ -6,23 +6,35 @@
  * Variables:
  * - categories: Array of items with keys: tid, label, color, slug, icon (added by preprocess).
  * - hero_icons: When TRUE, render hero category icon cards via mel-event-ui-icons.
+ * - show_icons: When TRUE (default), render compact icons on non-hero pills.
+ * - active_tid: Optional active category term ID for discovery headers.
  *
  * Note: Homepage hero provides .mel-home-hero__categories-scroll wrapper.
  */
 #}
 {% for c in categories %}
   {% set pill_mod = c.pill_color|default(c.slug)|default(c.label|lower|replace({' ': '-', '&': 'and', '+': ''}))|trim|lower|default('default') %}
+  {% set is_active = active_tid is not null and c.tid == active_tid %}
   <a
     href="{{ c.url|default(path('view.upcoming_events.page_category', {'arg_0': c.slug|default(c.tid)})) }}"
-    class="mel-category-pill mel-category-pill--{{ pill_mod|clean_class }}"
+    class="mel-category-pill mel-category-pill--{{ pill_mod|clean_class }}{% if is_active %} is-active{% endif %}"
     aria-label="{{ 'View events in'|t }} {{ c.label }}"
+    {% if is_active %}aria-current="page"{% endif %}
   >
     {% if hero_icons|default(false) %}
-      <span class="mel-home-hero__category-icon mel-home-hero__category-icon--{{ pill_mod|clean_class }}">
+      <span class="mel-home-hero__category-icon mel-home-hero__category-icon--{{ pill_mod|clean_class }}" aria-hidden="true">
         {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with {
           icon: c.icon|default('calendar'),
           class: 'mel-home-hero__category-glyph',
           size: 24
+        } only %}
+      </span>
+    {% elseif show_icons|default(true) %}
+      <span class="mel-category-pill__icon" aria-hidden="true">
+        {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with {
+          icon: c.icon|default('calendar'),
+          class: 'mel-category-pill__glyph',
+          size: 16
         } only %}
       </span>
     {% endif %}

--- a/web/modules/custom/myeventlane_front/myeventlane_front.module
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.module
@@ -83,8 +83,8 @@ function _myeventlane_front_home_hero_theme_urls(): array {
   }
 
   $mobile_candidates = [
-    $theme_path . '/images/mel/hero/mel-hero-mobile.png',
     $theme_path . '/images/mel/hero/mel-hero-home-community.jpg',
+    $theme_path . '/images/mel/hero/mel-hero-home.png',
   ];
   foreach ($mobile_candidates as $relative) {
     if (file_exists(DRUPAL_ROOT . '/' . $relative)) {

--- a/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/Block/HomeHeroBlock.php
@@ -99,6 +99,10 @@ final class HomeHeroBlock extends BlockBase implements ContainerFactoryPluginInt
         $hero_alt = $theme_hero['alt'];
       }
     }
+    elseif ($hero_image_url_mobile === NULL || $hero_image_url_mobile === '') {
+      // When Page Visuals supplies desktop only, reuse it on mobile (avoid legacy mascot art).
+      $hero_image_url_mobile = $hero_image_url;
+    }
 
     $featured_events = NULL;
     if ($hero_image_url === NULL && $this->featuredEventsRenderBuilder->hasHeroResults()) {

--- a/web/themes/custom/myeventlane_theme/images/mel/README.md
+++ b/web/themes/custom/myeventlane_theme/images/mel/README.md
@@ -10,7 +10,7 @@
 
 | Page | Path |
 |------|------|
-| **Homepage** (/) | `images/mel/hero/mel-hero-home-community.jpg` (preferred), `mel-hero-home.png`, `mel-hero-mobile.png` |
+| **Homepage** (/) | `images/mel/hero/mel-hero-home-community.jpg` (desktop + mobile), `mel-hero-home.png` fallback |
 | **Events** (/events) | `images/mel/hero/mel-hero-events.png` |
 | **Search** (/search) | `images/mel/hero/mel-hero-search.png` |
 

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1775,6 +1775,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         'label' => $term->label(),
         'url' => _myeventlane_theme_get_category_url($term),
         'slug' => $slug,
+        'icon' => _myeventlane_theme_category_hero_icon($slug),
       ];
     }
     $variables['mel_header_categories'] = $categories;
@@ -2260,6 +2261,7 @@ function myeventlane_theme_preprocess_page__events__category(array &$variables):
       'label' => $category_term->label(),
       'url' => _myeventlane_theme_get_category_url($category_term),
       'slug' => $slug,
+      'icon' => _myeventlane_theme_category_hero_icon($slug),
     ];
   }
 
@@ -3264,6 +3266,7 @@ function myeventlane_theme_preprocess_taxonomy_term(array &$variables): void {
         'label' => $cat_term->label(),
         'url' => _myeventlane_theme_get_category_url($cat_term),
         'slug' => $slug,
+        'icon' => _myeventlane_theme_category_hero_icon($slug),
       ];
     }
     
@@ -3565,7 +3568,7 @@ function _myeventlane_theme_get_active_category_term(): ?TermInterface {
 }
 
 /**
- * Maps category slug to mel-event-ui-icons icon id for hero category cards.
+ * Maps category slug to mel-event-ui-icons icon id (hero + compact pills).
  */
 function _myeventlane_theme_category_hero_icon(string $slug): string {
   $map = [
@@ -3580,7 +3583,9 @@ function _myeventlane_theme_category_hero_icon(string $slug): string {
     'family' => 'users',
     'food' => 'utensils',
     'food-drink' => 'utensils',
+    'food-and-drink' => 'utensils',
     'movie' => 'film',
+    'movies' => 'film',
     'sport' => 'activity',
     'sports' => 'activity',
   ];

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_category-pills.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_category-pills.scss
@@ -73,6 +73,38 @@
   }
 }
 
+// Compact SVG category icons (shared mel-event-ui-icons mapping).
+.mel-category-pill__icon,
+.mel-pill__category-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.125rem;
+  height: 1.125rem;
+  color: colors.$mel-color-accent;
+}
+
+.mel-category-pill__glyph,
+.mel-pill__category-glyph {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.mel-category-pills .mel-pill__category-icon {
+  color: inherit;
+  opacity: 0.92;
+}
+
+.mel-category-pill__icon {
+  color: colors.$mel-color-accent;
+}
+
+a.mel-category-pill.is-active .mel-category-pill__icon {
+  color: inherit;
+  opacity: 0.95;
+}
+
 .mel-pill__label {
   white-space: nowrap;
 }
@@ -98,14 +130,16 @@
   border-color: rgba(0, 0, 0, 0.06);
 }
 .mel-category-pills .mel-pill--cat-music { background: var(--mel-coral); color: #fff; }
-.mel-category-pills .mel-pill--cat-movie { background: var(--mel-blue); color: #fff; }
+.mel-category-pills .mel-pill--cat-movie,
+.mel-category-pills .mel-pill--cat-movies { background: var(--mel-blue); color: #fff; }
 .mel-category-pills .mel-pill--cat-workshop,
 .mel-category-pills .mel-pill--cat-workshops { background: var(--mel-lilac); color: var(--mel-navy); }
 .mel-category-pills .mel-pill--cat-arts { background: var(--mel-peach); color: var(--mel-navy); }
 .mel-category-pills .mel-pill--cat-lgbtqia,
 .mel-category-pills .mel-pill--cat-lgbtqi { background: var(--mel-mint); color: var(--mel-navy); }
 .mel-category-pills .mel-pill--cat-food,
-.mel-category-pills .mel-pill--cat-food-drink { background: var(--mel-orange); color: #fff; }
+.mel-category-pills .mel-pill--cat-food-drink,
+.mel-category-pills .mel-pill--cat-food-and-drink { background: var(--mel-orange); color: #fff; }
 .mel-category-pills .mel-pill--cat-community { background: var(--mel-sky); color: var(--mel-navy); }
 .mel-category-pills .mel-pill--cat-markets { background: var(--mel-butter); color: var(--mel-navy); }
 .mel-category-pills .mel-pill--cat-family { background: var(--mel-coral); color: #fff; }
@@ -135,8 +169,8 @@ a.mel-category-pill {
   display: inline-flex;
   align-items: center;
   gap: spacing.mel-space(2);
-  min-height: 44px;
-  padding: 0.35rem 1rem;
+  min-height: 36px;
+  padding: 0.35rem 0.85rem;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-semibold;
   font-size: typography.mel-font-size(sm);

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -193,11 +193,31 @@
   letter-spacing: normal;
 }
 
-.mel-event-card__image-badge,
-.mel-event-card__badge {
+// Top-left metadata stack: date pill + discovery/state badges (Spotlight, Hidden Gem, Sold out).
+.mel-event-card__badge-stack {
   position: absolute;
   top: 12px;
   left: 12px;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  max-width: calc(100% - 24px);
+  pointer-events: none;
+}
+
+.mel-event-card__badge-stack .mel-event-card__image-badge,
+.mel-event-card__badge-stack .mel-event-card__badge {
+  position: static;
+  top: auto;
+  left: auto;
+  right: auto;
+  max-width: 100%;
+}
+
+.mel-event-card__image-badge,
+.mel-event-card__badge {
   z-index: 3;
   max-width: calc(100% - 24px);
   opacity: 0.9;
@@ -222,12 +242,10 @@
   }
 }
 
-// Canonical floating date pill — single source of truth for all event card variants.
+// Canonical floating date pill — lives inside .mel-event-card__badge-stack.
 .mel-event-card__date-pill {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 4;
+  position: static;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -263,20 +281,6 @@
   text-transform: uppercase;
   color: color-mix(in srgb, mel.$mel-ds-color-text 72%, mel.$mel-ds-color-muted 28%);
   line-height: 1;
-}
-
-.mel-event-card:has(.mel-event-card__date-pill) .mel-event-card__image-badge,
-.mel-event-card:has(.mel-event-card__date-pill) .mel-event-card__badge {
-  top: 12px;
-  left: auto;
-  right: 12px;
-}
-
-.mel-event-card:has(.mel-event-card__date-pill) .mel-event-card__image-badge:not(.mel-event__category),
-.mel-event-card:has(.mel-event-card__date-pill) .mel-event-card__image .mel-event-card__image-badge:not(.mel-event__category) {
-  top: calc(12px + 56px + 4px);
-  left: 12px;
-  right: auto;
 }
 
 // Elevated price / RSVP label — fixed slot directly under title (non-hero cards).
@@ -1560,18 +1564,41 @@
     display: none;
   }
 
-  // Status badges (Featured, Sold out, boost) — not category pills on image.
+  // Status badges (Spotlight, Sold out, Hidden Gem) — not category pills on image.
   .mel-event-card__image-badge.mel-event__category {
     display: none;
   }
 
-  .mel-event-card__image-badge:not(.mel-event__category) {
-    display: block;
-    inset: auto auto 8px 8px;
+  .mel-event-card__badge-stack {
+    top: auto;
+    bottom: 8px;
+    left: 8px;
     max-width: calc(100% - 16px);
+    gap: 3px;
+  }
+
+  .mel-event-card__badge-stack .mel-event-card__image-badge:not(.mel-event__category) {
+    display: block;
+    max-width: 100%;
     font-size: 10px;
     padding: 4px 8px;
     opacity: 1;
+  }
+
+  .mel-event-card__badge-stack .mel-event-card__date-pill {
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
+    min-height: 44px;
+    border-radius: 12px;
+  }
+
+  .mel-event-card__badge-stack .mel-event-card__date-pill-day {
+    font-size: 16px;
+  }
+
+  .mel-event-card__badge-stack .mel-event-card__date-pill-month {
+    font-size: 9px;
   }
 
   .mel-event-card__price-slot {
@@ -1845,13 +1872,16 @@
       linear-gradient(145deg, color-mix(in srgb, mel.$mel-ds-color-primary 28%, #fff) 0%, color-mix(in srgb, mel.$mel-ds-color-accent 22%, #fff) 100%);
   }
 
-  .mel-event-card__image-badge,
-  .mel-event-card__badge {
+  .mel-event-card__badge-stack {
     top: 16px;
     left: 16px;
-    z-index: 3;
-    transform: none;
     max-width: calc(100% - 32px);
+  }
+
+  .mel-event-card__badge-stack .mel-event-card__image-badge,
+  .mel-event-card__badge-stack .mel-event-card__badge {
+    transform: none;
+    max-width: 100%;
   }
 
   .mel-event-card__body,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-cards.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-cards.scss
@@ -322,16 +322,10 @@
     object-position: center center;
   }
 
-  // Canonical image-badge from Twig (event_ui / field_promoted) — top-left stack.
-  .mel-event-card__image-badge:not(.mel-event__category) {
-    position: absolute;
+  // Canonical discovery badges inside shared top-left stack.
+  .mel-event-card__badge-stack .mel-event-card__image-badge:not(.mel-event__category) {
     display: inline-flex;
     align-items: center;
-    top: 12px;
-    left: 12px;
-    right: auto;
-    bottom: auto;
-    z-index: 4;
     width: auto;
     max-width: max-content;
     height: 18px;
@@ -344,12 +338,6 @@
     text-transform: uppercase;
     white-space: nowrap;
     opacity: 1;
-  }
-
-  &:has(.mel-event-card__date-pill) .mel-event-card__image-badge:not(.mel-event__category) {
-    top: calc(12px + 56px + 4px);
-    left: 12px;
-    right: auto;
   }
 
   .mel-event-card__body,

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_featured-carousel.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_featured-carousel.scss
@@ -151,7 +151,7 @@
     }
 
     // Hide category / featured pill on image (copy lives in glass panel)
-    .mel-event-card__category-pill,
+    .mel-event-card__badge-stack .mel-event-card__image-badge,
     .mel-event-card__image-badge {
       display: none;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -289,11 +289,8 @@
 .mel-home-hero__categories-bar {
   position: relative;
   z-index: 3;
-  margin-top: calc(-1 * #{spacing.mel-space(6)});
-  padding:
-    spacing.mel-space(6)
-    spacing.mel-space(4)
-    spacing.mel-space(4);
+  margin-top: 0;
+  padding: 0 spacing.mel-space(4) spacing.mel-space(4);
   background: linear-gradient(180deg, rgba(255, 253, 251, 0.96) 0%, #fff 55%);
   border-top: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 6%, #fff 94%);
   box-shadow: shadows.$mel-shadow-sm;
@@ -335,10 +332,10 @@
   align-items: center;
   justify-content: flex-start;
   gap: spacing.mel-space(2);
-  width: 88px;
-  min-height: 96px;
+  width: 80px;
+  min-height: 84px;
   min-width: 44px;
-  padding: spacing.mel-space(3) spacing.mel-space(2) spacing.mel-space(2);
+  padding: spacing.mel-space(2) spacing.mel-space(2) spacing.mel-space(1);
   border: 0;
   border-radius: radii.$mel-radius-md;
   background: transparent;
@@ -365,10 +362,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 52px;
-  height: 52px;
-  min-width: 52px;
-  min-height: 52px;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
   border-radius: radii.$mel-radius-md;
   background: #fff;
   box-shadow: shadows.$mel-shadow-sm;
@@ -394,7 +391,8 @@
   @include mel-home-hero-category-icon-tone(var(--mel-coral));
 }
 
-.mel-home-hero__category-icon--movie {
+.mel-home-hero__category-icon--movie,
+.mel-home-hero__category-icon--movies {
   @include mel-home-hero-category-icon-tone(var(--mel-blue));
 }
 
@@ -413,7 +411,8 @@
 }
 
 .mel-home-hero__category-icon--food,
-.mel-home-hero__category-icon--food-drink {
+.mel-home-hero__category-icon--food-drink,
+.mel-home-hero__category-icon--food-and-drink {
   @include mel-home-hero-category-icon-tone(var(--mel-orange));
 }
 
@@ -646,22 +645,20 @@
     object-position: center center;
   }
 
-  .mel-event-card--editorial.mel-event-card--hero:has(.mel-event-card__date-pill) .mel-event-card__image .mel-event-card__image-badge,
-  .mel-event-card--editorial.mel-event-card--hero:has(.mel-event-card__date-pill) .mel-event-card__image .mel-event-card__badge,
-  .mel-event-card--editorial.mel-event-card--hero:has(.mel-event-card__date-pill) .mel-event-card__image .mel-pill--on-image {
-    top: calc(12px + 56px + 4px);
-    left: 12px;
-  }
-
   // V5: compact featured pill — shrink-wrap only; never stretch across the image.
-  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-event-card__image-badge,
-  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-event-card__badge,
-  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-pill--on-image {
+  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__badge-stack {
     position: absolute;
     z-index: 4;
     top: 16px;
     left: 16px;
     right: auto;
+    gap: 4px;
+    max-width: calc(100% - 32px);
+  }
+
+  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-event-card__image-badge,
+  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-event-card__badge,
+  .mel-event-card--editorial.mel-event-card--hero .mel-event-card__image .mel-pill--on-image {
     display: inline-flex;
     align-items: center;
     width: auto;

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -393,7 +393,7 @@
       border-radius: 0;
     }
 
-    .mel-event-card__image-badge {
+    .mel-event-card__badge-stack {
       z-index: 4;
       top: 22px;
       left: 22px;

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_mel-browse.scss
@@ -124,8 +124,9 @@
   }
 
   .mel-pill {
-    min-height: 44px;
+    min-height: 36px;
     align-items: center;
+    gap: 8px;
     text-decoration: none;
 
     &:hover,

--- a/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/event-card/mel-event-card.html.twig
@@ -207,21 +207,24 @@
         <div class="mel-event-card__placeholder" aria-hidden="true"></div>
       {% endif %}
 
-      {% if _has_date_badge %}
-        <div class="mel-event-card__date-pill" aria-hidden="true">
-          <span class="mel-event-card__date-pill-day">{{ _date_day }}</span>
-          <span class="mel-event-card__date-pill-month">{{ _date_month }}</span>
+      {% if _has_date_badge or _image_badge_label %}
+        <div class="mel-event-card__badge-stack{% if not _has_date_badge %} mel-event-card__badge-stack--no-date{% endif %}" aria-hidden="true">
+          {% if _has_date_badge %}
+            <div class="mel-event-card__date-pill">
+              <span class="mel-event-card__date-pill-day">{{ _date_day }}</span>
+              <span class="mel-event-card__date-pill-month">{{ _date_month }}</span>
+            </div>
+          {% endif %}
+          {% if _image_badge_label %}
+            <span class="{% if _state_badge_type == 'category' %}mel-event__category {% endif %}mel-event-card__image-badge mel-event-card__badge mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ _state_badge_type|e('html_attr') }}">
+              <span class="mel-pill__label">{{ _image_badge_label }}</span>
+            </span>
+          {% endif %}
         </div>
       {% endif %}
 
       {% if _variant not in ['compact', 'list'] %}
         <div class="mel-event-card__overlay{% if _is_hero %} mel-event-card__overlay--hero{% elseif _variant == 'featured' %} mel-event-card__overlay--featured{% else %} mel-event-card__overlay--standard{% endif %}" aria-hidden="true"></div>
-      {% endif %}
-
-      {% if _image_badge_label %}
-        <span class="{% if _state_badge_type == 'category' %}mel-event__category {% endif %}mel-event-card__image-badge mel-event-card__badge mel-pill mel-pill--on-image mel-event-card__state-pill mel-event-card__state-pill--{{ _state_badge_type|e('html_attr') }}" aria-hidden="true">
-          <span class="mel-pill__label">{{ _image_badge_label }}</span>
-        </span>
       {% endif %}
     </div>
 

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
@@ -59,6 +59,13 @@
             class="mel-pill mel-pill--cat-{{ c.slug|default('default') }}{% if is_active %} is-active{% endif %}"
             {% if is_active %}aria-current="page"{% endif %}
           >
+            <span class="mel-pill__category-icon" aria-hidden="true">
+              {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with {
+                icon: c.icon|default('calendar'),
+                class: 'mel-pill__category-glyph',
+                size: 16
+              } only %}
+            </span>
             {{ c.label }}
           </a>
         {% endfor %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only theme, Twig, and block changes with no auth or data logic; main risk is visual regressions on homepage, browse headers, and event cards across breakpoints.
> 
> **Overview**
> Unifies **category navigation** with shared `mel-event-ui-icons`: compact icons on global category pills and page-header chips, optional `show_icons` / `active_tid` on the pills block, and `icon` on category data from theme preprocess (plus extra slug aliases like `movies` and `food-and-drink`).
> 
> **Homepage hero** mobile/desktop fallbacks now favor `mel-hero-home-community.jpg` and drop the legacy mobile mascot asset; when Page Visuals only sets a desktop image, that URL is reused on mobile. Hero category cards and the categories bar are tightened (smaller icons/cards, no overlapping negative margin on the strip).
> 
> **Event cards** move the date pill and image discovery badges (Spotlight, etc.) into a single top-left **`.mel-event-card__badge-stack`**, replacing scattered absolute positioning and `:has()` offset rules across Twig and SCSS (including list/hero/carousel variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbef5f241b3a3cfa8c4e8ff50711ed16bb3a807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->