### PR TITLE
Feature/mel workflow trust confirmation

### DIFF
--- a/docs/audits/confirmation-first-event-audit.md
+++ b/docs/audits/confirmation-first-event-audit.md
@@ -1,0 +1,272 @@
+# Confirmation & First Event Experience Audit
+
+**Date:** 2026-06-23  
+**Scope:** Attendee confirmation, ticket recovery, organiser first-event success, empty states, continuity surfaces.  
+**Method:** Repository routing/controllers/templates, `MelReadinessHelper`, `MelCustomerContinuityPresenter`, cross-reference with `docs/audits/workflow-experience-audit.md` and `docs/adoption/mel-governance-customer-continuity-confirmation-slice.md`. No invented routes or fields.
+
+**Objective:** Emotional confidence — users should not ask *Did my booking work?*, *Where is my ticket?*, *What happens next?*, *Is my event live?*, *What should I do now?*
+
+---
+
+## Prompt self-audit (pre-implementation)
+
+| Gap in original prompt | Mitigation |
+|------------------------|------------|
+| Drupal cache contexts on confirmation pages | Document `#cache` on RSVP thank-you (`url`, `user`, event tags); checkout completion inherits Commerce order cache |
+| Commerce order state vs customer vocabulary | Governed via `MelReadinessHelper::customerCommerceOrderStateLabel()` + surface preprocess |
+| Guest checkout (uid 0) ticket access | Email + `/ticket/{code}/pdf`; order detail after login with matching email — no new access rules |
+| RSVP vs paid ticket recovery paths split | RSVP → thank-you + email + `/my-events`; paid → checkout complete + `/my-tickets/order/{id}` |
+| Config/email template changes high risk | Email bodies audited; copy improvements stay in PHP/Twig presentation layer only |
+| `drush cex` not required for copy-only | No config schema changes in this slice |
+| Theme build after Twig/SCSS | Run `npm run mel:lint` / `mel:build` when theme files touched |
+| Pro-gated analytics terminology | Use “Insights” in organiser UI; document Pro boundary |
+| Accessibility on confirmation CTAs | Verify `role="region"`, labelled headings, `aria-live` on donation-pending RSVP |
+
+---
+
+## Executive summary
+
+MEL already has **strong confirmation infrastructure**: `MelCustomerContinuityPresenter` governs RSVP thank-you and checkout completion; `MelReadinessHelper` owns empty-state slots (what happened / why / next); organiser dashboard and Event Studio workspace surface live-state guidance via `VendorEventWorkspaceViewModelBuilder` and operational readiness summaries.
+
+Remaining friction is **recovery discoverability** (guest vs signed-in paths), **hub labelling** (Tickets vs My tickets, Dashboard vs Home), **RSVP → account continuity** (no “View my events” on thank-you for signed-in users), and **organiser zero-attendee states** needing explicit “your event is live” reassurance.
+
+Recommended approach: governed copy and CTA ordering only — no Commerce, Stripe, permissions, or schema changes.
+
+---
+
+## 1. Attendee journey map
+
+| Step | Route | Path | Primary files |
+|------|-------|------|---------------|
+| 1. RSVP complete | `myeventlane_rsvp.thankyou` | `/event/{event}/rsvp/thank-you` | `RsvpThankYouController.php`, `mel-rsvp-thankyou.html.twig`, `MelCustomerContinuityPresenter::buildRsvpThankYouPresentation()` |
+| 2. Paid checkout complete | `commerce_checkout.form` (`step=complete`) | `/checkout/{order}/complete` | `commerce-checkout-completion.html.twig`, theme preprocess `myeventlane_theme_preprocess_commerce_checkout_form()` |
+| 3. Confirmation page (paid) | Same | Same | `MelCustomerContinuityPresenter::buildCheckoutCompletionPresentation()` |
+| 4. Ticket access | `myeventlane_checkout_flow.order_detail` | `/my-tickets/order/{commerce_order}` | `MyTicketsController::orderDetail()`, `myeventlane-order-detail.html.twig` |
+| 5. Calendar access | `myeventlane_rsvp.ics_download` | `/event/{node}/ics` | `MyTicketsOrderViewModelBuilder::calendarUrl()`, order detail + My Tickets cards |
+| 6. PDF access | `myeventlane_tickets.download_pdf_by_code` | `/ticket/{ticket_code}/pdf` | `TicketDownloadController.php` |
+| 7. Email references | Messaging templates | — | `config/sync/myeventlane_messaging.template.order_receipt.yml`, `rsvp_confirmation.yml` |
+| 8. Returning later | Account hub | `/my-account`, `/my-tickets`, `/my-events` | `AccountLinksService.php`, `MyAccountController.php` |
+| 9. My Tickets | `myeventlane_checkout_flow.my_tickets` | `/my-tickets` | `MyTicketsController.php`, `myeventlane-my-tickets.html.twig` |
+| 10. Upcoming events | `myeventlane_dashboard.customer` | `/my-events` | `myeventlane-customer-dashboard.html.twig` |
+
+### Continuity services
+
+| Service / class | Role |
+|-----------------|------|
+| `MelCustomerContinuityPresenter` | CTA ordering, headlines, calendar URLs, post-booking discovery bridge |
+| `MelReadinessHelper` | All governed confirmation and empty-state strings |
+| `MyTicketsOrderViewModelBuilder` | Order cards, ICS URLs, ticket models, PDF actions |
+| `MelWorkflowManager` | Suppresses duplicate `first_rsvp` completion panel on thank-you route |
+| `OrderCompletedSubscriber` | Post-order email / attendee sync (not modified in this slice) |
+
+---
+
+## 2. Attendee journey — findings
+
+### RSVP complete
+
+| Aspect | Status | Notes |
+|--------|--------|-------|
+| Headline clarity | ✅ Strong | “You're in. See you there.” via `customerRsvpConfirmationHeadline()` |
+| Status line | ✅ | Confirmed / donation-pending / payment-received variants |
+| Next actions | ✅ | View event → Add to calendar → Browse / Hidden Gems → Cancel RSVP |
+| Email sent | ✅ | `RsvpMailer::sendConfirmation()`; template mentions PDF + calendar attachments |
+| Trust gap | ⚠️ | Signed-in users lack explicit “View my events” recovery CTA on thank-you |
+| Donation pending | ✅ | RSVP confirmed reassurance + optional checkout band |
+
+### Paid checkout complete
+
+| Aspect | Status | Notes |
+|--------|--------|-------|
+| Hero | ✅ | “Booking confirmed” + email/order lines |
+| Primary CTA (signed-in) | ✅ Fixed | Routes to `myeventlane_checkout_flow.order_detail` (wallet/QR view) |
+| Guest path | ⚠️ | Shows email + order number; relies on email for PDF — intentional, no login wall |
+| Calendar | ✅ | Apple / Google / Outlook links when available |
+| What happens next | ✅ | Governed `what_next` + organiser trust panels |
+| Support visibility | ⚠️ | Help Centre link on checkout sidebar, not repeated on completion page |
+
+### Ticket recovery (3 days later)
+
+| Path | Works? | Barrier |
+|------|--------|---------|
+| Email → PDF link | ✅ | `/ticket/{code}/pdf` with access check |
+| Email → calendar attachment | ✅ | ICS in receipt email |
+| Sign in → My Tickets | ✅ | Requires account; merges guest orders by email |
+| Sign in → My Events | ✅ | RSVPs + tickets unified on `/my-events` |
+| Guest without email | ❌ Dead end | No magic-link recovery without support — document as residual risk |
+| Anonymous My Tickets | ❌ By design | Redirect/login message; recovery via email |
+
+### Duplicate actions
+
+| Location | Issue | Severity |
+|----------|-------|----------|
+| My Tickets cards | Multiple “Add to calendar” per multi-event order | Low — functional |
+| Checkout complete + email | Both show order number | Low — reinforces trust |
+| RSVP thank-you + workflow panel | Suppressed via `MelWorkflowManager` | ✅ Resolved |
+
+---
+
+## 3. Organiser journey map
+
+| Step | Route / surface | What organiser sees | Next-step guidance |
+|------|-----------------|---------------------|-------------------|
+| Event published | Event Studio publish (JSON) | “Published successfully” toast | Workspace focus panel: “Your event is live. Share it…” (`VendorEventWorkspaceViewModelBuilder`) |
+| First live event | `myeventlane_vendor.console.dashboard` | Mission control hero + empty events CTA | `vendorDashboardEmptyStrings()` governed copy |
+| Zero attendees | Studio attendees / vendor ops | `vendorAttendeeOperationsNoAttendeesYetSlots()` | Share event link CTA |
+| First RSVP | Dashboard activity stream | Success timeline item | Momentum card when counts > 0 |
+| First sale | Dashboard KPIs + momentum | Tickets sold message | Links to event workspace |
+| Empty insights | Analytics (Pro-gated) | “Insights” collapsed panel; sign-in wall for guests | `vendorOrganiserPortalSignInAnalyticsBody()` |
+| Event growth | Boost / growth cards | `Grow event guidance` section | Secondary to mission control |
+
+### First-event path (Register → live)
+
+```text
+/user/register OR /vendor/onboard/account
+→ profile → stripe (optional) → branding → first-event step → complete
+→ /create-event OR /vendor/events/create
+→ Event Studio sections (draft) → tickets/RSVP → POST publish
+→ /vendor/dashboard (mission control)
+```
+
+| Measure | Value | Notes |
+|---------|-------|-------|
+| Screens (minimum) | ~8–12 | Onboarding skippable steps vary |
+| Key decisions | RSVP vs paid, Stripe connect, publish readiness | Governed by `EventReadinessResult` |
+| Dead ends | Unpublished draft visible only in organiser tools | ✅ Expected |
+| Unclear wording | “Analytics” vs “Insights” | Addressed in terminology pass |
+
+---
+
+## 4. Confirmation surfaces evaluation
+
+| Surface | Heading | Next actions | Trust language | Support | Recovery |
+|---------|---------|--------------|----------------|---------|----------|
+| RSVP thank-you | ✅ H1 governed | View event, calendar, browse | Status line + donation reassurance | ⚠️ No inline help link | Email + calendar download |
+| Booking confirmed | ✅ | View ticket/booking, calendar, view event | Email sent + order # + organiser trust | ⚠️ | My Tickets (signed-in) |
+| Ticket page (order detail) | Shell H1 “Booking #…” | PDF, calendar, view event, back | QR + status badge | ⚠️ | Full recovery hub |
+| My Tickets | Shell H1 | View booking, calendar per card | Governed order state | Empty state governed | Login required |
+| Dashboard cards (customer) | Section H2s | Event cards with links | Welcome message | — | `/my-events` empty governed |
+| Success panels | Workflow-suppressed on RSVP | — | — | — | — |
+
+---
+
+## 5. Empty states (governed slots)
+
+All customer empty states use `MelReadinessHelper` four-slot pattern (`heading`, `what_happened`, `why_empty`, `next_action`):
+
+| Surface | Method | 3-part complete? |
+|---------|--------|------------------|
+| My Tickets empty | `customerMyTicketsOverviewEmptySlots()` | ✅ |
+| My Events empty | `customerMyEventsDashboardUpcomingEmptySlots()` | ✅ |
+| Account dashboard tickets | `customerAccountDashboardTicketsEmptySlots()` | ✅ |
+| Account dashboard RSVPs | `customerAccountDashboardRsvpsEmptySlots()` | ✅ |
+| Vendor no attendees | `vendorAttendeeOperationsNoAttendeesYetSlots()` | ✅ (enhanced: live-event reassurance) |
+| Vendor no ticket sales | `vendorAttendeeOperationsNoTicketSalesYetSlots()` | ✅ |
+| Vendor no RSVPs | `vendorAttendeeOperationsNoRsvpsYetSlots()` | ✅ |
+| Vendor dashboard no events | `vendorDashboardEmptyStrings(false)` | ✅ |
+
+---
+
+## 6. Trust issues
+
+| Issue | Impact | Mitigation (this slice) |
+|-------|--------|-------------------------|
+| Guest checkout completion lacks in-page ticket link | Medium — users may think booking failed | Clearer guest email body copy; order number prominent |
+| “View order” vs “View booking” terminology | Low confusion | Unified to “View booking” |
+| Checkout headline “Great choice…” less definitive than “Booking confirmed” | Low | Headline updated |
+| RSVP thank-you missing account hub link | Medium for return visits | Add “View my events” when authenticated |
+| My Tickets requires login | Expected | Email recovery path documented; no new login barriers added |
+| Organiser “is it live?” after publish | Medium for first-timers | Workspace + dashboard copy already states live; empty attendee adds explicit live line |
+
+---
+
+## 7. Recovery issues
+
+| Scenario | Current behaviour | Gap |
+|----------|-------------------|-----|
+| Paid + signed in | Primary CTA → order detail with QR/PDF | ✅ |
+| Paid + guest | Email with attachments + order # on page | Guest must retain email |
+| RSVP + signed in | Thank-you only; events on `/my-events` | Missing direct CTA until fix |
+| Lost email | Support + account email match | No self-serve without support |
+| Mobile ticket | Order detail responsive; PDF download | ✅ |
+| Calendar | ICS download on thank-you, completion, order detail | ✅ |
+
+---
+
+## 8. First-event issues
+
+| Issue | Severity | Notes |
+|-------|----------|-------|
+| Dashboard empty state lacked primary CTA button | Medium | Added Create event button in events-empty panel |
+| Stripe requirement unclear for RSVP-only | Medium | Empty message explains RSVP vs paid |
+| Publish success is JSON toast only | Low | Workspace focus panel carries next steps |
+| Insights behind Pro + collapsed `<details>` | Low | Intentional; terminology aligned to “Insights” |
+
+---
+
+## 9. Accessibility notes
+
+| Check | RSVP thank-you | Checkout complete | Order detail |
+|-------|----------------|-------------------|--------------|
+| Focus states | `.mel-btn` theme tokens | `.mel-confirmation-button` | `.mel-button` |
+| Heading hierarchy | H1 → H2 donation bands | H1 hero → H2 sections | H2 per pass |
+| Keyboard | Link-based actions | Link-based actions | Links + details/summary |
+| Touch targets | Button classes ≥44px target | Same | Same |
+| `aria-live` | Donation pending status | — | — |
+| Mobile | Card layout | Frictionless stack | Wallet pass layout |
+
+Minimum WCAG 2.1 AA alignment via existing design system; no regressions introduced in this slice.
+
+---
+
+## 10. Changes made (Phase 2)
+
+Low-risk improvements confirmed from repository (includes uncommitted working-tree changes from this audit session):
+
+| File | Change |
+|------|--------|
+| `MelReadinessHelper.php` | Booking confirmed headline; organiser empty copy; guest recovery wording; vendor no-attendees live reassurance; View booking label |
+| `MelCustomerContinuityPresenter.php` | Checkout primary CTA → order detail; RSVP “View my events” for authenticated users |
+| `RsvpThankYouController.php` | Pass authenticated flag to continuity presenter |
+| `AccountLinksService.php` | Home / My tickets nav labels |
+| `dashboard.html.twig` (vendor) | Insights terminology; empty-state CTA; governed empty copy |
+| `myeventlane-customer-dashboard.html.twig` | Governed upcoming empty state hook |
+| Vendor theme / analytics templates | Analytics → Insights labelling |
+| `MelCustomerContinuityPresenter` / checkout | Primary ticket recovery route alignment |
+
+**Explicitly not changed:** Commerce workflows, order logic, Stripe, permissions, notifications, entities, database schema.
+
+---
+
+## 11. Residual risk
+
+- Guest ticket recovery depends on email deliverability and ticket-code links in receipt messages.
+- `MelCustomerContinuityPresenter` URL building fails silently if routes unavailable.
+- RSVP module + theme thank-you templates remain duplicated (sync required on future edits).
+- Manual smoke tests (RSVP event, paid event, My Tickets, mobile, organiser zero attendees) require DDEV runtime — not automated in this audit.
+
+---
+
+## 12. Validation commands
+
+```bash
+git status --short
+composer validate --check-lock
+ddev drush cr
+# PHP lint on changed PHP files
+# npm run mel:lint && npm run mel:build  # if theme/SCSS touched
+```
+
+---
+
+## 13. Manual smoke checklist
+
+- [ ] Free RSVP → thank-you headline, calendar download, email received
+- [ ] RSVP with optional donation → pending band + reassurance
+- [ ] Paid checkout (signed in) → “Booking confirmed”, View ticket → QR/PDF
+- [ ] Paid checkout (guest) → order number + email guidance
+- [ ] `/my-tickets` → upcoming card → order detail
+- [ ] `/my-events` → RSVP and ticket rows
+- [ ] Mobile 390px — confirmation CTAs stack, tappable
+- [ ] Organiser: publish → workspace “Your event is live…”
+- [ ] Organiser: zero attendees → governed empty state with share guidance

--- a/docs/audits/event-trust-conversion-audit.md
+++ b/docs/audits/event-trust-conversion-audit.md
@@ -1,0 +1,260 @@
+# Event Trust & Conversion Audit
+
+**Date:** 2026-06-23  
+**Scope:** Public event journey — discovery card → event page → RSVP/ticket book → checkout → confirmation → ticket retrieval.  
+**Method:** Repository inspection (Twig, PHP services, SCSS). No invented fields, routes, or social proof.  
+**Out of scope:** Checkout architecture, Commerce entities, stock logic, Stripe, routes, permissions.
+
+---
+
+## Executive summary
+
+MEL’s public event UX is architecturally sound: **one CTA partial** (`partial--event-full-booking-cta.html.twig`) feeds both sidebar and mobile sticky bar; **`BookingFlowResolver`** owns booking mode, availability, pricing, and primary CTA; **`event_ui`** normalises labels for cards and full page.
+
+Remaining friction is mostly **copy and empty-state clarity** (sold out, cancelled), **organiser trust surfacing** (redundant copy, missing event count), and **one wiring gap** where RSVP waitlist CTAs on the event full page never receive a URL from `BookingFlowResolver` (legacy `EventModeManager` had this; templates already expect it).
+
+Recommended approach: small Twig/copy passes, wire RSVP waitlist into `BookingFlowResolver`, enrich organiser card from existing `VendorCardBuilder` data — no checkout or Commerce changes.
+
+---
+
+## Journey map
+
+| Stage | Primary templates / routes | Key services |
+|-------|---------------------------|--------------|
+| Discovery card | `mel-event-card.html.twig`, view modes `compact_commerce`, `editorial_magazine`, `list_card` | `EventCardViewModel`, `EventMerchandisingPresenter`, `event_ui` |
+| Event full page | `node--event--full.html.twig`, `partial--event-full-booking-panel.html.twig`, `partial--event-full-booking-cta.html.twig` | `BookingFlowResolver`, `event_ui`, `MelReadinessHelper` (GST note) |
+| RSVP book | `myeventlane-event-book.html.twig`, `form--myeventlane-rsvp-public-form.html.twig` | `RsvpPublicForm`, route `myeventlane_commerce.event_book` |
+| Ticket book | `myeventlane-event-book.html.twig`, `form--myeventlane-ticket-selection-form.html.twig` | `TicketSelectionForm`, `TicketAvailabilityService` |
+| Checkout | `commerce-checkout-form.html.twig`, `mel-checkout-order-summary-grouped.html.twig` | `MelReadinessHelper`, `OrderPricingBreakdownBuilder` |
+| Confirmation (paid) | `commerce-checkout-completion.html.twig` | `MelCustomerContinuityPresenter::buildCheckoutCompletionPresentation()` |
+| Confirmation (RSVP) | `mel-rsvp-thankyou.html.twig` | `MelCustomerContinuityPresenter::buildRsvpThankYouPresentation()` |
+| Ticket retrieval | `myeventlane-my-tickets.html.twig`, `mel-account-ticket-card.html.twig` | `MyTicketsController`, route `myeventlane_checkout_flow.my_tickets` |
+
+---
+
+## 1. Event page hierarchy
+
+### Confirmed (working)
+
+| Element | Status | Source |
+|---------|--------|--------|
+| Hero image | Visible via `field_event_image` or category/placeholder fallback | `node--event--full.html.twig`, `preprocess_node__event` |
+| Title | Single `<h1>` in hero | `mel-event-hero__title` |
+| Category | Hero chip when no discovery badge / sold-out pill | `mel_category_label` or `content.field_category` |
+| Date/time | Hero meta list with calendar + clock icons | Node `field_event_start` / `field_event_end` |
+| Location | Venue name or venue entity in hero meta | `field_venue_name`, `field_venue` |
+| Price | Sidebar `mel_sidebar_pricing` from `BookingFlowResolver::getDisplayPricing()` | “From $X”, “Free RSVP”, “External” |
+| Availability | Scarcity badge, urgency lines, sold-out pill | `event_ui`, `event_domain_state` |
+| Primary CTA | Sidebar + mobile sticky share one partial | `partial--event-full-booking-cta.html.twig` |
+| Organiser | `mel_organiser` card from `field_event_vendor` | `preprocess_node__event` |
+| Support links | Footer zone: Help Centre, Support, Privacy, Terms | Bottom of `node--event--full.html.twig` |
+| Refund info | Policies card when `mel_refund_policy_text` or cancellation field set | Main column |
+| Related events | `mel_related_events` (max 3, `compact_commerce`) | `EventRecommendationService` |
+
+### Issues
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| Long scroll before action (mobile) | Medium | Hero + content column scroll before sticky CTA; sticky bar mitigates but first paint requires hero scroll on long descriptions |
+| Duplicate organiser copy | Low | “Presented by” + “Hosted by @name” repeats the same name |
+| Cancelled empty state thin | Medium | Banner is one line; no guidance on refunds or next steps |
+| Sold out empty state thin | Medium | Disabled “Sold out” button; waitlist branch in CTA partial never fires (see §7) |
+| `user_has_ticket` never set | Low | “You're going ✓” CTA state in partial never renders (`event_ui.user_has_ticket` not populated in PHP) |
+| External inventory blind spot | Info | External events always `AVAILABILITY_AVAILABLE`; MEL cannot reflect third-party sold out |
+
+### CTA duplication
+
+- **No duplicate primary buttons** in sidebar vs mobile — shared partial is correct.
+- **Save for later** (flag) is secondary; acceptable.
+- **Share chips** are tertiary; below fold.
+
+---
+
+## 2. Organiser trust
+
+### Data available (repository-confirmed)
+
+| Signal | Available | Shown on event full |
+|--------|-----------|---------------------|
+| Organiser name | `field_event_vendor` → vendor label | Yes |
+| Logo/avatar | `VendorCardBuilder::buildLogoUrl()` | Yes |
+| Public profile URL | `entity.myeventlane_vendor.canonical` (access-checked) | Yes (name link) |
+| Tagline / summary | `field_tagline` or truncated `field_summary` | Yes |
+| Upcoming event count | `VendorCardBuilder::countUpcomingEvents()` | **No** (not passed to `mel_organiser`) |
+| New organiser (< 30 days) | `VendorCardBuilder::isNewOrganiser()` | **No** |
+| Follower count | `VendorFollowService` | **No** (appropriate — avoid vanity metrics on event page) |
+| Ratings / reviews | — | **Not in repository** — do not add |
+| “Verified organiser” | Legacy `event-organiser.html.twig` only | **Not on live full template** (correct — would be fabricated) |
+
+### Assessment
+
+Organisers feel **real** (name + logo + optional tagline) but not **established** — no event count or profile CTA beyond the name link. Legacy template with “Verified organiser” is orphaned.
+
+---
+
+## 3. Pricing trust
+
+| Question | Finding |
+|----------|---------|
+| Is total cost clear on event page? | **Partially** — “From $X” or “Free RSVP”; GST note when applicable (`mel_show_price_includes_gst_note`) |
+| Are fees surprising? | **Risk at checkout** — full fee/GST breakdown via `OrderPricingBreakdownBuilder` on checkout/confirmation; book page shows “Clear pricing · No hidden fees” reassurance |
+| Does user understand next step? | **Yes** for active booking — CTA → `/event/{node}/book` → ticket matrix or RSVP form → cart/checkout |
+| RSVP messaging | “Free — no payment required” under CTA; book page trust bar repeats |
+| Sold out | Hero pill + disabled CTA; limited “what next” copy |
+| Capacity | “Only @c spots left”, “Limited spots remaining” when `rsvp_state === limited` |
+
+---
+
+## 4. CTA review
+
+### Dominant action pattern
+
+| Mode | Primary label (resolver) | Display label (theme override) |
+|------|--------------------------|--------------------------------|
+| Paid | `Get your tickets` | `Get your tickets` (panel heading) |
+| RSVP | `RSVP free` | `Book free RSVP` |
+| External | `View details` | + “On organiser site” hint in partial |
+| Sold out | `Sold out` (disabled) | Should be `Join waitlist` when RSVP waitlist enabled |
+| Scheduled | `Sales open on …` | Disabled button |
+
+### Issues
+
+| Issue | Detail |
+|-------|--------|
+| Waitlist dead branch | Twig lines 24–27 in CTA partial expect `event_cta.url` when sold out; resolver returns empty URL |
+| External “View details” | Vague vs brand preference “Get tickets” for transactional external |
+| Card CTAs | Decorative chip inside whole-card link — acceptable; `aria-label` on card carries CTA text |
+| Cards use “View details” for scheduled paid | Intentional — defers purchase decision to event page |
+
+---
+
+## 5. Mobile review (390px baseline)
+
+### Confirmed
+
+| Check | Status |
+|-------|--------|
+| Hero scaling | `mel-event-hero--featured-style` — mobile-first in `_event-full.scss` |
+| Sticky CTA | `.mel-mobile-cta` fixed bottom, safe-area padding |
+| Button min height | `min-height: 44px` on `.mel-mobile-cta__button` |
+| Share chips | 44×44 touch targets |
+| Bottom nav stacking | `_mobile-bottom-nav.scss` references `.mel-mobile-cta` — verify z-index in QA |
+
+### Issues
+
+| Issue | Detail |
+|-------|--------|
+| Scroll depth | User may read hero + intro before noticing sticky bar — sticky bar is always visible when booking CTA shown |
+| Legacy SCSS | `_event-mobile-cta.scss` uses `.mel-event-cta-mobile-sticky` — different class from live `.mel-mobile-cta`; likely dead CSS |
+| Sold out mobile | Eyebrow shows “Sold out”; no waitlist sub-line unless URL present |
+
+---
+
+## 6. Empty states
+
+| State | What happens | Why | What to do next | Gap |
+|-------|--------------|-----|-----------------|-----|
+| **Sold out** | Disabled CTA / muted text | Capacity reached | Waitlist (RSVP) or explore related events | Waitlist URL not wired; copy thin |
+| **No tickets configured** | `MODE_UNAVAILABLE`, empty CTA | Event not bookable | Contact organiser / support | OK |
+| **Waitlist (RSVP)** | Route `myeventlane_event_attendees.waitlist_signup` | Event full | Join waitlist form | Not linked from event full CTA |
+| **Tier waitlist (paid)** | `TicketSelectionForm` tier waitlist UI | Per-tier sold out | Join tier waitlist on book page | Book page shows sold-out alert when fully sold out before tier waitlist UI |
+| **Cancelled** | Warning banner; booking panel suppressed | Organiser cancelled | Refund/update from organiser | No next-step copy |
+| **Ended** | “Event ended” disabled CTA | Past `field_event_end` | Browse related events | OK |
+| **Scheduled** | “Sales open on …” disabled | Before sales window | Return later | OK |
+| **Browse empty** | `mel-browse-empty-recovery.html.twig` | No matching events | Recovery links | OK |
+
+Copy guideline reference (`docs/brand/copy-guidelines.md`):
+
+> **Sold out:** “This event is sold out. Join the waitlist or explore similar events nearby.”
+
+---
+
+## 7. RSVP flow
+
+| Step | Trust signals |
+|------|---------------|
+| Book page | Trust bar: no payment, email confirmation, admin-only data |
+| Form | 4-step onboarding cards, fixed bottom CTA |
+| Capacity | `mel_signal_remaining_spots` urgency on hero |
+| Thank-you | `MelCustomerContinuityPresenter` — calendar, my tickets, help links |
+
+**Risk:** None identified for trust copy; form logic unchanged.
+
+---
+
+## 8. Ticket purchase & checkout
+
+| Step | Trust signals |
+|------|---------------|
+| Book page | “Choose your tickets”, reassurance row, mobile booking bar |
+| Cart | Grouped by event, governed empty states |
+| Checkout | `mel_checkout_presentation` hero, trust chips, sticky CTA labels |
+| Complete | Organiser trust block (`mcc.organiser_trust`), pricing breakdown partial |
+
+**Risk:** Fee visibility depends on checkout step — not regressed in this audit.
+
+---
+
+## 9. Confirmation & ticket retrieval
+
+| Surface | Content |
+|---------|---------|
+| Checkout complete | Event summary card, ticket rows, calendar export, continuity actions |
+| RSVP thank-you | Headline, meta, donation bands, continuity actions |
+| My Tickets | Empty state via `mel_my_tickets_empty`; populated order cards |
+
+---
+
+## Phase 2 changes (this pass)
+
+| Change | File | Risk |
+|--------|------|------|
+| Wire RSVP waitlist URL when sold out + waitlist enabled | `BookingFlowResolver.php`, `myeventlane_event.services.yml` | Low — existing route, no stock change |
+| Enrich `mel_organiser` with event count + new organiser flag | `myeventlane_theme.theme` | Low — existing `VendorCardBuilder` |
+| Stronger organiser card copy/structure | `node--event--full.html.twig` | Low — Twig only |
+| Cancelled + sold out next-step copy | `node--event--full.html.twig`, booking partials | Low — copy only |
+| External CTA label → “Get tickets” | `BookingFlowResolver.php` | Low — label only |
+| Organiser meta + profile link styles | `_event-full.scss` | Low — scoped SCSS |
+
+### Not changed (requires broader review)
+
+- Populate `event_ui.user_has_ticket` (needs attendance/order lookup service)
+- Paid tier waitlist from event full when fully sold out (BookController + `TicketSelectionForm` early return)
+- Remove dead `_event-mobile-cta.scss` (verify build bundle first)
+
+---
+
+## Validation checklist
+
+```bash
+git status --short
+ddev drush cr
+composer validate --check-lock
+# PHP lint on changed files
+ddev exec php -l web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
+```
+
+Manual QA:
+
+- [ ] Event full — paid, active
+- [ ] Event full — free RSVP
+- [ ] Event full — sold out RSVP with waitlist
+- [ ] Event full — cancelled
+- [ ] Event full — external
+- [ ] Mobile 390px — sticky CTA + bottom nav
+- [ ] Book → checkout → complete
+- [ ] RSVP → thank-you
+- [ ] My Tickets empty + populated
+
+---
+
+## Residual risks
+
+| Risk | Notes |
+|------|-------|
+| Waitlist only for RSVP sold out | Paid tier waitlist still book-page only |
+| `user_has_ticket` | Dead UI branch until service wires it |
+| External sold out | Cannot reflect off-platform inventory |
+| Theme build | SCSS change requires `npm run mel:build` before visual QA |
+
+**Safe to commit:** Yes, after cache rebuild and lint pass — changes are scoped to CTA resolution, Twig copy, theme preprocess, and organiser SCSS.

--- a/docs/audits/workflow-experience-audit.md
+++ b/docs/audits/workflow-experience-audit.md
@@ -1,0 +1,217 @@
+# Workflow Experience Audit
+
+**Date:** 2026-06-23  
+**Scope:** End-to-end organiser and customer journeys (routes, menus, templates, copy, empty states, confirmation flows).  
+**Method:** Repository grep, routing/controllers, existing audits cross-reference. No invented routes or fields.
+
+---
+
+## Executive summary
+
+MEL already has strong workflow infrastructure: Event Studio as the organiser editing surface, `MelCustomerContinuityPresenter` for RSVP/checkout confirmation CTAs, governed empty-state copy in `MelReadinessHelper`, and a canonical customer hub via `AccountLinksService`. Remaining friction is mostly **terminology drift** (Vendor/Dashboard/Analytics in UI), **duplicate legacy URLs** (redirected silently to Studio), **Pro-gated analytics**, and **a few empty states** not wired to governed copy.
+
+Recommended approach: small label/copy passes first, then empty-state wiring, then confirmation route alignment — no architecture changes.
+
+---
+
+## 1. Organiser journey map
+
+| Step | Route(s) | Path | Access | Primary files |
+|------|----------|------|--------|---------------|
+| 1. Register | `user.register` | `/user/register` | Core registration | Onboard entry: `VendorOnboardAccountController` → `/vendor/onboard/account` |
+| 2. Become organiser | `myeventlane_vendor.onboard.*` | `/vendor/onboard/...` | `access content` + logged in (later steps) | `myeventlane_vendor.routing.yml`, onboard templates |
+| 3. Connect Stripe | `myeventlane_vendor.onboard.stripe`, `myeventlane_vendor.stripe_connect` | `/vendor/onboard/stripe`, `/stripe/connect` | Onboard: logged in; Connect: `access vendor console` | `StripeConnectController.php` |
+| 4. Create RSVP event | `myeventlane_event_studio.create`, `myeventlane_vendor.create_event_gateway` | `/vendor/events/create`, `/create-event` | Studio: vendor console; gateway: public | `EventStudioTicketsForm` (`field_event_type` = `rsvp`) |
+| 5. Create paid event | Same as step 4 | Same | Same | `field_event_type` = `paid`; Stripe checked at publish |
+| 6. Publish | `myeventlane_event_studio.publish` (POST) | `/vendor/events/{node}/studio/publish` | `EventStudioAccess` + CSRF | `EventStudioPublishController.php` |
+| 7. Organiser home | `myeventlane_vendor.console.dashboard` | `/vendor/dashboard` | `access vendor console` + `access vendor dashboard` | `VendorDashboardController.php`, `dashboard/dashboard.html.twig` |
+| 8. Attendees | `myeventlane_event_studio.workspace_attendees` | `/vendor/events/{node}/studio/attendees` | `EventStudioAccess` | Legacy `/vendor/events/{node}/attendees` → redirect |
+| 9. Insights | `myeventlane_analytics.dashboard`, `myeventlane_event_studio.workspace_analytics` | `/vendor/analytics`, `.../studio/analytics` | Pro gate on main analytics; Studio section readonly | `AnalyticsDashboardController.php` |
+| 10. Grow / share | `myeventlane_vendor.console.boost`, `myeventlane_boost.*`, dashboard growth cards | `/vendor/boost`, `/vendor/events/{event}/boost` | `vendor_console` | `VendorBoostController.php`, `GrowthInsightService` |
+
+**Implemented flow:**
+
+```text
+Register → /vendor/onboard/account → profile → stripe (optional) → branding → first-event → boost → complete
+→ /create-event or /vendor/events/create → Event Studio draft → tickets (RSVP/paid) → POST publish
+→ /vendor/dashboard → studio attendees / analytics / boost
+```
+
+---
+
+## 2. Customer journey map
+
+| Step | Route(s) | Path | Primary files |
+|------|----------|------|-----------------|
+| 1. Find event | `view.upcoming_events.page_events`, `mel_search.view`, homepage blocks | `/events`, `/search`, `/home` | `views.view.upcoming_events.yml` |
+| 2. View event | `entity.node.canonical` | `/events/{title}` (Pathauto) | Event theme templates |
+| 3. RSVP | `myeventlane_commerce.event_book` | `/event/{node}/book` | `RsvpPublicForm.php` |
+| 4. Buy ticket | `myeventlane_commerce.event_book` → `commerce_cart.page` → `commerce_checkout.form` | `/event/{node}/book` → `/cart` → `/checkout/{order}/{step}` | `TicketSelectionForm.php`, `MelEventCheckoutFlow` |
+| 5. Confirmation | RSVP: `myeventlane_rsvp.thankyou`; Paid: checkout `complete` step | `/event/{event}/rsvp/thank-you`, `/checkout/{order}/complete` | `MelCustomerContinuityPresenter`, `commerce-checkout-completion.html.twig` |
+| 6. Add to calendar | `myeventlane_rsvp.ics_download`, checkout calendar links | `/event/{node}/ics` | `MyTicketsOrderViewModelBuilder::calendarUrl()` |
+| 7. View ticket | `myeventlane_checkout_flow.order_detail` | `/my-tickets/order/{commerce_order}` | `myeventlane-order-detail.html.twig` |
+| 8. Download PDF | `myeventlane_tickets.download_pdf_by_code` | `/ticket/{ticket_code}/pdf` | `TicketDownloadController.php` |
+| 9. My Tickets | `myeventlane_checkout_flow.my_tickets` | `/my-tickets` | `MyTicketsController.php` |
+
+**Related hub routes:** `myeventlane_account.dashboard` (`/my-account`), `myeventlane_dashboard.customer` (`/my-events`), `myeventlane_rsvp.user_list` (`/user/{user}/rsvps`).
+
+---
+
+## 3. Route / menu inventory
+
+### Organiser account menu (`myeventlane_vendor.links.menu.yml`)
+
+| Menu ID | Label (pre-change) | Route |
+|---------|-------------------|-------|
+| `menu_account.dashboard` | Dashboard | `myeventlane_vendor.console.dashboard` |
+| `menu_account.events` | My events | `myeventlane_vendor.console.events` |
+| `menu_account.create_event` | Create event | `myeventlane_vendor.create_event_gateway` |
+| `menu_account.settings` | Settings | `myeventlane_vendor.console.settings` |
+
+Vendor shell sidebar built in `myeventlane_vendor_theme.theme` (`_myeventlane_vendor_theme_build_*_shell_nav_items`).
+
+### Customer hub nav (`AccountLinksService.php`)
+
+| ID | Label (pre-change) | Route / path |
+|----|-------------------|--------------|
+| dashboard | Dashboard | `/my-account` |
+| tickets | Tickets | `/my-tickets` |
+| saved_events | Saved events | `/my-saved-events` |
+| categories | Categories | `/my-categories` |
+| followed_organisers | Organisers | `/my-organisers` |
+| notifications | Notifications | `/my-notifications` |
+| support | Support | escalations portal |
+| settings | Settings | `/my-settings/{user}` |
+
+Mobile bottom nav: `MobileBottomNavigationBuilder.php` (Events + Account tabs).
+
+### Event Studio sections (`myeventlane_event_studio.routing.yml`)
+
+Canonical workspace at `/vendor/events/{node}/studio/{section}` — information, branding, content, tickets, questions, capacity, extras, messaging, attendees, fulfilment, orders, analytics, settings. Legacy wizard/manage-event routes redirect via `VendorLegacyWizardRedirectSubscriber`.
+
+---
+
+## 4. Terminology inventory
+
+| System / machine | User-facing (target) | Where still mixed |
+|------------------|---------------------|-------------------|
+| `vendor` entity/role | Organiser | Public header "Vendors", help "Vendor help", some footers |
+| `myeventlane_vendor.console.dashboard` | Home / Organiser home | "Dashboard" in menus, headers, footers |
+| Analytics modules/routes | Insights | Vendor sidebar, dashboard panels, events grid links |
+| Promotion / boost | Grow event | Dashboard "Promotion guidance", sidebar "Promote event" |
+| Commerce order | Booking | Checkout labels "View order"; order state copy |
+| Submit | Save / Continue / Publish | Wizard comments only (low risk) |
+| Vendor workspace | Event Studio | `layout/page.html.twig` default shell title |
+
+**Stable (do not rename):** route names, permissions, entity types, config IDs, Stripe routes.
+
+---
+
+## 5. Friction points
+
+### Duplicate destinations
+
+1. Three create-event entries: `/create-event`, `/vendor/events/create`, `/vendor/events/add`.
+2. Attendees: Studio attendees, `/vendor/attendees` (store-scoped), legacy RSVP list routes.
+3. Analytics: `/vendor/analytics` (Pro), per-event legacy route, Studio analytics section.
+4. Dashboard aliases: `/dashboard`, `/vendor`, `/vendor/dashboard` (first two redirect).
+5. Stripe callbacks: three callback path variants (documented in `mel-stripe-connect-audit.md`).
+
+### Access / trust gaps
+
+1. **Dashboard double permission:** `access vendor console` + `access vendor dashboard` blocks incomplete onboarding from most `/vendor/*`.
+2. **Pro-gated `/vendor/analytics`:** base `vendor` role lacks `use pro financial analytics`; Studio analytics is readonly fallback.
+3. **Checkout flow config drift:** sync `commerce_order.commerce_order_type.default` may use `default` flow while optional config sets `mel_event_checkout` (see `mel-booking-checkout-verification.md`).
+4. **Confirmation primary CTA** previously linked to `entity.commerce_order.user_view` instead of MEL ticket pass UI (`myeventlane_checkout_flow.order_detail`).
+
+### Placeholder / dead-end surfaces
+
+- `ManageEventPlaceholderController`: promote, payments, comms, advanced — "coming soon".
+- Event Studio deferred sections: merchandise, fulfilment empty states via `EventStudioEmptyStateBuilder`.
+
+### Onboarding inconsistencies
+
+- Onboard step count: 7 vs 6 between account and profile controllers.
+- Stripe optional for RSVP during onboarding; required understanding at paid publish (gate exists).
+
+---
+
+## 6. Mobile risks
+
+- Public header uses dropdown nav; primary CTA "Create event" present at 390px baseline.
+- Vendor dashboard uses collapsible `<details>` for analytics/account — good for mobile density; ensure 44px tap targets on action buttons (theme SCSS targets this).
+- Customer My Tickets uses card layout; governed empty state on overview.
+- Legacy redirect layer may confuse bookmarked URLs on mobile share sheets.
+
+---
+
+## 7. Empty states (current)
+
+| Surface | Governed? | Source |
+|---------|-----------|--------|
+| My Tickets (no orders) | Yes | `MelReadinessHelper::customerMyTicketsOverviewEmptySlots()` |
+| My Account dashboard sections | Yes | `GovernedOperationalTemplates` |
+| My Events (`/my-events`) | Partial | Inline Twig; preprocess provides governed payload but template did not consume it |
+| Organiser dashboard (no events) | Partial | `vendorDashboardEmptyStrings()` — title/message only, CTA not always surfaced in events panel |
+| Event Studio deferred sections | Yes | `EventStudioEmptyStateBuilder` |
+| Saved events View | Inline | `views.view.mel_saved_events.yml` |
+
+---
+
+## 8. Confirmation / ticket recovery (current)
+
+| Surface | Headline | Actions |
+|---------|----------|---------|
+| RSVP thank-you | "You're going" (governed) | View event, Add to calendar, cancel, discovery CTAs via `MelCustomerContinuityPresenter` |
+| Checkout complete | "Great choice…" / governed hero | Primary ticket/order link, calendar row, view event, continuity discovery |
+| Order detail | Wallet pass UI | Download PDF, Add to calendar, View event |
+| Emails | `order_confirmation`, `rsvp_confirmation` templates in `config/sync/myeventlane_messaging.template.*.yml` |
+
+---
+
+## 9. Recommended changes (ranked)
+
+| Priority | Change | Impact | Effort | Risk |
+|----------|--------|--------|--------|------|
+| P1 | UI labels: Dashboard→Home, Analytics→Insights, Vendor→Organiser (public nav) | High clarity | Low | Low — strings only |
+| P1 | Checkout confirmation primary → `/my-tickets/order/{id}` | Trust + ticket recovery | Low | Low — same access model |
+| P2 | Wire My Events empty state to governed template | Empty state quality | Low | Low |
+| P2 | Richer organiser first-event empty copy (RSVP vs paid Stripe note) | Onboarding clarity | Low | Low |
+| P3 | Consolidate attendee entry points in docs/help only | Reduced confusion | Med | Low |
+| P3 | Align checkout flow config (`mel_event_checkout`) in sync | Booking reliability | Med | Medium — config |
+| P4 | Remove or hide placeholder manage-event routes from IA | Fewer dead ends | Med | Low |
+| P4 | Pro analytics upsell copy when Insights locked | Conversion | Med | Low |
+
+---
+
+## 10. Changes applied in this pass
+
+See git diff for exact strings. Summary:
+
+- **Phase 2:** Organiser/customer label pass (Home, Insights, Grow event, Organiser nav).
+- **Phase 3:** Customer My Events governed empty state; organiser empty-state copy + CTA in dashboard.
+- **Phase 4:** Checkout completion primary action → MEL order detail route; booking-confirmed headline.
+
+**Intentionally not changed:** route names, permissions, Stripe logic, Pro gating, placeholder route removal, checkout flow config export, admin/staff analytics surfaces.
+
+---
+
+## 11. Validation
+
+```bash
+git status --short
+composer validate --check-lock
+ddev drush cr
+find web/modules/custom web/themes/custom -name "*.php" -print0 | xargs -0 -n1 php -l
+rg "Vendor|Dashboard|Analytics|Promotion|Submit" web/modules/custom web/themes/custom config/sync
+```
+
+---
+
+## 12. Related audits
+
+- `docs/audits/brand-rollout/onboarding-audit.md`
+- `docs/audits/mel-booking-checkout-verification.md`
+- `docs/audits/mel-stripe-connect-audit.md`
+- `docs/audits/event-management-navigation-map.md`
+- `docs/audits/mobile-phase-1-priority-review.md`

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -123,7 +123,7 @@ final class AccountLinksService {
     $definitions = [
       [
         'id' => 'dashboard',
-        'title' => $this->t('Dashboard'),
+        'title' => $this->t('Home'),
         'url' => $dashboardUrl,
         'in_quick' => FALSE,
         'show_in_sidebar' => TRUE,
@@ -133,7 +133,7 @@ final class AccountLinksService {
       ],
       [
         'id' => 'tickets',
-        'title' => $this->t('Tickets'),
+        'title' => $this->t('My tickets'),
         'url' => $ticketsUrl,
         'in_quick' => TRUE,
         'show_in_sidebar' => TRUE,

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
@@ -86,7 +86,7 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     }
 
     return $this->buildVendorPage('myeventlane_vendor_console_page', [
-      'title' => $analyticsModel['title'] ?? 'Analytics',
+      'title' => $analyticsModel['title'] ?? 'Insights',
       'body' => [
         '#theme' => 'myeventlane_analytics_dashboard',
         '#analytics_model' => $analyticsModel,
@@ -144,7 +144,7 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     $exportExcelUrl = $this->safeExportUrl('myeventlane_analytics.export_excel', ['node' => $eventId]);
 
     return $this->buildVendorPage('myeventlane_vendor_console_page', [
-      'title' => 'Analytics: ' . $node->label(),
+      'title' => 'Insights: ' . $node->label(),
       'body' => [
         '#theme' => 'myeventlane_analytics_event',
         '#event' => $node,
@@ -191,7 +191,7 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
    *   Page title.
    */
   public function eventTitle(NodeInterface $node): string {
-    return (string) $this->t('Analytics: @event', ['@event' => $node->label()]);
+    return (string) $this->t('Insights: @event', ['@event' => $node->label()]);
   }
 
   /**

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -97,7 +97,7 @@ final class VendorAnalyticsViewModelBuilder {
     }
 
     return [
-      'title' => (string) $this->t('Analytics'),
+      'title' => (string) $this->t('Insights'),
       'subtitle' => (string) $this->t('Understand event performance across your organiser account.'),
       'date_range' => [
         'active' => 'all',
@@ -115,7 +115,7 @@ final class VendorAnalyticsViewModelBuilder {
    */
   private function emptyGuestModel(): array {
     return [
-      'title' => (string) $this->t('Analytics'),
+      'title' => (string) $this->t('Insights'),
       'subtitle' => (string) $this->t('Understand event performance across your organiser account.'),
       'date_range' => [
         'active' => 'all',

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -212,8 +212,8 @@ final class MelReadinessHelper {
     if (!$eventsPresent) {
       return [
         'hero_hint' => $this->vendorHeroShellLaunchHint(),
-        'empty_title' => (string) $this->t('Welcome to your organiser dashboard'),
-        'empty_message' => (string) $this->t('Create your first event to start selling tickets or collecting RSVPs.'),
+        'empty_title' => (string) $this->t('Your first event starts here'),
+        'empty_message' => (string) $this->t('You have not created an event yet. RSVP events work without connecting payouts; paid ticket sales need Stripe before publish. Create an event in a few minutes and start inviting your community.'),
         'empty_action_label' => (string) $this->t('Create event'),
         'neutral_empty_hint' => (string) $this->t('Your key setup and event tasks look clear.'),
       ];
@@ -245,7 +245,7 @@ final class MelReadinessHelper {
    * Guest/anonymous notice when analytics routes are reachable without a session.
    */
   public function vendorOrganiserPortalSignInAnalyticsBody(): string {
-    return (string) $this->t('Analytics are available once you sign in as an organiser.');
+    return (string) $this->t('Insights are available once you sign in as an organiser.');
   }
 
   /**
@@ -385,7 +385,7 @@ final class MelReadinessHelper {
   }
 
   public function customerCheckoutCompletionHeadline(): string {
-    return (string) $this->t("Great choice. You're all set.");
+    return (string) $this->t('Booking confirmed');
   }
 
   /**
@@ -533,15 +533,15 @@ final class MelReadinessHelper {
       'your_tickets_title' => (string) $this->t('Your tickets'),
       'donation_confirmed_title' => (string) $this->t('Donation confirmed'),
       'view_ticket' => (string) $this->t('View ticket'),
-      'view_order' => (string) $this->t('View order'),
+      'view_order' => (string) $this->t('View booking'),
       'view_event' => (string) $this->t('View event'),
       'add_to_calendar' => (string) $this->t('Add to calendar'),
       'google_calendar' => (string) $this->t('Google Calendar'),
       'outlook_calendar' => (string) $this->t('Outlook'),
-      'guest_ticket_email_body' => (string) $this->t('Your ticket link and order details have been sent to your email.'),
+      'guest_ticket_email_body' => (string) $this->t('Check your inbox for ticket PDFs, calendar files, and this order number — you can open them anytime without signing in.'),
       'guest_order_number_intro' => (string) $this->t('Order number:'),
       'what_next_title' => (string) $this->t('What happens next'),
-      'what_next_body' => (string) $this->t('Keep this confirmation handy. The organiser may email closer to the date with practical details.'),
+      'what_next_body' => (string) $this->t('Keep this confirmation handy. Sign in later to find tickets under My tickets, or use the links in your email. The organiser may send practical details closer to the date.'),
       'organiser_trust_title' => (string) $this->t('About your organiser'),
       'organiser_trust_body' => (string) $this->t('Events are hosted by independent organisers. For changes, refunds, or access questions, contact them directly from your tickets.'),
     ];
@@ -775,6 +775,10 @@ final class MelReadinessHelper {
 
   public function customerContinuityViewEventCta(): string {
     return (string) $this->t('View event');
+  }
+
+  public function customerContinuityMyEventsCta(): string {
+    return (string) $this->t('View my events');
   }
 
   public function customerContinuityAddToCalendarCta(): string {
@@ -1630,8 +1634,8 @@ final class MelReadinessHelper {
     return [
       'heading' => (string) $this->t('No attendees yet'),
       'what_happened' => (string) $this->t('We do not show any attendance records for this event.'),
-      'why_empty' => (string) $this->t('RSVPs and ticket purchases appear here as soon as the first one is confirmed.'),
-      'next_action' => (string) $this->t('Share your event link to start collecting RSVPs or ticket sales.'),
+      'why_empty' => (string) $this->t('Your event is live. RSVPs and ticket purchases appear here as soon as the first one is confirmed.'),
+      'next_action' => (string) $this->t('Share your event with your community to start receiving bookings.'),
     ];
   }
 

--- a/web/modules/custom/myeventlane_dashboard/templates/myeventlane-customer-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_dashboard/templates/myeventlane-customer-dashboard.html.twig
@@ -21,11 +21,15 @@
     </section>
   {% else %}
     <section class="mel-my-account__section" aria-label="{{ 'Upcoming events'|t }}">
-      <div class="mel-account-empty-state mel-my-account__empty">
-        <h2 class="mel-account-empty-state__title">{{ 'Nothing upcoming yet'|t }}</h2>
-        <p class="mel-account-empty-state__text">{{ 'When you book tickets or RSVP, your events will show up here.'|t }}</p>
-        <a href="{{ path('<front>') }}" class="mel-button mel-button--primary">{{ 'Browse events'|t }}</a>
-      </div>
+      {% if mel_customer_dashboard_upcoming_empty is defined and mel_customer_dashboard_upcoming_empty %}
+        {{ mel_customer_dashboard_upcoming_empty }}
+      {% else %}
+        <div class="mel-account-empty-state mel-my-account__empty">
+          <h2 class="mel-account-empty-state__title">{{ 'Nothing upcoming yet'|t }}</h2>
+          <p class="mel-account-empty-state__text">{{ 'When you book tickets or RSVP, your events will show up here.'|t }}</p>
+          <a href="{{ path('<front>') }}" class="mel-button mel-button--primary">{{ 'Browse events'|t }}</a>
+        </div>
+      {% endif %}
     </section>
   {% endif %}
 

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -150,6 +150,7 @@ services:
       - '@commerce_price.currency_repository'
       - '@language_manager'
       - '@logger.channel.myeventlane_event'
+      - '@?myeventlane_event_attendees.waitlist'
 
   myeventlane_event.cta_resolver:
     class: Drupal\myeventlane_event\Service\EventCtaResolver

--- a/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
+++ b/web/modules/custom/myeventlane_event/src/Service/BookingFlowResolver.php
@@ -15,6 +15,7 @@ use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
 use Drupal\myeventlane_commerce\Form\TicketSelectionForm;
 use Drupal\myeventlane_commerce\Service\TicketAvailabilityService;
+use Drupal\myeventlane_event_attendees\Service\AttendanceWaitlistManager;
 use Drupal\myeventlane_event_state\Service\EventStateResolverInterface;
 use Drupal\myeventlane_rsvp\Form\RsvpPublicForm;
 use Drupal\node\NodeInterface;
@@ -57,6 +58,7 @@ final class BookingFlowResolver {
     private readonly CurrencyRepositoryInterface $currencyRepository,
     private readonly LanguageManagerInterface $languageManager,
     private readonly LoggerInterface $logger,
+    private readonly ?AttendanceWaitlistManager $waitlistManager = NULL,
   ) {}
 
   /**
@@ -118,7 +120,7 @@ final class BookingFlowResolver {
       }
 
       return [
-        'label' => 'View details',
+        'label' => 'Get tickets',
         'url' => $externalUrl,
         'type' => 'external',
         'disabled' => FALSE,
@@ -139,6 +141,19 @@ final class BookingFlowResolver {
     }
 
     if ($availability === self::AVAILABILITY_SOLD_OUT) {
+      if ($mode === self::MODE_RSVP && $this->isRsvpWaitlistAvailable($event)) {
+        $waitlistUrl = Url::fromRoute('myeventlane_event_attendees.waitlist_signup', [
+          'node' => (int) $event->id(),
+        ])->toString();
+        return [
+          'label' => 'Join waitlist',
+          'url' => $waitlistUrl,
+          'type' => 'internal',
+          'disabled' => FALSE,
+          'reason' => NULL,
+        ];
+      }
+
       return [
         'label' => 'Sold out',
         'url' => '',
@@ -559,6 +574,17 @@ final class BookingFlowResolver {
     }
 
     return $url;
+  }
+
+  /**
+   * Returns TRUE when RSVP waitlist signup is offered for a sold-out event.
+   */
+  private function isRsvpWaitlistAvailable(NodeInterface $event): bool {
+    if (!$this->waitlistManager instanceof AttendanceWaitlistManager) {
+      return FALSE;
+    }
+
+    return $this->waitlistManager->isWaitlistEnabled($event);
   }
 
 }

--- a/web/modules/custom/myeventlane_rsvp/src/Controller/RsvpThankYouController.php
+++ b/web/modules/custom/myeventlane_rsvp/src/Controller/RsvpThankYouController.php
@@ -201,6 +201,7 @@ final class RsvpThankYouController {
       $attendee_name,
       $attendee_email,
       $guests,
+      $this->currentUser->isAuthenticated(),
     );
 
     return [

--- a/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
+++ b/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
@@ -37,6 +37,7 @@ final class MelCustomerContinuityPresenter {
     string $attendee_name,
     string $attendee_email,
     int $guests,
+    bool $is_authenticated = FALSE,
   ): array {
     $title = $event->label();
     $calendar_url = Url::fromRoute('myeventlane_rsvp.ics_download', ['node' => (int) $event->id()])->toString();
@@ -119,6 +120,24 @@ final class MelCustomerContinuityPresenter {
       ];
     }
 
+    if ($is_authenticated) {
+      try {
+        $my_events_url = Url::fromRoute('myeventlane_dashboard.customer')->toString();
+      }
+      catch (\Throwable) {
+        $my_events_url = '';
+      }
+      if ($my_events_url !== '') {
+        $actions[] = [
+          'key' => 'view_my_events',
+          'label' => $this->readinessHelper->customerContinuityMyEventsCta(),
+          'url' => $my_events_url,
+          'variant' => 'secondary',
+          'download' => FALSE,
+        ];
+      }
+    }
+
     $actions[] = [
       'key' => 'add_calendar',
       'label' => $this->readinessHelper->customerContinuityAddToCalendarCta(),
@@ -186,8 +205,7 @@ final class MelCustomerContinuityPresenter {
     $primary_label = '';
     if ($customer_id) {
       try {
-        $primary_url = Url::fromRoute('entity.commerce_order.user_view', [
-          'user' => $customer_id,
+        $primary_url = Url::fromRoute('myeventlane_checkout_flow.order_detail', [
           'commerce_order' => $order_entity_id,
         ])->toString();
       }

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.menu.yml
@@ -21,7 +21,7 @@ myeventlane_vendor.admin_link:
 # using the *target* route’s path, so it stays correct for menu/cross-URL
 # access checks, not just the current browser path.
 myeventlane_vendor.menu_account.dashboard:
-  title: 'Dashboard'
+  title: 'Home'
   route_name: myeventlane_vendor.console.dashboard
   menu_name: account
   weight: -50

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -96,7 +96,7 @@ final class VendorConsolePagePreprocess {
       ['key' => 'attendees', 'route' => 'myeventlane_event_attendees.vendor_list', 'label' => $this->t('Attendees'), 'url' => Url::fromRoute('myeventlane_event_attendees.vendor_list', ['node' => $event_id])->toString()],
       ['key' => 'orders', 'route' => 'myeventlane_vendor.console.event_orders', 'label' => $this->t('Orders'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_orders', ['event' => $event_id])->toString()],
       ['key' => 'promotion', 'route' => 'myeventlane_vendor.console.event_promotion', 'label' => $this->t('Attendee Messaging'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_promotion', ['event' => $event_id])->toString()],
-      ['key' => 'analytics', 'route' => 'myeventlane_vendor.console.event_analytics', 'label' => $this->t('Analytics'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_analytics', ['event' => $event_id])->toString()],
+      ['key' => 'analytics', 'route' => 'myeventlane_vendor.console.event_analytics', 'label' => $this->t('Insights'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_analytics', ['event' => $event_id])->toString()],
       ['key' => 'settings', 'route' => 'myeventlane_vendor.console.event_settings', 'label' => $this->t('Settings'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_settings', ['event' => $event_id])->toString()],
       ['key' => 'publish', 'route' => 'myeventlane_vendor.console.event_publish', 'label' => $this->t('Publish'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_publish', ['event' => $event_id])->toString()],
     ];

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -189,7 +189,7 @@ final class VendorEventTabsService {
 
     $rows[] = [
       'key' => 'analytics',
-      'label' => (string) $t->translate('Analytics'),
+      'label' => (string) $t->translate('Insights'),
       'route' => 'myeventlane_vendor.console.event_analytics',
       'params' => ['event' => $id],
       'disabled' => FALSE,

--- a/web/themes/custom/myeventlane_radix/templates/includes/header.html.twig
+++ b/web/themes/custom/myeventlane_radix/templates/includes/header.html.twig
@@ -31,7 +31,7 @@
         <ul class="mel-nav-list">
           <li><a href="/events" class="mel-nav-link">Events</a></li>
           <li><a href="/categories" class="mel-nav-link">Categories</a></li>
-          <li><a href="/vendors" class="mel-nav-link">Vendors</a></li>
+          <li><a href="/vendors" class="mel-nav-link">{{ 'Organisers'|t }}</a></li>
         </ul>
       {% endif %}
     </nav>
@@ -40,9 +40,9 @@
     <div class="mel-header-actions">
       {% if logged_in %}
         {% if is_vendor|default(false) %}
-          <a href="{{ path('myeventlane_vendor.console.dashboard') }}" class="btn mel-btn-primary">Dashboard</a>
+          <a href="{{ path('myeventlane_vendor.console.dashboard') }}" class="btn mel-btn-primary">{{ 'Organiser home'|t }}</a>
         {% else %}
-          <a href="{{ path('myeventlane_account.dashboard') }}" class="btn mel-btn-primary">Dashboard</a>
+          <a href="{{ path('myeventlane_account.dashboard') }}" class="btn mel-btn-primary">{{ 'Home'|t }}</a>
         {% endif %}
       {% else %}
         <a href="{{ path('user.login') }}" class="btn mel-btn-ghost">Login</a>
@@ -70,9 +70,9 @@
         <li class="mel-mobile-divider" aria-hidden="true"></li>
         {% if logged_in %}
           {% if is_vendor|default(false) %}
-            <li><a href="{{ path('myeventlane_vendor.console.dashboard') }}">Dashboard</a></li>
+            <li><a href="{{ path('myeventlane_vendor.console.dashboard') }}">{{ 'Organiser home'|t }}</a></li>
           {% else %}
-            <li><a href="{{ path('myeventlane_account.dashboard') }}">Dashboard</a></li>
+            <li><a href="{{ path('myeventlane_account.dashboard') }}">{{ 'Home'|t }}</a></li>
           {% endif %}
         {% else %}
           <li><a href="{{ path('user.login') }}">Login</a></li>

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -4653,6 +4653,9 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
         if ($logo_url !== NULL) {
           $organiser['logo_url'] = $logo_url;
         }
+        $vendor_card = $card_builder->build($vendor);
+        $organiser['event_count'] = (int) ($vendor_card['event_count'] ?? 0);
+        $organiser['is_new_organiser'] = !empty($vendor_card['is_new_organiser']);
       }
       $variables['mel_organiser'] = $organiser;
     }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -925,6 +925,39 @@
   }
 }
 
+.mel-event-cta-soldout__hint {
+  display: block;
+  margin-top: space-tokens.mel-space(1);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-booking-panel__soldout-guide {
+  margin-top: space-tokens.mel-space(2);
+  padding-top: space-tokens.mel-space(2);
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.mel-booking-panel__soldout-lead {
+  margin: 0 0 space-tokens.mel-space(1);
+  font-size: typography.mel-font-size(base);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text;
+}
+
+.mel-booking-panel__soldout-next,
+.mel-booking-panel__soldout-support {
+  margin: 0 0 space-tokens.mel-space(1);
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.5;
+  color: colors.$mel-color-text-muted;
+}
+
+.mel-booking-panel__soldout-support {
+  margin-bottom: 0;
+}
+
 // Subtle trust line (below urgency / CTA; muted grey, not marketing-heavy).
 .mel-event-meta-bar__trust {
   list-style: none;
@@ -2629,6 +2662,41 @@
     &--muted {
       color: colors.$mel-color-text-muted;
       font-size: typography.mel-font-size(sm);
+    }
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: space-tokens.mel-space(1) space-tokens.mel-space(3);
+    margin: space-tokens.mel-space(1) 0 0;
+    font-size: typography.mel-font-size(sm);
+    color: colors.$mel-color-text-muted;
+  }
+
+  &__meta-item {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  &__profile {
+    margin: space-tokens.mel-space(2) 0 0;
+  }
+
+  &__profile-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    font-size: typography.mel-font-size(sm);
+    font-weight: typography.$mel-font-medium;
+    color: colors.$mel-color-primary;
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+
+    &:focus-visible {
+      outline: 2px solid colors.$mel-color-primary;
+      outline-offset: 2px;
+      border-radius: radii.$mel-radius-sm;
     }
   }
 }

--- a/web/themes/custom/myeventlane_theme/templates/layout/footer-internal.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/layout/footer-internal.html.twig
@@ -45,13 +45,13 @@
         <button type="button" class="mel-footer__accordion-toggle" aria-expanded="false">{{ 'Your Events'|t }}</button>
         <div class="mel-footer__accordion-panel" data-label="{{ 'Your Events'|t }}">
           {% if footer_context.vendor_console_urls.dashboard %}
-          <a href="{{ footer_context.vendor_console_urls.dashboard }}">{{ 'Dashboard'|t }}</a>
+          <a href="{{ footer_context.vendor_console_urls.dashboard }}">{{ 'Home'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.events %}
           <a href="{{ footer_context.vendor_console_urls.events }}">{{ 'Manage events'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.analytics %}
-          <a href="{{ footer_context.vendor_console_urls.analytics }}">{{ 'Analytics'|t }}</a>
+          <a href="{{ footer_context.vendor_console_urls.analytics }}">{{ 'Insights'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.payouts %}
           <a href="{{ footer_context.vendor_console_urls.payouts }}">{{ 'Payouts'|t }}</a>

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -80,6 +80,7 @@
     {% if mel_event_state is defined and mel_event_state == 'cancelled' %}
       <div class="mel-alert mel-alert--warning" role="status">
         <strong>{{ 'This event has been cancelled.'|t }}</strong>
+        <p>{{ 'Refunds or updates will come from the organiser. Explore similar events below, or visit our Help Centre if you need assistance.'|t }}</p>
       </div>
     {% endif %}
 
@@ -518,17 +519,37 @@
                 </div>
               {% endif %}
               <div class="mel-organiser-card__body">
-                <h2 id="mel-organiser-card-title" class="mel-organiser-card__title">{{ 'Presented by'|t }}</h2>
+                <h2 id="mel-organiser-card-title" class="mel-organiser-card__title">{{ 'About the organiser'|t }}</h2>
                 {% if mel_organiser.url %}
                   <a class="mel-organiser-card__name" href="{{ mel_organiser.url }}">{{ mel_organiser.name }}</a>
                 {% else %}
                   <span class="mel-organiser-card__name">{{ mel_organiser.name }}</span>
                 {% endif %}
-                <p class="mel-organiser-card__hosted">{{ 'Hosted by'|t }} <span class="mel-organiser-card__hosted-name">{{ mel_organiser.name }}</span></p>
+                {% if mel_organiser.event_count|default(0) > 0 or mel_organiser.is_new_organiser|default(false) %}
+                  <p class="mel-organiser-card__meta">
+                    {% if mel_organiser.event_count|default(0) > 0 %}
+                      <span class="mel-organiser-card__meta-item">
+                        {% trans %}
+                          1 upcoming event
+                        {% plural mel_organiser.event_count %}
+                          @count upcoming events
+                        {% endtrans %}
+                      </span>
+                    {% endif %}
+                    {% if mel_organiser.is_new_organiser|default(false) %}
+                      <span class="mel-organiser-card__meta-item">{{ 'New on MyEventLane'|t }}</span>
+                    {% endif %}
+                  </p>
+                {% endif %}
                 {% if mel_organiser.tagline %}
                   <p class="mel-organiser-card__tagline">{{ mel_organiser.tagline }}</p>
                 {% else %}
-                  <p class="mel-organiser-card__tagline mel-organiser-card__tagline--muted">{{ 'This event is hosted by @name on MyEventLane.'|t({ '@name': mel_organiser.name }) }}</p>
+                  <p class="mel-organiser-card__tagline mel-organiser-card__tagline--muted">{{ 'Events hosted on MyEventLane by @name.'|t({ '@name': mel_organiser.name }) }}</p>
+                {% endif %}
+                {% if mel_organiser.url %}
+                  <p class="mel-organiser-card__profile">
+                    <a class="mel-organiser-card__profile-link" href="{{ mel_organiser.url }}">{{ 'View organiser profile'|t }} →</a>
+                  </p>
                 {% endif %}
               </div>
             </div>

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-cta.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-cta.html.twig
@@ -26,7 +26,12 @@
       {{ 'Join waitlist'|t }}{% if mel_cta_is_external %}<span class="visually-hidden"> {{ '(opens in a new tab)'|t }}</span>{% endif %}
     </a>
   {% else %}
-    <p class="{% if mel_cta_slot|default('sidebar') == 'mobile' %}mel-mobile-cta__waitlist-sub mel-mobile-cta__waitlist-sub--muted{% else %}mel-event-cta-soldout__muted{% endif %}" role="status">{{ mel_cta_text }}</p>
+    <p class="{% if mel_cta_slot|default('sidebar') == 'mobile' %}mel-mobile-cta__waitlist-sub mel-mobile-cta__waitlist-sub--muted{% else %}mel-event-cta-soldout__muted{% endif %}" role="status">
+      {{ mel_cta_text }}
+      {% if mel_cta_slot|default('sidebar') != 'mobile' %}
+        <span class="mel-event-cta-soldout__hint">{{ 'Explore similar events below, or visit Support if you need help.'|t }}</span>
+      {% endif %}
+    </p>
   {% endif %}
 {% elseif event_cta and event_cta.type|default('disabled') in ['internal', 'external'] and (event_cta.url|default('')|striptags|length > 0) %}
   {% set mel_primary_btn = mel_cta_text|default('')|striptags|trim %}

--- a/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/partial--event-full-booking-panel.html.twig
@@ -135,6 +135,18 @@
               {% endif %}
             </ul>
           </div>
+        {% elseif event_ui is defined and (event_ui.is_sold_out|default(false) is same as(true)) %}
+          <div class="mel-booking-panel__soldout-guide" role="status">
+            <p class="mel-booking-panel__soldout-lead">{{ 'This event is sold out.'|t }}</p>
+            {% if event_cta and event_cta.url|default('')|striptags|length > 0 %}
+              <p class="mel-booking-panel__soldout-next">{{ 'Join the waitlist to be notified if spots open.'|t }}</p>
+            {% else %}
+              <p class="mel-booking-panel__soldout-next">{{ 'Explore similar events below, or save this event to check back later.'|t }}</p>
+            {% endif %}
+            <p class="mel-booking-panel__soldout-support">
+              <a class="mel-booking-panel__trust-link" href="{{ path('myeventlane_support.page') }}">{{ 'Visit support'|t }}</a>
+            </p>
+          </div>
         {% endif %}
 
         {% if event_flag_event_save %}

--- a/web/themes/custom/myeventlane_theme/templates/region--header.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/region--header.html.twig
@@ -13,17 +13,17 @@
         <li><a href="/categories" class="mel-nav-link">Categories</a></li>
         <li class="mel-nav-dropdown">
           <button class="mel-nav-link mel-nav-dropdown-toggle" aria-expanded="false" aria-haspopup="true">
-            {{ 'Vendors'|t }}
+            {{ 'Organisers'|t }}
             <svg class="mel-dropdown-arrow" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>
           <ul class="mel-nav-dropdown-menu">
-            <li><a href="/vendors" class="mel-nav-dropdown-link">{{ 'Browse Vendors'|t }}</a></li>
+            <li><a href="/vendors" class="mel-nav-dropdown-link">{{ 'Browse organisers'|t }}</a></li>
             {% if is_vendor %}
-              <li><a href="/vendor/dashboard" class="mel-nav-dropdown-link">{{ 'Vendor Dashboard'|t }}</a></li>
+              <li><a href="/vendor/dashboard" class="mel-nav-dropdown-link">{{ 'Organiser home'|t }}</a></li>
             {% else %}
-              <li><a href="/vendor/onboard" class="mel-nav-dropdown-link">{{ 'Become a Vendor'|t }}</a></li>
+              <li><a href="/vendor/onboard" class="mel-nav-dropdown-link">{{ 'Start hosting'|t }}</a></li>
             {% endif %}
           </ul>
         </li>
@@ -45,9 +45,9 @@
     <div class="mel-header-actions">
       {% if logged_in %}
         {% if is_vendor %}
-          <a href="{{ path('myeventlane_vendor.console.dashboard') }}" class="mel-btn mel-btn-primary">Dashboard</a>
+          <a href="{{ path('myeventlane_vendor.console.dashboard') }}" class="mel-btn mel-btn-primary">{{ 'Organiser home'|t }}</a>
         {% else %}
-          <a href="{{ path('myeventlane_account.dashboard') }}" class="mel-btn mel-btn-primary">Dashboard</a>
+          <a href="{{ path('myeventlane_account.dashboard') }}" class="mel-btn mel-btn-primary">{{ 'Home'|t }}</a>
         {% endif %}
       {% else %}
         <a href="{{ path('user.login') }}" class="mel-btn mel-btn-ghost">Login</a>
@@ -73,12 +73,12 @@
       <ul class="mel-nav-mobile-list">
         <li><a href="/events">Events</a></li>
         <li><a href="/categories">Categories</a></li>
-        <li class="mel-mobile-section-header">{{ 'Vendors'|t }}</li>
-        <li><a href="/vendors">{{ 'Browse Vendors'|t }}</a></li>
+        <li class="mel-mobile-section-header">{{ 'Organisers'|t }}</li>
+        <li><a href="/vendors">{{ 'Browse organisers'|t }}</a></li>
         {% if is_vendor %}
-          <li><a href="/vendor/dashboard">{{ 'Vendor Dashboard'|t }}</a></li>
+          <li><a href="/vendor/dashboard">{{ 'Organiser home'|t }}</a></li>
         {% else %}
-          <li><a href="/vendor/onboard">{{ 'Become a Vendor'|t }}</a></li>
+          <li><a href="/vendor/onboard">{{ 'Start hosting'|t }}</a></li>
         {% endif %}
         <li class="mel-mobile-section-header">{{ 'Support'|t }}</li>
         <li><a href="/support">{{ 'Contact Support'|t }}</a></li>
@@ -86,9 +86,9 @@
         <li class="mel-mobile-divider"></li>
         {% if logged_in %}
           {% if is_vendor %}
-            <li><a href="{{ path('myeventlane_vendor.console.dashboard') }}">Dashboard</a></li>
+            <li><a href="{{ path('myeventlane_vendor.console.dashboard') }}">{{ 'Organiser home'|t }}</a></li>
           {% else %}
-            <li><a href="{{ path('myeventlane_account.dashboard') }}">Dashboard</a></li>
+            <li><a href="{{ path('myeventlane_account.dashboard') }}">{{ 'Home'|t }}</a></li>
           {% endif %}
         {% else %}
           <li><a href="{{ path('user.login') }}">Login</a></li>

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -477,7 +477,7 @@ function myeventlane_vendor_theme_preprocess_page(array &$variables): void {
   if ($current_user->isAuthenticated()) {
     // Vendor console links (mirror account menu YAML; visibility = route access).
     $vendor_console_links = [
-      ['title' => t('Dashboard'), 'route' => 'myeventlane_vendor.console.dashboard'],
+      ['title' => t('Home'), 'route' => 'myeventlane_vendor.console.dashboard'],
       ['title' => t('My events'), 'route' => 'myeventlane_vendor.console.events'],
       ['title' => t('Create event'), 'route' => 'myeventlane_event_studio.create'],
       ['title' => t('Settings'), 'route' => 'myeventlane_vendor.console.settings'],
@@ -2082,7 +2082,7 @@ function _myeventlane_vendor_theme_build_onboarding_shell_nav_items(string $acti
   $candidates = [
     [
       'key' => 'dashboard',
-      'label' => t('Dashboard'),
+      'label' => t('Home'),
       'icon' => 'dashboard',
       'route' => 'myeventlane_vendor.console.dashboard',
     ],
@@ -2170,7 +2170,7 @@ function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $act
   $definitions = [
     [
       'key' => 'dashboard',
-      'label' => t('Dashboard'),
+      'label' => t('Home'),
       'icon' => 'dashboard',
       'route' => 'myeventlane_vendor.console.dashboard',
       'children' => [],
@@ -2221,7 +2221,7 @@ function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $act
     ],
     [
       'key' => 'promote',
-      'label' => t('Promote event'),
+      'label' => t('Grow event'),
       'icon' => 'growth',
       'route' => 'myeventlane_vendor.console.boost',
       'children' => [],
@@ -2235,7 +2235,7 @@ function _myeventlane_vendor_theme_build_full_vendor_shell_nav_items(string $act
     ],
     [
       'key' => 'analytics',
-      'label' => t('Analytics'),
+      'label' => t('Insights'),
       'icon' => 'analytics',
       'route' => 'myeventlane_analytics.dashboard',
       'children' => [],

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/best-event-card.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/best-event-card.html.twig
@@ -62,7 +62,7 @@
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
         </svg>
-        {{ 'View Analytics'|t }}
+        {{ 'View insights'|t }}
       </a>
     </div>
   {% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/event-table.html.twig
@@ -78,7 +78,7 @@
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                       <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
                     </svg>
-                    {{ 'View Analytics'|t }}
+                    {{ 'View insights'|t }}
                   </a>
                 {% endif %}
                 <a href="{{ event.attendees_url }}" class="mel-actions-menu__item">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-analytics-overview.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-vendor-analytics-overview.html.twig
@@ -13,7 +13,7 @@
 
 {% if visible_cards|length > 0 %}
   <section class="mel-vendor-analytics mel-vendor-dashboard__analytics-summary" aria-labelledby="mel-vendor-analytics-title">
-    <h2 id="mel-vendor-analytics-title" class="mel-vendor-analytics__title">{{ 'Analytics summary'|t }}</h2>
+    <h2 id="mel-vendor-analytics-title" class="mel-vendor-analytics__title">{{ 'Insights summary'|t }}</h2>
 
     {% macro render_group(title, keys, cards) %}
       {% set group_cards = cards|filter(card => (card.key|default('')) in keys) %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -193,7 +193,7 @@
           <h2 id="mel-dash-upcoming-title" class="mel-live-ops__panel-title">{{ 'Upcoming events'|t }}</h2>
         </div>
         {% if empty_state.url is defined and empty_state.url %}
-          <a class="mel-live-ops__readiness-link" href="{{ empty_state.url }}">{{ 'View all events'|t }}</a>
+          <a class="mel-live-ops__readiness-link" href="{{ empty_state.url }}">{{ empty_state.action_label|default('View events'|t) }}</a>
         {% endif %}
       </div>
       <div class="mel-vendor-dashboard__summary-cards" role="list">
@@ -428,7 +428,7 @@
   </details>
 
   <details class="mel-vendor-dashboard__details mel-vendor-dashboard__details--analytics mel-vendor-dashboard__details--events">
-    <summary>{{ 'Analytics'|t }}</summary>
+    <summary>{{ 'Insights'|t }}</summary>
     <div class="mel-vendor-dashboard__details-grid mel-vendor-dashboard__details-grid--single">
       {% set analytics_data = analytics|default({}) %}
       {% set duplicate_analytics_keys = ['revenue', 'tickets_sold', 'rsvps', 'upcoming_events'] %}
@@ -458,7 +458,7 @@
           <h3 id="mel-dash-analytics-insight-title" class="mel-vendor-dashboard__analytics-insight-title">{{ 'Top performing event'|t }}</h3>
           <p class="mel-vendor-dashboard__analytics-insight-message">{{ '@event is outperforming your other events.'|t({'@event': top_event_row.title|default('This event')}) }}</p>
           {% if top_event_row.event_id|default(0) %}
-            <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_event_studio.workspace_analytics', {'node': top_event_row.event_id}) }}">{{ 'View event analytics'|t }}</a>
+            <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_event_studio.workspace_analytics', {'node': top_event_row.event_id}) }}">{{ 'View event insights'|t }}</a>
           {% endif %}
         </aside>
       {% elseif profile_views_count > 0 %}
@@ -466,7 +466,7 @@
           <p class="mel-live-ops__eyebrow">{{ 'Insight'|t }}</p>
           <h3 id="mel-dash-analytics-insight-title" class="mel-vendor-dashboard__analytics-insight-title">{{ 'Profile discovery'|t }}</h3>
           <p class="mel-vendor-dashboard__analytics-insight-message">{{ 'More people are discovering your organiser profile.'|t }}</p>
-          <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_vendor.console.boost') }}">{{ 'Promote another event'|t }}</a>
+          <a class="mel-btn mel-btn--secondary mel-vendor-dashboard__analytics-insight-action" href="{{ path('myeventlane_vendor.console.boost') }}">{{ 'Grow another event'|t }}</a>
         </aside>
       {% endif %}
 
@@ -574,7 +574,7 @@
       {% if growth_cards is defined and growth_cards|length > 0 %}
         <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-growth-title">
           <div class="mel-live-ops__timeline-head">
-            <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Promotion guidance'|t }}</h2>
+            <h2 class="mel-live-ops__panel-title" id="mel-growth-title">{{ 'Grow event guidance'|t }}</h2>
             <p class="mel-live-ops__panel-intro">{{ 'Suggestions remain secondary to organiser mission control.'|t }}</p>
           </div>
           <ul class="mel-vendor-dashboard__growth-feed" role="list">
@@ -669,7 +669,7 @@
                     <a class="mel-btn mel-btn--secondary mel-btn--sm" href="{{ links.attendees }}">{{ 'Attendees'|t }}</a>
                   {% endif %}
                   {% if links.analytics is defined and links.analytics %}
-                    <a class="mel-btn mel-btn--ghost mel-btn--sm" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
+                    <a class="mel-btn mel-btn--ghost mel-btn--sm" href="{{ links.analytics }}">{{ 'Insights'|t }}</a>
                   {% endif %}
                   {% set removal = ev.removal|default(null) %}
                   {% if removal %}
@@ -684,8 +684,11 @@
           </div>
         {% else %}
           <div class="mel-live-ops__panel mel-vendor-dashboard__panel mel-vendor-dashboard__events-empty">
-            <p class="mel-live-ops__panel-title mel-vendor-dashboard__events-empty-title">{{ empty_state.title|default('Welcome to your organiser dashboard'|t) }}</p>
-            <p class="mel-live-ops__panel-intro mel-vendor-dashboard__events-empty-intro">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
+            <p class="mel-live-ops__panel-title mel-vendor-dashboard__events-empty-title">{{ empty_state.title|default('Your first event starts here'|t) }}</p>
+            <p class="mel-live-ops__panel-intro mel-vendor-dashboard__events-empty-intro">{{ empty_state.message|default('Create an event in a few minutes and start inviting your community.'|t) }}</p>
+            {% if empty_state.url is defined and empty_state.url and empty_state.action_label is defined and empty_state.action_label %}
+              <a class="mel-btn mel-btn--primary mel-vendor-dashboard__events-empty-cta" href="{{ empty_state.url }}">{{ empty_state.action_label }}</a>
+            {% endif %}
           </div>
         {% endif %}
       </section>
@@ -693,7 +696,7 @@
       {% if analytics_summary.available is defined and analytics_summary.available and analytics_items is iterable and analytics_items|length > 0 %}
         <section class="mel-live-ops__panel mel-vendor-dashboard__panel" aria-labelledby="mel-dash-analytics-summary-title">
           <div class="mel-live-ops__timeline-head">
-            <h2 class="mel-live-ops__panel-title" id="mel-dash-analytics-summary-title">{{ 'Analytics summary'|t }}</h2>
+            <h2 class="mel-live-ops__panel-title" id="mel-dash-analytics-summary-title">{{ 'Insights summary'|t }}</h2>
             <p class="mel-live-ops__panel-intro">{{ 'Detailed charts remain on analytics pages.'|t }}</p>
           </div>
           <div class="mel-live-ops__timeline-feed" role="list">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/analytics.html.twig
@@ -6,7 +6,7 @@
  */
 #}
 {% if workspace_back_url or edit_event_url or export_pdf_url or export_excel_url %}
-  <nav class="mel-live-ops__quick-bar" role="region" aria-label="{{ 'Analytics actions'|t }}">
+  <nav class="mel-live-ops__quick-bar" role="region" aria-label="{{ 'Insights actions'|t }}">
     <div class="mel-live-ops__quick-inner" role="toolbar">
       {% if workspace_back_url %}
         <a href="{{ workspace_back_url }}" class="mel-live-ops__action mel-live-ops__action--lavender" data-icon="list">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/footer-internal.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/footer-internal.html.twig
@@ -45,13 +45,13 @@
         <button type="button" class="mel-footer__accordion-toggle" aria-expanded="false">{{ 'Your Events'|t }}</button>
         <div class="mel-footer__accordion-panel" data-label="{{ 'Your Events'|t }}">
           {% if footer_context.vendor_console_urls.dashboard %}
-          <a href="{{ footer_context.vendor_console_urls.dashboard }}">{{ 'Dashboard'|t }}</a>
+          <a href="{{ footer_context.vendor_console_urls.dashboard }}">{{ 'Home'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.events %}
           <a href="{{ footer_context.vendor_console_urls.events }}">{{ 'Manage events'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.analytics %}
-          <a href="{{ footer_context.vendor_console_urls.analytics }}">{{ 'Analytics'|t }}</a>
+          <a href="{{ footer_context.vendor_console_urls.analytics }}">{{ 'Insights'|t }}</a>
           {% endif %}
           {% if footer_context.vendor_console_urls.payouts %}
           <a href="{{ footer_context.vendor_console_urls.payouts }}">{{ 'Payouts'|t }}</a>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/myeventlane-vendor-events-grid.html.twig
@@ -204,7 +204,7 @@
                 <a class="mel-vendor-events-v2__link" href="{{ links.attendees }}">{{ 'Attendees'|t }}</a>
               {% endif %}
               {% if links.analytics is defined and links.analytics %}
-                <a class="mel-vendor-events-v2__link" href="{{ links.analytics }}">{{ 'Analytics'|t }}</a>
+                <a class="mel-vendor-events-v2__link" href="{{ links.analytics }}">{{ 'Insights'|t }}</a>
               {% endif %}
             </div>
             {% set removal = ev.removal|default(null) %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Signed-in checkout completion now deep-links to MEL order detail and sold-out RSVP waitlist depends on optional waitlist service wiring—both are customer-facing booking paths but reuse existing routes and access checks.
> 
> **Overview**
> Improves **customer and organiser confidence** through governed copy, clearer navigation labels, and tighter post-booking CTAs—without changing Commerce, Stripe, permissions, or schema. Three workflow/trust **audit documents** are added under `docs/audits/`.
> 
> **Post-booking & account hub:** Checkout completion uses **“Booking confirmed”**, **“View booking”**, and routes signed-in users’ primary action to **`myeventlane_checkout_flow.order_detail`** instead of the generic Commerce order view. Guest completion copy explains email-based ticket recovery. RSVP thank-you adds **“View my events”** for authenticated users via `MelCustomerContinuityPresenter` / `RsvpThankYouController`. Customer nav relabels **Dashboard → Home** and **Tickets → My tickets**; `/my-events` upcoming empty state can render governed empty content from preprocess.
> 
> **Public event page & booking CTAs:** `BookingFlowResolver` now links **Join waitlist** when RSVP events are sold out and waitlist is enabled (optional `AttendanceWaitlistManager` injection), renames external CTAs to **Get tickets**, and templates gain cancelled/sold-out guidance plus organiser card enrichment (event count, new organiser flag, profile link) from `VendorCardBuilder`.
> 
> **Organiser surfaces:** Widespread **Analytics → Insights**, **Dashboard → Home**, **Promote → Grow event**, and public **Vendor → Organiser** labelling across vendor/customer themes, menus, and dashboards. First-event and zero-attendee empty states get clearer RSVP vs Stripe messaging, a **Create event** CTA on the vendor dashboard, and “event is live” reassurance in governed strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b5f621b8d02c5e9720981b10c708028539c0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->