### PR TITLE
Add upload directory management and access control for page visuals

### DIFF
--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.install
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.install
@@ -7,6 +7,32 @@ declare(strict_types=1);
  * Install and update hooks for MyEventLane Page Visuals.
  */
 
+use Drupal\Core\File\FileSystemInterface;
+
+/**
+ * Implements hook_install().
+ */
+function myeventlane_page_visuals_install(): void {
+  myeventlane_page_visuals_ensure_upload_directory();
+}
+
+/**
+ * Ensures public://page-visuals exists for managed_file uploads.
+ */
+function myeventlane_page_visuals_ensure_upload_directory(): string {
+  $directory = 'public://page-visuals';
+  $file_system = \Drupal::service('file_system');
+  if ($file_system->prepareDirectory(
+    $directory,
+    FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+  )) {
+    return (string) t('Page visual upload directory is ready.');
+  }
+
+  \Drupal::logger('myeventlane_page_visuals')->error('Could not create or write public://page-visuals during update.');
+  return (string) t('Could not create public://page-visuals — check shared files directory permissions on the server.');
+}
+
 /**
  * Migrate media_id to media_uuid for config portability across environments.
  */
@@ -81,4 +107,11 @@ function myeventlane_page_visuals_update_9002(): string {
   return $updated > 0
     ? (string) t('Migrated @count page visual(s) to desktop/mobile fields.', ['@count' => $updated])
     : (string) t('No page visuals required migration.');
+}
+
+/**
+ * Ensure the page visual upload directory exists (staging shared files).
+ */
+function myeventlane_page_visuals_update_9003(): string {
+  return myeventlane_page_visuals_ensure_upload_directory();
 }

--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.module
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.module
@@ -7,7 +7,9 @@ declare(strict_types=1);
  * MyEventLane Page Visuals - centralized hero/illustration image management.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Implements hook_preprocess_page().
@@ -53,4 +55,19 @@ function myeventlane_page_visuals_preprocess_page(array &$variables): void {
     $variables['#cache']['tags'] ?? [],
     $metadata->getCacheTags()
   );
+}
+
+/**
+ * Implements hook_media_create_access().
+ *
+ * Allows page visual administrators to create image media when saving uploads.
+ */
+function myeventlane_page_visuals_media_create_access(AccountInterface $account, array $context, $entity_bundle = NULL): AccessResult {
+  if (($context['entity_type_id'] ?? '') !== 'media' || $entity_bundle !== 'image') {
+    return AccessResult::neutral();
+  }
+  if ($account->hasPermission('administer myeventlane page visuals')) {
+    return AccessResult::allowed()->cachePerPermissions();
+  }
+  return AccessResult::neutral();
 }

--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
@@ -6,6 +6,19 @@ services:
       - '@entity.repository'
       - '@file_url_generator'
 
+  myeventlane.page_visual_media_manager:
+    class: Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager
+    arguments:
+      - '@entity_type.manager'
+      - '@file_system'
+      - '@file.usage'
+      - '@current_user'
+      - '@logger.channel.myeventlane_page_visuals'
+
+  logger.channel.myeventlane_page_visuals:
+    parent: logger.channel_base
+    arguments: ['myeventlane_page_visuals']
+
   myeventlane_page_visuals.config_subscriber:
     class: Drupal\myeventlane_page_visuals\EventSubscriber\PageVisualConfigSubscriber
     tags:

--- a/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
@@ -11,7 +11,7 @@ use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
-use Drupal\media\Entity\Media;
+use Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
@@ -42,6 +42,13 @@ final class PageVisualForm extends EntityForm {
   protected EntityRepositoryInterface $entityRepository;
 
   /**
+   * Page visual media and file helper.
+   *
+   * @var \Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager
+   */
+  protected PageVisualMediaManager $pageVisualMediaManager;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
@@ -49,6 +56,7 @@ final class PageVisualForm extends EntityForm {
     $instance->entityTypeManager = $container->get('entity_type.manager');
     $instance->routeProvider = $container->get('router.route_provider');
     $instance->entityRepository = $container->get('entity.repository');
+    $instance->pageVisualMediaManager = $container->get('myeventlane.page_visual_media_manager');
     return $instance;
   }
 
@@ -167,7 +175,7 @@ final class PageVisualForm extends EntityForm {
       '#type' => 'managed_file',
       '#title' => $this->t('Desktop image'),
       '#description' => $this->t('Upload an image for desktop viewports (PNG, JPG, JPEG, GIF, WebP). Required when enabled.'),
-      '#upload_location' => 'public://page-visuals/',
+      '#upload_location' => PageVisualMediaManager::UPLOAD_DIRECTORY . '/',
       '#upload_validators' => [
         'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
       ],
@@ -179,7 +187,7 @@ final class PageVisualForm extends EntityForm {
       '#type' => 'managed_file',
       '#title' => $this->t('Mobile image'),
       '#description' => $this->t('Optional: upload a different image for mobile viewports. If empty, desktop image is used.'),
-      '#upload_location' => 'public://page-visuals/',
+      '#upload_location' => PageVisualMediaManager::UPLOAD_DIRECTORY . '/',
       '#upload_validators' => [
         'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
       ],
@@ -247,46 +255,6 @@ final class PageVisualForm extends EntityForm {
   }
 
   /**
-   * Creates a Media entity from an uploaded file. Returns UUID if Media exists.
-   *
-   * @param int $fid
-   *   The file entity ID.
-   *
-   * @return string|null
-   *   The Media entity UUID.
-   */
-  private function createOrGetMediaFromFile(int $fid): ?string {
-    $file_storage = $this->entityTypeManager->getStorage('file');
-    $file = $file_storage->load($fid);
-    if (!$file instanceof FileInterface) {
-      return NULL;
-    }
-    $file->setPermanent();
-    $file->save();
-
-    $media_storage = $this->entityTypeManager->getStorage('media');
-    $existing = $media_storage->loadByProperties([
-      'bundle' => 'image',
-      'field_media_image' => $fid,
-    ]);
-    $media = $existing ? reset($existing) : NULL;
-
-    if ($media instanceof MediaInterface) {
-      return $media->uuid();
-    }
-
-    $media = Media::create([
-      'bundle' => 'image',
-      'name' => $file->getFilename(),
-      'field_media_image' => [
-        'target_id' => $fid,
-      ],
-    ]);
-    $media->save();
-    return $media->uuid();
-  }
-
-  /**
    * Gets the file fid for managed_file default value (from existing Media).
    */
   private function getFileDefaultValue(?string $media_uuid): array {
@@ -306,6 +274,15 @@ final class PageVisualForm extends EntityForm {
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
     parent::validateForm($form, $form_state);
+
+    if (!$this->pageVisualMediaManager->ensureUploadDirectoryReady()) {
+      $form_state->setErrorByName(
+        'image_upload_desktop',
+        $this->t('Hero image uploads are unavailable because @dir is not writable. Ask an administrator to fix file permissions on the shared files directory.', [
+          '@dir' => PageVisualMediaManager::UPLOAD_DIRECTORY,
+        ])
+      );
+    }
 
     $route_select = $form_state->getValue('route_name');
     $route_name = $route_select === '__custom__'
@@ -342,21 +319,39 @@ final class PageVisualForm extends EntityForm {
       ? trim((string) $form_state->getValue('route_name_custom'))
       : $route_select;
 
-    $fids_desktop = $form_state->getValue('image_upload_desktop');
+    $alt_text = trim((string) $form_state->getValue('alt_text'));
+
     $media_uuid_desktop = NULL;
+    $desktop_fid = 0;
+    $fids_desktop = $form_state->getValue('image_upload_desktop');
     if (!empty($fids_desktop) && is_array($fids_desktop)) {
-      $fid = (int) reset($fids_desktop);
-      if ($fid > 0) {
-        $media_uuid_desktop = $this->createOrGetMediaFromFile($fid);
+      $desktop_fid = (int) reset($fids_desktop);
+      if ($desktop_fid > 0) {
+        $media_uuid_desktop = $this->pageVisualMediaManager->createOrGetMediaFromFile($desktop_fid, $alt_text);
+        if ($media_uuid_desktop === NULL) {
+          $form_state->setErrorByName(
+            'image_upload_desktop',
+            $this->t('Could not save the desktop image. Check file permissions or try uploading again.')
+          );
+          return 0;
+        }
       }
     }
 
-    $fids_mobile = $form_state->getValue('image_upload_mobile');
     $media_uuid_mobile = NULL;
+    $mobile_fid = 0;
+    $fids_mobile = $form_state->getValue('image_upload_mobile');
     if (!empty($fids_mobile) && is_array($fids_mobile)) {
-      $fid = (int) reset($fids_mobile);
-      if ($fid > 0) {
-        $media_uuid_mobile = $this->createOrGetMediaFromFile($fid);
+      $mobile_fid = (int) reset($fids_mobile);
+      if ($mobile_fid > 0) {
+        $media_uuid_mobile = $this->pageVisualMediaManager->createOrGetMediaFromFile($mobile_fid, $alt_text);
+        if ($media_uuid_mobile === NULL) {
+          $form_state->setErrorByName(
+            'image_upload_mobile',
+            $this->t('Could not save the mobile image. Check file permissions or try uploading again.')
+          );
+          return 0;
+        }
       }
     }
 
@@ -364,10 +359,20 @@ final class PageVisualForm extends EntityForm {
     $entity->set('media_uuid_desktop', $media_uuid_desktop);
     $entity->set('media_uuid_mobile', $media_uuid_mobile);
     $entity->set('hide_on_mobile', (bool) $form_state->getValue('hide_on_mobile'));
-    $entity->set('alt_text', (string) $form_state->getValue('alt_text'));
+    $entity->set('alt_text', $alt_text);
     $entity->set('enabled', (bool) $form_state->getValue('enabled'));
 
     $result = parent::save($form, $form_state);
+
+    if ($result !== SAVED_NEW && $result !== SAVED_UPDATED) {
+      return $result;
+    }
+
+    $visual_id = (string) $entity->id();
+    $this->pageVisualMediaManager->registerFileUsage($desktop_fid, $visual_id);
+    if ($mobile_fid > 0 && $mobile_fid !== $desktop_fid) {
+      $this->pageVisualMediaManager->registerFileUsage($mobile_fid, $visual_id);
+    }
 
     $this->messenger()->addStatus($this->t('Page visual %label has been saved.', [
       '%label' => $entity->label(),

--- a/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualMediaManager.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualMediaManager.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_page_visuals\Service;
+
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\file\FileInterface;
+use Drupal\file\FileUsage\FileUsageInterface;
+use Drupal\media\Entity\Media;
+use Drupal\media\MediaInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Creates image media and registers file usage for page visual uploads.
+ */
+final class PageVisualMediaManager {
+
+  /**
+   * Upload directory for page visual hero images.
+   */
+  public const UPLOAD_DIRECTORY = 'public://page-visuals';
+
+  /**
+   * Constructs the manager.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly FileSystemInterface $fileSystem,
+    private readonly FileUsageInterface $fileUsage,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Ensures the upload directory exists and is writable.
+   */
+  public function ensureUploadDirectoryReady(): bool {
+    $directory = self::UPLOAD_DIRECTORY;
+    if ($this->fileSystem->prepareDirectory(
+      $directory,
+      FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+    )) {
+      return TRUE;
+    }
+
+    $this->logger->error('Page visual upload directory is missing or not writable: @dir', [
+      '@dir' => self::UPLOAD_DIRECTORY,
+    ]);
+    return FALSE;
+  }
+
+  /**
+   * Creates or reuses image media for an uploaded file.
+   *
+   * @return string|null
+   *   Media UUID, or NULL on failure.
+   */
+  public function createOrGetMediaFromFile(int $fid, string $alt_text): ?string {
+    $file = $this->entityTypeManager->getStorage('file')->load($fid);
+    if (!$file instanceof FileInterface) {
+      $this->logger->error('Page visual save failed: uploaded file @fid was not found.', [
+        '@fid' => (string) $fid,
+      ]);
+      return NULL;
+    }
+
+    if (!$this->fileSystem->realpath($file->getFileUri())) {
+      $this->logger->error('Page visual save failed: physical file missing for @uri (fid @fid).', [
+        '@uri' => $file->getFileUri(),
+        '@fid' => (string) $fid,
+      ]);
+      return NULL;
+    }
+
+    $file->setPermanent();
+    $file->save();
+
+    $media_storage = $this->entityTypeManager->getStorage('media');
+    $existing = $media_storage->loadByProperties([
+      'bundle' => 'image',
+      'field_media_image.target_id' => $fid,
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+    if ($media instanceof MediaInterface) {
+      return $media->uuid();
+    }
+
+    try {
+      $media = Media::create([
+        'bundle' => 'image',
+        'uid' => (int) $this->currentUser->id(),
+        'name' => $file->getFilename(),
+        'field_media_image' => [
+          'target_id' => $fid,
+          'alt' => $alt_text,
+        ],
+      ]);
+      $media->save();
+    }
+    catch (EntityStorageException $e) {
+      $this->logger->error('Page visual save failed while creating media for fid @fid: @message', [
+        '@fid' => (string) $fid,
+        '@message' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
+
+    return $media->uuid();
+  }
+
+  /**
+   * Registers file usage so uploaded files are not garbage-collected.
+   */
+  public function registerFileUsage(int $fid, string $visual_id): void {
+    if ($fid <= 0 || $visual_id === '') {
+      return;
+    }
+
+    $file = $this->entityTypeManager->getStorage('file')->load($fid);
+    if (!$file instanceof FileInterface) {
+      return;
+    }
+
+    $this->fileUsage->add(
+      $file,
+      'myeventlane_page_visuals',
+      'myeventlane_page_visual',
+      $visual_id
+    );
+  }
+
+}


### PR DESCRIPTION
- Implemented `myeventlane_page_visuals_install` to ensure the upload directory exists.
- Added `myeventlane_page_visuals_ensure_upload_directory` function for directory creation and permission handling.
- Introduced `myeventlane_page_visuals_update_9003` to ensure the upload directory during updates.
- Added access control for media creation in `myeventlane_page_visuals_media_create_access`.
- Refactored `PageVisualForm` to utilize `PageVisualMediaManager` for upload locations.
- Updated service definitions in `myeventlane_page_visuals.services.yml` for new media manager and logger service.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds narrow media create access and changes upload/save paths for admin-only config; low blast radius but touches file permissions and entity creation on failure paths.
> 
> **Overview**
> Makes page visual hero uploads reliable on shared/staging filesystems and gives admins clearer failures when saves break.
> 
> **Upload directory** is created on module install and via update `9003`, reusing a shared `ensure_upload_directory` helper. The admin form now **blocks saves** when `public://page-visuals` is missing or not writable.
> 
> Media/file logic moves into **`PageVisualMediaManager`**: permanent files, reuse-or-create image media (with **alt text on the image field**), logging on missing files or storage errors, and **file usage** registration tied to the page visual config after a successful save. **`hook_media_create_access`** lets users with `administer myeventlane page visuals` create image media during upload without broader media permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f7e61980c92a2bcca6ef8ae888f3d9ea44a43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->