### PR TITLE
Refactor payment gateway restoration process in E2E tests

### DIFF
--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,10 +1,63 @@
-import { runDrushPhp } from './helpers/drush.js';
+import { isDdevUnavailable, runDrushPhpRaw } from './helpers/drush.js';
 
-export default async function globalTeardown(): Promise<void> {
+interface RestoreResult {
+  restored?: boolean;
+  reason?: string;
+  gateways?: string[];
+}
+
+function parseRestoreResult(stdout: string): RestoreResult | null {
+  if (stdout === '') {
+    return null;
+  }
   try {
-    runDrushPhp('tests/e2e/scripts/restore-payment-gateways.php');
+    return JSON.parse(stdout) as RestoreResult;
   }
   catch {
-    // Non-fatal if DDEV is not running after local dev.
+    return null;
+  }
+}
+
+export default async function globalTeardown(): Promise<void> {
+  const result = runDrushPhpRaw('tests/e2e/scripts/restore-payment-gateways.php');
+
+  if (isDdevUnavailable(result)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'E2E teardown: skipped payment gateway restore because DDEV is not running. '
+      + 'If tests used manual payment mode, run restore manually when DDEV is back up.',
+    );
+    return;
+  }
+
+  const restore = parseRestoreResult(result.stdout);
+
+  if (result.status === 0 && restore?.restored) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `E2E teardown: restored payment gateways (${restore.gateways?.join(', ') ?? 'unknown'}).`,
+    );
+    return;
+  }
+
+  if (result.status === 0 && restore?.reason === 'no state file') {
+    return;
+  }
+
+  if (result.status === 0 && restore?.reason === 'empty state') {
+    // eslint-disable-next-line no-console
+    console.warn('E2E teardown: payment gateway state file was empty; nothing to restore.');
+    return;
+  }
+
+  const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+  // eslint-disable-next-line no-console
+  console.error(
+    'E2E teardown: failed to restore payment gateways. '
+    + 'Stripe gateways may still be disabled on this DDEV site.',
+  );
+  if (detail) {
+    // eslint-disable-next-line no-console
+    console.error(detail);
   }
 }

--- a/tests/e2e/helpers/drush.ts
+++ b/tests/e2e/helpers/drush.ts
@@ -4,21 +4,76 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 
+export interface DrushPhpResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
 export function runDrushPhp(
   scriptPath: string,
   env: Record<string, string> = {},
 ): string {
+  const result = runDrushPhpRaw(scriptPath, env);
+  if (result.status !== 0) {
+    const details = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+    throw new Error(
+      details
+        ? `Drush script failed (${scriptPath}, exit ${result.status}): ${details}`
+        : `Drush script failed (${scriptPath}, exit ${result.status})`,
+    );
+  }
+  return result.stdout;
+}
+
+export function runDrushPhpRaw(
+  scriptPath: string,
+  env: Record<string, string> = {},
+): DrushPhpResult {
   const envPrefix = Object.entries(env)
     .map(([key, value]) => `${key}=${shellQuote(value)}`)
     .join(' ');
   const command = envPrefix
     ? `ddev exec env ${envPrefix} drush php:script ${scriptPath}`
     : `ddev drush php:script ${scriptPath}`;
-  return execSync(command, {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }).trim();
+  try {
+    return {
+      stdout: execSync(command, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim(),
+      stderr: '',
+      status: 0,
+    };
+  }
+  catch (error) {
+    if (!isExecSyncError(error)) {
+      throw error;
+    }
+    return {
+      stdout: String(error.stdout ?? '').trim(),
+      stderr: String(error.stderr ?? '').trim(),
+      status: typeof error.status === 'number' ? error.status : 1,
+    };
+  }
+}
+
+export function isDdevUnavailable(result: Pick<DrushPhpResult, 'stderr' | 'status'>): boolean {
+  const combined = result.stderr.toLowerCase();
+  return (
+    combined.includes('project is not running')
+    || combined.includes('could not connect')
+    || combined.includes('ddev is not running')
+    || combined.includes('failed to run ddev')
+    || combined.includes('failed to execute command')
+  );
+}
+
+function isExecSyncError(
+  error: unknown,
+): error is Error & { status?: number; stdout?: string | Buffer; stderr?: string | Buffer } {
+  return error instanceof Error && 'status' in error;
 }
 
 function shellQuote(value: string): string {

--- a/tests/e2e/scripts/restore-payment-gateways.php
+++ b/tests/e2e/scripts/restore-payment-gateways.php
@@ -17,16 +17,16 @@ if (!defined('DRUPAL_ROOT')) {
 
 $stateFile = DRUPAL_ROOT . '/../tests/e2e/fixtures/payment-gateway-state.json';
 if (!is_readable($stateFile)) {
-  echo json_encode(['restored' => FALSE, 'reason' => 'no state file']);
-  exit(0);
+  echo json_encode(['restored' => FALSE, 'reason' => 'no state file'], JSON_THROW_ON_ERROR);
+  return;
 }
 
 $state = json_decode((string) file_get_contents($stateFile), TRUE, 512, JSON_THROW_ON_ERROR);
 $previous = $state['previous'] ?? [];
 if (!is_array($previous) || $previous === []) {
   unlink($stateFile);
-  echo json_encode(['restored' => FALSE, 'reason' => 'empty state']);
-  exit(0);
+  echo json_encode(['restored' => FALSE, 'reason' => 'empty state'], JSON_THROW_ON_ERROR);
+  return;
 }
 
 $gatewayStorage = \Drupal::entityTypeManager()->getStorage('commerce_payment_gateway');


### PR DESCRIPTION
- Updated `restore-payment-gateways.php` to use JSON_THROW_ON_ERROR for error handling.
- Enhanced `drush.ts` with improved error handling and added `isDdevUnavailable` function.
- Modified `global-teardown.ts` to utilize `runDrushPhpRaw` and handle DDEV availability checks, improving robustness of the teardown process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E test infrastructure and a Drush restore script; no production checkout or payment logic is modified.
> 
> **Overview**
> E2E **global teardown** no longer swallows Drush failures: it runs the restore script via a **non-throwing** helper, detects when **DDEV is down**, and logs clear outcomes (restored gateways, skipped restore, empty/missing state, or a hard failure with stderr/stdout).
> 
> The **Drush helper** adds `runDrushPhpRaw` (exit code + streams) and `isDdevUnavailable`; existing `runDrushPhp` callers still get thrown errors on non-zero exits. The **restore PHP script** uses `return` instead of `exit(0)` for benign “nothing to restore” paths and `JSON_THROW_ON_ERROR` when emitting JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f66bbe19ec1b962003765a93435e8277f64dd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->