### PR TITLE
Cursor/2026 06 19 9jxb e3016

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
@@ -28,7 +28,7 @@ services:
   myeventlane_checkout_flow.order_pricing_breakdown:
     class: Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder
     arguments:
-      - '@commerce_price.currency_formatter'
+      - '@myeventlane_commerce.currency_formatter.lazy'
       - '@entity_type.manager'
       - '@config.factory'
       - '@myeventlane_commerce.order_item_classifier'
@@ -38,7 +38,7 @@ services:
     class: Drupal\myeventlane_checkout_flow\Service\CheckoutGroupedSummaryBuilder
     arguments:
       - '@entity_type.manager'
-      - '@commerce_price.currency_formatter'
+      - '@myeventlane_commerce.currency_formatter.lazy'
       - '@date.formatter'
       - '@myeventlane_checkout_flow.order_pricing_breakdown'
       - '@myeventlane_event.booking_flow_resolver'
@@ -52,7 +52,7 @@ services:
   myeventlane_checkout_flow.tax_invoice_presentation:
     class: Drupal\myeventlane_checkout_flow\Service\TaxInvoicePresentationBuilder
     arguments:
-      - '@commerce_price.currency_formatter'
+      - '@myeventlane_commerce.currency_formatter.lazy'
       - '@date.formatter'
       - '@myeventlane_checkout_flow.order_pricing_breakdown'
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/FeeTransparencyPane.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/FeeTransparencyPane.php
@@ -7,7 +7,7 @@ namespace Drupal\myeventlane_checkout_flow\Plugin\Commerce\CheckoutPane;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\CheckoutPaneBase;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutFlow\CheckoutFlowInterface;
 use Drupal\commerce_order\OrderRefreshInterface;
-use Drupal\commerce_price\CurrencyFormatter;
+use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder;
@@ -28,9 +28,9 @@ final class FeeTransparencyPane extends CheckoutPaneBase {
   /**
    * The currency formatter.
    *
-   * @var \Drupal\commerce_price\CurrencyFormatter
+   * @var \CommerceGuys\Intl\Formatter\CurrencyFormatterInterface
    */
-  private CurrencyFormatter $currencyFormatter;
+  private CurrencyFormatterInterface $currencyFormatter;
 
   /**
    * The order refresh service.
@@ -58,7 +58,7 @@ final class FeeTransparencyPane extends CheckoutPaneBase {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?CheckoutFlowInterface $checkout_flow = NULL) {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition, $checkout_flow);
-    $instance->currencyFormatter = $container->get('commerce_price.currency_formatter');
+    $instance->currencyFormatter = $container->get('myeventlane_commerce.currency_formatter.lazy');
     $instance->orderRefresh = $container->get('commerce_order.order_refresh');
     $instance->configFactory = $container->get('config.factory');
     $instance->orderPricingBreakdown = $container->get('myeventlane_checkout_flow.order_pricing_breakdown');

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/CheckoutGroupedSummaryBuilder.php
@@ -6,7 +6,7 @@ namespace Drupal\myeventlane_checkout_flow\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
-use Drupal\commerce_price\CurrencyFormatter;
+use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\commerce_price\Price;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Datetime\DateFormatterInterface;
@@ -27,7 +27,7 @@ final class CheckoutGroupedSummaryBuilder implements CheckoutGroupedSummaryBuild
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly CurrencyFormatterInterface $currencyFormatter,
     private readonly DateFormatterInterface $dateFormatter,
     private readonly OrderPricingBreakdownBuilder $orderPricingBreakdown,
     private readonly BookingFlowResolver $bookingFlowResolver,

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/OrderPricingBreakdownBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_checkout_flow\Service;
 
+use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
-use Drupal\commerce_price\CurrencyFormatter;
 use Drupal\commerce_price\Price;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -22,7 +22,7 @@ use Drupal\myeventlane_core\MelReadinessHelper;
 final class OrderPricingBreakdownBuilder {
 
   public function __construct(
-    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly CurrencyFormatterInterface $currencyFormatter,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly ConfigFactoryInterface $configFactory,
     private readonly OrderItemClassifier $orderItemClassifier,

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
@@ -6,7 +6,7 @@ namespace Drupal\myeventlane_checkout_flow\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
-use Drupal\commerce_price\CurrencyFormatter;
+use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\commerce_price\Price;
 use Drupal\Core\Datetime\DateFormatterInterface;
 
@@ -19,7 +19,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 final class TaxInvoicePresentationBuilder {
 
   public function __construct(
-    private readonly CurrencyFormatter $currencyFormatter,
+    private readonly CurrencyFormatterInterface $currencyFormatter,
     private readonly DateFormatterInterface $dateFormatter,
     private readonly OrderPricingBreakdownBuilder $orderPricingBreakdown,
   ) {}

--- a/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
+++ b/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
@@ -288,6 +288,10 @@
     });
   }
 
+  function isMobileViewport() {
+    return window.matchMedia('(max-width: 767px)').matches;
+  }
+
   function initBell(root, settings) {
     var trigger = root.querySelector('[data-mel-notif-bell-trigger]');
     var panel = root.querySelector('[data-mel-notif-bell-panel]');
@@ -339,7 +343,12 @@
       setOpen(!open);
     }
 
+    root.melNotifBellSetOpen = setOpen;
+
     trigger.addEventListener('click', function (e) {
+      if (isMobileViewport()) {
+        return;
+      }
       e.stopPropagation();
       toggle();
     });
@@ -358,12 +367,18 @@
     }
 
     document.addEventListener('click', function (ev) {
+      if (isMobileViewport()) {
+        return;
+      }
       if (open && !root.contains(ev.target)) {
         setOpen(false);
       }
     });
 
     document.addEventListener('keydown', function (ev) {
+      if (isMobileViewport()) {
+        return;
+      }
       if (ev.key === 'Escape' && open) {
         setOpen(false);
         trigger.focus();

--- a/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
+++ b/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
@@ -1,22 +1,31 @@
 /**
  * @file
- * Account dropdown functionality - direct script (not ES module).
- * This ensures it works even if ES modules aren't supported.
+ * Account dropdown — desktop flyout only below md (768px).
+ *
+ * Mobile account sheets are owned by mel-mobile-overlays.js.
  */
 
-(function() {
+(function () {
   'use strict';
+
+  const DESKTOP_MQ = window.matchMedia('(min-width: 768px)');
+
+  /**
+   * @returns {boolean}
+   */
+  function isDesktopViewport() {
+    return DESKTOP_MQ.matches;
+  }
 
   function initAccountDropdown(context) {
     context = context || document;
     const dropdowns = context.querySelectorAll('.mel-account-dropdown');
-    
-    dropdowns.forEach(function(dropdown) {
-      // Skip if already initialized
+
+    dropdowns.forEach(function (dropdown) {
       if (dropdown.hasAttribute('data-dropdown-initialized')) {
         return;
       }
-      
+
       dropdown.setAttribute('data-dropdown-initialized', 'true');
       const toggle = dropdown.querySelector('.mel-account-toggle');
       const menu = dropdown.querySelector('.mel-account-menu');
@@ -26,81 +35,87 @@
         return;
       }
 
-      // Remove any existing listeners by cloning
       const newToggle = toggle.cloneNode(true);
       toggle.parentNode.replaceChild(newToggle, toggle);
       const newMenu = dropdown.querySelector('.mel-account-menu');
 
-      newToggle.addEventListener('click', function(e) {
+      newToggle.addEventListener('click', function (e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
+
         e.preventDefault();
         e.stopPropagation();
-        
+
         const isOpen = dropdown.classList.contains('is-open');
-        
+
         if (isOpen) {
           dropdown.classList.remove('is-open');
           newToggle.setAttribute('aria-expanded', 'false');
           newMenu.setAttribute('aria-hidden', 'true');
-        } else {
-          // Close all others
-          document.querySelectorAll('.mel-account-dropdown.is-open').forEach(function(other) {
+        }
+        else {
+          document.querySelectorAll('.mel-account-dropdown.is-open').forEach(function (other) {
             if (other !== dropdown) {
               other.classList.remove('is-open');
               const otherToggle = other.querySelector('.mel-account-toggle');
               const otherMenu = other.querySelector('.mel-account-menu');
-              if (otherToggle) otherToggle.setAttribute('aria-expanded', 'false');
-              if (otherMenu) otherMenu.setAttribute('aria-hidden', 'true');
+              if (otherToggle) {
+                otherToggle.setAttribute('aria-expanded', 'false');
+              }
+              if (otherMenu) {
+                otherMenu.setAttribute('aria-hidden', 'true');
+              }
             }
           });
-          
+
           dropdown.classList.add('is-open');
           newToggle.setAttribute('aria-expanded', 'true');
           newMenu.setAttribute('aria-hidden', 'false');
         }
       });
 
-      // Close on outside click
-      const closeHandler = function(e) {
+      document.addEventListener('click', function (e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
         if (!dropdown.contains(e.target) && dropdown.classList.contains('is-open')) {
           dropdown.classList.remove('is-open');
           newToggle.setAttribute('aria-expanded', 'false');
           newMenu.setAttribute('aria-hidden', 'true');
         }
-      };
-      document.addEventListener('click', closeHandler, true);
+      }, true);
 
-      // Escape key
-      const escapeHandler = function(e) {
+      document.addEventListener('keydown', function (e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
         if (e.key === 'Escape' && dropdown.classList.contains('is-open')) {
           dropdown.classList.remove('is-open');
           newToggle.setAttribute('aria-expanded', 'false');
           newMenu.setAttribute('aria-hidden', 'true');
           newToggle.focus();
         }
-      };
-      document.addEventListener('keydown', escapeHandler);
+      });
     });
   }
 
-  // Initialize immediately and on DOM ready
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
       initAccountDropdown();
     });
-  } else {
-    // Small delay to ensure elements are rendered
-    setTimeout(function() {
+  }
+  else {
+    setTimeout(function () {
       initAccountDropdown();
     }, 50);
   }
 
-  // Also register as Drupal behavior
   if (typeof Drupal !== 'undefined' && Drupal.behaviors) {
     Drupal.behaviors.myeventlaneAccountDropdownDirect = {
-      attach: function(context) {
+      attach: function (context) {
         initAccountDropdown(context);
-      }
+      },
     };
   }
 })();
-

--- a/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
+++ b/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
@@ -62,6 +62,7 @@ function portalPanel(panel) {
   panel.classList.add('mel-mobile-overlay-sheet');
   panel.dataset.melPortaled = '1';
   getPortal().appendChild(panel);
+  getPortal().setAttribute('aria-hidden', 'false');
 }
 
 /**
@@ -78,6 +79,11 @@ function unportalPanel(panel) {
   }
   panel.classList.remove('mel-mobile-overlay-sheet');
   delete panel.dataset.melPortaled;
+
+  const portal = document.getElementById(PORTAL_ID);
+  if (portal && !portal.childElementCount) {
+    portal.setAttribute('aria-hidden', 'true');
+  }
 }
 
 /**
@@ -106,6 +112,17 @@ export function notifyOverlayClosed(id) {
     activeOverlay = null;
     setBodyOverlayState(false);
   }
+}
+
+/**
+ * @param {HTMLElement} trigger
+ * @param {boolean} expanded
+ */
+function setCartTriggerExpanded(trigger, expanded) {
+  if (!trigger) {
+    return;
+  }
+  trigger.setAttribute('aria-expanded', expanded ? 'true' : 'false');
 }
 
 /**
@@ -142,13 +159,19 @@ export function closeAllMobileOverlays(except = null) {
 
   document.querySelectorAll('[data-mel-notif-bell-panel].is-open').forEach((panel) => {
     if (except !== 'notifications') {
-      panel.classList.remove('is-open');
-      panel.hidden = true;
-      unportalPanel(panel);
-      const trigger = document.querySelector(`[aria-controls="${panel.id}"]`)
-        || panel.closest('[data-mel-notif-bell]')?.querySelector('[data-mel-notif-bell-trigger]');
-      if (trigger) {
-        trigger.setAttribute('aria-expanded', 'false');
+      const root = panel.closest('[data-mel-notif-bell]');
+      if (root && typeof root.melNotifBellSetOpen === 'function') {
+        root.melNotifBellSetOpen(false);
+      }
+      else {
+        panel.classList.remove('is-open');
+        panel.hidden = true;
+        unportalPanel(panel);
+        const trigger = document.querySelector(`[aria-controls="${panel.id}"]`)
+          || root?.querySelector('[data-mel-notif-bell-trigger]');
+        if (trigger) {
+          trigger.setAttribute('aria-expanded', 'false');
+        }
       }
     }
   });
@@ -157,9 +180,11 @@ export function closeAllMobileOverlays(except = null) {
     if (except !== 'cart') {
       block.classList.remove('is-open');
       const panel = block.querySelector('.mel-mini-cart');
+      const link = block.querySelector('.mel-cart-block-link');
       if (panel) {
         unportalPanel(panel);
       }
+      setCartTriggerExpanded(link, false);
     }
   });
 
@@ -181,11 +206,9 @@ function closeActiveOverlay(trigger) {
     return;
   }
   closeAllMobileOverlays();
-  if (trigger && typeof trigger.focus === 'function') {
-    requestAnimationFrame(() => trigger.focus());
-  }
-  else if (lastFocus && typeof lastFocus.focus === 'function') {
-    requestAnimationFrame(() => lastFocus.focus());
+  const returnTarget = trigger || lastFocus;
+  if (returnTarget && typeof returnTarget.focus === 'function') {
+    requestAnimationFrame(() => returnTarget.focus());
   }
 }
 
@@ -231,6 +254,41 @@ function watchNotificationPanel(panel) {
 }
 
 /**
+ * @param {HTMLElement} root
+ * @param {HTMLElement} trigger
+ * @param {HTMLElement} panel
+ */
+function toggleNotificationOverlay(root, trigger, panel) {
+  const isOpen = panel.classList.contains('is-open') && !panel.hidden;
+  const setOpen = root.melNotifBellSetOpen;
+
+  if (typeof setOpen !== 'function') {
+    return;
+  }
+
+  if (!isOpen) {
+    closeAllMobileOverlays('notifications');
+    setOpen(true);
+    requestAnimationFrame(() => {
+      if (!isMobileViewport() || !panel.classList.contains('is-open') || panel.hidden) {
+        return;
+      }
+      portalPanel(panel);
+      markOverlayOpen('notifications', trigger);
+      syncMobileOverlayLayout();
+      const focusable = panel.querySelector('button:not([disabled]), a[href]');
+      if (focusable) {
+        focusable.focus();
+      }
+    });
+  }
+  else {
+    setOpen(false);
+    closeActiveOverlay(trigger);
+  }
+}
+
+/**
  * Initialize mobile overlay coordination.
  *
  * @param {Document|Element} context
@@ -263,6 +321,13 @@ export function initMobileOverlays(context) {
       return;
     }
 
+    link.setAttribute('aria-controls', panel.id || 'mel-mini-cart-panel');
+    link.setAttribute('aria-expanded', 'false');
+    if (!panel.id) {
+      panel.id = 'mel-mini-cart-panel';
+    }
+    panel.setAttribute('aria-hidden', 'true');
+
     link.addEventListener('click', (event) => {
       if (!isMobileViewport()) {
         return;
@@ -274,6 +339,8 @@ export function initMobileOverlays(context) {
       if (opening) {
         closeAllMobileOverlays('cart');
         block.classList.add('is-open');
+        setCartTriggerExpanded(link, true);
+        panel.setAttribute('aria-hidden', 'false');
         portalPanel(panel);
         markOverlayOpen('cart', link);
         requestAnimationFrame(() => {
@@ -285,6 +352,8 @@ export function initMobileOverlays(context) {
       }
       else {
         block.classList.remove('is-open');
+        setCartTriggerExpanded(link, false);
+        panel.setAttribute('aria-hidden', 'true');
         unportalPanel(panel);
         closeActiveOverlay(link);
       }
@@ -334,23 +403,12 @@ export function initMobileOverlays(context) {
 
     const notifTrigger = event.target.closest('[data-mel-notif-bell-trigger]');
     if (notifTrigger) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
       const root = notifTrigger.closest('[data-mel-notif-bell]');
       const panel = root?.querySelector('[data-mel-notif-bell-panel]');
-      const opening = panel && !panel.classList.contains('is-open');
-      if (opening) {
-        closeAllMobileOverlays('notifications');
-        lastFocus = notifTrigger;
-        // Let mel-notifications-ui.js toggle first, then portal on next frame.
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            if (!isMobileViewport() || !panel.classList.contains('is-open') || panel.hidden) {
-              return;
-            }
-            portalPanel(panel);
-            markOverlayOpen('notifications', notifTrigger);
-            syncMobileOverlayLayout();
-          });
-        });
+      if (root && panel) {
+        toggleNotificationOverlay(root, notifTrigger, panel);
       }
       return;
     }
@@ -369,11 +427,7 @@ export function initMobileOverlays(context) {
       activeOverlay
       && !event.target.closest('.mel-cart-block, .mel-account-dropdown, [data-mel-notif-bell], .mobile-drawer, #mel-mobile-overlay-portal')
     ) {
-      const returnTrigger = lastFocus;
-      closeAllMobileOverlays();
-      if (returnTrigger && typeof returnTrigger.focus === 'function') {
-        requestAnimationFrame(() => returnTrigger.focus());
-      }
+      closeActiveOverlay(lastFocus);
     }
   }, true);
 
@@ -399,11 +453,7 @@ export function initMobileOverlays(context) {
     }
 
     event.preventDefault();
-    const returnTrigger = lastFocus;
-    closeAllMobileOverlays();
-    if (returnTrigger && typeof returnTrigger.focus === 'function') {
-      requestAnimationFrame(() => returnTrigger.focus());
-    }
+    closeActiveOverlay(lastFocus);
   });
 
   if (typeof MOBILE_MQ.addEventListener === 'function') {

--- a/web/themes/custom/myeventlane_theme/src/js/mobile-drawer.js
+++ b/web/themes/custom/myeventlane_theme/src/js/mobile-drawer.js
@@ -76,7 +76,10 @@ export function initMobileDrawer(context) {
         panel.setAttribute('aria-modal', 'true');
         summary.setAttribute('aria-expanded', 'true');
         drawer.classList.add('is-open');
-        document.body.classList.add('mel-drawer-open');
+
+        if (!isMobileViewport()) {
+          document.body.classList.add('mel-drawer-open');
+        }
 
         const firstFocusable = panel.querySelector('a[href], button:not([disabled])');
         if (firstFocusable) {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_mel-mobile-overlays.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_mel-mobile-overlays.scss
@@ -45,6 +45,10 @@
   box-shadow: shadows.$mel-shadow-lg;
 }
 
+body.mel-mobile-overlay-active {
+  overflow: hidden;
+}
+
 body.mel-mobile-overlay-active::before {
   content: '';
   position: fixed;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Checkout and invoice strings depend on the lazy formatter proxy behaving like Commerce’s formatter; mobile overlay changes affect cart, account, notifications, and drawer UX across breakpoints.
> 
> **Overview**
> **Checkout pricing display** now injects `myeventlane_commerce.currency_formatter.lazy` instead of `commerce_price.currency_formatter` across order breakdown, grouped summary, tax invoice presentation, and the fee transparency pane. Types are updated to `CurrencyFormatterInterface`./CommerceGuys\Intl\Formatter\CurrencyFormatterInterface` so formatting stays on the shared lazy proxy used elsewhere in commerce.
> 
> **Mobile header overlays** are split by viewport: the account dropdown script only opens/closes flyouts at **768px+**, while **mel-mobile-overlays.js** owns cart, account sheet, and notification bell below that breakpoint. The notification UI exposes `melNotifBellSetOpen` and skips its own click/outside/Escape handlers on mobile so the coordinator can portal panels, enforce one overlay at a time, and manage **aria-expanded** / **aria-hidden** (including cart trigger and empty portal). Closing overlays restores focus consistently; notification toggling is centralized in `toggleNotificationOverlay`. **mobile-drawer.js** only adds `mel-drawer-open` on the body when not mobile; SCSS adds **overflow: hidden** on `body.mel-mobile-overlay-active` for scroll lock behind the scrim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43939179bc44875299ccbbcd557c6eb37011549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->