### PR TITLE
Align category pages with homepage discovery design

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -443,6 +443,19 @@
   display: none;
 }
 
+// Active category — lavender ring + weight (not colour alone; aria-current on link).
+.mel-home-hero__categories-scroll .mel-category-pill.is-active {
+  color: mel.$mel-ds-color-text;
+  font-weight: 800;
+
+  .mel-home-hero__category-icon {
+    background: color-mix(in srgb, var(--mel-lilac) 38%, #fff);
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--mel-lilac) 62%, transparent),
+      shadows.$mel-shadow-sm;
+  }
+}
+
 .mel-home-hero__view-all {
   flex: 0 0 auto;
   min-height: 44px;

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-page-header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-page-header.scss
@@ -1,18 +1,33 @@
+// ==========================================================================
+// MEL Page Header — listing pages + category discovery hero continuity
+// ==========================================================================
+
+@use '../base/mel-ds-tokens' as mel;
+@use '../tokens/breakpoints';
+@use '../tokens/colors';
+@use '../tokens/radii';
+@use '../tokens/shadows';
+@use '../tokens/spacing';
+@use '../tokens/typography';
+
+// ---------------------------------------------------------------------------
+// Default listing header (search, browse, calendar)
+// ---------------------------------------------------------------------------
+
 .mel-page-header {
   max-width: 1200px;
-  margin: 0 auto 32px;
-  padding: 32px 24px 16px;
+  margin: 0 auto spacing.mel-space(4);
+  padding: spacing.mel-space(4) spacing.mel-space(3) spacing.mel-space(2);
 
   &--hero {
     position: relative;
-    padding: clamp(3rem, 6vw, 5rem) 24px 2rem;
-    border-radius: 16px;
+    padding: clamp(3rem, 6vw, 5rem) spacing.mel-space(3) spacing.mel-space(4);
+    border-radius: radii.$mel-radius-lg;
     background: linear-gradient(135deg, rgba(254, 245, 236, 0.5) 0%, rgba(230, 217, 255, 0.5) 100%),
       var(--mel-hero-bg);
     background-size: 100% 100%, cover;
     background-position: 0 0, center;
 
-    // Mobile-specific hero image when --mel-hero-bg-mobile is set.
     @media (width <= 767px) {
       background-image: linear-gradient(
           135deg,
@@ -27,13 +42,352 @@
 .mel-page-title {
   font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 800;
-  // Page titles are brand text; coral is reserved for conversion CTAs.
   color: var(--mel-text);
-  margin-bottom: 8px;
+  margin-bottom: spacing.mel-space(1);
 }
 
 .mel-page-tagline {
   font-size: 1.125rem;
   color: #475467;
-  margin-bottom: 24px;
+  margin-bottom: spacing.mel-space(3);
+}
+
+// ---------------------------------------------------------------------------
+// Category discovery hero — aligned with homepage mel-home-hero
+// ---------------------------------------------------------------------------
+
+.mel-page--category {
+  background: linear-gradient(180deg, #fff 0%, mel.$mel-ds-color-bg 100%);
+
+  .mel-main {
+    padding-top: 0;
+    padding-bottom: spacing.mel-space(2);
+  }
+
+  .mel-container--wide {
+    padding-inline: clamp(16px, 3vw, 24px);
+  }
+}
+
+.mel-page-header--discovery {
+  max-width: none;
+  margin: 0 0 spacing.mel-space(4);
+  padding: 0;
+}
+
+.mel-page-header__discovery {
+  background: linear-gradient(180deg, #fff 0%, mel.$mel-ds-color-bg 100%);
+  border-radius: radii.$mel-radius-lg;
+  overflow: hidden;
+  box-shadow: shadows.$mel-shadow-sm;
+}
+
+.mel-page-header__discovery--hide-mobile-art {
+  @include breakpoints.mel-break(md, max) {
+    .mel-page-header__media {
+      display: none;
+    }
+  }
+}
+
+.mel-page-header__banner {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  min-height: clamp(360px, 52vw, 480px);
+  overflow: hidden;
+  color: #fff;
+}
+
+.mel-page-header__media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+
+  picture {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.mel-page-header__media-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 34% 44%;
+  transform: scale(1.12);
+  transform-origin: 34% 44%;
+
+  @include breakpoints.mel-break(md, max) {
+    object-position: 42% 48%;
+    transform: scale(1.08);
+    transform-origin: 42% 48%;
+  }
+}
+
+.mel-page-header__media--placeholder {
+  background:
+    radial-gradient(circle at 26% 30%, rgba(255, 255, 255, 0.58), transparent 22%),
+    radial-gradient(circle at 70% 22%, rgba(246, 196, 122, 0.52), transparent 28%),
+    radial-gradient(circle at 68% 74%, rgba(124, 131, 253, 0.42), transparent 30%),
+    linear-gradient(135deg, rgba(242, 109, 91, 0.32), rgba(255, 255, 255, 0.2));
+}
+
+.mel-page-header__scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(12, 16, 24, 0.72) 0%, rgba(12, 16, 24, 0.42) 38%, rgba(12, 16, 24, 0.08) 68%, transparent 100%),
+    linear-gradient(180deg, rgba(8, 10, 14, 0.18) 0%, transparent 34%, rgba(8, 10, 14, 0.42) 100%);
+}
+
+.mel-page-header__banner-inner {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: clamp(24px, 4vw, 40px);
+  width: 100%;
+  min-height: inherit;
+  padding:
+    clamp(2rem, 5vw, 3.5rem) clamp(20px, 4vw, 32px)
+    clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.mel-page-header__copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: min(100%, 34rem);
+  min-width: 0;
+}
+
+.mel-page-header__title {
+  max-width: 22ch;
+  margin: 0;
+  color: #fff;
+  font-family: mel.$mel-ds-font-main;
+  font-size: clamp(2rem, 5.5vw, 3.35rem);
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  line-height: 1.08;
+  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.35);
+}
+
+.mel-page-header--discovery .mel-category-discovery__lede {
+  margin: clamp(12px, 2vw, 18px) 0 0;
+  max-width: 32rem;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: clamp(1.05rem, 2.1vw, 1.25rem);
+  font-weight: 700;
+  line-height: 1.35;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.28);
+}
+
+.mel-page-header--discovery .mel-discovery-subtitle {
+  margin: spacing.mel-space(2) 0 0;
+  max-width: 32rem;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: clamp(1rem, 2vw, 1.125rem);
+  font-weight: 500;
+  line-height: 1.5;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.28);
+}
+
+.mel-page-header__search-shell {
+  width: min(100%, 640px);
+  margin-top: auto;
+  align-self: flex-start;
+}
+
+.mel-page-header__search {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: clamp(20px, 3vw, 28px);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 20px 48px rgba(12, 16, 24, 0.18);
+
+  @supports (backdrop-filter: blur(1px)) {
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+  }
+
+  @include breakpoints.mel-break(sm) {
+    flex-direction: row;
+    align-items: stretch;
+    gap: 8px;
+    padding: 8px;
+    border-radius: 999px;
+  }
+
+  .mel-front-search {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    min-width: 0;
+
+    @include breakpoints.mel-break(sm) {
+      flex-direction: row;
+      align-items: stretch;
+      flex: 1 1 auto;
+      gap: 8px;
+    }
+  }
+
+  .mel-front-search__input {
+    width: 100%;
+    min-width: 0;
+    min-height: 52px;
+    padding: 0 18px;
+    border: 0;
+    border-radius: clamp(14px, 2vw, 999px);
+    background: transparent;
+    color: mel.$mel-ds-color-text;
+    font: inherit;
+    font-size: clamp(1rem, 2vw, 1.0625rem);
+    box-shadow: none;
+
+    @include breakpoints.mel-break(sm) {
+      min-height: 56px;
+      flex: 1 1 auto;
+    }
+
+    &::placeholder {
+      color: color-mix(in srgb, mel.$mel-ds-color-muted 88%, mel.$mel-ds-color-text 12%);
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px color-mix(in srgb, mel.$mel-ds-color-primary 24%, transparent);
+    }
+  }
+
+  .mel-front-search__btn {
+    flex: 0 0 auto;
+    min-height: 52px;
+    min-width: 44px;
+    padding: 0 clamp(22px, 4vw, 28px);
+    border: 0;
+    border-radius: clamp(14px, 2vw, 999px);
+    background: mel.$mel-ds-color-primary;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 800;
+    font-size: clamp(1rem, 2vw, 1.0625rem);
+    white-space: nowrap;
+    box-shadow: 0 12px 32px color-mix(in srgb, mel.$mel-ds-color-primary 28%, transparent);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+
+    @include breakpoints.mel-break(sm) {
+      min-height: 56px;
+      align-self: stretch;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 36px color-mix(in srgb, mel.$mel-ds-color-primary 34%, transparent);
+      }
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        0 0 0 2px #fff,
+        0 0 0 5px color-mix(in srgb, mel.$mel-ds-color-primary 38%, transparent);
+    }
+  }
+}
+
+// Category listing surface below hero
+.mel-category-listing {
+  padding: spacing.mel-space(4) spacing.mel-space(3);
+  border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 8%, #fff 92%);
+  border-radius: radii.$mel-radius-lg;
+  background: mel.$mel-ds-color-surface;
+  box-shadow: shadows.$mel-shadow-sm;
+
+  @include breakpoints.mel-break(md) {
+    padding: spacing.mel-space(5) spacing.mel-space(4);
+  }
+}
+
+.mel-page--category .mel-discovery--category {
+  padding-top: 0;
+
+  .mel-category-follow-region--discovery {
+    margin-bottom: spacing.mel-space(3);
+  }
+
+  .mel-chip-bar {
+    margin-bottom: spacing.mel-space(4);
+    gap: spacing.mel-space(2);
+  }
+
+  .mel-chip-bar .mel-chip {
+    min-height: 44px;
+    padding: spacing.mel-space(2) spacing.mel-space(4);
+    border: 1px solid color-mix(in srgb, mel.$mel-ds-color-text 10%, #fff 90%);
+    border-radius: radii.$mel-radius-full;
+    background: color-mix(in srgb, mel.$mel-ds-color-bg 55%, #fff 45%);
+    font-weight: typography.$mel-font-semibold;
+    box-shadow: none;
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: color-mix(in srgb, mel.$mel-ds-color-bg 70%, #fff 30%);
+        border-color: color-mix(in srgb, mel.$mel-ds-color-text 14%, #fff 86%);
+        transform: translateY(-1px);
+      }
+    }
+  }
+
+  .mel-chip-bar .mel-chip.is-active {
+    background: mel.$mel-ds-color-primary;
+    border-color: mel.$mel-ds-color-primary;
+    color: #fff;
+    font-weight: typography.$mel-font-bold;
+    box-shadow: 0 4px 14px color-mix(in srgb, mel.$mel-ds-color-primary 28%, transparent);
+  }
+
+  .view-content {
+    margin-top: spacing.mel-space(1);
+  }
+}
+
+@media (width <= 767px) {
+  .mel-page-header__banner {
+    min-height: clamp(420px, 110vw, 500px);
+  }
+
+  .mel-page-header__scrim {
+    background:
+      linear-gradient(180deg, rgba(12, 16, 24, 0.72) 0%, rgba(12, 16, 24, 0.38) 42%, rgba(12, 16, 24, 0.52) 100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-page-header__media-img {
+    transform: none;
+  }
 }

--- a/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mel-page-header.html.twig
@@ -9,12 +9,15 @@
  * - title: Page title string.
  * - show_search: Boolean; when TRUE renders the MEL search block.
  * - show_categories: Boolean; when TRUE renders the MEL category pills UI.
- * - categories: Optional array of items with keys: tid, label, slug.
+ * - categories: Optional array of items with keys: tid, label, slug, icon.
  * - active_category_tid: Optional; overrides mel_active_category_tid for the active pill.
  * - hero_image_url: Optional URL for hero background (desktop).
  * - hero_image_url_mobile: Optional URL for hero background (mobile viewports).
  * - hero_hide_on_mobile: Boolean; when TRUE, hide hero on mobile.
  * - hide_page_title: When TRUE, skip default h1 + tagline (e.g. browse supplies its own).
+ * - variant: Optional 'discovery' for category landing hero continuity.
+ * - lede: Optional discovery lede (category pages).
+ * - subtitle: Optional discovery subtitle (category pages).
  */
 #}
 {% set show_search = show_search|default(false) %}
@@ -26,9 +29,103 @@
 {% set hero_hide_on_mobile = hero_hide_on_mobile|default(false) %}
 {% set has_hero = hero_image_url and not hero_hide_on_mobile %}
 {% set active_tid = active_category_tid|default(mel_active_category_tid|default(null)) %}
+{% set variant = variant|default('default') %}
+{% set is_discovery = variant == 'discovery' %}
 
 {{ attach_library('myeventlane_theme/mel-listing-header') }}
 
+{% if is_discovery %}
+<section class="mel-page-header mel-page-header--discovery{% if has_hero %} mel-page-header--discovery-hero{% endif %}">
+  <div class="mel-page-header__discovery{% if hero_hide_on_mobile %} mel-page-header__discovery--hide-mobile-art{% endif %}">
+    <div class="mel-page-header__banner">
+      {% if hero_image_url %}
+        <div class="mel-page-header__media" aria-hidden="true">
+          {% if hero_image_url_mobile and not hero_hide_on_mobile %}
+            <picture>
+              <source media="(max-width: 767px)" srcset="{{ hero_image_url_mobile }}">
+              <img
+                class="mel-page-header__media-img"
+                src="{{ hero_image_url }}"
+                alt=""
+                width="1024"
+                height="682"
+                loading="eager"
+                decoding="async"
+                fetchpriority="high"
+              />
+            </picture>
+          {% else %}
+            <img
+              class="mel-page-header__media-img"
+              src="{{ hero_image_url }}"
+              alt=""
+              width="1024"
+              height="682"
+              loading="eager"
+              decoding="async"
+              fetchpriority="high"
+            />
+          {% endif %}
+        </div>
+      {% else %}
+        <div class="mel-page-header__media mel-page-header__media--placeholder" aria-hidden="true"></div>
+      {% endif %}
+
+      <div class="mel-page-header__scrim" aria-hidden="true"></div>
+
+      <div class="mel-page-header__banner-inner mel-container mel-container--wide">
+        {% if not hide_page_title %}
+          <div class="mel-page-header__copy">
+            <h1 class="mel-page-header__title">{{ title }}</h1>
+            {% if lede %}
+              <p class="mel-category-discovery__lede">{{ lede }}</p>
+            {% endif %}
+            {% if subtitle %}
+              <p class="mel-discovery-subtitle">{{ subtitle }}</p>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        {% if show_search %}
+          <div class="mel-page-header__search-shell">
+            <div class="mel-page-header__search">
+              {% include '@myeventlane_theme/components/front/_front-search.html.twig' with {
+                front: {}
+              } only %}
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+
+    {% if show_categories and categories %}
+      <div class="mel-home-hero__categories-bar">
+        <div class="mel-home-hero__categories-inner mel-container mel-container--wide">
+          <nav class="mel-home-hero__categories" aria-label="{{ 'Browse by category'|t }}">
+            <a class="mel-home-hero__category-card mel-home-hero__category-card--all" href="{{ path('view.upcoming_events.page_events') }}">
+              <span class="mel-home-hero__category-icon mel-home-hero__category-icon--all" aria-hidden="true">
+                {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with {
+                  icon: 'calendar',
+                  class: 'mel-home-hero__category-glyph',
+                  size: 24
+                } only %}
+              </span>
+              <span class="mel-home-hero__category-label">{{ 'All Events'|t }}</span>
+            </a>
+            <div class="mel-home-hero__categories-scroll">
+              {% include '@myeventlane_blocks/myeventlane-category-pills.html.twig' with {
+                categories: categories,
+                hero_icons: true,
+                active_tid: active_tid
+              } only %}
+            </div>
+          </nav>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</section>
+{% else %}
 {% set hero_style = (hero_image_url and not hero_hide_on_mobile) ? ('--mel-hero-bg: url(' ~ hero_image_url ~ ')' ~ (hero_image_url_mobile ? '; --mel-hero-bg-mobile: url(' ~ hero_image_url_mobile ~ ')' : '')) : '' %}
 
 <section class="mel-page-header{% if has_hero %} mel-page-header--hero{% endif %}"{% if hero_style %} style="{{ hero_style }}"{% endif %}>
@@ -43,7 +140,6 @@
   {% endif %}
 
   {% if show_search %}
-    {# Reuse the exact homepage search UI markup. #}
     {% include '@myeventlane_theme/components/front/_front-search.html.twig' with {
       front: {}
     } only %}
@@ -73,3 +169,4 @@
     </div>
   {% endif %}
 </section>
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
@@ -23,30 +23,23 @@
   {# ==================== MAIN CONTENT ==================== #}
   <main id="main-content" class="mel-main">
     <div class="mel-container mel-container--wide">
-      <div class="mel-content">
-        {% set header_title = (current_category is defined) ? current_category.name : 'Events' %}
-        {% include '@myeventlane_theme/components/mel-page-header.html.twig' with {
-          title: header_title,
-          show_search: true,
-          show_categories: true,
-          categories: mel_header_categories|default([]),
-          hero_image_url: mel_hero_image_url|default(null),
-          hero_image_url_mobile: mel_hero_image_url_mobile|default(null),
-          hero_hide_on_mobile: mel_hero_hide_on_mobile|default(false)
-        } %}
+      {% set header_title = (current_category is defined) ? current_category.name : 'Events' %}
+      {% include '@myeventlane_theme/components/mel-page-header.html.twig' with {
+        title: header_title,
+        variant: 'discovery',
+        show_search: true,
+        show_categories: true,
+        categories: mel_header_categories|default([]),
+        hero_image_url: mel_hero_image_url|default(null),
+        hero_image_url_mobile: mel_hero_image_url_mobile|default(null),
+        hero_hide_on_mobile: mel_hero_hide_on_mobile|default(false),
+        lede: (current_category is defined) ? "Find something you'll love"|t : null,
+        subtitle: (current_category is defined) ? 'Discover events in @name'|t({'@name': current_category.name}) : null
+      } %}
 
-        {% if current_category is defined %}
-          <p class="mel-category-discovery__lede">
-            {{ "Find something you'll love"|t }}
-          </p>
-          <p class="mel-discovery-subtitle">
-            {{ 'Discover events in @name'|t({'@name': current_category.name}) }}
-          </p>
-        {% endif %}
-
+      <div class="mel-category-listing">
         {{ page.content }}
       </div>
-
     </div>
   </main>
 
@@ -56,4 +49,3 @@
   </div>
 
 </div>
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Theme and Twig presentation only; no backend or auth changes. Verify category/search links and mobile hero hide behavior on category routes.
> 
> **Overview**
> Category event listings now use a **discovery** variant of `mel-page-header` instead of the simpler listing hero, so the page opens with a homepage-style banner (hero image or placeholder, scrim, title, lede/subtitle, and frosted search) plus the **home hero category strip** (All Events + scrollable icon pills from the shared pills partial).
> 
> **`page--events--category`** passes `variant: 'discovery'`, moves lede/subtitle into the header component, and wraps view output in **`mel-category-listing`**. Default listing pages keep the existing header markup and pill strip.
> 
> **`_mel-page-header.scss`** grows to tokenize the default header and add discovery layout, search chrome, listing card surface, and chip-bar styling under **`mel-page--category`**. **`_home-hero.scss`** adds **`.is-active`** pill styling (lavender ring + weight) for the shared category nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00ecfb6147fee2c664bcec4ebd6270d3c58f4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->