### PR TITLE
Enhance DDEV availability check in drush helper function to prioritiz…

### DIFF
--- a/tests/e2e/helpers/drush.ts
+++ b/tests/e2e/helpers/drush.ts
@@ -93,11 +93,17 @@ export function isDdevUnavailable(
     return false;
   }
 
+  // Check DDEV/docker down first: wrapper text like "Failed to execute command"
+  // can appear alongside project-down errors and must not mask unavailability.
+  if (DDEV_UNAVAILABLE_PATTERNS.some((pattern) => pattern.test(stderr))) {
+    return true;
+  }
+
   if (INNER_COMMAND_FAILURE_PATTERNS.some((pattern) => pattern.test(stderr))) {
     return false;
   }
 
-  return DDEV_UNAVAILABLE_PATTERNS.some((pattern) => pattern.test(stderr));
+  return false;
 }
 
 function isExecSyncError(


### PR DESCRIPTION
…e docker status. Added logic to ensure that specific error patterns do not mask DDEV unavailability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-helper logic only; no production runtime or security impact.
> 
> **Overview**
> **`isDdevUnavailable`** in the e2e Drush helper now treats **DDEV/docker-down stderr patterns before** inner “command failed” patterns (e.g. `Failed to execute command`), so mixed stderr no longer reports DDEV as available when the project or Docker is actually down.
> 
> The function **no longer falls through** to “unavailable if any DDEV pattern matches”; after those checks it returns **`false`** unless an unavailable pattern matched earlier. Teardown (e.g. global teardown skipping gateway restore) can correctly skip when DDEV is stopped instead of treating the run as a real Drush failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c54553f79b2db284ce2a930220cb2afa7988c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->