### PR TITLE
fix(theme): apply mel-drawer-open on mobile drawer open

### DIFF
--- a/web/themes/custom/myeventlane_theme/src/js/mobile-drawer.js
+++ b/web/themes/custom/myeventlane_theme/src/js/mobile-drawer.js
@@ -76,10 +76,7 @@ export function initMobileDrawer(context) {
         panel.setAttribute('aria-modal', 'true');
         summary.setAttribute('aria-expanded', 'true');
         drawer.classList.add('is-open');
-
-        if (!isMobileViewport()) {
-          document.body.classList.add('mel-drawer-open');
-        }
+        document.body.classList.add('mel-drawer-open');
 
         const firstFocusable = panel.querySelector('a[href], button:not([disabled])');
         if (firstFocusable) {


### PR DESCRIPTION
Mobile overlay backdrop sat above the header because mel-drawer-open was desktop-only; lifting the header on open restores clickable drawer links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional removal in drawer toggle JS; close behaviour unchanged and scope is mobile overlay stacking only.
> 
> **Overview**
> Opening the mobile nav drawer now always adds **`mel-drawer-open`** on `document.body`, instead of only when the viewport is **not** mobile.
> 
> That body class is what triggers the mobile-only site header **z-index lift** above the shared overlay backdrop. Without it on mobile, the backdrop intercepted taps on drawer links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c1c8a8c5d036aeb8f15177870b42b8435ca13f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->