### PR TITLE
Unify customer account experience around shared event cards

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -13,6 +13,7 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\myeventlane_surface\MelCustomerRouteCatalog;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_theme().
@@ -25,10 +26,15 @@ function myeventlane_account_theme(): array {
         'logo_url' => '',
         'avatar_url' => '',
         'avatar_initials' => '',
+        'hub_user_id' => 0,
+        'upcoming_ticket_count' => 0,
+        'upcoming_rsvp_count' => 0,
+        'upcoming_event_count' => 0,
         'upcoming_tickets' => [],
         'upcoming_rsvps' => [],
-        'saved_events' => [],
         'past_events' => [],
+        'notifications_preview' => [],
+        'notifications_inbox_url' => '',
         'account_links' => [],
         'hub_quick_links' => [],
         'hub_discover_url' => '',
@@ -37,9 +43,8 @@ function myeventlane_account_theme(): array {
         'review_eligible' => [],
         'mel_account_dashboard_tickets_empty' => NULL,
         'mel_account_dashboard_rsvps_empty' => NULL,
-        'mel_account_dashboard_saved_empty' => NULL,
         'mel_account_dashboard_past_empty' => NULL,
-        'account_hero' => NULL,
+        'mel_account_dashboard_notifications_empty' => NULL,
       ],
       'template' => 'myeventlane-my-account-dashboard',
     ],
@@ -84,6 +89,26 @@ function myeventlane_account_preprocess_myeventlane_my_account_dashboard(array &
   }
   catch (\Throwable) {
     $variables['hub_calendar_url'] = Url::fromRoute('<front>')->toString();
+  }
+
+  if (\Drupal::moduleHandler()->moduleExists('myeventlane_notifications')
+    && \Drupal::currentUser()->hasPermission('access myeventlane notifications')
+    && \Drupal::hasService('myeventlane_notifications.user_inbox')
+    && \Drupal::hasService('myeventlane_notifications.view_builder')) {
+    try {
+      $variables['notifications_inbox_url'] = Url::fromRoute('myeventlane_notifications.inbox', [], ['absolute' => FALSE])->toString();
+      $uid = (int) \Drupal::currentUser()->id();
+      /** @var \Drupal\myeventlane_notifications\Service\NotificationUserInboxService $inbox */
+      $inbox = \Drupal::service('myeventlane_notifications.user_inbox');
+      /** @var \Drupal\myeventlane_notifications\Service\NotificationViewBuilder $viewBuilder */
+      $viewBuilder = \Drupal::service('myeventlane_notifications.view_builder');
+      $ids = $inbox->getUnreadDeliveryIds($uid, 3, \Drupal\myeventlane_notifications\NotificationContext::publicBellContexts());
+      $variables['notifications_preview'] = $viewBuilder->buildRowsForDeliveries($ids, $uid);
+    }
+    catch (\Throwable) {
+      $variables['notifications_preview'] = [];
+      $variables['notifications_inbox_url'] = '';
+    }
   }
 }
 
@@ -224,6 +249,11 @@ function myeventlane_account_preprocess_page__account(array &$variables): void {
     $variables['account_heading'] = $heading;
   }
 
+  $description = _myeventlane_account_page_description($route_name);
+  if ($description !== NULL) {
+    $variables['account_page_description'] = $description;
+  }
+
   if ($account->isAnonymous()) {
     return;
   }
@@ -266,6 +296,7 @@ function myeventlane_account_preprocess_page__account(array &$variables): void {
  */
 function _myeventlane_account_page_heading(?string $route_name) {
   return match ($route_name) {
+    'myeventlane_account.dashboard' => t('Dashboard'),
     'myeventlane_account.past_events' => t('Past events'),
     'myeventlane_account.settings', 'myeventlane_account.settings_redirect' => t('Settings'),
     'myeventlane_checkout_flow.my_tickets' => t('Tickets'),
@@ -273,13 +304,89 @@ function _myeventlane_account_page_heading(?string $route_name) {
     'myeventlane_checkout_flow.order_tax_invoice_pdf' => t('Payment receipt'),
     'myeventlane_dashboard.customer' => t('My events'),
     'view.mel_saved_events.page_1' => t('Saved events'),
-    'myeventlane_account.followed_organisers' => t('Followed organisers'),
+    'myeventlane_account.followed_organisers' => t('Your organisers'),
     'myeventlane_notifications.inbox' => t('Notifications'),
     'myeventlane_notifications.preferences' => t('Notification preferences'),
-    'myeventlane_core.my_categories' => t('Categories'),
+    'myeventlane_core.my_categories' => t('Your communities'),
     'myeventlane_rsvp.user_list' => t('RSVPs'),
     default => NULL,
   };
+}
+
+/**
+ * Optional lede copy for hub routes (page shell); body templates must not repeat.
+ */
+function _myeventlane_account_page_description(?string $route_name) {
+  return match ($route_name) {
+    'myeventlane_account.past_events' => t('Events you have already attended.'),
+    'myeventlane_account.settings', 'myeventlane_account.settings_redirect' => t('Personal details, sign-in security, and how we stay in touch.'),
+    'myeventlane_checkout_flow.my_tickets' => t('Manage bookings, download tickets, and access your events.'),
+    'myeventlane_checkout_flow.order_detail' => t('Booking details, tickets, and receipts for this order.'),
+    'view.mel_saved_events.page_1' => t('Events you want to revisit later.'),
+    'myeventlane_account.followed_organisers' => t('See events from organisers you follow.'),
+    'myeventlane_notifications.inbox' => t('Ticket confirmations and important updates, organised for you.'),
+    'myeventlane_notifications.preferences' => t('Choose how and when we reach you.'),
+    'myeventlane_core.my_categories' => t('Stay connected with the categories you follow.'),
+    'myeventlane_rsvp.user_list' => t('Events you have RSVP’d to.'),
+    default => NULL,
+  };
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for mel_notification_inbox.
+ */
+function myeventlane_account_preprocess_mel_notification_inbox(array &$variables): void {
+  $variables['in_account_shell'] = TRUE;
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for views_view.
+ */
+function myeventlane_account_preprocess_views_view(array &$variables): void {
+  $view = $variables['view'] ?? NULL;
+  if ($view === NULL || $view->id() !== 'mel_saved_events') {
+    return;
+  }
+  if ($variables['attributes'] instanceof Attribute) {
+    $variables['attributes']->addClass('mel-collection-page', 'mel-collection-page--saved-events');
+  }
+  else {
+    $variables['attributes']['class'][] = 'mel-collection-page';
+    $variables['attributes']['class'][] = 'mel-collection-page--saved-events';
+  }
+  $variables['#attached']['library'][] = 'flag/link_ajax';
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for views_view_unformatted.
+ */
+function myeventlane_account_preprocess_views_view_unformatted(array &$variables): void {
+  $view = $variables['view'] ?? NULL;
+  if ($view === NULL || $view->id() !== 'mel_saved_events') {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_account\Service\CustomerHubDataBuilder $builder */
+  $builder = \Drupal::service('myeventlane_account.customer_hub_data_builder');
+  $rows = [];
+  foreach ($view->result as $delta => $row) {
+    $entity = $row->_entity ?? NULL;
+    if (!$entity instanceof NodeInterface || $entity->bundle() !== 'event') {
+      $rows[$delta] = $variables['rows'][$delta] ?? ['#markup' => ''];
+      continue;
+    }
+    $rows[$delta] = [
+      '#theme' => 'mel_account_event_card',
+      '#event' => $builder->buildHubEventFromNode($entity, 'saved'),
+      '#card_variant' => 'saved',
+      '#event_save_flag' => $builder->buildEventSaveFlagLink((int) $entity->id()),
+      '#cache' => [
+        'tags' => array_merge($entity->getCacheTags(), ['flag.flag.event_save']),
+        'contexts' => ['user'],
+      ],
+    ];
+  }
+  $variables['rows'] = $rows;
 }
 
 /**

--- a/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
+++ b/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
@@ -9,7 +9,6 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_account\Service\AccountLinksService;
-use Drupal\myeventlane_account\Service\CustomerAccountHeroBuilder;
 use Drupal\myeventlane_account\Service\CustomerHubDataBuilder;
 use Drupal\myeventlane_core\Service\DisplayNameResolver;
 use Drupal\myeventlane_core\GovernedOperationalTemplates;
@@ -32,7 +31,6 @@ final class MyAccountController extends ControllerBase {
     private readonly TimeInterface $time,
     private readonly GovernedOperationalTemplates $operationalTemplates,
     private readonly CustomerHubDataBuilder $customerHubDataBuilder,
-    private readonly CustomerAccountHeroBuilder $customerAccountHeroBuilder,
   ) {}
 
   /**
@@ -45,7 +43,6 @@ final class MyAccountController extends ControllerBase {
       $container->get('datetime.time'),
       $container->get('myeventlane_surface.governed_operational_templates'),
       $container->get('myeventlane_account.customer_hub_data_builder'),
-      $container->get('myeventlane_account.customer_account_hero_builder'),
     );
   }
 
@@ -72,7 +69,6 @@ final class MyAccountController extends ControllerBase {
     $upcomingTickets = $participation['upcoming_tickets'];
     $upcomingRsvps = $participation['upcoming_rsvps'];
     $pastEvents = $participation['past_events'];
-    $savedEventsPreview = $this->customerHubDataBuilder->buildSavedEventsPreview($userId, 3);
 
     $accountLinks = $this->accountLinksService->buildNavigationItems();
 
@@ -80,39 +76,30 @@ final class MyAccountController extends ControllerBase {
       ->addCacheContexts(['user', 'route'])
       ->addCacheTags(['user:' . $userId, 'node_list', 'flag.flag.event_save'])
       ->setCacheMaxAge(300);
-    foreach (array_merge($upcomingTickets, $upcomingRsvps, $pastEvents, $savedEventsPreview) as $event) {
+    foreach (array_merge($upcomingTickets, $upcomingRsvps, $pastEvents) as $event) {
       $cache->addCacheTags(['node:' . $event['id']]);
     }
 
-    $reviewEligible = $this->getReviewEligibleEvents(array_slice($pastEvents, 0, 3), $userId);
+    $reviewEligible = $this->getReviewEligibleEvents(array_slice($pastEvents, 0, 6), $userId);
 
-    $heroData = $this->customerAccountHeroBuilder->buildDashboardHero(
-      $userId,
-      count($upcomingTickets),
-      count($upcomingRsvps),
-    );
+    $upcomingTicketCount = count($upcomingTickets);
+    $upcomingRsvpCount = count($upcomingRsvps);
 
     $build = [
       '#theme' => 'myeventlane_my_account_dashboard',
       '#display_name' => $displayName,
-      '#upcoming_tickets' => array_slice($upcomingTickets, 0, 3),
-      '#upcoming_rsvps' => array_slice($upcomingRsvps, 0, 3),
-      '#saved_events' => $savedEventsPreview,
-      '#past_events' => array_slice($pastEvents, 0, 3),
+      '#hub_user_id' => $userId,
+      '#upcoming_ticket_count' => $upcomingTicketCount,
+      '#upcoming_rsvp_count' => $upcomingRsvpCount,
+      '#upcoming_event_count' => $upcomingTicketCount + $upcomingRsvpCount,
+      '#upcoming_tickets' => array_slice($upcomingTickets, 0, 6),
+      '#upcoming_rsvps' => array_slice($upcomingRsvps, 0, 6),
+      '#past_events' => array_slice($pastEvents, 0, 6),
       '#account_links' => $accountLinks,
       '#show_review_cta' => $this->config('myeventlane_account.reviews')->get('enabled') ?? FALSE,
       '#review_eligible' => $reviewEligible,
       '#attached' => [
         'library' => ['myeventlane_theme/global-styling'],
-      ],
-      '#account_hero' => [
-        '#theme' => 'mel_account_hero',
-        '#headline' => $heroData['headline'],
-        '#body' => $heroData['body'],
-        '#primary_label' => $heroData['primary_label'],
-        '#primary_url' => $heroData['primary_url'],
-        '#secondary_label' => $heroData['secondary_label'],
-        '#secondary_url' => $heroData['secondary_url'],
       ],
     ];
     if ($upcomingTickets === []) {
@@ -123,9 +110,6 @@ final class MyAccountController extends ControllerBase {
     }
     if ($pastEvents === []) {
       $build['#mel_account_dashboard_past_empty'] = $this->operationalTemplates->accountDashboardPastPreviewEmpty();
-    }
-    if ($savedEventsPreview === []) {
-      $build['#mel_account_dashboard_saved_empty'] = $this->operationalTemplates->accountDashboardSavedEventsEmpty();
     }
     $cache->applyTo($build);
     return $build;

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -122,18 +122,11 @@ final class AccountLinksService {
 
     $definitions = [
       [
-        'id' => 'discover',
-        'title' => $this->t('Discover'),
-        'url' => $discoverUrl,
-        'in_quick' => TRUE,
-        'routes_match' => [],
-      ],
-      [
         'id' => 'dashboard',
         'title' => $this->t('Dashboard'),
         'url' => $dashboardUrl,
         'in_quick' => FALSE,
-        'show_in_sidebar' => FALSE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => [
           'myeventlane_account.dashboard',
         ],
@@ -151,20 +144,11 @@ final class AccountLinksService {
         ],
       ],
       [
-        'id' => 'my_events',
-        'title' => $this->t('All my events'),
-        'url' => $eventsUrl,
-        'in_quick' => TRUE,
-        'show_in_sidebar' => FALSE,
-        'routes_match' => [
-          'myeventlane_dashboard.customer',
-        ],
-      ],
-      [
         'id' => 'saved_events',
         'title' => $this->t('Saved events'),
         'url' => $savedEventsUrl,
         'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => [
           'view.mel_saved_events.page_1',
         ],
@@ -174,6 +158,7 @@ final class AccountLinksService {
         'title' => $this->t('Categories'),
         'url' => $categoriesUrl,
         'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => [
           'myeventlane_core.my_categories',
         ],
@@ -183,8 +168,20 @@ final class AccountLinksService {
         'title' => $this->t('Organisers'),
         'url' => $followedOrganisersUrl,
         'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => [
           'myeventlane_account.followed_organisers',
+        ],
+      ],
+      [
+        'id' => 'notifications',
+        'title' => $this->t('Notifications'),
+        'url' => $notificationsUrl,
+        'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
+        'routes_match' => [
+          'myeventlane_notifications.inbox',
+          'myeventlane_notifications.preferences',
         ],
       ],
       [
@@ -192,26 +189,36 @@ final class AccountLinksService {
         'title' => $this->t('Support'),
         'url' => $supportUrl,
         'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => $supportRoutesMatch,
-      ],
-      [
-        'id' => 'notifications',
-        'title' => $this->t('Notifications'),
-        'url' => $notificationsUrl,
-        'in_quick' => TRUE,
-        'routes_match' => [
-          'myeventlane_notifications.inbox',
-          'myeventlane_notifications.preferences',
-        ],
       ],
       [
         'id' => 'settings',
         'title' => $this->t('Settings'),
         'url' => $settingsUrl,
         'in_quick' => TRUE,
+        'show_in_sidebar' => TRUE,
         'routes_match' => [
           'myeventlane_account.settings',
           'myeventlane_account.settings_redirect',
+        ],
+      ],
+      [
+        'id' => 'discover',
+        'title' => $this->t('Discover'),
+        'url' => $discoverUrl,
+        'in_quick' => TRUE,
+        'show_in_sidebar' => FALSE,
+        'routes_match' => [],
+      ],
+      [
+        'id' => 'my_events',
+        'title' => $this->t('All my events'),
+        'url' => $eventsUrl,
+        'in_quick' => TRUE,
+        'show_in_sidebar' => FALSE,
+        'routes_match' => [
+          'myeventlane_dashboard.customer',
         ],
       ],
       [

--- a/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
+++ b/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_account\Service;
 
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
 use Drupal\image\ImageStyleInterface;
@@ -78,6 +79,45 @@ final class CustomerHubDataBuilder {
       'past_events' => $pastEvents,
       'unified_upcoming' => $unifiedUpcoming,
       'unified_past' => $pastEvents,
+    ];
+  }
+
+  /**
+   * Builds a hub event card row from a published event node.
+   *
+   * Used by Saved Events and other customer surfaces that share
+   * mel-account-event-card.html.twig.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildHubEventFromNode(NodeInterface $event, string $source = 'saved'): array {
+    return $this->buildEventItem($event, $source, '', NULL, NULL);
+  }
+
+  /**
+   * Flag AJAX link for save / unsave on hub event cards.
+   *
+   * @return array<string, mixed>|null
+   *   Render array for flag.link_builder, or NULL when Flag is unavailable.
+   */
+  public function buildEventSaveFlagLink(int $eventId): ?array {
+    if ($eventId < 1) {
+      return NULL;
+    }
+    if (!\Drupal::moduleHandler()->moduleExists('flag') || !\Drupal::hasService('flag.link_builder')) {
+      return NULL;
+    }
+    return [
+      '#lazy_builder' => [
+        'flag.link_builder:build',
+        [
+          'node',
+          (string) $eventId,
+          'event_save',
+          'default',
+        ],
+      ],
+      '#create_placeholder' => TRUE,
     ];
   }
 
@@ -181,15 +221,22 @@ final class CustomerHubDataBuilder {
         continue;
       }
 
-      $orderItemId = $attendee->hasField('order_item') && !$attendee->get('order_item')->isEmpty()
-        ? (int) $attendee->get('order_item')->target_id
-        : NULL;
+      $orderItemId = NULL;
+      $orderId = NULL;
+      if ($attendee->hasField('order_item') && !$attendee->get('order_item')->isEmpty()) {
+        $orderItemId = (int) $attendee->get('order_item')->target_id;
+        $orderItemEntity = $attendee->get('order_item')->entity;
+        if ($orderItemEntity instanceof OrderItemInterface) {
+          $orderId = (int) $orderItemEntity->getOrderId() ?: NULL;
+        }
+      }
       $eventMap[$eventId] = $this->buildEventItem(
         $event,
         $source,
         $attendee->get('ticket_code')->value ?? '',
         (int) $attendee->id(),
         $orderItemId,
+        $orderId,
       );
     }
 
@@ -252,7 +299,7 @@ final class CustomerHubDataBuilder {
           }
         }
 
-        $eventMap[$eventId] = $this->buildEventItem($event, 'ticket', $ticketCode, $attendeeId, (int) $orderItem->id());
+        $eventMap[$eventId] = $this->buildEventItem($event, 'ticket', $ticketCode, $attendeeId, (int) $orderItem->id(), (int) $order->id());
       }
     }
 
@@ -326,7 +373,7 @@ final class CustomerHubDataBuilder {
   /**
    * @return array<string, mixed>
    */
-  private function buildEventItem(NodeInterface $event, string $source, string $ticketCode, ?int $attendeeId, ?int $orderItemId): array {
+  private function buildEventItem(NodeInterface $event, string $source, string $ticketCode, ?int $attendeeId, ?int $orderItemId, ?int $orderId = NULL): array {
     $eventId = (int) $event->id();
     $startTime = $this->getEventStartTime($event);
     $endTime = $this->getEventEndTime($event);
@@ -350,6 +397,28 @@ final class CustomerHubDataBuilder {
 
     $code = trim($ticketCode);
     $hasTicketCode = $code !== '';
+    $pdfAvailable = ($orderItemId !== NULL && $orderItemId > 0) || $hasTicketCode;
+
+    // Deep link to the My Tickets order screen. Access is enforced by the
+    // target route's _custom_access; the URL is only built for the user's own
+    // rows, and reuses an existing route (no new route declared here).
+    $ticketUrl = NULL;
+    if ($orderId !== NULL && $orderId > 0) {
+      $ticketUrl = Url::fromRoute('myeventlane_checkout_flow.order_detail', ['commerce_order' => $orderId])->toString();
+    }
+
+    // Reuse the canonical ticket PDF endpoints (ownership enforced in
+    // TicketDownloadController). Prefer the by-code route; fall back to the
+    // order-item route when no ticket code is present.
+    $pdfUrl = NULL;
+    if ($pdfAvailable) {
+      if ($hasTicketCode) {
+        $pdfUrl = Url::fromRoute('myeventlane_tickets.download_pdf_by_code', ['ticket_code' => $code])->toString();
+      }
+      elseif ($orderItemId !== NULL && $orderItemId > 0) {
+        $pdfUrl = Url::fromRoute('myeventlane_tickets.download_pdf', ['order_item_id' => $orderItemId])->toString();
+      }
+    }
 
     return [
       'id' => $eventId,
@@ -367,7 +436,10 @@ final class CustomerHubDataBuilder {
       'has_ticket_code' => $hasTicketCode,
       'attendee_id' => $attendeeId,
       'order_item_id' => $orderItemId,
-      'pdf_available' => ($orderItemId !== NULL && $orderItemId > 0) || $hasTicketCode,
+      'order_id' => $orderId,
+      'pdf_available' => $pdfAvailable,
+      'ticket_url' => $ticketUrl,
+      'pdf_url' => $pdfUrl,
     ];
   }
 

--- a/web/modules/custom/myeventlane_account/templates/mel-account-followed-organisers.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/mel-account-followed-organisers.html.twig
@@ -8,7 +8,7 @@
  * - empty: Render array when there are no follows.
  */
 #}
-<section class="mel-my-account__section mel-dashboard__section" aria-label="{{ 'Followed organisers list'|t }}">
+<section class="mel-collection-page mel-collection-page--organisers mel-my-account__section mel-dashboard__section" aria-label="{{ 'Followed organisers list'|t }}">
   {% if vendors is not empty %}
     <div class="mel-my-account__vendor-grid" role="list">
       {% for vendor in vendors %}

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-dashboard.html.twig
@@ -1,27 +1,54 @@
 {#
 /**
  * @file
- * Customer My Account dashboard template (body only).
+ * Customer My Account dashboard — customer home (body only).
  *
  * Page shell (sidebar, workflow regions, header) comes from page--account.html.twig.
  */
 #}
 
-{% if account_hero %}
-  <div class="mel-my-account__hero-slot">
-    {{ account_hero }}
+<section class="mel-dashboard-welcome" aria-labelledby="dashboard-welcome-title">
+  <div class="mel-dashboard-welcome__layout">
+    <div class="mel-dashboard-welcome__primary">
+      <h2 id="dashboard-welcome-title" class="mel-dashboard-welcome__title">
+        {% if display_name|default('')|trim != '' %}
+          {{ 'Welcome, @name'|t({'@name': display_name}) }}
+        {% else %}
+          {{ 'Welcome back'|t }}
+        {% endif %}
+      </h2>
+      <p class="mel-dashboard-welcome__lede">{{ 'Your upcoming plans, tickets, and updates in one place.'|t }}</p>
+    </div>
+    <dl class="mel-dashboard-welcome__stats" aria-label="{{ 'Your activity'|t }}">
+      <div class="mel-dashboard-welcome__stat">
+        <dt>{{ 'Upcoming events'|t }}</dt>
+        <dd>{{ upcoming_event_count|default(0) }}</dd>
+      </div>
+      <div class="mel-dashboard-welcome__stat">
+        <dt>{{ 'Tickets'|t }}</dt>
+        <dd>{{ upcoming_ticket_count|default(0) }}</dd>
+      </div>
+      <div class="mel-dashboard-welcome__stat">
+        <dt>{{ 'RSVPs'|t }}</dt>
+        <dd>{{ upcoming_rsvp_count|default(0) }}</dd>
+      </div>
+    </dl>
   </div>
-{% endif %}
+</section>
 
-<section class="mel-my-account__section mel-dashboard__section" aria-labelledby="your-tickets-title">
-  <h2 id="your-tickets-title" class="mel-my-account__section-title">{{ 'Your tickets'|t }}</h2>
+<section class="mel-my-account__section mel-dashboard__section" aria-labelledby="upcoming-events-title">
+  <h2 id="upcoming-events-title" class="mel-my-account__section-title">{{ 'Upcoming events'|t }}</h2>
   {% if upcoming_tickets is not empty %}
     <div class="mel-my-account__cards">
       {% for event in upcoming_tickets %}
-        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with { event: event } only %}
+        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with {
+          event: event,
+          hub_user_id: hub_user_id|default(0),
+          card_variant: 'ticket',
+        } only %}
       {% endfor %}
     </div>
-    <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-my-account__view-all">{{ 'View all tickets'|t }}</a>
+    <a href="{{ path('myeventlane_checkout_flow.my_tickets') }}" class="mel-my-account__view-all">{{ 'Manage tickets'|t }}</a>
   {% else %}
     {% if mel_account_dashboard_tickets_empty is defined and mel_account_dashboard_tickets_empty %}
       {{ mel_account_dashboard_tickets_empty }}
@@ -34,10 +61,16 @@
   {% if upcoming_rsvps is not empty %}
     <div class="mel-my-account__cards">
       {% for event in upcoming_rsvps %}
-        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with { event: event } only %}
+        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with {
+          event: event,
+          hub_user_id: hub_user_id|default(0),
+          card_variant: 'rsvp',
+        } only %}
       {% endfor %}
     </div>
-    <a href="{{ path('myeventlane_dashboard.customer') }}" class="mel-my-account__view-all">{{ 'View all events'|t }}</a>
+    {% if hub_user_id|default(0) > 0 %}
+      <a href="{{ path('myeventlane_rsvp.user_list', {'user': hub_user_id}) }}" class="mel-my-account__view-all">{{ 'View all RSVPs'|t }}</a>
+    {% endif %}
   {% else %}
     {% if mel_account_dashboard_rsvps_empty is defined and mel_account_dashboard_rsvps_empty %}
       {{ mel_account_dashboard_rsvps_empty }}
@@ -45,39 +78,43 @@
   {% endif %}
 </section>
 
-<section class="mel-my-account__section mel-dashboard__section" aria-labelledby="saved-events-title">
-  <h2 id="saved-events-title" class="mel-my-account__section-title">{{ 'Saved events'|t }}</h2>
-  {% if saved_events is not empty %}
-    <div class="mel-my-account__cards">
-      {% for event in saved_events %}
-        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with { event: event } only %}
+<section class="mel-my-account__section mel-dashboard__section mel-dashboard__section--notifications" aria-labelledby="notifications-preview-title">
+  <h2 id="notifications-preview-title" class="mel-my-account__section-title">{{ 'Notifications'|t }}</h2>
+  {% if notifications_preview is not empty %}
+    <ul class="mel-dashboard-notifications">
+      {% for row in notifications_preview %}
+        <li class="mel-dashboard-notifications__item">
+          {% if row.action is defined and row.action and row.action.url|default('') %}
+            <a href="{{ row.action.url }}" class="mel-dashboard-notifications__link">
+              <span class="mel-dashboard-notifications__title">{{ row.title }}</span>
+              {% if row.message_preview %}
+                <span class="mel-dashboard-notifications__preview">{{ row.message_preview }}</span>
+              {% endif %}
+            </a>
+          {% else %}
+            <div class="mel-dashboard-notifications__link mel-dashboard-notifications__link--static">
+              <span class="mel-dashboard-notifications__title">{{ row.title }}</span>
+              {% if row.message_preview %}
+                <span class="mel-dashboard-notifications__preview">{{ row.message_preview }}</span>
+              {% endif %}
+            </div>
+          {% endif %}
+        </li>
       {% endfor %}
-    </div>
-    <a href="{{ path('view.mel_saved_events.page_1') }}" class="mel-my-account__view-all">{{ 'View all saved events'|t }}</a>
+    </ul>
+    {% if notifications_inbox_url %}
+      <a href="{{ notifications_inbox_url }}" class="mel-my-account__view-all">{{ 'View all notifications'|t }}</a>
+    {% endif %}
   {% else %}
-    {% if mel_account_dashboard_saved_empty is defined and mel_account_dashboard_saved_empty %}
-      {{ mel_account_dashboard_saved_empty }}
+    {% if mel_account_dashboard_notifications_empty is defined and mel_account_dashboard_notifications_empty %}
+      {{ mel_account_dashboard_notifications_empty }}
+    {% else %}
+      <p class="mel-my-account__empty">{{ 'No new notifications right now.'|t }}</p>
+      {% if notifications_inbox_url %}
+        <a href="{{ notifications_inbox_url }}" class="mel-my-account__view-all">{{ 'Open notifications'|t }}</a>
+      {% endif %}
     {% endif %}
   {% endif %}
-</section>
-
-<section class="mel-my-account__section mel-my-account__quick-actions" aria-labelledby="quick-actions-title">
-  <h2 id="quick-actions-title" class="mel-my-account__section-title">{{ 'Quick actions'|t }}</h2>
-  <div class="mel-my-account__quick-actions-grid">
-    <a href="{{ hub_discover_url|default(path('<front>')) }}" class="mel-my-account__quick-action">
-      <span class="mel-my-account__quick-action-icon" aria-hidden="true">{{ '🔍' }}</span>
-      <span>{{ 'Browse events'|t }}</span>
-    </a>
-    <a href="{{ hub_calendar_url|default(path('<front>')) }}" class="mel-my-account__quick-action">
-      <span class="mel-my-account__quick-action-icon" aria-hidden="true">{{ '📅' }}</span>
-      <span>{{ 'Calendar'|t }}</span>
-    </a>
-    {% for link in hub_quick_links|default([]) %}
-      <a href="{{ link.url }}" class="mel-my-account__quick-action">
-        <span class="mel-my-account__quick-action-text">{{ link.title }}</span>
-      </a>
-    {% endfor %}
-  </div>
 </section>
 
 <section class="mel-my-account__section mel-dashboard__section" aria-labelledby="past-events-title">
@@ -86,50 +123,12 @@
     <div class="mel-my-account__cards">
       {% for event in past_events %}
         {% set primary_review = show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
-        <article class="mel-card mel-my-account__card mel-my-account__card--past">
-          <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
-            {% if event.image_url %}
-              <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
-            {% endif %}
-          </div>
-          <div class="mel-card__body">
-            <h3 class="mel-card__title">{{ event.title }}</h3>
-            <div class="mel-card__meta">
-              {% if event.start_date %}
-                <time datetime="{{ event.start_date }}">{{ event.start_date }}</time><br>
-              {% endif %}
-              {% if event.location %}
-                {{ event.location }}
-              {% endif %}
-            </div>
-            <div class="mel-card__actions">
-              {% if primary_review %}
-                <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-button mel-button--primary">{{ 'Leave a review'|t }}</a>
-              {% elseif event.pdf_available %}
-                {% if event.has_ticket_code %}
-                  <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View ticket'|t }}</a>
-                {% else %}
-                  <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View ticket'|t }}</a>
-                {% endif %}
-              {% else %}
-                <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View event'|t }}</a>
-              {% endif %}
-              {% if primary_review or event.pdf_available or event.ics_url %}
-                <div class="mel-card__links">
-                  {% if primary_review or event.pdf_available %}
-                    <a href="{{ event.url }}">{{ 'View event'|t }}</a>
-                  {% endif %}
-                  {% if event.ics_url %}
-                    <a href="{{ event.ics_url }}" download>{{ 'Add to calendar'|t }}</a>
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
-            {% if event.has_ticket_code %}
-              <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
-            {% endif %}
-          </div>
-        </article>
+        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with {
+          event: event,
+          hub_user_id: hub_user_id|default(0),
+          card_variant: 'past',
+          show_review_cta: primary_review,
+        } only %}
       {% endfor %}
     </div>
     <a href="{{ path('myeventlane_account.past_events') }}" class="mel-my-account__view-all">{{ 'View all past events'|t }}</a>

--- a/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-past-events.html.twig
+++ b/web/modules/custom/myeventlane_account/templates/myeventlane-my-account-past-events.html.twig
@@ -8,54 +8,16 @@
 #}
 
 {% if past_events is not empty %}
-  <section class="mel-dashboard__section" aria-label="{{ 'Past events list'|t }}">
-    <div class="mel-my-account__cards">
+  <section class="mel-collection-page mel-collection-page--past mel-dashboard__section" aria-label="{{ 'Past events list'|t }}">
+    <div class="mel-my-account__cards mel-collection-page__cards">
       {% for event in past_events %}
         {% set primary_review = show_review_cta and review_eligible[event.id] is defined and review_eligible[event.id] %}
-        <article class="mel-card mel-my-account__card mel-my-account__card--past">
-          <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
-            {% if event.image_url %}
-              <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
-            {% endif %}
-          </div>
-          <div class="mel-card__body">
-            <h2 class="mel-card__title">{{ event.title }}</h2>
-            <div class="mel-card__meta">
-              {% if event.start_date %}
-                <time datetime="{{ event.start_date }}">{{ event.start_date }}</time><br>
-              {% endif %}
-              {% if event.location %}
-                {{ event.location }}
-              {% endif %}
-            </div>
-            <div class="mel-card__actions">
-              {% if primary_review %}
-                <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-button mel-button--primary">{{ 'Leave a review'|t }}</a>
-              {% elseif event.pdf_available %}
-                {% if event.has_ticket_code %}
-                  <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
-                {% else %}
-                  <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View Ticket'|t }}</a>
-                {% endif %}
-              {% else %}
-                <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View Event'|t }}</a>
-              {% endif %}
-              {% if primary_review or event.pdf_available or event.ics_url %}
-                <div class="mel-card__links">
-                  {% if primary_review or event.pdf_available %}
-                    <a href="{{ event.url }}">{{ 'View Event'|t }}</a>
-                  {% endif %}
-                  {% if event.ics_url %}
-                    <a href="{{ event.ics_url }}" download>{{ 'Add to Calendar'|t }}</a>
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
-            {% if event.has_ticket_code %}
-              <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
-            {% endif %}
-          </div>
-        </article>
+        {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with {
+          event: event,
+          hub_user_id: 0,
+          card_variant: 'past',
+          show_review_cta: primary_review,
+        } only %}
       {% endfor %}
     </div>
   </section>

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-my-tickets.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-my-tickets.html.twig
@@ -5,12 +5,6 @@
  */
 #}
 <div class="mel-my-tickets">
-  <div class="mel-page-header">
-    <p class="mel-page-description">
-      {{ 'Your bookings, calendar files, and event access in one place.'|t }}
-    </p>
-  </div>
-
   {% if upcoming_orders|length > 0 %}
     <div class="mel-section mel-mt-6">
       <h2 class="mel-section-title">{{ 'Upcoming'|t }}</h2>

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
@@ -1,32 +1,88 @@
 {#
 /**
  * @file
- * Booking detail — customer language; shell provides page H1.
+ * Booking detail — wallet / boarding-pass presentation; shell provides page H1.
  */
 #}
 
-<div class="mel-order-detail">
-  <div class="mel-page-header">
+<div class="mel-order-detail mel-order-detail--wallet">
+  <div class="mel-order-detail__nav">
     <a href="{{ url('myeventlane_checkout_flow.my_tickets') }}" class="mel-link mel-back-link">
       {{ '← Back to tickets'|t }}
     </a>
-    <p class="mel-page-lede mel-mt-2">{{ 'Booking reference:'|t }} {{ order.order_number|default(title) }}</p>
-    <div class="mel-order-meta mel-mt-2">
-      <span class="mel-order-date">
-        <strong>{{ 'Purchased'|t }}:</strong> {{ order.placed_date }}
-      </span>
-      <span class="mel-order-status">
-        <strong>{{ 'Confirmation'|t }}:</strong> {{ order.state_customer_presentation|default(order.state) }}
-      </span>
-    </div>
-    {% if order.total_price > 0 %}
-      <p class="mel-mt-3">
-        <a href="{{ url('myeventlane_checkout_flow.order_tax_invoice_pdf', {'commerce_order': order.order_id}) }}" class="mel-button mel-button--secondary">
-          {{ 'Download payment receipt (PDF)'|t }}
-        </a>
-      </p>
-    {% endif %}
   </div>
+
+  {% if order.ticket_models|default([])|length > 0 %}
+  <div class="mel-order-detail__passes" aria-label="{{ 'Your tickets'|t }}">
+    {% for ticket in order.ticket_models %}
+      {% set event = order.events|first %}
+      <article class="mel-ticket-pass">
+        <header class="mel-ticket-pass__header">
+          <div class="mel-ticket-pass__event">
+            {% if event %}
+              <h2 class="mel-ticket-pass__event-title">
+                <a href="{{ event.url }}" class="mel-link">{{ event.title }}</a>
+              </h2>
+              {% if event.start_date %}
+                <p class="mel-ticket-pass__when">
+                  {{ event.start_date }}{% if event.start_time %} · {{ event.start_time }}{% endif %}
+                  {% if event.location %} · {{ event.location }}{% endif %}
+                </p>
+              {% endif %}
+            {% else %}
+              <h2 class="mel-ticket-pass__event-title">{{ ticket.ticket.entitlement_label }}</h2>
+            {% endif %}
+          </div>
+          <span class="mel-badge mel-badge--success mel-ticket-pass__status">{{ ticket.ticket.status_label }}</span>
+        </header>
+
+        {% if ticket.qr.data_uri %}
+          <div class="mel-ticket-pass__qr" aria-label="{{ 'Ticket QR code'|t }}">
+            <img src="{{ ticket.qr.data_uri }}" alt="{{ 'Scan at entry'|t }}" width="200" height="200">
+            <p class="mel-ticket-pass__qr-hint">{{ 'Show this code at entry'|t }}</p>
+          </div>
+        {% endif %}
+
+        <div class="mel-ticket-pass__details">
+          <p class="mel-ticket-pass__entitlement">
+            <strong>{{ ticket.ticket.entitlement_label }}</strong>
+          </p>
+          {% if ticket.holder.name or ticket.holder.email %}
+            <p class="mel-ticket-pass__holder">
+              <span class="mel-ticket-pass__label">{{ 'Ticket holder'|t }}</span>
+              {{ ticket.holder.name|default('') }}
+              {% if ticket.holder.email %}
+                <span class="mel-ticket-pass__email">{{ ticket.holder.email }}</span>
+              {% endif %}
+            </p>
+          {% endif %}
+        </div>
+
+        <div class="mel-ticket-pass__actions">
+          {% if ticket.actions.pdf.download.url %}
+            <a href="{{ ticket.actions.pdf.download.url }}" class="mel-button mel-button--primary">
+              {{ 'Download ticket'|t }}
+            </a>
+          {% endif %}
+          {% if event and event.ics_url %}
+            <a href="{{ event.ics_url }}" class="mel-button mel-button--secondary" download>
+              {{ 'Add to calendar'|t }}
+            </a>
+          {% endif %}
+          {% if event %}
+            <a href="{{ event.url }}" class="mel-button mel-button--secondary">
+              {{ 'View event'|t }}
+            </a>
+          {% endif %}
+        </div>
+
+        {% if ticket.scanner.message %}
+          <p class="mel-ticket-pass__scan-note">{{ ticket.scanner.message }}</p>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </div>
+  {% endif %}
 
   {% if operational_addon_guidance %}
     <div class="mel-order-detail-addon-guidance mel-section mel-mt-4" role="region" aria-label="{{ 'Your add-ons'|t }}">
@@ -34,7 +90,7 @@
     </div>
   {% endif %}
 
-  {% if order.events|length > 0 %}
+  {% if order.events|length > 0 and order.ticket_models|default([])|length == 0 %}
     <div class="mel-section mel-mt-6">
       <h2 class="mel-section-title">{{ 'Your events'|t }}</h2>
       {% for event in order.events %}
@@ -43,49 +99,9 @@
             <h3 class="mel-event-title">
               <a href="{{ event.url }}" class="mel-link">{{ event.title }}</a>
             </h3>
-
-            <div class="mel-event-details mel-mt-3">
-              {% if event.start_date %}
-                <div class="mel-event-detail-row">
-                  <strong>{{ 'When'|t }}:</strong> {{ event.start_date }}
-                  {% if event.end_date and event.end_date != event.start_date %}
-                    – {{ event.end_date }}
-                  {% endif %}
-                </div>
-              {% endif %}
-              {% if event.start_time %}
-                <div class="mel-event-detail-row">
-                  <strong>{{ 'Time'|t }}:</strong> {{ event.start_time }}
-                  {% if event.end_time %}
-                    – {{ event.end_time }}
-                  {% endif %}
-                </div>
-              {% endif %}
-              {% if event.location %}
-                <div class="mel-event-detail-row">
-                  <strong>{{ 'Where'|t }}:</strong> {{ event.location }}
-                </div>
-              {% endif %}
-            </div>
-
             <div class="mel-event-actions mel-mt-4">
-              <a href="{{ event.ics_url }}"
-                 class="mel-button mel-button--primary"
-                 download>
-                {{ 'Add to calendar (.ics)'|t }}
-              </a>
-              <a href="{{ event.url }}" class="mel-button mel-button--secondary">
-                {{ 'View event page'|t }}
-              </a>
-              {% if event.can_refund and event.refund_url %}
-                <a href="{{ event.refund_url }}" class="mel-button mel-button--secondary">
-                  {{ 'Request refund'|t }}
-                </a>
-              {% elseif event.refund_ineligible_reason is defined and event.refund_ineligible_reason %}
-                <p class="mel-event-refund-note mel-text--muted mel-mt-2">
-                  {{ 'Support note:'|t }} {{ event.refund_ineligible_reason }}
-                </p>
-              {% endif %}
+              <a href="{{ event.ics_url }}" class="mel-button mel-button--primary" download>{{ 'Add to calendar'|t }}</a>
+              <a href="{{ event.url }}" class="mel-button mel-button--secondary">{{ 'View event page'|t }}</a>
             </div>
           </div>
         </div>
@@ -93,140 +109,17 @@
     </div>
   {% endif %}
 
-  {% if order.ticket_models|default([])|length > 0 %}
-    <div class="mel-section mel-mt-6">
-      <h2 class="mel-section-title">{{ 'Tickets and entitlements'|t }}</h2>
-      <div class="mel-card mel-mt-4">
-        <div class="mel-card-body">
-          {% for ticket in order.ticket_models %}
-            <div class="mel-ticket-item mel-mt-4{% if not loop.first %} mel-pt-4 mel-border-top{% endif %}">
-              <div class="mel-ticket-header">
-                <div class="mel-ticket-title">
-                  <strong>{{ ticket.ticket.entitlement_label }}</strong>
-                  {% if ticket.ticket.code %}
-                    <span class="mel-ticket-code">{{ ticket.ticket.code }}</span>
-                  {% endif %}
-                </div>
-                {% if ticket.actions.pdf.download.url and ticket.holder.name and ticket.holder.email %}
-                  <div class="mel-ticket-action">
-                    <a href="{{ ticket.actions.pdf.download.url }}" class="mel-button mel-button--secondary">
-                      {{ ticket.actions.pdf.download.label|default('Download PDF'|t) }}
-                    </a>
-                  </div>
-                {% endif %}
-              </div>
-
-              <div class="mel-ticket-meta mel-mt-2">
-                <span class="mel-ticket-status">
-                  <strong>{{ 'Status'|t }}:</strong> {{ ticket.ticket.status_label }}
-                </span>
-                {% if ticket.fulfilment.status_label %}
-                  <span class="mel-ticket-fulfilment">
-                    <strong>{{ 'Fulfilment'|t }}:</strong> {{ ticket.fulfilment.status_label }}
-                  </span>
-                {% endif %}
-                {% if ticket.expiry.expired %}
-                  <span class="mel-ticket-expiry">
-                    <strong>{{ 'Expiry'|t }}:</strong> {{ 'Expired'|t }}
-                  </span>
-                {% elseif ticket.expiry.timestamp|default(0) > 0 %}
-                  <span class="mel-ticket-expiry">
-                    <strong>{{ 'Expires'|t }}:</strong> {{ ticket.expiry.timestamp|date('F j, Y g:i A') }}
-                  </span>
-                {% endif %}
-              </div>
-
-              {% if ticket.holder.name or ticket.holder.email %}
-                <div class="mel-ticket-holder mel-mt-2">
-                  <strong>{{ 'Holder'|t }}:</strong>
-                  {{ ticket.holder.name|default('') }}
-                  {% if ticket.holder.email %}
-                    <span class="mel-attendee-email">({{ ticket.holder.email }})</span>
-                  {% endif %}
-                </div>
-              {% endif %}
-
-              {% if ticket.ticket.entitlement_type|default('ticket') != 'ticket' or ticket.redemption.multi_use %}
-                <div class="mel-ticket-redemption mel-mt-2">
-                  <strong>{{ 'Redemptions'|t }}:</strong>
-                  {{ ticket.redemption.remaining }} {{ 'remaining of'|t }} {{ ticket.redemption.limit }}
-                </div>
-              {% endif %}
-
-              {% if ticket.fulfilment.collect_location or ticket.fulfilment.collect_window.start_timestamp|default(0) > 0 or ticket.fulfilment.vehicle_registration %}
-                <div class="mel-ticket-fulfilment-details mel-mt-2">
-                  {% if ticket.fulfilment.collect_location %}
-                    <div><strong>{{ 'Collect at'|t }}:</strong> {{ ticket.fulfilment.collect_location }}</div>
-                  {% endif %}
-                  {% if ticket.fulfilment.collect_window.start_timestamp|default(0) > 0 %}
-                    <div>
-                      <strong>{{ 'Collection window'|t }}:</strong>
-                      {{ ticket.fulfilment.collect_window.start_timestamp|date('F j, Y g:i A') }}
-                      {% if ticket.fulfilment.collect_window.end_timestamp|default(0) > 0 %}
-                        – {{ ticket.fulfilment.collect_window.end_timestamp|date('F j, Y g:i A') }}
-                      {% endif %}
-                    </div>
-                  {% endif %}
-                  {% if ticket.fulfilment.vehicle_registration %}
-                    <div><strong>{{ 'Vehicle'|t }}:</strong> {{ ticket.fulfilment.vehicle_registration }}</div>
-                  {% endif %}
-                </div>
-              {% endif %}
-
-              {% if ticket.qr.data_uri %}
-                <div class="mel-ticket-qr mel-mt-3">
-                  <img src="{{ ticket.qr.data_uri }}" alt="{{ 'Ticket QR code'|t }}">
-                </div>
-              {% endif %}
-
-              {% if ticket.scanner.message %}
-                <p class="mel-ticket-scan-status mel-text--muted mel-mt-2">{{ ticket.scanner.message }}</p>
-              {% endif %}
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-  {% elseif order.ticket_items|length > 0 %}
+  {% if order.ticket_models|default([])|length == 0 and order.ticket_items|length > 0 %}
     <div class="mel-section mel-mt-6">
       <h2 class="mel-section-title">{{ 'Tickets'|t }}</h2>
       <div class="mel-card mel-mt-4">
         <div class="mel-card-body">
           {% for ticket in order.ticket_items %}
-            <div class="mel-ticket-item mel-mt-4{% if not loop.first %} mel-pt-4 mel-border-top{% endif %}{% if ticket.operational_addon_display|default(null) %} mel-ticket-item--operational-addon{% endif %}">
-              <div class="mel-ticket-header">
-                <div class="mel-ticket-title">
-                  {% if ticket.operational_addon_display|default(null) %}
-                    {% include '@myeventlane_commerce/mel-operational-order-item-line.html.twig' with { display: ticket.operational_addon_display } only %}
-                  {% else %}
-                    <strong>{{ ticket.title }}</strong>
-                  {% endif %}
-                </div>
-                <div class="mel-ticket-price">
-                  ${{ ticket.price|number_format(2) }}
-                </div>
-              </div>
+            <div class="mel-ticket-item mel-mt-4{% if not loop.first %} mel-pt-4 mel-border-top{% endif %}">
+              <strong>{{ ticket.title }}</strong>
               <div class="mel-ticket-meta mel-mt-2">
-                <span class="mel-ticket-quantity">
-                  {{ 'Quantity'|t }}: {{ ticket.quantity }}
-                </span>
+                <span>{{ 'Quantity'|t }}: {{ ticket.quantity }}</span>
               </div>
-
-              {% if ticket.attendees|length > 0 %}
-                <div class="mel-attendees mel-mt-3">
-                  <strong>{{ 'Guests'|t }}:</strong>
-                  <ul class="mel-attendee-list mel-mt-2">
-                    {% for attendee in ticket.attendees %}
-                      <li>
-                        {{ attendee.name }}
-                        {% if attendee.email %}
-                          <span class="mel-attendee-email">({{ attendee.email }})</span>
-                        {% endif %}
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </div>
-              {% endif %}
             </div>
           {% endfor %}
         </div>
@@ -242,28 +135,38 @@
           <p class="mel-donation-amount mel-mt-2">
             <strong>{{ 'Amount'|t }}:</strong> ${{ order.donation_total|number_format(2) }}
           </p>
-          <p class="mel-donation-note mel-mt-2">
-            {{ 'Thank you — your support helps communities run great events.'|t }}
-          </p>
         </div>
       </div>
     </div>
   {% endif %}
 
-  <div class="mel-section mel-mt-6">
-    <div class="mel-card">
-      <div class="mel-card-body">
-        <div class="mel-total-row">
-          <span class="mel-total-label">{{ 'Amount paid'|t }}</span>
-          <span class="mel-total-amount">${{ order.total_price|number_format(2) }}</span>
-        </div>
-      </div>
+  <details class="mel-order-detail__purchase mel-mt-6">
+    <summary class="mel-order-detail__purchase-summary">{{ 'Purchase details'|t }}</summary>
+    <div class="mel-order-detail__purchase-body">
+      <p class="mel-order-detail__reference">
+        <strong>{{ 'Booking reference'|t }}:</strong> {{ order.order_number|default(title) }}
+      </p>
+      <p>
+        <strong>{{ 'Purchased'|t }}:</strong> {{ order.placed_date }}
+      </p>
+      <p>
+        <strong>{{ 'Confirmation'|t }}:</strong> {{ order.state_customer_presentation|default(order.state) }}
+      </p>
+      <p>
+        <strong>{{ 'Amount paid'|t }}:</strong> ${{ order.total_price|number_format(2) }}
+      </p>
+      {% if order.total_price > 0 %}
+        <p class="mel-mt-3">
+          <a href="{{ url('myeventlane_checkout_flow.order_tax_invoice_pdf', {'commerce_order': order.order_id}) }}" class="mel-button mel-button--secondary">
+            {{ 'Download payment receipt (PDF)'|t }}
+          </a>
+        </p>
+      {% endif %}
     </div>
-  </div>
+  </details>
 
   <div class="mel-order-actions mel-mt-6">
-    <a href="{{ url('myeventlane_checkout_flow.my_tickets') }}"
-       class="mel-button mel-button--secondary">
+    <a href="{{ url('myeventlane_checkout_flow.my_tickets') }}" class="mel-button mel-button--secondary">
       {{ 'Back to tickets'|t }}
     </a>
   </div>

--- a/web/modules/custom/myeventlane_core/src/Controller/MyCategoriesController.php
+++ b/web/modules/custom/myeventlane_core/src/Controller/MyCategoriesController.php
@@ -133,19 +133,26 @@ final class MyCategoriesController extends ControllerBase {
             continue;
           }
           $newEvents[] = [
-            'id' => $event->id(),
+            'id' => (int) $event->id(),
             'title' => $event->label(),
             'url' => $event->toUrl()->toString(),
-            'thumbnail_url' => $this->eventThumbnailUrl($event),
+            'image_url' => $this->eventThumbnailUrl($event),
             'start_date' => $startTime ? date('M j, Y', $startTime) : '',
             'start_time' => $startTime ? date('g:ia', $startTime) : '',
-            'venue' => $event->hasField('field_venue_name') && !$event->get('field_venue_name')->isEmpty()
-              ? $event->get('field_venue_name')->value
+            'location' => $event->hasField('field_venue_name') && !$event->get('field_venue_name')->isEmpty()
+              ? (string) $event->get('field_venue_name')->value
               : '',
             'ics_url' => Url::fromRoute('myeventlane_rsvp.ics_download', ['node' => $event->id()])->toString(),
+            'source' => 'category',
             'is_boosted' => $this->boostManager->isBoosted($event),
+            'event_save_flag' => $this->eventSaveFlagLink($event),
           ];
         }
+      }
+
+      $description = '';
+      if ($category->hasField('description') && !$category->get('description')->isEmpty()) {
+        $description = trim(strip_tags((string) $category->get('description')->value));
       }
 
       $categoryData[] = [
@@ -153,9 +160,10 @@ final class MyCategoriesController extends ControllerBase {
         'id' => $category->id(),
         'name' => $category->label(),
         'url' => $category->toUrl()->toString(),
+        'description' => $description,
         'follow_cta' => $this->categoryFollowFlagLink($category),
-        'new_events' => $newEvents,
-        'new_events_count' => count($newEvents),
+        'events' => $newEvents,
+        'event_count' => count($newEvents),
       ];
     }
 
@@ -173,7 +181,7 @@ final class MyCategoriesController extends ControllerBase {
       ],
       '#cache' => [
         'contexts' => ['user'],
-        'tags' => ['taxonomy_term_list', 'node_list', 'flag.flag.follow_category'],
+        'tags' => ['taxonomy_term_list', 'node_list', 'flag.flag.follow_category', 'flag.flag.event_save'],
         'max-age' => 300,
       ],
     ];
@@ -222,6 +230,33 @@ final class MyCategoriesController extends ControllerBase {
           'taxonomy_term',
           (string) $term->id(),
           'follow_category',
+          'default',
+        ],
+      ],
+      '#create_placeholder' => TRUE,
+    ];
+  }
+
+  /**
+   * Builds the canonical Flag AJAX link for save / unsave on category event rows.
+   */
+  private function eventSaveFlagLink(NodeInterface $event): ?array {
+    if ($event->bundle() !== 'event') {
+      return NULL;
+    }
+
+    $flag = $this->flagService->getFlagById('event_save');
+    if ($flag === NULL) {
+      return NULL;
+    }
+
+    return [
+      '#lazy_builder' => [
+        'flag.link_builder:build',
+        [
+          'node',
+          (string) $event->id(),
+          'event_save',
           'default',
         ],
       ],

--- a/web/modules/custom/myeventlane_core/templates/myeventlane-my-categories.html.twig
+++ b/web/modules/custom/myeventlane_core/templates/myeventlane-my-categories.html.twig
@@ -1,81 +1,58 @@
 {#
 /**
  * @file
- * Template for the My Categories page (account shell provides page H1).
+ * My Categories — collection page body (account shell provides H1 + lede).
  *
- * Available variables:
- * - followed_categories: Array of category data with new events.
+ * Variables:
+ * - followed_categories: Category rows with header metadata and event cards.
  * - mel_category_follow_empty: Empty state when user follows nothing.
- * - mel_category_follow_section_no_new_events: Copy when a followed category has no new items this week.
+ * - mel_category_follow_section_no_new_events: Copy when a category has no new items.
  */
 #}
-<div class="mel-my-categories-wrapper">
+<div class="mel-collection-page mel-collection-page--categories">
 
   {% if followed_categories is empty %}
     {% if mel_category_follow_empty is defined and mel_category_follow_empty %}
       {{ mel_category_follow_empty }}
     {% endif %}
   {% else %}
-    <p class="mel-intro-text">{{ 'Categories you follow and what is new this week.'|t }}</p>
-
     {% for category in followed_categories %}
-      <section class="mel-category-section" aria-labelledby="category-{{ category.id }}-title">
-        <div class="mel-category-header">
-          <h2 id="category-{{ category.id }}-title" class="mel-section-title">
-            <a href="{{ category.url }}">{{ category.name }}</a>
-          </h2>
+      <section class="mel-collection-page__group mel-category-section" aria-labelledby="category-{{ category.id }}-title">
+        <article class="mel-card mel-category-header-card">
+          <div class="mel-category-header-card__main">
+            <h2 id="category-{{ category.id }}-title" class="mel-category-header-card__title">
+              <a href="{{ category.url }}">{{ category.name }}</a>
+            </h2>
+            <p class="mel-category-header-card__count">
+              {% if category.event_count > 0 %}
+                {{ '@count new this week'|t({'@count': category.event_count}) }}
+              {% else %}
+                {{ 'No new events this week'|t }}
+              {% endif %}
+            </p>
+            {% if category.description %}
+              <p class="mel-category-header-card__description">{{ category.description }}</p>
+            {% endif %}
+          </div>
           {% if category.follow_cta %}
-            {% include '@myeventlane_theme/components/mel-category-follow-cta.html.twig' with {
-              mel_category_follow_flag: category.follow_cta,
-              mel_category_follow_login_url: null,
-              category_display_name: category.name,
-              mel_category_follow_modifier: 'account'
-            } %}
+            <div class="mel-category-header-card__follow">
+              {% include '@myeventlane_theme/components/mel-category-follow-cta.html.twig' with {
+                mel_category_follow_flag: category.follow_cta,
+                mel_category_follow_login_url: null,
+                category_display_name: category.name,
+                mel_category_follow_modifier: 'account-header'
+              } %}
+            </div>
           {% endif %}
-        </div>
+        </article>
 
-        {% if category.new_events_count > 0 %}
-          <div class="mel-events-grid">
-            {% for event in category.new_events %}
-              <article class="mel-event-card">
-                {% if event.is_boosted %}
-                  <div class="mel-category-event-card__featured" aria-label="{{ 'Spotlight'|t }}">
-                    {{ 'Spotlight'|t }}
-                  </div>
-                {% endif %}
-                <div class="mel-event-card-body{% if event.thumbnail_url %} mel-event-card-body--with-thumb{% endif %}">
-                  {% if event.thumbnail_url %}
-                    <div class="mel-category-event-thumb">
-                      <img src="{{ event.thumbnail_url }}" alt="" width="72" height="72" loading="lazy" decoding="async">
-                    </div>
-                  {% endif %}
-                  <div class="mel-event-card-body-main">
-                    <h3 class="mel-event-card-title">
-                      <a href="{{ event.url }}">{{ event.title }}</a>
-                    </h3>
-                    <div class="mel-event-card-meta">
-                      {% if event.start_date %}
-                        <div class="mel-event-card-meta-item">
-                          <span class="mel-event-card-meta-icon" aria-hidden="true">📅</span>
-                          <span>{{ event.start_date }}{% if event.start_time %} {{ 'at'|t }} {{ event.start_time }}{% endif %}</span>
-                        </div>
-                      {% endif %}
-                      {% if event.venue %}
-                        <div class="mel-event-card-meta-item">
-                          <span class="mel-event-card-meta-icon" aria-hidden="true">📍</span>
-                          <span>{{ event.venue }}</span>
-                        </div>
-                      {% endif %}
-                    </div>
-                    <div class="mel-event-card-footer">
-                      <a href="{{ event.url }}" class="mel-btn mel-btn-primary mel-btn-sm">{{ 'View event'|t }}</a>
-                      {% if event.ics_url %}
-                        <a href="{{ event.ics_url }}" class="mel-btn mel-btn-link mel-btn-sm" download>{{ 'Add to calendar'|t }}</a>
-                      {% endif %}
-                    </div>
-                  </div>
-                </div>
-              </article>
+        {% if category.event_count > 0 %}
+          <div class="mel-my-account__cards mel-collection-page__cards">
+            {% for event in category.events %}
+              {% include '@myeventlane_theme/account/mel-account-event-card.html.twig' with {
+                event: event,
+                card_variant: 'category',
+              } only %}
             {% endfor %}
           </div>
         {% else %}

--- a/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
+++ b/web/modules/custom/myeventlane_notifications/myeventlane_notifications.module
@@ -88,6 +88,7 @@ function myeventlane_notifications_theme(array $existing, string $type, string $
         'mark_all_form' => NULL,
         'pager_info' => [],
         'settings_url' => NULL,
+        'in_account_shell' => FALSE,
       ],
       'template' => 'mel-notification-inbox',
     ],

--- a/web/modules/custom/myeventlane_notifications/templates/mel-notification-inbox.html.twig
+++ b/web/modules/custom/myeventlane_notifications/templates/mel-notification-inbox.html.twig
@@ -4,18 +4,24 @@
  * Full notifications inbox (tabs, filters, grouped list, empty state).
  */
 #}
-<div class="mel-notif-inbox mel-container">
-  <header class="mel-notif-inbox__header">
-    <div class="mel-notif-inbox__header-row">
-      <div>
-        <h1 class="mel-notif-inbox__title">{{ 'Notifications'|t }}</h1>
-        <p class="mel-notif-inbox__lede">{{ 'Personal tickets, business sales, and platform updates — organised by context.'|t }}</p>
+<div class="mel-notif-inbox mel-container{% if in_account_shell %} mel-notif-inbox--account-shell{% endif %}">
+  {% if not in_account_shell %}
+    <header class="mel-notif-inbox__header">
+      <div class="mel-notif-inbox__header-row">
+        <div>
+          <h1 class="mel-notif-inbox__title">{{ 'Notifications'|t }}</h1>
+          <p class="mel-notif-inbox__lede">{{ 'Personal tickets, business sales, and platform updates — organised by context.'|t }}</p>
+        </div>
+        {% if settings_url %}
+          <a href="{{ settings_url }}" class="mel-notif-inbox__settings">{{ 'Notification settings'|t }}</a>
+        {% endif %}
       </div>
-      {% if settings_url %}
-        <a href="{{ settings_url }}" class="mel-notif-inbox__settings">{{ 'Notification settings'|t }}</a>
-      {% endif %}
+    </header>
+  {% elseif settings_url %}
+    <div class="mel-notif-inbox__toolbar mel-notif-inbox__toolbar--settings">
+      <a href="{{ settings_url }}" class="mel-notif-inbox__settings">{{ 'Notification settings'|t }}</a>
     </div>
-  </header>
+  {% endif %}
 
   <nav class="mel-notif-inbox__tabs" aria-label="{{ 'Notification context'|t }}">
     {% for link in tab_links %}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -157,6 +157,16 @@ function myeventlane_theme_theme(array $existing, string $type, string $theme, s
       ],
       'template' => 'account/mel-account-hero',
     ],
+    'mel_account_event_card' => [
+      'variables' => [
+        'event' => [],
+        'card_variant' => '',
+        'hub_user_id' => 0,
+        'show_review_cta' => FALSE,
+        'event_save_flag' => NULL,
+      ],
+      'template' => 'account/mel-account-event-card',
+    ],
     'mel_checkout_order_summary_grouped' => [
       'variables' => [
         'grouped_items' => [],

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_account-cards.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_account-cards.scss
@@ -1,8 +1,247 @@
 // Hub event / RSVP cards — shared with discovery .mel-card patterns.
 
+@use 'sass:color';
+@use '../tokens/breakpoints';
 @use '../tokens/radii';
 @use '../tokens/colors';
+@use '../tokens/shadows';
 @use '../tokens/spacing';
+@use '../tokens/typography';
+
+// Fixed thumb size — hub rows must not stretch images to card height.
+$mel-account-event-thumb: 5.5rem;
+
+// Card list spacing — used on dashboard, categories, saved events, past events.
+.mel-my-account__cards,
+.mel-collection-page__cards {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(3);
+}
+
+.mel-account-event-card--compact {
+  overflow: hidden;
+
+  &:hover {
+    transform: none;
+    box-shadow: shadows.$mel-shadow-sm;
+  }
+
+  // Inner row isolates layout from .mel-dashboard__section .mel-card { flex } rules.
+  .mel-account-event-card__row {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .mel-account-event-card__media,
+  .mel-card__image {
+    overflow: hidden;
+    flex-shrink: 0;
+    width: 100%;
+    background: colors.$mel-color-surface-alt;
+  }
+
+  .mel-account-event-card__media img,
+  .mel-card__image img {
+    display: block;
+    width: 100%;
+    height: $mel-account-event-thumb;
+    max-height: $mel-account-event-thumb;
+    object-fit: cover;
+  }
+
+  .mel-account-event-card__media--placeholder,
+  .mel-card__image--placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: $mel-account-event-thumb;
+    min-height: $mel-account-event-thumb;
+    max-height: $mel-account-event-thumb;
+    color: colors.$mel-color-text-muted;
+    background: linear-gradient(135deg, var(--mel-peach) 0%, var(--mel-lilac) 100%);
+
+    &::before {
+      content: '🎫';
+      font-size: 1.25rem;
+      opacity: 0.6;
+    }
+  }
+
+  .mel-account-event-card__content,
+  .mel-card__body {
+    padding: spacing.mel-space(3);
+    min-width: 0;
+  }
+
+  .mel-card__title {
+    margin: 0 0 spacing.mel-space(1);
+    font-size: typography.mel-font-size(base);
+    font-weight: typography.$mel-font-bold;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .mel-card__meta {
+    display: flex;
+    flex-direction: column;
+    gap: spacing.mel-space(1);
+    margin-bottom: spacing.mel-space(2);
+    font-size: typography.mel-font-size(sm);
+    color: colors.$mel-color-text-muted;
+    line-height: typography.$mel-leading-relaxed;
+  }
+
+  .mel-account-event-card__venue {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mel-account-event-card__status {
+    margin-bottom: spacing.mel-space(2);
+  }
+
+  .mel-account-event-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing.mel-space(1) spacing.mel-space(2);
+    margin-top: spacing.mel-space(2);
+  }
+
+  .mel-account-event-card__action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: spacing.mel-space(2) spacing.mel-space(3);
+    border-radius: radii.$mel-radius-pill;
+    font-size: typography.mel-font-size(xs);
+    font-weight: typography.$mel-font-semibold;
+    color: colors.$mel-color-primary;
+    text-decoration: none;
+    background: color.adjust(colors.$mel-color-primary, $alpha: -0.92);
+
+    &:hover {
+      background: color.adjust(colors.$mel-color-primary, $alpha: -0.86);
+    }
+
+    &:focus-visible {
+      @include colors.mel-focus-ring;
+    }
+
+    &--primary {
+      background: colors.$mel-color-primary;
+      color: colors.$mel-color-text-inverse;
+
+      &:hover {
+        background: colors.$mel-color-primary-hover;
+        color: colors.$mel-color-text-inverse;
+      }
+    }
+  }
+
+  .mel-account-event-card__flag {
+    display: inline-flex;
+
+    .flag {
+      margin: 0;
+    }
+
+    .flag a {
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      padding: spacing.mel-space(2) spacing.mel-space(3);
+      border-radius: radii.$mel-radius-pill;
+      font-size: typography.mel-font-size(xs);
+      font-weight: typography.$mel-font-semibold;
+      color: colors.$mel-color-text-muted;
+      text-decoration: none;
+      background: colors.$mel-color-surface-alt;
+      border: 1px solid rgba(41, 50, 65, 0.12);
+
+      &:hover {
+        background: color.adjust(colors.$mel-color-surface-alt, $lightness: -3%);
+        color: colors.$mel-color-text;
+      }
+
+      &:focus-visible {
+        @include colors.mel-focus-ring;
+      }
+    }
+
+    .flag.action-unflag a {
+      color: colors.$mel-color-primary;
+      background: color.adjust(colors.$mel-color-primary, $alpha: -0.92);
+      border-color: transparent;
+
+      &:hover {
+        background: color.adjust(colors.$mel-color-primary, $alpha: -0.86);
+      }
+    }
+  }
+
+  @include breakpoints.mel-break(md, max) {
+    .mel-account-event-card__actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .mel-account-event-card__action,
+    .mel-account-event-card__flag .flag a {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+
+  @include breakpoints.mel-break(md) {
+    .mel-account-event-card__row {
+      display: grid;
+      grid-template-columns: $mel-account-event-thumb minmax(0, 1fr);
+      gap: spacing.mel-space(3);
+      align-items: center;
+      padding: spacing.mel-space(3);
+    }
+
+    .mel-account-event-card__media,
+    .mel-card__image {
+      width: $mel-account-event-thumb;
+      height: $mel-account-event-thumb;
+      margin: 0;
+      border-radius: radii.$mel-radius-md;
+      align-self: center;
+    }
+
+    .mel-account-event-card__media img,
+    .mel-card__image img {
+      width: 100%;
+      height: 100%;
+      max-height: none;
+    }
+
+    .mel-account-event-card__media--placeholder,
+    .mel-card__image--placeholder {
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      max-height: none;
+    }
+
+    .mel-account-event-card__content,
+    .mel-card__body {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 0;
+    }
+  }
+}
 
 .mel-account-event-card,
 .mel-account-rsvp-card {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_cards.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_cards.scss
@@ -232,62 +232,89 @@
     margin-bottom: spacing.mel-space(4);
   }
 
-  .mel-my-account__cards {
-    display: grid;
-    gap: spacing.mel-space(5);
-    grid-template-columns: 1fr;
-
-    @include breakpoints.mel-break(md) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @include breakpoints.mel-break(lg) {
-      grid-template-columns: repeat(3, 1fr);
+  // Hub event cards: layout lives in components/_account-cards.scss.
+  .mel-account-event-card--compact {
+    .mel-card__actions {
+      display: none;
     }
   }
 
-  .mel-card__image {
-    position: relative;
-    overflow: hidden;
-    flex-shrink: 0;
-    background: colors.$mel-color-surface-alt;
-  }
-
-  .mel-card__image img {
-    display: block;
-    width: 100%;
-    height: 160px;
-    object-fit: cover;
-  }
-
-  .mel-card__image--placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 160px;
-    color: colors.$mel-color-text-muted;
-    background: linear-gradient(135deg, var(--mel-peach) 0%, var(--mel-lilac) 100%);
-
-    &::before {
-      content: '🎫';
-      font-size: 2.5rem;
-      opacity: 0.6;
-    }
-  }
-
-  .mel-card__meta {
-    font-size: typography.mel-font-size(sm);
-    color: colors.$mel-color-text-muted;
-    line-height: typography.$mel-leading-relaxed;
-    margin-bottom: spacing.mel-space(5);
-  }
-
-  .mel-card__actions {
+  .mel-card:not(.mel-account-event-card--compact) {
     display: flex;
     flex-direction: column;
-    gap: spacing.mel-space(3);
-    margin-top: auto;
-    padding-top: spacing.mel-space(4);
+    min-height: 100%;
+    background: colors.$mel-color-surface;
+    border: none;
+    border-radius: radii.$mel-radius-md;
+    box-shadow: 0 4px 16px rgba(36, 48, 58, 0.1);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 8px 24px rgba(36, 48, 58, 0.12);
+    }
+
+    .mel-card__image {
+      position: relative;
+      overflow: hidden;
+      flex-shrink: 0;
+      background: colors.$mel-color-surface-alt;
+    }
+
+    .mel-card__image img {
+      display: block;
+      width: 100%;
+      height: 88px;
+      object-fit: cover;
+    }
+
+    .mel-card__image--placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 88px;
+      color: colors.$mel-color-text-muted;
+      background: linear-gradient(135deg, var(--mel-peach) 0%, var(--mel-lilac) 100%);
+
+      &::before {
+        content: '🎫';
+        font-size: 2.5rem;
+        opacity: 0.6;
+      }
+    }
+
+    .mel-card__body {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      min-height: 0;
+      padding: spacing.mel-space(5);
+    }
+
+    .mel-card__title {
+      margin: 0 0 spacing.mel-space(2) 0;
+      font-size: typography.mel-font-size(xl);
+      font-weight: typography.$mel-font-bold;
+      line-height: 1.3;
+      color: colors.$mel-color-text;
+    }
+
+    .mel-card__meta {
+      font-size: typography.mel-font-size(sm);
+      color: colors.$mel-color-text-muted;
+      line-height: typography.$mel-leading-relaxed;
+      margin-bottom: spacing.mel-space(5);
+    }
+
+    .mel-card__actions {
+      display: flex;
+      flex-direction: column;
+      gap: spacing.mel-space(3);
+      margin-top: auto;
+      padding-top: spacing.mel-space(4);
+    }
   }
 
   .mel-card__links {
@@ -314,40 +341,6 @@
         @include colors.mel-focus-ring;
       }
     }
-  }
-
-  .mel-card {
-    display: flex;
-    flex-direction: column;
-    min-height: 100%;
-    background: colors.$mel-color-surface;
-    border: none;
-    border-radius: radii.$mel-radius-md;
-    box-shadow: 0 4px 16px rgba(36, 48, 58, 0.1);
-    transition:
-      transform 0.2s ease,
-      box-shadow 0.2s ease;
-
-    &:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 8px 24px rgba(36, 48, 58, 0.12);
-    }
-  }
-
-  .mel-card__body {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    min-height: 0;
-    padding: spacing.mel-space(5);
-  }
-
-  .mel-card__title {
-    margin: 0 0 spacing.mel-space(2) 0;
-    font-size: typography.mel-font-size(xl);
-    font-weight: typography.$mel-font-bold;
-    line-height: 1.3;
-    color: colors.$mel-color-text;
   }
 
   .mel-button {

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_my-account.scss
@@ -129,19 +129,164 @@
 }
 
 // ---------------------------------------------------------------------------
+// Dashboard welcome band
+// ---------------------------------------------------------------------------
+
+.mel-dashboard-welcome {
+  margin-bottom: spacing.mel-space(5);
+  padding: spacing.mel-space(4);
+  background: colors.$mel-color-surface;
+  border-radius: radii.$mel-radius-md;
+  box-shadow: shadows.$mel-shadow-sm;
+}
+
+.mel-dashboard-welcome__layout {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+  align-items: flex-start;
+
+  @include breakpoints.mel-break(md) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+  }
+}
+
+.mel-dashboard-welcome__title {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(2xl);
+  font-weight: typography.$mel-font-extrabold;
+  color: colors.$mel-color-text;
+  text-align: left;
+
+  @include breakpoints.mel-break(md) {
+    font-size: typography.mel-font-size(3xl);
+  }
+}
+
+.mel-dashboard-welcome__lede {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  max-width: 36rem;
+}
+
+.mel-dashboard-welcome__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: spacing.mel-space(2);
+  width: 100%;
+  margin: 0;
+
+  @include breakpoints.mel-break(md) {
+    width: auto;
+    min-width: 280px;
+  }
+}
+
+.mel-dashboard-welcome__stat {
+  padding: spacing.mel-space(3);
+  border-radius: radii.$mel-radius-md;
+  background: colors.$mel-color-bg;
+  text-align: center;
+
+  dt {
+    margin: 0 0 spacing.mel-space(1);
+    font-size: typography.mel-font-size(xs);
+    font-weight: typography.$mel-font-medium;
+    color: colors.$mel-color-text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  dd {
+    margin: 0;
+    font-size: typography.mel-font-size(xl);
+    font-weight: typography.$mel-font-extrabold;
+    color: colors.$mel-color-primary;
+  }
+}
+
+.mel-dashboard-notifications {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(2);
+}
+
+.mel-dashboard-notifications__item {
+  margin: 0;
+}
+
+.mel-dashboard-notifications__link {
+  display: block;
+  min-height: 44px;
+  padding: spacing.mel-space(3) spacing.mel-space(4);
+  border-radius: radii.$mel-radius-md;
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-sm;
+  text-decoration: none;
+  color: colors.$mel-color-text;
+  border-left: 3px solid colors.$mel-color-secondary;
+
+  &:hover {
+    box-shadow: shadows.$mel-shadow-md;
+  }
+
+  &:focus-visible {
+    @include colors.mel-focus-ring;
+  }
+
+  &--static {
+    cursor: default;
+  }
+}
+
+.mel-dashboard-notifications__title {
+  display: block;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+}
+
+.mel-dashboard-notifications__preview {
+  display: block;
+  margin-top: spacing.mel-space(1);
+  font-size: typography.mel-font-size(xs);
+  color: colors.$mel-color-text-muted;
+}
+
+// ---------------------------------------------------------------------------
 // Header row — welcome + avatar (site header supplies global branding)
 // ---------------------------------------------------------------------------
 
 .mel-my-account__header {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  gap: spacing.mel-space(4);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: spacing.mel-space(3) spacing.mel-space(4);
   margin-bottom: spacing.mel-space(4);
 
   @include breakpoints.mel-break(md) {
+    align-items: center;
     margin-bottom: spacing.mel-space(5);
   }
+}
+
+.mel-my-account__header-text {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.mel-my-account__lede {
+  margin: spacing.mel-space(2) 0 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  max-width: 40rem;
+  line-height: typography.$mel-leading-relaxed;
 }
 
 .mel-my-account__logo {
@@ -168,10 +313,12 @@
 }
 
 .mel-my-account__welcome {
+  flex: 1 1 auto;
   font-size: typography.mel-font-size(2xl);
   font-weight: typography.$mel-font-extrabold;
   color: colors.$mel-color-text;
   margin: 0;
+  text-align: left;
 
   @include breakpoints.mel-break(md) {
     font-size: typography.mel-font-size(3xl);
@@ -232,7 +379,8 @@
 
 // Card grid + dashboard section titles: components/_cards.scss (.mel-dashboard__section).
 
-.mel-my-account__card {
+// Title clamp for legacy account cards (not hub event rows).
+.mel-my-account__card:not(.mel-account-event-card--compact) {
   .mel-card__title {
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -362,51 +510,94 @@
   box-shadow: shadows.$mel-shadow-sm;
 }
 
-.mel-category-section .mel-event-card {
-  position: relative;
+// ---------------------------------------------------------------------------
+// Customer collection pages (categories, organisers, saved events)
+// ---------------------------------------------------------------------------
+
+.mel-collection-page {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(5);
+}
+
+.mel-collection-page__group {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+}
+
+
+.mel-category-header-card {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+  padding: spacing.mel-space(4);
+  background: colors.$mel-color-surface;
+  border-radius: radii.$mel-radius-lg;
+  box-shadow: shadows.$mel-shadow-sm;
+  border: 1px solid rgba(41, 50, 65, 0.08);
+
+  @include breakpoints.mel-break(md) {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: spacing.mel-space(5);
+  }
+}
+
+.mel-category-header-card__main {
+  flex: 1;
+  min-width: 0;
+}
+
+.mel-category-header-card__title {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(xl);
+  font-weight: typography.$mel-font-bold;
+
+  a {
+    color: colors.$mel-color-text;
+    text-decoration: none;
+
+    &:hover {
+      color: colors.$mel-color-primary;
+    }
+  }
+}
+
+.mel-category-header-card__count {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-primary;
+}
+
+.mel-category-header-card__description {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  line-height: typography.$mel-leading-relaxed;
+}
+
+.mel-category-header-card__follow {
+  flex-shrink: 0;
+  width: 100%;
+
+  @include breakpoints.mel-break(md) {
+    width: auto;
+    max-width: 12rem;
+  }
+
+  .mel-category-follow__btn,
+  .flag a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    width: 100%;
+  }
 }
 
 .mel-my-categories-wrapper {
-  .mel-category-header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: spacing.mel-space(3);
-    margin-bottom: spacing.mel-space(4);
-  }
-
-  .mel-section-title {
-    margin: 0;
-    font-size: typography.mel-font-size(lg);
-    font-weight: typography.$mel-font-bold;
-  }
-
-  .mel-intro-text {
-    margin: 0 0 spacing.mel-space(5);
-    color: colors.$mel-color-text-muted;
-  }
-
-  .mel-event-card-body--with-thumb {
-    display: flex;
-    gap: spacing.mel-space(3);
-    align-items: flex-start;
-  }
-
-  .mel-category-event-thumb {
-    flex: 0 0 auto;
-
-    img {
-      display: block;
-      width: 72px;
-      height: 72px;
-      object-fit: cover;
-      border-radius: radii.$mel-radius-md;
-    }
-  }
-
-  .mel-event-card-body-main {
-    flex: 1;
-    min-width: 0;
-  }
+  // Legacy wrapper retained for empty-state hooks; layout uses .mel-collection-page.
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
@@ -411,12 +411,11 @@
   display: flex;
   flex-direction: column;
   gap: spacing.mel-space(6);
-  background: var(--mel-paper, #fef5ec);
+  background: colors.$mel-color-bg;
 }
 
-// Orange-forward styling for My Tickets page (#e67e22 = vivid orange)
 .mel-my-tickets .mel-page-title {
-  color: #e67e22;
+  color: colors.$mel-color-text;
 }
 
 .mel-my-tickets .mel-page-description {
@@ -425,39 +424,44 @@
 
 .mel-my-tickets .mel-section-title {
   color: colors.$mel-color-text;
-  border-bottom: 2px solid #e67e22;
+  border-bottom: 2px solid colors.$mel-color-primary;
   padding-bottom: spacing.mel-space(2);
 }
 
 .mel-my-tickets .mel-order-cards {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: spacing.mel-space(4);
+  grid-template-columns: 1fr;
+
+  @include breakpoints.mel-break(md) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .mel-my-tickets .mel-order-card {
-  border: 2px solid rgba(245, 160, 76, 0.25);
+  border: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.8);
+  border-radius: radii.$mel-radius-md;
   box-shadow: shadows.$mel-shadow-sm;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
 
   &:hover {
-    border-color: rgba(245, 160, 76, 0.45);
-    box-shadow: 0 6px 18px rgba(245, 160, 76, 0.15);
+    border-color: color.adjust(colors.$mel-color-primary, $alpha: -0.65);
+    box-shadow: shadows.$mel-shadow-md;
   }
 }
 
 .mel-my-tickets .mel-order-card:nth-child(even) {
-  background: linear-gradient(to right, rgba(255, 241, 191, 0.2) 0%, transparent 100%);
+  background: color.adjust(colors.$mel-color-secondary, $alpha: -0.94);
 }
 
 .mel-my-tickets .mel-event-title a,
 .mel-my-tickets .mel-link {
-  color: #e67e22;
+  color: colors.$mel-color-primary;
   font-weight: typography.$mel-font-semibold;
   text-decoration: none;
 
   &:hover {
-    color: #c96d1a;
+    color: colors.$mel-color-primary-hover;
     text-decoration: underline;
   }
 }
@@ -478,32 +482,32 @@
 }
 
 .mel-my-tickets .mel-btn-primary {
-  background: #e67e22;
-  color: #fff;
+  background: colors.$mel-color-primary;
+  color: colors.$mel-color-text-inverse;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;
 
   &:hover {
-    background: #c96d1a;
-    box-shadow: 0 4px 14px rgba(230, 126, 34, 0.4);
+    background: colors.$mel-color-primary-hover;
+    box-shadow: shadows.$mel-shadow-sm;
   }
 }
 
 .mel-my-tickets .mel-btn-secondary {
   background: transparent;
-  border: 2px solid #e67e22;
-  color: #e67e22;
+  border: 2px solid colors.$mel-color-primary;
+  color: colors.$mel-color-primary;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;
 
   &:hover {
-    background: rgba(245, 160, 76, 0.12);
+    background: color.adjust(colors.$mel-color-primary, $alpha: -0.92);
   }
 }
 
 .mel-my-tickets .mel-past-events {
-  border: 2px solid rgba(245, 160, 76, 0.25);
-  border-radius: radii.$mel-radius-xl;
+  border: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.8);
+  border-radius: radii.$mel-radius-md;
   background: colors.$mel-color-surface;
   box-shadow: shadows.$mel-shadow-sm;
   overflow: hidden;
@@ -513,8 +517,8 @@
   padding: spacing.mel-space(4);
   font-weight: typography.$mel-font-semibold;
   cursor: pointer;
-  background: linear-gradient(90deg, rgba(255, 241, 191, 0.6) 0%, rgba(245, 160, 76, 0.15) 100%);
-  border-bottom: 1px solid rgba(245, 160, 76, 0.2);
+  background: color.adjust(colors.$mel-color-secondary, $alpha: -0.92);
+  border-bottom: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.85);
   color: colors.$mel-color-text;
   list-style: none;
 
@@ -533,12 +537,12 @@
     display: inline-block;
     margin-right: spacing.mel-space(2);
     font-size: 0.7em;
-    color: #e67e22;
+    color: colors.$mel-color-primary;
     transition: transform 0.2s ease;
   }
 
   &:hover {
-    background: linear-gradient(90deg, rgba(255, 241, 191, 0.8) 0%, rgba(245, 160, 76, 0.2) 100%);
+    background: color.adjust(colors.$mel-color-secondary, $alpha: -0.88);
   }
 }
 
@@ -547,20 +551,20 @@
 }
 
 .mel-my-tickets .mel-empty-state .mel-card {
-  border: 2px solid rgba(245, 160, 76, 0.25);
-  border-radius: radii.$mel-radius-xl;
+  border: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.8);
+  border-radius: radii.$mel-radius-md;
   text-align: center;
 }
 
 .mel-my-tickets .mel-empty-state .mel-btn-primary {
-  background: #e67e22;
-  color: #fff;
+  background: colors.$mel-color-primary;
+  color: colors.$mel-color-text-inverse;
   border-radius: radii.$mel-radius-full;
   font-weight: typography.$mel-font-bold;
 
   &:hover {
-    background: #c96d1a;
-    box-shadow: 0 4px 14px rgba(230, 126, 34, 0.4);
+    background: colors.$mel-color-primary-hover;
+    box-shadow: shadows.$mel-shadow-sm;
   }
 }
 
@@ -674,6 +678,166 @@
 .mel-ticket-qr-label {
   font-size: typography.mel-font-size(sm);
   color: colors.$mel-color-text-muted;
+}
+
+// ---------------------------------------------------------------------------
+// Order detail — wallet / boarding pass
+// ---------------------------------------------------------------------------
+
+.mel-order-detail--wallet {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+}
+
+.mel-order-detail__nav {
+  margin-bottom: spacing.mel-space(2);
+}
+
+.mel-order-detail__passes {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.mel-space(4);
+}
+
+.mel-ticket-pass {
+  background: colors.$mel-color-surface;
+  border-radius: radii.$mel-radius-md;
+  box-shadow: shadows.$mel-shadow-md;
+  overflow: hidden;
+  border: 1px solid color.adjust(colors.$mel-color-secondary, $alpha: -0.75);
+}
+
+.mel-ticket-pass__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: spacing.mel-space(3);
+  padding: spacing.mel-space(4);
+  background: linear-gradient(135deg, color.adjust(colors.$mel-color-secondary, $alpha: -0.88) 0%, color.adjust(colors.$mel-color-primary, $alpha: -0.92) 100%);
+}
+
+.mel-ticket-pass__event-title {
+  margin: 0;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-bold;
+
+  a {
+    color: colors.$mel-color-text;
+    text-decoration: none;
+
+    &:hover {
+      color: colors.$mel-color-primary;
+    }
+  }
+}
+
+.mel-ticket-pass__when {
+  margin: spacing.mel-space(2) 0 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-ticket-pass__qr {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: spacing.mel-space(5) spacing.mel-space(4);
+  background: colors.$mel-color-bg;
+
+  img {
+    width: min(220px, 70vw);
+    height: auto;
+    border-radius: radii.$mel-radius-sm;
+    box-shadow: shadows.$mel-shadow-sm;
+    background: #fff;
+    padding: spacing.mel-space(2);
+  }
+}
+
+.mel-ticket-pass__qr-hint {
+  margin: spacing.mel-space(3) 0 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+  text-align: center;
+}
+
+.mel-ticket-pass__details {
+  padding: spacing.mel-space(4);
+}
+
+.mel-ticket-pass__entitlement {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(base);
+}
+
+.mel-ticket-pass__holder {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+}
+
+.mel-ticket-pass__label {
+  display: block;
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-semibold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: colors.$mel-color-text-muted;
+  margin-bottom: spacing.mel-space(1);
+}
+
+.mel-ticket-pass__email {
+  display: block;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-ticket-pass__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2);
+  padding: 0 spacing.mel-space(4) spacing.mel-space(4);
+
+  .mel-button {
+    min-height: 44px;
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+.mel-ticket-pass__scan-note {
+  margin: 0;
+  padding: 0 spacing.mel-space(4) spacing.mel-space(4);
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-order-detail__purchase {
+  border-radius: radii.$mel-radius-md;
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-sm;
+  padding: spacing.mel-space(3) spacing.mel-space(4);
+}
+
+.mel-order-detail__purchase-summary {
+  cursor: pointer;
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text-muted;
+  list-style: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.mel-order-detail__purchase-body {
+  margin-top: spacing.mel-space(3);
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+
+  p {
+    margin: 0 0 spacing.mel-space(2);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/themes/custom/myeventlane_theme/templates/account/mel-account-event-card.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/account/mel-account-event-card.html.twig
@@ -1,54 +1,84 @@
 {#
 /**
  * @file
- * Shared customer hub event card (tickets, RSVPs, My events).
+ * Shared customer hub event card (tickets, RSVPs, past events, collections).
  *
- * Expects variable `event` with keys from CustomerHubDataBuilder rows.
+ * Expects variable `event` with keys from CustomerHubDataBuilder or compatible rows.
+ * Optional: card_variant (ticket|rsvp|past|category|saved), hub_user_id, show_review_cta.
  */
 #}
-<article class="mel-card mel-my-account__card mel-account-event-card">
-  <div class="mel-card__image{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
-    {% if event.image_url %}
-      <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
-    {% endif %}
-  </div>
-  <div class="mel-card__body">
-    <h3 class="mel-card__title">
-      <a href="{{ event.url }}">{{ event.title }}</a>
-    </h3>
-    <div class="mel-card__meta">
-      {% if event.start_date %}
-        <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} {{ event.start_time }}{% endif %}</time><br>
-      {% endif %}
-      {% if event.location %}
-        {{ event.location }}
+<article class="mel-card mel-my-account__card mel-account-event-card mel-account-event-card--compact{% if card_variant|default('') %} mel-account-event-card--{{ card_variant }}{% endif %}">
+  <div class="mel-account-event-card__row">
+    <div class="mel-card__image mel-account-event-card__media{% if not event.image_url %} mel-card__image--placeholder{% endif %}">
+      {% if event.image_url %}
+        <img src="{{ event.image_url }}" alt="" loading="lazy" onerror="this.style.display='none'; this.parentElement.classList.add('mel-card__image--placeholder');" />
       {% endif %}
     </div>
-    <div class="mel-card__actions">
-      {% if event.source == 'saved' %}
-        <span class="mel-badge mel-badge--neutral">{{ 'Saved'|t }}</span>
-      {% elseif event.source == 'rsvp' %}
-        <span class="mel-badge mel-badge--info">{{ 'RSVP'|t }}</span>
-      {% else %}
-        <span class="mel-badge mel-badge--success">{{ 'Ticket'|t }}</span>
-      {% endif %}
-      {% if event.source == 'saved' %}
-        <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View event'|t }}</a>
-      {% elseif event.pdf_available %}
-        {% if event.has_ticket_code %}
-          <a href="{{ path('myeventlane_tickets.download_pdf_by_code', {'ticket_code': event.ticket_code}) }}" class="mel-button mel-button--primary">{{ 'View ticket'|t }}</a>
-        {% else %}
-          <a href="{{ path('myeventlane_tickets.download_pdf', {'order_item_id': event.order_item_id}) }}" class="mel-button mel-button--primary">{{ 'View ticket'|t }}</a>
+    <div class="mel-card__body mel-account-event-card__content">
+      <h3 class="mel-card__title">
+        <a href="{{ event.url }}">{{ event.title }}</a>
+      </h3>
+      <div class="mel-card__meta">
+        {% if event.start_date %}
+          <time datetime="{{ event.start_date }}">{{ event.start_date }}{% if event.start_time %} · {{ event.start_time }}{% endif %}</time>
         {% endif %}
-      {% else %}
-        <a href="{{ event.url }}" class="mel-button mel-button--primary">{{ 'View event'|t }}</a>
-      {% endif %}
-      {% if event.ics_url %}
-        <a href="{{ event.ics_url }}" class="mel-button mel-button--secondary" download>{{ 'Add to calendar'|t }}</a>
-      {% endif %}
+        {% if event.location %}
+          <span class="mel-account-event-card__venue">{{ event.location }}</span>
+        {% endif %}
+      </div>
+      <div class="mel-account-event-card__status">
+        {% if event.source == 'saved' or card_variant|default('') == 'saved' %}
+          <span class="mel-badge mel-badge--neutral">{{ 'Saved'|t }}</span>
+        {% elseif card_variant|default('') == 'category' %}
+          <span class="mel-badge mel-badge--info">{{ 'Upcoming'|t }}</span>
+        {% elseif event.source == 'rsvp' or card_variant|default('') == 'rsvp' %}
+          <span class="mel-badge mel-badge--info">{{ 'RSVP'|t }}</span>
+        {% elseif card_variant|default('') == 'past' %}
+          <span class="mel-badge mel-badge--neutral">{{ 'Past'|t }}</span>
+        {% else %}
+          <span class="mel-badge mel-badge--success">{{ 'Ticket'|t }}</span>
+        {% endif %}
+      </div>
+      <div class="mel-account-event-card__actions">
+        {% if card_variant|default('') == 'rsvp' or event.source == 'rsvp' %}
+          {% if hub_user_id|default(0) > 0 %}
+            <a href="{{ path('myeventlane_rsvp.user_list', {'user': hub_user_id}) }}" class="mel-account-event-card__action mel-account-event-card__action--primary">{{ 'Manage RSVP'|t }}</a>
+          {% endif %}
+          <a href="{{ event.url }}" class="mel-account-event-card__action">{{ 'View event'|t }}</a>
+          {% if event.ics_url %}
+            <a href="{{ event.ics_url }}" class="mel-account-event-card__action" download>{{ 'Add to calendar'|t }}</a>
+          {% endif %}
+        {% elseif card_variant|default('') == 'past' %}
+          {% if show_review_cta|default(false) %}
+            <a href="{{ path('myeventlane_account.event_review', { node: event.id }) }}" class="mel-account-event-card__action mel-account-event-card__action--primary">{{ 'Leave a review'|t }}</a>
+          {% else %}
+            <a href="{{ event.url }}" class="mel-account-event-card__action mel-account-event-card__action--primary">{{ 'View event'|t }}</a>
+          {% endif %}
+          {% if event.ics_url %}
+            <a href="{{ event.ics_url }}" class="mel-account-event-card__action" download>{{ 'Add to calendar'|t }}</a>
+          {% endif %}
+        {% elseif card_variant|default('') == 'category' or card_variant|default('') == 'saved' %}
+          <a href="{{ event.url }}" class="mel-account-event-card__action mel-account-event-card__action--primary">{{ 'View event'|t }}</a>
+          {% if event.ics_url %}
+            <a href="{{ event.ics_url }}" class="mel-account-event-card__action" download>{{ 'Add to calendar'|t }}</a>
+          {% endif %}
+          {% set _event_save_flag = event_save_flag|default(event.event_save_flag|default(null)) %}
+          {% if _event_save_flag %}
+            <span class="mel-account-event-card__flag">{{ _event_save_flag }}</span>
+          {% endif %}
+        {% else %}
+          {% if event.pdf_url %}
+            <a href="{{ event.pdf_url }}" class="mel-account-event-card__action mel-account-event-card__action--primary">{{ 'Download ticket'|t }}</a>
+          {% endif %}
+          {% if event.ticket_url %}
+            <a href="{{ event.ticket_url }}" class="mel-account-event-card__action{% if not event.pdf_url %} mel-account-event-card__action--primary{% endif %}">{{ 'View ticket'|t }}</a>
+          {% endif %}
+          <a href="{{ event.url }}" class="mel-account-event-card__action{% if not event.ticket_url %} mel-account-event-card__action--primary{% endif %}">{{ 'View event'|t }}</a>
+          {% if event.ics_url %}
+            <a href="{{ event.ics_url }}" class="mel-account-event-card__action" download>{{ 'Add to calendar'|t }}</a>
+          {% endif %}
+        {% endif %}
+      </div>
     </div>
-    {% if event.has_ticket_code %}
-      <p class="mel-my-account__ticket-code" title="{{ 'Ticket code'|t }}">{{ event.ticket_code }}</p>
-    {% endif %}
   </div>
 </article>

--- a/web/themes/custom/myeventlane_theme/templates/page--account.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--account.html.twig
@@ -11,6 +11,7 @@
  * - display_name: User display name.
  * - account_show_header_logo: When TRUE, prepend dashboard home/logo control (dashboard route).
  * - account_heading: Optional custom H1 markup object; when absent, greeting uses Welcome line.
+ * - account_page_description: Optional lede below the shell H1.
  * - account_settings_compact_header: TRUE on Settings hub routes (tighter header; form owns sections).
  */
 #}
@@ -53,15 +54,20 @@
               {% endif %}
             </a>
           {% endif %}
-          <h1 class="mel-my-account__welcome">
-            {% if account_heading %}
-              {{ account_heading }}
-            {% elseif display_name|default('')|trim != '' %}
-              {{ 'Welcome, @name!'|t({'@name': display_name}) }}
-            {% else %}
-              {{ 'Account'|t }}
+          <div class="mel-my-account__header-text">
+            <h1 class="mel-my-account__welcome">
+              {% if account_heading %}
+                {{ account_heading }}
+              {% elseif display_name|default('')|trim != '' %}
+                {{ 'Welcome, @name!'|t({'@name': display_name}) }}
+              {% else %}
+                {{ 'Account'|t }}
+              {% endif %}
+            </h1>
+            {% if account_page_description %}
+              <p class="mel-my-account__lede">{{ account_page_description }}</p>
             {% endif %}
-          </h1>
+          </div>
           <div class="mel-my-account__avatar" aria-hidden="true">
             {% if avatar_url %}
               <img src="{{ avatar_url }}" alt="" width="44" height="44" />

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-saved-events--page-1.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--mel-saved-events--page-1.html.twig
@@ -1,0 +1,62 @@
+{#
+/**
+ * @file
+ * Saved events page view — account collection layout (compact rows).
+ */
+#}
+{%
+  set classes = [
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+    'mel-collection-page',
+    'mel-collection-page--saved-events',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {{ title }}
+  {{ title_suffix }}
+
+  {% if header %}
+    <div class="view-header">
+      {{ header }}
+    </div>
+  {% endif %}
+
+  {{ exposed }}
+
+  {% if attachment_before %}
+    <div class="attachment attachment-before">
+      {{ attachment_before }}
+    </div>
+  {% endif %}
+
+  {% if rows %}
+    <div class="view-content">
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    <div class="view-empty mel-empty-state mel-empty-state--governed" role="status">
+      {{ empty }}
+    </div>
+  {% endif %}
+  {{ pager }}
+
+  {% if attachment_after %}
+    <div class="attachment attachment-after">
+      {{ attachment_after }}
+    </div>
+  {% endif %}
+  {{ more }}
+
+  {% if footer %}
+    <div class="view-footer">
+      {{ footer }}
+    </div>
+  {% endif %}
+
+  {{ feed_icons }}
+</div>

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--mel-saved-events--page-1.html.twig
@@ -1,10 +1,14 @@
 {#
 /**
  * @file
- * Saved events — compact_commerce grid.
+ * Saved events — shared customer hub event cards (mel-account-event-card).
  */
 #}
-{% include '@myeventlane_theme/includes/mel-event-rows-wrapper.html.twig' with {
-  rows: rows,
-  mel_is_event_view: mel_is_event_view|default(true),
-} only %}
+{% if title %}
+  <h3>{{ title }}</h3>
+{% endif %}
+<div class="mel-my-account__cards mel-collection-page__cards">
+  {% for row in rows %}
+    {{- row -}}
+  {% endfor %}
+</div>


### PR DESCRIPTION
Customer account surfaces now follow two presentation models:

1. Customer event cards
   - Dashboard
   - Saved events
   - Categories
   - Organisers

2. Ticket management
   - My Tickets
   - Order detail
   - QR
   - PDF

The event card experience is attendee and discovery focused.

The ticket experience is entitlement and fulfilment focused.

Models remain separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad customer-hub and checkout UI changes touch navigation, ticket deep links, and a simplified order-detail template; access still depends on existing routes, but regressions in fulfilment display or linking are plausible.
> 
> **Overview**
> This PR **unifies attendee-facing account pages** around a shared compact **`mel-account-event-card`** (dashboard, past events, saved-events View, and “Your communities”) and adds **collection-page** styling plus **save/unsave** Flag links where relevant.
> 
> The **dashboard** drops the old hero and saved-events preview in favor of a **welcome band with activity stats**, a **notifications preview** (when the notifications module is available), and deeper links on hub cards via new **`ticket_url` / `pdf_url` / `order_id`** fields from `CustomerHubDataBuilder`.
> 
> **Account shell IA** changes: more routes show in the sidebar, hub **H1 titles and ledes** move into `page--account`, and copy is retitled (e.g. Dashboard, Your communities). **Tickets** stay a separate model: **order detail** is reworked as wallet-style passes with QR-first layout and purchase info in a collapsible block; **My Tickets** loses duplicate intro copy and picks up refreshed layout tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513041c63e55f6f79c0b1f93f8b43dd2011a068b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->