### PR TITLE
Add validation step to ensure nginx reference configs are excluded fr…

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -182,6 +182,19 @@ jobs:
             exit 1
           }
 
+      - name: Validate artifact excludes nginx reference configs
+        run: |
+          set -euo pipefail
+          archive_path="${{ steps.package.outputs.artifact_path }}"
+          leaked=$(tar -tzf "$archive_path" | grep -E '(^|/)staging-nginx\.conf$|(^|/)infrastructure/' || true)
+          if [ -n "$leaked" ]; then
+            echo "❌ Artifact must not bundle nginx reference configs (staging-nginx.conf or infrastructure/)"
+            echo "   Install includes on the VPS during provisioning — see infrastructure/README.md"
+            echo "$leaked"
+            exit 1
+          fi
+          echo "OK: nginx reference configs excluded from release artifact"
+
       - name: Validate artifact registers state_readiness_helper (staging Drush)
         run: |
           set -euo pipefail


### PR DESCRIPTION
…om artifacts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; no runtime or deploy script behavior is modified beyond failing builds when excluded nginx reference files appear in the artifact.
> 
> **Overview**
> Adds a **post-package CI check** in `reusable-build.yml` that lists the release tarball and **fails the build** if `staging-nginx.conf` or any path under `infrastructure/` is present.
> 
> This mirrors the existing tar `--exclude` rules with an explicit guardrail so nginx reference configs cannot slip into deploy artifacts (they are meant to be installed on the VPS during provisioning per `infrastructure/README.md`). The step runs alongside other artifact validations (e.g. required PHP code and services) before upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d9f8136129543bfc0e587d2b80d6c5b359aeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->