### PR TITLE
Add empty panel and next event sections to dashboard styles and template

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_dashboard-live-ops.scss
@@ -313,6 +313,188 @@ $mel-dash-lavender: #7c83fd;
     }
   }
 
+  &__empty-panel {
+    display: grid;
+    gap: $spacing-3;
+    padding: $spacing-5 $spacing-4;
+    border: 1px solid rgba($mel-shell-border, 0.75);
+    border-radius: $radius-workspace-card;
+    background: $mel-shell-surface;
+    box-shadow: $shadow-sm;
+
+    @include respond-to(md) {
+      padding: $spacing-6;
+      gap: $spacing-4;
+    }
+  }
+
+  &__empty-panel-title {
+    margin: 0;
+    color: $mel-ws-navy;
+    font-size: clamp(1.25rem, 3.4vw, 1.5rem);
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+  }
+
+  &__empty-panel-body {
+    margin: 0;
+    max-width: 36rem;
+    color: $text-secondary;
+    font-size: $font-size-base;
+    line-height: $line-height-relaxed;
+  }
+
+  &__empty-panel-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    padding-top: $spacing-2;
+
+    .mel-btn {
+      min-height: 2.75rem;
+      flex: 1 1 100%;
+
+      @include respond-to(sm) {
+        flex: 0 1 auto;
+      }
+    }
+
+    .mel-btn--primary {
+      max-width: 18rem;
+
+      @include respond-to(sm) {
+        min-width: 12rem;
+      }
+    }
+  }
+
+  &__next-event {
+    display: grid;
+    gap: $spacing-4;
+    padding: $spacing-4;
+    border: 1px solid rgba($mel-ws-purple, 0.16);
+    border-radius: $radius-workspace-card;
+    background: $mel-shell-surface;
+    box-shadow: $shadow-sm;
+
+    @include respond-to(md) {
+      padding: $spacing-5;
+      gap: $spacing-5;
+    }
+  }
+
+  &__next-event-head {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+  }
+
+  &__next-event-title {
+    margin: 0;
+    color: $mel-ws-navy;
+    font-size: clamp(1.25rem, 3.2vw, 1.4375rem);
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    letter-spacing: -0.02em;
+  }
+
+  &__next-event-date {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: $line-height-normal;
+  }
+
+  &__next-event-body {
+    display: grid;
+    gap: $spacing-1;
+    min-width: 0;
+  }
+
+  &__next-event-status {
+    margin: 0;
+    color: $mel-ws-purple;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: 0.04em;
+    line-height: 1.25;
+    text-transform: uppercase;
+  }
+
+  &__next-event-metric {
+    margin: 0;
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-semibold;
+    line-height: $line-height-normal;
+  }
+
+  &__next-event-summary {
+    margin: 0;
+    color: $text-primary;
+    font-size: $font-size-sm;
+    line-height: $line-height-relaxed;
+  }
+
+  &__next-event-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+    padding-top: $spacing-2;
+    border-top: 1px solid rgba($mel-shell-border, 0.75);
+
+    .mel-btn {
+      min-height: 2.75rem;
+      flex: 1 1 100%;
+
+      @include respond-to(sm) {
+        flex: 0 1 auto;
+      }
+    }
+
+    .mel-btn--primary {
+      @include respond-to(sm) {
+        min-width: 12rem;
+      }
+    }
+  }
+
+  &__section--tertiary {
+    padding: $spacing-2 $spacing-3;
+    border-color: rgba($mel-shell-border, 0.45);
+    background: transparent;
+    box-shadow: none;
+
+    @include respond-to(md) {
+      padding: $spacing-3 $spacing-4;
+    }
+
+    .mel-vendor-dashboard__section-head {
+      margin-bottom: $spacing-2;
+    }
+
+    .mel-vendor-dashboard__section-head--compact {
+      margin-bottom: $spacing-2;
+    }
+
+    .mel-live-ops__panel-title {
+      font-size: $font-size-sm;
+      font-weight: $font-weight-semibold;
+    }
+
+    .mel-live-ops__eyebrow {
+      font-size: $font-size-xs;
+      color: $text-muted;
+    }
+
+    .mel-vendor-dashboard__timeline-item,
+    .mel-vendor-dashboard__action-queue-item,
+    .mel-vendor-dashboard__summary-card {
+      border-color: rgba($mel-shell-border, 0.55);
+    }
+  }
+
   &__mission-hero-layout--solo {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -36,6 +36,12 @@
 {% set metric_rows = kpis %}
 {% set events_empty = model_events is not iterable or model_events|length == 0 %}
 {% set create_action = organiser_actions|filter(item => item.key|default('') == 'create')|first|default(null) %}
+{% set support_action = organiser_actions|filter(item => item.key|default('') == 'support')|first|default(null) %}
+{% set has_active_current_event = current_event and current_event.status|default('') != 'past' %}
+{% set next_event = model_events|filter(ev => ev.status|default('') != 'past')|first|default(null) %}
+{% set show_next_event = not has_active_current_event and next_event %}
+{% set empty_create_url = create_action.url|default(empty_state.url|default(null)) %}
+{% set empty_create_label = create_action.label|default(empty_state.action_label|default('Create event'|t)) %}
 {% set priority_sev = priority_action.severity|default('info') %}
 {% set priority_needs_attention = priority_action and (priority_sev == 'error' or priority_sev == 'warning') %}
 {% set show_priority_message = priority_action and priority_action.message is defined and priority_action.message %}
@@ -79,8 +85,6 @@
             <p class="mel-vendor-dashboard__mission-message{% if priority_needs_attention %} mel-vendor-dashboard__mission-message--attention{% endif %}">{{ priority_action.message }}</p>
           {% elseif hero_shell_hint %}
             <p class="mel-vendor-dashboard__workspace-hero-lead">{{ hero_shell_hint }}</p>
-          {% elseif events_empty %}
-            <p class="mel-vendor-dashboard__workspace-hero-lead mel-vendor-dashboard__empty-hero-message">{{ empty_state.message|default('Create your first event to start selling tickets or collecting RSVPs.'|t) }}</p>
           {% endif %}
 
           {% if not events_empty %}
@@ -101,31 +105,46 @@
             </ul>
           {% endif %}
 
-          {% set primary_cta_url = null %}
-          {% set primary_cta_label = null %}
-          {% if priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label and (priority_needs_attention or show_priority_message) %}
-            {% set primary_cta_url = priority_action.url %}
-            {% set primary_cta_label = priority_action.action_label %}
-          {% elseif create_action and create_action.url is defined and create_action.url %}
-            {% set primary_cta_url = create_action.url %}
-            {% set primary_cta_label = create_action.label|default('Create event'|t) %}
-          {% elseif events_empty and empty_state.url is defined and empty_state.url %}
-            {% set primary_cta_url = empty_state.url %}
-            {% set primary_cta_label = empty_state.action_label|default('Create event'|t) %}
-          {% endif %}
+          {% if not events_empty %}
+            {% set primary_cta_url = null %}
+            {% set primary_cta_label = null %}
+            {% if priority_action and priority_action.url is defined and priority_action.url and priority_action.action_label is defined and priority_action.action_label and (priority_needs_attention or show_priority_message) %}
+              {% set primary_cta_url = priority_action.url %}
+              {% set primary_cta_label = priority_action.action_label %}
+            {% elseif create_action and create_action.url is defined and create_action.url %}
+              {% set primary_cta_url = create_action.url %}
+              {% set primary_cta_label = create_action.label|default('Create event'|t) %}
+            {% endif %}
 
-          {% if primary_cta_url and primary_cta_label %}
-            <div class="mel-vendor-dashboard__mission-actions mel-vendor-dashboard__workspace-hero-actions">
-              <a class="mel-btn mel-btn--primary{% if events_empty %} mel-btn--lg{% endif %}" href="{{ primary_cta_url }}">{{ primary_cta_label }}</a>
-            </div>
+            {% if primary_cta_url and primary_cta_label %}
+              <div class="mel-vendor-dashboard__mission-actions mel-vendor-dashboard__workspace-hero-actions">
+                <a class="mel-btn mel-btn--primary" href="{{ primary_cta_url }}">{{ primary_cta_label }}</a>
+              </div>
+            {% endif %}
           {% endif %}
         </div>
       </div>
     </div>
   </section>
 
+  {# Slice 1b — Empty organiser panel (0 events). #}
+  {% if events_empty %}
+    <section class="mel-vendor-dashboard__empty-panel" aria-labelledby="mel-dash-empty-panel-title">
+      <h2 id="mel-dash-empty-panel-title" class="mel-vendor-dashboard__empty-panel-title">{{ "You're ready to publish your first event."|t }}</h2>
+      <p class="mel-vendor-dashboard__empty-panel-body">{{ 'Create your first event to begin selling tickets, managing attendees and running live events.'|t }}</p>
+      {% if empty_create_url %}
+        <div class="mel-vendor-dashboard__empty-panel-actions">
+          <a class="mel-btn mel-btn--primary mel-btn--lg" href="{{ empty_create_url }}">{{ empty_create_label }}</a>
+          {% if support_action and support_action.url is defined and support_action.url %}
+            <a class="mel-btn mel-btn--secondary" href="{{ support_action.url }}">{{ support_action.label|default('Support'|t) }}</a>
+          {% endif %}
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
   {# Slice 2 — Current event operations surface. #}
-  {% if current_event %}
+  {% if has_active_current_event %}
     {% set ce_status = current_event.status|default('') %}
     {% set ce_summary = current_event.operation_summary|default('') %}
     {% set ce_attendee = current_event.attendee_summary|default('') %}
@@ -221,8 +240,47 @@
     </section>
   {% endif %}
 
+  {# Slice 2b — Next event surface (no active current event). #}
+  {% if show_next_event %}
+    {% set ne_summary = next_event.operation_summary|default('') %}
+    {% set ne_metric = next_event.metric_label|default('') %}
+    {% set ne_quick = next_event.quick_actions|default([])|filter(a => a.url is defined and a.url) %}
+    {% set ne_primary = ne_quick|first|default(null) %}
+    <section class="mel-vendor-dashboard__next-event" aria-labelledby="mel-dash-next-event-title">
+      <div class="mel-vendor-dashboard__next-event-head">
+        <p class="mel-live-ops__eyebrow">{{ 'Next event'|t }}</p>
+        <h2 id="mel-dash-next-event-title" class="mel-vendor-dashboard__next-event-title">{{ next_event.title|default('Untitled event'|t) }}</h2>
+        {% if next_event.date_label is defined and next_event.date_label %}
+          <p class="mel-vendor-dashboard__next-event-date">{{ next_event.date_label }}</p>
+        {% endif %}
+      </div>
+
+      <div class="mel-vendor-dashboard__next-event-body">
+        {% if next_event.status_label is defined and next_event.status_label %}
+          <p class="mel-vendor-dashboard__next-event-status">{{ next_event.status_label }}</p>
+        {% endif %}
+        {% if ne_metric %}
+          <p class="mel-vendor-dashboard__next-event-metric">{{ ne_metric }}</p>
+        {% endif %}
+        {% if ne_summary %}
+          <p class="mel-vendor-dashboard__next-event-summary">{{ ne_summary }}</p>
+        {% endif %}
+      </div>
+
+      {% if ne_primary %}
+        {% set ne_secondary = ne_quick|filter(a => a.key|default('') != ne_primary.key|default(''))|slice(0, 3) %}
+        <nav class="mel-vendor-dashboard__next-event-actions" aria-label="{{ 'Next event actions'|t }}">
+          <a class="mel-btn mel-btn--primary" href="{{ ne_primary.url }}">{{ ne_primary.label }}</a>
+          {% for action in ne_secondary %}
+            <a class="mel-btn mel-btn--secondary" href="{{ action.url }}">{{ action.label }}</a>
+          {% endfor %}
+        </nav>
+      {% endif %}
+    </section>
+  {% endif %}
+
   {% if workspace_updates is iterable and workspace_updates|length > 0 %}
-    <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary" aria-labelledby="mel-dash-workspace-title">
+    <section class="mel-vendor-dashboard__workspace-updates mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__activity-stream--secondary mel-vendor-dashboard__section--tertiary" aria-labelledby="mel-dash-workspace-title">
       <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
         <p class="mel-live-ops__eyebrow">{{ 'Account'|t }}</p>
         <h2 id="mel-dash-workspace-title" class="mel-live-ops__panel-title">{{ 'Needs attention'|t }}</h2>
@@ -248,7 +306,7 @@
 
   {% if not events_empty %}
     {% if attention_events is iterable and attention_events|length > 0 %}
-      <section class="mel-vendor-dashboard__attention-strip mel-vendor-dashboard__attention-strip--compact mel-vendor-dashboard__action-queue" aria-labelledby="mel-dash-attention-title">
+      <section class="mel-vendor-dashboard__attention-strip mel-vendor-dashboard__attention-strip--compact mel-vendor-dashboard__action-queue mel-vendor-dashboard__section--tertiary" aria-labelledby="mel-dash-attention-title">
         <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
           <p class="mel-live-ops__eyebrow">{{ 'What needs your attention'|t }}</p>
           <h2 id="mel-dash-attention-title" class="mel-live-ops__panel-title">{{ 'Events to fix or finish'|t }}</h2>
@@ -279,7 +337,7 @@
     {% endif %}
 
     {% if upcoming_events is iterable and upcoming_events|length > 0 %}
-    <section class="mel-vendor-dashboard__upcoming-strip mel-vendor-dashboard__upcoming-strip--compact" aria-labelledby="mel-dash-upcoming-title">
+    <section class="mel-vendor-dashboard__upcoming-strip mel-vendor-dashboard__upcoming-strip--compact mel-vendor-dashboard__section--tertiary" aria-labelledby="mel-dash-upcoming-title">
       <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
         <div>
           <p class="mel-live-ops__eyebrow">{{ 'Next up'|t }}</p>
@@ -318,7 +376,7 @@
     </section>
     {% endif %}
 
-    <section class="mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact" aria-labelledby="mel-dash-activity-title">
+    <section class="mel-vendor-dashboard__activity-stream mel-vendor-dashboard__activity-stream--compact mel-vendor-dashboard__section--tertiary" aria-labelledby="mel-dash-activity-title">
     <div class="mel-vendor-dashboard__section-head mel-vendor-dashboard__section-head--compact">
       <p class="mel-live-ops__eyebrow">{{ 'What happened recently'|t }}</p>
       <h2 id="mel-dash-activity-title" class="mel-live-ops__panel-title">{{ 'Recent activity'|t }}</h2>


### PR DESCRIPTION
- Introduced SCSS styles for empty panel and next event sections in _dashboard-live-ops.scss, enhancing layout and responsiveness.
- Updated dashboard.html.twig to include logic for displaying next event details and support actions, improving user experience when no current events are active.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Twig and SCSS changes to the vendor dashboard; no backend or access-control changes in this diff.
> 
> **Overview**
> Refines the vendor **mission control** layout so zero-event organisers get a dedicated onboarding panel, and organisers without an active **current event** still see a focused **next event** block instead of leaning on the hero for CTAs.
> 
> **Empty state (0 events):** Removes the empty-state lead copy and create CTAs from the mission hero. Adds a new **`mel-vendor-dashboard__empty-panel`** section with publish-first messaging, primary **Create event**, and optional **Support** from `organiser_actions`. Hero stats and primary CTAs only render when the organiser has events.
> 
> **Current vs next event:** The current-event operations slice (and event metrics) now gates on **`has_active_current_event`** (`current_event` exists and status is not `past`), not merely `current_event` being set. When there is no active current event but a non-past event exists in `model.events`, a **Next event** panel shows title, date, status, metric/summary, and quick actions (primary + up to three secondary).
> 
> **Visual hierarchy:** Adds SCSS for empty panel, next event, and a **`__section--tertiary`** modifier applied to workspace updates, attention, upcoming, and recent activity so those strips read as de-emphasised relative to the hero and primary event surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3899f0e4f90f9abf2287868c3ceab6992da196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->