### PR TITLE
Refactor DDEV availability check in Drush helper. Updated `isDdevUnav…

### DIFF
--- a/tests/e2e/helpers/drush.ts
+++ b/tests/e2e/helpers/drush.ts
@@ -59,15 +59,45 @@ export function runDrushPhpRaw(
   }
 }
 
-export function isDdevUnavailable(result: Pick<DrushPhpResult, 'stderr' | 'status'>): boolean {
-  const combined = result.stderr.toLowerCase();
-  return (
-    combined.includes('project is not running')
-    || combined.includes('could not connect')
-    || combined.includes('ddev is not running')
-    || combined.includes('failed to run ddev')
-    || combined.includes('failed to execute command')
-  );
+const DDEV_UNAVAILABLE_PATTERNS = [
+  /project ['"]?[\w.-]+['"]? is not running/i,
+  /project is not yet running/i,
+  /use 'ddev start' first/i,
+  /no running container found/i,
+  /failed to start [\w.-]+:/i,
+  /cannot connect to the docker daemon/i,
+  /could not connect to docker/i,
+  /docker is not running/i,
+  /(?:^|\s)ddev(?:\s|:).*command not found/i,
+  /command not found.*(?:^|\s)ddev(?:\s|$)/i,
+];
+
+/** Drush/Drupal failures that prove the DDEV container ran. */
+const INNER_COMMAND_FAILURE_PATTERNS = [
+  /failed to run drush/i,
+  /failed to execute command/i,
+  /could not connect to (?:database|mysql|mariadb|postgres|db)\b/i,
+  /sqlstate\[/i,
+];
+
+export function isDdevUnavailable(
+  result: Pick<DrushPhpResult, 'stderr' | 'stdout' | 'status'>,
+): boolean {
+  const stderr = result.stderr;
+  if (stderr === '') {
+    return false;
+  }
+
+  // Script stdout means DDEV reached the container and Drush bootstrapped Drupal.
+  if (result.stdout.trim() !== '') {
+    return false;
+  }
+
+  if (INNER_COMMAND_FAILURE_PATTERNS.some((pattern) => pattern.test(stderr))) {
+    return false;
+  }
+
+  return DDEV_UNAVAILABLE_PATTERNS.some((pattern) => pattern.test(stderr));
 }
 
 function isExecSyncError(


### PR DESCRIPTION
…ailable` function to utilize regex patterns for improved accuracy in detecting DDEV unavailability and added handling for stdout and inner command failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-helper-only change with no production runtime impact; behavior shift is limited to when e2e teardown treats failures as “DDEV down.”
> 
> **Overview**
> **`isDdevUnavailable`** in the e2e Drush helper no longer uses simple substring checks on stderr. It now uses **regex lists** for infrastructure failures (project not running, Docker/DDEV missing or down) and treats **non-empty stdout** or **inner Drush/DB errors** (e.g. `failed to run drush`, DB connection, `SQLSTATE`) as proof that DDEV reached the container—so those cases are **not** classified as “DDEV unavailable.”
> 
> Empty stderr still means available. Callers like **`global-teardown`** can skip gateway restore only when the failure is truly at the DDEV/Docker layer, not when Drupal/Drush failed inside a running stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafeb3f9bd6346a52cd8c309768ee2843e41d97b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->