### PR TITLE
Fix/mel reminder single owner

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f576ab3d6c3f1a51792d18d189e5802",
+    "content-hash": "6ab7b58ac2d4135c94447c9a0c9d22b8",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/docs/development/local-mail.md
+++ b/docs/development/local-mail.md
@@ -1,0 +1,98 @@
+# Local mail (DDEV)
+
+MyEventLane messaging on local development must use Drupal core mail (`drupal_mail`) and Mailpit. Production uses Postmark via `config/sync/myeventlane_messaging.settings.yml` (`delivery_provider: postmark`).
+
+## Architecture
+
+| Layer | Local (DDEV) | Production |
+| --- | --- | --- |
+| Messaging delivery | `DrupalMailProvider` (`delivery_provider: drupal_mail`) | `PostmarkDeliveryProvider` |
+| Transport | `mime_mail` → PHP `sendmail` → Mailpit (`localhost:1025`) | Postmark API |
+| Secrets | None required | `MEL_POSTMARK_SERVER_TOKEN`, `MEL_POSTMARK_WEBHOOK_SECRET` |
+
+Flow for queued messages:
+
+```text
+MessagingManager::sendNow()
+  → DeliveryProviderManager
+  → DrupalMailProvider (local)
+  → plugin.manager.mail
+  → mime_mail
+  → sendmail / Mailpit
+```
+
+Attachments from `MessagingManager::queue()` pass through `DrupalMailProvider` unchanged (same shapes as Postmark: `filename` + `content` + `mime`).
+
+## Committed local overrides
+
+**Delivery provider (DDEV only)** — `web/sites/default/settings.mel_shared_session.php`:
+
+```php
+if (getenv('IS_DDEV_PROJECT') === 'true') {
+  $config['myeventlane_messaging.settings']['delivery_provider'] = 'drupal_mail';
+}
+```
+
+This override is intentional: `delivery_provider` must not be `drupal_mail` in `config/sync` (production ships `postmark`).
+
+**Mailpit transport** — DDEV-generated `web/sites/default/settings.ddev.php` points Symfony Mailer transports at `localhost:1025`. Active stack uses `config/sync/system.mail.yml` (`mime_mail` + `sendmail`), which DDEV routes to Mailpit by default.
+
+**Domain URLs** — `web/sites/default/settings.local.php` (optional, per-developer) overrides `myeventlane_core.domain_settings` for `*.ddev.site`. Not required for mail capture.
+
+## Postmark on local (optional)
+
+`settings.mel_shared_session.php` merges Postmark tokens from the environment when set. With `delivery_provider` forced to `drupal_mail`, tokens are unused for outbound mail. Do not set `MEL_POSTMARK_SERVER_TOKEN` locally unless you are explicitly testing Postmark (not recommended for day-to-day dev).
+
+## Mailpit UI
+
+After sending mail:
+
+```text
+https://myeventlane.ddev.site:8025
+```
+
+Or from the project root:
+
+```bash
+ddev mailpit
+```
+
+## Process the messaging queue
+
+```bash
+ddev drush mel:msg-run
+```
+
+Scan schedulers (reminders, cart, boost) without sending:
+
+```bash
+ddev drush mel:msg-scan
+ddev drush mel:msg-run
+```
+
+## Quick smoke test
+
+```bash
+ddev drush myeventlane:messaging:test order_confirmation you@example.test
+ddev drush mel:msg-run
+```
+
+Open Mailpit and confirm one message to `you@example.test`.
+
+## Verify active provider
+
+```bash
+ddev drush php:eval "echo \Drupal::service('myeventlane_messaging.delivery_provider_manager')->getProvider()->id();"
+```
+
+Expected on DDEV: `drupal_mail`.
+
+## Related docs
+
+- Attachment validation checklist: [mail-attachment-validation.md](./mail-attachment-validation.md)
+- Order confirmation troubleshooting: [../TROUBLESHOOTING_RECEIPT_EMAILS.md](../TROUBLESHOOTING_RECEIPT_EMAILS.md)
+
+## Residual risk
+
+- `settings.local.php` is loaded only under DDEV (`settings.php`). Do not commit secrets; keep API keys in env or gitignored `config.local.yaml`.
+- Category B mail (Drupal auth, some module `mail()` calls) also flows through Mailpit but is outside `myeventlane_messaging` delivery providers.

--- a/docs/development/mail-attachment-validation.md
+++ b/docs/development/mail-attachment-validation.md
@@ -1,0 +1,123 @@
+# Mail attachment validation (local)
+
+Repeatable checks for transactional email attachments. Run on DDEV after confirming [local-mail.md](./local-mail.md) (`delivery_provider` = `drupal_mail`, Mailpit reachable).
+
+Do not modify messaging code unless a step below fails; trace producer → resolver → provider → transport.
+
+## Preconditions
+
+```bash
+ddev drush cr
+ddev drush php:eval "echo \Drupal::service('myeventlane_messaging.delivery_provider_manager')->getProvider()->id();"
+# expect: drupal_mail
+```
+
+Open Mailpit: `https://myeventlane.ddev.site:8025`
+
+## 1. Order confirmation (PDF + ICS)
+
+**Producer:** `OrderConfirmationQueueBuilder` → `MessagingManager::queue()`  
+**Resolver:** `OrderConfirmationAttachmentResolver` at send time (ticket PDFs)  
+**Provider:** `DrupalMailProvider` → `mime_mail`
+
+Use a completed order with ticket-backed line items and checkout holder data:
+
+```bash
+# Replace ORDER_ID and email as needed
+ddev drush php:eval "
+\$order = \Drupal::entityTypeManager()->getStorage('commerce_order')->load(ORDER_ID);
+\Drupal::service('myeventlane_messaging.order_confirmation_queue_builder')->queue(\$order, 'you@example.test');
+"
+ddev drush mel:msg-run
+```
+
+**Mailpit expectations:**
+
+| Attachment | MIME | Notes |
+| --- | --- | --- |
+| `event-*.ics` | `text/calendar` | One per event on the order |
+| `*.pdf` | `application/pdf` | One per **assigned** `myeventlane_ticket` row |
+
+If PDFs missing: check ticket status (`issued_unassigned` vs `assigned`) and holder fields:
+
+```bash
+ddev drush sqlq "SELECT id,status,holder_email FROM myeventlane_ticket WHERE order_id=ORDER_ID"
+```
+
+## 2. RSVP confirmation
+
+**Producer:** RSVP / messaging queue (template key from your event RSVP flow)
+
+Trigger via UI or module-specific drush if available. After queue processing:
+
+**Mailpit expectations:**
+
+| Attachment | MIME |
+| --- | --- |
+| `event-*.ics` | `text/calendar` |
+
+## 3. Event reminder (ICS)
+
+```bash
+ddev drush mel:reminder-test 24h you@example.test ORDER_ID
+ddev drush mel:msg-run
+```
+
+**Mailpit expectations:**
+
+| Attachment | MIME |
+| --- | --- |
+| `event-*.ics` | `text/calendar` |
+
+## 4. Ticket-ready email (assigned ticket PDF)
+
+Requires `myeventlane_ticket` with `status=assigned` and holder name/email. After assignment:
+
+```bash
+# Load ticket TICKET_ID, then:
+ddev drush php:eval "
+\$ticket = \Drupal::entityTypeManager()->getStorage('myeventlane_ticket')->load(TICKET_ID);
+\Drupal::service('myeventlane_tickets.ticket_mailer')->sendAssignedTicket(\$ticket);
+"
+```
+
+**Mailpit expectations:**
+
+| Attachment | MIME |
+| --- | --- |
+| `*.pdf` | `application/pdf` |
+
+## 5. Postmark attachment shapes (staging only)
+
+On staging with Postmark enabled, the same attachment counts and MIME types apply. `PostmarkDeliveryProvider` accepts:
+
+1. MEL shape: `filename`, `content` (raw bytes), `mime`
+2. Postmark shape: `Name`, `Content` (base64), `ContentType`
+3. File path shape: `path`, `name`, `content_type`
+
+## Failure tracing
+
+| Symptom | Check |
+| --- | --- |
+| No email in Mailpit | `ddev drush queue:list`; run `mel:msg-run`; `ddev drush ws --count=20` |
+| Email without attachments | Watchdog: `Order confirmation: ticket PDF not attached` |
+| PDF skipped | Ticket `holder_name` / `holder_email` empty or `issued_unassigned` |
+| ICS missing | `myeventlane_rsvp.ics_generator` service; event start field |
+| Wrong provider | `delivery_provider` override in DDEV `settings.mel_shared_session.php` |
+
+## Log tail
+
+```bash
+ddev drush ws --count=50
+ddev drush queue:list
+```
+
+## Record results
+
+When validating a release, note in your test log:
+
+- Template key
+- Recipient
+- Attachment count in Mailpit
+- Each attachment filename and Content-Type
+- Any watchdog warnings from `myeventlane_messaging` or `myeventlane_tickets`

--- a/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
+++ b/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
@@ -44,6 +44,7 @@ final class CustomerHubDataBuilder {
    * }
    */
   public function buildParticipationLists(int $userId, string $userEmail, int $now, bool $includeRsvpSubmissions = TRUE): array {
+    $userEmail = trim($userEmail);
     $eventMap = $this->buildEventMap($userId, $userEmail, $includeRsvpSubmissions);
 
     $upcomingTickets = [];
@@ -144,7 +145,15 @@ final class CustomerHubDataBuilder {
       ->condition('status', EventAttendee::STATUS_CONFIRMED);
 
     if ($userId > 0) {
-      $attendeeQuery->condition('uid', $userId);
+      if ($userEmail !== '') {
+        $identityGroup = $attendeeQuery->orConditionGroup()
+          ->condition('uid', $userId)
+          ->condition('email', $userEmail);
+        $attendeeQuery->condition($identityGroup);
+      }
+      else {
+        $attendeeQuery->condition('uid', $userId);
+      }
     }
     elseif ($userEmail !== '') {
       $attendeeQuery->condition('email', $userEmail);
@@ -157,8 +166,13 @@ final class CustomerHubDataBuilder {
     $attendees = !empty($attendeeIds) ? $attendeeStorage->loadMultiple($attendeeIds) : [];
 
     foreach ($attendees as $attendee) {
-      $eventId = $attendee->get('event')->target_id;
-      if (!$eventId || isset($eventMap[$eventId])) {
+      $eventId = (int) $attendee->get('event')->target_id;
+      if ($eventId < 1) {
+        continue;
+      }
+
+      $source = (string) ($attendee->get('source')->value ?? 'ticket');
+      if (isset($eventMap[$eventId]) && !$this->ticketSourcePrecedes($source, (string) ($eventMap[$eventId]['source'] ?? ''))) {
         continue;
       }
 
@@ -172,7 +186,7 @@ final class CustomerHubDataBuilder {
         : NULL;
       $eventMap[$eventId] = $this->buildEventItem(
         $event,
-        $attendee->get('source')->value ?? 'ticket',
+        $source,
         $attendee->get('ticket_code')->value ?? '',
         (int) $attendee->id(),
         $orderItemId,
@@ -217,7 +231,7 @@ final class CustomerHubDataBuilder {
         }
 
         $eventId = (int) $event->id();
-        if (isset($eventMap[$eventId])) {
+        if (isset($eventMap[$eventId]) && ($eventMap[$eventId]['source'] ?? '') === 'ticket') {
           continue;
         }
 
@@ -272,6 +286,16 @@ final class CustomerHubDataBuilder {
     }
 
     return $eventMap;
+  }
+
+  /**
+   * Ticket purchases outrank RSVP rows for the same event in hub previews.
+   */
+  private function ticketSourcePrecedes(string $candidateSource, string $existingSource): bool {
+    if ($candidateSource === 'ticket' && $existingSource !== 'ticket') {
+      return TRUE;
+    }
+    return $existingSource === '';
   }
 
   /**

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.info.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 lifecycle: stable
 
 dependencies:
+  - myeventlane_account:myeventlane_account
   - myeventlane_attendee:myeventlane_attendee
   - myeventlane_core:myeventlane_core
   - myeventlane_event:myeventlane_event

--- a/web/modules/custom/myeventlane_messaging/src/Service/EventReminderScheduler.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/EventReminderScheduler.php
@@ -13,6 +13,8 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Url;
 use Drupal\myeventlane_attendee\Attendee\AttendeeInterface;
+use Drupal\myeventlane_attendee\Attendee\RsvpAttendee;
+use Drupal\myeventlane_attendee\Attendee\TicketAttendee;
 use Drupal\myeventlane_attendee\Service\AttendeeRepositoryResolver;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_notifications\Service\ReminderNotificationTriggerService;
@@ -318,14 +320,9 @@ final class EventReminderScheduler {
    */
   private function buildOrderContext(OrderInterface $order, NodeInterface $event, string $timeframe): array {
     $event_url = $this->buildPublicUrl($event->toUrl('canonical', ['absolute' => FALSE])->toString());
-    $my_tickets_url = $this->buildPublicUrl('/my-tickets/order/' . $order->id());
+    $my_tickets_url = $this->buildOrderDetailUrl((int) $order->id());
     if (!$event_url) {
       $event_url = $event->toUrl('canonical', ['absolute' => TRUE])->toString(TRUE)->getGeneratedUrl();
-    }
-    if (!$my_tickets_url) {
-      $my_tickets_url = Url::fromRoute('myeventlane_checkout_flow.order_detail', [
-        'commerce_order' => $order->id(),
-      ], ['absolute' => TRUE])->toString(TRUE)->getGeneratedUrl();
     }
 
     $context = [
@@ -382,17 +379,132 @@ final class EventReminderScheduler {
       'attendee_count' => $attendeeNames !== [] ? count($attendeeNames) : 1,
     ];
 
-    $attendeeId = $attendee->getAttendeeId();
-    if (str_starts_with($attendeeId, 'rsvp:')) {
-      $context['submission_id'] = (int) substr($attendeeId, 5);
-    }
-    elseif (str_starts_with($attendeeId, 'ticket:')) {
-      $context['attendee_id'] = $attendeeId;
-    }
-
+    $this->appendAttendeeReferenceContext($context, $attendee);
     $this->appendEventScheduleContext($context, $event);
 
     return $context;
+  }
+
+  /**
+   * Adds booking reference and CTA URLs expected by reminder templates.
+   *
+   * @param array<string, mixed> $context
+   *   Context array to mutate.
+   * @param \Drupal\myeventlane_attendee\Attendee\AttendeeInterface $attendee
+   *   RSVP or ticket attendee.
+   */
+  private function appendAttendeeReferenceContext(array &$context, AttendeeInterface $attendee): void {
+    if ($attendee instanceof RsvpAttendee) {
+      $submissionId = (int) substr($attendee->getAttendeeId(), 5);
+      $context['submission_id'] = $submissionId;
+      $context['order_number'] = 'RSVP-' . $submissionId;
+      $context['my_tickets_url'] = $this->buildAccountHubUrl();
+      return;
+    }
+
+    if ($attendee instanceof TicketAttendee) {
+      $context['attendee_id'] = $attendee->getAttendeeId();
+      $orderReference = $this->resolveOrderReferenceFromTicketAttendee($attendee);
+      if ($orderReference !== NULL) {
+        $context += $orderReference;
+        return;
+      }
+
+      $ticketCode = trim($attendee->getEventAttendee()->getTicketCode() ?? '');
+      $context['order_number'] = $ticketCode !== '' ? $ticketCode : $attendee->getAttendeeId();
+      $context['my_tickets_url'] = $this->buildMyTicketsHubUrl();
+      return;
+    }
+
+    $attendeeId = $attendee->getAttendeeId();
+    if (str_starts_with($attendeeId, 'rsvp:')) {
+      $submissionId = (int) substr($attendeeId, 5);
+      $context['submission_id'] = $submissionId;
+      $context['order_number'] = 'RSVP-' . $submissionId;
+      $context['my_tickets_url'] = $this->buildAccountHubUrl();
+    }
+    elseif (str_starts_with($attendeeId, 'ticket:')) {
+      $context['attendee_id'] = $attendeeId;
+      $context['order_number'] = $attendeeId;
+      $context['my_tickets_url'] = $this->buildMyTicketsHubUrl();
+    }
+  }
+
+  /**
+   * Resolves commerce order reference fields for a ticket attendee.
+   *
+   * @return array{order_id: int, order_number: string|null, my_tickets_url: string}|null
+   *   Order context when an order item link exists, otherwise NULL.
+   */
+  private function resolveOrderReferenceFromTicketAttendee(TicketAttendee $attendee): ?array {
+    $eventAttendee = $attendee->getEventAttendee();
+    if (!$eventAttendee->hasField('order_item') || $eventAttendee->get('order_item')->isEmpty()) {
+      return NULL;
+    }
+
+    $orderItem = $eventAttendee->get('order_item')->entity;
+    if (!$orderItem instanceof OrderItemInterface) {
+      return NULL;
+    }
+
+    try {
+      $order = $orderItem->getOrder();
+      if (!$order instanceof OrderInterface) {
+        return NULL;
+      }
+    }
+    catch (\Exception $e) {
+      return NULL;
+    }
+
+    $orderId = (int) $order->id();
+    return [
+      'order_id' => $orderId,
+      'order_number' => $order->getOrderNumber(),
+      'my_tickets_url' => $this->buildOrderDetailUrl($orderId),
+    ];
+  }
+
+  /**
+   * Builds the public order detail URL used by reminder templates.
+   */
+  private function buildOrderDetailUrl(int $orderId): string {
+    $url = $this->buildPublicUrl('/my-tickets/order/' . $orderId);
+    if ($url !== NULL) {
+      return $url;
+    }
+
+    return Url::fromRoute('myeventlane_checkout_flow.order_detail', [
+      'commerce_order' => $orderId,
+    ], ['absolute' => TRUE])->toString(TRUE)->getGeneratedUrl();
+  }
+
+  /**
+   * Builds the customer tickets hub URL for non-order ticket holders.
+   */
+  private function buildMyTicketsHubUrl(): string {
+    $url = $this->buildPublicUrl('/my-tickets');
+    if ($url !== NULL) {
+      return $url;
+    }
+
+    return Url::fromRoute('myeventlane_checkout_flow.my_tickets', [], [
+      'absolute' => TRUE,
+    ])->toString(TRUE)->getGeneratedUrl();
+  }
+
+  /**
+   * Builds the customer account hub URL for RSVP holders.
+   */
+  private function buildAccountHubUrl(): string {
+    $url = $this->buildPublicUrl('/my-account');
+    if ($url !== NULL) {
+      return $url;
+    }
+
+    return Url::fromRoute('myeventlane_account.dashboard', [], [
+      'absolute' => TRUE,
+    ])->toString(TRUE)->getGeneratedUrl();
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketIssuer.php
@@ -13,6 +13,7 @@ use Drupal\mel_ticket\Entity\TicketType;
 use Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifierInterface;
 use Drupal\myeventlane_tickets\Entity\Ticket;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Issues ticket rows for paid Commerce orders.
@@ -139,6 +140,7 @@ final class TicketIssuer {
           'status' => Ticket::STATUS_ISSUED_UNASSIGNED,
         ];
         $ticket = $ticket_storage->create($values);
+        $this->applyCheckoutHolderToTicket($ticket, $order_item, $i);
         $ticket->save();
       }
     }
@@ -187,6 +189,43 @@ final class TicketIssuer {
     }
 
     return NULL;
+  }
+
+  /**
+   * Maps checkout ticket-holder paragraphs onto issued ticket rows when present.
+   *
+   * Holder details collected at checkout (field_ticket_holder) are the canonical
+   * source for PDF generation; unassigned status remains when no holder email exists.
+   */
+  private function applyCheckoutHolderToTicket(Ticket $ticket, OrderItemInterface $order_item, int $holder_index): void {
+    if (!$order_item->hasField('field_ticket_holder') || $order_item->get('field_ticket_holder')->isEmpty()) {
+      return;
+    }
+
+    $holders = $order_item->get('field_ticket_holder')->referencedEntities();
+    if (!isset($holders[$holder_index]) || !$holders[$holder_index] instanceof ParagraphInterface) {
+      return;
+    }
+
+    $holder = $holders[$holder_index];
+    $firstName = $holder->hasField('field_first_name') && !$holder->get('field_first_name')->isEmpty()
+      ? trim((string) $holder->get('field_first_name')->value)
+      : '';
+    $lastName = $holder->hasField('field_last_name') && !$holder->get('field_last_name')->isEmpty()
+      ? trim((string) $holder->get('field_last_name')->value)
+      : '';
+    $holderName = trim($firstName . ' ' . $lastName);
+    $holderEmail = $holder->hasField('field_email') && !$holder->get('field_email')->isEmpty()
+      ? trim((string) $holder->get('field_email')->value)
+      : '';
+
+    if ($holderName === '' || $holderEmail === '') {
+      return;
+    }
+
+    $ticket->set('holder_name', $holderName);
+    $ticket->set('holder_email', $holderEmail);
+    $ticket->set('status', Ticket::STATUS_ASSIGNED);
   }
 
 }

--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -56,6 +56,9 @@ $mel_trusted_staging_prod = [
 
 if (getenv('IS_DDEV_PROJECT') === 'true') {
   $settings['trusted_host_patterns'] = $mel_trusted_ddev;
+  // Local mail: never use Postmark in DDEV. MessagingManager reads delivery_provider
+  // from config; production keeps postmark in config/sync — override only here.
+  $config['myeventlane_messaging.settings']['delivery_provider'] = 'drupal_mail';
 }
 else {
   $settings['trusted_host_patterns'] = array_values(array_unique(array_merge(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect transactional reminder content, ticket assignment at checkout, and customer hub event deduplication—customer-facing but not auth or payments core.
> 
> **Overview**
> Improves **event reminder** template context so RSVP and ticket recipients get sensible `order_number` and **my tickets / account hub** links, including commerce order resolution when a ticket attendee is tied to an order item. Order-based reminders now build order detail URLs through a shared helper.
> 
> **Ticket issuance** copies checkout `field_ticket_holder` paragraphs onto each issued row and marks tickets **assigned** when holder name and email are present, so PDFs and confirmations can attach at send time.
> 
> **Customer hub** participation lists trim email, match attendees by uid **or** email when both exist, and prefer **ticket** over RSVP when the same event appears from multiple sources.
> 
> Adds **DDEV-only** `delivery_provider: drupal_mail` in `settings.mel_shared_session.php` plus developer docs for local Mailpit and attachment validation. Declares `myeventlane_account` as a messaging module dependency. `composer.lock` content-hash only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca54d9dffa67ee39508a5d40ce41aa25f61ad943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->