### PR TITLE
Feature/mobile bottom navigation

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
+++ b/web/themes/custom/myeventlane_theme/src/js/account-dropdown.js
@@ -75,7 +75,7 @@
       });
 
       // Close on outside click
-      const closeHandler = function(e) {
+      const closeHandler = function (e) {
         if (!isDesktopViewport()) {
           return;
         }
@@ -84,10 +84,12 @@
           newToggle.setAttribute('aria-expanded', 'false');
           newMenu.setAttribute('aria-hidden', 'true');
         }
-      }, true);
+      };
+
+      document.addEventListener('click', closeHandler, true);
 
       // Escape key
-      const escapeHandler = function(e) {
+      const escapeHandler = function (e) {
         if (!isDesktopViewport()) {
           return;
         }
@@ -97,7 +99,9 @@
           newMenu.setAttribute('aria-hidden', 'true');
           newToggle.focus();
         }
-      });
+      };
+
+      document.addEventListener('keydown', escapeHandler);
     });
   }
 

--- a/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
+++ b/web/themes/custom/myeventlane_theme/src/js/mel-mobile-overlays.js
@@ -297,10 +297,16 @@ function toggleNotificationOverlay(root, trigger, panel) {
   const isOpen = panel.classList.contains('is-open') && !panel.hidden;
 
   if (!isOpen) {
-    closeAllMobileOverlays('notifications');
+    // Close other overlays only — do not pass 'notifications' as except or
+    // closeAllMobileOverlays turns on backdrop/scroll lock before the panel is
+    // portaled; an early rAF exit would strand that state with no visible sheet.
+    closeAllMobileOverlays();
     setOpen(true);
     requestAnimationFrame(() => {
       if (!isMobileViewport() || !panel.classList.contains('is-open') || panel.hidden) {
+        if (panel.classList.contains('is-open') && !panel.hidden) {
+          setOpen(false);
+        }
         return;
       }
       portalPanel(panel);
@@ -314,6 +320,10 @@ function toggleNotificationOverlay(root, trigger, panel) {
   }
   else {
     setOpen(false);
+    // setOpen(false) removes .is-open before closeActiveOverlay runs, so
+    // closeAllMobileOverlays no longer matches this panel — unportal explicitly
+    // (same pattern as the account overlay close path).
+    unportalPanel(panel);
     closeActiveOverlay(trigger);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Front-end overlay and dropdown UX fixes only; no auth, data, or API changes.
> 
> **Overview**
> Fixes **desktop account dropdown** behavior where outside-click and Escape handlers were syntactically broken (listeners were never registered correctly). Handlers are now defined as standalone functions and attached with `document.addEventListener` for click (capture) and keydown.
> 
> Adjusts **mobile notification bell** open/close in the overlay coordinator: opening calls `closeAllMobileOverlays()` without an `except` id so backdrop/scroll lock is not applied before the panel is portaled (avoiding stranded overlay state if the next animation frame bails). If that frame detects an invalid mobile/open state while the panel still looks open, it rolls back with `setOpen(false)`. Closing explicitly **unportals** the panel before `closeActiveOverlay`, matching the account sheet pattern, because `setOpen(false)` clears `.is-open` and the bulk closer no longer finds the panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f181aa1181e706e3f7de14670e29124f7ff53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->