### PR TITLE
fix(analytics): register event-health/growth vars in live hook_theme

### DIFF
--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.module
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.module
@@ -18,6 +18,8 @@ function myeventlane_analytics_theme(): array {
         'summary_stats' => [],
         'event_analytics' => [],
         'mel_analytics_events_empty' => NULL,
+        // Presentation-only: existing GrowthInsightService cards, surfaced here.
+        'growth_cards' => [],
       ],
       'template' => 'analytics-dashboard',
     ],
@@ -35,6 +37,9 @@ function myeventlane_analytics_theme(): array {
         'bottlenecks' => [],
         'total_revenue' => 0.0,
         'total_tickets' => 0,
+        // Presentation-only: plain-language health line + next-step actions.
+        'event_health' => [],
+        'growth_actions' => [],
       ],
       'template' => 'analytics-event',
     ],

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.theme
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.theme
@@ -12,11 +12,8 @@ function myeventlane_analytics_theme(): array {
   return [
     'myeventlane_analytics_dashboard' => [
       'variables' => [
-        'analytics_model' => [],
         'summary_stats' => [],
         'event_analytics' => [],
-        // Presentation-only: existing GrowthInsightService cards, surfaced here.
-        'growth_cards' => [],
       ],
       'template' => 'analytics-dashboard',
     ],
@@ -30,13 +27,6 @@ function myeventlane_analytics_theme(): array {
         'bottlenecks' => [],
         'total_revenue' => 0.0,
         'total_tickets' => 0,
-        'workspace_back_url' => NULL,
-        'vendor_analytics_home_url' => NULL,
-        'export_pdf_url' => NULL,
-        'export_excel_url' => NULL,
-        // Presentation-only: plain-language health line + next-step actions.
-        'event_health' => [],
-        'growth_actions' => [],
       ],
       'template' => 'analytics-event',
     ],


### PR DESCRIPTION
The prior auto-commit added the new theme variables to the dead myeventlane_analytics.theme file (modules load hook_theme from .module, not .theme), so event_health, growth_actions and growth_cards never reached their templates. Declare them in the live .module hook_theme and restore the inert .theme file to its original state.

Presentation-only: no Commerce/Stripe/permission/entity changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme variable registration only; no business logic, permissions, or commerce changes.
> 
> **Overview**
> **Fixes analytics UI data not reaching Twig** by declaring presentation variables on the **active** `hook_theme()` in `myeventlane_analytics.module` instead of the unused duplicate in `myeventlane_analytics.theme`.
> 
> The dashboard theme now exposes **`growth_cards`**; the per-event analytics theme exposes **`event_health`** and **`growth_actions`**, matching what controllers already pass into `#theme` render arrays. The `.theme` copy of `hook_theme()` is rolled back so it no longer lists those vars (or the extra event URL/export keys that were only added there), avoiding a misleading second definition that Drupal never loads for this module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf702779a8e0ed3a9fdbdb15cd6327da082389d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->