### PR TITLE
Add mobile bottom navigation

### DIFF
--- a/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
+++ b/web/modules/custom/myeventlane_front/myeventlane_front.services.yml
@@ -59,6 +59,13 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_core.event_category_url'
 
+  myeventlane_front.mobile_bottom_navigation:
+    class: Drupal\myeventlane_front\Service\MobileBottomNavigationBuilder
+    arguments:
+      - '@current_route_match'
+      - '@path.matcher'
+      - '@request_stack'
+
   myeventlane_front.sitemap_builder:
     class: Drupal\myeventlane_front\Service\SitemapBuilder
     arguments:

--- a/web/modules/custom/myeventlane_front/src/Service/MobileBottomNavigationBuilder.php
+++ b/web/modules/custom/myeventlane_front/src/Service/MobileBottomNavigationBuilder.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_front\Service;
+
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\myeventlane_surface\MelCustomerRouteCatalog;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Canonical mobile bottom navigation for the public marketplace theme.
+ *
+ * Route names and active-state rules live here only — Twig renders labels/icons.
+ */
+final class MobileBottomNavigationBuilder {
+
+  use StringTranslationTrait;
+
+  /**
+   * Upcoming-events browse routes that highlight the Events tab.
+   *
+   * Community Favourites (page_popular) is excluded — it highlights Community.
+   *
+   * @var list<string>
+   */
+  private const EVENTS_ROUTE_NAMES = [
+    'view.upcoming_events.page_events',
+    'view.upcoming_events.page_category',
+    'view.upcoming_events.page_today',
+    'view.upcoming_events.page_this_weekend',
+    'view.upcoming_events.page_free',
+    'view.upcoming_events.page_hidden_gems',
+    'mel_search.view',
+  ];
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly PathMatcherInterface $pathMatcher,
+    private readonly RequestStack $requestStack,
+  ) {}
+
+  /**
+   * Whether the bottom navigation should render on the active request.
+   */
+  public function shouldRender(bool $auth_minimal = FALSE): bool {
+    if ($auth_minimal) {
+      return FALSE;
+    }
+
+    $route = $this->routeMatch->getRouteName() ?? '';
+    if ($route === '') {
+      return FALSE;
+    }
+
+    return !str_starts_with($route, 'commerce_checkout.');
+  }
+
+  /**
+   * Builds bottom navigation items for Twig.
+   *
+   * Each item: id, title, url, icon, active, route_name (for debugging/docs).
+   *
+   * @return list<array<string, mixed>>
+   */
+  public function buildItems(): array {
+    $currentRoute = $this->routeMatch->getRouteName() ?? '';
+    $request = $this->requestStack->getCurrentRequest();
+    $currentPath = $request ? $request->getPathInfo() : '/';
+
+    $definitions = [
+      [
+        'id' => 'home',
+        'title' => $this->t('Home'),
+        'route_name' => '<front>',
+        'icon' => 'home',
+        'active' => $this->pathMatcher->isFrontPage() || $currentRoute === 'view.frontpage.page_1',
+      ],
+      [
+        'id' => 'events',
+        'title' => $this->t('Events'),
+        'route_name' => 'view.upcoming_events.page_events',
+        'icon' => 'ticket',
+        'active' => in_array($currentRoute, self::EVENTS_ROUTE_NAMES, TRUE),
+      ],
+      [
+        'id' => 'calendar',
+        'title' => $this->t('Calendar'),
+        'route_name' => 'view.events_calendar.page_calendar',
+        'icon' => 'calendar',
+        'active' => $currentRoute === 'view.events_calendar.page_calendar',
+      ],
+      [
+        'id' => 'community',
+        'title' => $this->t('Community'),
+        'route_name' => 'view.upcoming_events.page_popular',
+        'icon' => 'heart',
+        'active' => $currentRoute === 'view.upcoming_events.page_popular',
+      ],
+      [
+        'id' => 'account',
+        'title' => $this->t('Account'),
+        'route_name' => 'myeventlane_account.dashboard',
+        'icon' => 'user',
+        'active' => MelCustomerRouteCatalog::isCustomerSurface($currentRoute, $currentPath),
+      ],
+    ];
+
+    $items = [];
+    foreach ($definitions as $definition) {
+      $url = $this->routeUrl((string) $definition['route_name']);
+      if ($url === NULL) {
+        continue;
+      }
+      $items[] = [
+        'id' => $definition['id'],
+        'title' => $definition['title'],
+        'url' => $url,
+        'icon' => $definition['icon'],
+        'active' => (bool) $definition['active'],
+        'route_name' => $definition['route_name'],
+      ];
+    }
+
+    return $items;
+  }
+
+  /**
+   * Resolves an internal URL for a route name, skipping missing optional routes.
+   */
+  private function routeUrl(string $route_name): ?string {
+    try {
+      return Url::fromRoute($route_name, [], ['absolute' => FALSE])->toString();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -204,6 +204,12 @@ function myeventlane_theme_theme(array $existing, string $type, string $theme, s
       ],
       'template' => 'components/mobile-drawer/mobile-drawer',
     ],
+    'mobile_bottom_nav' => [
+      'variables' => [
+        'items' => [],
+      ],
+      'template' => 'components/mobile-bottom-nav/mobile-bottom-nav',
+    ],
   ];
 }
 
@@ -1576,6 +1582,18 @@ function myeventlane_theme_preprocess_html(array &$variables): void {
     }
   }
 
+  if (\Drupal::hasService('myeventlane_front.mobile_bottom_navigation')) {
+    $auth_minimal = FALSE;
+    if (\Drupal::moduleHandler()->moduleExists('myeventlane_surface')) {
+      $surface = \Drupal::service('myeventlane_surface.resolver')->resolve();
+      $auth_minimal = $surface === \Drupal\myeventlane_core\MelSurfaceId::Auth;
+    }
+    $nav_builder = \Drupal::service('myeventlane_front.mobile_bottom_navigation');
+    if ($nav_builder->shouldRender($auth_minimal)) {
+      $variables['attributes']['class'][] = 'mel-has-mobile-bottom-nav';
+    }
+  }
+
   $route_node = $route_match ? $route_match->getParameter('node') : NULL;
   if ($route_node instanceof NodeInterface && $route_node->bundle() === 'event') {
     $variables['attributes']['class'][] = 'mel-body--event-full';
@@ -1646,6 +1664,23 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
   $variables['mel_footer_show_cta_band'] = empty($variables['is_front']);
   $variables['mel_is_organiser'] = \Drupal::currentUser()->hasPermission('access vendor dashboard');
   $variables['#attached']['library'][] = 'myeventlane_theme/footer-internal';
+
+  $auth_minimal = !empty($variables['mel_surface_auth_minimal']);
+  if (\Drupal::hasService('myeventlane_front.mobile_bottom_navigation')) {
+    $nav_builder = \Drupal::service('myeventlane_front.mobile_bottom_navigation');
+    if ($nav_builder->shouldRender($auth_minimal)) {
+      $variables['mel_mobile_bottom_nav'] = [
+        '#theme' => 'mobile_bottom_nav',
+        '#items' => $nav_builder->buildItems(),
+        '#cache' => [
+          'contexts' => ['route', 'user'],
+        ],
+      ];
+    }
+    else {
+      $variables['mel_mobile_bottom_nav'] = [];
+    }
+  }
 
   // Internal footer context (layout/footer-internal.html.twig).
   try {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mobile-bottom-nav.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mobile-bottom-nav.scss
@@ -1,0 +1,122 @@
+// ==========================================================================
+// Mobile bottom navigation — public marketplace (below md / 768px)
+// ==========================================================================
+// Layer: z.mel-z(header) = 100 — below overlay sheets (dropdown 150) and drawer (200).
+// Body class .mel-has-mobile-bottom-nav sets --mel-mobile-bottom-nav-height for page padding.
+
+@use '../tokens/breakpoints';
+@use '../tokens/colors';
+@use '../tokens/spacing';
+@use '../tokens/typography';
+@use '../tokens/zindex' as z;
+
+$mel-mobile-bottom-nav-bar-height: 56px;
+
+body.mel-has-mobile-bottom-nav {
+  --mel-mobile-bottom-nav-height: calc(#{$mel-mobile-bottom-nav-bar-height} + env(safe-area-inset-bottom, 0px));
+
+  @include breakpoints.mel-break(md, max) {
+    .mel-page {
+      padding-bottom: var(--mel-mobile-bottom-nav-height);
+    }
+
+    .mel-mobile-cta {
+      bottom: var(--mel-mobile-bottom-nav-height);
+    }
+  }
+}
+
+.mel-mobile-bottom-nav {
+  display: none;
+
+  @include breakpoints.mel-break(md, max) {
+    display: block;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: z.mel-z(header);
+    box-sizing: border-box;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background: #fffdf9;
+    border-top: 1px solid colors.$mel-color-border;
+    font-family: var(--mel-font-head, 'Nunito', system-ui, sans-serif);
+  }
+}
+
+.mel-mobile-bottom-nav__list {
+  display: flex;
+  align-items: stretch;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  min-height: $mel-mobile-bottom-nav-bar-height;
+}
+
+.mel-mobile-bottom-nav__item {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.mel-mobile-bottom-nav__link {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: spacing.mel-space(1);
+  min-height: 44px;
+  padding: spacing.mel-space(2) spacing.mel-space(1);
+  color: colors.$mel-color-text;
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-medium;
+  line-height: 1.2;
+  text-decoration: none;
+  text-align: center;
+  box-sizing: border-box;
+
+  &:hover {
+    color: colors.$mel-color-accent;
+    background: color-mix(in srgb, colors.$mel-color-accent 10%, #fffdf9);
+  }
+
+  &:focus-visible {
+    @include colors.mel-focus-ring;
+    color: colors.$mel-color-accent;
+  }
+}
+
+.mel-mobile-bottom-nav__link--active {
+  color: colors.$mel-color-primary;
+  font-weight: typography.$mel-font-bold;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 22%;
+    right: 22%;
+    height: 2px;
+    border-radius: 1px;
+    background: colors.$mel-color-primary;
+  }
+}
+
+.mel-mobile-bottom-nav__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.mel-mobile-bottom-nav__svg {
+  display: block;
+}
+
+.mel-mobile-bottom-nav__label {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/main.scss
@@ -132,6 +132,7 @@
 @use 'components/site-header';
 @use 'components/mobile-drawer';
 @use 'components/mel-mobile-overlays';
+@use 'components/mobile-bottom-nav';
 @use 'components/mel-header-footer';
 @use 'components/panels';
 @use 'components/hero';

--- a/web/themes/custom/myeventlane_theme/templates/components/mobile-bottom-nav/mobile-bottom-nav.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/components/mobile-bottom-nav/mobile-bottom-nav.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Mobile-only bottom navigation (below mel-breakpoint-md).
+ *
+ * Variables:
+ * - items: list of { id, title, url, icon, active }
+ */
+#}
+{% if items is not empty %}
+  <nav class="mel-mobile-bottom-nav" aria-label="{{ 'Primary mobile navigation'|t }}">
+    <ul class="mel-mobile-bottom-nav__list">
+      {% for item in items %}
+        <li class="mel-mobile-bottom-nav__item">
+          <a
+            class="mel-mobile-bottom-nav__link{% if item.active %} mel-mobile-bottom-nav__link--active{% endif %}"
+            href="{{ item.url }}"
+            {% if item.active %}aria-current="page"{% endif %}
+          >
+            <span class="mel-mobile-bottom-nav__icon" aria-hidden="true">
+              {% include '@myeventlane_theme/includes/mel-event-ui-icons.html.twig' with {
+                icon: item.icon,
+                class: 'mel-mobile-bottom-nav__svg',
+                size: 22
+              } only %}
+            </span>
+            <span class="mel-mobile-bottom-nav__label">{{ item.title }}</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+{% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-event-ui-icons.html.twig
@@ -5,7 +5,10 @@
 {% set _size = size|default(24) %}
 {% set _class = (class|default('mel-event-icon'))|e('html_attr') %}
 <svg class="{{ _class }}" width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-  {% if icon == 'calendar' %}
+  {% if icon == 'home' %}
+    <path d="M5 10.75V19a1.25 1.25 0 0 0 1.25 1.25H9.5V15a2 2 0 0 1 2-2h1a2 2 0 0 1 2 2v5.25h3.25A1.25 1.25 0 0 0 19 19v-8.25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M4.25 10.75 12 4.5l7.75 6.25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  {% elseif icon == 'calendar' %}
     <rect x="3.5" y="5.5" width="17" height="15" rx="2.25" stroke="currentColor" stroke-width="1.75"/>
     <path d="M8 4v3M16 4v3M3.5 10h17" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
   {% elseif icon == 'clock' %}

--- a/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--events--category.html.twig
@@ -48,4 +48,6 @@
     {% include '@myeventlane_theme/includes/footer.html.twig' %}
   </div>
 
+  {{ mel_mobile_bottom_nav }}
+
 </div>

--- a/web/themes/custom/myeventlane_theme/templates/page.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page.html.twig
@@ -81,4 +81,6 @@
   {% endif %}
 
   {% include '@myeventlane_theme/includes/footer.html.twig' %}
+
+  {{ mel_mobile_bottom_nav }}
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Public UI and navigation only; checkout and auth-minimal surfaces are explicitly excluded, with no auth or payment logic changes.
> 
> **Overview**
> Adds a **fixed mobile bottom tab bar** (Home, Events, Calendar, Community, Account) for the public marketplace theme on viewports below 768px.
> 
> **`MobileBottomNavigationBuilder`** centralizes tab targets, URL resolution (skipping missing routes), and **active-state rules**—including a broad set of upcoming-events/search routes for Events, Community Favourites for Community, and `MelCustomerRouteCatalog` for Account. The bar is **suppressed** on minimal auth surfaces and on **`commerce_checkout.*`** routes.
> 
> Theme preprocess attaches a **`mobile_bottom_nav`** render array (route/user cache contexts), adds **`mel-has-mobile-bottom-nav`** on the body for layout padding and CTA offset, and outputs the nav after the footer in **`page.html.twig`** and the category events page template. New SCSS handles safe-area insets, z-index, and active styling; the shared icon partial gains a **home** glyph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad09bc4cc8c1133ef7fc777a4cbcf82c1cbfef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->