### PR TITLE
Enhance PageVisualMediaManager with file usage synchronization and re…

### DIFF
--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
@@ -10,6 +10,7 @@ services:
     class: Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager
     arguments:
       - '@entity_type.manager'
+      - '@entity.repository'
       - '@file_system'
       - '@file.usage'
       - '@current_user'

--- a/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualDeleteForm.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualDeleteForm.php
@@ -8,11 +8,29 @@ use Drupal\Core\Entity\EntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Delete form for Page Visual config entities.
  */
 final class PageVisualDeleteForm extends EntityConfirmFormBase {
+
+  /**
+   * Page visual media and file helper.
+   *
+   * @var \Drupal\myeventlane_page_visuals\Service\PageVisualMediaManager
+   */
+  protected PageVisualMediaManager $pageVisualMediaManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->pageVisualMediaManager = $container->get('myeventlane.page_visual_media_manager');
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -41,9 +59,16 @@ final class PageVisualDeleteForm extends EntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    $this->entity->delete();
+    $entity = $this->entity;
+    $this->pageVisualMediaManager->releaseFileUsageForVisual(
+      (string) $entity->id(),
+      $entity->getMediaUuidDesktop(),
+      $entity->getMediaUuidMobile(),
+    );
+
+    $entity->delete();
     $this->messenger()->addStatus($this->t('Page visual %label has been deleted.', [
-      '%label' => $this->entity->label(),
+      '%label' => $entity->label(),
     ]));
     $form_state->setRedirectUrl($this->getCancelUrl());
   }

--- a/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
@@ -313,6 +313,8 @@ final class PageVisualForm extends EntityForm {
    */
   public function save(array $form, FormStateInterface $form_state): int {
     $entity = $this->entity;
+    $old_desktop_uuid = $entity->getMediaUuidDesktop();
+    $old_mobile_uuid = $entity->getMediaUuidMobile();
 
     $route_select = $form_state->getValue('route_name');
     $route_name = $route_select === '__custom__'
@@ -369,10 +371,13 @@ final class PageVisualForm extends EntityForm {
     }
 
     $visual_id = (string) $entity->id();
-    $this->pageVisualMediaManager->registerFileUsage($desktop_fid, $visual_id);
-    if ($mobile_fid > 0 && $mobile_fid !== $desktop_fid) {
-      $this->pageVisualMediaManager->registerFileUsage($mobile_fid, $visual_id);
-    }
+    $this->pageVisualMediaManager->syncFileUsageForVisual(
+      $visual_id,
+      $old_desktop_uuid,
+      $old_mobile_uuid,
+      $desktop_fid,
+      $mobile_fid,
+    );
 
     $this->messenger()->addStatus($this->t('Page visual %label has been saved.', [
       '%label' => $entity->label(),

--- a/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualMediaManager.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualMediaManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_page_visuals\Service;
 
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -25,10 +26,21 @@ final class PageVisualMediaManager {
   public const UPLOAD_DIRECTORY = 'public://page-visuals';
 
   /**
+   * File usage module name.
+   */
+  private const FILE_USAGE_MODULE = 'myeventlane_page_visuals';
+
+  /**
+   * File usage entity type.
+   */
+  private const FILE_USAGE_TYPE = 'myeventlane_page_visual';
+
+  /**
    * Constructs the manager.
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EntityRepositoryInterface $entityRepository,
     private readonly FileSystemInterface $fileSystem,
     private readonly FileUsageInterface $fileUsage,
     private readonly AccountProxyInterface $currentUser,
@@ -113,6 +125,74 @@ final class PageVisualMediaManager {
   }
 
   /**
+   * Gets the file ID referenced by a media UUID.
+   */
+  public function getFileIdFromMediaUuid(?string $media_uuid): int {
+    if ($media_uuid === NULL || $media_uuid === '') {
+      return 0;
+    }
+
+    $media = $this->entityRepository->loadEntityByUuid('media', $media_uuid);
+    if (!$media instanceof MediaInterface || !$media->hasField('field_media_image') || $media->get('field_media_image')->isEmpty()) {
+      return 0;
+    }
+
+    $file = $media->get('field_media_image')->entity;
+    return $file instanceof FileInterface ? (int) $file->id() : 0;
+  }
+
+  /**
+   * Syncs file usage after a page visual save.
+   *
+   * Removes stale references when images are replaced or cleared, and only
+   * registers usage for newly referenced files so counts do not inflate.
+   */
+  public function syncFileUsageForVisual(
+    string $visual_id,
+    ?string $old_desktop_uuid,
+    ?string $old_mobile_uuid,
+    int $new_desktop_fid,
+    int $new_mobile_fid,
+  ): void {
+    if ($visual_id === '') {
+      return;
+    }
+
+    $old_fids = $this->collectFileIdsInUse(
+      $this->getFileIdFromMediaUuid($old_desktop_uuid),
+      $this->getFileIdFromMediaUuid($old_mobile_uuid),
+    );
+    $new_fids = $this->collectFileIdsInUse($new_desktop_fid, $new_mobile_fid);
+
+    foreach (array_diff($old_fids, $new_fids) as $fid) {
+      $this->removeFileUsage($fid, $visual_id);
+    }
+    foreach (array_diff($new_fids, $old_fids) as $fid) {
+      $this->registerFileUsage($fid, $visual_id);
+    }
+  }
+
+  /**
+   * Removes all file usage registered for a page visual.
+   */
+  public function releaseFileUsageForVisual(
+    string $visual_id,
+    ?string $desktop_uuid,
+    ?string $mobile_uuid,
+  ): void {
+    if ($visual_id === '') {
+      return;
+    }
+
+    foreach ($this->collectFileIdsInUse(
+      $this->getFileIdFromMediaUuid($desktop_uuid),
+      $this->getFileIdFromMediaUuid($mobile_uuid),
+    ) as $fid) {
+      $this->removeFileUsage($fid, $visual_id);
+    }
+  }
+
+  /**
    * Registers file usage so uploaded files are not garbage-collected.
    */
   public function registerFileUsage(int $fid, string $visual_id): void {
@@ -127,10 +207,47 @@ final class PageVisualMediaManager {
 
     $this->fileUsage->add(
       $file,
-      'myeventlane_page_visuals',
-      'myeventlane_page_visual',
+      self::FILE_USAGE_MODULE,
+      self::FILE_USAGE_TYPE,
       $visual_id
     );
+  }
+
+  /**
+   * Removes file usage for a page visual reference.
+   */
+  public function removeFileUsage(int $fid, string $visual_id): void {
+    if ($fid <= 0 || $visual_id === '') {
+      return;
+    }
+
+    $file = $this->entityTypeManager->getStorage('file')->load($fid);
+    if (!$file instanceof FileInterface) {
+      return;
+    }
+
+    $this->fileUsage->delete(
+      $file,
+      self::FILE_USAGE_MODULE,
+      self::FILE_USAGE_TYPE,
+      $visual_id
+    );
+  }
+
+  /**
+   * Builds unique file IDs in use for desktop/mobile slots.
+   *
+   * @return list<int>
+   */
+  private function collectFileIdsInUse(int $desktop_fid, int $mobile_fid): array {
+    $fids = [];
+    if ($desktop_fid > 0) {
+      $fids[$desktop_fid] = $desktop_fid;
+    }
+    if ($mobile_fid > 0) {
+      $fids[$mobile_fid] = $mobile_fid;
+    }
+    return array_values($fids);
   }
 
 }


### PR DESCRIPTION
…pository integration. Updated PageVisualDeleteForm to release file usage on deletion and modified PageVisualForm to sync file usage during save. Added methods for managing file IDs from media UUIDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to admin config entity lifecycle and file usage bookkeeping; no changes to public routes or auth, though incorrect usage sync could affect file cleanup timing.
> 
> **Overview**
> Fixes **Drupal file usage** for page visual hero images so references stay accurate when images change or a visual is removed.
> 
> **PageVisualMediaManager** now resolves file IDs from media UUIDs (via injected `entity.repository`), adds `syncFileUsageForVisual` to drop usage for replaced/cleared desktop/mobile files and register only newly referenced files, and adds `releaseFileUsageForVisual` plus `removeFileUsage` for teardown. File usage module/type strings are centralized as constants.
> 
> **PageVisualForm** captures pre-save media UUIDs and calls `syncFileUsageForVisual` after save instead of always registering current file IDs (which could inflate usage counts and leave stale references).
> 
> **PageVisualDeleteForm** injects the media manager and calls `releaseFileUsageForVisual` before deleting the config entity so files are not left permanently marked in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c52893328ff1ac24399d51770e62564e8fc921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->