### PR TITLE
Feature/mel public visitor navigation

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -130,7 +130,7 @@ $mel-dash-lavender: #7c83fd;
   &__workspace-hero-title {
     margin: 0;
     color: $mel-ws-navy;
-    font-size: clamp(1.625rem, 4.8vw, 2.25rem);
+    font-size: clamp(1.375rem, 3.8vw, 1.75rem);
     font-weight: $font-weight-bold;
     line-height: $line-height-tight;
     letter-spacing: -0.02em;
@@ -167,18 +167,18 @@ $mel-dash-lavender: #7c83fd;
     display: grid;
     gap: $spacing-1;
     min-width: 0;
-    padding: $spacing-3;
-    border: 1px solid rgba($mel-ws-navy, 0.08);
-    border-radius: $radius-lg;
-    background: rgba($mel-shell-page-bg, 0.72);
+    padding: $spacing-2 $spacing-3;
+    border: 1px solid rgba($mel-ws-navy, 0.06);
+    border-radius: $radius-md;
+    background: rgba($mel-shell-page-bg, 0.55);
   }
 
   &__workspace-hero-stat-value {
     color: $mel-ws-navy;
-    font-size: clamp(1.125rem, 2.6vw, 1.375rem);
+    font-size: clamp(1rem, 2.2vw, 1.125rem);
     font-weight: $font-weight-bold;
     line-height: $line-height-tight;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.01em;
     overflow-wrap: anywhere;
   }
 
@@ -229,10 +229,9 @@ $mel-dash-lavender: #7c83fd;
   }
 
   &__mission-hero .mel-live-ops__hero-surface {
-    background:
-      radial-gradient(640px circle at 100% 0%, rgba($mel-ws-purple, 0.05), transparent 45%),
-      $mel-shell-surface;
-    border: 1px solid $mel-shell-border;
+    background: $mel-shell-surface;
+    border: 1px solid rgba($mel-shell-border, 0.85);
+    box-shadow: none;
   }
 
   &__mission-hero--empty {
@@ -472,11 +471,11 @@ $mel-dash-lavender: #7c83fd;
     }
 
     .mel-live-ops__hero-surface {
-      box-shadow: $shadow-sm;
+      box-shadow: none;
     }
 
     &--attention .mel-live-ops__hero-surface {
-      border-left: 4px solid $warning;
+      border-left: 3px solid $warning;
     }
 
     &--attention .mel-vendor-dashboard__mission-message {
@@ -501,22 +500,22 @@ $mel-dash-lavender: #7c83fd;
   }
 
   &__mission-stats {
-    margin-top: $spacing-4;
+    margin-top: $spacing-3;
   }
 
   &__workspace-hero-stat--primary {
-    border-color: rgba($mel-ws-coral, 0.22);
-    background: rgba($mel-ws-coral, 0.06);
+    border-color: rgba($mel-ws-coral, 0.16);
+    background: rgba($mel-ws-coral, 0.04);
 
     .mel-vendor-dashboard__workspace-hero-stat-value {
       color: $mel-ws-coral;
-      font-size: clamp(1.375rem, 3.2vw, 1.625rem);
+      font-size: clamp(1.0625rem, 2.4vw, 1.1875rem);
     }
   }
 
   &__workspace-hero-stat--secondary {
-    border-color: rgba($mel-ws-purple, 0.2);
-    background: rgba($mel-ws-purple-tint, 0.35);
+    border-color: rgba($mel-ws-purple, 0.14);
+    background: rgba($mel-ws-purple-tint, 0.22);
 
     .mel-vendor-dashboard__workspace-hero-stat-value {
       color: $mel-ws-purple;
@@ -529,16 +528,16 @@ $mel-dash-lavender: #7c83fd;
 
   &__current-event {
     display: grid;
-    gap: $spacing-4;
-    padding: $spacing-4;
-    border: 1px solid rgba($mel-ws-purple, 0.14);
+    gap: $spacing-5;
+    padding: $spacing-5;
+    border: 2px solid rgba($mel-ws-purple, 0.22);
     border-radius: $radius-workspace-card;
     background: $mel-shell-surface;
-    box-shadow: $shadow-xs;
+    box-shadow: $shadow-sm;
 
     @include respond-to(md) {
-      padding: $spacing-5 $spacing-6;
-      gap: $spacing-5;
+      padding: $spacing-6;
+      gap: $spacing-6;
     }
   }
 
@@ -559,7 +558,7 @@ $mel-dash-lavender: #7c83fd;
   &__current-event-title {
     margin: 0;
     color: $mel-ws-navy;
-    font-size: clamp(1.25rem, 3.2vw, 1.5rem);
+    font-size: clamp(1.375rem, 3.6vw, 1.625rem);
     font-weight: $font-weight-bold;
     line-height: $line-height-tight;
     letter-spacing: -0.02em;
@@ -642,15 +641,21 @@ $mel-dash-lavender: #7c83fd;
     display: flex;
     flex-wrap: wrap;
     gap: $spacing-2;
-    padding-top: $spacing-1;
+    padding-top: $spacing-3;
     border-top: 1px solid rgba($mel-shell-border, 0.85);
 
     .mel-btn {
       min-height: 2.75rem;
-      flex: 1 1 calc(50% - #{$spacing-2});
+      flex: 1 1 100%;
 
       @include respond-to(sm) {
         flex: 0 1 auto;
+      }
+    }
+
+    .mel-btn--primary {
+      @include respond-to(sm) {
+        min-width: 12rem;
       }
     }
   }
@@ -676,14 +681,17 @@ $mel-dash-lavender: #7c83fd;
     display: flex;
     flex-wrap: wrap;
     gap: $spacing-2;
-    margin-top: $spacing-4;
+    margin-top: $spacing-3;
+    width: 100%;
 
     .mel-btn {
       min-height: 2.75rem;
-      flex: 1 1 calc(50% - #{$spacing-2});
+      flex: 1 1 100%;
+      max-width: 18rem;
 
       @include respond-to(sm) {
         flex: 0 1 auto;
+        width: auto;
       }
     }
   }
@@ -702,39 +710,53 @@ $mel-dash-lavender: #7c83fd;
   &__activity-stream,
   &__workspace-updates,
   &__upcoming-strip {
-    padding: $spacing-4;
-    border: 1px solid $mel-shell-border;
+    padding: $spacing-3 $spacing-4;
+    border: 1px solid rgba($mel-shell-border, 0.65);
     border-radius: $radius-workspace-card;
-    background: $mel-shell-surface;
+    background: transparent;
     box-shadow: none;
   }
 
   &__workspace-updates {
-    background: $mel-brand-surface-soft;
-    border-color: rgba($mel-shell-border, 0.8);
+    background: transparent;
+    border-color: rgba($mel-shell-border, 0.65);
     box-shadow: none;
   }
 
   &__activity-stream--secondary {
     padding: $spacing-3 $spacing-4;
-    border-color: rgba($mel-shell-border, 0.75);
-    background: rgba($mel-shell-page-bg, 0.65);
+    border-color: rgba($mel-shell-border, 0.6);
+    background: transparent;
 
     .mel-live-ops__panel-title {
-      font-size: $font-size-lg;
+      font-size: $font-size-base;
+      font-weight: $font-weight-semibold;
+    }
+
+    .mel-live-ops__eyebrow {
+      font-size: $font-size-xs;
     }
   }
 
   &__workspace-updates.mel-vendor-dashboard__activity-stream--secondary {
-    background: $mel-brand-surface-soft;
+    background: transparent;
   }
 
   &__attention-strip,
   &__upcoming-strip,
   &__activity-stream:not(.mel-vendor-dashboard__activity-stream--secondary) {
     box-shadow: none;
-    border-color: rgba($mel-shell-border, 0.8);
-    background: rgba($mel-shell-page-bg, 0.55);
+    border-color: rgba($mel-shell-border, 0.6);
+    background: transparent;
+
+    .mel-live-ops__panel-title {
+      font-size: $font-size-base;
+      font-weight: $font-weight-semibold;
+    }
+
+    .mel-live-ops__eyebrow {
+      font-size: $font-size-xs;
+    }
   }
 
   &__quick-actions.mel-live-ops__quick-bar {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -441,6 +441,29 @@ $mel-dash-lavender: #7c83fd;
     .mel-vendor-dashboard__metric-card--neutral {
       background: $mel-shell-page-bg;
     }
+
+    &--event {
+      .mel-vendor-dashboard__metric-board.mel-live-ops__metric-board {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+
+        @include respond-to(md) {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          max-width: none;
+        }
+
+        @include respond-to(lg) {
+          grid-template-columns: repeat(5, minmax(0, 1fr));
+        }
+      }
+    }
+  }
+
+  &__metric-context {
+    margin: 0;
+    color: $text-muted;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-medium;
+    line-height: $line-height-normal;
   }
 
   &__mission-hero {
@@ -574,6 +597,14 @@ $mel-dash-lavender: #7c83fd;
     color: $text-primary;
     font-size: $font-size-base;
     line-height: $line-height-relaxed;
+  }
+
+  &__current-event-attendees {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-normal;
   }
 
   &__current-event-metric {

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -504,6 +504,126 @@ $mel-dash-lavender: #7c83fd;
     background: rgba($mel-shell-page-bg, 0.72);
   }
 
+  &__current-event {
+    display: grid;
+    gap: $spacing-4;
+    padding: $spacing-4;
+    border: 1px solid rgba($mel-ws-purple, 0.14);
+    border-radius: $radius-workspace-card;
+    background: $mel-shell-surface;
+    box-shadow: $shadow-xs;
+
+    @include respond-to(md) {
+      padding: $spacing-5 $spacing-6;
+      gap: $spacing-5;
+    }
+  }
+
+  &__current-event-head {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+  }
+
+  &__current-event-ident {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: $spacing-2;
+    min-width: 0;
+  }
+
+  &__current-event-title {
+    margin: 0;
+    color: $mel-ws-navy;
+    font-size: clamp(1.25rem, 3.2vw, 1.5rem);
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+  }
+
+  &__current-event-date {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__current-event-body {
+    display: grid;
+    gap: $spacing-2;
+    min-width: 0;
+  }
+
+  &__current-event-status {
+    margin: 0;
+    color: $mel-ws-purple;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.04em;
+    line-height: 1.25;
+    text-transform: uppercase;
+
+    &--muted {
+      color: $text-secondary;
+    }
+  }
+
+  &__current-event-summary {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-base;
+    line-height: $line-height-relaxed;
+  }
+
+  &__current-event-metric {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-normal;
+  }
+
+  &__current-event-reasons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    margin: $spacing-1 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__current-event-reason {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    padding: 0 $spacing-2;
+    border-radius: $radius-sm;
+    background: rgba($warning-light, 0.22);
+    border: 1px solid rgba($warning, 0.18);
+    color: $text-primary;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    line-height: 1.25;
+  }
+
+  &__current-event-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    padding-top: $spacing-1;
+    border-top: 1px solid rgba($mel-shell-border, 0.85);
+
+    .mel-btn {
+      min-height: 2.75rem;
+      flex: 1 1 calc(50% - #{$spacing-2});
+
+      @include respond-to(sm) {
+        flex: 0 1 auto;
+      }
+    }
+  }
+
   &__mission-hero-layout {
     @include respond-to(md) {
       grid-template-columns: minmax(0, 1fr) minmax(14rem, 0.36fr);

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -146,11 +146,17 @@ $mel-dash-lavender: #7c83fd;
 
   &__workspace-hero-stats {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: $spacing-3;
+    grid-template-columns: 1fr;
+    gap: $spacing-2;
     margin: 0;
     padding: 0;
     list-style: none;
+    width: 100%;
+
+    @include respond-to(sm) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: $spacing-3;
+    }
 
     @include respond-to(md) {
       gap: $spacing-4;
@@ -173,6 +179,7 @@ $mel-dash-lavender: #7c83fd;
     font-weight: $font-weight-bold;
     line-height: $line-height-tight;
     letter-spacing: -0.02em;
+    overflow-wrap: anywhere;
   }
 
   &__workspace-hero-stat-label {
@@ -234,6 +241,23 @@ $mel-dash-lavender: #7c83fd;
         radial-gradient(720px circle at 50% -10%, rgba($mel-ws-coral, 0.1), transparent 58%),
         $mel-shell-page-bg;
       box-shadow: $shadow-sm;
+    }
+
+    .mel-live-ops__hero-primary {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+
+    .mel-vendor-dashboard__mission-actions {
+      justify-content: center;
+      width: 100%;
+
+      .mel-btn--primary {
+        width: 100%;
+        max-width: 18rem;
+      }
     }
   }
 
@@ -334,16 +358,13 @@ $mel-dash-lavender: #7c83fd;
     .mel-vendor-dashboard__metric-board.mel-live-ops__metric-board {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: $spacing-3;
+      gap: $spacing-2;
       margin-top: 0;
 
       @include respond-to(md) {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: $spacing-4;
-      }
-
-      @include respond-to(lg) {
-        grid-template-columns: repeat(5, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: $spacing-3;
+        max-width: 28rem;
       }
     }
 
@@ -354,26 +375,26 @@ $mel-dash-lavender: #7c83fd;
       justify-content: center;
       gap: $spacing-1;
       min-width: 0;
-      min-height: 4.5rem;
-      padding: $spacing-3 $spacing-4;
-      border: 1px solid $mel-shell-border;
-      border-radius: $radius-lg;
-      background: $mel-shell-page-bg;
+      min-height: 3.75rem;
+      padding: $spacing-2 $spacing-3;
+      border: 1px solid rgba($mel-shell-border, 0.75);
+      border-radius: $radius-md;
+      background: rgba($mel-shell-page-bg, 0.55);
       box-shadow: none;
 
       @include respond-to(md) {
-        min-height: 5rem;
-        padding: $spacing-4;
+        min-height: 4rem;
+        padding: $spacing-3;
       }
     }
 
     .mel-live-ops__stat-value {
       margin: 0;
       color: $mel-ws-navy;
-      font-size: clamp(1.25rem, 2.8vw, 1.5rem);
+      font-size: clamp(1rem, 2.2vw, 1.125rem);
       font-weight: $font-weight-bold;
       line-height: $line-height-tight;
-      letter-spacing: -0.02em;
+      letter-spacing: -0.01em;
     }
 
     .mel-live-ops__stat-label {
@@ -426,6 +447,61 @@ $mel-dash-lavender: #7c83fd;
     .mel-vendor-dashboard__metric-board.mel-live-ops__metric-board {
       display: none;
     }
+
+    .mel-live-ops__hero-surface {
+      box-shadow: $shadow-sm;
+    }
+
+    &--attention .mel-live-ops__hero-surface {
+      border-left: 4px solid $warning;
+    }
+
+    &--attention .mel-vendor-dashboard__mission-message {
+      color: $text-primary;
+      font-weight: $font-weight-semibold;
+    }
+  }
+
+  &__mission-message {
+    margin: $spacing-2 0 0;
+    max-width: 42rem;
+    color: $text-secondary;
+    font-size: $font-size-base;
+    line-height: $line-height-relaxed;
+
+    &--attention {
+      padding: $spacing-3;
+      border-radius: $radius-lg;
+      background: rgba($warning-light, 0.18);
+      border: 1px solid rgba($warning, 0.2);
+    }
+  }
+
+  &__mission-stats {
+    margin-top: $spacing-4;
+  }
+
+  &__workspace-hero-stat--primary {
+    border-color: rgba($mel-ws-coral, 0.22);
+    background: rgba($mel-ws-coral, 0.06);
+
+    .mel-vendor-dashboard__workspace-hero-stat-value {
+      color: $mel-ws-coral;
+      font-size: clamp(1.375rem, 3.2vw, 1.625rem);
+    }
+  }
+
+  &__workspace-hero-stat--secondary {
+    border-color: rgba($mel-ws-purple, 0.2);
+    background: rgba($mel-ws-purple-tint, 0.35);
+
+    .mel-vendor-dashboard__workspace-hero-stat-value {
+      color: $mel-ws-purple;
+    }
+  }
+
+  &__workspace-hero-stat--neutral {
+    background: rgba($mel-shell-page-bg, 0.72);
   }
 
   &__mission-hero-layout {
@@ -446,8 +522,19 @@ $mel-dash-lavender: #7c83fd;
   }
 
   &__mission-actions {
-    display: grid;
+    display: flex;
+    flex-wrap: wrap;
     gap: $spacing-2;
+    margin-top: $spacing-4;
+
+    .mel-btn {
+      min-height: 2.75rem;
+      flex: 1 1 calc(50% - #{$spacing-2});
+
+      @include respond-to(sm) {
+        flex: 0 1 auto;
+      }
+    }
   }
 
   &__section-head {
@@ -494,7 +581,9 @@ $mel-dash-lavender: #7c83fd;
   &__attention-strip,
   &__upcoming-strip,
   &__activity-stream:not(.mel-vendor-dashboard__activity-stream--secondary) {
-    box-shadow: $shadow-xs;
+    box-shadow: none;
+    border-color: rgba($mel-shell-border, 0.8);
+    background: rgba($mel-shell-page-bg, 0.55);
   }
 
   &__quick-actions.mel-live-ops__quick-bar {
@@ -1207,10 +1296,10 @@ $mel-dash-lavender: #7c83fd;
     min-width: 0;
     min-height: 2.75rem;
     padding: $spacing-3;
-    border: 1px solid rgba($ml-vendor-navy, 0.1);
+    border: 1px solid rgba($mel-shell-border, 0.75);
     border-radius: $radius-lg;
-    background: $ml-vendor-bg;
-    box-shadow: $shadow-xs;
+    background: rgba($mel-shell-page-bg, 0.65);
+    box-shadow: none;
   }
 
   &__summary-card-layout {

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -36,117 +36,107 @@
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
 {% set create_action = organiser_actions|filter(item => item.key|default('') == 'create')|first|default(null) %}
 {% set manage_events_action = organiser_actions|filter(item => item.key|default('') == 'events')|first|default(null) %}
-{% set snapshot_defs = [
+{% set priority_sev = priority_action.severity|default('info') %}
+{% set priority_needs_attention = priority_action and (priority_sev == 'error' or priority_sev == 'warning') %}
+{% set hero_stat_defs = [
   { key: 'revenue', label: 'Revenue'|t, pool: 'kpis', emphasis: 'primary' },
   { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis', emphasis: 'secondary' },
   { key: 'live_events', label: 'Live events'|t, pool: 'overview', emphasis: 'neutral' },
+] %}
+{% set snapshot_defs = [
   { key: 'bookings', label: 'Bookings'|t, pool: 'overview', emphasis: 'neutral' },
   { key: 'upcoming_events', label: 'Upcoming'|t, pool: 'overview', emphasis: 'neutral' },
 ] %}
-{% set hero_stat_defs = [
-  { key: 'live_events', label: 'Live events'|t, pool: 'overview' },
-  { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis' },
-  { key: 'revenue', label: 'Revenue'|t, pool: 'kpis' },
-] %}
 
 <section class="mel-live-operations mel-vendor-dashboard{% if events_empty %} mel-vendor-dashboard--empty{% endif %}" data-mel-vendor-dashboard>
-  {% if priority_action %}
-    {% set priority_sev = priority_action.severity|default('info') %}
-    {% set priority_chip = priority_sev == 'error' or priority_sev == 'warning' ? 'warn' : (priority_sev == 'success' ? 'success' : 'info') %}
-    <section class="mel-vendor-dashboard__priority mel-vendor-dashboard__priority--{{ priority_chip }}" aria-labelledby="mel-dash-priority-title">
-      <div>
-        <p class="mel-live-ops__eyebrow">{{ 'What needs your attention'|t }}</p>
-        <h2 id="mel-dash-priority-title" class="mel-vendor-dashboard__priority-title">{{ priority_action.title|default('Review next step'|t) }}</h2>
-        {% if priority_action.message is defined and priority_action.message %}
-          <p class="mel-vendor-dashboard__priority-message">{{ priority_action.message }}</p>
-        {% endif %}
-      </div>
-      {% if priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
-        <a class="mel-btn mel-btn--primary mel-vendor-dashboard__priority-action" href="{{ priority_action.url }}">{{ priority_action.action_label }}</a>
-      {% endif %}
-    </section>
-  {% endif %}
+  {# Slice 1 — Mission hero: priority, welcome, stats, and CTAs in one surface. #}
+  <section class="mel-vendor-dashboard__mission-hero mel-live-ops__hero{% if events_empty %} mel-vendor-dashboard__mission-hero--empty{% endif %}{% if priority_needs_attention %} mel-vendor-dashboard__mission-hero--attention{% endif %}" aria-labelledby="mel-dash-hero-title">
+    <div class="mel-live-ops__hero-surface">
+      <div class="mel-vendor-dashboard__mission-hero-layout mel-live-ops__hero-layout mel-vendor-dashboard__mission-hero-layout--solo">
+        <div class="mel-live-ops__hero-primary">
+          <p class="mel-live-ops__eyebrow">{{ 'Running your events'|t }}</p>
+          <h1 id="mel-dash-hero-title" class="mel-live-ops__hero-title mel-vendor-dashboard__workspace-hero-title">
+            {% if events_empty %}
+              {% if organiser_display_name %}
+                {{ 'Welcome, @name'|t({'@name': organiser_display_name}) }}
+              {% else %}
+                {{ empty_state.title|default('Welcome to MyEventLane'|t) }}
+              {% endif %}
+            {% else %}
+              {% if organiser_display_name %}
+                {{ organiser_display_name }}
+              {% elseif vendor.label|default('') is not empty %}
+                {{ vendor.label }}
+              {% else %}
+                {{ 'Welcome back'|t }}
+              {% endif %}
+            {% endif %}
+          </h1>
 
-  {% if events_empty %}
-    {% set empty_cta_url = empty_state.url|default(create_action.url|default(null)) %}
-    {% set empty_cta_label = empty_state.action_label|default(create_action.label|default(null)) %}
-    <section class="mel-vendor-dashboard__workspace-hero mel-vendor-dashboard__workspace-hero--empty" aria-labelledby="mel-dash-hero-title">
-      <div class="mel-vendor-dashboard__workspace-hero-body">
-        <p class="mel-live-ops__eyebrow">{{ 'Organiser workspace'|t }}</p>
-        <h1 id="mel-dash-hero-title" class="mel-vendor-dashboard__workspace-hero-title">
-          {% if organiser_display_name %}
-            {{ 'Welcome, @name'|t({'@name': organiser_display_name}) }}
-          {% else %}
-            {{ empty_state.title|default('Welcome to MyEventLane'|t) }}
+          {% if priority_action and priority_action.message is defined and priority_action.message %}
+            <p class="mel-vendor-dashboard__mission-message{% if priority_needs_attention %} mel-vendor-dashboard__mission-message--attention{% endif %}">{{ priority_action.message }}</p>
+          {% elseif hero_shell_hint %}
+            <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
+          {% elseif events_empty %}
+            <p class="mel-vendor-dashboard__workspace-hero-lead mel-vendor-dashboard__empty-hero-message">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
           {% endif %}
-        </h1>
-        {% if hero_shell_hint %}
-          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
-        {% else %}
-          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
-        {% endif %}
-        {% if empty_cta_url and empty_cta_label %}
-          <div class="mel-vendor-dashboard__workspace-hero-actions">
-            <a class="mel-btn mel-btn--primary mel-btn--lg" href="{{ empty_cta_url }}">{{ empty_cta_label }}</a>
-          </div>
-        {% endif %}
-      </div>
-    </section>
-  {% else %}
-    <section class="mel-vendor-dashboard__workspace-hero" aria-labelledby="mel-dash-hero-title">
-      <div class="mel-vendor-dashboard__workspace-hero-body">
-        {% if vendor.label|default('') is not empty %}
-          <p class="mel-vendor-dashboard__workspace-hero-context">{{ vendor.label }}</p>
-        {% else %}
-          <p class="mel-live-ops__eyebrow">{{ 'Organiser workspace'|t }}</p>
-        {% endif %}
-        <h1 id="mel-dash-hero-title" class="mel-vendor-dashboard__workspace-hero-title">
-          {% if organiser_display_name %}
-            {{ 'Welcome back, @name'|t({'@name': organiser_display_name}) }}
-          {% else %}
-            {{ 'Welcome back'|t }}
-          {% endif %}
-        </h1>
-        {% if hero_shell_hint %}
-          <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
-        {% endif %}
-      </div>
 
-      <ul class="mel-vendor-dashboard__workspace-hero-stats" role="list" aria-label="{{ 'Today at a glance'|t }}">
-        {% for def in hero_stat_defs %}
-          {% if def.pool == 'overview' %}
-            {% set stat_match = organiser_overview|filter(item => item.key|default('') == def.key)|first|default(null) %}
-          {% else %}
-            {% set stat_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
+          {% if not events_empty %}
+            <ul class="mel-vendor-dashboard__workspace-hero-stats mel-vendor-dashboard__mission-stats" role="list" aria-label="{{ 'Your business'|t }}">
+              {% for def in hero_stat_defs %}
+                {% if def.pool == 'overview' %}
+                  {% set stat_match = organiser_overview|filter(item => item.key|default('') == def.key)|first|default(null) %}
+                {% else %}
+                  {% set stat_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
+                {% endif %}
+                {% set stat_value = stat_match ? stat_match.value|default('0') : '0' %}
+                {% set stat_emphasis = def.emphasis|default('neutral') %}
+                <li class="mel-vendor-dashboard__workspace-hero-stat mel-vendor-dashboard__workspace-hero-stat--{{ stat_emphasis }}" role="listitem">
+                  <span class="mel-vendor-dashboard__workspace-hero-stat-value">{{ stat_value }}</span>
+                  <span class="mel-vendor-dashboard__workspace-hero-stat-label">{{ def.label }}</span>
+                </li>
+              {% endfor %}
+            </ul>
           {% endif %}
-          {% set stat_value = stat_match ? stat_match.value|default('0') : '0' %}
-          <li class="mel-vendor-dashboard__workspace-hero-stat{% if def.key == 'revenue' %} mel-vendor-dashboard__workspace-hero-stat--revenue{% endif %}" role="listitem">
-            <span class="mel-vendor-dashboard__workspace-hero-stat-value">{{ stat_value }}</span>
-            <span class="mel-vendor-dashboard__workspace-hero-stat-label">{{ def.label }}</span>
-          </li>
-        {% endfor %}
-      </ul>
 
-      {% if (priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label) or (manage_events_action and manage_events_action.url is defined and manage_events_action.url) or (create_action and create_action.url is defined and create_action.url) %}
-        <div class="mel-vendor-dashboard__workspace-hero-actions">
-          {% if priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
-            <a class="mel-btn mel-btn--primary" href="{{ priority_action.url }}">{{ priority_action.action_label }}</a>
+          {% set primary_cta_url = null %}
+          {% set primary_cta_label = null %}
+          {% if priority_needs_attention and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
+            {% set primary_cta_url = priority_action.url %}
+            {% set primary_cta_label = priority_action.action_label %}
+          {% elseif create_action and create_action.url is defined and create_action.url %}
+            {% set primary_cta_url = create_action.url %}
+            {% set primary_cta_label = create_action.label|default('Create event'|t) %}
+          {% elseif events_empty and empty_state.url is defined and empty_state.url %}
+            {% set primary_cta_url = empty_state.url %}
+            {% set primary_cta_label = empty_state.action_label|default('Create event'|t) %}
           {% endif %}
-          {% if manage_events_action.url is defined and manage_events_action.url %}
-            <a class="mel-btn mel-btn--secondary" href="{{ manage_events_action.url }}">{{ manage_events_action.label }}</a>
-          {% elseif create_action.url is defined and create_action.url %}
-            <a class="mel-btn mel-btn--secondary" href="{{ create_action.url }}">{{ create_action.label }}</a>
+
+          {% set secondary_cta_url = null %}
+          {% set secondary_cta_label = null %}
+          {% if not events_empty and manage_events_action and manage_events_action.url is defined and manage_events_action.url %}
+            {% set secondary_cta_url = manage_events_action.url %}
+            {% set secondary_cta_label = manage_events_action.label|default('Manage events'|t) %}
+          {% endif %}
+
+          {% if primary_cta_url and primary_cta_label %}
+            <div class="mel-vendor-dashboard__mission-actions mel-vendor-dashboard__workspace-hero-actions">
+              <a class="mel-btn mel-btn--primary{% if events_empty %} mel-btn--lg{% endif %}" href="{{ primary_cta_url }}">{{ primary_cta_label }}</a>
+              {% if secondary_cta_url and secondary_cta_label %}
+                <a class="mel-btn mel-btn--secondary" href="{{ secondary_cta_url }}">{{ secondary_cta_label }}</a>
+              {% endif %}
+            </div>
           {% endif %}
         </div>
-      {% endif %}
-    </section>
-  {% endif %}
+      </div>
+    </div>
+  </section>
 
   <section class="mel-vendor-dashboard__metric-strip mel-vendor-dashboard__metric-strip--compact{% if events_empty %} mel-vendor-dashboard__metric-strip--starter{% endif %}" aria-labelledby="mel-dash-metrics-title">
     <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
       <div>
         <p class="mel-live-ops__eyebrow">{{ 'At a glance'|t }}</p>
-        <h2 id="mel-dash-metrics-title" class="mel-live-ops__panel-title">{{ 'Your numbers'|t }}</h2>
+        <h2 id="mel-dash-metrics-title" class="mel-live-ops__panel-title">{{ 'Your business'|t }}</h2>
       </div>
     </div>
     {% if events_empty %}
@@ -172,8 +162,8 @@
   {% if workspace_updates is iterable and workspace_updates|length > 0 %}
     <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-title">
       <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
-        <p class="mel-live-ops__eyebrow">{{ 'What needs your attention'|t }}</p>
-        <h2 id="mel-dash-workspace-title" class="mel-live-ops__panel-title">{{ 'Workspace updates'|t }}</h2>
+        <p class="mel-live-ops__eyebrow">{{ 'Account'|t }}</p>
+        <h2 id="mel-dash-workspace-title" class="mel-live-ops__panel-title">{{ 'Needs attention'|t }}</h2>
       </div>
       <ol class="mel-vendor-dashboard__timeline mel-vendor-dashboard__timeline--workspace" role="list">
         {% for item in workspace_updates|slice(0, 6) %}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -31,6 +31,7 @@
 {% set analytics_items = analytics_summary.items|default([]) %}
 {% set activity_items = dashboard_activity_items|default([]) %}
 {% set workspace_updates = model.workspace_updates|default([]) %}
+{% set current_event = model.current_event|default(null) %}
 {% set dashboard_vendor_id = vendor.id|default(null) %}
 {% set metric_rows = kpis %}
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
@@ -131,6 +132,63 @@
       </div>
     </div>
   </section>
+
+  {# Slice 2 — Current event operations surface. #}
+  {% if current_event %}
+    {% set ce_links = current_event.links|default({}) %}
+    {% set ce_status = current_event.status|default('') %}
+    {% set ce_summary = current_event.operation_summary|default('') %}
+    {% set show_live_badge = ce_status == 'upcoming' and ce_summary and 'live' in ce_summary|lower %}
+    <section class="mel-vendor-dashboard__current-event" aria-labelledby="mel-dash-current-event-title">
+      <div class="mel-vendor-dashboard__current-event-head">
+        <div class="mel-vendor-dashboard__current-event-ident">
+          {% if show_live_badge %}
+            <span class="mel-live-ops__chip mel-live-ops__chip--live" role="status">{{ 'LIVE'|t }}</span>
+          {% endif %}
+          <h2 id="mel-dash-current-event-title" class="mel-vendor-dashboard__current-event-title">{{ current_event.title|default('Untitled event'|t) }}</h2>
+        </div>
+        {% if current_event.date_label is defined and current_event.date_label %}
+          <p class="mel-vendor-dashboard__current-event-date">{{ current_event.date_label }}</p>
+        {% endif %}
+      </div>
+
+      <div class="mel-vendor-dashboard__current-event-body">
+        {% if current_event.status_label is defined and current_event.status_label and not show_live_badge %}
+          <p class="mel-vendor-dashboard__current-event-status">{{ current_event.status_label }}</p>
+        {% elseif current_event.status_label is defined and current_event.status_label %}
+          <p class="mel-vendor-dashboard__current-event-status mel-vendor-dashboard__current-event-status--muted">{{ current_event.status_label }}</p>
+        {% endif %}
+
+        {% if ce_summary %}
+          <p class="mel-vendor-dashboard__current-event-summary">{{ ce_summary }}</p>
+        {% endif %}
+
+        {% if current_event.metric_label is defined and current_event.metric_label %}
+          <p class="mel-vendor-dashboard__current-event-metric">{{ current_event.metric_label }}</p>
+        {% endif %}
+
+        {% set ce_reasons = current_event.attention_reasons|default([]) %}
+        {% if ce_reasons is iterable and ce_reasons|length > 0 %}
+          <ul class="mel-vendor-dashboard__current-event-reasons" role="list" aria-label="{{ 'Needs attention'|t }}">
+            {% for reason in ce_reasons|slice(0, 3) %}
+              <li class="mel-vendor-dashboard__current-event-reason" role="listitem">{{ reason }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+
+      {% if (ce_links.checkin is defined and ce_links.checkin) or (ce_links.manage is defined and ce_links.manage) %}
+        <div class="mel-vendor-dashboard__current-event-actions">
+          {% if ce_links.checkin is defined and ce_links.checkin %}
+            <a class="mel-btn mel-btn--primary" href="{{ ce_links.checkin }}">{{ 'Open Door Mode'|t }}</a>
+          {% endif %}
+          {% if ce_links.manage is defined and ce_links.manage %}
+            <a class="mel-btn mel-btn--secondary" href="{{ ce_links.manage }}">{{ 'Manage Event'|t }}</a>
+          {% endif %}
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
 
   <section class="mel-vendor-dashboard__metric-strip mel-vendor-dashboard__metric-strip--compact{% if events_empty %} mel-vendor-dashboard__metric-strip--starter{% endif %}" aria-labelledby="mel-dash-metrics-title">
     <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -36,7 +36,6 @@
 {% set metric_rows = kpis %}
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
 {% set create_action = organiser_actions|filter(item => item.key|default('') == 'create')|first|default(null) %}
-{% set manage_events_action = organiser_actions|filter(item => item.key|default('') == 'events')|first|default(null) %}
 {% set priority_sev = priority_action.severity|default('info') %}
 {% set priority_needs_attention = priority_action and (priority_sev == 'error' or priority_sev == 'warning') %}
 {% set show_priority_message = priority_action and priority_action.message is defined and priority_action.message %}
@@ -115,19 +114,9 @@
             {% set primary_cta_label = empty_state.action_label|default('Create event'|t) %}
           {% endif %}
 
-          {% set secondary_cta_url = null %}
-          {% set secondary_cta_label = null %}
-          {% if not events_empty and manage_events_action and manage_events_action.url is defined and manage_events_action.url %}
-            {% set secondary_cta_url = manage_events_action.url %}
-            {% set secondary_cta_label = manage_events_action.label|default('Manage events'|t) %}
-          {% endif %}
-
           {% if primary_cta_url and primary_cta_label %}
             <div class="mel-vendor-dashboard__mission-actions mel-vendor-dashboard__workspace-hero-actions">
               <a class="mel-btn mel-btn--primary{% if events_empty %} mel-btn--lg{% endif %}" href="{{ primary_cta_url }}">{{ primary_cta_label }}</a>
-              {% if secondary_cta_url and secondary_cta_label %}
-                <a class="mel-btn mel-btn--secondary" href="{{ secondary_cta_url }}">{{ secondary_cta_label }}</a>
-              {% endif %}
             </div>
           {% endif %}
         </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -39,6 +39,8 @@
 {% set manage_events_action = organiser_actions|filter(item => item.key|default('') == 'events')|first|default(null) %}
 {% set priority_sev = priority_action.severity|default('info') %}
 {% set priority_needs_attention = priority_action and (priority_sev == 'error' or priority_sev == 'warning') %}
+{% set show_priority_message = priority_action and priority_action.message is defined and priority_action.message %}
+{% set event_in_session_label = 'Event today'|t %}
 {% set hero_stat_defs = [
   { key: 'revenue', label: 'Revenue'|t, pool: 'kpis', emphasis: 'primary' },
   { key: 'tickets_sold', label: 'Tickets sold'|t, pool: 'kpis', emphasis: 'secondary' },
@@ -74,7 +76,7 @@
             {% endif %}
           </h1>
 
-          {% if priority_action and priority_action.message is defined and priority_action.message %}
+          {% if show_priority_message %}
             <p class="mel-vendor-dashboard__mission-message{% if priority_needs_attention %} mel-vendor-dashboard__mission-message--attention{% endif %}">{{ priority_action.message }}</p>
           {% elseif hero_shell_hint %}
             <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
@@ -102,7 +104,7 @@
 
           {% set primary_cta_url = null %}
           {% set primary_cta_label = null %}
-          {% if priority_needs_attention and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label %}
+          {% if priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label and (priority_needs_attention or show_priority_message) %}
             {% set primary_cta_url = priority_action.url %}
             {% set primary_cta_label = priority_action.action_label %}
           {% elseif create_action and create_action.url is defined and create_action.url %}
@@ -135,10 +137,14 @@
 
   {# Slice 2 — Current event operations surface. #}
   {% if current_event %}
-    {% set ce_links = current_event.links|default({}) %}
     {% set ce_status = current_event.status|default('') %}
     {% set ce_summary = current_event.operation_summary|default('') %}
-    {% set show_live_badge = ce_status == 'upcoming' and ce_summary and 'live' in ce_summary|lower %}
+    {% set ce_attendee = current_event.attendee_summary|default('') %}
+    {% set ce_reasons = current_event.attention_reasons|default([]) %}
+    {% set show_live_badge = ce_status == 'upcoming' and event_in_session_label in ce_reasons %}
+    {% set ce_quick = current_event.quick_actions|default([])|filter(a => a.url is defined and a.url) %}
+    {% set qa_checkin = ce_quick|filter(a => a.key|default('') == 'checkin')|first|default(null) %}
+    {% set qa_primary = qa_checkin ?: ce_quick|first|default(null) %}
     <section class="mel-vendor-dashboard__current-event" aria-labelledby="mel-dash-current-event-title">
       <div class="mel-vendor-dashboard__current-event-head">
         <div class="mel-vendor-dashboard__current-event-ident">
@@ -163,11 +169,10 @@
           <p class="mel-vendor-dashboard__current-event-summary">{{ ce_summary }}</p>
         {% endif %}
 
-        {% if current_event.metric_label is defined and current_event.metric_label %}
-          <p class="mel-vendor-dashboard__current-event-metric">{{ current_event.metric_label }}</p>
+        {% if ce_attendee %}
+          <p class="mel-vendor-dashboard__current-event-attendees">{{ ce_attendee }}</p>
         {% endif %}
 
-        {% set ce_reasons = current_event.attention_reasons|default([]) %}
         {% if ce_reasons is iterable and ce_reasons|length > 0 %}
           <ul class="mel-vendor-dashboard__current-event-reasons" role="list" aria-label="{{ 'Needs attention'|t }}">
             {% for reason in ce_reasons|slice(0, 3) %}
@@ -177,45 +182,55 @@
         {% endif %}
       </div>
 
-      {% if (ce_links.checkin is defined and ce_links.checkin) or (ce_links.manage is defined and ce_links.manage) %}
-        <div class="mel-vendor-dashboard__current-event-actions">
-          {% if ce_links.checkin is defined and ce_links.checkin %}
-            <a class="mel-btn mel-btn--primary" href="{{ ce_links.checkin }}">{{ 'Open Door Mode'|t }}</a>
-          {% endif %}
-          {% if ce_links.manage is defined and ce_links.manage %}
-            <a class="mel-btn mel-btn--secondary" href="{{ ce_links.manage }}">{{ 'Manage Event'|t }}</a>
-          {% endif %}
-        </div>
+      {% if qa_primary %}
+        {% set qa_secondary = ce_quick|filter(a => a.key|default('') != qa_primary.key|default(''))|slice(0, 4) %}
+        <nav class="mel-vendor-dashboard__current-event-actions" aria-label="{{ 'Current event actions'|t }}">
+          <a class="mel-btn mel-btn--primary" href="{{ qa_primary.url }}">{{ qa_primary.label }}</a>
+          {% for action in qa_secondary %}
+            <a class="mel-btn mel-btn--secondary" href="{{ action.url }}">{{ action.label }}</a>
+          {% endfor %}
+        </nav>
       {% endif %}
     </section>
-  {% endif %}
 
-  <section class="mel-vendor-dashboard__metric-strip mel-vendor-dashboard__metric-strip--compact{% if events_empty %} mel-vendor-dashboard__metric-strip--starter{% endif %}" aria-labelledby="mel-dash-metrics-title">
-    <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
-      <div>
-        <p class="mel-live-ops__eyebrow">{{ 'At a glance'|t }}</p>
-        <h2 id="mel-dash-metrics-title" class="mel-live-ops__panel-title">{{ 'Your business'|t }}</h2>
+    {# Slice 3 — Event metrics (current event only). #}
+    {% set event_metrics = current_event.metrics|default([]) %}
+    <section class="mel-vendor-dashboard__metric-strip mel-vendor-dashboard__metric-strip--compact mel-vendor-dashboard__metric-strip--event" aria-labelledby="mel-dash-metrics-title">
+      <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
+        <div>
+          <p class="mel-live-ops__eyebrow">{{ 'At a glance'|t }}</p>
+          <h2 id="mel-dash-metrics-title" class="mel-live-ops__panel-title">{{ 'This event'|t }}</h2>
+        </div>
       </div>
-    </div>
-    {% if events_empty %}
-      <p class="mel-vendor-dashboard__metric-intro">{{ 'These update once you publish an event and start taking bookings.'|t }}</p>
-    {% endif %}
-    <div class="mel-vendor-dashboard__metric-board mel-live-ops__metric-board" role="list" aria-label="{{ 'Business snapshot'|t }}">
-      {% for def in snapshot_defs %}
-        {% if def.pool == 'overview' %}
-          {% set snapshot_match = organiser_overview|filter(item => item.key|default('') == def.key)|first|default(null) %}
+      <div class="mel-vendor-dashboard__metric-board mel-live-ops__metric-board" role="list" aria-label="{{ 'Event snapshot'|t }}">
+        {% if event_metrics is iterable and event_metrics|length > 0 %}
+          {% for metric in event_metrics|slice(0, 5) %}
+            <article class="mel-live-ops__stat-card mel-vendor-dashboard__metric-card mel-vendor-dashboard__metric-card--neutral" role="listitem">
+              <span class="mel-live-ops__stat-value">{{ metric.value|default('—') }}</span>
+              <span class="mel-live-ops__stat-label">{{ metric.label|default('') }}</span>
+              {% if metric.context is defined and metric.context %}
+                <span class="mel-vendor-dashboard__metric-context">{{ metric.context }}</span>
+              {% endif %}
+            </article>
+          {% endfor %}
         {% else %}
-          {% set snapshot_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
+          {% for def in snapshot_defs %}
+            {% if def.pool == 'overview' %}
+              {% set snapshot_match = organiser_overview|filter(item => item.key|default('') == def.key)|first|default(null) %}
+            {% else %}
+              {% set snapshot_match = kpis|filter(item => item.key|default('') == def.key)|first|default(null) %}
+            {% endif %}
+            {% set metric_value = snapshot_match ? snapshot_match.value|default('0') : '0' %}
+            {% set stat_emphasis = def.emphasis|default('neutral') %}
+            <article class="mel-live-ops__stat-card mel-vendor-dashboard__metric-card mel-vendor-dashboard__metric-card--{{ stat_emphasis }}" role="listitem">
+              <span class="mel-live-ops__stat-value">{{ metric_value }}</span>
+              <span class="mel-live-ops__stat-label">{{ def.label }}</span>
+            </article>
+          {% endfor %}
         {% endif %}
-        {% set metric_value = snapshot_match ? snapshot_match.value|default('0') : '0' %}
-        {% set stat_emphasis = def.emphasis|default('neutral') %}
-        <article class="mel-live-ops__stat-card mel-vendor-dashboard__metric-card mel-vendor-dashboard__metric-card--{{ stat_emphasis }}" role="listitem">
-          <span class="mel-live-ops__stat-value">{{ metric_value }}</span>
-          <span class="mel-live-ops__stat-label">{{ def.label }}</span>
-        </article>
-      {% endfor %}
-    </div>
-  </section>
+      </div>
+    </section>
+  {% endif %}
 
   {% if workspace_updates is iterable and workspace_updates|length > 0 %}
     <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-title">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only Twig and theme SCSS changes; behaviour depends on existing `current_event` view-model data with no auth or backend logic in this diff.
> 
> **Overview**
> **Restructures the organiser vendor dashboard** around a single **mission hero** instead of a separate priority strip plus split empty/full workspace heroes. Priority messaging, welcome copy, business KPI stats (revenue, tickets, live events), and one primary CTA now live in that hero, with warning styling when the priority action needs attention.
> 
> When **`model.current_event`** is present, the template adds a **current event** block (LIVE badge, summaries, attention reasons, check-in–first quick actions) and an **“This event”** metric strip fed by `current_event.metrics` (with overview/KPI fallback). The always-visible **“Your numbers”** business metric strip is removed from the main flow in favor of event-scoped metrics under the current event.
> 
> **SCSS** tightens typography and spacing, stacks hero stats on small screens, flattens strip/panel chrome (transparent backgrounds, lighter borders), and adds styles for mission messages, current-event card, stat emphasis variants, and event-specific metric grids. Workspace updates copy shifts to **Account / Needs attention**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22cf329cab8ec5f891b3f70ebd72e49e5c9d3b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->