### PR TITLE
Phase 2: Mobile bottom navigation and overlay stability

### DIFF
--- a/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
+++ b/web/modules/custom/myeventlane_notifications/js/mel-notifications-ui.js
@@ -339,7 +339,21 @@
       setOpen(!open);
     }
 
+    // Below md (768px) the mobile overlay coordinator (mel-mobile-overlays.js)
+    // owns open/close, outside-click, Escape, focus return, backdrop and body
+    // scroll lock. Expose setOpen so the coordinator can drive this panel, and
+    // keep the module's own desktop handlers inert on mobile to avoid two
+    // controllers fighting over open state (which strands the overlay backdrop).
+    root.melNotifBellSetOpen = setOpen;
+
+    function isMobileViewport() {
+      return window.matchMedia('(max-width: 767px)').matches;
+    }
+
     trigger.addEventListener('click', function (e) {
+      if (isMobileViewport()) {
+        return;
+      }
       e.stopPropagation();
       toggle();
     });
@@ -358,12 +372,18 @@
     }
 
     document.addEventListener('click', function (ev) {
+      if (isMobileViewport()) {
+        return;
+      }
       if (open && !root.contains(ev.target)) {
         setOpen(false);
       }
     });
 
     document.addEventListener('keydown', function (ev) {
+      if (isMobileViewport()) {
+        return;
+      }
       if (ev.key === 'Escape' && open) {
         setOpen(false);
         trigger.focus();

--- a/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
+++ b/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
@@ -7,6 +7,15 @@
 (function() {
   'use strict';
 
+  // Below md (768px) the mobile overlay coordinator (mel-mobile-overlays.js) is
+  // the single source of truth for account open/close, outside-click, Escape,
+  // focus return, backdrop, body scroll lock and mutual exclusion. This script
+  // owns the desktop flyout only and must stay inert on mobile, otherwise two
+  // controllers clear `is-open` independently and strand the overlay backdrop.
+  function isDesktopViewport() {
+    return window.matchMedia('(min-width: 768px)').matches;
+  }
+
   function initAccountDropdown(context) {
     context = context || document;
     const dropdowns = context.querySelectorAll('.mel-account-dropdown');
@@ -32,9 +41,12 @@
       const newMenu = dropdown.querySelector('.mel-account-menu');
 
       newToggle.addEventListener('click', function(e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
-        
+
         const isOpen = dropdown.classList.contains('is-open');
         
         if (isOpen) {
@@ -61,6 +73,9 @@
 
       // Close on outside click
       const closeHandler = function(e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
         if (!dropdown.contains(e.target) && dropdown.classList.contains('is-open')) {
           dropdown.classList.remove('is-open');
           newToggle.setAttribute('aria-expanded', 'false');
@@ -71,6 +86,9 @@
 
       // Escape key
       const escapeHandler = function(e) {
+        if (!isDesktopViewport()) {
+          return;
+        }
         if (e.key === 'Escape' && dropdown.classList.contains('is-open')) {
           dropdown.classList.remove('is-open');
           newToggle.setAttribute('aria-expanded', 'false');

--- a/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
+++ b/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
@@ -7,6 +7,7 @@
 
 const MOBILE_MQ = window.matchMedia('(max-width: 767px)');
 const PORTAL_ID = 'mel-mobile-overlay-portal';
+const NOTIF_PANEL_ID = 'mel-notif-bell-panel';
 
 /** @type {string|null} */
 let activeOverlay = null;
@@ -46,6 +47,33 @@ function getPortal() {
     document.body.appendChild(portal);
   }
   return portal;
+}
+
+/**
+ * Resolve an overlay panel even after it has been moved into the portal.
+ *
+ * Account/notification panels are portaled out of their trigger's container on
+ * open, so `container.querySelector(selector)` returns null while open. Look the
+ * panel up by id first, then in the container, then in the portal.
+ *
+ * @param {HTMLElement|null} container
+ * @param {string} selector
+ * @param {string|null} id
+ * @returns {HTMLElement|null}
+ */
+function resolveOverlayPanel(container, selector, id = null) {
+  if (id) {
+    const byId = document.getElementById(id);
+    if (byId) {
+      return byId;
+    }
+  }
+  const inContainer = container?.querySelector(selector);
+  if (inContainer) {
+    return inContainer;
+  }
+  const portal = document.getElementById(PORTAL_ID);
+  return portal ? portal.querySelector(selector) : null;
 }
 
 /**
@@ -129,7 +157,9 @@ export function closeAllMobileOverlays(except = null) {
     if (except !== 'account') {
       dropdown.classList.remove('is-open');
       const toggle = dropdown.querySelector('.mel-account-toggle');
-      const menu = dropdown.querySelector('.mel-account-menu');
+      // The menu is portaled out of the dropdown while open — resolve it via the
+      // portal so it is always unportaled and never stranded.
+      const menu = resolveOverlayPanel(dropdown, '.mel-account-menu');
       if (toggle) {
         toggle.setAttribute('aria-expanded', 'false');
       }
@@ -142,11 +172,20 @@ export function closeAllMobileOverlays(except = null) {
 
   document.querySelectorAll('[data-mel-notif-bell-panel].is-open').forEach((panel) => {
     if (except !== 'notifications') {
-      panel.classList.remove('is-open');
-      panel.hidden = true;
+      const root = panel.closest('[data-mel-notif-bell]')
+        || document.querySelector('[data-mel-notif-bell]');
+      if (root && typeof root.melNotifBellSetOpen === 'function') {
+        root.melNotifBellSetOpen(false);
+      }
+      else {
+        panel.classList.remove('is-open');
+        panel.hidden = true;
+      }
+      // Always reconcile portal + trigger state regardless of close path, so
+      // closing never depends on the notification observer firing.
       unportalPanel(panel);
       const trigger = document.querySelector(`[aria-controls="${panel.id}"]`)
-        || panel.closest('[data-mel-notif-bell]')?.querySelector('[data-mel-notif-bell-trigger]');
+        || root?.querySelector('[data-mel-notif-bell-trigger]');
       if (trigger) {
         trigger.setAttribute('aria-expanded', 'false');
       }
@@ -190,6 +229,12 @@ function closeActiveOverlay(trigger) {
 }
 
 /**
+ * Reconcile coordinator state when the notification panel closes from outside
+ * the coordinator — the module's own "mark all read" action calls setOpen(false)
+ * directly, and leaving the mobile breakpoint hides the panel. Opening, portaling
+ * and mutual exclusion are owned solely by toggleNotificationOverlay() (the single
+ * source of truth); this observer never drives the open lifecycle.
+ *
  * @param {HTMLElement} panel
  */
 function watchNotificationPanel(panel) {
@@ -199,35 +244,61 @@ function watchNotificationPanel(panel) {
   panel.setAttribute('data-mel-notif-overlay-watch', '1');
 
   const observer = new MutationObserver(() => {
-    if (!isMobileViewport()) {
-      if (panel.dataset.melPortaled === '1') {
-        unportalPanel(panel);
-      }
+    const isOpen = panel.classList.contains('is-open') && !panel.hidden;
+    if (isOpen) {
       return;
     }
-
-    const isOpen = panel.classList.contains('is-open') && !panel.hidden;
-    const trigger = document.querySelector('[data-mel-notif-bell-trigger][aria-controls="mel-notif-bell-panel"]')
-      || document.querySelector('[data-mel-notif-bell-trigger]');
-
-    if (isOpen) {
-      if (activeOverlay !== 'notifications') {
-        closeAllMobileOverlays('notifications');
-      }
-      portalPanel(panel);
-      if (trigger) {
-        markOverlayOpen('notifications', trigger);
-      }
-    }
-    else {
+    if (panel.dataset.melPortaled === '1') {
       unportalPanel(panel);
-      if (activeOverlay === 'notifications') {
-        notifyOverlayClosed('notifications');
-      }
+    }
+    if (activeOverlay === 'notifications') {
+      notifyOverlayClosed('notifications');
     }
   });
 
   observer.observe(panel, { attributes: true, attributeFilter: ['class', 'hidden'] });
+}
+
+/**
+ * Open or close the notification panel as the single coordinator-owned lifecycle.
+ *
+ * @param {HTMLElement} root
+ * @param {HTMLElement} trigger
+ * @param {HTMLElement} panel
+ */
+function toggleNotificationOverlay(root, trigger, panel) {
+  // Drive the module's panel when its API is available; fall back to toggling the
+  // panel directly so the coordinator is self-sufficient if the module is absent.
+  const setOpen = typeof root.melNotifBellSetOpen === 'function'
+    ? root.melNotifBellSetOpen
+    : (v) => {
+        trigger.setAttribute('aria-expanded', v ? 'true' : 'false');
+        panel.hidden = !v;
+        panel.classList.toggle('is-open', v);
+      };
+
+  const isOpen = panel.classList.contains('is-open') && !panel.hidden;
+
+  if (!isOpen) {
+    closeAllMobileOverlays('notifications');
+    setOpen(true);
+    requestAnimationFrame(() => {
+      if (!isMobileViewport() || !panel.classList.contains('is-open') || panel.hidden) {
+        return;
+      }
+      portalPanel(panel);
+      markOverlayOpen('notifications', trigger);
+      syncMobileOverlayLayout();
+      const focusable = panel.querySelector('button:not([disabled]), a[href]');
+      if (focusable) {
+        focusable.focus();
+      }
+    });
+  }
+  else {
+    setOpen(false);
+    closeActiveOverlay(trigger);
+  }
 }
 
 /**
@@ -302,7 +373,10 @@ export function initMobileOverlays(context) {
       event.stopImmediatePropagation();
 
       const dropdown = toggle.closest('.mel-account-dropdown');
-      const menu = dropdown?.querySelector('.mel-account-menu');
+      // Resolve via the portal too — on the second tap the menu has been moved
+      // into #mel-mobile-overlay-portal, so a plain dropdown query returns null
+      // and the close path would otherwise bail (leaving the backdrop stranded).
+      const menu = dropdown ? resolveOverlayPanel(dropdown, '.mel-account-menu') : null;
       if (!dropdown || !menu) {
         return;
       }
@@ -334,23 +408,12 @@ export function initMobileOverlays(context) {
 
     const notifTrigger = event.target.closest('[data-mel-notif-bell-trigger]');
     if (notifTrigger) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
       const root = notifTrigger.closest('[data-mel-notif-bell]');
-      const panel = root?.querySelector('[data-mel-notif-bell-panel]');
-      const opening = panel && !panel.classList.contains('is-open');
-      if (opening) {
-        closeAllMobileOverlays('notifications');
-        lastFocus = notifTrigger;
-        // Let mel-notifications-ui.js toggle first, then portal on next frame.
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            if (!isMobileViewport() || !panel.classList.contains('is-open') || panel.hidden) {
-              return;
-            }
-            portalPanel(panel);
-            markOverlayOpen('notifications', notifTrigger);
-            syncMobileOverlayLayout();
-          });
-        });
+      const panel = resolveOverlayPanel(root, '[data-mel-notif-bell-panel]', NOTIF_PANEL_ID);
+      if (root && panel) {
+        toggleNotificationOverlay(root, notifTrigger, panel);
       }
       return;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_site-header.scss
@@ -13,6 +13,20 @@
 .site-header {
   position: relative;
   z-index: 100;
+
+  // The mobile drawer panel is a DOM child of .site-header, so this stacking
+  // context (z-index: 100) caps the whole drawer subtree at root-level 100 —
+  // beneath the shared overlay backdrop (body.mel-mobile-overlay-active::before,
+  // z-index 149), whose pointer-events: auto then intercepts every drawer tap.
+  // While the drawer is open, lift the header above the backdrop. Mobile only;
+  // desktop behaviour and the portaled overlays (account/notif/cart) are
+  // unaffected — they escape to #mel-mobile-overlay-portal independently.
+  @include breakpoints.mel-break(md, max) {
+    body.mel-drawer-open & {
+      z-index: 200;
+    }
+  }
+
   background: #fff;
   border-bottom: 1px solid rgba(41, 50, 65, 0.12);
   height: 64px;


### PR DESCRIPTION
- Add mobile bottom navigation
- Add Community destination
- Fix mobile drawer interaction issues
- Fix notification overlay lifecycle
- Fix account menu overlay lifecycle
- Ensure only one mobile overlay is active at a time
- Preserve desktop navigation behaviour

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical mobile nav UX (overlay mutex, portaling, z-index); the account-dropdown diff may have removed document listeners for outside-click/Escape on desktop, which would be a functional regression if shipped as-is.
> 
> **Overview**
> Fixes **stranded mobile overlay backdrops** and broken second-tap closes by making **`mel-mobile-overlays.js`** the only controller below 768px, while desktop flyouts stay on the theme/module scripts.
> 
> **Notification bell** (`mel-notifications-ui.js`): documents the split; adds a local mobile viewport check so the module’s click/outside/Escape handlers **no-op on mobile** while still exposing **`melNotifBellSetOpen`** for the coordinator.
> 
> **Mobile coordinator** (`mel-mobile-overlays.js`): adds **`resolveOverlayPanel`** (id → container → portal) so account menus and the notification panel can be found after portaling; uses it when toggling account/notifications and when closing all overlays. Notification **open/portaling/mutex** moves entirely into **`toggleNotificationOverlay`** (with a fallback **`setOpen`** if the module API is missing); the mutation observer **only cleans up on close** (unportal + clear active overlay). Closing notifications always **unportals and resets `aria-expanded`**, even when **`melNotifBellSetOpen(false)`** runs from “mark all read”.
> 
> **Account dropdown** (`account-dropdown.js`): clarifies desktop-only ownership via comments and inline **`matchMedia`**; refactors close/escape into named handlers (verify they are still attached to `document` in the built file—diff suggests **`addEventListener` may have been dropped**, which would break desktop dismiss).
> 
> **Header stacking** (`_site-header.scss`): on mobile, raises **`.site-header` z-index to 200** when **`body.mel-drawer-open`** so drawer taps aren’t blocked by the shared overlay backdrop (z-index 149).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73afcc0e88fb9b90f251c0da0b442dfc7df32383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->