### PR TITLE
Fix mobile bottom nav on browse event pages.

### DIFF
--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1557,6 +1557,39 @@ function _myeventlane_theme_build_calendar_links(NodeInterface $event): array {
 }
 
 /**
+ * Whether mobile bottom navigation should render (body padding class).
+ */
+function _myeventlane_theme_mobile_bottom_nav_should_render(bool $auth_minimal = FALSE): bool {
+  if (!\Drupal::hasService('myeventlane_front.mobile_bottom_navigation')) {
+    return FALSE;
+  }
+
+  return \Drupal::service('myeventlane_front.mobile_bottom_navigation')->shouldRender($auth_minimal);
+}
+
+/**
+ * Builds the mobile bottom navigation render array for page templates.
+ *
+ * @return array<string, mixed>
+ *   Render array for mobile_bottom_nav, or empty when nav should not render.
+ */
+function _myeventlane_theme_build_mobile_bottom_nav(bool $auth_minimal = FALSE): array {
+  if (!_myeventlane_theme_mobile_bottom_nav_should_render($auth_minimal)) {
+    return [];
+  }
+
+  $nav_builder = \Drupal::service('myeventlane_front.mobile_bottom_navigation');
+
+  return [
+    '#theme' => 'mobile_bottom_nav',
+    '#items' => $nav_builder->buildItems(),
+    '#cache' => [
+      'contexts' => ['route', 'user'],
+    ],
+  ];
+}
+
+/**
  * Implements hook_preprocess_html().
  */
 function myeventlane_theme_preprocess_html(array &$variables): void {
@@ -1582,16 +1615,13 @@ function myeventlane_theme_preprocess_html(array &$variables): void {
     }
   }
 
-  if (\Drupal::hasService('myeventlane_front.mobile_bottom_navigation')) {
-    $auth_minimal = FALSE;
-    if (\Drupal::moduleHandler()->moduleExists('myeventlane_surface')) {
-      $surface = \Drupal::service('myeventlane_surface.resolver')->resolve();
-      $auth_minimal = $surface === \Drupal\myeventlane_core\MelSurfaceId::Auth;
-    }
-    $nav_builder = \Drupal::service('myeventlane_front.mobile_bottom_navigation');
-    if ($nav_builder->shouldRender($auth_minimal)) {
-      $variables['attributes']['class'][] = 'mel-has-mobile-bottom-nav';
-    }
+  $auth_minimal = FALSE;
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_surface')) {
+    $surface = \Drupal::service('myeventlane_surface.resolver')->resolve();
+    $auth_minimal = $surface === \Drupal\myeventlane_core\MelSurfaceId::Auth;
+  }
+  if (_myeventlane_theme_mobile_bottom_nav_should_render($auth_minimal)) {
+    $variables['attributes']['class'][] = 'mel-has-mobile-bottom-nav';
   }
 
   $route_node = $route_match ? $route_match->getParameter('node') : NULL;
@@ -1666,21 +1696,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
   $variables['#attached']['library'][] = 'myeventlane_theme/footer-internal';
 
   $auth_minimal = !empty($variables['mel_surface_auth_minimal']);
-  if (\Drupal::hasService('myeventlane_front.mobile_bottom_navigation')) {
-    $nav_builder = \Drupal::service('myeventlane_front.mobile_bottom_navigation');
-    if ($nav_builder->shouldRender($auth_minimal)) {
-      $variables['mel_mobile_bottom_nav'] = [
-        '#theme' => 'mobile_bottom_nav',
-        '#items' => $nav_builder->buildItems(),
-        '#cache' => [
-          'contexts' => ['route', 'user'],
-        ],
-      ];
-    }
-    else {
-      $variables['mel_mobile_bottom_nav'] = [];
-    }
-  }
+  $variables['mel_mobile_bottom_nav'] = _myeventlane_theme_build_mobile_bottom_nav($auth_minimal);
 
   // Internal footer context (layout/footer-internal.html.twig).
   try {

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-browse-events-page-shell.html.twig
@@ -5,6 +5,9 @@
  *
  * Canonical runtime owner for browse-route H1, lede, prompt, and quicklink filter labels.
  * Route-specific copy is passed from page--view--upcoming-events--page-*.html.twig overrides.
+ *
+ * Variables from myeventlane_theme_preprocess_page():
+ * - mel_mobile_bottom_nav — mobile bottom navigation render array.
  */
 #}
 <div class="mel-page mel-page--events">

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-free.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-free.html.twig
@@ -10,4 +10,5 @@
   mel_browse_heading: 'Free events and RSVP gatherings'|t,
   mel_browse_lede: 'Community experiences with no ticket cost — easy ways to join in.'|t,
   mel_browse_prompt: 'Browse all events or see what’s on this weekend.'|t,
+  mel_mobile_bottom_nav: mel_mobile_bottom_nav,
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-hidden-gems.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-hidden-gems.html.twig
@@ -10,4 +10,5 @@
   mel_browse_heading: 'Hidden Gems'|t,
   mel_browse_lede: 'High-value local experiences you might not have found yet.'|t,
   mel_browse_prompt: 'Browse all events or see what’s on this weekend.'|t,
+  mel_mobile_bottom_nav: mel_mobile_bottom_nav,
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-popular.html.twig
@@ -10,4 +10,5 @@
   mel_browse_heading: 'Community Favourites'|t,
   mel_browse_lede: 'Experiences people are joining — ranked by real tickets and RSVPs this week.'|t,
   mel_browse_prompt: 'Browse all events or see what’s happening today.'|t,
+  mel_mobile_bottom_nav: mel_mobile_bottom_nav,
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-this-weekend.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-this-weekend.html.twig
@@ -10,4 +10,5 @@
   mel_browse_heading: 'Events this weekend'|t,
   mel_browse_lede: 'Plan your Saturday and Sunday — markets, gigs, workshops, and community moments.'|t,
   mel_browse_prompt: 'Try another time or explore everything coming up.'|t,
+  mel_mobile_bottom_nav: mel_mobile_bottom_nav,
 } %}

--- a/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-today.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--view--upcoming-events--page-today.html.twig
@@ -10,4 +10,5 @@
   mel_browse_heading: 'Events happening today'|t,
   mel_browse_lede: 'See what’s on across MyEventLane — new listings land throughout the day.'|t,
   mel_browse_prompt: 'Pick another time or browse all upcoming events.'|t,
+  mel_mobile_bottom_nav: mel_mobile_bottom_nav,
 } %}


### PR DESCRIPTION
Browse routes use mel-browse-events-page-shell.html.twig instead of page.html.twig, so the nav render array from preprocess_page was never output. Centralise nav building in theme helpers, always assign mel_mobile_bottom_nav, and pass it explicitly into browse shell includes so body padding and the nav bar stay in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme-only template and preprocess refactor with no auth or data changes; main risk is missing a browse page override that still omits the nav variable.
> 
> **Overview**
> Browse event routes render **`mel-browse-events-page-shell.html.twig`** instead of **`page.html.twig`**, so **`mel_mobile_bottom_nav`** from **`preprocess_page`** was never printed even when the body still got **`mel-has-mobile-bottom-nav`** padding.
> 
> This PR **centralises** mobile bottom nav in **`_myeventlane_theme_mobile_bottom_nav_should_render()`** and **`_myeventlane_theme_build_mobile_bottom_nav()`**, uses them from **`preprocess_html`** and **`preprocess_page`**, and **always assigns** **`mel_mobile_bottom_nav`** (empty array when hidden). Each **`page--view--upcoming-events--page-*.html.twig`** override **passes** **`mel_mobile_bottom_nav`** into the shell include so the bar and body padding stay aligned on Today, Weekend, Free, Popular, and Hidden Gems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33236240a68388bb1b44661be357ee32ef29a4c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->