### PR TITLE
Feature/mel public visitor navigation

### DIFF
--- a/docs/phase-7a-event-workspace-mobile-audit.md
+++ b/docs/phase-7a-event-workspace-mobile-audit.md
@@ -1,0 +1,97 @@
+# Phase 7A — Event workspace mobile audit
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-24  
+**Scope:** Operations hub (`/vendor/events/{event}/operations`), Door Mode, workspace shell chrome.
+
+---
+
+## 1. Audit method
+
+Repository SCSS and Twig were reviewed for layout contracts at 320, 375, 768, 1024, and 1280px. **Runtime verification is required** — items marked **[needs runtime]** cannot be confirmed from static analysis alone.
+
+---
+
+## 2. Breakpoint evidence (SCSS)
+
+| Breakpoint | Source | Behaviour |
+|------------|--------|-----------|
+| ≤767px (sm max) | `_live-operations.scss` | Quick bar horizontal scroll; actions `min-height: 2.75rem`; hero padding reduced; door sticky CTA `min-height: 2.75rem` |
+| 768px+ (md) | `_live-operations.scss` | Quick inner grid wraps to multi-column (`grid-auto-flow: row`, `auto-fit minmax(9.5rem)`) |
+| 1024px+ (lg) | `_live-operations.scss` | Metric board 3 columns |
+| 1280px+ (xl) | `_live-operations.scss` | Metric board 6 columns; split layout for roster |
+
+Workspace tabs: `_workspace.scss` — horizontal scroll, `min-height: 2.75rem`, `overflow-x: auto`.
+
+---
+
+## 3. Slice verification checklist
+
+### Toolbar (operations mission bar)
+
+| Check | SCSS evidence | Runtime |
+|-------|---------------|---------|
+| 44px touch targets | `.mel-live-ops__action` `min-height: 2.75rem` at sm max | **[needs runtime]** |
+| Primary Door Mode first | `.mel-live-ops__action--featured { order: -1 }` + Twig icon order | **[needs runtime]** |
+| Horizontal scroll at 320/375 | `.mel-live-ops__quick-inner` `overflow-x: auto` | **[needs runtime]** |
+| Wrap at 768+ | `@include mel-break(md)` grid row flow | **[needs runtime]** |
+| No duplicate Door CTA | Hero partial has no door link; toolbar only | Confirmed in Twig |
+
+### Event identity hero
+
+| Check | Evidence | Runtime |
+|-------|----------|---------|
+| Single identity surface | `suppress_workspace_header` for live ops themes | Confirmed in `.theme` |
+| Title overflow | `clamp()` on `.mel-live-ops__hero-title` | **[needs runtime]** |
+| Hero height on 320 | Reduced padding on sm max | **[needs runtime]** |
+| Venue/date visible | Hero partial `start_line`, `venue_line` from view model | Confirmed in builder |
+
+### Health strip
+
+| Check | Evidence | Runtime |
+|-------|----------|---------|
+| Chips wrap | `.mel-live-ops__chip-row` `flex-wrap: wrap` | **[needs runtime]** |
+| Check-in rate chip | Twig `@pct% checked in` from existing metrics | Confirmed |
+| No invented signals | Chips from `buildHeroStatusChips()` only | Confirmed in PHP |
+
+### Layout hierarchy
+
+| Check | Evidence | Runtime |
+|-------|----------|---------|
+| Reduced shadow depth | Stat cards, panels, search card `box-shadow: none` | **[needs runtime]** |
+| Card-in-card reduced | Search card padding/border flattened | **[needs runtime]** |
+
+### Accessibility
+
+| Check | Evidence | Runtime |
+|-------|----------|---------|
+| No invalid tab roles | `workspace-tabs.html.twig` — nav links only | Confirmed |
+| Progressbar on check-in ring | Hero partial `role="progressbar"` | Confirmed |
+| Focus order toolbar → hero → metrics | DOM order in `mel-venue-operations.html.twig` | **[needs runtime]** |
+| Door one-handed use | Sticky `Scan QR` bottom bar + mega CTA | **[needs runtime]** |
+
+---
+
+## 4. Assumptions
+
+1. Orders toolbar link uses existing route `myeventlane_vendor.console.event_orders` via `safeRouteUrl()` — same pattern as tabs service; access enforced by route requirements.
+2. Door settings action remains in `operational_actions` but is excluded from the mission bar (not in `ops_toolbar_icons`).
+3. Mission-control overview (`mel-event-workspace.html.twig` staff model) is unchanged — Phase 7A targets operations surfaces.
+
+---
+
+## 5. Screenshots required (manual)
+
+Capture at **320, 375, 768, 1024, 1280** for:
+
+1. `/vendor/events/{event}/operations` — full page above fold
+2. Same — toolbar scrolled/wrapped state
+3. Door Mode — hero + scanner + sticky CTA
+4. Health strip with capacity / live chips visible
+
+---
+
+## Related docs
+
+- [workspace-tab-governance.md](workspace-tab-governance.md)
+- [vendor-experience-v3-audit-2026-06-23.md](vendor-experience-v3-audit-2026-06-23.md)

--- a/docs/vendor-experience-v3-audit-2026-06-23.md
+++ b/docs/vendor-experience-v3-audit-2026-06-23.md
@@ -264,6 +264,14 @@ Reusable, well-formed components: `kpi-card`, `empty-state`, `status-badge`,
 > `<section>`s with grid modifiers; without runtime testing the small-screen stacking
 > order (priority → hero → events) cannot be confirmed. **[needs runtime]**
 
+> **Finding D-7 (med).** `VendorDashboardController::buildDashboardActivity()`
+> runs Commerce and entity queries on every dashboard request, but
+> `VendorDashboardViewModelBuilder::buildActivityItems()` synthetic rows took
+> precedence in Twig — real activity (including timestamps) was discarded.
+> **Phase 4B (Option C)** resolves this by separating `dashboard_activity_items`
+> (real activity) from `workspace_updates` (organiser setup status) without new
+> queries.
+
 ---
 
 ## 8. Accessibility audit
@@ -361,7 +369,9 @@ fragmented IA, multiple shells, split palette — not missing features.
    nav sources of truth — medium.
 7. **C-1 / C-2 / SC-3** Orphaned SCSS, boost component sprawl, oversized page SCSS —
    medium.
-8. **L-3, S-4, A-2, A-3, SC-2, SC-4, C-3** — low/medium polish.
+8. **D-7** Dashboard activity queries discarded by synthetic view-model feed —
+   medium (resolved Phase 4B).
+9. **L-3, S-4, A-2, A-3, SC-2, SC-4, C-3** — low/medium polish.
 
 ---
 

--- a/docs/workspace-tab-governance.md
+++ b/docs/workspace-tab-governance.md
@@ -1,0 +1,97 @@
+# Workspace tab governance — Phase 6B
+
+**Repository:** `/Users/anna/myeventlane`  
+**Date:** 2026-06-24  
+**Scope:** Event workspace horizontal section navigation (`workspace-tabs.html.twig`).
+
+---
+
+## 1. Tab ownership
+
+| Source | Status | Role |
+|--------|--------|------|
+| `VendorEventTabsService` | **Canonical** | Builds tab rows from routes, mode gates (RSVP/tickets), and `AccessManager` checks. Exposes `getTabs()` (legacy string URLs for controllers) and `buildWorkspaceTabs()` (Url objects + `available` for mission-control model). |
+| `VendorEventWorkspaceViewModelBuilder` | Consumer | Calls `buildWorkspaceTabs()` for `model.tabs` on mission-control overview. |
+| Event workspace controllers | Consumers | Inject `VendorEventTabsService::getTabs($event, $activeKey)` and pass `#tabs` to `mel_event_workspace`. |
+| `VendorConsolePagePreprocess` | **Legacy** | Hard-coded tab list on `myeventlane_vendor_console_page` without mode gates or access checks. Used only by `vendor-console-page.html.twig` (staff console shell). Do not extend. |
+| `myeventlane_vendor.links.task.yml` | **Disabled at runtime** | Local task definitions exist for documentation and staff/admin themes; vendor theme blocks are `status: false` in config sync. |
+| `EventStudioSectionManager` | Separate system | Event Studio sidebar/sections — not merged with workspace tabs (out of scope). |
+
+---
+
+## 2. ARIA implementation (after Phase 6B)
+
+| Element | Before | After |
+|---------|--------|-------|
+| Wrapper | `<nav role="tablist" aria-label="Event sections">` | `<nav aria-label="Event sections">` |
+| Active link | `role="tab"` + `aria-selected="true"` + `aria-current="page"` | `aria-current="page"` only |
+| Inactive link | `role="tab"` + `aria-selected="false"` | Plain `<a>` (no tab roles) |
+| Disabled item | `role="tab"` + `aria-disabled="true"` | `<span aria-disabled="true">` (retained) |
+
+**Rationale:** Items navigate to distinct routes (full page loads). No `role="tabpanel"` regions and no JavaScript tab switching exist in the workspace shell — WAI-ARIA tab widget semantics were invalid.
+
+---
+
+## 3. Consumers of workspace tabs
+
+| Template / surface | Tab data source | Visible to |
+|--------------------|-----------------|------------|
+| `mel-event-workspace.html.twig` (mission control) | `vendor_event_workspace_model.tabs` via `buildWorkspaceTabs()` | Staff only (`show_workspace_tabs`) |
+| `mel-event-workspace.html.twig` (legacy shell) | `#tabs` from controllers via `getTabs()` | Staff only |
+| `vendor-console-page.html.twig` | `VendorConsolePagePreprocess` workspace.tabs | Staff console pages |
+
+**Staff gating:** `myeventlane_vendor_theme_preprocess_mel_event_workspace()` sets `show_workspace_tabs` from `_myeventlane_vendor_theme_is_vendor_workspace_staff()` (`administer nodes` or uid 1). Vendors use Event Studio navigation instead; tab variables are cleared for non-staff.
+
+**Controllers using `VendorEventTabsService::getTabs()`:** overview, tickets, RSVPs, attendees, operations, orders, add-on orders, refund requests, analytics, settings, boost (module).
+
+---
+
+## 4. Local task usage
+
+File: `web/modules/custom/myeventlane_vendor/myeventlane_vendor.links.task.yml`
+
+Defines event workspace local tasks (Manage event, Tickets, Orders, RSVPs, Analytics, Settings, etc.) with `base_route: myeventlane_vendor.console.event_workspace`.
+
+**Vendor theme rendering:** Disabled in config sync:
+
+- `block.block.myeventlane_vendor_theme_primary_local_tasks.yml` — `status: false`
+- `block.block.myeventlane_vendor_theme_secondary_local_tasks.yml` — `status: false`
+
+Workspace navigation is rendered exclusively by the Twig partial + `VendorEventTabsService`, not Drupal local tasks blocks.
+
+---
+
+## 5. Staff mission control — future opportunities (document only)
+
+Audited surfaces in `mel-event-workspace.html.twig` (staff-only mission control):
+
+| Surface | Current state | Future opportunity |
+|---------|---------------|-------------------|
+| Mission-control hero | Event identity, readiness chip, primary CTAs | Align heading hierarchy with live-ops hero partial when staff shell converges |
+| Sales snapshot | Metric cards with optional links | Ensure `aria-label` on linked vs static cards is distinct for screen readers |
+| Action grid (Sales / Setup / Growth) | Tile links without explicit list semantics | Consider `<ul role="list">` for grouped shortcuts if tile count grows |
+| Workspace header (non-model fallback) | `workspace-header.html.twig` with `role="region"` | Consolidate with mission-control hero to reduce duplicate event identity |
+| Lifecycle guidance / readiness panels | Collapsible `<details>` | Keyboard and `aria-expanded` already native; review live region for dynamic readiness updates |
+| Horizontal tab bar | Fixed in Phase 6B | Monitor overflow at 320px with 10+ tabs; SCSS already provides horizontal scroll + 44px targets |
+
+No implementation in Phase 6B — operational and dashboard work remain out of scope.
+
+---
+
+## 6. Mobile verification (SCSS evidence)
+
+From `web/themes/custom/myeventlane_vendor_theme/src/scss/components/_workspace.scss`:
+
+- `.mel-tabs--horizontal`: `overflow-x: auto`, `-webkit-overflow-scrolling: touch`, `flex-wrap: nowrap`
+- `.mel-tab`: `min-height: 2.75rem` (44px), `padding: $spacing-2 $spacing-4`
+- `:focus-visible`: 3px focus ring on `$mel-ws-purple`
+- `prefers-reduced-motion`: transition duration collapsed
+
+Breakpoints inherit vendor theme `respond-to(md)` elsewhere; horizontal scroll handles 320–375px overflow without wrapping.
+
+---
+
+## Related docs
+
+- [workspace-ownership-map.md](audits/workspace-ownership-map.md) — vendor workspace vs Event Studio ownership
+- [vendor-console-v2-route-map.md](vendor-console-v2-route-map.md) — route and template map

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelVenueOperationsViewModelBuilder.php
@@ -365,18 +365,27 @@ final class MelVenueOperationsViewModelBuilder {
     $door = $this->safeRouteUrl('myeventlane_event_attendees.vendor_operations_door', ['node' => $eventId]);
     if ($door !== '') {
       $actions[] = [
-        'label' => (string) $this->t('Start scanning'),
+        'label' => (string) $this->t('Open door mode'),
         'url' => $door,
         'variant' => 'primary',
         'icon' => 'scan',
       ];
     }
     $actions[] = [
-      'label' => (string) $this->t('View attendee list'),
+      'label' => (string) $this->t('Attendees'),
       'url' => Url::fromRoute('myeventlane_event_attendees.vendor_list', ['node' => $eventId])->toString(),
       'variant' => 'lavender',
       'icon' => 'list',
     ];
+    $orders = $this->safeRouteUrl('myeventlane_vendor.console.event_orders', ['event' => $eventId]);
+    if ($orders !== '') {
+      $actions[] = [
+        'label' => (string) $this->t('Orders'),
+        'url' => $orders,
+        'variant' => 'lavender',
+        'icon' => 'orders',
+      ];
+    }
     $actions[] = [
       'label' => (string) $this->t('Export CSV'),
       'url' => Url::fromRoute('myeventlane_event_attendees.vendor_export', ['node' => $eventId])->toString(),
@@ -395,7 +404,7 @@ final class MelVenueOperationsViewModelBuilder {
     }
     if ($manualUrl !== '') {
       $actions[] = [
-        'label' => (string) $this->t('Manual lookup'),
+        'label' => (string) $this->t('Search'),
         'url' => $manualUrl,
         'variant' => 'lavender',
         'icon' => 'search',

--- a/web/modules/custom/myeventlane_checkout_flow/templates/mel-vendor-door-checkin.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/mel-vendor-door-checkin.html.twig
@@ -20,26 +20,15 @@
         </span>
       {% endif %}
     </div>
-
-    {% if event %}
-      <h1 class="mel-vendor-door__event-heading">{{ event.label() }}</h1>
-    {% else %}
-      <h1 class="mel-vendor-door__event-heading">{{ 'Door check-in'|t }}</h1>
-    {% endif %}
-
-    {% if door_context.count_line %}
-      <div class="mel-vendor-door__live-count" aria-live="polite">
-        <span class="mel-vendor-door__live-dot" aria-hidden="true"></span>
-        <span class="mel-vendor-door__live-strong">{{ door_context.live_indicator }}</span>
-        <span>{{ door_context.count_line }}</span>
-      </div>
-      <div class="mel-vendor-door__mini-metrics" aria-label="{{ 'Check-in completeness'|t }}">
-        <span>{{ door_context.checked_in }}/{{ door_context.total }} {{ 'in'|t }}</span>
-        <span class="mel-vendor-door__divider" aria-hidden="true">/</span>
-        <span>{{ door_context.rate_percent|default(0) }}% {{ 'rate'|t }}</span>
-      </div>
-    {% endif %}
   </header>
+
+  {% include '@myeventlane_vendor_theme/components/mel-live-ops-operations-hero.html.twig' with {
+    variant: 'door',
+    door_context: door_context,
+    event_title: event ? event.label() : ('Door check-in'|t),
+    title_id: 'mel-vendor-door-hero-title',
+    eyebrow: 'Running your event'|t,
+  } only %}
 
   <main class="mel-vendor-door__main">
     <section class="mel-vendor-door__scanner-shell" aria-labelledby="mel-vendor-door-scan-heading">

--- a/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
@@ -7,18 +7,20 @@
  * recent_activity, links, search, operational_actions, mel_venue_operations_empty.
  */
 #}
-{% set pct = hero.check_in_rate_percent|default(metrics.check_in_rate_percent|default(0)) %}
 {% set checkin_csrf = csrf.checkin_token|default('') %}
+{% set ops_toolbar_icons = ['scan', 'list', 'export', 'search'] %}
+{% set toolbar_actions = operational_actions|default([])|filter(action => action.icon|default('') in ops_toolbar_icons) %}
 
 <div class="mel-venue-operations mel-live-operations"
      data-mel-venue-operations
      data-mel-ops-checkin-token="{{ checkin_csrf|e('html_attr') }}">
-  {% if operational_actions is iterable and operational_actions|length > 0 %}
+  {% if toolbar_actions is iterable and toolbar_actions|length > 0 %}
     <nav class="mel-live-ops__quick-bar" aria-label="{{ 'Operational actions'|t }}">
-      <div class="mel-live-ops__quick-inner" role="toolbar">
-        {% for action in operational_actions %}
+      <div class="mel-live-ops__quick-inner">
+        {% for action in toolbar_actions %}
+          {% set is_door_mode = action.icon|default('') == 'scan' %}
           <a
-            class="mel-live-ops__action mel-live-ops__action--{{ action.variant|default('lavender') }}{% if loop.first %} mel-live-ops__action--featured{% endif %}"
+            class="mel-live-ops__action mel-live-ops__action--{{ is_door_mode ? 'primary' : action.variant|default('lavender') }}{% if is_door_mode %} mel-live-ops__action--featured{% endif %}"
             href="{{ action.url }}"
             data-icon="{{ action.icon|default('')|e('html_attr') }}"
           >
@@ -30,64 +32,13 @@
     </nav>
   {% endif %}
 
-  <section class="mel-live-ops__hero" aria-labelledby="mel-live-ops-hero-title">
-    <div class="mel-live-ops__hero-surface">
-      <div class="mel-live-ops__hero-layout">
-        <div class="mel-live-ops__hero-primary">
-          <p class="mel-live-ops__eyebrow">{{ 'Live venue operations'|t }}</p>
-          <h1 id="mel-live-ops-hero-title" class="mel-live-ops__hero-title">{{ hero.title|default('') }}</h1>
-
-          {% if hero.start|default('') is not empty %}
-            <p class="mel-live-ops__hero-datetime">{{ hero.start }}</p>
-          {% endif %}
-          {% if hero.venue|default('') is not empty %}
-            <p class="mel-live-ops__hero-venue">{{ hero.venue }}</p>
-          {% endif %}
-
-          {% if hero.status_chips is defined and hero.status_chips is iterable and hero.status_chips|length > 0 %}
-            <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Status'|t }}">
-              {% for chip in hero.status_chips %}
-                <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip.modifier|default('calm')|e('html_attr') }}">{{ chip.label|default('') }}</span>
-              {% endfor %}
-            </div>
-          {% endif %}
-
-          {% if hero.live_indicator|default('') is not empty %}
-            <p class="mel-live-ops__live-pulse" role="status">
-              <span class="mel-live-ops__pulse-dot" aria-hidden="true"></span>
-              <span>{{ hero.live_indicator }}</span>
-            </p>
-          {% endif %}
-          {% if hero.last_sync_formatted|default('') is not empty %}
-            <p class="mel-live-ops__sync-meta">
-              <time datetime="{{ hero.last_sync_iso|default('') }}">{{ 'Last refreshed'|t }} · {{ hero.last_sync_formatted }}</time>
-            </p>
-          {% endif %}
-        </div>
-
-        <div class="mel-live-ops__hero-aside">
-          <div class="mel-live-ops__progress-shell" data-mel-ops-progress-shell style="--mel-ops-progress: {{ pct }};">
-            <div class="mel-live-ops__progress-ring" data-mel-ops-progress-ring role="progressbar" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ 'Check-in completion'|t }}">
-              <span class="mel-live-ops__progress-ring-label">
-                <span class="mel-live-ops__progress-percent" data-mel-ops-progress-percent>{{ pct }}%</span>
-                <span class="mel-live-ops__progress-caption">{{ 'checked in'|t }}</span>
-              </span>
-            </div>
-            <div class="mel-live-ops__progress-track" aria-hidden="true">
-              <span class="mel-live-ops__progress-fill" data-mel-ops-progress-fill style="width: {{ pct }}%;"></span>
-            </div>
-            <div class="mel-live-ops__hero-summary">
-              <p class="mel-live-ops__summary-line">{{ hero.attendance_state|default('') }}</p>
-              <p class="mel-live-ops__summary-muted">{{ hero.readiness|default('') }}</p>
-            </div>
-          </div>
-          {% if links.door_checkin is defined and links.door_checkin %}
-            <a class="mel-live-ops__hero-cta mel-btn mel-btn--primary" href="{{ links.door_checkin }}">{{ 'Open door mode'|t }}</a>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  </section>
+  {% include '@myeventlane_vendor_theme/components/mel-live-ops-operations-hero.html.twig' with {
+    variant: 'hub',
+    hero: hero,
+    metrics: metrics,
+    title_id: 'mel-live-ops-hero-title',
+    eyebrow: 'Running your event'|t,
+  } only %}
 
   {% if mel_venue_operations_empty %}
     <div class="mel-live-ops__empty-wrap">
@@ -96,7 +47,7 @@
   {% endif %}
 
   <section class="mel-live-ops__metrics" aria-labelledby="mel-live-ops-metrics-title">
-    <h2 id="mel-live-ops-metrics-title" class="visually-hidden">{{ 'Operational metrics'|t }}</h2>
+    <h2 id="mel-live-ops-metrics-title" class="visually-hidden">{{ 'At the door'|t }}</h2>
     <div class="mel-live-ops__metric-board" role="list">
       <article class="mel-live-ops__stat-card mel-live-ops__stat-card--total" role="listitem" data-mel-metric="total">
         <span class="mel-live-ops__stat-icon" aria-hidden="true"></span>
@@ -156,7 +107,7 @@
       <section id="mel-ops-attendee-search" class="mel-live-ops__search-panel">
         <div class="mel-live-ops__search-card">
           <label class="mel-live-ops__search-heading" for="mel-venue-ops-search">{{ 'Find attendee'|t }}</label>
-          <p class="mel-live-ops__search-intro">{{ 'Filter this list instantly — searches stay on this device.'|t }}</p>
+          <p class="mel-live-ops__search-intro">{{ 'Find someone on the door list — search stays on this device.'|t }}</p>
           <div class="mel-live-ops__search-field-wrap">
             <span class="mel-live-ops__search-icon" aria-hidden="true"></span>
             <input
@@ -216,7 +167,7 @@
     <section class="mel-live-ops__attendees" aria-labelledby="mel-live-ops-attendees-title">
       <div class="mel-live-ops__attendees-head">
         <h2 id="mel-live-ops-attendees-title" class="mel-live-ops__panel-title">{{ 'Attendee roster'|t }}</h2>
-        <p class="mel-live-ops__panel-intro">{{ 'Check people in confidently with one tap.'|t }}</p>
+        <p class="mel-live-ops__panel-intro">{{ 'Check people in with one tap, or start scanning from the toolbar above.'|t }}</p>
       </div>
 
       <p class="mel-live-ops__filter-empty" data-mel-ops-filter-empty hidden role="status">{{ 'Nothing matches your search.'|t }}</p>

--- a/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
@@ -8,25 +8,28 @@
  */
 #}
 {% set checkin_csrf = csrf.checkin_token|default('') %}
-{% set ops_toolbar_icons = ['scan', 'list', 'export', 'search'] %}
-{% set toolbar_actions = operational_actions|default([])|filter(action => action.icon|default('') in ops_toolbar_icons) %}
+{% set ops_toolbar_icons = ['scan', 'list', 'orders', 'export', 'search'] %}
 
 <div class="mel-venue-operations mel-live-operations"
      data-mel-venue-operations
      data-mel-ops-checkin-token="{{ checkin_csrf|e('html_attr') }}">
-  {% if toolbar_actions is iterable and toolbar_actions|length > 0 %}
+  {% if operational_actions is iterable and operational_actions|length > 0 %}
     <nav class="mel-live-ops__quick-bar" aria-label="{{ 'Operational actions'|t }}">
       <div class="mel-live-ops__quick-inner">
-        {% for action in toolbar_actions %}
-          {% set is_door_mode = action.icon|default('') == 'scan' %}
-          <a
-            class="mel-live-ops__action mel-live-ops__action--{{ is_door_mode ? 'primary' : action.variant|default('lavender') }}{% if is_door_mode %} mel-live-ops__action--featured{% endif %}"
-            href="{{ action.url }}"
-            data-icon="{{ action.icon|default('')|e('html_attr') }}"
-          >
-            <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
-            <span class="mel-live-ops__action-label">{{ action.label }}</span>
-          </a>
+        {% for icon in ops_toolbar_icons %}
+          {% for action in operational_actions %}
+            {% if action.icon|default('') == icon %}
+              {% set is_door_mode = icon == 'scan' %}
+              <a
+                class="mel-live-ops__action mel-live-ops__action--{{ is_door_mode ? 'primary' : action.variant|default('lavender') }}{% if is_door_mode %} mel-live-ops__action--featured{% endif %}"
+                href="{{ action.url }}"
+                data-icon="{{ icon|e('html_attr') }}"
+              >
+                <span class="mel-live-ops__action-glyph" aria-hidden="true"></span>
+                <span class="mel-live-ops__action-label">{{ action.label }}</span>
+              </a>
+            {% endif %}
+          {% endfor %}
         {% endfor %}
       </div>
     </nav>

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -2471,12 +2471,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
     }
 
     usort($items, static fn(array $a, array $b): int => ((int) ($b['timestamp'] ?? 0)) <=> ((int) ($a['timestamp'] ?? 0)));
-    $items = array_slice($items, 0, 6);
-    foreach ($items as &$item) {
-      unset($item['timestamp']);
-    }
 
-    return $items;
+    return array_slice($items, 0, 6);
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -156,7 +156,7 @@ final class VendorDashboardViewModelBuilder {
     $model['organiser_overview'] = $this->buildOrganiserOverview($model);
     $model['attention_events'] = $this->buildAttentionEvents($events);
     $model['upcoming_events'] = $this->buildUpcomingEvents($events);
-    $model['activity_items'] = $this->buildActivityItems($events, $readiness);
+    $model['workspace_updates'] = $this->buildWorkspaceUpdates($readiness);
     $model['hero_shell_hint'] = $this->heroShellHint($model);
     $model['homepage_visibility'] = $this->buildHomepageVisibilityReport($vendor, $account);
 
@@ -200,7 +200,7 @@ final class VendorDashboardViewModelBuilder {
       'upcoming_events' => [],
       'priority_action' => NULL,
       'secondary_actions' => [],
-      'activity_items' => [],
+      'workspace_updates' => [],
       'analytics_summary' => [
         'available' => FALSE,
         'items' => [],
@@ -1366,8 +1366,14 @@ final class VendorDashboardViewModelBuilder {
    *
    * @return list<array<string, mixed>>
    */
-  private function buildActivityItems(array $events, array $readiness): array {
+  /**
+   * Completed organiser workspace status lines (not event activity).
+   *
+   * @return list<array{type: string, message: string, url: \Drupal\Core\Url|null}>
+   */
+  private function buildWorkspaceUpdates(array $readiness): array {
     $items = [];
+
     if ((bool) ($readiness['stripe_ready'] ?? FALSE)) {
       $items[] = [
         'type' => 'success',
@@ -1378,52 +1384,17 @@ final class VendorDashboardViewModelBuilder {
       ];
     }
 
-    foreach ($events as $event) {
-      if (!is_array($event)) {
-        continue;
-      }
-      $title = (string) ($event['title'] ?? '');
-      if ($title === '') {
-        continue;
-      }
-      $links = $event['links'] ?? [];
-      $url = is_array($links) && isset($links['manage']) && $links['manage'] instanceof Url ? $links['manage'] : NULL;
-      $status = (string) ($event['status'] ?? '');
-      if ($status === 'draft') {
-        $items[] = [
-          'type' => 'warning',
-          'message' => (string) $this->t('@event is still in draft.', ['@event' => $title]),
-          'url' => $url,
-        ];
-      }
-      else {
-        $items[] = [
-          'type' => 'info',
-          'message' => (string) $this->t('@event is @state.', [
-            '@event' => $title,
-            '@state' => (string) ($event['status_label'] ?? $status),
-          ]),
-          'url' => $url,
-        ];
-      }
-
-      $metricLabel = (string) ($event['metric_label'] ?? '');
-      if ($metricLabel !== '') {
-        $items[] = [
-          'type' => 'success',
-          'message' => (string) $this->t('@metrics for @event.', [
-            '@event' => $title,
-            '@metrics' => $metricLabel,
-          ]),
-          'url' => $url,
-        ];
-      }
-      if (count($items) >= 6) {
-        break;
-      }
+    if ((bool) ($readiness['profile_complete'] ?? FALSE)) {
+      $items[] = [
+        'type' => 'success',
+        'message' => (string) $this->t('Your organiser profile is complete.'),
+        'url' => $this->routeExists('myeventlane_vendor.console.settings')
+          ? $this->safeUrlFromRoute('myeventlane_vendor.console.settings')
+          : NULL,
+      ];
     }
 
-    return array_slice($items, 0, 6);
+    return $items;
   }
 
   /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_live-operations.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_live-operations.scss
@@ -1175,7 +1175,7 @@ a.mel-live-ops__stat-card {
   }
 
   &__top {
-    margin-bottom: melsp.mel-space(5);
+    margin-bottom: melsp.mel-space(3);
   }
 
   &__top-row {
@@ -1710,5 +1710,85 @@ a.mel-live-ops__stat-card {
   &:hover {
     color: inherit;
     text-decoration: none;
+  }
+}
+
+// =============================================================================
+// Phase 6A — canonical /operations hub + shared identity partial
+// =============================================================================
+
+.mel-workspace--live-ops-surface {
+  .mel-live-ops__quick-bar {
+    top: 0;
+    margin-top: 0;
+  }
+
+  .mel-live-ops__hero-surface {
+    @include melbp.mel-break(sm, max) {
+      padding: melsp.mel-space(4);
+    }
+  }
+}
+
+@include melbp.mel-break(md) {
+  .mel-live-ops__quick-inner {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+    overflow-x: visible;
+    padding-bottom: 0;
+  }
+}
+
+.mel-live-ops__hero--door {
+  margin-bottom: melsp.mel-space(4);
+
+  .mel-live-ops__hero-surface {
+    padding: melsp.mel-space(4);
+    background:
+      radial-gradient(720px circle at 100% 0%, rgba(124, 131, 253, 0.14), transparent 52%),
+      rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.14);
+    box-shadow: none;
+  }
+
+  .mel-live-ops__hero-title,
+  .mel-live-ops__eyebrow,
+  .mel-live-ops__summary-line {
+    color: #{melc.$mel-color-surface};
+  }
+
+  .mel-live-ops__eyebrow {
+    color: rgba(255, 255, 255, 0.72);
+  }
+
+  .mel-live-ops__summary-muted,
+  .mel-live-ops__sync-meta,
+  .mel-live-ops__hero-datetime,
+  .mel-live-ops__hero-venue {
+    color: rgba(255, 255, 255, 0.72);
+  }
+
+  .mel-live-ops__hero-summary {
+    background: rgba(0, 0, 0, 0.22);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .mel-live-ops__hero-layout {
+    @include melbp.mel-break(md) {
+      grid-template-columns: minmax(0, 1fr) minmax(220px, 0.75fr);
+      gap: melsp.mel-space(4);
+    }
+  }
+}
+
+@include melbp.mel-break(sm, max) {
+  .mel-live-ops__action {
+    min-height: 2.75rem;
+    padding-inline: melsp.mel-space(3);
+  }
+
+  .mel-vendor-door__sticky-btn,
+  .mel-vendor-door__mega-cta {
+    min-height: 2.75rem;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_live-operations.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_live-operations.scss
@@ -34,11 +34,12 @@ $mel-live-dur-panel: 0.42s;
   position: sticky;
   top: 0;
   z-index: 3;
-  margin: melsp.mel-space(3) (-1 * melsp.mel-space(2)) melsp.mel-space(4);
+  margin: melsp.mel-space(3) (-1 * melsp.mel-space(2)) melsp.mel-space(3);
   padding: melsp.mel-space(3) melsp.mel-space(3) melsp.mel-space(2);
   background: #{melc.$mel-color-surface-alt};
+  border: 1px solid #{melc.$mel-color-border};
   border-radius: melrad.$mel-radius-md;
-  box-shadow: melsh.$mel-shadow-sm;
+  box-shadow: none;
   scroll-margin-top: melsp.mel-space(2);
 
   // Narrow phones (~390px): ease horizontal bleed so the pill lane stays tappable.
@@ -55,9 +56,7 @@ $mel-live-dur-panel: 0.42s;
   }
 
   &:focus-within {
-    box-shadow:
-      melsh.$mel-shadow-sm,
-      0 0 0 2px rgba(124, 131, 253, 0.22);
+    box-shadow: 0 0 0 2px rgba(124, 131, 253, 0.22);
   }
 }
 
@@ -110,6 +109,10 @@ $mel-live-dur-panel: 0.42s;
 
   &[data-icon='list'] .mel-live-ops__action-glyph::before {
     content: '☰';
+  }
+
+  &[data-icon='orders'] .mel-live-ops__action-glyph::before {
+    content: '◫';
   }
 
   &[data-icon='export'] .mel-live-ops__action-glyph::before {
@@ -188,17 +191,12 @@ $mel-live-dur-panel: 0.42s;
 .mel-live-ops__hero-surface {
   border-radius: melrad.$mel-radius-lg;
   padding: clamp(#{melsp.mel-space(4)}, 6vw, #{melsp.mel-space(6)});
-  backdrop-filter: blur(8px);
   background:
-    radial-gradient(1200px circle at -10% 0%, rgba(124, 131, 253, 0.18), transparent 55%),
-    radial-gradient(900px circle at 120% 110%, rgba(242, 109, 91, 0.16), transparent 45%),
-    linear-gradient(
-      128deg,
-      #{melc.$mel-color-surface} 18%,
-      $mel-live-surface-stop 100%
-    );
+    radial-gradient(1200px circle at -10% 0%, rgba(124, 131, 253, 0.12), transparent 55%),
+    radial-gradient(900px circle at 120% 110%, rgba(242, 109, 91, 0.1), transparent 45%),
+    #{melc.$mel-color-surface};
   border: 1px solid #{melc.$mel-color-border};
-  box-shadow: melsh.$mel-shadow-glass;
+  box-shadow: none;
 }
 
 .mel-live-ops__hero-layout {
@@ -281,6 +279,19 @@ $mel-live-dur-panel: 0.42s;
 
 .mel-live-ops__chip-row--compact {
   margin-top: melsp.mel-space(2);
+}
+
+.mel-live-ops__health-strip {
+  margin-top: melsp.mel-space(3);
+  padding: melsp.mel-space(3) melsp.mel-space(4);
+  border-radius: melrad.$mel-radius-md;
+  border: 1px solid #{melc.$mel-color-border};
+  background: #{melc.$mel-color-surface-alt};
+}
+
+.mel-live-ops__chip-row--health {
+  margin-top: 0;
+  gap: melsp.mel-space(2);
 }
 
 .mel-live-ops__chip {
@@ -460,7 +471,7 @@ $mel-live-dur-panel: 0.42s;
   padding: melsp.mel-space(3);
   border-radius: melrad.$mel-radius-md;
   border: 1px solid #{melc.$mel-color-border};
-  background: #{melc.$mel-color-surface-alt};
+  background: #{melc.$mel-color-surface};
 }
 
 .mel-live-ops__hero-cta {
@@ -495,7 +506,7 @@ $mel-live-dur-panel: 0.42s;
 }
 
 .mel-live-ops__metric-board {
-  margin-top: melsp.mel-space(5);
+  margin-top: melsp.mel-space(4);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: melsp.mel-space(3);
@@ -518,20 +529,16 @@ $mel-live-dur-panel: 0.42s;
   padding: melsp.mel-space(4);
   border-radius: melrad.$mel-radius-md;
   border: 1px solid #{melc.$mel-color-border};
-  box-shadow: melsh.$mel-shadow-sm;
+  box-shadow: none;
   background: #{melc.$mel-color-surface};
   transition:
-    transform $mel-live-dur-quick $mel-live-ease-material,
-    border-color $mel-live-dur-quick $mel-live-ease-material,
-    box-shadow $mel-live-dur-quick $mel-live-ease-material;
+    border-color $mel-live-dur-quick $mel-live-ease-material;
   display: grid;
   gap: melsp.mel-space(2);
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      transform: translateY(-2px);
       border-color: rgba(124, 131, 253, 0.45);
-      box-shadow: melsh.$mel-shadow-lg;
     }
   }
 }
@@ -647,11 +654,11 @@ a.mel-live-ops__stat-card {
 }
 
 .mel-live-ops__search-card {
-  padding: melsp.mel-space(5);
-  border-radius: melrad.$mel-radius-lg;
+  padding: melsp.mel-space(4);
+  border-radius: melrad.$mel-radius-md;
   border: 1px solid #{melc.$mel-color-border};
   background: #{melc.$mel-color-surface};
-  box-shadow: melsh.$mel-shadow-sm;
+  box-shadow: none;
 }
 
 .mel-live-ops__search-heading {
@@ -730,19 +737,20 @@ a.mel-live-ops__stat-card {
 
 // Generic operational panel shell (dashboard + multi-surface reuse).
 .mel-live-ops__panel {
-  padding: melsp.mel-space(5);
-  border-radius: melrad.$mel-radius-lg;
+  padding: melsp.mel-space(4);
+  border-radius: melrad.$mel-radius-md;
   border: 1px solid #{melc.$mel-color-border};
-  background: #{melc.$mel-color-surface-alt};
-  box-shadow: melsh.$mel-shadow-sm;
+  background: #{melc.$mel-color-surface};
+  box-shadow: none;
 }
 
 // Timeline / recent arrivals.
 .mel-live-ops__timeline {
-  padding: melsp.mel-space(5);
-  border-radius: melrad.$mel-radius-lg;
-  border: 1px dashed rgba(124, 131, 253, 0.35);
+  padding: melsp.mel-space(4);
+  border-radius: melrad.$mel-radius-md;
+  border: 1px solid rgba(124, 131, 253, 0.2);
   background: #{melc.$mel-color-surface-alt};
+  box-shadow: none;
 }
 
 .mel-live-ops__panel-title {
@@ -1714,7 +1722,7 @@ a.mel-live-ops__stat-card {
 }
 
 // =============================================================================
-// Phase 6A — canonical /operations hub + shared identity partial
+// Phase 6A / 7A — canonical /operations hub + shared identity partial
 // =============================================================================
 
 .mel-workspace--live-ops-surface {
@@ -1726,6 +1734,12 @@ a.mel-live-ops__stat-card {
   .mel-live-ops__hero-surface {
     @include melbp.mel-break(sm, max) {
       padding: melsp.mel-space(4);
+    }
+  }
+
+  .mel-live-ops__health-strip {
+    @include melbp.mel-break(sm, max) {
+      padding-inline: melsp.mel-space(3);
     }
   }
 }
@@ -1749,6 +1763,15 @@ a.mel-live-ops__stat-card {
       rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.14);
     box-shadow: none;
+  }
+
+  .mel-live-ops__health-strip {
+    border-color: rgba(255, 255, 255, 0.14);
+    background: rgba(0, 0, 0, 0.18);
+  }
+
+  .mel-live-ops__chip-row--health .mel-live-ops__chip {
+    border-color: rgba(255, 255, 255, 0.18);
   }
 
   .mel-live-ops__hero-title,

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1614,6 +1614,23 @@ function myeventlane_vendor_theme_preprocess_mel_event_workspace(array &$variabl
     }
   }
 
+  // Live ops surfaces (operations hub + door mode) render their own identity hero.
+  $content = $variables['content'] ?? NULL;
+  $content_theme = is_array($content) ? (string) ($content['#theme'] ?? '') : '';
+  if ($content_theme === '') {
+    $route_name = (string) \Drupal::routeMatch()->getRouteName();
+    $content_theme = match ($route_name) {
+      'myeventlane_event_attendees.vendor_operations' => 'mel_venue_operations',
+      'myeventlane_event_attendees.vendor_operations_door' => 'mel_vendor_door_checkin',
+      default => '',
+    };
+  }
+  $variables['mel_workspace_content_theme'] = $content_theme;
+  $variables['suppress_workspace_header'] = in_array($content_theme, [
+    'mel_venue_operations',
+    'mel_vendor_door_checkin',
+  ], TRUE);
+
   // Vendors use Event Studio navigation; staff retain workspace tab chrome.
   $account = \Drupal::currentUser();
   $variables['show_workspace_tabs'] = _myeventlane_vendor_theme_is_vendor_workspace_staff($account);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1838,6 +1838,29 @@ function myeventlane_vendor_theme_preprocess_myeventlane_vendor_event_settings_p
 }
 
 /**
+ * Implements hook_preprocess_HOOK() for myeventlane_vendor_dashboard.
+ *
+ * Adds relative timestamp labels for real activity rows using the MEL date
+ * formatter (formatTimeDiffSince). Twig falls back to format_date('short').
+ */
+function myeventlane_vendor_theme_preprocess_myeventlane_vendor_dashboard(array &$variables): void {
+  if (empty($variables['dashboard_activity_items']) || !is_array($variables['dashboard_activity_items'])) {
+    return;
+  }
+  if (!\Drupal::hasService('myeventlane_core.date_formatter')) {
+    return;
+  }
+  /** @var \Drupal\myeventlane_core\Service\DateFormatter $formatter */
+  $formatter = \Drupal::service('myeventlane_core.date_formatter');
+  foreach ($variables['dashboard_activity_items'] as &$item) {
+    if (!is_array($item) || empty($item['timestamp'])) {
+      continue;
+    }
+    $item['timestamp_label'] = $formatter->formatRelative((int) $item['timestamp']);
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK() for myeventlane_vendor_console_page.
  *
  * Adds a consistent meta line (event type • status • date) for event workspace

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_workspace.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_workspace.scss
@@ -704,3 +704,18 @@
   display: none;
 }
 
+// Live ops hub + door mode — inner template owns event identity; skip duplicate shell chrome.
+.mel-workspace--live-ops-surface {
+  .mel-workspace__content--event-management {
+    padding-top: 0;
+  }
+
+  .mel-workspace__body {
+    padding-top: $spacing-2;
+
+    @include respond-to(md) {
+      padding-top: $spacing-3;
+    }
+  }
+}
+

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_navigation.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/layout/_navigation.scss
@@ -202,13 +202,26 @@
   font-size: $font-size-lg;
 }
 
+.mel-sidebar__nav-groups {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-5;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.mel-sidebar__group {
+  display: grid;
+  gap: $spacing-1;
+}
+
 .mel-sidebar__nav {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: $spacing-2;
+  gap: $spacing-1;
 }
 
 .mel-sidebar__item {
@@ -226,6 +239,10 @@
   padding: 0 0 0 $spacing-8;
   display: grid;
   gap: 2px;
+}
+
+.mel-sidebar__subitem--nested-top-level .mel-sidebar__subnav-link {
+  font-weight: $font-weight-medium;
 }
 
 .mel-sidebar__subnav-link {
@@ -274,9 +291,10 @@
   }
 
   &.is-active {
-    background: rgba(255, 255, 255, 0.16);
-    border-color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.22);
     color: $text-inverse;
+    font-weight: $font-weight-semibold;
 
     &::before {
       content: '';
@@ -284,11 +302,18 @@
       left: 0;
       top: 50%;
       transform: translateY(-50%);
-      width: 4px;
-      height: 26px;
+      width: 3px;
+      height: 22px;
       background: $ml-accent-coral;
       border-radius: 0 $radius-sm $radius-sm 0;
     }
+  }
+
+  &--compact {
+    min-height: 40px;
+    padding: $spacing-2 $spacing-3 $spacing-2 $spacing-4;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-medium;
   }
 }
 
@@ -329,12 +354,18 @@
 }
 
 .mel-sidebar__section-label {
-  padding: $spacing-2 $spacing-4;
+  margin: 0;
+  padding: 0 $spacing-4 $spacing-1;
   font-size: $font-size-xs;
   font-weight: $font-weight-semibold;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.42);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  line-height: 1.3;
+}
+
+.mel-sidebar__group--dashboard .mel-sidebar__section-label {
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .mel-sidebar__footer {
@@ -587,5 +618,34 @@
   .mel-vendor-console__nav-item:focus-visible {
     outline: 2px solid #7c83fd;
     outline-offset: 2px;
+  }
+
+  &.mel-vendor-shell--dashboard {
+    .mel-shell-header--dashboard {
+      padding-block: $spacing-3;
+      border-bottom-color: transparent;
+      background: transparent;
+      backdrop-filter: none;
+
+      @include respond-to(md) {
+        padding-block: $spacing-4;
+      }
+    }
+
+    .mel-shell-header--dashboard .mel-shell-header__left {
+      align-items: center;
+    }
+
+    .mel-shell-header--dashboard .mel-shell-header__actions {
+      margin-left: auto;
+    }
+
+    .mel-vendor-shell__content {
+      padding-top: $spacing-2;
+
+      @include respond-to(md) {
+        padding-top: $spacing-3;
+      }
+    }
   }
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -471,6 +471,12 @@ $mel-dash-lavender: #7c83fd;
     box-shadow: none;
   }
 
+  &__workspace-updates {
+    background: $mel-brand-surface-soft;
+    border-color: rgba($mel-shell-border, 0.8);
+    box-shadow: none;
+  }
+
   &__activity-stream--secondary {
     padding: $spacing-3 $spacing-4;
     border-color: rgba($mel-shell-border, 0.75);
@@ -479,6 +485,10 @@ $mel-dash-lavender: #7c83fd;
     .mel-live-ops__panel-title {
       font-size: $font-size-lg;
     }
+  }
+
+  &__workspace-updates.mel-vendor-dashboard__activity-stream--secondary {
+    background: $mel-brand-surface-soft;
   }
 
   &__attention-strip,
@@ -1402,10 +1412,6 @@ $mel-dash-lavender: #7c83fd;
 
     &__timeline-time {
       white-space: normal;
-    }
-
-    &__timeline-link {
-      min-height: auto;
     }
   }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -85,6 +85,142 @@ $mel-dash-lavender: #7c83fd;
     }
   }
 
+  &__workspace-hero {
+    display: grid;
+    gap: $spacing-5;
+    padding: $spacing-5 $spacing-4;
+    border: 1px solid rgba($mel-ws-purple, 0.12);
+    border-radius: $radius-workspace-card;
+    background:
+      radial-gradient(720px circle at 100% 0%, rgba($mel-ws-purple, 0.08), transparent 52%),
+      radial-gradient(560px circle at 0% 100%, rgba($mel-ws-coral, 0.06), transparent 48%),
+      $mel-shell-surface;
+    box-shadow: $shadow-sm;
+
+    @include respond-to(md) {
+      padding: $spacing-6 $spacing-6;
+      gap: $spacing-6;
+    }
+
+    &--empty {
+      text-align: center;
+      justify-items: center;
+      background:
+        radial-gradient(720px circle at 50% -10%, rgba($mel-ws-coral, 0.1), transparent 58%),
+        $mel-shell-page-bg;
+    }
+  }
+
+  &__workspace-hero-body {
+    display: grid;
+    gap: $spacing-2;
+    min-width: 0;
+  }
+
+  &__workspace-hero-context {
+    margin: 0;
+    color: $mel-ws-purple;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.06em;
+    line-height: 1.3;
+    text-transform: uppercase;
+  }
+
+  &__workspace-hero-title {
+    margin: 0;
+    color: $mel-ws-navy;
+    font-size: clamp(1.625rem, 4.8vw, 2.25rem);
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+  }
+
+  &__workspace-hero-lead {
+    margin: $spacing-1 0 0;
+    max-width: 42rem;
+    color: $text-secondary;
+    font-size: $font-size-base;
+    line-height: $line-height-relaxed;
+  }
+
+  &__workspace-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: $spacing-3;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    @include respond-to(md) {
+      gap: $spacing-4;
+    }
+  }
+
+  &__workspace-hero-stat {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+    padding: $spacing-3;
+    border: 1px solid rgba($mel-ws-navy, 0.08);
+    border-radius: $radius-lg;
+    background: rgba($mel-shell-page-bg, 0.72);
+  }
+
+  &__workspace-hero-stat-value {
+    color: $mel-ws-navy;
+    font-size: clamp(1.125rem, 2.6vw, 1.375rem);
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+  }
+
+  &__workspace-hero-stat-label {
+    color: $text-secondary;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.04em;
+    line-height: 1.25;
+    text-transform: uppercase;
+  }
+
+  &__workspace-hero-stat--revenue {
+    border-color: rgba($mel-ws-coral, 0.22);
+    background: rgba($mel-ws-coral, 0.06);
+
+    .mel-vendor-dashboard__workspace-hero-stat-value {
+      color: $mel-ws-coral;
+      font-size: clamp(1.25rem, 3vw, 1.5rem);
+    }
+  }
+
+  &__workspace-hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+
+    .mel-btn {
+      min-height: 2.75rem;
+    }
+  }
+
+  &__workspace-hero--empty &__workspace-hero-lead {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 32rem;
+  }
+
+  &__workspace-hero--empty &__workspace-hero-actions {
+    justify-content: center;
+    margin-top: $spacing-2;
+    width: 100%;
+
+    .mel-btn {
+      width: 100%;
+      max-width: 18rem;
+    }
+  }
+
   &__mission-hero .mel-live-ops__hero-surface {
     background:
       radial-gradient(640px circle at 100% 0%, rgba($mel-ws-purple, 0.05), transparent 45%),
@@ -171,10 +307,16 @@ $mel-dash-lavender: #7c83fd;
     border: 1px solid $mel-shell-border;
     border-radius: $radius-workspace-card;
     background: $mel-shell-surface;
-    box-shadow: $shadow-xs;
+    box-shadow: none;
 
     @include respond-to(md) {
       padding: $spacing-5 $spacing-6;
+    }
+
+    &--compact {
+      padding-top: $spacing-3;
+      border-color: rgba($mel-shell-border, 0.85);
+      background: transparent;
     }
 
     &--starter {
@@ -255,6 +397,29 @@ $mel-dash-lavender: #7c83fd;
     .mel-live-ops__stat-card--capacity .mel-live-ops__stat-value {
       color: $ml-color-accent;
     }
+
+    .mel-vendor-dashboard__metric-card--primary {
+      border-color: rgba($mel-ws-coral, 0.24);
+      background: rgba($mel-ws-coral, 0.05);
+
+      .mel-live-ops__stat-value {
+        color: $mel-ws-coral;
+        font-size: clamp(1.375rem, 3vw, 1.625rem);
+      }
+    }
+
+    .mel-vendor-dashboard__metric-card--secondary {
+      border-color: rgba($mel-ws-purple, 0.2);
+      background: rgba($mel-ws-purple-tint, 0.35);
+
+      .mel-live-ops__stat-value {
+        color: $mel-ws-purple;
+      }
+    }
+
+    .mel-vendor-dashboard__metric-card--neutral {
+      background: $mel-shell-page-bg;
+    }
   }
 
   &__mission-hero {
@@ -297,11 +462,28 @@ $mel-dash-lavender: #7c83fd;
   &__overview-strip,
   &__attention-strip,
   &__activity-stream,
+  &__workspace-updates,
   &__upcoming-strip {
     padding: $spacing-4;
     border: 1px solid $mel-shell-border;
     border-radius: $radius-workspace-card;
     background: $mel-shell-surface;
+    box-shadow: none;
+  }
+
+  &__activity-stream--secondary {
+    padding: $spacing-3 $spacing-4;
+    border-color: rgba($mel-shell-border, 0.75);
+    background: rgba($mel-shell-page-bg, 0.65);
+
+    .mel-live-ops__panel-title {
+      font-size: $font-size-lg;
+    }
+  }
+
+  &__attention-strip,
+  &__upcoming-strip,
+  &__activity-stream:not(.mel-vendor-dashboard__activity-stream--secondary) {
     box-shadow: $shadow-xs;
   }
 
@@ -1103,12 +1285,29 @@ $mel-dash-lavender: #7c83fd;
     border-left: 2px solid rgba($ml-vendor-navy, 0.1);
   }
 
+  &__timeline--activity {
+    display: grid;
+    gap: $spacing-1;
+  }
+
+  &__timeline--workspace {
+    border-left-color: rgba($success, 0.18);
+  }
+
   &__timeline-item {
     position: relative;
     display: flex;
     gap: $spacing-3;
     min-height: 2.75rem;
     padding: $spacing-2 0 $spacing-2 $spacing-3;
+  }
+
+  &__timeline--activity &__timeline-item {
+    padding: $spacing-3;
+    margin-left: $spacing-1;
+    border: 1px solid rgba($ml-vendor-navy, 0.08);
+    border-radius: $radius-lg;
+    background: $bg-primary;
   }
 
   &__timeline-marker {
@@ -1129,6 +1328,10 @@ $mel-dash-lavender: #7c83fd;
     line-height: 1;
   }
 
+  &__timeline--activity &__timeline-marker {
+    top: $spacing-4;
+  }
+
   &__timeline-item--success &__timeline-marker {
     border-color: rgba($success, 0.45);
     color: $success;
@@ -1140,10 +1343,29 @@ $mel-dash-lavender: #7c83fd;
   }
 
   &__timeline-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: $spacing-1 $spacing-3;
     min-width: 0;
     flex: 1 1 auto;
     font-size: $font-size-sm;
     line-height: $line-height-normal;
+  }
+
+  &__timeline-body {
+    min-width: 0;
+    flex: 1 1 12rem;
+  }
+
+  &__timeline-time {
+    flex: 0 0 auto;
+    color: $text-secondary;
+    font-size: $font-size-xs;
+    font-variant-numeric: tabular-nums;
+    line-height: $line-height-normal;
+    white-space: nowrap;
   }
 
   &__timeline-link,
@@ -1163,6 +1385,27 @@ $mel-dash-lavender: #7c83fd;
       outline: 2px solid rgba($primary, 0.35);
       outline-offset: 2px;
       border-radius: $radius-sm;
+    }
+  }
+
+  @media (max-width: 767px) {
+    &__timeline--activity &__timeline-item {
+      flex-direction: column;
+      gap: $spacing-2;
+    }
+
+    &__timeline-content {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: $spacing-1;
+    }
+
+    &__timeline-time {
+      white-space: normal;
+    }
+
+    &__timeline-link {
+      min-height: auto;
     }
   }
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-live-ops-operations-hero.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-live-ops-operations-hero.html.twig
@@ -28,7 +28,7 @@
   {% set last_sync_iso = door_context.last_sync_iso|default('') %}
   {% set start_line = '' %}
   {% set venue_line = '' %}
-  {% set status_chips = [] %}
+  {% set status_chips = live_indicator is not empty ? [{'label': live_indicator, 'modifier': 'live'}] : [] %}
 {% else %}
   {% set display_title = hero.title|default('') %}
   {% set pct = hero.check_in_rate_percent|default(metrics.check_in_rate_percent|default(0)) %}
@@ -58,15 +58,7 @@
           <p class="mel-live-ops__hero-venue">{{ venue_line }}</p>
         {% endif %}
 
-        {% if status_chips is iterable and status_chips|length > 0 %}
-          <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Status'|t }}">
-            {% for chip in status_chips %}
-              <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip.modifier|default('calm')|e('html_attr') }}">{{ chip.label|default('') }}</span>
-            {% endfor %}
-          </div>
-        {% endif %}
-
-        {% if live_indicator is not empty %}
+        {% if live_indicator is not empty and surface == 'hub' %}
           <p class="mel-live-ops__live-pulse" role="status">
             <span class="mel-live-ops__pulse-dot" aria-hidden="true"></span>
             <span>{{ live_indicator }}</span>
@@ -102,4 +94,17 @@
       </div>
     </div>
   </div>
+
+  {% if status_chips is iterable and status_chips|length > 0 or pct > 0 %}
+    <div class="mel-live-ops__health-strip" role="group" aria-label="{{ 'Event health'|t }}">
+      <div class="mel-live-ops__chip-row mel-live-ops__chip-row--health">
+        {% for chip in status_chips %}
+          <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip.modifier|default('calm')|e('html_attr') }}">{{ chip.label|default('') }}</span>
+        {% endfor %}
+        {% if pct > 0 %}
+          <span class="mel-live-ops__chip mel-live-ops__chip--info">{{ '@pct% checked in'|t({'@pct': pct }) }}</span>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
 </section>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-live-ops-operations-hero.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/mel-live-ops-operations-hero.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+ * @file
+ * Shared live operations identity — hub (/operations) and door mode.
+ *
+ * Uses existing view-model fields only (no revenue or sales totals).
+ *
+ * @var string variant hub|door
+ * @var array hero Hub hero from MelVenueOperationsViewModelBuilder
+ * @var array metrics Hub metrics (pct fallback)
+ * @var array door_context Door header context
+ * @var string event_title Door event title when hero is unavailable
+ * @var string title_id Heading id for aria-labelledby
+ * @var string eyebrow Section eyebrow copy
+ */
+#}
+{% set surface = variant|default('hub') %}
+{% set title_id = title_id|default('mel-live-ops-hero-title') %}
+{% set eyebrow = eyebrow|default('Running your event'|t) %}
+
+{% if surface == 'door' %}
+  {% set display_title = event_title|default('') %}
+  {% set pct = door_context.rate_percent|default(0) %}
+  {% set attendance_state = door_context.count_line|default('') %}
+  {% set readiness_line = '' %}
+  {% set live_indicator = door_context.live_indicator|default('') %}
+  {% set last_sync_formatted = door_context.last_sync_formatted|default('') %}
+  {% set last_sync_iso = door_context.last_sync_iso|default('') %}
+  {% set start_line = '' %}
+  {% set venue_line = '' %}
+  {% set status_chips = [] %}
+{% else %}
+  {% set display_title = hero.title|default('') %}
+  {% set pct = hero.check_in_rate_percent|default(metrics.check_in_rate_percent|default(0)) %}
+  {% set attendance_state = hero.attendance_state|default('') %}
+  {% set readiness_line = hero.readiness|default('') %}
+  {% set live_indicator = hero.live_indicator|default('') %}
+  {% set last_sync_formatted = hero.last_sync_formatted|default('') %}
+  {% set last_sync_iso = hero.last_sync_iso|default('') %}
+  {% set start_line = hero.start|default('') %}
+  {% set venue_line = hero.venue|default('') %}
+  {% set status_chips = hero.status_chips|default([]) %}
+{% endif %}
+
+<section class="mel-live-ops__hero mel-live-ops__hero--{{ surface|e('html_attr') }}" aria-labelledby="{{ title_id }}">
+  <div class="mel-live-ops__hero-surface">
+    <div class="mel-live-ops__hero-layout">
+      <div class="mel-live-ops__hero-primary">
+        <p class="mel-live-ops__eyebrow">{{ eyebrow }}</p>
+        {% if display_title is not empty %}
+          <h1 id="{{ title_id }}" class="mel-live-ops__hero-title">{{ display_title }}</h1>
+        {% endif %}
+
+        {% if start_line is not empty %}
+          <p class="mel-live-ops__hero-datetime">{{ start_line }}</p>
+        {% endif %}
+        {% if venue_line is not empty %}
+          <p class="mel-live-ops__hero-venue">{{ venue_line }}</p>
+        {% endif %}
+
+        {% if status_chips is iterable and status_chips|length > 0 %}
+          <div class="mel-live-ops__chip-row" role="group" aria-label="{{ 'Status'|t }}">
+            {% for chip in status_chips %}
+              <span class="mel-live-ops__chip mel-live-ops__chip--{{ chip.modifier|default('calm')|e('html_attr') }}">{{ chip.label|default('') }}</span>
+            {% endfor %}
+          </div>
+        {% endif %}
+
+        {% if live_indicator is not empty %}
+          <p class="mel-live-ops__live-pulse" role="status">
+            <span class="mel-live-ops__pulse-dot" aria-hidden="true"></span>
+            <span>{{ live_indicator }}</span>
+          </p>
+        {% endif %}
+        {% if last_sync_formatted is not empty %}
+          <p class="mel-live-ops__sync-meta">
+            <time datetime="{{ last_sync_iso }}">{{ 'Last refreshed'|t }} · {{ last_sync_formatted }}</time>
+          </p>
+        {% endif %}
+      </div>
+
+      <div class="mel-live-ops__hero-aside">
+        <div class="mel-live-ops__progress-shell" data-mel-ops-progress-shell style="--mel-ops-progress: {{ pct }};">
+          <div class="mel-live-ops__progress-ring" data-mel-ops-progress-ring role="progressbar" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ 'Check-in completion'|t }}">
+            <span class="mel-live-ops__progress-ring-label">
+              <span class="mel-live-ops__progress-percent" data-mel-ops-progress-percent>{{ pct }}%</span>
+              <span class="mel-live-ops__progress-caption">{{ 'checked in'|t }}</span>
+            </span>
+          </div>
+          <div class="mel-live-ops__progress-track" aria-hidden="true">
+            <span class="mel-live-ops__progress-fill" data-mel-ops-progress-fill style="width: {{ pct }}%;"></span>
+          </div>
+          <div class="mel-live-ops__hero-summary">
+            {% if attendance_state is not empty %}
+              <p class="mel-live-ops__summary-line">{{ attendance_state }}</p>
+            {% endif %}
+            {% if readiness_line is not empty %}
+              <p class="mel-live-ops__summary-muted">{{ readiness_line }}</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/components/workspace/workspace-tabs.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/components/workspace/workspace-tabs.html.twig
@@ -3,6 +3,9 @@
  * @file
  * Event workspace section links (horizontal). Data from VendorEventTabsService
  * or TASK 8 workspace tab models (available flag).
+ *
+ * Navigation semantics only — parent template supplies <nav aria-label="…">.
+ * Each item is a full-page link, not a WAI-ARIA tab widget.
  */
 #}
 {% if tabs %}
@@ -11,25 +14,19 @@
     {% if unavailable %}
       <span
         class="mel-tab mel-tab--disabled"
-        role="tab"
         aria-disabled="true"
-        aria-selected="false"
         {% if tab.disabled_reason|default('') %}title="{{ tab.disabled_reason|e }}"{% endif %}
       >{{ tab.label }}</span>
     {% elseif tab.url %}
       <a
         href="{{ tab.url }}"
         class="mel-tab{% if tab.active %} is-active{% endif %}"
-        role="tab"
         {% if tab.active %}aria-current="page"{% endif %}
-        aria-selected="{{ tab.active ? 'true' : 'false' }}"
       >{{ tab.label }}</a>
     {% else %}
       <span
         class="mel-tab mel-tab--disabled"
-        role="tab"
         aria-disabled="true"
-        aria-selected="false"
       >{{ tab.label }}</span>
     {% endif %}
   {% endfor %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -3,12 +3,16 @@
  * @file
  * Organiser mission control dashboard — action-first layout.
  *
- * Visible: priority, quick actions, hero, metrics, attention, upcoming, activity.
+ * Visible: priority, quick actions, hero, metrics, workspace updates, attention,
+ * upcoming, recent activity.
  * Reporting surfaces live in collapsed <details> panels (organisers with events).
  */
 #}
 {% set model = vendor_dashboard_view_model|default({}) %}
 {% set vendor = model.vendor|default({}) %}
+{% set account_summary = account|default({}) %}
+{% set organiser_display_name = account_summary.display_name|default('') %}
+{% set hero_shell_hint = model.hero_shell_hint|default('') %}
 {% set readiness = model.readiness|default({}) %}
 {% set homepage_readiness = homepage_readiness|default(null) %}
 {% set homepage_visibility = model.homepage_visibility|default(null) %}
@@ -25,19 +29,25 @@
 {% set empty_state = model.empty_state|default({}) %}
 {% set analytics_summary = model.analytics_summary|default({}) %}
 {% set analytics_items = analytics_summary.items|default([]) %}
-{% set activity_items = model.activity_items|default(dashboard_activity_items|default([])) %}
+{% set activity_items = dashboard_activity_items|default([]) %}
+{% set workspace_updates = model.workspace_updates|default([]) %}
 {% set dashboard_vendor_id = vendor.id|default(null) %}
 {% set metric_rows = kpis %}
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
 {% set create_action = organiser_actions|filter(item => item.key|default('') == 'create')|first|default(null) %}
+{% set manage_events_action = organiser_actions|filter(item => item.key|default('') == 'events')|first|default(null) %}
 {% set snapshot_defs = [
+  { key: 'revenue', label: 'Revenue'|t, pool: 'kpis', emphasis: 'primary' },
+  { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis', emphasis: 'secondary' },
+  { key: 'live_events', label: 'Live events'|t, pool: 'overview', emphasis: 'neutral' },
+  { key: 'bookings', label: 'Bookings'|t, pool: 'overview', emphasis: 'neutral' },
+  { key: 'upcoming_events', label: 'Upcoming'|t, pool: 'overview', emphasis: 'neutral' },
+] %}
+{% set hero_stat_defs = [
   { key: 'live_events', label: 'Live events'|t, pool: 'overview' },
-  { key: 'upcoming_events', label: 'Upcoming'|t, pool: 'overview' },
-  { key: 'bookings', label: 'Bookings'|t, pool: 'overview' },
   { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis' },
   { key: 'revenue', label: 'Revenue'|t, pool: 'kpis' },
 ] %}
-{% set snapshot_modifiers = ['total', 'in', 'ready', 'capacity', 'remain'] %}
 
 <section class="mel-live-operations mel-vendor-dashboard{% if events_empty %} mel-vendor-dashboard--empty{% endif %}" data-mel-vendor-dashboard>
   {% if priority_action %}
@@ -57,60 +67,82 @@
     </section>
   {% endif %}
 
-  {% if organiser_actions is iterable and organiser_actions|length > 0 %}
-    <nav class="mel-vendor-dashboard__quick-actions mel-live-ops__quick-bar" aria-label="{{ 'Quick actions'|t }}">
-      <div class="mel-live-ops__quick-inner">
-        {% for action in organiser_actions %}
-          {% set action_key = action.key|default('') %}
-          {% set is_create = action_key == 'create' %}
-          {% set action_variant = action.variant|default(is_create ? 'primary' : 'secondary') %}
-          {% if action.url is defined and action.url %}
-            <a
-              class="mel-btn mel-btn--{{ action_variant }} mel-live-ops__quick-btn{% if is_create %} mel-vendor-dashboard__quick-btn--create{% endif %}"
-              href="{{ action.url }}"
-            >{{ action.label }}</a>
-          {% endif %}
-        {% endfor %}
-      </div>
-    </nav>
-  {% endif %}
-
   {% if events_empty %}
     {% set empty_cta_url = empty_state.url|default(create_action.url|default(null)) %}
     {% set empty_cta_label = empty_state.action_label|default(create_action.label|default(null)) %}
-    <section class="mel-live-ops__hero mel-vendor-dashboard__mission-hero mel-vendor-dashboard__mission-hero--empty" aria-labelledby="mel-dash-hero-title">
-      <div class="mel-live-ops__hero-surface mel-vendor-dashboard__empty-hero mel-vendor-dashboard__empty-state" role="status">
-        <p class="mel-live-ops__eyebrow">{{ 'Organiser dashboard'|t }}</p>
-        <h1 id="mel-dash-hero-title" class="mel-live-ops__hero-title mel-vendor-dashboard__empty-state-title">{{ empty_state.title|default('Welcome to MyEventLane'|t) }}</h1>
-        <p class="mel-live-ops__hero-venue mel-vendor-dashboard__empty-hero-message">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
+    <section class="mel-vendor-dashboard__workspace-hero mel-vendor-dashboard__workspace-hero--empty" aria-labelledby="mel-dash-hero-title">
+      <div class="mel-vendor-dashboard__workspace-hero-body">
+        <p class="mel-live-ops__eyebrow">{{ 'Organiser workspace'|t }}</p>
+        <h1 id="mel-dash-hero-title" class="mel-vendor-dashboard__workspace-hero-title">
+          {% if organiser_display_name %}
+            {{ 'Welcome, @name'|t({'@name': organiser_display_name}) }}
+          {% else %}
+            {{ empty_state.title|default('Welcome to MyEventLane'|t) }}
+          {% endif %}
+        </h1>
+        {% if hero_shell_hint %}
+          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
+        {% else %}
+          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
+        {% endif %}
         {% if empty_cta_url and empty_cta_label %}
-          <div class="mel-vendor-dashboard__empty-hero-cta">
+          <div class="mel-vendor-dashboard__workspace-hero-actions">
             <a class="mel-btn mel-btn--primary mel-btn--lg" href="{{ empty_cta_url }}">{{ empty_cta_label }}</a>
           </div>
         {% endif %}
       </div>
     </section>
   {% else %}
-    <section class="mel-live-ops__hero mel-vendor-dashboard__mission-hero" aria-labelledby="mel-dash-hero-title">
-      <div class="mel-live-ops__hero-surface">
-        <div class="mel-live-ops__hero-layout mel-vendor-dashboard__mission-hero-layout mel-vendor-dashboard__mission-hero-layout--solo">
-          <div class="mel-live-ops__hero-primary">
-            <p class="mel-live-ops__eyebrow">{{ 'Organiser dashboard'|t }}</p>
-            <h1 id="mel-dash-hero-title" class="mel-live-ops__hero-title">
-              {% if vendor.label|default('') is not empty %}
-                {{ vendor.label }}
-              {% else %}
-                {{ 'Your organiser dashboard'|t }}
-              {% endif %}
-            </h1>
-            <p class="mel-live-ops__hero-venue">{{ 'Manage events, track attendees, and grow your audience.'|t }}</p>
-          </div>
-        </div>
+    <section class="mel-vendor-dashboard__workspace-hero" aria-labelledby="mel-dash-hero-title">
+      <div class="mel-vendor-dashboard__workspace-hero-body">
+        {% if vendor.label|default('') is not empty %}
+          <p class="mel-vendor-dashboard__workspace-hero-context">{{ vendor.label }}</p>
+        {% else %}
+          <p class="mel-live-ops__eyebrow">{{ 'Organiser workspace'|t }}</p>
+        {% endif %}
+        <h1 id="mel-dash-hero-title" class="mel-vendor-dashboard__workspace-hero-title">
+          {% if organiser_display_name %}
+            {{ 'Welcome back, @name'|t({'@name': organiser_display_name}) }}
+          {% else %}
+            {{ 'Welcome back'|t }}
+          {% endif %}
+        </h1>
+        {% if hero_shell_hint %}
+          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
+        {% endif %}
       </div>
+
+      <ul class="mel-vendor-dashboard__workspace-hero-stats" role="list" aria-label="{{ 'Today at a glance'|t }}">
+        {% for def in hero_stat_defs %}
+          {% if def.pool == 'overview' %}
+            {% set stat_match = organiser_overview|filter(item => item.key|default('') == def.key)|first|default(null) %}
+          {% else %}
+            {% set stat_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
+          {% endif %}
+          {% set stat_value = stat_match ? stat_match.value|default('0') : '0' %}
+          <li class="mel-vendor-dashboard__workspace-hero-stat{% if def.key == 'revenue' %} mel-vendor-dashboard__workspace-hero-stat--revenue{% endif %}" role="listitem">
+            <span class="mel-vendor-dashboard__workspace-hero-stat-value">{{ stat_value }}</span>
+            <span class="mel-vendor-dashboard__workspace-hero-stat-label">{{ def.label }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+
+      {% if (priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label) or (manage_events_action and manage_events_action.url is defined and manage_events_action.url) or (create_action and create_action.url is defined and create_action.url) %}
+        <div class="mel-vendor-dashboard__workspace-hero-actions">
+          {% if priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
+            <a class="mel-btn mel-btn--primary" href="{{ priority_action.url }}">{{ priority_action.action_label }}</a>
+          {% endif %}
+          {% if manage_events_action.url is defined and manage_events_action.url %}
+            <a class="mel-btn mel-btn--secondary" href="{{ manage_events_action.url }}">{{ manage_events_action.label }}</a>
+          {% elseif create_action.url is defined and create_action.url %}
+            <a class="mel-btn mel-btn--secondary" href="{{ create_action.url }}">{{ create_action.label }}</a>
+          {% endif %}
+        </div>
+      {% endif %}
     </section>
   {% endif %}
 
-  <section class="mel-vendor-dashboard__metric-strip{% if events_empty %} mel-vendor-dashboard__metric-strip--starter{% endif %}" aria-labelledby="mel-dash-metrics-title">
+  <section class="mel-vendor-dashboard__metric-strip mel-vendor-dashboard__metric-strip--compact{% if events_empty %} mel-vendor-dashboard__metric-strip--starter{% endif %}" aria-labelledby="mel-dash-metrics-title">
     <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
       <div>
         <p class="mel-live-ops__eyebrow">{{ 'At a glance'|t }}</p>
@@ -128,14 +160,39 @@
           {% set snapshot_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
         {% endif %}
         {% set metric_value = snapshot_match ? snapshot_match.value|default('0') : '0' %}
-        {% set stat_mod = snapshot_modifiers[loop.index0 % snapshot_modifiers|length] %}
-        <article class="mel-live-ops__stat-card mel-live-ops__stat-card--{{ stat_mod }} mel-vendor-dashboard__metric-card" role="listitem">
+        {% set stat_emphasis = def.emphasis|default('neutral') %}
+        <article class="mel-live-ops__stat-card mel-vendor-dashboard__metric-card mel-vendor-dashboard__metric-card--{{ stat_emphasis }}" role="listitem">
           <span class="mel-live-ops__stat-value">{{ metric_value }}</span>
           <span class="mel-live-ops__stat-label">{{ def.label }}</span>
         </article>
       {% endfor %}
     </div>
   </section>
+
+  {% if workspace_updates is iterable and workspace_updates|length > 0 %}
+    <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-updates-title">
+      <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
+        <p class="mel-live-ops__eyebrow">{{ 'Your workspace'|t }}</p>
+        <h2 id="mel-dash-workspace-updates-title" class="mel-live-ops__panel-title">{{ 'Workspace updates'|t }}</h2>
+      </div>
+      <ol class="mel-vendor-dashboard__timeline mel-vendor-dashboard__timeline--workspace" role="list">
+        {% for item in workspace_updates|slice(0, 6) %}
+          {% set row_type = item.type|default('info') %}
+          {% set feed_icon = row_type == 'success' ? '✓' : '•' %}
+          <li class="mel-vendor-dashboard__timeline-item mel-vendor-dashboard__timeline-item--{{ row_type == 'success' ? 'success' : (row_type == 'warning' ? 'warn' : 'info') }}" role="listitem">
+            <span class="mel-vendor-dashboard__timeline-marker" aria-hidden="true">{{ feed_icon }}</span>
+            <div class="mel-vendor-dashboard__timeline-content">
+              {% if item.url is defined and item.url %}
+                <a class="mel-vendor-dashboard__timeline-link" href="{{ item.url }}">{{ item.message|default('') }}</a>
+              {% else %}
+                <span class="mel-vendor-dashboard__timeline-text">{{ item.message|default('') }}</span>
+              {% endif %}
+            </div>
+          </li>
+        {% endfor %}
+      </ol>
+    </section>
+  {% endif %}
 
   {% if not events_empty %}
     {% if attention_events is iterable and attention_events|length > 0 %}
@@ -215,24 +272,31 @@
       <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent activity'|t }}</h2>
     </div>
     {% if activity_items is iterable and activity_items|length > 0 %}
-      <ol class="mel-vendor-dashboard__timeline" role="list">
+      <ol class="mel-vendor-dashboard__timeline mel-vendor-dashboard__timeline--activity" role="list">
         {% for item in activity_items|slice(0, 5) %}
           {% set row_type = item.type|default('info') %}
           {% set feed_icon = row_type == 'success' ? '✓' : '•' %}
           <li class="mel-vendor-dashboard__timeline-item mel-vendor-dashboard__timeline-item--{{ row_type == 'success' ? 'success' : (row_type == 'warning' ? 'warn' : 'info') }}" role="listitem">
             <span class="mel-vendor-dashboard__timeline-marker" aria-hidden="true">{{ feed_icon }}</span>
             <div class="mel-vendor-dashboard__timeline-content">
-              {% if item.url is defined and item.url %}
-                <a class="mel-vendor-dashboard__timeline-link" href="{{ item.url }}">{{ item.message|default('') }}</a>
-              {% else %}
-                <span class="mel-vendor-dashboard__timeline-text">{{ item.message|default('') }}</span>
+              <div class="mel-vendor-dashboard__timeline-body">
+                {% if item.url is defined and item.url %}
+                  <a class="mel-vendor-dashboard__timeline-link" href="{{ item.url }}">{{ item.message|default('') }}</a>
+                {% else %}
+                  <span class="mel-vendor-dashboard__timeline-text">{{ item.message|default('') }}</span>
+                {% endif %}
+              </div>
+              {% if item.timestamp_label is defined and item.timestamp_label %}
+                <time class="mel-vendor-dashboard__timeline-time"{% if item.timestamp is defined and item.timestamp %} datetime="{{ item.timestamp|date('c') }}"{% endif %}>{{ item.timestamp_label }}</time>
+              {% elseif item.timestamp is defined and item.timestamp %}
+                <time class="mel-vendor-dashboard__timeline-time" datetime="{{ item.timestamp|date('c') }}">{{ item.timestamp|format_date('short') }}</time>
               {% endif %}
             </div>
           </li>
         {% endfor %}
       </ol>
     {% else %}
-      <p class="mel-live-ops__muted">{{ 'Operational activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
+      <p class="mel-live-ops__muted">{{ 'Activity will appear after bookings, RSVPs, check-ins, or event updates.'|t }}</p>
     {% endif %}
   </section>
 

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -170,10 +170,10 @@
   </section>
 
   {% if workspace_updates is iterable and workspace_updates|length > 0 %}
-    <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-updates-title">
+    <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-title">
       <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
-        <p class="mel-live-ops__eyebrow">{{ 'Your workspace'|t }}</p>
-        <h2 id="mel-dash-workspace-updates-title" class="mel-live-ops__panel-title">{{ 'Workspace updates'|t }}</h2>
+        <p class="mel-live-ops__eyebrow">{{ 'What needs your attention'|t }}</p>
+        <h2 id="mel-dash-workspace-title" class="mel-live-ops__panel-title">{{ 'Workspace updates'|t }}</h2>
       </div>
       <ol class="mel-vendor-dashboard__timeline mel-vendor-dashboard__timeline--workspace" role="list">
         {% for item in workspace_updates|slice(0, 6) %}
@@ -268,7 +268,7 @@
 
     <section class="mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact" aria-labelledby="mel-dash-activity-title">
     <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
-      <p class="mel-live-ops__eyebrow">{{ 'What is happening'|t }}</p>
+      <p class="mel-live-ops__eyebrow">{{ 'What happened recently'|t }}</p>
       <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent activity'|t }}</h2>
     </div>
     {% if activity_items is iterable and activity_items|length > 0 %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar-nav-item.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar-nav-item.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Single vendor shell sidebar nav item (top-level link or disabled state).
+ *
+ * @var item array Nav item from VendorNavBuilder.
+ * @var compact bool When true, omit icon (nested Event Editor).
+ */
+#}
+{% set compact = compact|default(false) %}
+{% if item.url and not item.is_disabled %}
+  <a href="{{ item.url }}"
+     class="mel-sidebar__link mel-vendor-console__nav-item mel-vendor-console__mobile-nav-item{% if compact %} mel-sidebar__link--compact{% endif %}{% if item.is_active %} mel-vendor-console__nav-item--active is-active{% endif %}"
+     {% if item.is_active %}aria-current="page"{% endif %}>
+    {% if not compact %}
+      <span class="mel-sidebar__link-icon" aria-hidden="true">
+        {% include '@myeventlane_vendor_theme/components/sidebar-icon.html.twig' with { icon: item.icon|default('dashboard') } only %}
+      </span>
+    {% endif %}
+    <span class="mel-sidebar__link-label">{{ item.label }}</span>
+  </a>
+{% else %}
+  {% set event_scoped_keys = ['orders', 'checkin', 'check_in', 'ticket_holders', 'event_editor'] %}
+  {% set disabled_reason = item.key in event_scoped_keys
+    ? 'Open this from an event'|t
+    : 'Available soon'|t %}
+  {% set disabled_badge = item.key in event_scoped_keys
+    ? 'Event-only'|t
+    : 'Soon'|t %}
+  <span class="mel-sidebar__link mel-vendor-console__nav-item mel-sidebar__link--disabled{% if compact %} mel-sidebar__link--compact{% endif %}"
+        aria-disabled="true"
+        title="{{ disabled_reason }}">
+    {% if not compact %}
+      <span class="mel-sidebar__link-icon" aria-hidden="true">
+        {% include '@myeventlane_vendor_theme/components/sidebar-icon.html.twig' with { icon: item.icon|default('dashboard') } only %}
+      </span>
+    {% endif %}
+    <span class="mel-sidebar__link-label">{{ item.label }}</span>
+    <span class="mel-sidebar__link-badge">{{ disabled_badge }}</span>
+  </span>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar-nav-subitem.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar-nav-subitem.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Vendor shell sidebar subnav link (nested under a group item).
+ *
+ * @var child array Child nav item or nested top-level item.
+ */
+#}
+{% if child.url and not child.is_disabled %}
+  <a href="{{ child.url }}"
+     class="mel-sidebar__subnav-link mel-vendor-console__nav-item mel-vendor-console__mobile-nav-item{% if child.is_active %} mel-vendor-console__nav-item--active is-active{% endif %}"
+     {% if child.is_active %}aria-current="page"{% endif %}>
+    {{ child.label }}
+  </a>
+{% else %}
+  <span class="mel-sidebar__subnav-link mel-sidebar__subnav-link--disabled"
+        aria-disabled="true"
+        title="{{ 'Select an event first'|t }}">
+    {{ child.label }}
+  </span>
+{% endif %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/sidebar.html.twig
@@ -2,6 +2,8 @@
 /**
  * @file
  * Left navigation sidebar for MyEventLane Vendor Console.
+ *
+ * Groups VendorNavBuilder items by key (presentation only — IA unchanged in PHP).
  */
 #}
 <nav class="mel-sidebar mel-vendor-console__nav" aria-label="{{ 'Organiser navigation'|t }}">
@@ -23,64 +25,63 @@
   {# Nav items MUST come from myeventlane_vendor_theme_preprocess_page — never use |default(hardcoded):
      Twig's default() treats [] as empty and would replace PHP-built onboarding-safe nav. #}
   {% set nav_items = page.vendor_shell_nav_items is defined ? page.vendor_shell_nav_items : [] %}
+  {% set nav_groups = [
+    { id: 'dashboard', label: 'Dashboard'|t, keys: ['dashboard'] },
+    { id: 'events', label: 'Events'|t, keys: ['events'] },
+    { id: 'operations', label: 'Operations'|t, keys: ['orders', 'ticket_holders', 'checkin', 'refund_requests'] },
+    { id: 'growth', label: 'Growth'|t, keys: ['promote', 'messaging', 'analytics'] },
+    { id: 'account', label: 'Account'|t, keys: ['payouts', 'settings', 'support'] },
+  ] %}
 
-  <ul class="mel-sidebar__nav" role="list">
-    {% for item in nav_items %}
-      <li class="mel-sidebar__item{% if item.children|default([]) %} mel-sidebar__item--with-subnav{% endif %}">
-        {% if item.url and not item.is_disabled %}
-          <a href="{{ item.url }}"
-             class="mel-sidebar__link mel-vendor-console__nav-item mel-vendor-console__mobile-nav-item{% if item.is_active %} mel-vendor-console__nav-item--active is-active{% endif %}"
-             {% if item.is_active %}aria-current="page"{% endif %}>
-            <span class="mel-sidebar__link-icon" aria-hidden="true">
-              {% include '@myeventlane_vendor_theme/components/sidebar-icon.html.twig' with { icon: item.icon|default('dashboard') } only %}
-            </span>
-            <span class="mel-sidebar__link-label">{{ item.label }}</span>
-          </a>
-        {% else %}
-          {# Items that need an event context use a clearer disabled reason; #}
-          {# others fall back to the calmer 'Available soon' wording. #}
-          {% set event_scoped_keys = ['orders', 'checkin', 'check_in', 'ticket_holders', 'event_editor'] %}
-          {% set disabled_reason = item.key in event_scoped_keys
-            ? 'Open this from an event'|t
-            : 'Available soon'|t %}
-          {% set disabled_badge = item.key in event_scoped_keys
-            ? 'Event-only'|t
-            : 'Soon'|t %}
-          <span class="mel-sidebar__link mel-vendor-console__nav-item mel-sidebar__link--disabled"
-                aria-disabled="true"
-                title="{{ disabled_reason }}">
-            <span class="mel-sidebar__link-icon" aria-hidden="true">
-              {% include '@myeventlane_vendor_theme/components/sidebar-icon.html.twig' with { icon: item.icon|default('dashboard') } only %}
-            </span>
-            <span class="mel-sidebar__link-label">{{ item.label }}</span>
-            <span class="mel-sidebar__link-badge">{{ disabled_badge }}</span>
-          </span>
-        {% endif %}
+  <div class="mel-sidebar__nav-groups">
+    {% for group in nav_groups %}
+      {% set visible_items = nav_items|filter(item => item.key|default('') in group.keys) %}
+      {% if visible_items|length > 0 %}
+        <section class="mel-sidebar__group mel-sidebar__group--{{ group.id }}" aria-label="{{ group.label }}">
+          <p class="mel-sidebar__section-label" id="mel-sidebar-group-{{ group.id }}">{{ group.label }}</p>
+          <ul class="mel-sidebar__nav" role="list" aria-labelledby="mel-sidebar-group-{{ group.id }}">
+            {% for key in group.keys %}
+              {% for item in nav_items %}
+                {% if item.key|default('') == key %}
+                  {% set is_events_group = group.id == 'events' %}
+                  {% set event_editor_item = null %}
+                  {% if is_events_group %}
+                    {% for candidate in nav_items %}
+                      {% if candidate.key|default('') == 'event_editor' %}
+                        {% set event_editor_item = candidate %}
+                      {% endif %}
+                    {% endfor %}
+                  {% endif %}
+                  {% set wizard_children = item.children|default([]) %}
+                  {% set nest_event_editor = is_events_group and event_editor_item and wizard_children|length == 0 %}
+                  {% set has_subnav = wizard_children|length > 0 or nest_event_editor %}
 
-        {% if item.children|default([]) %}
-          <ul class="mel-sidebar__subnav" role="list">
-            {% for child in item.children %}
-              <li class="mel-sidebar__subitem">
-                {% if child.url and not child.is_disabled %}
-                  <a href="{{ child.url }}"
-                     class="mel-sidebar__subnav-link mel-vendor-console__nav-item mel-vendor-console__mobile-nav-item{% if child.is_active %} mel-vendor-console__nav-item--active is-active{% endif %}"
-                     {% if child.is_active %}aria-current="page"{% endif %}>
-                    {{ child.label }}
-                  </a>
-                {% else %}
-                  <span class="mel-sidebar__subnav-link"
-                        aria-disabled="true"
-                        title="{{ 'Select an event first'|t }}">
-                    {{ child.label }}
-                  </span>
+                  <li class="mel-sidebar__item{% if has_subnav %} mel-sidebar__item--with-subnav{% endif %}">
+                    {% include '@myeventlane_vendor_theme/includes/sidebar-nav-item.html.twig' with { item: item } only %}
+
+                    {% if has_subnav %}
+                      <ul class="mel-sidebar__subnav" role="list">
+                        {% for child in wizard_children %}
+                          <li class="mel-sidebar__subitem">
+                            {% include '@myeventlane_vendor_theme/includes/sidebar-nav-subitem.html.twig' with { child: child } only %}
+                          </li>
+                        {% endfor %}
+                        {% if nest_event_editor %}
+                          <li class="mel-sidebar__subitem mel-sidebar__subitem--nested-top-level">
+                            {% include '@myeventlane_vendor_theme/includes/sidebar-nav-subitem.html.twig' with { child: event_editor_item } only %}
+                          </li>
+                        {% endif %}
+                      </ul>
+                    {% endif %}
+                  </li>
                 {% endif %}
-              </li>
+              {% endfor %}
             {% endfor %}
           </ul>
-        {% endif %}
-      </li>
+        </section>
+      {% endif %}
     {% endfor %}
-  </ul>
+  </div>
 
   <div class="mel-sidebar__footer">
     <a class="mel-sidebar__link" href="{{ page.main_site_url|default('/') }}">
@@ -113,4 +114,3 @@
     {% endif %}
   </div>
 </nav>
-

--- a/web/themes/custom/myeventlane_vendor_theme/templates/includes/vendor-shell-header.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/includes/vendor-shell-header.html.twig
@@ -4,9 +4,13 @@
  * VendorShell header region (title, notifications, primary action).
  *
  * Included from layout/page.html.twig — canonical vendor console shell.
+ *
+ * @var hide_shell_title bool When true (dashboard route), titles are visually
+ *   hidden so the dashboard workspace hero owns the page heading.
  */
 #}
-<header class="mel-shell-header mel-vendor-console__header" role="banner">
+{% set hide_shell_title = hide_shell_title|default(false) %}
+<header class="mel-shell-header mel-vendor-console__header{% if hide_shell_title %} mel-shell-header--dashboard{% endif %}" role="banner">
   <div class="mel-shell-header__left">
     <button class="mel-shell-header__menu-btn"
             type="button"
@@ -17,12 +21,14 @@
       <span aria-hidden="true">☰</span>
     </button>
 
-    <div class="mel-shell-header__titles">
-      <h1 class="mel-shell-header__title">{{ page.shell_page_title|default('Vendor workspace'|t) }}</h1>
-      {% if page.shell_page_subtitle %}
-        <p class="mel-shell-header__subtitle">{{ page.shell_page_subtitle }}</p>
-      {% endif %}
-    </div>
+    {% if not hide_shell_title %}
+      <div class="mel-shell-header__titles">
+        <h1 class="mel-shell-header__title">{{ page.shell_page_title|default('Vendor workspace'|t) }}</h1>
+        {% if page.shell_page_subtitle %}
+          <p class="mel-shell-header__subtitle">{{ page.shell_page_subtitle }}</p>
+        {% endif %}
+      </div>
+    {% endif %}
   </div>
 
   <div class="mel-shell-header__actions">
@@ -31,7 +37,7 @@
         {{ page.mel_notification_bell }}
       </div>
     {% endif %}
-    {% if page.shell_primary_action %}
+    {% if page.shell_primary_action and not hide_shell_title %}
       <a href="{{ page.shell_primary_action.url }}" class="mel-btn mel-btn--primary mel-vendor-console__primary-action">
         {{ page.shell_primary_action.label }}
       </a>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/layout/page.html.twig
@@ -21,7 +21,7 @@
 {# Hidden overlay must not block clicks. #}
 <div class="mel-sidebar-overlay" data-sidebar-overlay style="pointer-events:none;"></div>
 
-<div class="mel-vendor-console mel-vendor-shell{% if page.wizard_sidebar_active %} mel-vendor-shell--wizard-sidebar{% endif %}">
+<div class="mel-vendor-console mel-vendor-shell{% if is_dashboard_route %} mel-vendor-shell--dashboard{% endif %}{% if page.wizard_sidebar_active %} mel-vendor-shell--wizard-sidebar{% endif %}">
   <aside id="mel-vendor-sidebar" class="mel-vendor-shell__sidebar mel-vendor-sidebar mel-vendor-console__sidebar" role="navigation" aria-label="{{ 'Organiser navigation'|t }}" data-sidebar>
     {% include '@myeventlane_vendor_theme/includes/sidebar.html.twig' with { page: page } %}
   </aside>
@@ -29,6 +29,7 @@
   <div class="mel-vendor-shell__main mel-vendor-console__main">
     {% include '@myeventlane_vendor_theme/includes/vendor-shell-header.html.twig' with {
       page: page,
+      hide_shell_title: is_dashboard_route,
     } only %}
 
     {% if page.vendor_alert is defined %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -317,7 +317,7 @@
 
       {% if show_workspace_tabs|default(true) and model.tabs is iterable and model.tabs is not empty %}
         <div class="mel-live-ops__tab-bar mel-workspace__tab-bar">
-          <nav class="mel-tabs mel-tabs--horizontal mel-live-ops__tab-nav" role="tablist" aria-label="{{ 'Event sections'|t }}">
+          <nav class="mel-tabs mel-tabs--horizontal mel-live-ops__tab-nav" aria-label="{{ 'Event sections'|t }}">
             {% include '@myeventlane_vendor_theme/components/workspace/workspace-tabs.html.twig' with { tabs: model.tabs } %}
           </nav>
         </div>
@@ -340,7 +340,7 @@
 
   {% if show_workspace_tabs|default(true) and not has_ws_model and tabs %}
     <div class="mel-workspace__tab-bar">
-      <nav class="mel-tabs mel-tabs--horizontal" role="tablist" aria-label="{{ 'Event sections'|t }}">
+      <nav class="mel-tabs mel-tabs--horizontal" aria-label="{{ 'Event sections'|t }}">
         {% include '@myeventlane_vendor_theme/components/workspace/workspace-tabs.html.twig' %}
       </nav>
     </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig
@@ -7,7 +7,7 @@
 {% set model = vendor_event_workspace_model|default({}) %}
 {% set has_ws_model = model.event is defined and model.event.nid is defined %}
 
-<div class="mel-workspace mel-workspace--surface{% if sidebar %} mel-workspace--with-ticket-tools{% endif %}">
+<div class="mel-workspace mel-workspace--surface{% if sidebar %} mel-workspace--with-ticket-tools{% endif %}{% if suppress_workspace_header|default(false) %} mel-workspace--live-ops-surface{% endif %}">
   {% if has_ws_model and model.empty_state.title|default('') is not empty %}
     <div class="mel-live-ops__panel mel-live-ops__workspace-empty" role="alert">
       <h2 class="mel-live-ops__panel-title">{{ model.empty_state.title }}</h2>
@@ -325,7 +325,7 @@
     </div>
   {% elseif header_stats is not empty %}
     {% include '@myeventlane_vendor_theme/mel-event/mel-event-header.html.twig' %}
-  {% else %}
+  {% elseif not suppress_workspace_header|default(false) %}
     <div class="mel-event-management-shell">
       {% if manage_event_back.url is defined and manage_event_back.url %}
         <nav class="mel-event-manage-back mel-event-management-shell__back" aria-label="{{ 'Event navigation'|t }}">
@@ -414,7 +414,7 @@
               </div>
             {% endif %}
           </div>
-        {% elseif not has_ws_model %}
+        {% elseif not has_ws_model and not suppress_workspace_header|default(false) %}
           <div class="mel-insights-empty">
             <p>{{ "Your event is looking good. We'll let you know if anything needs attention."|t }}</p>
           </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad vendor UI and Twig changes on operations/check-in and dashboard feeds; activity display behavior changes but uses existing controller queries without new backend paths.
> 
> **Overview**
> **Live operations (hub + door mode)** share a new `mel-live-ops-operations-hero` partial with a health strip; inline hero markup and the duplicate “Open door mode” hero CTA are removed. The operations mission bar orders actions by icon (`scan` first as primary), adds an **Orders** shortcut, shortens labels, and drops door settings from the bar. Theme preprocess sets **`suppress_workspace_header`** on operations/door routes so the workspace shell does not duplicate event identity; related SCSS flattens shadows and adds mobile touch-target and toolbar wrap rules.
> 
> **Vendor dashboard** stops using synthetic `activity_items` from the view model: Twig reads **`dashboard_activity_items`** from the controller, while **`workspace_updates`** holds organiser readiness lines (Stripe/profile). A new workspace hero, compact metrics, and relative **`timestamp_label`** preprocess on recent activity replace the old mission-hero + quick-actions strip; the dashboard route hides the shell page title so the hero owns the heading.
> 
> **Accessibility:** event workspace section links lose invalid **`role="tablist"` / `role="tab"`** semantics (nav links with `aria-current` only).
> 
> **Sidebar** is regrouped in Twig (Dashboard / Events / Operations / Growth / Account) via small nav partials; styling tweaks for active states and dashboard shell header.
> 
> **Docs:** Phase 7A mobile audit, workspace tab governance (Phase 6B), and audit note **D-7** (dashboard activity fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f93f2490784e6bf0908eabec30efa713131d8d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->