### PR TITLE
Rename Community Favourites navigation label

### DIFF
--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -3226,7 +3226,7 @@ display:
       path: events/popular
       menu:
         type: normal
-        title: 'Community Favourites'
+        title: Community
         description: 'Events people are joining this week'
         weight: 2
         enabled: true

--- a/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/PublicFooterNavigationBuilder.php
@@ -46,7 +46,7 @@ final class PublicFooterNavigationBuilder {
       $this->routeLink('Today', 'view.upcoming_events.page_today'),
       $this->routeLink('This weekend', 'view.upcoming_events.page_this_weekend'),
       $this->routeLink('Free events', 'view.upcoming_events.page_free'),
-      $this->routeLink('Community Favourites', 'view.upcoming_events.page_popular'),
+      $this->routeLink('Community', 'view.upcoming_events.page_popular'),
     ]));
     $discover_links = array_merge($discover_links, $this->buildCategoryLinks());
 

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -33,7 +33,7 @@
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_today' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_today') }}">{{ 'Today'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_this_weekend' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_this_weekend') }}">{{ 'This weekend'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_free' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_free') }}">{{ 'Free events'|t }}</a>
-          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Community Favourites'|t }}</a>
+          <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_popular' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_popular') }}">{{ 'Community'|t }}</a>
           <a class="mel-filter-chip{% if mel_browse_active_display|default('') == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}" href="{{ path('view.upcoming_events.page_hidden_gems') }}">{{ 'Hidden Gems'|t }}</a>
         </nav>
 
@@ -59,5 +59,7 @@
   <div class="mel-region-footer">
     {% include '@myeventlane_theme/includes/footer.html.twig' %}
   </div>
+
+  {{ mel_mobile_bottom_nav }}
 
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/includes/mel-events-discovery-filters.html.twig
@@ -31,7 +31,7 @@
   <a
     href="{{ path('view.upcoming_events.page_popular') }}"
     class="mel-filter-chip{% if d == 'page_popular' %} mel-filter-chip--active{% endif %}"
-  >{{ 'Community Favourites'|t }}</a>
+  >{{ 'Community'|t }}</a>
   <a
     href="{{ path('view.upcoming_events.page_hidden_gems') }}"
     class="mel-filter-chip{% if d == 'page_hidden_gems' %} mel-filter-chip--active{% endif %}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy and template output only; no routing, permissions, or discovery query changes.
> 
> **Overview**
> Renames the **Community Favourites** quicklink to **Community** everywhere users pick the `/events/popular` browse route: main menu config for `page_popular`, footer Discover links in `PublicFooterNavigationBuilder`, and the filter chips in `mel-browse-events-page-shell.html.twig` and `mel-events-discovery-filters.html.twig`. Routes and view logic are unchanged; only visible link/menu copy is updated.
> 
> Also outputs **`mel_mobile_bottom_nav`** at the bottom of the shared events browse page shell so mobile bottom navigation appears on those browse layouts.
> 
> **Note:** The Views display still uses **Community Favourites** for `display_title` / page `title` in config; only the main menu entry title was shortened in this diff—page H1/title may still say the old name unless updated elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2a3d32266918001b5983528f9bddaa6df75c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->