### PR TITLE
Fix/date pill placement

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-card.scss
@@ -1570,8 +1570,10 @@
   }
 
   .mel-event-card__badge-stack {
-    top: auto;
-    bottom: 8px;
+    position: absolute;
+    z-index: 4;
+    top: 8px;
+    bottom: auto;
     left: 8px;
     max-width: calc(100% - 16px);
     gap: 3px;

--- a/web/themes/custom/myeventlane_theme/src/scss/utilities/_skeletons.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/utilities/_skeletons.scss
@@ -39,7 +39,8 @@
   isolation: isolate;
 
   // Keep children above shimmer by default (stacked / compact cards).
-  > * {
+  // Badge stack must stay absolute — it overlays the image top-left.
+  > *:not(.mel-event-card__badge-stack) {
     position: relative;
     z-index: 1;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped SCSS-only changes to compact card badges and loading shimmer stacking; no backend or auth impact.
> 
> **Overview**
> Fixes **date pill / badge stack** placement on **compact** event cards by anchoring `.mel-event-card__badge-stack` to the **top-left** of the thumbnail (`top: 8px`, `position: absolute`, `z-index: 4`) instead of the **bottom-left**.
> 
> Updates skeleton shimmer layering so direct children of `.mel-event-card__image` no longer all get `position: relative`—**`.mel-event-card__badge-stack` is excluded** so absolute overlay positioning is preserved while images still sit above the shimmer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b064619a9fb79232c17f2e749a9492ddf73070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->