### PR TITLE
Polish discovery pager styling

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-pager.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-pager.scss
@@ -1,0 +1,207 @@
+// ==========================================================================
+// MEL pager — discovery listings and public paginated views
+// ==========================================================================
+
+@use '../tokens/breakpoints';
+@use '../tokens/colors';
+@use '../tokens/radii';
+@use '../tokens/spacing';
+@use '../tokens/typography';
+@use '../base/mel-ds-tokens' as mel;
+
+.mel-pager {
+  width: 100%;
+  margin: mel.$mel-ds-space-xl 0 0;
+  padding: mel.$mel-ds-space-lg 0 mel.$mel-ds-space-md;
+}
+
+.mel-pager__items {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: spacing.mel-space(2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mel-pager__item {
+  margin: 0;
+  padding: 0;
+}
+
+.mel-pager__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 spacing.mel-space(3);
+  border: 1px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-sm;
+  background: colors.$mel-color-surface;
+  color: colors.$mel-color-text;
+  font-family: typography.$mel-font-family;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    background-color var(--mel-motion-fast, 0.15s) ease,
+    border-color var(--mel-motion-fast, 0.15s) ease,
+    color var(--mel-motion-fast, 0.15s) ease,
+    box-shadow var(--mel-motion-fast, 0.15s) ease;
+
+  &:hover {
+    background: colors.$mel-color-pastel-lavender;
+    border-color: color-mix(in srgb, colors.$mel-color-accent 35%, colors.$mel-color-border);
+    color: colors.$mel-color-text;
+    text-decoration: none;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    @include colors.mel-focus-ring;
+  }
+}
+
+.mel-pager__link--nav {
+  padding-inline: spacing.mel-space(4);
+}
+
+.mel-pager__link--edge {
+  font-size: typography.mel-font-size(xs);
+  padding-inline: spacing.mel-space(3);
+}
+
+.mel-pager__link--page {
+  min-width: 44px;
+  padding-inline: spacing.mel-space(2);
+}
+
+.mel-pager__link--current {
+  background: colors.$mel-color-primary;
+  border-color: colors.$mel-color-primary;
+  color: colors.$mel-color-text-inverse;
+  cursor: default;
+  box-shadow: 0 2px 8px rgba(colors.$mel-color-primary, 0.22);
+}
+
+.mel-pager__item--current .mel-pager__link--current:hover {
+  background: colors.$mel-color-primary;
+  border-color: colors.$mel-color-primary;
+  color: colors.$mel-color-text-inverse;
+}
+
+.mel-pager__item--ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 44px;
+  padding: 0 spacing.mel-space(1);
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  user-select: none;
+}
+
+.mel-pager__label {
+  display: inline-flex;
+  align-items: center;
+  gap: spacing.mel-space(1);
+}
+
+.mel-pager__icon {
+  font-size: typography.mel-font-size(lg);
+  line-height: 1;
+}
+
+.mel-pager__item--status {
+  display: none;
+}
+
+.mel-pager__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 spacing.mel-space(2);
+  color: colors.$mel-color-text-muted;
+  font-family: typography.$mel-font-family;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+}
+
+// Discovery listing spacing — keeps pager clear of cards and footer CTAs.
+.mel-discovery .mel-pager,
+.mel-browse__results .mel-pager {
+  margin-top: mel.$mel-ds-space-2xl;
+  padding-top: mel.$mel-ds-space-lg;
+  border-top: 1px solid color-mix(in srgb, colors.$mel-color-text 8%, transparent);
+}
+
+@include breakpoints.mel-break(md, max) {
+  .mel-pager__items {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: spacing.mel-space(2);
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .mel-pager__item--first,
+  .mel-pager__item--last,
+  .mel-pager__item--page,
+  .mel-pager__item--ellipsis {
+    display: none;
+  }
+
+  .mel-pager__item--previous {
+    grid-column: 1;
+    justify-self: start;
+  }
+
+  .mel-pager__item--status {
+    display: list-item;
+    grid-column: 2;
+    justify-self: center;
+  }
+
+  .mel-pager__item--next {
+    grid-column: 3;
+    justify-self: end;
+  }
+
+  .mel-pager__link--nav {
+    width: 100%;
+    max-width: 11rem;
+  }
+
+  .mel-pager__item--previous .mel-pager__link--nav {
+    justify-content: flex-start;
+  }
+
+  .mel-pager__item--next .mel-pager__link--nav {
+    justify-content: flex-end;
+  }
+}
+
+@include breakpoints.mel-break(md) {
+  .mel-pager__item--status {
+    display: none;
+  }
+
+  .mel-pager__item--first,
+  .mel-pager__item--last {
+    .mel-pager__link--edge {
+      min-width: auto;
+    }
+  }
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -122,6 +122,7 @@
 @use 'components/buttons';
 @use 'components/cards';
 @use 'components/chips';
+@use 'components/mel-pager';
 @use 'components/category-pills';
 @use 'components/category-follow';
 @use 'components/alerts';

--- a/web/themes/custom/myeventlane_theme/templates/navigation/pager.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/navigation/pager.html.twig
@@ -1,0 +1,76 @@
+{#
+/**
+ * @file
+ * MEL pager — pill controls for discovery and other public listings.
+ *
+ * @see core/modules/system/templates/pager.html.twig
+ * @see \Drupal\Core\Pager\PagerPreprocess::preprocessPager()
+ */
+#}
+{% if items %}
+  <nav class="pager mel-pager" role="navigation" aria-labelledby="{{ heading_id }}">
+    <{{ pagination_heading_level }} id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</{{ pagination_heading_level }}>
+    <ul class="pager__items mel-pager__items js-pager__items">
+      {% if items.first %}
+        <li class="pager__item pager__item--first mel-pager__item mel-pager__item--first">
+          <a href="{{ items.first.href }}" class="mel-pager__link mel-pager__link--edge" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'First page'|t }}</span>
+            <span class="mel-pager__label" aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous mel-pager__item mel-pager__item--previous">
+          <a href="{{ items.previous.href }}" class="mel-pager__link mel-pager__link--nav" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span class="mel-pager__label" aria-hidden="true"><span class="mel-pager__icon" aria-hidden="true">‹</span> {{ 'Previous'|t }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {% if ellipses.previous %}
+        <li class="pager__item pager__item--ellipsis mel-pager__item mel-pager__item--ellipsis" role="presentation" aria-hidden="true">&hellip;</li>
+      {% endif %}
+      {% for key, item in items.pages %}
+        <li class="pager__item mel-pager__item mel-pager__item--page{{ current == key ? ' is-active mel-pager__item--current' : '' }}">
+          {% if current == key %}
+            {% set title = 'Current page'|t %}
+            <span class="mel-pager__link mel-pager__link--current" aria-current="page" title="{{ title }}">
+              <span class="visually-hidden">{{ 'Page'|t }}</span>
+              {{- key -}}
+            </span>
+          {% else %}
+            {% set title = 'Go to page @key'|t({'@key': key}) %}
+            <a href="{{ item.href }}" class="mel-pager__link mel-pager__link--page" title="{{ title }}"{{ item.attributes|without('href', 'title') }}>
+              <span class="visually-hidden">{{ 'Page'|t }}</span>
+              {{- key -}}
+            </a>
+          {% endif %}
+        </li>
+      {% endfor %}
+      {% if ellipses.next %}
+        <li class="pager__item pager__item--ellipsis mel-pager__item mel-pager__item--ellipsis" role="presentation" aria-hidden="true">&hellip;</li>
+      {% endif %}
+      {% if current %}
+        <li class="pager__item mel-pager__item mel-pager__item--status">
+          <span class="mel-pager__status" aria-current="page">{{ 'Page @num'|t({'@num': current}) }}</span>
+        </li>
+      {% endif %}
+      {% if items.next %}
+        <li class="pager__item pager__item--next mel-pager__item mel-pager__item--next">
+          <a href="{{ items.next.href }}" class="mel-pager__link mel-pager__link--nav" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span class="mel-pager__label" aria-hidden="true">{{ 'Next'|t }} <span class="mel-pager__icon" aria-hidden="true">›</span></span>
+          </a>
+        </li>
+      {% endif %}
+      {% if items.last %}
+        <li class="pager__item pager__item--last mel-pager__item mel-pager__item--last">
+          <a href="{{ items.last.href }}" class="mel-pager__link mel-pager__link--edge" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'Last page'|t }}</span>
+            <span class="mel-pager__label" aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only theme changes to pagination markup and CSS; no backend or routing logic.
> 
> **Overview**
> Introduces a **theme-level Drupal pager override** so public paginated views (especially discovery and browse) use MEL pill-style controls instead of the default markup alone.
> 
> The new **`pager.html.twig`** keeps core pager variables and accessibility patterns (visually hidden labels, `aria-current`, `rel` on prev/next) while adding `mel-pager` BEM classes for nav, page numbers, first/last, and a mobile-only **“Page @num”** status row.
> 
> **`_mel-pager.scss`** styles those controls with design tokens (44px touch targets, primary current page, focus ring, hover states) and adds extra top spacing plus a divider on **`.mel-discovery`** and **`.mel-browse__results`**. Below the `md` breakpoint, the pager collapses to a three-column grid: Previous | current page status | Next, hiding numbered pages and first/last links.
> 
> **`main.scss`** pulls in the new component stylesheet so the styles ship with the theme build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9b371182ad37c6731b347aadb7a47c24dcef1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->