### PR TITLE
Feature/mel public visitor navigation

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -882,10 +882,10 @@ final class VendorDashboardViewModelBuilder {
   private function attendeeSummary(int $ticketsSold, int $rsvpCount): string {
     $parts = [];
     if ($ticketsSold > 0) {
-      $parts[] = (string) $this->t('@count tickets sold', ['@count' => $ticketsSold]);
+      $parts[] = (string) $this->formatPlural($ticketsSold, '1 ticket sold', '@count tickets sold');
     }
     if ($rsvpCount > 0) {
-      $parts[] = (string) $this->t('@count RSVPs received', ['@count' => $rsvpCount]);
+      $parts[] = (string) $this->formatPlural($rsvpCount, '1 RSVP received', '@count RSVPs received');
     }
     if ($parts === []) {
       return (string) $this->t('No attendee activity yet.');

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -531,7 +531,7 @@ function myeventlane_theme_preprocess_site_header(array &$variables): void {
   $base_path = base_path();
 
   // Branding: logo link (PNG wordmark; SVG icon retained for legacy surfaces).
-  $logo_path = $base_path . $theme_path . '/images/logo.png';
+  $logo_path = $base_path . $theme_path . '/images/logo.webp';
   $variables['branding'] = [
     '#type' => 'link',
     '#title' => [

--- a/web/themes/custom/myeventlane_theme/templates/includes/mel-footer-brand-block.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/includes/mel-footer-brand-block.html.twig
@@ -10,7 +10,7 @@
   <div class="mel-footer-brand__inner">
     <img
       class="mel-footer-brand__logo"
-      src="{{ base_path }}{{ directory }}/images/logo.png"
+      src="{{ base_path }}{{ directory }}/images/logo.webp"
       alt="{{ 'MyEventLane'|t }}"
       width="200"
       height="52"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display example: copy and static asset path changes only; no auth, commerce, or routing logic touched.
> 
> **Overview**
> Small polish alongside the public navigation work: the **site header** and **footer brand block** now load the wordmark from `logo.webp` instead of `logo.png`, keeping header and footer in sync.
> 
> On the **organiser dashboard**, attendee summary strings for tickets sold and RSVPs use **`formatPlural`** (same pattern as impressions/clicks labels elsewhere in `VendorDashboardViewModelBuilder`) so a count of **1** reads naturally instead of always using the plural `@count` form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f242f8515d9d72b9ccb7b504d6ce4387cd8e3e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->