### PR TITLE
Add governance and security guardrails

### DIFF
--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Config safety check
+        run: bash scripts/check-config-safety.sh
+
+      - name: Webroot safety check
+        run: bash scripts/check-webroot-safety.sh
+
       - name: Verify config/sync has no DDEV hostnames
         shell: bash
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,30 @@
+name: Security scan
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,86 @@
+# MyEventLane secret scanning — targeted rules for payment, webhook, QR, dumps, and keys.
+# Avoids generic-api-key noise from Drupal CSRF tokens in audit artefacts.
+#
+# Local scan (current tree):
+#   docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest detect --source=/repo --config=/repo/.gitleaks.toml --no-git --verbose
+#
+# Local scan (recent commits):
+#   docker run --rm -v "$PWD:/repo" -w /repo zricethezav/gitleaks:latest detect --config=.gitleaks.toml --log-opts="HEAD~10..HEAD"
+
+title = "MyEventLane gitleaks"
+
+[allowlist]
+description = "Vendor paths, audit artefacts, docs placeholders, empty config, and test fixtures"
+paths = [
+  '''(?i)(?:^|/)\.ddev/''',
+  '''(?i)(?:^|/)vendor/''',
+  '''(?i)(?:^|/)vendor\.bak/''',
+  '''(?i)(?:^|/)node_modules/''',
+  '''(?i)(?:^|/)web/core/''',
+  '''(?i)(?:^|/)web/modules/contrib/''',
+  '''(?i)(?:^|/)web/themes/contrib/''',
+  '''(?i)(?:^|/)dist/''',
+  '''(?i)(?:^|/)scripts/audit/output/''',
+  '''(?i)(?:^|/)web/modules/custom/.+/tests/''',
+]
+regexes = [
+  '''local-dev-only-change-me''',
+  '''your_webhook_secret''',
+  '''change-me''',
+  '''whsec_\.\.\.''',
+  '''whsec_…''',
+  '''sk_test_\.\.\.''',
+  '''sk_test_…''',
+  '''sk_live_\.\.\.''',
+  '''sk_live_…''',
+  '''pk_test_\.\.\.''',
+  '''pk_live_\.\.\.''',
+  '''rk_live_\.\.\.''',
+  '''webhook_signing_secret:\s*[''"]?[''"]?''',
+  '''webhook_secret:\s*[''"]?[''"]?''',
+  '''stripe_webhook_secret:\s*[''"]?[''"]?''',
+  '''sk_live_ABCDEFGHIJ''',
+  '''BQokikJOvBiI2HlWgH4olfQ2''',
+]
+
+[[rules]]
+id = "stripe-access-token"
+description = "Stripe secret or restricted key (sk_/rk_)"
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = [
+  "sk_test",
+  "sk_live",
+  "sk_prod",
+  "rk_test",
+  "rk_live",
+  "rk_prod",
+]
+
+[[rules]]
+id = "mel-stripe-webhook-secret"
+description = "Stripe webhook signing secret (whsec_)"
+regex = '''\bwhsec_[a-zA-Z0-9]{16,}\b'''
+keywords = ["whsec_"]
+
+[[rules]]
+id = "mel-qr-signing-secret-env"
+description = "MEL QR signing secret in environment assignment"
+regex = '''(?i)MEL_QR_SECRET\s*=\s*['"]?[a-zA-Z0-9+/=_-]{16,}['"]?'''
+keywords = ["MEL_QR_SECRET"]
+
+[[rules]]
+id = "mel-qr-signing-secret-settings"
+description = "MEL QR signing secret in Drupal settings"
+regex = '''(?i)\$settings\['myeventlane_(?:ticket_)?qr_secret'\]\s*=\s*['"][^'"]{16,}['"]'''
+keywords = ["myeventlane_qr_secret"]
+
+[[rules]]
+id = "mel-sql-dump"
+description = "Committed SQL database dump"
+regex = '''(?i)(?:INSERT\s+INTO|CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|DROP\s+TABLE|COPY\s+public\.|mysqldump|pg_dump)'''
+path = '''\.(sql|sql\.gz)$'''
+
+[[rules]]
+id = "mel-private-key-block"
+description = "Private key material (PEM block with body)"
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]{64,}?KEY(?: BLOCK)?-----'''

--- a/scripts/check-config-safety.sh
+++ b/scripts/check-config-safety.sh
@@ -18,7 +18,7 @@ if [ ! -d "$CONFIG_DIR" ]; then
 fi
 
 grep_config() {
-  grep -R --include='*.yml' --include='*.yaml' -n "$@" "$CONFIG_DIR" 2>/dev/null || true
+  grep -R -F --include='*.yml' --include='*.yaml' -n "$@" "$CONFIG_DIR" 2>/dev/null || true
 }
 
 check_staging_domain() {

--- a/scripts/check-config-safety.sh
+++ b/scripts/check-config-safety.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# CI / pre-deploy check: fail if exported config contains staging hosts,
+# QR secrets, or phpinfo references that must not ship to production.
+#
+# Custom modules may legitimately reference staging hostnames for environment
+# detection; the drift risk is in config/sync.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CONFIG_DIR="config/sync"
+FAIL=0
+
+if [ ! -d "$CONFIG_DIR" ]; then
+  echo "ERROR: Missing $CONFIG_DIR directory."
+  exit 1
+fi
+
+grep_config() {
+  grep -R --include='*.yml' --include='*.yaml' -n "$@" "$CONFIG_DIR" 2>/dev/null || true
+}
+
+check_staging_domain() {
+  local domain="$1"
+  local matches
+  matches="$(grep_config "$domain")"
+  if [ -n "$matches" ]; then
+    echo "Unsafe staging domain found: $domain"
+    echo "$matches"
+    FAIL=1
+  fi
+}
+
+check_staging_domain "staging.myeventlane.com.au"
+check_staging_domain "vendor.staging.myeventlane.com.au"
+check_staging_domain "admin.staging.myeventlane.com.au"
+
+matches="$(grep_config "qr_secret")"
+if [ -n "$matches" ]; then
+  echo "QR secret found in config sync."
+  echo "$matches"
+  FAIL=1
+fi
+
+matches="$(grep_config "phpinfo-temp.php")"
+if [ -n "$matches" ]; then
+  echo "phpinfo-temp.php reference found in config sync."
+  echo "$matches"
+  FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Config safety check passed."

--- a/scripts/check-webroot-safety.sh
+++ b/scripts/check-webroot-safety.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# CI / pre-deploy check: fail if the public web root contains backup archives,
+# database dumps, or phpinfo probes that must never be web-accessible.
+#
+# Drupal core/contrib ship test fixtures (*.sql, *.tar.gz) under web/core; those
+# are excluded here so the check catches accidental operator dumps instead.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -d web ]; then
+  echo "ERROR: Missing web directory."
+  exit 1
+fi
+
+matches="$(
+  find web \
+    \( \
+      -path 'web/core' -o \
+      -path 'web/core/*' -o \
+      -path 'web/modules/contrib' -o \
+      -path 'web/modules/contrib/*' -o \
+      -path 'web/profiles/contrib' -o \
+      -path 'web/profiles/contrib/*' -o \
+      -path 'web/themes/contrib' -o \
+      -path 'web/themes/contrib/*' \
+    \) -prune -o \
+    -type f \( \
+      -name '*.sql' -o \
+      -name '*.sql.gz' -o \
+      -name '*.tar' -o \
+      -name '*.tar.gz' -o \
+      -name '*.zip' -o \
+      -name 'phpinfo*.php' \
+    \) -print \
+  2>/dev/null || true
+)"
+
+if [ -n "$matches" ]; then
+  echo "Unsafe files found in web root:"
+  echo "$matches"
+  exit 1
+fi
+
+echo "Webroot safety check passed."

--- a/web/modules/custom/myeventlane_governance/myeventlane_governance.info.yml
+++ b/web/modules/custom/myeventlane_governance/myeventlane_governance.info.yml
@@ -1,0 +1,6 @@
+name: 'MyEventLane Governance'
+type: module
+description: 'Cross-cutting governance regression tests for MyEventLane custom modules.'
+package: MyEventLane
+core_version_requirement: ^11
+lifecycle: stable

--- a/web/modules/custom/myeventlane_governance/tests/src/Kernel/PublicRouteGovernanceTest.php
+++ b/web/modules/custom/myeventlane_governance/tests/src/Kernel/PublicRouteGovernanceTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_governance\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Scans custom routing YAML for _access: TRUE routes and enforces an allowlist.
+ *
+ * Every route open at the Drupal access layer must be documented here with the
+ * compensating control that protects it (signature verification, controller gate,
+ * CSRF, flood limits, published-content-only Views, etc.).
+ *
+ * @group myeventlane_governance
+ */
+final class PublicRouteGovernanceTest extends TestCase {
+
+  /**
+   * Routes intentionally open at the Drupal access layer with compensating controls.
+   *
+   * @var array<string, string>
+   */
+  protected array $allowedPublicRoutes = [
+    'myeventlane_admin_dashboard.stripe_payout_webhook' => 'Secured by Stripe signature verification in StripeWebhookController.',
+    'myeventlane_auth.login' => 'OAuth login entry; AuthController validates client_id and OAuth params before issuing codes.',
+    'myeventlane_auth.me' => 'OAuth userinfo; TokenController requires a valid Bearer access token before returning profile fields.',
+    'myeventlane_auth.mel_continue' => 'Anonymous-safe redirect handoff to core login with destination preserved.',
+    'myeventlane_auth.mel_email_entry' => 'Anonymous-safe sign-in placeholder linking to core login via mel_continue.',
+    'myeventlane_auth.refresh' => 'OAuth refresh; TokenController enforces client credentials and a valid refresh token.',
+    'myeventlane_auth.revoke' => 'OAuth revocation; TokenController requires client credentials plus refresh or Bearer token.',
+    'myeventlane_auth.token' => 'OAuth token exchange; TokenController enforces client credentials, one-time code, and redirect_uri.',
+    'myeventlane_auth.vendor_sso_callback' => 'Vendor SSO callback; validates HMAC-signed OAuth state and one-time authorization code.',
+    'myeventlane_boost.performance_guide_pdf' => 'Anonymous-safe static marketing PDF; no vendor or financial data.',
+    'myeventlane_core.error_403' => 'Anonymous-safe themed 403 error markup only.',
+    'myeventlane_core.error_404' => 'Anonymous-safe themed 404 error markup only.',
+    'myeventlane_core.health' => 'Load-balancer health probe returning ok/error status strings only (no secrets).',
+    'myeventlane_event.passcode_gate' => 'Event passcode form; EventPasscodeForm validates passcode and Form API CSRF on POST.',
+    'myeventlane_help.analytics_click' => 'Help panel click beacon; HelpAnalyticsController accepts anonymous-safe click keys only.',
+    'myeventlane_help_assistant.ask' => 'Help assistant JSON POST; flood limits and public help retrieval only (read-only).',
+    'myeventlane_help_centre.article_feedback' => 'Help feedback POST; CSRF token, flood limits, and help_article bundle check.',
+    'myeventlane_help_centre.attendees_index' => 'Public attendee help listing via published Views content only.',
+    'myeventlane_help_centre.category_index' => 'Public help category listing via published Views; term entity access applies.',
+    'myeventlane_help_centre.organisers_index' => 'Public organiser help listing via published Views content only.',
+    'myeventlane_help_centre.policies_index' => 'Public policies help listing via published Views content only.',
+    'myeventlane_help_centre.public_index' => 'Public Help Centre index via published Views content only.',
+    'myeventlane_help_centre.search' => 'Public help search via published article and FAQ Views only.',
+    'myeventlane_help_centre.vendors_index' => 'Organiser help hub; controller redirects anonymous users to login.',
+    'myeventlane_messaging.postmark_webhook_bounce' => 'Secured by X-Webhook-Secret header validation in PostmarkWebhookController.',
+    'myeventlane_messaging.postmark_webhook_delivery' => 'Secured by X-Webhook-Secret header validation in PostmarkWebhookController.',
+    'myeventlane_pro.subscription_webhook' => 'Secured by Stripe signature verification in ProSubscriptionWebhookController.',
+    'myeventlane_public_trust.page' => 'Public trust page; aggregated cached metrics only, no PII.',
+    'myeventlane_vendor.create_event_gateway' => 'Create-event entry; controller redirects anonymous users and enforces onboarding.',
+    'myeventlane_vendor.login_alias' => 'Vendor login alias; redirect-only to core user.login with safe destination.',
+    'myeventlane_vendor.shell.dashboard' => 'Vendor shell entry; permission-based redirect only, no sensitive payload.',
+    'myeventlane_vendor.shell.vendor_root' => 'Vendor console root; permission-based redirect only, no sensitive payload.',
+    'myeventlane_vendor.stripe_callback' => 'Stripe Connect return; controller requires authenticated user and account_id validation.',
+    'myeventlane_vendor.stripe_callback_legacy' => 'Legacy Stripe Connect return; same authenticated account_id validation as stripe_callback.',
+    'myeventlane_vendor.stripe_onboard_return' => 'Stripe onboarding return; controller requires authentication and account_id validation.',
+    'mel_search.autocomplete' => 'Public search autocomplete JSON from Search API indexes; no private entity fields.',
+    'mel_search.view' => 'Public event discovery search via Search API indexes; published events only.',
+  ];
+
+  /**
+   * Ensures every _access: TRUE route in custom modules is allowlisted with a reason.
+   */
+  public function testPublicRoutesAreAllowlisted(): void {
+    $discovered = $this->discoverPublicRoutes();
+
+    $missing = [];
+    foreach ($discovered as $routeName => $sourceFile) {
+      if (!array_key_exists($routeName, $this->allowedPublicRoutes)) {
+        $missing[$routeName] = $sourceFile;
+      }
+    }
+
+    $stale = array_diff_key($this->allowedPublicRoutes, $discovered);
+
+    $messages = [];
+    if ($missing !== []) {
+      $lines = [];
+      foreach ($missing as $routeName => $sourceFile) {
+        $lines[] = sprintf('- %s (%s)', $routeName, $this->relativePath($sourceFile));
+      }
+      $messages[] = "Unallowlisted public routes found:\n" . implode("\n", $lines);
+    }
+    if ($stale !== []) {
+      $lines = [];
+      foreach (array_keys($stale) as $routeName) {
+        $lines[] = sprintf('- %s', $routeName);
+      }
+      $messages[] = "Allowlist entries no longer present in routing YAML:\n" . implode("\n", $lines);
+    }
+
+    $this->assertSame([], $missing, implode("\n\n", $messages));
+    $this->assertSame([], $stale, implode("\n\n", $messages));
+  }
+
+  /**
+   * Ensures every allowlist entry documents a non-empty compensating control.
+   */
+  public function testAllowlistReasonsAreDocumented(): void {
+    foreach ($this->allowedPublicRoutes as $routeName => $reason) {
+      $this->assertNotSame('', trim($reason), sprintf('Allowlist reason for %s must not be empty.', $routeName));
+    }
+  }
+
+  /**
+   * @return array<string, string>
+   *   Route name keyed to absolute routing YAML path.
+   */
+  private function discoverPublicRoutes(): array {
+    $customModulesDir = dirname(__DIR__, 4);
+    $this->assertDirectoryExists($customModulesDir);
+
+    $pattern = $customModulesDir . '/*/*.routing.yml';
+    $files = glob($pattern) ?: [];
+    $files = array_values(array_filter(
+      $files,
+      static fn (string $path): bool => !str_contains($path, '/tests/'),
+    ));
+    sort($files);
+
+    $publicRoutes = [];
+    foreach ($files as $file) {
+      try {
+        $parsed = Yaml::parseFile($file);
+      }
+      catch (ParseException $exception) {
+        $this->fail(sprintf('Failed parsing %s: %s', $this->relativePath($file), $exception->getMessage()));
+      }
+
+      if (!is_array($parsed)) {
+        continue;
+      }
+
+      foreach ($parsed as $routeName => $definition) {
+        if (!is_string($routeName) || !is_array($definition)) {
+          continue;
+        }
+        if ($this->isPublicAccessRoute($definition)) {
+          $publicRoutes[$routeName] = $file;
+        }
+      }
+    }
+
+    ksort($publicRoutes);
+    return $publicRoutes;
+  }
+
+  /**
+   * @param array<string, mixed> $definition
+   */
+  private function isPublicAccessRoute(array $definition): bool {
+    $requirements = $definition['requirements'] ?? NULL;
+    if (!is_array($requirements) || !array_key_exists('_access', $requirements)) {
+      return FALSE;
+    }
+
+    return $this->isTrueAccessValue($requirements['_access']);
+  }
+
+  private function isTrueAccessValue(mixed $value): bool {
+    if ($value === TRUE) {
+      return TRUE;
+    }
+    if (is_string($value) && strtoupper(trim($value)) === 'TRUE') {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  private function relativePath(string $absolutePath): string {
+    $webRoot = dirname(__DIR__, 5);
+    $prefix = rtrim($webRoot, '/') . '/';
+    if (str_starts_with($absolutePath, $prefix)) {
+      return substr($absolutePath, strlen($prefix));
+    }
+    return $absolutePath;
+  }
+
+}

--- a/web/modules/custom/myeventlane_governance/tests/src/Kernel/WebrootSafetyGovernanceTest.php
+++ b/web/modules/custom/myeventlane_governance/tests/src/Kernel/WebrootSafetyGovernanceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_governance\Kernel;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures the public web root does not contain backup archives or phpinfo probes.
+ *
+ * @group myeventlane_governance
+ */
+final class WebrootSafetyGovernanceTest extends TestCase {
+
+  /**
+   * Directory prefixes excluded from the scan (core/contrib test fixtures).
+   *
+   * @var list<string>
+   */
+  private const EXCLUDED_PREFIXES = [
+    'web/core/',
+    'web/modules/contrib/',
+    'web/profiles/contrib/',
+    'web/themes/contrib/',
+  ];
+
+  /**
+   * Unsafe filename patterns that must not appear under web/.
+   */
+  private const UNSAFE_PATTERNS = [
+    '/\.sql$/',
+    '/\.sql\.gz$/',
+    '/\.tar$/',
+    '/\.tar\.gz$/',
+    '/\.zip$/',
+    '/^phpinfo.*\.php$/',
+  ];
+
+  /**
+   * Fails when backup archives, SQL dumps, or phpinfo scripts exist in web/.
+   */
+  public function testWebrootHasNoUnsafeFiles(): void {
+    $repoRoot = dirname(__DIR__, 7);
+    $webDir = $repoRoot . '/web';
+    $this->assertDirectoryExists($webDir);
+
+    $unsafe = [];
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator($webDir, \FilesystemIterator::SKIP_DOTS),
+    );
+
+    foreach ($iterator as $fileInfo) {
+      if (!$fileInfo instanceof \SplFileInfo || !$fileInfo->isFile()) {
+        continue;
+      }
+
+      $relative = $this->relativePath($repoRoot, $fileInfo->getPathname());
+      if ($this->isExcluded($relative)) {
+        continue;
+      }
+
+      $basename = $fileInfo->getBasename();
+      foreach (self::UNSAFE_PATTERNS as $pattern) {
+        if (preg_match($pattern, $basename) === 1) {
+          $unsafe[] = $relative;
+          break;
+        }
+      }
+    }
+
+    sort($unsafe);
+    $this->assertSame([], $unsafe, $unsafe === [] ? '' : "Unsafe files found in web root:\n- " . implode("\n- ", $unsafe));
+  }
+
+  private function isExcluded(string $relativePath): bool {
+    foreach (self::EXCLUDED_PREFIXES as $prefix) {
+      if (str_starts_with($relativePath, $prefix)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  private function relativePath(string $repoRoot, string $absolutePath): string {
+    $prefix = rtrim($repoRoot, '/') . '/';
+    if (str_starts_with($absolutePath, $prefix)) {
+      return substr($absolutePath, strlen($prefix));
+    }
+    return $absolutePath;
+  }
+
+}

--- a/web/phpunit-governance.xml
+++ b/web/phpunit-governance.xml
@@ -50,6 +50,8 @@
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalCartProjectionBuilderTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/TicketBackedOrderItemClassifierTest.php</file>
+      <file>modules/custom/myeventlane_governance/tests/src/Kernel/PublicRouteGovernanceTest.php</file>
+      <file>modules/custom/myeventlane_governance/tests/src/Kernel/WebrootSafetyGovernanceTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are additive CI/scripts/tests with no runtime application logic; main risk is false positives blocking builds until allowlists or rules are tuned.
> 
> **Overview**
> Adds **CI guardrails** so unsafe config, webroot artifacts, and secrets are caught before merge.
> 
> The **PHP Composer** workflow now runs `scripts/check-config-safety.sh` and `scripts/check-webroot-safety.sh` up front (staging hostnames, `qr_secret`, phpinfo references in `config/sync`; dumps/archives/phpinfo under `web/` outside core/contrib).
> 
> A new **Security scan** workflow runs **gitleaks** on PR/push to `main` using `.gitleaks.toml` (Stripe keys/webhooks, MEL QR secrets, SQL dumps, PEM private keys, with vendor/placeholder allowlists).
> 
> Introduces **`myeventlane_governance`** with PHPUnit checks: an allowlist for every custom `_access: TRUE` route (with documented compensating controls) and a webroot unsafe-file scan mirrored in CI. Both tests are wired into `web/phpunit-governance.xml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3df2a87abc012291af7986210eda902e553b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->