### PR TITLE
Cursor/2026 06 23 oo09 41f96

### DIFF
--- a/docs/audits/event-health-insights-audit.md
+++ b/docs/audits/event-health-insights-audit.md
@@ -1,0 +1,231 @@
+# Event Health & Insights Audit
+
+**Module surfaces:** `myeventlane_analytics`, `myeventlane_reporting`, `myeventlane_event_studio`, `myeventlane_growth`, `myeventlane_vendor`
+**Date:** 2026-06-23
+**Branch:** `feature/mel-workflow-trust-confirmation`
+**Author role:** Product/UX + Drupal 11 partner (repository-first)
+**Objective:** Turn organiser analytics into *guidance* — confidence, meaning, and a clear next action. Not a BI/reporting project. Interpret existing data only; do not invent data, estimate numbers, or build scoring systems.
+
+---
+
+## 0. Executive summary
+
+MEL already has most of the *guidance* machinery the brief asks for. The problem is **inconsistency**, not absence:
+
+- **Good (already humane):** `/vendor/analytics` (v2 view model) gives KPIs with plain-language context, empty states, and per-event CTAs. Event Studio's **Event health** panel summarises Publish / Promotion / Boost with tone + plain language. `GrowthInsightService` produces deterministic, encouraging, action-linked cards ("Ticket sales are slower than expected → Boost", "Your event is gaining traction → Boost final push") wired to **existing routes**.
+- **Weak (raw numbers, feels like Drupal):** the **per-event "Advanced analytics" page** (`analytics-event.html.twig`, route `myeventlane_analytics.event` → `/vendor/analytics/event/{node}`) is the legacy surface. It shows bare metrics, hardcoded colours/currency, a chart with no text alternative, and **no empty states / no "what to do next."**
+
+**Highest-impact, lowest-risk move:** bring the per-event page up to the standard the rest of the product already sets — reusing existing copy patterns from `VendorAnalyticsViewModelBuilder` and existing CTA routes. No new entities, no Commerce/Stripe changes, no scoring.
+
+---
+
+## 1. Inventory — routes, controllers, services, view models, templates
+
+### 1.1 `myeventlane_analytics` (organiser-facing analytics)
+
+| Element | Path / Class |
+|---|---|
+| Route: vendor dashboard | `myeventlane_analytics.dashboard` → `/vendor/analytics` |
+| Route: per-event | `myeventlane_analytics.event` → `/vendor/analytics/event/{node}` |
+| Route: exports | `…export_pdf`, `…export_excel` (per-event) |
+| Route: admin revenue | `myeventlane_analytics.admin_revenue` (admin, out of scope) |
+| Controller | `Controller/AnalyticsDashboardController.php` (`dashboard`, `eventAnalytics`, `exportPdf`, `exportExcel`) |
+| View model (dashboard) | `Service/VendorAnalyticsViewModelBuilder.php` — TASK 9 contract: `title, subtitle, date_range, kpis, events, insights, empty_state` |
+| Supporting services | `AnalyticsDataService`, `SalesAnalyticsService`, `ConversionAnalyticsService`, `PopularEventsService`, `TrendingCategoriesService`, `OrderItemClassifier`, `ReportGeneratorService` |
+| Phase7 query layer | `Phase7/Service/AnalyticsQueryService`, `AdminRevenueQueryService`, `Scope/AnalyticsScopeResolver`, `Guard/AnalyticsQueryGuard` (vendor isolation, currency segmentation — covered by kernel tests) |
+| Template: dashboard | `templates/analytics-dashboard.html.twig` (**v2, good**) |
+| Template: per-event | `templates/analytics-event.html.twig` (**legacy, raw**) |
+| Assets | `css/analytics.css`, `js/analytics.js` (Chart.js canvases) |
+
+### 1.2 `myeventlane_reporting` (event insights)
+
+| Element | Path / Class |
+|---|---|
+| Routes | `myeventlane_reporting.event_insights.overview` / `.attendees` / `.checkins` → `/vendor/events/{event}/insights/*` |
+| Controllers | `EventInsightsController`, `VendorInsightsController`, `AdminReportsController`, `ChartDataController`, `ExportCentreController` |
+| Access | `Access/VendorReportingAccess.php` |
+| Templates | `myeventlane-reporting-event-insights.html.twig`, `…vendor-insights`, `…kpi-card`, admin variants |
+
+### 1.3 `myeventlane_event_studio` (workspace + event health)
+
+| Element | Path / Class |
+|---|---|
+| Controllers | `EventStudioController`, `EventStudioPublishController` |
+| Presentation service | `Service/EventStudioWorkspacePresentation.php` — `buildEventHealth()`, `buildReadinessSummary()`, AJAX payloads |
+| Templates | `mel-event-studio-event-health.html.twig` (**accessible: `role="region"`, `aria-labelledby`, `dl/dt/dd`**), `mel-event-studio-workspace.html.twig` |
+| Tests | `EventStudioWorkspaceStateMatrixTest`, `…PresentationContractTest`, `…UxConsolidationTest` |
+
+### 1.4 `myeventlane_growth` (deterministic guidance cards)
+
+| Element | Path / Class |
+|---|---|
+| Service | `Service/GrowthInsightService.php` (+ `GrowthTrackingService`, `GrowthOrganiserSignals`) |
+| Config | `myeventlane_growth.settings` (thresholds, cooldowns, `limits.max_dashboard_cards`), schema present |
+| Form | `Form/GrowthSettingsForm.php` |
+| Output | Cards: `key, type, severity, title, message, cta_route, cta_params, card_class, event_id` → CTAs to `myeventlane_boost.*`, `myeventlane_event.duplicate`, `myeventlane_vendor.console.audience`, `myeventlane_pro.*` |
+
+---
+
+## 2. Per-metric review — *what does it mean / is it understandable / does the organiser know what to do?*
+
+### 2.1 `/vendor/analytics` dashboard KPIs (view model) — **mostly good**
+
+| Metric | Meaning clear? | Guidance? | Verdict |
+|---|---|---|---|
+| Revenue | Yes — context: "Net ticket revenue after refunds · completed orders only" | Indirect (per-event CTAs) | Useful |
+| Tickets sold | Yes — context: "Published events you manage · completed ticket orders" | Indirect | Useful |
+| RSVPs | Yes — "Confirmed RSVPs on published events you manage" | Indirect | Useful |
+| Upcoming events | Yes — "Published events starting soon or in progress" | Indirect | Useful |
+| `insights` array | N/A — **currently passed as `[]`** by the view model | None rendered | **Gap: template renders insights, model never fills them** |
+
+> The dashboard template (`analytics-dashboard.html.twig:69-78`) has a complete insights region, but `VendorAnalyticsViewModelBuilder` sets `'insights' => []` (lines ~108, 126). Guidance that exists in `GrowthInsightService` is **not surfaced on this page**. (See Missing Guidance §4.)
+
+### 2.2 Per-event "Advanced analytics" (`analytics-event.html.twig`) — **raw numbers**
+
+| Metric | Meaning clear to organiser? | Knows what to do? | Verdict |
+|---|---|---|---|
+| Total Revenue | Partially — no "after refunds" qualifier here; hardcoded `$` (multi-currency unsafe) | No | Confusing |
+| Tickets Sold | Yes | No | Raw |
+| Average per Day | **No** — average of what window? since publish? | No | Confusing |
+| Sales Trend (↗/↘/→) | Partially — colour-only meaning (green/red) | No | **Confusing + a11y risk** |
+| Sales Over Time (chart) | Chart only — **no text/table alternative** | No | **a11y fail** |
+| Conversion Funnel (views→cart→checkout→completed) | Labels OK, but bare counts | No | Raw |
+| Conversion Rates (4×%) | **No** — "is 12% good?" unanswered | No | Confusing |
+| Ticket Type Breakdown | Yes (has table) | No | Useful-ish |
+| Conversion Bottlenecks | **Yes — includes `recommendation` text** | Partially | **Good pattern (already guidance)** |
+
+---
+
+## 3. Confusing / raw / duplicate / empty findings
+
+### 3.1 Raw numbers without interpretation
+- Per-event page: "Average per Day", conversion rates, funnel counts, trend — presented as figures with no "good/normal/needs attention" framing and no next action.
+
+### 3.2 Unexplained metrics
+- "Average per Day" — undefined window.
+- Conversion rate percentages — no benchmark or interpretation (brief explicitly wants "Are these numbers good?" answered).
+
+### 3.3 Duplicate / overlapping surfaces (navigation confusion, not data duplication)
+- Per-event analytics exists in **three** places: `/vendor/analytics/event/{node}` (advanced), `/vendor/events/{event}/insights/*` (reporting), and Event Studio workspace → Analytics. The per-event template's own subtitle admits this: *"Primary workspace analytics live under Event workspace → Analytics."* → **organiser disorientation risk.** (Document, do not silently merge — see Risks.)
+
+### 3.4 Empty charts / empty tables
+- Per-event page sections are wrapped in `{% if … is not empty %}` and simply **vanish** when empty. No "no data yet" explanation. A newly published event shows a near-blank page → "is it broken?"
+- Dashboard insights region is structurally present but never populated (empty by construction).
+
+### 3.5 Feels like Drupal / Bootstrap (not MEL)
+- `analytics-event.html.twig` uses **inline `style=""` throughout**, **hardcoded hex** (`#28a745`, `#dc3545`, `#666`, `#fff3cd`) instead of MEL tokens, and a hardcoded **`$`** currency symbol. This is the single most "un-MEL" page in the set and contradicts the token/contrast direction in `DESIGN_SYSTEM.md`.
+
+---
+
+## 4. Missing guidance
+
+1. **Per-event page has no "what to do next."** It has metrics but (except Bottlenecks) no CTAs to existing routes (Share, Grow/Boost, View attendees, Duplicate). Dead-end analytics.
+2. **Growth insights not surfaced on `/vendor/analytics`.** The view model passes `insights => []` while `GrowthInsightService` already produces relevant cards. The interpretation layer exists but isn't connected to this page.
+3. **No plain-language event-health line on the per-event page** equivalent to Event Studio's "Published · Ready" / "Needs attention".
+4. **Conversion numbers lack interpretation.** Brief wants "Are these good?" — answerable with existing data via simple deterministic bands (e.g. "Most views are converting" vs "Few views are converting yet") **without** inventing a score.
+
+---
+
+## 5. Empty states — required: *what happened / what it means / what to do next*
+
+| State | Current | Target (existing data + existing routes only) |
+|---|---|---|
+| No views yet | Section hidden | "No views yet. Your event needs to be seen before it can sell. → **Share event**" |
+| No attendees / no sales | Section hidden | "No bookings yet. This is normal for a newly published event. → **Share event** / **Grow event**" |
+| No insights | Region renders nothing | "Nothing needs your attention right now — your event is on track." |
+| Newly published | Near-blank page | "Your event is newly published. Numbers appear as people discover it. → **Share event**" |
+| Metrics failed to load | Sections vanish | Reuse view model's existing "Not available yet · Try again shortly" pattern |
+
+The dashboard already models this well (`empty_state` in the view model, `mel_analytics_events_empty`); the per-event page should adopt the same approach.
+
+---
+
+## 6. Event health interpretation (existing data only — no scoring, no estimates)
+
+Reuse the deterministic, tone-based pattern already in `EventStudioWorkspacePresentation::buildEventHealth()` and the encouraging copy style in `GrowthInsightService`. Allowed interpretive statements, all derivable from existing fields:
+
+- "Your event is newly published." (published recently, low/zero views)
+- "Your event is gaining interest." (views rising, mirrors existing `boost_traction` logic inputs)
+- "Bookings are increasing." (tickets/RSVPs trend `increasing` — already computed in `sales_velocity.trend`)
+- "Your event is almost full." (`percent_sold` near capacity — field already used by GrowthInsightService)
+- "Sales are slower than expected — more people need to see it." (mirrors existing `boost_slow_sales` threshold)
+
+No new thresholds invented where `myeventlane_growth.settings` already defines them (`slow_sales_percent`, `traction_percent`, `strong_event_min_filled`). **Reuse config, do not add a parallel scoring system.**
+
+---
+
+## 7. Growth actions (use existing routes only)
+
+| Situation | Action label | Existing route |
+|---|---|---|
+| Low/no views | Share event | (vendor share/event canonical URL — confirm in controller) |
+| Slow sales, boostable | Grow event / Boost | `myeventlane_boost.wizard.step1` |
+| Has attendees | View attendees | `myeventlane_vendor.console.audience` |
+| Event ended well | Duplicate event | `myeventlane_event.duplicate` |
+| View public listing | View event | event node canonical |
+
+All already used by `GrowthInsightService` — no new routes needed.
+
+---
+
+## 8. Accessibility audit
+
+| Check | Event Studio health | `/vendor/analytics` dashboard | Per-event advanced |
+|---|---|---|---|
+| Semantic regions / landmarks | ✅ `role="region"`, `aria-labelledby` | ✅ `aria-label`/`aria-labelledby` | ⚠️ generic `<div>`s, inline-styled |
+| Plain language | ✅ | ✅ | ❌ raw metrics |
+| Colour independence | ✅ tone class + text | ✅ | ❌ trend conveyed by colour + arrow only; hardcoded hex |
+| Chart alternative | n/a | n/a | ❌ time-series `<canvas>` has **no** table/text alt (funnel & ticket breakdown do have tables) |
+| Keyboard support | ✅ (links) | ✅ | ⚠️ links OK, but no focus styling guarantees with inline styles |
+| Contrast (tokens) | ✅ | ✅ | ❌ hardcoded greys (#666) on white, unverified |
+
+**Priority a11y fixes (per-event page):** (1) text alternative for the time-series chart, (2) trend not by colour alone, (3) move off inline styles/hardcoded hex onto MEL tokens.
+
+---
+
+## 9. Risks register (for the implementation phase)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Touching Commerce/Stripe/order data | High (forbidden) | All proposed changes are **presentation-layer only**; read existing view-model fields. No query/Commerce edits. |
+| Vendor data isolation regression | High | Do not alter `AnalyticsQueryGuard` / `AnalyticsScopeResolver`; rely on existing access checks. Per-event route already access-controlled. |
+| Multi-currency: hardcoded `$` | Medium | Replace with currency-aware formatting **only if** view model already exposes a formatted/currency value; otherwise document and leave. Do not introduce currency logic. |
+| Creating a parallel "scoring" system | Medium (forbidden) | Reuse `myeventlane_growth.settings` thresholds + existing `sales_velocity.trend`; deterministic statements only. |
+| Duplicating components / second token system | Medium | Reuse `mel-kpi-card`, event-health classes, MEL tokens (`DESIGN_SYSTEM.md`). No new parallel CSS systems. |
+| Surfacing GrowthInsights on dashboard changes behaviour | Medium | Treat as separate, optional step; gate behind explicit approval (it changes what organisers see). |
+| Three overlapping per-event analytics destinations | Low-Med | **Document only.** Do not merge/redirect routes in this pass (navigation/IA decision, needs product sign-off). |
+
+---
+
+## 10. Recommended changes (scoped, presentation-only)
+
+**Tier 1 — Quick wins (low risk, high clarity):**
+1. Add empty states to `analytics-event.html.twig` (what happened / what it means / what to do + existing-route CTA).
+2. Add a text alternative (visually-hidden table or summary) for the time-series chart.
+3. Make trend not colour-dependent (already has arrow + word — ensure the word is always present and not colour-only for meaning).
+
+**Tier 2 — Clarity & MEL feel:**
+4. Replace inline styles + hardcoded hex/`$` with MEL tokens and existing `mel-kpi-card` / analytics classes.
+5. Add a one-line plain-language **event-health summary** at the top of the per-event page, reusing `EventStudioWorkspacePresentation` patterns (deterministic, existing data).
+6. Add interpretive captions under conversion metrics ("Most views are converting" / "Few views converting yet") using existing thresholds.
+
+**Tier 3 — Connect existing guidance (needs explicit approval — changes what organisers see):**
+7. Populate the dashboard `insights` from `GrowthInsightService` (currently `[]`).
+
+**Out of scope / document only:** merging the three per-event destinations; any Commerce, Stripe, permission, entity, or third-party-analytics change; AI summaries.
+
+---
+
+## 11. Validation plan (run before commit)
+
+```bash
+git status --short
+ddev composer validate --check-lock     # composer validate --check-lock
+ddev drush cr
+# PHP lint on any changed PHP:
+find <changed php> -name '*.php' -print0 | xargs -0 -n1 php -l
+# Theme assets if SCSS/Twig touched:
+npm run mel:lint && npm run mel:build
+```
+
+No change should claim "validated" until these run.

--- a/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
+++ b/web/modules/custom/myeventlane_account/src/Service/AccountLinksService.php
@@ -123,7 +123,7 @@ final class AccountLinksService {
     $definitions = [
       [
         'id' => 'dashboard',
-        'title' => $this->t('Home'),
+        'title' => $this->t('Dashboard'),
         'url' => $dashboardUrl,
         'in_quick' => FALSE,
         'show_in_sidebar' => TRUE,

--- a/web/modules/custom/myeventlane_analytics/css/analytics.css
+++ b/web/modules/custom/myeventlane_analytics/css/analytics.css
@@ -1,38 +1,206 @@
 /**
  * @file
  * Styles for MyEventLane Analytics.
+ *
+ * Uses MEL runtime design tokens (vendor theme) only — no new tokens or
+ * ad-hoc colours. Meaning is never conveyed by colour alone.
  */
 
 .mel-analytics-dashboard,
 .mel-analytics-event {
-  max-width: 1200px;
+  max-width: var(--mel-max, 1200px);
   margin: 0 auto;
-  padding: 2rem;
+  padding: var(--mel-space-6, 2rem);
 }
 
 .mel-analytics-title {
   font-size: 2rem;
   font-weight: 700;
-  margin-bottom: 2rem;
-  color: #333;
+  margin-bottom: var(--mel-space-6, 2rem);
+  color: var(--mel-text);
 }
 
 .mel-section-title {
   font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 1.5rem;
-  color: #333;
+  margin-bottom: var(--mel-space-5, 1.5rem);
+  color: var(--mel-text);
+}
+
+/* Plain-language health line. */
+.mel-analytics-health {
+  background: var(--mel-surface);
+  border: var(--mel-border);
+  border-left: 4px solid var(--mel-muted);
+  border-radius: var(--mel-radius-2, 14px);
+  box-shadow: var(--mel-shadow-1);
+  padding: var(--mel-space-5, 1.5rem);
+  margin-bottom: var(--mel-space-6, 2rem);
+}
+
+.mel-analytics-health--ready,
+.mel-analytics-health--info {
+  border-left-color: var(--mel-accent);
+}
+
+.mel-analytics-health--attention {
+  border-left-color: var(--mel-coral);
+}
+
+.mel-analytics-health--muted {
+  border-left-color: var(--mel-muted);
+}
+
+.mel-analytics-health__headline {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  color: var(--mel-text);
+}
+
+.mel-analytics-health__detail {
+  margin: 0;
+  color: var(--mel-muted);
+}
+
+/* Next-step actions. */
+.mel-analytics-actions {
+  list-style: none;
+  margin: var(--mel-space-4, 1rem) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mel-space-3, 0.75rem);
+}
+
+/* Empty states. */
+.mel-analytics-empty {
+  background: var(--mel-surface);
+  border: var(--mel-border);
+  border-radius: var(--mel-radius-2, 14px);
+  box-shadow: var(--mel-shadow-1);
+  padding: var(--mel-space-6, 2rem);
+  text-align: center;
+}
+
+.mel-analytics-empty__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  color: var(--mel-text);
+}
+
+.mel-analytics-empty__text {
+  margin: 0 auto;
+  max-width: 48ch;
+  color: var(--mel-muted);
+}
+
+.mel-analytics-empty .mel-analytics-actions {
+  justify-content: center;
+}
+
+/* Summary cards. */
+.mel-analytics-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--mel-space-5, 1.5rem);
+  margin-bottom: var(--mel-space-6, 2rem);
 }
 
 .mel-analytics-card {
+  background: var(--mel-surface);
+  border: var(--mel-border);
+  border-radius: var(--mel-radius-1, 8px);
+  box-shadow: var(--mel-shadow-1);
+  padding: var(--mel-space-5, 1.5rem);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .mel-analytics-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--mel-shadow-2);
 }
 
+.mel-analytics-card__label {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--mel-muted);
+}
+
+.mel-analytics-card__value {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--mel-text);
+}
+
+.mel-analytics-card__value--trend {
+  font-size: 1.25rem;
+}
+
+.mel-analytics-card__value--down {
+  color: var(--mel-coral);
+}
+
+.mel-analytics-card__caption {
+  margin: var(--mel-space-2, 0.5rem) 0 0;
+  font-size: 0.8125rem;
+  color: var(--mel-muted);
+}
+
+/* Section panels. */
+.mel-analytics-section {
+  background: var(--mel-surface);
+  border: var(--mel-border);
+  border-radius: var(--mel-radius-1, 8px);
+  box-shadow: var(--mel-shadow-1);
+  padding: var(--mel-space-6, 2rem);
+  margin-bottom: var(--mel-space-6, 2rem);
+}
+
+.mel-analytics-section--attention {
+  border-left: 4px solid var(--mel-coral);
+}
+
+.mel-analytics-section__intro {
+  margin: 0 0 var(--mel-space-5, 1.5rem);
+  color: var(--mel-muted);
+}
+
+.mel-analytics-section__empty {
+  margin: 0;
+  color: var(--mel-muted);
+}
+
+/* Chart wrappers + table alternative. */
+.mel-analytics-chart {
+  position: relative;
+  height: 400px;
+}
+
+.mel-analytics-chart--funnel {
+  height: 300px;
+  margin-bottom: var(--mel-space-5, 1.5rem);
+}
+
+.mel-analytics-chart-alt {
+  margin-top: var(--mel-space-4, 1rem);
+}
+
+.mel-analytics-chart-alt > summary {
+  cursor: pointer;
+  color: var(--mel-focus);
+  font-weight: 600;
+}
+
+.mel-analytics-chart-alt__summary {
+  margin: var(--mel-space-3, 0.75rem) 0;
+  color: var(--mel-muted);
+}
+
+/* Tables. */
 .mel-table {
   width: 100%;
   border-collapse: collapse;
@@ -41,18 +209,51 @@
 .mel-table th {
   font-weight: 600;
   text-align: left;
-  padding: 1rem;
-  border-bottom: 2px solid #ddd;
-  background-color: #f5f5f5;
+  padding: var(--mel-space-4, 1rem);
+  border-bottom: 2px solid var(--mel-surface-2);
+  background-color: var(--mel-surface-2);
+  color: var(--mel-text);
 }
 
 .mel-table td {
-  padding: 1rem;
-  border-bottom: 1px solid #eee;
+  padding: var(--mel-space-4, 1rem);
+  border-bottom: var(--mel-border);
+  color: var(--mel-text);
 }
 
 .mel-table tr:hover {
-  background-color: #f9f9f9;
+  background-color: var(--mel-bg);
+}
+
+.mel-table__num {
+  text-align: right;
+}
+
+/* Funnel. */
+.mel-analytics-funnel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-4, 1rem);
+}
+
+.mel-analytics-funnel__stage {
+  background: var(--mel-surface-2);
+  border-radius: var(--mel-radius-1, 8px);
+  padding: var(--mel-space-4, 1rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mel-analytics-funnel__label {
+  font-weight: 600;
+  color: var(--mel-text);
+}
+
+.mel-analytics-funnel__count {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--mel-text);
 }
 
 .mel-funnel-stage {
@@ -69,27 +270,70 @@
   height: 0;
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid #f5f5f5;
+  border-top: 8px solid var(--mel-surface-2);
 }
 
 .mel-funnel-stage:last-child::after {
   display: none;
 }
 
+/* Conversion rates. */
+.mel-analytics-rates {
+  margin-top: var(--mel-space-5, 1.5rem);
+  padding-top: var(--mel-space-5, 1.5rem);
+  border-top: var(--mel-border);
+}
 
+.mel-analytics-rates__title {
+  font-size: 1rem;
+  margin: 0 0 var(--mel-space-4, 1rem);
+  color: var(--mel-text);
+}
 
+.mel-analytics-rates__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--mel-space-4, 1rem);
+}
 
+.mel-analytics-rate__label {
+  font-size: 0.875rem;
+  color: var(--mel-muted);
+}
 
+.mel-analytics-rate__value {
+  margin: var(--mel-space-1, 0.25rem) 0 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--mel-text);
+}
 
+.mel-analytics-rates__caption {
+  margin: var(--mel-space-4, 1rem) 0 0;
+  color: var(--mel-muted);
+}
 
+/* Bottlenecks. */
+.mel-analytics-bottleneck {
+  background: var(--mel-surface-2);
+  border-radius: var(--mel-radius-1, 8px);
+  padding: var(--mel-space-4, 1rem);
+  margin-bottom: var(--mel-space-4, 1rem);
+}
 
+.mel-analytics-bottleneck__title {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--mel-text);
+}
 
+.mel-analytics-bottleneck__rate {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  color: var(--mel-muted);
+}
 
-
-
-
-
-
-
-
-
+.mel-analytics-bottleneck__rec {
+  margin: 0;
+  color: var(--mel-text);
+}

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.theme
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.theme
@@ -12,8 +12,11 @@ function myeventlane_analytics_theme(): array {
   return [
     'myeventlane_analytics_dashboard' => [
       'variables' => [
+        'analytics_model' => [],
         'summary_stats' => [],
         'event_analytics' => [],
+        // Presentation-only: existing GrowthInsightService cards, surfaced here.
+        'growth_cards' => [],
       ],
       'template' => 'analytics-dashboard',
     ],
@@ -27,6 +30,13 @@ function myeventlane_analytics_theme(): array {
         'bottlenecks' => [],
         'total_revenue' => 0.0,
         'total_tickets' => 0,
+        'workspace_back_url' => NULL,
+        'vendor_analytics_home_url' => NULL,
+        'export_pdf_url' => NULL,
+        'export_excel_url' => NULL,
+        // Presentation-only: plain-language health line + next-step actions.
+        'event_health' => [],
+        'growth_actions' => [],
       ],
       'template' => 'analytics-event',
     ],

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_analytics\Controller;
 use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -17,6 +18,8 @@ use Drupal\myeventlane_analytics\Service\ConversionAnalyticsService;
 use Drupal\myeventlane_analytics\Service\ReportGeneratorService;
 use Drupal\myeventlane_analytics\Service\SalesAnalyticsService;
 use Drupal\myeventlane_analytics\Service\VendorAnalyticsViewModelBuilder;
+use Drupal\myeventlane_growth\Service\GrowthInsightService;
+use Drupal\myeventlane_growth\Service\GrowthTrackingService;
 use Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\myeventlane_core\Service\DomainDetector;
@@ -47,6 +50,10 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     private readonly VendorAnalyticsViewModelBuilder $vendorAnalyticsViewModelBuilder,
     private readonly EventVendorAccessChecker $eventAccessChecker,
     private readonly AccessManagerInterface $accessManager,
+    // Optional: existing growth guidance, surfaced (not recomputed) on the dashboard.
+    private readonly ?GrowthInsightService $growthInsight = NULL,
+    private readonly ?GrowthTrackingService $growthTracking = NULL,
+    private readonly ?CsrfTokenGenerator $csrfToken = NULL,
   ) {
     parent::__construct($domainDetector, $currentUser, $messenger);
   }
@@ -66,6 +73,9 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
       $container->get('myeventlane_analytics.vendor_view_model_builder'),
       $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('access_manager'),
+      $container->has('myeventlane_growth.insight') ? $container->get('myeventlane_growth.insight') : NULL,
+      $container->has('myeventlane_growth.tracking') ? $container->get('myeventlane_growth.tracking') : NULL,
+      $container->get('csrf_token'),
     );
   }
 
@@ -85,6 +95,24 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
       }
     }
 
+    // Presentation-only: surface existing GrowthInsightService guidance. The
+    // service performs its own deterministic calculations and DB-backed counts;
+    // we pass no recomputed event metrics (events => []) so nothing is invented.
+    $growthCards = $this->buildGrowthCards();
+
+    $libraries = [
+      'myeventlane_vendor_theme/global-styling',
+      'myeventlane_analytics/analytics',
+    ];
+    $drupalSettings = [];
+    if ($growthCards !== [] && $this->csrfToken) {
+      $libraries[] = 'myeventlane_growth/dashboard_cards';
+      $drupalSettings['melGrowth'] = [
+        'dismissUrl' => Url::fromRoute('myeventlane_growth.dismiss')->toString(TRUE)->getGeneratedUrl(),
+        'csrfToken' => $this->csrfToken->get('rest'),
+      ];
+    }
+
     return $this->buildVendorPage('myeventlane_vendor_console_page', [
       'title' => $analyticsModel['title'] ?? 'Insights',
       'body' => [
@@ -92,12 +120,11 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
         '#analytics_model' => $analyticsModel,
         '#summary_stats' => [],
         '#event_analytics' => [],
+        '#growth_cards' => $growthCards,
       ],
       '#attached' => [
-        'library' => [
-          'myeventlane_vendor_theme/global-styling',
-          'myeventlane_analytics/analytics',
-        ],
+        'library' => $libraries,
+        'drupalSettings' => $drupalSettings,
       ],
       '#cache' => [
         'contexts' => ['user'],
@@ -105,6 +132,60 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
         'max-age' => 300,
       ],
     ]);
+  }
+
+  /**
+   * Surfaces existing organiser growth insights (no new logic or data).
+   *
+   * Reuses GrowthInsightService calculations and myeventlane_growth.settings.
+   * Account-level rules (Pro nudges, retention, engagement) apply; per-event
+   * Boost rules are intentionally inactive here because we do not recompute
+   * per-event metric rows on this surface.
+   *
+   * @return array<int, array<string, mixed>>
+   */
+  private function buildGrowthCards(): array {
+    if (!$this->growthInsight) {
+      return [];
+    }
+
+    $uid = (int) $this->currentUser->id();
+    try {
+      $cards = $this->growthInsight->buildInsights([
+        'uid' => $uid,
+        'account' => $this->currentUser,
+        'surface' => 'analytics',
+        'events' => [],
+      ]);
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('myeventlane_analytics')->warning('Growth cards failed on analytics: @m', ['@m' => $e->getMessage()]);
+      return [];
+    }
+
+    if ($cards === [] || !$this->growthTracking) {
+      return $cards;
+    }
+
+    // Record impressions exactly as the dashboard does, so cooldowns advance.
+    foreach ($cards as $card) {
+      if (!is_array($card)) {
+        continue;
+      }
+      $eid = isset($card['event_id']) ? (int) $card['event_id'] : NULL;
+      if ($eid !== NULL && $eid <= 0) {
+        $eid = NULL;
+      }
+      $this->growthTracking->recordImpression(
+        (string) ($card['key'] ?? ''),
+        $uid,
+        $eid,
+        'analytics',
+        ['title' => (string) ($card['title'] ?? '')],
+      );
+    }
+
+    return $cards;
   }
 
   /**
@@ -143,6 +224,13 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     $exportPdfUrl = $this->safeExportUrl('myeventlane_analytics.export_pdf', ['node' => $eventId]);
     $exportExcelUrl = $this->safeExportUrl('myeventlane_analytics.export_excel', ['node' => $eventId]);
 
+    // Presentation-only: turn existing metrics into a plain-language health
+    // line and existing-route next actions. No new metrics or thresholds.
+    $views = (int) ($conversionFunnel['views'] ?? 0);
+    $trend = (string) ($salesVelocity['trend'] ?? 'stable');
+    $eventHealth = $this->buildEventHealthLine($node, $totalTickets, $views, $trend);
+    $growthActions = $this->buildGrowthActions($eventId);
+
     return $this->buildVendorPage('myeventlane_vendor_console_page', [
       'title' => 'Insights: ' . $node->label(),
       'body' => [
@@ -159,6 +247,8 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
         '#bottlenecks' => $bottlenecks,
         '#total_revenue' => $totalRevenue,
         '#total_tickets' => $totalTickets,
+        '#event_health' => $eventHealth,
+        '#growth_actions' => $growthActions,
       ],
       '#attached' => [
         'library' => [
@@ -265,6 +355,84 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     }
 
     return AccessResult::forbidden('You do not have access to view analytics for this event.');
+  }
+
+  /**
+   * Plain-language event health line derived from existing metrics only.
+   *
+   * Maps the already-computed sales velocity trend and current totals onto a
+   * human sentence. No thresholds, scoring, or data fetching are introduced.
+   *
+   * @return array{headline: string, detail: string, tone: string}
+   */
+  private function buildEventHealthLine(NodeInterface $node, int $totalTickets, int $views, string $trend): array {
+    if (!$node->isPublished()) {
+      return [
+        'headline' => (string) $this->t('This event is a draft.'),
+        'detail' => (string) $this->t('Publish it so people can find and book.'),
+        'tone' => 'muted',
+      ];
+    }
+
+    if ($totalTickets <= 0 && $views <= 0) {
+      return [
+        'headline' => (string) $this->t('Your event is newly published.'),
+        'detail' => (string) $this->t('Numbers appear here as people discover it. Sharing helps it get seen.'),
+        'tone' => 'info',
+      ];
+    }
+
+    if ($totalTickets <= 0 && $views > 0) {
+      return [
+        'headline' => (string) $this->t('Your event is gaining interest.'),
+        'detail' => (string) $this->t('People are viewing it — a nudge can turn interest into bookings.'),
+        'tone' => 'info',
+      ];
+    }
+
+    if ($trend === 'increasing') {
+      return [
+        'headline' => (string) $this->t('Bookings are increasing.'),
+        'detail' => (string) $this->t('Momentum is building. Keep sharing to make the most of it.'),
+        'tone' => 'ready',
+      ];
+    }
+
+    if ($trend === 'decreasing') {
+      return [
+        'headline' => (string) $this->t('Sales have slowed recently.'),
+        'detail' => (string) $this->t('A fresh share or a boost can help more people see it.'),
+        'tone' => 'attention',
+      ];
+    }
+
+    return [
+      'headline' => (string) $this->t('Your event is ticking along steadily.'),
+      'detail' => (string) $this->t('Bookings are steady. Sharing again can lift them further.'),
+      'tone' => 'ready',
+    ];
+  }
+
+  /**
+   * Next-step actions using existing, access-checked routes only.
+   *
+   * @return array<int, array{label: string, url: string}>
+   */
+  private function buildGrowthActions(int $eventId): array {
+    $candidates = [
+      [(string) $this->t('Grow event'), 'myeventlane_boost.wizard.step1', ['event' => $eventId]],
+      [(string) $this->t('View attendees'), 'myeventlane_vendor.console.audience', []],
+      [(string) $this->t('View event'), 'entity.node.canonical', ['node' => $eventId]],
+    ];
+
+    $actions = [];
+    foreach ($candidates as [$label, $route, $params]) {
+      $url = $this->safeExportUrl($route, $params);
+      if ($url !== NULL) {
+        $actions[] = ['label' => $label, 'url' => $url];
+      }
+    }
+    return $actions;
   }
 
   /**

--- a/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
@@ -52,6 +52,36 @@
     </section>
   {% endif %}
 
+  {# Existing organiser guidance (GrowthInsightService) — reuses the canonical
+     mel-growth-card component. Kept outside the Pro lock so upgrade nudges show. #}
+  {% if growth_cards is defined and growth_cards|length > 0 %}
+    <section class="mel-vendor-analytics-v2__guidance" aria-labelledby="mel-analytics-guidance-title">
+      <h2 id="mel-analytics-guidance-title" class="mel-vendor-analytics-v2__section-title">{{ 'Suggestions for you'|t }}</h2>
+      <ul class="mel-growth-stack" role="list">
+        {% for card in growth_cards %}
+          <li>
+            <article class="mel-growth-card {{ card.card_class|default('') }}" role="listitem" data-insight-key="{{ card.key }}"{% if card.event_id is defined and card.event_id %} data-event-id="{{ card.event_id }}"{% endif %}>
+              <div class="mel-growth-card__body">
+                <h3 class="mel-growth-card__title">{{ card.title }}</h3>
+                <p class="mel-growth-card__message">{{ card.message }}</p>
+                <div class="mel-growth-card__actions">
+                  {% if card.cta_track_url %}
+                    <a href="{{ card.cta_track_url }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                  {% elseif card.cta_route %}
+                    <a href="{{ path(card.cta_route, card.cta_params|default({})) }}" class="mel-btn mel-btn--secondary">{{ 'View'|t }}</a>
+                  {% endif %}
+                </div>
+              </div>
+              {% if card.dismissible %}
+                <button type="button" class="mel-growth-card__dismiss" data-mel-growth-dismiss aria-label="{{ 'Dismiss suggestion'|t }}">{{ 'Dismiss'|t }}</button>
+              {% endif %}
+            </article>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
   <div class="mel-analytics-lock-wrapper{% if is_pro is defined and not is_pro %} mel-analytics-lock-wrapper--locked{% endif %}">
 
     {% if is_pro is defined and not is_pro %}

--- a/web/modules/custom/myeventlane_analytics/templates/analytics-event.html.twig
+++ b/web/modules/custom/myeventlane_analytics/templates/analytics-event.html.twig
@@ -12,8 +12,15 @@
  * - bottlenecks: Conversion bottlenecks.
  * - total_revenue: Total revenue.
  * - total_tickets: Total tickets sold.
+ * - event_health: { headline, detail, tone } plain-language summary.
+ * - growth_actions: list of { label, url } next-step actions (existing routes).
+ *
+ * Note: presentation-only. Interpretations are derived from the values above;
+ * no metrics, thresholds, or currency logic are computed in this template.
  */
 #}
+{% set has_any_data = total_tickets > 0 or (conversion_funnel and conversion_funnel.views|default(0) > 0) or time_series is not empty %}
+
 <div class="mel-analytics-event mel-vendor-analytics-v2">
 
   <header class="mel-vendor-analytics-v2__legacy-toolbar mel-analytics-event__toolbar">
@@ -43,138 +50,168 @@
     {% endif %}
   </header>
 
+  {# Plain-language health line + next steps. #}
+  {% if event_health.headline is defined and event_health.headline %}
+    <section class="mel-analytics-health mel-analytics-health--{{ event_health.tone|default('info')|clean_class }}" aria-labelledby="mel-analytics-health-title" role="region">
+      <h2 id="mel-analytics-health-title" class="mel-analytics-health__headline">{{ event_health.headline }}</h2>
+      {% if event_health.detail %}
+        <p class="mel-analytics-health__detail">{{ event_health.detail }}</p>
+      {% endif %}
+      {% if growth_actions is defined and growth_actions|length > 0 %}
+        <ul class="mel-analytics-actions" role="list">
+          {% for action in growth_actions %}
+            <li><a href="{{ action.url }}" class="mel-btn mel-btn-primary">{{ action.label }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {# Whole-page empty state for a published event with nothing to show yet. #}
+  {% if not has_any_data %}
+    <section class="mel-analytics-empty" role="region" aria-label="{{ 'No data yet'|t }}">
+      <h2 class="mel-analytics-empty__title">{{ 'No numbers yet'|t }}</h2>
+      <p class="mel-analytics-empty__text">{{ 'This is normal for a newly published event. Views, bookings, and sales will appear here as people discover it.'|t }}</p>
+      {% if growth_actions is defined and growth_actions|length > 0 %}
+        <ul class="mel-analytics-actions" role="list">
+          {% for action in growth_actions %}
+            <li><a href="{{ action.url }}" class="mel-btn mel-btn-primary">{{ action.label }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </section>
+  {% else %}
+
   {# Summary Cards #}
-  <div class="mel-analytics-summary" style="
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  ">
-    <div class="mel-analytics-card" style="
-      background: white;
-      padding: 1.5rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    ">
-      <h3 style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #666; font-weight: 600;">{{ 'Total Revenue'|t }}</h3>
-      <p style="margin: 0; font-size: 2rem; font-weight: 700; color: #28a745;">${{ total_revenue|number_format(2) }}</p>
+  <div class="mel-analytics-summary">
+    <div class="mel-analytics-card">
+      <h3 class="mel-analytics-card__label">{{ 'Total Revenue'|t }}</h3>
+      <p class="mel-analytics-card__value mel-analytics-card__value--revenue">${{ total_revenue|number_format(2) }}</p>
     </div>
 
-    <div class="mel-analytics-card" style="
-      background: white;
-      padding: 1.5rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    ">
-      <h3 style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #666; font-weight: 600;">{{ 'Tickets Sold'|t }}</h3>
-      <p style="margin: 0; font-size: 2rem; font-weight: 700; color: #333;">{{ total_tickets }}</p>
+    <div class="mel-analytics-card">
+      <h3 class="mel-analytics-card__label">{{ 'Tickets Sold'|t }}</h3>
+      <p class="mel-analytics-card__value">{{ total_tickets }}</p>
     </div>
 
-    <div class="mel-analytics-card" style="
-      background: white;
-      padding: 1.5rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    ">
-      <h3 style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #666; font-weight: 600;">{{ 'Average per Day'|t }}</h3>
-      <p style="margin: 0; font-size: 2rem; font-weight: 700; color: #333;">{{ sales_velocity.average_per_day }}</p>
+    <div class="mel-analytics-card">
+      <h3 class="mel-analytics-card__label">{{ 'Average per Day'|t }}</h3>
+      <p class="mel-analytics-card__value">{{ sales_velocity.average_per_day }}</p>
+      <p class="mel-analytics-card__caption">{{ 'Tickets sold per day since this event was published.'|t }}</p>
     </div>
 
-    <div class="mel-analytics-card" style="
-      background: white;
-      padding: 1.5rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    ">
-      <h3 style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #666; font-weight: 600;">{{ 'Sales Trend'|t }}</h3>
-      <p style="margin: 0; font-size: 1.25rem; font-weight: 700; color: {% if sales_velocity.trend == 'increasing' %}#28a745{% elseif sales_velocity.trend == 'decreasing' %}#dc3545{% else %}#666{% endif %};">
-        {% if sales_velocity.trend == 'increasing' %}
-          ↗ {{ 'Increasing'|t }}
-        {% elseif sales_velocity.trend == 'decreasing' %}
-          ↘ {{ 'Decreasing'|t }}
-        {% else %}
-          → {{ 'Stable'|t }}
-        {% endif %}
-      </p>
+    <div class="mel-analytics-card">
+      <h3 class="mel-analytics-card__label">{{ 'Sales Trend'|t }}</h3>
+      {% if sales_velocity.trend == 'increasing' %}
+        <p class="mel-analytics-card__value mel-analytics-card__value--trend mel-analytics-card__value--up">
+          <span aria-hidden="true">↗</span> {{ 'Increasing'|t }}
+        </p>
+        <p class="mel-analytics-card__caption">{{ 'Bookings are picking up.'|t }}</p>
+      {% elseif sales_velocity.trend == 'decreasing' %}
+        <p class="mel-analytics-card__value mel-analytics-card__value--trend mel-analytics-card__value--down">
+          <span aria-hidden="true">↘</span> {{ 'Decreasing'|t }}
+        </p>
+        <p class="mel-analytics-card__caption">{{ 'Bookings have slowed recently.'|t }}</p>
+      {% else %}
+        <p class="mel-analytics-card__value mel-analytics-card__value--trend mel-analytics-card__value--stable">
+          <span aria-hidden="true">→</span> {{ 'Stable'|t }}
+        </p>
+        <p class="mel-analytics-card__caption">{{ 'Bookings are holding steady.'|t }}</p>
+      {% endif %}
     </div>
   </div>
 
   {# Time Series Chart #}
-  {% if time_series is not empty %}
-    <section class="mel-analytics-section" style="
-      background: white;
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      margin-bottom: 2rem;
-    ">
-      <h2 class="mel-section-title">{{ 'Sales Over Time'|t }}</h2>
-      <div style="position: relative; height: 400px;">
-        <canvas id="analytics-time-series-chart"></canvas>
+  <section class="mel-analytics-section">
+    <h2 class="mel-section-title">{{ 'Sales Over Time'|t }}</h2>
+    {% if time_series is not empty %}
+      <div class="mel-analytics-chart">
+        <canvas id="analytics-time-series-chart" aria-describedby="mel-analytics-time-series-table-summary"></canvas>
       </div>
-    </section>
-  {% endif %}
+      {# Text alternative for the canvas chart (keyboard + screen-reader accessible). #}
+      <details class="mel-analytics-chart-alt">
+        <summary>{{ 'View this chart as a table'|t }}</summary>
+        <p id="mel-analytics-time-series-table-summary" class="mel-analytics-chart-alt__summary">{{ 'Tickets sold and revenue by day.'|t }}</p>
+        <table class="mel-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ 'Date'|t }}</th>
+              <th scope="col">{{ 'Tickets'|t }}</th>
+              <th scope="col">{{ 'Revenue'|t }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for point in time_series %}
+              <tr>
+                <td>{{ point.date }}</td>
+                <td>{{ point.ticket_count }}</td>
+                <td>${{ point.revenue|number_format(2) }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </details>
+    {% else %}
+      <p class="mel-analytics-section__empty">{{ 'No sales recorded yet. Once people start booking, your daily sales will appear here.'|t }}</p>
+    {% endif %}
+  </section>
 
   {# Conversion Funnel #}
   {% if conversion_funnel %}
-    <section class="mel-analytics-section" style="
-      background: white;
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      margin-bottom: 2rem;
-    ">
+    <section class="mel-analytics-section">
       <h2 class="mel-section-title">{{ 'Conversion Funnel'|t }}</h2>
-      
-      {# Chart visualization #}
-      <div style="position: relative; height: 300px; margin-bottom: 2rem;">
-        <canvas id="analytics-conversion-funnel-chart"></canvas>
+      <p class="mel-analytics-section__intro">{{ 'How many people moved from viewing your event to completing a booking.'|t }}</p>
+
+      <div class="mel-analytics-chart mel-analytics-chart--funnel">
+        <canvas id="analytics-conversion-funnel-chart" aria-hidden="true"></canvas>
       </div>
-      
-      <div class="mel-funnel" style="display: flex; flex-direction: column; gap: 1rem;">
+
+      <div class="mel-analytics-funnel">
         {% set stages = [
-          {'key': 'views', 'label': 'Event Views', 'count': conversion_funnel.views},
-          {'key': 'cart_additions', 'label': 'Added to Cart', 'count': conversion_funnel.cart_additions},
-          {'key': 'checkout_started', 'label': 'Checkout Started', 'count': conversion_funnel.checkout_started},
-          {'key': 'completed', 'label': 'Completed', 'count': conversion_funnel.completed},
+          {'key': 'views', 'label': 'Event Views'|t, 'count': conversion_funnel.views},
+          {'key': 'cart_additions', 'label': 'Added to Cart'|t, 'count': conversion_funnel.cart_additions},
+          {'key': 'checkout_started', 'label': 'Checkout Started'|t, 'count': conversion_funnel.checkout_started},
+          {'key': 'completed', 'label': 'Completed'|t, 'count': conversion_funnel.completed},
         ] %}
-        
         {% for stage in stages %}
-          <div class="mel-funnel-stage" style="
-            background: #f5f5f5;
-            padding: 1rem;
-            border-radius: 4px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-          ">
-            <span style="font-weight: 600;">{{ stage.label }}</span>
-            <span style="font-size: 1.25rem; font-weight: 700;">{{ stage.count }}</span>
+          <div class="mel-analytics-funnel__stage mel-funnel-stage">
+            <span class="mel-analytics-funnel__label">{{ stage.label }}</span>
+            <span class="mel-analytics-funnel__count">{{ stage.count }}</span>
           </div>
         {% endfor %}
       </div>
 
       {% if conversion_funnel.conversion_rates %}
-        <div style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;">
-          <h3 style="font-size: 1rem; margin-bottom: 1rem;">{{ 'Conversion Rates'|t }}</h3>
-          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
-            <div>
-              <span style="font-size: 0.875rem; color: #666;">{{ 'Views to Cart'|t }}</span>
-              <p style="margin: 0.25rem 0 0 0; font-size: 1.5rem; font-weight: 700;">{{ conversion_funnel.conversion_rates.views_to_cart }}%</p>
+        {% set overall = conversion_funnel.conversion_rates.overall %}
+        <div class="mel-analytics-rates">
+          <h3 class="mel-analytics-rates__title">{{ 'Conversion Rates'|t }}</h3>
+          <div class="mel-analytics-rates__grid">
+            <div class="mel-analytics-rate">
+              <span class="mel-analytics-rate__label">{{ 'Views to Cart'|t }}</span>
+              <p class="mel-analytics-rate__value">{{ conversion_funnel.conversion_rates.views_to_cart }}%</p>
             </div>
-            <div>
-              <span style="font-size: 0.875rem; color: #666;">{{ 'Cart to Checkout'|t }}</span>
-              <p style="margin: 0.25rem 0 0 0; font-size: 1.5rem; font-weight: 700;">{{ conversion_funnel.conversion_rates.cart_to_checkout }}%</p>
+            <div class="mel-analytics-rate">
+              <span class="mel-analytics-rate__label">{{ 'Cart to Checkout'|t }}</span>
+              <p class="mel-analytics-rate__value">{{ conversion_funnel.conversion_rates.cart_to_checkout }}%</p>
             </div>
-            <div>
-              <span style="font-size: 0.875rem; color: #666;">{{ 'Checkout to Complete'|t }}</span>
-              <p style="margin: 0.25rem 0 0 0; font-size: 1.5rem; font-weight: 700;">{{ conversion_funnel.conversion_rates.checkout_to_complete }}%</p>
+            <div class="mel-analytics-rate">
+              <span class="mel-analytics-rate__label">{{ 'Checkout to Complete'|t }}</span>
+              <p class="mel-analytics-rate__value">{{ conversion_funnel.conversion_rates.checkout_to_complete }}%</p>
             </div>
-            <div>
-              <span style="font-size: 0.875rem; color: #666;">{{ 'Overall Conversion'|t }}</span>
-              <p style="margin: 0.25rem 0 0 0; font-size: 1.5rem; font-weight: 700;">{{ conversion_funnel.conversion_rates.overall }}%</p>
+            <div class="mel-analytics-rate">
+              <span class="mel-analytics-rate__label">{{ 'Overall Conversion'|t }}</span>
+              <p class="mel-analytics-rate__value">{{ overall }}%</p>
             </div>
           </div>
+          {# Plain-language explanation of what the rate means — no invented
+             benchmark or threshold; only distinguishes "have views" vs not. #}
+          <p class="mel-analytics-rates__caption">
+            {% if overall is null or conversion_funnel.views|default(0) <= 0 %}
+              {{ 'Not enough views yet to read a conversion rate. Sharing your event will help.'|t }}
+            {% else %}
+              {{ 'Overall conversion is the share of viewers who completed a booking. Sharing again keeps it growing.'|t }}
+            {% endif %}
+          </p>
         </div>
       {% endif %}
     </section>
@@ -182,34 +219,27 @@
 
   {# Ticket Breakdown #}
   {% if ticket_breakdown is not empty %}
-    <section class="mel-analytics-section" style="
-      background: white;
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      margin-bottom: 2rem;
-    ">
+    <section class="mel-analytics-section">
       <h2 class="mel-section-title">{{ 'Ticket Type Breakdown'|t }}</h2>
-      
-      {# Chart visualization #}
-      <div style="position: relative; height: 300px; margin-bottom: 2rem;">
-        <canvas id="analytics-ticket-breakdown-chart"></canvas>
+
+      <div class="mel-analytics-chart mel-analytics-chart--funnel">
+        <canvas id="analytics-ticket-breakdown-chart" aria-hidden="true"></canvas>
       </div>
-      
-      <table class="mel-table" style="width: 100%; border-collapse: collapse;">
+
+      <table class="mel-table">
         <thead>
-          <tr style="background-color: #f5f5f5;">
-            <th style="padding: 1rem; text-align: left; border-bottom: 2px solid #ddd;">{{ 'Ticket Type'|t }}</th>
-            <th style="padding: 1rem; text-align: right; border-bottom: 2px solid #ddd;">{{ 'Sold'|t }}</th>
-            <th style="padding: 1rem; text-align: right; border-bottom: 2px solid #ddd;">{{ 'Revenue'|t }}</th>
+          <tr>
+            <th scope="col">{{ 'Ticket Type'|t }}</th>
+            <th scope="col" class="mel-table__num">{{ 'Sold'|t }}</th>
+            <th scope="col" class="mel-table__num">{{ 'Revenue'|t }}</th>
           </tr>
         </thead>
         <tbody>
           {% for ticket in ticket_breakdown %}
-            <tr style="border-bottom: 1px solid #eee;">
-              <td style="padding: 1rem; font-weight: 600;">{{ ticket.ticket_type }}</td>
-              <td style="padding: 1rem; text-align: right;">{{ ticket.sold }}</td>
-              <td style="padding: 1rem; text-align: right; font-weight: 600; color: #28a745;">${{ ticket.revenue|number_format(2) }}</td>
+            <tr>
+              <td>{{ ticket.ticket_type }}</td>
+              <td class="mel-table__num">{{ ticket.sold }}</td>
+              <td class="mel-table__num mel-table__num--revenue">${{ ticket.revenue|number_format(2) }}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -217,34 +247,22 @@
     </section>
   {% endif %}
 
-  {# Bottlenecks #}
+  {# Bottlenecks (already guidance: each has a recommendation). #}
   {% if bottlenecks is not empty %}
-    <section class="mel-analytics-section" style="
-      background: #fff3cd;
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      margin-bottom: 2rem;
-      border-left: 4px solid #ffc107;
-    ">
-      <h2 class="mel-section-title">{{ 'Conversion Bottlenecks'|t }}</h2>
-      
+    <section class="mel-analytics-section mel-analytics-section--attention">
+      <h2 class="mel-section-title">{{ 'Where people drop off'|t }}</h2>
       {% for bottleneck in bottlenecks %}
-        <div style="margin-bottom: 1rem; padding: 1rem; background: white; border-radius: 4px;">
-          <h3 style="margin: 0 0 0.5rem 0; font-size: 1rem; font-weight: 600;">{{ bottleneck.label }}</h3>
-          <p style="margin: 0 0 0.5rem 0; color: #666;">
+        <div class="mel-analytics-bottleneck">
+          <h3 class="mel-analytics-bottleneck__title">{{ bottleneck.label }}</h3>
+          <p class="mel-analytics-bottleneck__rate">
             <strong>{{ 'Drop-off rate:'|t }}</strong> {{ bottleneck.drop_off_rate }}%
           </p>
-          <p style="margin: 0; color: #333;">{{ bottleneck.recommendation }}</p>
+          <p class="mel-analytics-bottleneck__rec">{{ bottleneck.recommendation }}</p>
         </div>
       {% endfor %}
     </section>
   {% endif %}
 
+  {% endif %}{# has_any_data #}
+
 </div>
-
-
-
-
-
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what organisers see (growth cards + impressions/cooldowns) and relies on optional `myeventlane_growth`; analytics access and data paths are unchanged but UX behaviour is user-facing.
> 
> **Overview**
> Adds **`docs/audits/event-health-insights-audit.md`**, documenting gaps and a presentation-only plan to align per-event analytics with existing MEL guidance patterns.
> 
> **Vendor analytics (`myeventlane_analytics`):** The dashboard now surfaces **`GrowthInsightService`** cards (“Suggestions for you”) via optional growth services, dismiss JS/settings, and impression tracking on the `analytics` surface. Per-event **Advanced analytics** gets a plain-language **event health** block and **next-step CTAs** (Grow, attendees, public event) from existing routes, built in `AnalyticsDashboardController` from current funnel/velocity totals—no new queries or scoring.
> 
> **Per-event template/CSS:** Replaces inline styles and hardcoded colours with **MEL token–based** `analytics.css` (health, empty states, sections, funnel, bottlenecks). Twig adds **empty states**, metric **captions**, trend text not colour-only, a **collapsible table** alt for the time-series chart, and section-level “no data” copy. Theme hook variables extended for `growth_cards`, `event_health`, and `growth_actions`.
> 
> **Minor:** Customer hub nav label **Home → Dashboard** in `AccountLinksService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba54344c7c2dcba5804e4ca91a164d94fb68de32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->