### PR TITLE
Add chip bar for event filtering in upcoming events view

### DIFF
--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-category.html.twig
@@ -8,6 +8,7 @@
 #}
 {% if not mel_chip_listing_fragment|default(false) %}
   {{ attach_library('myeventlane_theme/mel-events-discovery') }}
+  {{ attach_library('myeventlane_theme/mel-chips') }}
 {% endif %}
 
 {% if mel_chip_listing_fragment|default(false) %}
@@ -34,6 +35,30 @@
         } %}
       </div>
     {% endif %}
+
+    <div
+      class="mel-chip-bar"
+      data-chip-bar
+      data-category-tid="{{ term.id }}"
+    >
+      {% set chips = {
+        'all': 'All',
+        'now': '🔥 Happening now',
+        'weekend': '🎉 This weekend',
+        'free': '💸 Free events',
+        'trending': '💖 Trending'
+      } %}
+
+      {% for key, label in chips %}
+        <button
+          type="button"
+          class="mel-chip{{ key == (default_chip|default('all')) ? ' is-active' }}"
+          data-chip="{{ key }}"
+        >
+          {{ label|t }}
+        </button>
+      {% endfor %}
+    </div>
   {% endif %}
 
   <div data-mel-filter-results>


### PR DESCRIPTION
- Introduced a new chip bar component to allow users to filter upcoming events by categories such as 'All', 'Happening now', 'This weekend', 'Free events', and 'Trending'.
- Attached the necessary library for the chip functionality to enhance user interaction and event discovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Twig and library attachment; filtering behavior relies on existing JS and server-side chip handling already used elsewhere.
> 
> **Overview**
> The **category upcoming events** view template now loads the **`mel-chips`** library (with **`mel-events-discovery`**) on full-page renders so chip behavior is available outside AJAX fragments.
> 
> When a category term is present, it renders a **`mel-chip-bar`** above the listing with five filter buttons (All, Happening now, This weekend, Free events, Trending), **`data-category-tid`**, and an **`is-active`** state driven by **`default_chip`**. That bar sits immediately before the existing **`data-mel-filter-results`** region so **`mel-chips.js`** can swap the grid without a full reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9ba06f85a8270be5e19d844dd5061987103240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->