### PR TITLE
fix(page-visuals): ensure upload dir before AJAX and on deploy

### DIFF
--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -258,6 +258,7 @@ echo "Deploying release: $TIMESTAMP"
 
 mkdir -p "$APP_PATH/releases"
 mkdir -p "$SHARED_PATH/files"
+mkdir -p "$SHARED_PATH/files/page-visuals"
 
 mel_report_disk_usage
 mel_prune_old_releases

--- a/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Form/PageVisualForm.php
@@ -111,6 +111,9 @@ final class PageVisualForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state): array {
     $form = parent::form($form, $form_state);
 
+    // Create public://page-visuals before managed_file AJAX upload (validate runs too late).
+    $this->pageVisualMediaManager->ensureUploadDirectoryReady();
+
     $entity = $this->entity;
     $storage = $this->entityTypeManager->getStorage('myeventlane_page_visual');
 


### PR DESCRIPTION
## Summary

- Ensures `public://page-visuals` is prepared at **form build** time (before managed_file AJAX upload; validate runs too late).
- Creates `~/staging/shared/files/page-visuals` during remote deploy.

The main Page Visuals upload fix (`PageVisualMediaManager`, `update_9003`, media create access) already landed via PR #648. This PR adds the remaining staging hardening only.

## Test plan

- [ ] Merge to `main` and confirm staging deploy runs
- [ ] On staging: `~/bin/drush512 updb -y --uri=https://staging.myeventlane.com.au` (once, if `9003` not yet applied)
- [ ] Upload desktop hero image at `/admin/config/myeventlane/page-visuals/manage/home_hero`
- [ ] Save form and confirm hero appears on homepage


Made with [Cursor](https://cursor.com)