### PR TITLE
Update reusable-build.yml to modify exclusion pattern for 'infrastruc…

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -166,7 +166,7 @@ jobs:
             --exclude='delete-*.php' \
             --exclude='install-*.php' \
             --exclude='create-*.php' \
-            --exclude='infrastructure/' \
+            --exclude='infrastructure' \
             --exclude='staging-nginx.conf' \
             --exclude='phpcs.xml' \
             --exclude='phpunit-governance.xml' \


### PR DESCRIPTION
…ture' directory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI packaging exclude tweak with no application or deploy-script logic changes beyond artifact contents.
> 
> **Overview**
> Updates the **Package release artifact** step in `reusable-build.yml` so the deploy tarball omits nginx reference material: the tar exclude changes from `--exclude='infrastructure/'` to `--exclude='infrastructure'`.
> 
> That aligns GNU tar’s exclude matching with the existing post-package check that fails if `infrastructure/` paths appear in the archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc427b864503a7214d55923384fb324aa5e2a72c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->